### PR TITLE
chore(todo): seed 3 concurrency-review follow-up TODOs

### DIFF
--- a/_project/TODO/main/planning/server-adapter-independent-connection-optin.yaml
+++ b/_project/TODO/main/planning/server-adapter-independent-connection-optin.yaml
@@ -1,0 +1,101 @@
+id: server-adapter-independent-connection-optin
+title: "Opt a real server adapter into per-stream INDEPENDENT_CONNECTION so the throughput session seam is used in production"
+worktree: main
+priority: Medium
+status: Not Started
+category: Core Functionality
+
+description: |
+  throughput-independent-sessions-per-stream (#1095) landed the platform
+  capability seam -- a `StreamConnectionCapability` enum
+  (benchbox/platforms/base/connection_wrappers.py:51) plus a
+  `PlatformAdapter.new_stream_connection()` hook and
+  `stream_connection_capability` class attribute
+  (benchbox/platforms/base/adapter.py:120,593) -- and proved it with a
+  SQLite-per-connection stand-in. But NO concrete server adapter opts in: every
+  production adapter stays on the default `SHARED_CURSOR` path. So the seam is a
+  correct, fail-fast, tested extension point that is currently UNUSED in
+  production, and the TODO's business value (real multi-user throughput on cloud
+  warehouses, where a connection IS a session and cursors of one connection
+  serialize or raise) is not yet realized.
+
+  This item makes the seam live: pick at least one real server-style engine and
+  have its adapter declare `INDEPENDENT_CONNECTION` and override
+  `new_stream_connection()` to hand each throughput stream its own
+  connection/session. PostgreSQL (benchbox/platforms/postgresql.py) is the
+  natural first candidate -- it is already used by UAT docker cells, its driver
+  (psycopg) does not support truly concurrent statement execution across cursors
+  of one connection, and #1094 explicitly deferred a Postgres throughput UAT
+  cell (its w4) that this would enable.
+
+  IN THE SAME PASS, route the throughput MAINTENANCE (RF1/RF2) connection_factory
+  closures in benchbox/platforms/base/execution.py through the capability too:
+  today they still call `_make_stream_cursor(connection)` directly, so a server
+  engine's refresh stream shares the query stream's session. The
+  independent-sessions review flagged this as the natural companion cleanup.
+
+prior_art:
+  - "benchbox/platforms/base/adapter.py:593 — PlatformAdapter.new_stream_connection() hook to override; :120 stream_connection_capability default (SHARED_CURSOR); :637 the fail-fast NotImplementedError when INDEPENDENT_CONNECTION is declared without an override."
+  - "benchbox/platforms/base/connection_wrappers.py:51 — StreamConnectionCapability enum (SHARED_CURSOR / INDEPENDENT_CONNECTION)."
+  - "benchbox/platforms/postgresql.py — the first server adapter to opt in (fresh connection/session per stream)."
+  - "benchbox/platforms/base/execution.py — the throughput query connection_factory closures already route through new_stream_connection(); the RF1/RF2 maintenance closures do NOT yet and should in this pass."
+  - "tests/integration/test_throughput_session_isolation.py — the existing SQLite-per-connection isolation harness to extend to a real server engine (session-local SET must not leak across streams)."
+  - "_project/DONE/main/planning/throughput-uat-and-ci-coverage.yaml — its deferred w4 (docker Postgres throughput cell) that this unlocks."
+
+work:
+  - id: w1
+    summary: "Have PostgreSQL adapter declare INDEPENDENT_CONNECTION and override new_stream_connection() to open a fresh session per stream"
+    status: pending
+    notes: |
+      Open a new connection/session from the adapter's existing connection
+      config; ensure it is closed per stream in _execute_stream's finally
+      (the seam already closes what new_stream_connection returns).
+  - id: w2
+    summary: "Route the throughput maintenance (RF1/RF2) connection_factory closures through new_stream_connection() as well"
+    needs: [w1]
+    status: pending
+  - id: w3
+    summary: "Prove real session isolation on Postgres: a session-local SET in one stream is invisible in another; concurrent statements do not serialize on one connection"
+    needs: [w1]
+    status: pending
+    notes: "Extend tests/integration/test_throughput_session_isolation.py from the SQLite stand-in to a real Postgres (docker) engine, marked slow/integration."
+  - id: w4
+    summary: "Add the deferred docker Postgres throughput UAT cell (throughput-uat-and-ci-coverage w4)"
+    needs: [w3]
+    status: pending
+
+must_preserve:
+  - "Embedded DuckDB (and every adapter that does not opt in) keeps SHARED_CURSOR cursor sharing with no perf regression and zero extra connections."
+  - "The fail-fast contract: declaring INDEPENDENT_CONNECTION without overriding new_stream_connection() still raises, never silently falls back to a shared session."
+  - "Per-stream connections are still closed in _execute_stream's finally block."
+
+anti_patterns:
+  - "DO NOT flip the default capability to INDEPENDENT_CONNECTION -- because embedded engines are correct with cursor sharing -- opt in per server adapter only."
+  - "DO NOT open N real connections for engines that don't need them -- gate strictly behind the per-adapter capability."
+
+verification:
+  - description: "Postgres streams are session-isolated and the seam is exercised in production"
+    command: "uv run -- python -m pytest tests/integration -k 'throughput_session_isolation and postgres' -n 0 -v"
+    expected_output: "session-local state does not leak across streams on a real server engine"
+
+scope_limit:
+  only_modify:
+    - "benchbox/platforms/postgresql.py"
+    - "benchbox/platforms/base/execution.py"
+    - "tests/integration/"
+    - "tests/uat/"
+
+impact:
+  business_value: |
+    Multi-user throughput on cloud/server warehouses is a primary BenchBox use
+    case; without a per-stream session it under-reports concurrency or errors.
+    This converts the landed seam into real measurement value.
+
+deps:
+  needs: []
+
+metadata:
+  tags: [concurrency, throughput, platforms, sessions, postgres, follow-up]
+  estimated_effort: Medium
+  created_date: "2026-07-11"
+  origin: "Follow-up from throughput-independent-sessions-per-stream (#1095): the capability seam shipped but no server adapter opts in."

--- a/_project/TODO/main/planning/throughput-executor-nonblocking-shutdown.yaml
+++ b/_project/TODO/main/planning/throughput-executor-nonblocking-shutdown.yaml
@@ -1,0 +1,93 @@
+id: throughput-executor-nonblocking-shutdown
+title: "Let the throughput executor return without blocking on a hung/leaked stream at shutdown"
+worktree: main
+priority: Medium
+status: Not Started
+category: Core Functionality
+
+description: |
+  throughput-timeout-leak-and-success-gates (#1106) fixed the real timeout bug
+  (the per-stream timeout was dead code because `as_completed()` only yields
+  already-done futures) and added opt-in cooperative cancellation. But a residual
+  remains, explicitly accepted by that item as out of scope:
+  `StreamRunner.execute()` runs its streams inside a `with ThreadPoolExecutor(...)`
+  block (benchbox/core/throughput/runner.py), and the context manager's `__exit__`
+  calls `shutdown(wait=True)`. So even though a timed-out stream is now correctly
+  surfaced (logged + recorded in `result.errors`), `execute()` still cannot
+  RETURN until every worker thread finishes. With cooperative cancellation OFF
+  (the default), a genuinely hung stream blocks `execute()` -- and therefore the
+  whole throughput phase, and any subsequent phase (e.g. maintenance) -- for as
+  long as the stream keeps running against the DB.
+
+  Goal: allow the executor to return promptly once its timeout/accounting window
+  closes, without waiting on a zombie stream, while still never hard-killing a
+  thread (Python cannot do so safely). The likely mechanism is to manage the
+  pool manually (`ThreadPoolExecutor(...)` without the `with` block, or
+  `shutdown(wait=False)`) so the leaked thread is abandoned to run out in the
+  background -- with its connection ownership and resource accounting clearly
+  documented -- rather than blocking the main thread. This must compose with the
+  already-shipped leak surfacing and cooperative-cancel opt-in.
+
+  Note the subtlety: abandoning a thread that still holds a DB connection has its
+  own hazards (connection not closed until the thread ends; a later phase running
+  while the zombie hammers the DB). The design must decide and document what
+  happens to the leaked stream's connection and how TTT/accounting treat the
+  overlap -- this is why #1106 deferred it rather than squeezing it in.
+
+prior_art:
+  - "benchbox/core/throughput/runner.py:StreamRunner.execute — the `with ThreadPoolExecutor` block whose implicit shutdown(wait=True) at __exit__ blocks return; the as_completed(timeout=...) classification loop and leaked-stream surfacing already landed here."
+  - "benchbox/core/tpch/throughput_test.py / benchbox/core/tpcds/throughput_test.py — the cooperative-cancel poll (config.cancel_on_timeout, per-stream threading.Event) this must compose with."
+  - "docs/development/throughput-result-alignment.md — documents the timed-out-stream leak behavior; update alongside any change to shutdown semantics."
+
+work:
+  - id: w0
+    summary: "Reproduce the block: a hung stream (sleep past a tiny stream_timeout, cancellation off) keeps execute() from returning until the sleep ends"
+    status: pending
+    notes: "Add/inspect a timing test proving execute() wall-clock is bounded by the hung stream today, not the timeout. Capture to /tmp/throughput-shutdown-w0.log."
+  - id: w1
+    summary: "Manage the pool so execute() returns once the timeout/accounting window closes, abandoning (not killing) a still-running leaked thread"
+    needs: [w0]
+    status: pending
+  - id: w2
+    summary: "Decide and document the leaked stream's connection ownership and how TTT/accounting treat a zombie that outlives execute()"
+    needs: [w1]
+    status: pending
+  - id: w3
+    summary: "Test: execute() returns within ~timeout even with a hung stream; leaked stream still surfaced in result.errors; cooperative-cancel path unaffected"
+    needs: [w1, w2]
+    status: pending
+
+must_preserve:
+  - "The already-shipped leak surfacing: a timed-out/leaked stream is still logged (logger.warning) and recorded in result.errors."
+  - "as_completed accounting semantics (streams_executed / successful / errors) for the normal, non-hung path."
+  - "Opt-in cooperative cancellation (config.cancel_on_timeout default False) keeps working and still bounds a stream to ~one more query."
+  - "The robust cancel-event guard (honor only a real set threading.Event) added in #1106 stays intact."
+
+anti_patterns:
+  - "DO NOT hard-kill or forcibly interrupt threads -- because Python cannot do so safely -- abandon the thread to run out and surface it instead."
+  - "DO NOT silently leak the connection -- because a zombie stream holding a session can starve a later phase -- decide and document ownership explicitly."
+  - "DO NOT change default timeout behavior for healthy runs -- only the hung-stream shutdown path changes."
+
+verification:
+  - description: "execute() returns near the timeout even with a hung stream, and the stream is still surfaced"
+    command: "uv run -- python -m pytest tests/unit/core/throughput/ tests/integration/test_throughput_corrections.py -n 0 -v"
+    expected_output: "execute() wall-clock bounded by timeout not the hung stream; leaked stream in result.errors; cancel tests still pass"
+
+scope_limit:
+  only_modify:
+    - "benchbox/core/throughput/runner.py"
+    - "docs/development/throughput-result-alignment.md"
+    - "tests/unit/core/throughput/"
+    - "tests/integration/"
+
+impact:
+  business_value: |
+    A hung stream should not stall the whole throughput phase (and downstream
+    phases) for the full duration of the zombie. Bounding executor return time
+    makes long throughput runs and their timeouts actually meaningful.
+
+metadata:
+  tags: [concurrency, throughput, robustness, executor, timeout, follow-up]
+  estimated_effort: Medium
+  created_date: "2026-07-11"
+  origin: "Follow-up explicitly deferred by throughput-timeout-leak-and-success-gates (#1106)."

--- a/_project/TODO/main/planning/tpch-throughput-rowcount-validation-range-mode.yaml
+++ b/_project/TODO/main/planning/tpch-throughput-rowcount-validation-range-mode.yaml
@@ -1,0 +1,122 @@
+id: tpch-throughput-rowcount-validation-range-mode
+title: "Fix TPC-H throughput row-count validation for the spec's non-deterministic queries (wire up RANGE mode)"
+worktree: main
+priority: Medium-High
+status: Not Started
+category: Testing and Quality Assurance
+
+description: |
+  TPC-H throughput fails row-count validation for queries 11, 16, 18, and 20 on
+  EVERY stream, at SF=1 on DuckDB, for ANY seed choice (reproduced with seed=42,
+  seed=7, and no seed). This is NOT a concurrency bug: the identical 4 queries
+  fail identically in single-stream POWER mode with a non-reference seed, while
+  POWER mode with no seed (qgen defaults, exact validation against the official
+  answer files) passes cleanly.
+
+  ROOT CAUSE (hypothesis, to confirm in w0): the throughput driver derives each
+  stream's per-query seed as `seed + stream_id*1000 + position`
+  (benchbox/core/tpch/throughput_test.py), so no throughput query (beyond
+  possibly the first query of stream 0) can ever land on the reference-seed
+  exact-match validation path. Every throughput query therefore falls back to
+  the LOOSE (+-50%) tolerance in benchbox/core/expected_results/tpch_results.py,
+  which is not wide enough for these 4 TPC-H-spec-sanctioned non-deterministic
+  queries (their row counts legitimately vary with substitution parameters).
+  tpch_results.py's own docstring flags a RANGE mode as "reserved for future
+  use" and NOT yet wired up for TPC-H (tpch_results.py:23-26) -- almost certainly
+  the intended fix: validate these queries against a spec-derived acceptable
+  RANGE rather than an exact reference or a blanket +-50% band.
+
+  Discovered during throughput-uat-and-ci-coverage (#1094) verification against a
+  live SF=1 DuckDB run. Previously invisible because the throughput driver was
+  only ever exercised against Mock connections before
+  throughput-real-db-integration-tests (#1074), and that item's new tests run at
+  SF=0.01, which does not reproduce this SF=1-scale manifestation.
+
+  BLAST RADIUS TODAY: the nightly throughput UAT cell's `uat-sweep` step is
+  marked `continue-on-error: true` (.github/workflows/nightly.yml:591-596)
+  specifically to tolerate this known defect; the concurrency invariant that
+  item protects (requested stream count reaches the driver) is hard-gated by a
+  separate step, but the cell's overall clean-pass status stays red until this
+  is fixed. Closing this lets that continue-on-error be removed so a NEW
+  correctness regression in the throughput cell fails the nightly outright.
+
+prior_art:
+  - "benchbox/core/expected_results/tpch_results.py:23-26 — the documented, unused RANGE mode ('reserved for future use'); this item wires it up for TPC-H's non-deterministic queries."
+  - "benchbox/core/expected_results/tpch_results.py — existing EXACT and LOOSE (+-50%) validation modes and the per-query mode selection to extend."
+  - "benchbox/core/tpch/throughput_test.py — the per-query seed derivation `seed + stream_id*1000 + position` that keeps throughput queries off the exact-match path."
+  - "tests/uat/throughput.py:validate_throughput_metric — the UAT validator that currently documents this as a known non-gating failure; re-gate it once fixed."
+  - ".github/workflows/nightly.yml:591-596 — the `continue-on-error: true` on the throughput uat-sweep step to remove once this lands."
+  - "_sources/tpc-h/specification.pdf — spec basis for the acceptable row-count ranges of Q11/Q16/Q18/Q20."
+
+work:
+  - id: w0
+    summary: "Confirm the defect and its root cause: reproduce Q11/16/18/20 loose-tolerance failure at SF=1, and prove throughput seeds never hit the exact-match path"
+    status: pending
+    notes: |
+      Run a real DuckDB TPC-H throughput (or single-stream power with a
+      non-reference seed) at SF=1; capture which validation mode each of
+      Q11/16/18/20 resolves to and why they fail. Confirm POWER with no seed
+      passes. Capture to /tmp/tpch-rowcount-w0.log and summarize which queries,
+      which mode, observed vs expected counts.
+  - id: w1
+    summary: "Derive spec-sanctioned acceptable row-count RANGES for the affected non-deterministic TPC-H queries"
+    needs: [w0]
+    status: pending
+    notes: |
+      From the TPC-H spec / qgen substitution-parameter domains, establish the
+      legitimate min/max row-count band per affected query. Document the spec
+      basis; do NOT invent bounds -- if a query's range is not spec-derivable,
+      say so and keep it on LOOSE with a recorded justification.
+  - id: w2
+    summary: "Wire up RANGE validation mode in tpch_results.py and assign the affected queries to it"
+    needs: [w1]
+    status: pending
+  - id: w3
+    summary: "Add tests pinning that Q11/16/18/20 pass RANGE validation across streams/seeds and that a planted out-of-range count still fails"
+    needs: [w2]
+    status: pending
+  - id: w4
+    summary: "Re-gate the nightly throughput cell: remove continue-on-error from the uat-sweep step and re-enable validate_throughput_metric as a hard gate"
+    needs: [w3]
+    status: pending
+    notes: "Only after w3 proves the cell passes cleanly at SF=1."
+
+must_preserve:
+  - "EXACT validation (reference-seed path) still fires and stays strict for deterministic queries and power/no-seed runs."
+  - "Do not widen validation for queries that are actually deterministic -- only the spec-sanctioned non-deterministic queries move to RANGE."
+  - "The concurrency invariant already hard-gated in nightly (requested stream count reaches the driver) keeps its own independent gate."
+
+anti_patterns:
+  - "DO NOT 'fix' this by widening the global LOOSE tolerance -- that would mask real regressions on every query; scope RANGE to the specific spec-non-deterministic queries."
+  - "DO NOT invent row-count bounds -- derive them from the spec/substitution domains, or leave the query on LOOSE with a recorded reason."
+  - "DO NOT change the throughput per-query seed scheme to force exact-match -- that collides with byte-identity guarantees from throughput-pregenerate-query-streams; fix validation, not generation."
+
+verification:
+  - description: "Q11/16/18/20 pass validation in TPC-H throughput at SF=1 and a planted out-of-range count fails"
+    command: "uv run -- python -m pytest tests/integration -k 'tpch and throughput and (range or rowcount or validation)' -n 0 -v"
+    expected_output: "affected queries validate via RANGE; planted out-of-range count is rejected"
+  - description: "Nightly throughput UAT cell passes cleanly (no continue-on-error needed)"
+    command: "make uat-sweep CONFIG=tests/uat/configs/uat-throughput-duckdb-nightly.yaml"
+    expected_output: "throughput cell validates with no known-defect leniency"
+
+scope_limit:
+  only_modify:
+    - "benchbox/core/expected_results/tpch_results.py"
+    - "tests/integration/"
+    - "tests/uat/throughput.py"
+    - ".github/workflows/nightly.yml"
+
+impact:
+  business_value: |
+    TPC-H throughput result validation is currently either too strict (fails
+    spec-legal queries) or too loose (would miss real regressions). A spec-
+    derived RANGE mode makes throughput validation trustworthy and lets the
+    nightly cell hard-gate correctness.
+  technical_debt: |
+    Removes a standing continue-on-error carve-out in nightly CI.
+
+metadata:
+  tags: [tpc-h, throughput, validation, correctness, range-mode, follow-up]
+  estimated_effort: Medium
+  created_date: "2026-07-11"
+  origin: "Follow-up from concurrency-review batch; discovered during throughput-uat-and-ci-coverage (#1094) verification."


### PR DESCRIPTION
Captures the three out-of-scope follow-ups surfaced during the concurrency
batch, each documented in the relevant merged PR but not previously filed:

- tpch-throughput-rowcount-validation-range-mode (Med-High): Q11/16/18/20 fail
  TPC-H throughput row-count validation at SF=1 for any seed (loose +-50%
  fallback too narrow); wire up the "reserved for future use" RANGE mode. Lets
  the nightly throughput cell drop its continue-on-error carve-out (#1094).
- server-adapter-independent-connection-optin (Med): opt PostgreSQL into the
  INDEPENDENT_CONNECTION seam landed in #1095 so per-stream sessions are used in
  production; also route the RF1/RF2 maintenance closures through it.
- throughput-executor-nonblocking-shutdown (Med): let StreamRunner.execute()
  return without blocking on a hung/leaked stream at shutdown(wait=True),
  explicitly deferred by #1106.

All three validate; check-graph clean (no cycles / dangling refs).

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
