### PR TITLE
chore(todo): seed auto-revert incident TODOs (fix landing, signature attribution, medium PR lane, placeholder safety)

### DIFF
--- a/_project/TODO/auto-revert-incident/planning/auto-revert-signature-attribution.yaml
+++ b/_project/TODO/auto-revert-incident/planning/auto-revert-signature-attribution.yaml
@@ -51,8 +51,18 @@ prior_art:
 - "scripts/path_filter_decision.py - precedent for workflow logic extracted to a stdlib-only tested script instead of inline bash (pr.yml ci-paths job)"
 - ".github/workflows/develop-post-merge.yml:432-552 metrics job - stale MEDIUM_TEST_RESULT comment lives here; metrics JSON schema must stay backward-compatible"
 work:
+- id: w0
+  summary: "Re-validate the incident evidence: confirm the auto-revert job's if-condition still fires on any gate failure at develop tip, and pin the 2026-07-10 facts."
+  status: pending
+  notes: |
+    The CI run links (29097093548 etc.) expire; the durable pins are the
+    revert PRs themselves (#1099, #1104, #1107-#1112, #1115, #1120-#1122,
+    #1125-#1127 - only #1099/#1112 blamed guilty commits) and the
+    if-condition at develop-post-merge.yml:239. Record the re-check (SHA +
+    condition text) in the PR body.
 - id: w1
   summary: "Emit failure signatures: junit XML via PYTEST_ADDOPTS on the pytest gates plus an always-run signature-artifact upload step per gate job."
+  needs: [w0]
   status: pending
   notes: |
     Set PYTEST_ADDOPTS="--junitxml=<file>" as a step env in the workflow so
@@ -99,7 +109,8 @@ approach: |
   Keep the workflow as orchestration; put comparison logic in a tested
   stdlib-only script following the path_filter_decision.py precedent. Fail
   open (current always-revert behavior) whenever the previous run's signature
-  is unavailable.
+  is unavailable. Coordination: medium-tier-pre-merge-lane also touches
+  develop-post-merge.yml and deps.needs on this TODO - land this one first.
 anti_patterns:
 - "Do not implement a green->red-transition-only guard (misses new failures on an already-red develop)"
 - "Do not parse human-oriented pytest terminal output; use junit XML"

--- a/_project/TODO/auto-revert-incident/planning/auto-revert-signature-attribution.yaml
+++ b/_project/TODO/auto-revert-incident/planning/auto-revert-signature-attribution.yaml
@@ -1,0 +1,124 @@
+id: "auto-revert-signature-attribution"
+title: "Make auto-revert-on-failure signature-aware so persistent red does not blame every subsequent merge"
+worktree: "auto-revert-incident"
+priority: "High"
+status: "Not Started"
+category: "Core Functionality"
+description: |
+  The auto-revert-on-failure job in .github/workflows/develop-post-merge.yml
+  fires on ANY gate-job failure and reverts `github.sha` unconditionally. On
+  2026-07-10 two real breakages (#1093 test-side, #1100 code-side) produced
+  15 consecutive red runs and ~14 auto-revert PRs, of which only 2 (#1099,
+  #1112) blamed the guilty commit. TODO-only and docs-only merges (#1118,
+  #1123) got revert PRs. When the pile of revert PRs was bulk-closed at
+  19:22, the one correct revert (#1112) was discarded with the noise.
+
+  Fix: attribute by failure signature, not by newest SHA.
+
+  - Each gate job (lint, fast-test, explorer-tokens, medium-test) exposes a
+    machine-readable failure signature (for pytest lanes: the set of failed
+    test node IDs; for lint/token lanes: the failing job name + step is
+    enough) uploaded as a per-run artifact.
+  - auto-revert-on-failure downloads the signature artifact of the PREVIOUS
+    completed develop-post-merge run and diffs:
+      * previous run green, or new failure IDs appeared -> this merge
+        introduced them: open the revert PR (current behavior), listing the
+        new failure IDs in the body.
+      * previous run red with an identical-or-superset signature and no new
+        IDs -> do NOT open a revert PR; upsert a single open
+        "develop red" incident issue (label incident:develop-red) appending
+        the run link, so persistent red is one issue, not N PRs.
+  - A plain green->red transition guard is NOT sufficient: #1100 added a
+    second failure to an already-red develop and a transition guard would
+    have skipped the one revert PR that was actually correct. Signature
+    diffing handles both cases.
+
+  Also in scope (same file):
+  - When all gate jobs succeed, auto-close any open auto-revert/* PRs and
+    open incident:develop-red issues with a comment naming the green run
+    (extension alongside close-orphaned-prs).
+  - Fix the stale metrics-job comment (lines ~448-451) claiming
+    MEDIUM_TEST_RESULT is inert under continue-on-error; medium-test was
+    promoted to blocking on 2026-07-06.
+impact:
+  business_value: "Auto-revert becomes a trustworthy incident signal: one correct revert PR per real breakage instead of a flood of wrong-blame PRs that train people to bulk-close them."
+  user_impact: "Reviewers stop triaging bogus revert PRs; persistent red is tracked in one incident issue with the full run history."
+  technical_debt: "Removes the miscalibrated always-revert heuristic; adds a small tested comparison script instead of more inline bash."
+prior_art:
+- ".github/workflows/develop-post-merge.yml:231-430 auto-revert-on-failure - extend, keep conflict-issue fallback and idempotency guards"
+- ".github/workflows/develop-post-merge.yml:112-229 close-orphaned-prs - same close-PRs-with-comment shape to reuse for green-run cleanup"
+- ".github/workflows/develop-post-merge.yml:325-366 open_manual_action_issue - existing issue-dedup-by-search pattern to generalize for the incident issue upsert"
+- "scripts/path_filter_decision.py - precedent for workflow logic extracted to a stdlib-only tested script instead of inline bash (pr.yml ci-paths job)"
+- ".github/workflows/develop-post-merge.yml:432-552 metrics job - stale MEDIUM_TEST_RESULT comment lives here; metrics JSON schema must stay backward-compatible"
+work:
+- id: w1
+  summary: "Emit failure signatures: junit XML via PYTEST_ADDOPTS on the pytest gates plus an always-run signature-artifact upload step per gate job."
+  status: pending
+  notes: |
+    Set PYTEST_ADDOPTS="--junitxml=<file>" as a step env in the workflow so
+    `make ci-test` / `make test-medium` pick it up without changing local
+    developer behavior. Extract failed node IDs with a stdlib-only script
+    (see w2); upload with actions/upload-artifact, if: always().
+- id: w2
+  summary: "Add stdlib-only scripts/post_merge_signature.py: build a signature JSON from junit XML / job results, and diff two signatures returning the set of NEW failure IDs; unit-test both paths."
+  needs: [w1]
+  status: pending
+- id: w3
+  summary: "Gate auto-revert on the signature diff vs the previous run: revert PR only when new failure IDs exist, else upsert the incident issue."
+  needs: [w2]
+  status: pending
+  notes: |
+    Previous-run lookup: gh api /actions/workflows/develop-post-merge.yml/runs
+    ?branch=develop&status=completed&per_page=1&created<... or walk runs and
+    pick the one whose run_number is highest below the current run. Missing
+    artifact (expired, first run after this change) must fail open into
+    today's behavior, never crash the job.
+- id: w4
+  summary: "Green-run cleanup job: when all four gates succeed, close open auto-revert/* PRs and open incident issues, commenting the green run and SHA."
+  needs: []
+  status: pending
+  notes: |
+    Covers both incident:develop-red and incident:develop-red-revert-conflict
+    issues. Reuse the close-orphaned-prs close-with-comment shape.
+- id: w5
+  summary: "Fix the stale metrics-job MEDIUM_TEST_RESULT comment; extend the metrics JSON with the signature outcome (new_failure_ids, revert_suppressed) as additive fields only."
+  needs: [w3]
+  status: pending
+deferred:
+- summary: "Retroactive relabeling/closing of pre-existing bogus revert PRs"
+  reason: "Handled operationally by fix-session-isolation-placeholder-rows w3."
+- summary: "Signature capture for jobs added later (e.g. a future PR-lane medium job)"
+  reason: "This TODO covers the four develop-post-merge gates; new lanes adopt the same helper when added."
+must_preserve:
+- "Existing conflict fallback: git revert conflict still opens the incident:develop-red-revert-conflict issue with SHA-in-body dedup"
+- "Idempotency: re-runs for the same SHA must not open duplicate revert PRs or issues"
+- "close-orphaned-prs semantics untouched"
+- "Metrics artifact stays a superset of the current JSON schema (existing keys unchanged)"
+- "A genuinely new failure on an already-red develop STILL opens a revert PR (the #1100 case)"
+approach: |
+  Keep the workflow as orchestration; put comparison logic in a tested
+  stdlib-only script following the path_filter_decision.py precedent. Fail
+  open (current always-revert behavior) whenever the previous run's signature
+  is unavailable.
+anti_patterns:
+- "Do not implement a green->red-transition-only guard (misses new failures on an already-red develop)"
+- "Do not parse human-oriented pytest terminal output; use junit XML"
+- "Do not add third-party dependencies for the signature script (stdlib only, like the existing token-scan gates)"
+- "Do not silently skip reverting when signature comparison errors out - fail open to a revert PR, and say so in its body"
+verification:
+- description: "New signature build/diff unit tests are green."
+  command: "uv run -- python -m pytest tests/unit/test_post_merge_signature.py -q"
+  expected_output: "all pass"
+- description: "The edited workflow still parses as YAML."
+  command: "uv run -- python -c \"import yaml; yaml.safe_load(open('.github/workflows/develop-post-merge.yml'))\""
+  expected_output: "exit 0"
+- description: "Post-merge observation: one develop-post-merge run opens no bogus revert PR on green and its metrics artifact still parses."
+  command: "gh run list --workflow=develop-post-merge.yml --limit 1 (or GitHub MCP equivalent) after merge"
+  expected_output: "green run; no new auto-revert/* PR; metrics JSON parses"
+scope_limit:
+  only_modify:
+  - ".github/workflows/develop-post-merge.yml"
+  - "scripts/post_merge_signature.py"
+  - "tests/unit/test_post_merge_signature.py"
+deps:
+  needs: []

--- a/_project/TODO/auto-revert-incident/planning/fix-session-isolation-placeholder-rows.yaml
+++ b/_project/TODO/auto-revert-incident/planning/fix-session-isolation-placeholder-rows.yaml
@@ -1,0 +1,108 @@
+id: "fix-session-isolation-placeholder-rows"
+title: "Fix session-isolation test broken by placeholder-row fetchall (develop red since 13:42Z 2026-07-10)"
+worktree: "auto-revert-incident"
+priority: "Critical"
+status: "Not Started"
+category: "Testing and Quality Assurance"
+description: |
+  Develop's post-merge medium-test lane has been red continuously since
+  2026-07-10 13:42Z. The live breakage:
+
+  tests/integration/test_throughput_session_isolation.py:243
+  TestSharedCursorCapabilityIsDuckDBDefault::
+  test_streams_share_one_connection_no_new_connections_opened
+  fails `assert [(None,)] == [(7,)]`.
+
+  Root cause: PR #1100 (squash 7b6d1eef) changed
+  PlatformAdapterCursor._extract_rows() (benchbox/platforms/base/
+  connection_wrappers.py) so `rows_returned` takes priority over `first_row`
+  and, when the adapter reports only a count, fetchall() returns
+  cardinality-preserving placeholders `[(None,)] * row_count`. The test
+  (added by PR #1095, squash 7d8370bc, merged 25 min earlier - classic
+  stale-base squash race) asserts the ACTUAL VALUE fetched through the
+  validation-mode wrapper, which is now placeholder data by design.
+
+  Evidence (re-runnable, see w0):
+  - Fails deterministically at develop tip fc31f360 in isolation:
+    `uv run -- python -m pytest tests/integration/test_throughput_session_isolation.py -q`
+    -> 1 failed, 3 passed.
+  - Passes with pre-#1100 wrapper:
+    `git checkout 7b6d1eef~1 -- benchbox/platforms/base/connection_wrappers.py`
+    then same command -> 4 passed (restore with `git checkout HEAD -- ...`).
+  - CI: #1100's own merge run 29097093548 shows this failure appearing
+    alongside the (since fixed-forward by #1113) preflight failure; every
+    develop-post-merge run since fails on it (e.g. 29117490896, 29121630594).
+
+  The fix is test-side: #1100's placeholder contract is reviewed, intentional
+  behavior (truthful counts without GIL-serialized materialization). The test
+  must keep proving the SHARED_CURSOR capability (a table created via stream
+  A's handle is visible via stream B's handle; closing A does not tear down
+  the shared connection) without depending on wrapper-fetched VALUES:
+  assert cardinality through the wrapper, and verify the actual value through
+  the raw shared DuckDB connection, which shares the same session/catalog.
+
+  Once merged and the develop-post-merge run is green, the flood of bogus
+  auto-revert PRs stops and the superseded ones must be closed (w3).
+impact:
+  business_value: "Unblocks develop: every merge currently triggers a red post-merge run and a bogus auto-revert PR blaming an innocent commit."
+  user_impact: "Restores trust in the incident:develop-red signal; stops reviewer time being burned on revert PRs that would not fix anything."
+  technical_debt: "None added; removes a value-assertion that contradicts the reviewed placeholder-rows contract."
+prior_art:
+- "benchbox/platforms/base/connection_wrappers.py:287-320 _extract_rows placeholder priority order (rows > rows_returned > first_row) - the contract the test must respect, not change"
+- "tests/integration/test_throughput_session_isolation.py:227-252 the failing test - fix in place, keep both post-close assertions"
+- "tests/integration/test_throughput_session_isolation.py:153-157 _stream_wrapper - reproduces execution.py's per-stream connection_factory; keep using it"
+work:
+- id: w0
+  summary: "Re-validate the evidence at current develop tip: run the single failing test, confirm the [(None,)] failure signature, and record command + SHA + FAIL line in the PR body."
+  status: pending
+- id: w1
+  summary: "Rewrite the two value assertions (lines 243, 250): cardinality via the wrapper cursor, actual value via the raw shared_connection."
+  needs: [w0]
+  status: pending
+  notes: |
+    The raw `shared_connection` (duckdb connection from
+    adapter.create_connection()) sees the same catalog/session as both stream
+    cursors, so `shared_connection.execute("SELECT value FROM shared_state")
+    .fetchall() == [(7,)]` proves the INSERT through stream A landed with the
+    real value while `len(stream_b.execute(...).fetchall()) == 1` proves
+    stream B's handle shares the session. Update the test docstring to say
+    why values are checked on the raw connection (placeholder-rows contract).
+- id: w2
+  summary: "Run the full test file plus the throughput real-duckdb regression file locally; both green."
+  needs: [w1]
+  status: pending
+- id: w3
+  summary: "Post-merge ops: once develop-post-merge is green, close superseded open auto-revert PRs with a comment linking this fix-forward PR."
+  needs: [w2]
+  status: pending
+  notes: |
+    Ops action, not code: use gh/GitHub MCP. Close #1120, #1121, #1122,
+    #1125, #1126, plus any opened since. Do NOT merge any of them -
+    reverting the blamed PRs would not fix develop. The one revert PR that
+    correctly blamed #1100 (#1112) was already closed on 2026-07-10 19:22.
+deferred:
+- summary: "Change _extract_rows to thread first_row into the first placeholder slot"
+  reason: "Design change to the reviewed #1100 contract; superseded by the placeholder-rows-fetch-safety TODO which handles consumer-facing safety holistically."
+must_preserve:
+- "The test still fails if streams were given independent connections (the anti-pattern the SHARED_CURSOR capability forbids for DuckDB)"
+- "The post-close assertion: closing stream A's cursor must not tear down the shared connection under stream B"
+- "TestIndependentConnectionCapabilityIsolatesSessions is untouched"
+approach: |
+  Test-only fix. Keep the existing structure and _stream_wrapper seam; swap
+  value assertions for cardinality-via-wrapper + value-via-raw-connection.
+anti_patterns:
+- "Do not modify benchbox/platforms/base/connection_wrappers.py to special-case this test"
+- "Do not skip/xfail the test or drop it from the medium tier"
+- "Do not weaken to an existence-only check (must still verify the inserted value, via the raw connection)"
+verification:
+- description: "The incident test file is fully green."
+  command: "uv run -- python -m pytest tests/integration/test_throughput_session_isolation.py -q"
+  expected_output: "4 passed"
+- description: "The #1100 truthful-row-count contract tests stay green (untouched)."
+  command: "uv run -- python -m pytest tests/integration/test_throughput_real_duckdb.py -q"
+  expected_output: "all pass"
+scope_limit:
+  only_modify:
+  - "tests/integration/test_throughput_session_isolation.py"
+deps:
+  needs: []

--- a/_project/TODO/auto-revert-incident/planning/fix-session-isolation-placeholder-rows.yaml
+++ b/_project/TODO/auto-revert-incident/planning/fix-session-isolation-placeholder-rows.yaml
@@ -1,12 +1,13 @@
 id: "fix-session-isolation-placeholder-rows"
-title: "Fix session-isolation test broken by placeholder-row fetchall (develop red since 13:42Z 2026-07-10)"
+title: "Land the placeholder-rows fix for the session-isolation failure keeping develop red (via existing PR #1117)"
 worktree: "auto-revert-incident"
 priority: "Critical"
 status: "Not Started"
 category: "Testing and Quality Assurance"
 description: |
   Develop's post-merge medium-test lane has been red continuously since
-  2026-07-10 13:42Z. The live breakage:
+  2026-07-10 12:42Z (first on the #1093 preflight failure, fixed forward by
+  #1113). The breakage still live, introduced 13:42Z:
 
   tests/integration/test_throughput_session_isolation.py:243
   TestSharedCursorCapabilityIsDuckDBDefault::
@@ -33,13 +34,23 @@ description: |
     alongside the (since fixed-forward by #1113) preflight failure; every
     develop-post-merge run since fails on it (e.g. 29117490896, 29121630594).
 
-  The fix is test-side: #1100's placeholder contract is reviewed, intentional
-  behavior (truthful counts without GIL-serialized materialization). The test
-  must keep proving the SHARED_CURSOR capability (a table created via stream
-  A's handle is visible via stream B's handle; closing A does not tear down
-  the shared connection) without depending on wrapper-fetched VALUES:
-  assert cardinality through the wrapper, and verify the actual value through
-  the raw shared DuckDB connection, which shares the same session/catalog.
+  PRIMARY PATH - land the existing fix, do not write a competing one:
+  PR #1117 (fix/1100-cursor-row-count-followup, opened 2026-07-10 19:08)
+  already fixes this code-side: _extract_rows() now threads the real
+  first_row into the first slot of the padded placeholder list, so the test
+  passes unchanged; it ships unit tests confirmed to reproduce the exact
+  [(None,)] == [(7,)] CI diff when the fix is stashed. Auto-merge is already
+  enabled on it, but its PR CI failed on exactly one UNRELATED test:
+  tests/uat/test_throughput.py::test_resolve_official_result_path_is_case_
+  and_dash_insensitive - the mtime-boundary flake that #1119 (merged 19:34Z,
+  after #1117's base d54d64ed was cut) de-flaked on develop. Updating
+  #1117's branch onto the develop tip re-runs CI with the de-flake in the
+  tree; green CI lets the enabled auto-merge land it.
+
+  FALLBACK (only if #1117's refreshed CI fails for cause): fix test-side -
+  assert cardinality through the wrapper and verify the actual value through
+  the raw shared DuckDB connection (same session/catalog), preserving the
+  SHARED_CURSOR proof without depending on wrapper-fetched values.
 
   Once merged and the develop-post-merge run is green, the flood of bogus
   auto-revert PRs stops and the superseded ones must be closed (w3).
@@ -48,27 +59,30 @@ impact:
   user_impact: "Restores trust in the incident:develop-red signal; stops reviewer time being burned on revert PRs that would not fix anything."
   technical_debt: "None added; removes a value-assertion that contradicts the reviewed placeholder-rows contract."
 prior_art:
-- "benchbox/platforms/base/connection_wrappers.py:287-320 _extract_rows placeholder priority order (rows > rows_returned > first_row) - the contract the test must respect, not change"
-- "tests/integration/test_throughput_session_isolation.py:227-252 the failing test - fix in place, keep both post-close assertions"
+- "PR #1117 (fix/1100-cursor-row-count-followup) - the existing code-side fix to land; do not duplicate it"
+- "benchbox/platforms/base/connection_wrappers.py:~289-318 _extract_rows placeholder priority order (rows > rows_returned > first_row; placeholder pad at ~312)"
+- "tests/integration/test_throughput_session_isolation.py:227-252 the failing test (fallback path edits it in place, keeping both post-close assertions)"
 - "tests/integration/test_throughput_session_isolation.py:153-157 _stream_wrapper - reproduces execution.py's per-stream connection_factory; keep using it"
 work:
 - id: w0
-  summary: "Re-validate the evidence at current develop tip: run the single failing test, confirm the [(None,)] failure signature, and record command + SHA + FAIL line in the PR body."
+  summary: "Re-validate: failing test still red at develop tip with the [(None,)] signature; #1117 still open with only the mtime flake red; #1117's head merged into the tip locally turns the test green."
   status: pending
+  notes: |
+    Record commands + SHAs + result lines in the close-out. The local
+    merge-tree check (git fetch the PR head, merge into a throwaway branch
+    off origin/develop, run the test file) is the go/no-go for w1.
 - id: w1
-  summary: "Rewrite the two value assertions (lines 243, 250): cardinality via the wrapper cursor, actual value via the raw shared_connection."
+  summary: "Update #1117's branch onto the develop tip (GitHub MCP update_pull_request_branch), watch its PR CI; auto-merge (already enabled) lands it on green."
   needs: [w0]
   status: pending
   notes: |
-    The raw `shared_connection` (duckdb connection from
-    adapter.create_connection()) sees the same catalog/session as both stream
-    cursors, so `shared_connection.execute("SELECT value FROM shared_state")
-    .fetchall() == [(7,)]` proves the INSERT through stream A landed with the
-    real value while `len(stream_b.execute(...).fetchall()) == 1` proves
-    stream B's handle shares the session. Update the test docstring to say
-    why values are checked on the raw connection (placeholder-rows contract).
+    FALLBACK if refreshed CI fails for cause (not flake): rewrite the two
+    value assertions (lines 243, 250) test-side - cardinality via the
+    wrapper cursor, actual value via the raw shared_connection (same
+    session/catalog), docstring updated to explain the placeholder-rows
+    contract - in a fix/ PR of its own, and close #1117 with the reason.
 - id: w2
-  summary: "Run the full test file plus the throughput real-duckdb regression file locally; both green."
+  summary: "Confirm the develop-post-merge run for the merge SHA is green (medium-test passes, session-isolation test included)."
   needs: [w1]
   status: pending
 - id: w3
@@ -77,30 +91,35 @@ work:
   status: pending
   notes: |
     Ops action, not code: use gh/GitHub MCP. Close #1120, #1121, #1122,
-    #1125, #1126, plus any opened since. Do NOT merge any of them -
+    #1125, #1126, #1127, plus any opened since. Do NOT merge any of them -
     reverting the blamed PRs would not fix develop. The one revert PR that
     correctly blamed #1100 (#1112) was already closed on 2026-07-10 19:22.
 deferred:
-- summary: "Change _extract_rows to thread first_row into the first placeholder slot"
-  reason: "Design change to the reviewed #1100 contract; superseded by the placeholder-rows-fetch-safety TODO which handles consumer-facing safety holistically."
+- summary: "Additional consumer-facing hardening of the placeholder-rows contract"
+  reason: "Handled holistically by the placeholder-rows-fetch-safety TODO once #1117's refinement (first_row threaded into the first placeholder slot) is on develop."
 must_preserve:
 - "The test still fails if streams were given independent connections (the anti-pattern the SHARED_CURSOR capability forbids for DuckDB)"
 - "The post-close assertion: closing stream A's cursor must not tear down the shared connection under stream B"
 - "TestIndependentConnectionCapabilityIsolatesSessions is untouched"
 approach: |
-  Test-only fix. Keep the existing structure and _stream_wrapper seam; swap
-  value assertions for cardinality-via-wrapper + value-via-raw-connection.
+  Ship the existing fix: refresh #1117's branch so its already-enabled
+  auto-merge can land; verify on the local merge tree first. Only fall back
+  to the test-side rewrite if the refreshed CI fails for cause.
 anti_patterns:
-- "Do not modify benchbox/platforms/base/connection_wrappers.py to special-case this test"
+- "Do not open a competing fix PR while #1117 is viable (duplicate work, conflicting merges)"
 - "Do not skip/xfail the test or drop it from the medium tier"
-- "Do not weaken to an existence-only check (must still verify the inserted value, via the raw connection)"
+- "Do not merge any auto-revert/* PR to get green (reverting the blamed PRs would not fix develop)"
+- "Fallback only: do not weaken the test to an existence-only check (must still verify the inserted value, via the raw connection)"
 verification:
-- description: "The incident test file is fully green."
-  command: "uv run -- python -m pytest tests/integration/test_throughput_session_isolation.py -q"
+- description: "Pre-flight: #1117's head merged into the develop tip locally turns the incident test file green."
+  command: "git fetch origin pull/1117/head && git merge into a throwaway branch off origin/develop, then uv run -- python -m pytest tests/integration/test_throughput_session_isolation.py -q"
   expected_output: "4 passed"
-- description: "The #1100 truthful-row-count contract tests stay green (untouched)."
+- description: "The #1100 truthful-row-count contract tests stay green on the same merge tree."
   command: "uv run -- python -m pytest tests/integration/test_throughput_real_duckdb.py -q"
   expected_output: "all pass"
+- description: "Post-merge: develop-post-merge run at the merge SHA is green."
+  command: "GitHub MCP actions_get on the develop-post-merge run for the merge commit"
+  expected_output: "conclusion: success; no new auto-revert PR"
 scope_limit:
   only_modify:
   - "tests/integration/test_throughput_session_isolation.py"

--- a/_project/TODO/auto-revert-incident/planning/medium-tier-pre-merge-lane.yaml
+++ b/_project/TODO/auto-revert-incident/planning/medium-tier-pre-merge-lane.yaml
@@ -16,9 +16,11 @@ description: |
     asserted on.
 
   Fix: add a `medium-test` job to .github/workflows/pr.yml, gated on the
-  existing ci-paths classifier's `code-paths` output so docs/TODO-only PRs
-  skip it. Mirror the develop-post-merge job (python 3.12, uv sync --group
-  dev, make test-medium, timeout-minutes 30).
+  existing ci-paths classifier's `needs-code-ci` boolean output (the gate
+  every existing conditional code job uses - `code-paths` is a newline-joined
+  path LIST, never 'true') so docs/TODO-only PRs skip it. Mirror the
+  develop-post-merge job (python 3.12, uv sync --group dev, make
+  test-medium, timeout-minutes 30).
 
   Note the residual gap this does NOT close: a stale-base squash race
   (#1095 x #1100) can still land a semantic conflict because PR CI tests the
@@ -30,26 +32,31 @@ impact:
   user_impact: "Code-PR authors get a pre-merge medium signal; docs/TODO PRs stay fast."
   technical_debt: "Closes the 'blocking post-merge lane with no pre-merge consumer' asymmetry introduced by the 2026-07-06 medium-tier promotion."
 prior_art:
-- ".github/workflows/pr.yml:16-56 ci-paths job with code-paths output - gate the new job on it exactly like existing conditional jobs"
+- ".github/workflows/pr.yml:263,393 code-lint/code-test gate on needs-code-ci == 'true' - the exact gating precedent to copy (NOT code-paths, which is a path list)"
+- ".github/workflows/pr.yml:16-56 ci-paths job that computes the needs-code-ci output"
 - ".github/workflows/develop-post-merge.yml:74-110 the medium-test job to mirror (steps, python version, timeout, promotion-history comment)"
 - "Makefile:90-91 test-medium target - reuse as-is, no new pytest invocation"
-- "_project/TODO/main/planning/medium-tier-ci-home.yaml - the original 'where should medium run' decision record referenced by the post-merge job comment; update its trail"
+- "_project/DONE/main/medium-tier-ci-home.yaml - the original 'where should medium run' decision record (already in DONE; read-only, do not edit)"
 work:
 - id: w1
-  summary: "Add the medium-test job to pr.yml: needs ci-paths, if code-paths == 'true', checkout + setup-python 3.12 + setup-uv + uv sync --group dev + make test-medium, timeout-minutes 30."
+  summary: "Add the medium-test job to pr.yml: needs ci-paths, if needs-code-ci == 'true' (mirror code-test's gate at pr.yml:393), make test-medium, timeout-minutes 30."
   status: pending
   notes: |
-    Confirm pr.yml's concurrency block cancels superseded runs so force-push
-    storms do not stack 30-minute jobs; add cancel-in-progress if absent.
+    Steps: checkout + setup-python 3.12 + setup-uv + uv sync --group dev +
+    make test-medium. Confirm pr.yml's concurrency block cancels superseded
+    runs so force-push storms do not stack 30-minute jobs; add
+    cancel-in-progress if absent.
 - id: w2
   summary: "Update the develop-post-merge medium-test job comment to record the new PR-lane consumer; post-merge stays as the squash-race safety net."
   needs: [w1]
   status: pending
   notes: |
-    Also update the medium-tier-ci-home planning trail
-    (_project/TODO/main/planning/medium-tier-ci-home.yaml) if it still
-    exists; if it moved to DONE, leave the DONE record untouched and note
-    that in the PR body instead.
+    The original decision record already moved to
+    _project/DONE/main/medium-tier-ci-home.yaml - leave the DONE record
+    untouched and note the new consumer in the PR body instead.
+    Coordination: auto-revert-signature-attribution rewrites
+    develop-post-merge.yml heavily; this TODO lands AFTER it (deps.needs)
+    so this comment tweak rebases trivially.
 - id: w3
   summary: "Validate on this TODO's own PR: the job must trigger (workflow files count as code paths or adjust the classifier lists accordingly) and pass; capture the run link in the PR body."
   needs: [w1]
@@ -76,7 +83,7 @@ verification:
   expected_output: "exit 0"
 - description: "Path classifier fires for code diffs and skips docs-only diffs."
   command: "uv run -- python scripts/path_filter_decision.py --help then dry-run per its documented usage against a docs-only and a code file list"
-  expected_output: "code-paths true only for the code diff"
+  expected_output: "needs-code-ci is 'true' only for the code diff"
 - description: "This TODO's own PR run executes the new medium-test job."
   command: "PR checks on the branch (gh pr checks or GitHub MCP get_check_runs)"
   expected_output: "medium-test job present and green; run link captured in PR body"
@@ -84,6 +91,5 @@ scope_limit:
   only_modify:
   - ".github/workflows/pr.yml"
   - ".github/workflows/develop-post-merge.yml"
-  - "_project/TODO/main/planning/medium-tier-ci-home.yaml"
 deps:
-  needs: []
+  needs: [fix-session-isolation-placeholder-rows, auto-revert-signature-attribution]

--- a/_project/TODO/auto-revert-incident/planning/medium-tier-pre-merge-lane.yaml
+++ b/_project/TODO/auto-revert-incident/planning/medium-tier-pre-merge-lane.yaml
@@ -1,0 +1,89 @@
+id: "medium-tier-pre-merge-lane"
+title: "Run the medium test tier pre-merge on code PRs so medium breakage cannot land unexecuted"
+worktree: "auto-revert-incident"
+priority: "High"
+status: "Not Started"
+category: "Testing and Quality Assurance"
+description: |
+  The medium tier (`make test-medium`, Makefile:90-91, ~18-27 min on the
+  runner at -n 2..5) runs ONLY in develop-post-merge; no PR lane executes it.
+  Both 2026-07-10 breakages were therefore invisible pre-merge:
+
+  - #1093 changed the TPC-DS preflight code path; the medium-tier test that
+    pinned the old path was never run on the PR and went red post-merge.
+  - #1095 ADDED a medium-marked test that had never executed in any CI when
+    #1100 (branched from a base without it) changed the semantics it
+    asserted on.
+
+  Fix: add a `medium-test` job to .github/workflows/pr.yml, gated on the
+  existing ci-paths classifier's `code-paths` output so docs/TODO-only PRs
+  skip it. Mirror the develop-post-merge job (python 3.12, uv sync --group
+  dev, make test-medium, timeout-minutes 30).
+
+  Note the residual gap this does NOT close: a stale-base squash race
+  (#1095 x #1100) can still land a semantic conflict because PR CI tests the
+  PR's own merge tree, not the eventual develop tip. That is what
+  develop-post-merge remains the safety net for; the durable structural fix
+  (GitHub merge queue) needs repo-settings/admin work and is deferred.
+impact:
+  business_value: "Medium-tier breakage is caught on the PR where it is cheap to fix, instead of turning develop red and triggering the auto-revert machinery."
+  user_impact: "Code-PR authors get a pre-merge medium signal; docs/TODO PRs stay fast."
+  technical_debt: "Closes the 'blocking post-merge lane with no pre-merge consumer' asymmetry introduced by the 2026-07-06 medium-tier promotion."
+prior_art:
+- ".github/workflows/pr.yml:16-56 ci-paths job with code-paths output - gate the new job on it exactly like existing conditional jobs"
+- ".github/workflows/develop-post-merge.yml:74-110 the medium-test job to mirror (steps, python version, timeout, promotion-history comment)"
+- "Makefile:90-91 test-medium target - reuse as-is, no new pytest invocation"
+- "_project/TODO/main/planning/medium-tier-ci-home.yaml - the original 'where should medium run' decision record referenced by the post-merge job comment; update its trail"
+work:
+- id: w1
+  summary: "Add the medium-test job to pr.yml: needs ci-paths, if code-paths == 'true', checkout + setup-python 3.12 + setup-uv + uv sync --group dev + make test-medium, timeout-minutes 30."
+  status: pending
+  notes: |
+    Confirm pr.yml's concurrency block cancels superseded runs so force-push
+    storms do not stack 30-minute jobs; add cancel-in-progress if absent.
+- id: w2
+  summary: "Update the develop-post-merge medium-test job comment to record the new PR-lane consumer; post-merge stays as the squash-race safety net."
+  needs: [w1]
+  status: pending
+  notes: |
+    Also update the medium-tier-ci-home planning trail
+    (_project/TODO/main/planning/medium-tier-ci-home.yaml) if it still
+    exists; if it moved to DONE, leave the DONE record untouched and note
+    that in the PR body instead.
+- id: w3
+  summary: "Validate on this TODO's own PR: the job must trigger (workflow files count as code paths or adjust the classifier lists accordingly) and pass; capture the run link in the PR body."
+  needs: [w1]
+  status: pending
+deferred:
+- summary: "Make the new job a required status check in the develop ruleset"
+  reason: "Branch-protection/ruleset change is admin/settings work, not repo code; without it auto-merge does not wait for this job - flag to the repo owner in the PR body."
+- summary: "GitHub merge queue for develop"
+  reason: "The structural fix for stale-base squash races, but requires repo-settings evaluation (queue latency, runner budget); record as its own decision item if pursued."
+must_preserve:
+- "Docs/TODO/markdown-only PRs must not start the medium job (ci-paths gating)"
+- "develop-post-merge medium-test job stays blocking and wired to auto-revert (it is the safety net for stale-base races PR CI cannot see)"
+- "Makefile test-medium semantics unchanged (local developer runtime unaffected)"
+approach: |
+  Pure workflow addition to pr.yml plus comment/doc trail updates. Reuse the
+  ci-paths classifier; do not invent a second path filter.
+anti_patterns:
+- "Do not duplicate the pytest command inline in pr.yml - call make test-medium so PR lane and post-merge lane cannot drift"
+- "Do not run the medium tier unconditionally on every PR (docs PRs would eat 30 runner-minutes for nothing)"
+- "Do not remove or weaken the post-merge medium-test job as 'redundant'"
+verification:
+- description: "The edited workflow still parses as YAML."
+  command: "uv run -- python -c \"import yaml; yaml.safe_load(open('.github/workflows/pr.yml'))\""
+  expected_output: "exit 0"
+- description: "Path classifier fires for code diffs and skips docs-only diffs."
+  command: "uv run -- python scripts/path_filter_decision.py --help then dry-run per its documented usage against a docs-only and a code file list"
+  expected_output: "code-paths true only for the code diff"
+- description: "This TODO's own PR run executes the new medium-test job."
+  command: "PR checks on the branch (gh pr checks or GitHub MCP get_check_runs)"
+  expected_output: "medium-test job present and green; run link captured in PR body"
+scope_limit:
+  only_modify:
+  - ".github/workflows/pr.yml"
+  - ".github/workflows/develop-post-merge.yml"
+  - "_project/TODO/main/planning/medium-tier-ci-home.yaml"
+deps:
+  needs: []

--- a/_project/TODO/auto-revert-incident/planning/placeholder-rows-fetch-safety.yaml
+++ b/_project/TODO/auto-revert-incident/planning/placeholder-rows-fetch-safety.yaml
@@ -1,0 +1,86 @@
+id: "placeholder-rows-fetch-safety"
+title: "Make PlatformAdapterCursor placeholder rows impossible to mistake for real data"
+worktree: "auto-revert-incident"
+priority: "Medium"
+status: "Not Started"
+category: "Code Quality and Technical Debt"
+description: |
+  Since #1100, PlatformAdapterCursor.fetchall()/fetchone()/.rows fabricate
+  cardinality-preserving placeholders `[(None,)] * rows_returned` whenever
+  the platform result carries only a count (benchbox/platforms/base/
+  connection_wrappers.py:287-320). That design is correct for the throughput
+  drivers (truthful counts, no GIL-serialized materialization) but is a
+  correctness footgun for any consumer that reads VALUES: the data looks like
+  a real result set full of NULLs. First bite: the session-isolation test
+  incident of 2026-07-10 (see fix-session-isolation-placeholder-rows), where
+  `assert fetchall() == [(7,)]` silently became `[(None,)]`.
+
+  Make placeholder materialization unmistakable without changing the
+  contract:
+  - expose an explicit `has_real_rows` (or equivalent) property derived from
+    which _extract_rows branch fired;
+  - log a one-time warning when placeholder rows are actually materialized
+    via fetchall()/fetchone()/.rows (not when only row_count() is used -
+    that path must stay silent and lazy);
+  - audit in-repo consumers of fetchall()/fetchone()/.rows on
+    PlatformAdapterCursor for value-dependence and fix or annotate each;
+  - document the contract in the class docstring.
+impact:
+  business_value: "Prevents the next silent wrong-values bug in benchmark result handling - a soundness-adjacent class of error for a benchmarking tool."
+  user_impact: "Anyone driving platforms through the wrapper gets a loud signal the first time they touch placeholder data."
+  technical_debt: "Converts an implicit, discoverable-only-by-incident contract into an explicit, warned, documented one."
+prior_art:
+- "benchbox/platforms/base/connection_wrappers.py:279-330 PlatformAdapterCursor - extend; the lazy `rows` property and row_count() fast path are the #1100 contract to preserve"
+- "benchbox/platforms/base/connection_wrappers.py count_query_rows()/row_count() - the sanctioned count-only path that must remain warning-free"
+- "tests/integration/test_throughput_real_duckdb.py - pins truthful row counts from #1100; must stay green"
+work:
+- id: w1
+  summary: "Audit all in-repo call sites of PlatformAdapterCursor fetchall/fetchone/.rows; classify each as count-only, value-dependent-with-real-rows, or value-dependent-at-risk; record the table in the PR body."
+  status: pending
+- id: w2
+  summary: "Implement has_real_rows plus a once-per-cursor warning on placeholder materialization; document the three-branch contract."
+  notes: |
+    Keep row_count()/count_query_rows and the lazy no-materialization path
+    silent; the warning fires only when placeholder rows are actually
+    materialized via fetchall()/fetchone()/.rows.
+  needs: [w1]
+  status: pending
+- id: w3
+  summary: "Unit-test the warning/has_real_rows matrix and fix any at-risk consumer found in w1 within scope."
+  needs: [w2]
+  status: pending
+  notes: |
+    Matrix: placeholder fetch warns once and has_real_rows is False;
+    explicit-rows fetch does not warn and has_real_rows is True; count-only
+    usage (row_count()/count_query_rows) never warns.
+deferred:
+- summary: "Sentinel row objects or hard errors on placeholder fetch"
+  reason: "Behavior-breaking for legitimate cardinality-only consumers; revisit only if the warning proves insufficient."
+- summary: "Adapter-side full-row materialization below a size threshold"
+  reason: "Reintroduces the GIL/materialization cost #1100 removed; needs its own perf evidence."
+must_preserve:
+- "#1100 semantics: rows > rows_returned > first_row priority; truthful counts; no materialization on the count-only path"
+- "fetchall() return SHAPE unchanged (list of tuples) - only observability is added"
+- "tests/integration/test_throughput_real_duckdb.py and the throughput drivers' row_count() path stay green and warning-free"
+approach: |
+  Additive observability on the existing class; no consumer-facing API
+  breaks. Audit first (w1) so the warning lands with the consumer table as
+  evidence, not speculation.
+anti_patterns:
+- "Do not warn on every fetch call (once per cursor) or on count-only paths"
+- "Do not change what fetchall() returns for real rows"
+- "Do not fix at-risk consumers by re-materializing full results inside the throughput drivers"
+verification:
+- description: "Wrapper unit tests including the new warning/has_real_rows cases are green."
+  command: "uv run -- python -m pytest tests/unit/platforms/ -k connection_wrapper -q"
+  expected_output: "all pass, including new placeholder-warning cases"
+- description: "The #1100 contract tests and the incident test stay green."
+  command: "uv run -- python -m pytest tests/integration/test_throughput_real_duckdb.py tests/integration/test_throughput_session_isolation.py -q"
+  expected_output: "all pass"
+scope_limit:
+  only_modify:
+  - "benchbox/platforms/base/connection_wrappers.py"
+  - "tests/unit/**"
+  - "Files identified in the w1 audit as at-risk value consumers (list them in the PR body before editing)"
+deps:
+  needs: [fix-session-isolation-placeholder-rows]

--- a/_project/TODO/auto-revert-incident/planning/placeholder-rows-fetch-safety.yaml
+++ b/_project/TODO/auto-revert-incident/planning/placeholder-rows-fetch-safety.yaml
@@ -8,7 +8,8 @@ description: |
   Since #1100, PlatformAdapterCursor.fetchall()/fetchone()/.rows fabricate
   cardinality-preserving placeholders `[(None,)] * rows_returned` whenever
   the platform result carries only a count (benchbox/platforms/base/
-  connection_wrappers.py:287-320). That design is correct for the throughput
+  connection_wrappers.py:~289-318; #1117 refines this to thread the real
+  first_row into the first slot). That design is correct for the throughput
   drivers (truthful counts, no GIL-serialized materialization) but is a
   correctness footgun for any consumer that reads VALUES: the data looks like
   a real result set full of NULLs. First bite: the session-isolation test
@@ -30,8 +31,9 @@ impact:
   user_impact: "Anyone driving platforms through the wrapper gets a loud signal the first time they touch placeholder data."
   technical_debt: "Converts an implicit, discoverable-only-by-incident contract into an explicit, warned, documented one."
 prior_art:
-- "benchbox/platforms/base/connection_wrappers.py:279-330 PlatformAdapterCursor - extend; the lazy `rows` property and row_count() fast path are the #1100 contract to preserve"
+- "benchbox/platforms/base/connection_wrappers.py:~272-330 PlatformAdapterCursor - extend; the lazy `rows` property and row_count() fast path are the #1100 contract to preserve"
 - "benchbox/platforms/base/connection_wrappers.py count_query_rows()/row_count() - the sanctioned count-only path that must remain warning-free"
+- "PR #1117 - first_row now threads into the first placeholder slot and adds tests/unit/platforms/base/test_connection_wrappers.py; build on both"
 - "tests/integration/test_throughput_real_duckdb.py - pins truthful row counts from #1100; must stay green"
 work:
 - id: w1
@@ -46,7 +48,7 @@ work:
   needs: [w1]
   status: pending
 - id: w3
-  summary: "Unit-test the warning/has_real_rows matrix and fix any at-risk consumer found in w1 within scope."
+  summary: "Unit-test the warning/has_real_rows matrix; file follow-up TODOs for any at-risk consumers found in w1 (do not edit them here)."
   needs: [w2]
   status: pending
   notes: |
@@ -54,12 +56,14 @@ work:
     explicit-rows fetch does not warn and has_real_rows is True; count-only
     usage (row_count()/count_query_rows) never warns.
 deferred:
+- summary: "Fixes to at-risk value consumers found by the w1 audit"
+  reason: "Not edited under this TODO: the audit table goes in the PR body and each consumer fix becomes a follow-up TODO (or rides this PR only after scope_limit is explicitly amended with the exact paths in a review-visible commit)."
 - summary: "Sentinel row objects or hard errors on placeholder fetch"
   reason: "Behavior-breaking for legitimate cardinality-only consumers; revisit only if the warning proves insufficient."
 - summary: "Adapter-side full-row materialization below a size threshold"
   reason: "Reintroduces the GIL/materialization cost #1100 removed; needs its own perf evidence."
 must_preserve:
-- "#1100 semantics: rows > rows_returned > first_row priority; truthful counts; no materialization on the count-only path"
+- "#1100+#1117 semantics: rows > rows_returned (with first_row threaded into slot 0) > first_row priority; truthful counts; no materialization on the count-only path"
 - "fetchall() return SHAPE unchanged (list of tuples) - only observability is added"
 - "tests/integration/test_throughput_real_duckdb.py and the throughput drivers' row_count() path stay green and warning-free"
 approach: |
@@ -71,16 +75,15 @@ anti_patterns:
 - "Do not change what fetchall() returns for real rows"
 - "Do not fix at-risk consumers by re-materializing full results inside the throughput drivers"
 verification:
-- description: "Wrapper unit tests including the new warning/has_real_rows cases are green."
-  command: "uv run -- python -m pytest tests/unit/platforms/ -k connection_wrapper -q"
-  expected_output: "all pass, including new placeholder-warning cases"
+- description: "Wrapper unit tests including the new warning/has_real_rows cases are green (file lands with #1117; extend it)."
+  command: "uv run -- python -m pytest tests/unit/platforms/base/test_connection_wrappers.py -q"
+  expected_output: "nonzero tests collected; all pass, including new placeholder-warning cases"
 - description: "The #1100 contract tests and the incident test stay green."
   command: "uv run -- python -m pytest tests/integration/test_throughput_real_duckdb.py tests/integration/test_throughput_session_isolation.py -q"
   expected_output: "all pass"
 scope_limit:
   only_modify:
   - "benchbox/platforms/base/connection_wrappers.py"
-  - "tests/unit/**"
-  - "Files identified in the w1 audit as at-risk value consumers (list them in the PR body before editing)"
+  - "tests/unit/platforms/base/test_connection_wrappers.py"
 deps:
   needs: [fix-session-isolation-placeholder-rows]


### PR DESCRIPTION
# Pull Request

## Description

Four TODOs (new worktree group `auto-revert-incident`) converting the 2026-07-10 develop-red / auto-revert-PR-flood incident analysis into actionable work:

- `fix-session-isolation-placeholder-rows` (**Critical**) — stop the bleeding: land existing PR #1117 (branch refresh; its only CI red was the mtime flake #1119 already de-flaked on develop), confirm develop-post-merge green, close superseded revert PRs #1120/#1121/#1122/#1125/#1126/#1127. Test-side rewrite kept as fallback.
- `auto-revert-signature-attribution` (**High**) — make `auto-revert-on-failure` diff failure signatures (junit-derived failed-test IDs) against the previous run: revert PR only for merges that introduce NEW failures; persistent red goes to one deduped incident issue; green runs auto-close stale `auto-revert/*` PRs; stale `MEDIUM_TEST_RESULT` comment fixed.
- `medium-tier-pre-merge-lane` (**High**) — add a `needs-code-ci`-gated `medium-test` job to `pr.yml` so medium-tier breakage can no longer land unexecuted (both #1093 and #1095/#1100 were invisible pre-merge). Required-check flip and merge-queue evaluation deferred as admin work.
- `placeholder-rows-fetch-safety` (**Medium**) — make placeholder `fetchall()` results unmistakable (`has_real_rows` + once-per-cursor warning), audit value-dependent consumers; consumer fixes become follow-up TODOs.

Incident background (root-cause analysis in session): every merge since 12:42Z on 2026-07-10 produced a red develop-post-merge run and a wrong-blame revert PR — 15 red runs, ~14 revert PRs, only 2 correctly attributed (#1099 → #1093, #1112 → #1100) — because the medium tier has no pre-merge consumer and the auto-revert job attributes any red run to the newest SHA.

## Type of Change

- [x] Refactor / chore (TODO planning records only; no code changes)

## Testing

- `uv run --project _project/scripts -- python _project/scripts/validate_todo.py <each new file>` — all 4 valid.
- `todo_cli.py check-graph` — no cycles, no dangling references (122 items).
- `generate_indexes.py` — regenerated (indexes are gitignored).
- Six-axis TODO review (clarity/completeness/actionability/freshness/guardrails/work-breakdown) performed by a second-model pass; all Critical/Required findings applied, including the `code-paths` vs `needs-code-ci` gating bug that would have made the planned PR-lane job permanently skipped.

## Public Contract Check

- [x] I updated `docs/reference/public-contracts.md`, or this PR does not change public, beta-public, deprecated, generated, experimental, or repo-only contract surfaces. (Planning YAML only.)
- [x] I checked result schema fields, MCP tool parameters, platform support status, wrapper facades, adapter subclassing hooks, and generated docs for contract-map impact. (None affected.)
- [x] Any platform/benchmark count claim in docs is generated/checked from registry metadata, or explicitly marked editorial/non-authoritative. (N/A.)

## Documentation

- [x] I updated the relevant user-facing docs. (N/A — planning records.)
- [x] I added regression notes for behavior changes. (N/A.)
- [x] I confirmed API contract wording remains accurate. (N/A.)

## Code Quality

- [x] I ran formatting and lint/type checks. (YAML validated by the TODO schema validator; pr.yml's TODO-graph gate covers these paths.)
- [x] I reviewed impacted modules for backwards compatibility and migration impact. (N/A.)
- [x] I added/updated tests for behavior changes and error paths. (N/A — each TODO carries its own verification block.)
- [x] I confirmed public contracts and release checklists are still valid.

## Artifact Hygiene

- [x] I did not commit raw screenshots, browser reports, generated logs, benchmark outputs, or temporary binary artifacts.

## Notes

Implementation of these TODOs follows immediately via the batch flow (one PR per TODO, dependency-ordered: fix → signature-attribution → medium-lane; placeholder-safety after fix). The `medium-tier-pre-merge-lane` job will not be a *required* check until the develop ruleset is updated — that admin step is flagged in the TODO's deferred list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FKz7FioN7DUZA44PrdQVYC

---
_Generated by [Claude Code](https://claude.ai/code/session_01FKz7FioN7DUZA44PrdQVYC)_