### PR TITLE
fix(platforms): make placeholder cursor rows unmistakable (has_real_rows + one-time warning)

### DIFF
--- a/_project/DONE/auto-revert-incident/active/placeholder-rows-fetch-safety.yaml
+++ b/_project/DONE/auto-revert-incident/active/placeholder-rows-fetch-safety.yaml
@@ -2,7 +2,8 @@ id: "placeholder-rows-fetch-safety"
 title: "Make PlatformAdapterCursor placeholder rows impossible to mistake for real data"
 worktree: "auto-revert-incident"
 priority: "Medium"
-status: "Not Started"
+status: "Completed"
+completed_date: "2026-07-11"
 category: "Code Quality and Technical Debt"
 description: |
   Since #1100, PlatformAdapterCursor.fetchall()/fetchone()/.rows fabricate
@@ -38,7 +39,7 @@ prior_art:
 work:
 - id: w1
   summary: "Audit all in-repo call sites of PlatformAdapterCursor fetchall/fetchone/.rows; classify each as count-only, value-dependent-with-real-rows, or value-dependent-at-risk; record the table in the PR body."
-  status: pending
+  status: done
 - id: w2
   summary: "Implement has_real_rows plus a once-per-cursor warning on placeholder materialization; document the three-branch contract."
   notes: |
@@ -46,11 +47,11 @@ work:
     silent; the warning fires only when placeholder rows are actually
     materialized via fetchall()/fetchone()/.rows.
   needs: [w1]
-  status: pending
+  status: done
 - id: w3
   summary: "Unit-test the warning/has_real_rows matrix; file follow-up TODOs for any at-risk consumers found in w1 (do not edit them here)."
   needs: [w2]
-  status: pending
+  status: done
   notes: |
     Matrix: placeholder fetch warns once and has_real_rows is False;
     explicit-rows fetch does not warn and has_real_rows is True; count-only

--- a/benchbox/platforms/base/connection_wrappers.py
+++ b/benchbox/platforms/base/connection_wrappers.py
@@ -441,7 +441,8 @@ class PlatformAdapterCursor:
 
     def fetchone(self):
         """Return one row."""
-        return self.rows[0] if self.rows else None
+        rows = self.rows
+        return rows[0] if rows else None
 
     def row_count(self) -> int:
         """Return this cursor's row count without forcing full materialization.

--- a/benchbox/platforms/base/connection_wrappers.py
+++ b/benchbox/platforms/base/connection_wrappers.py
@@ -17,11 +17,14 @@ continue to work via re-exports in `adapter.py`.
 
 from __future__ import annotations
 
+import logging
 from enum import Enum
 from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
     from benchbox.platforms.base.adapter import PlatformAdapter
+
+logger = logging.getLogger(__name__)
 
 
 class DriverIsolationCapability(Enum):
@@ -270,7 +273,45 @@ class PlatformAdapterConnection:
 
 
 class PlatformAdapterCursor:
-    """Cursor-like wrapper around platform adapter execution results."""
+    """Cursor-like wrapper around platform adapter execution results.
+
+    ``platform_result`` (the dict handed in at construction) carries one of
+    three shapes, and every fetch-shaped accessor (``rows``/``fetchall()``/
+    ``fetchone()``) resolves to exactly one of these three branches - see
+    ``_extract_rows()`` for the priority order:
+
+      1. **Explicit rows** - ``platform_result["rows"]`` is a real,
+         fully-materialized list/tuple of row tuples. ``has_real_rows`` is
+         ``True`` and nothing is fabricated.
+      2. **Count + sampled first row** - ``rows_returned`` (an int
+         cardinality) plus ``first_row`` (one real sampled row, per
+         ``sql_execution.execute_sql_query``). Element 0 of the returned
+         list is the real ``first_row``; every remaining element is a
+         fabricated ``(None,)`` placeholder that exists only to preserve
+         list length (#1117). ``has_real_rows`` is ``False`` here even
+         though index 0 is genuine - the list as a whole is not safe to
+         read past index 0.
+      3. **Count only, or first_row only** - either an all-placeholder
+         ``[(None,)] * rows_returned`` list (no sampled row available), or
+         (when no ``rows_returned`` count is present at all) a single real
+         ``[first_row]``. ``has_real_rows`` is ``False`` in both cases: the
+         former is fully fabricated, and the latter - while its one element
+         is real - carries no confirmed cardinality guarantee beyond it.
+
+    Callers that only need a row *count* should use ``row_count()`` (or the
+    module-level ``count_query_rows()``) instead of ``fetchall()``/``.rows``:
+    that path reads ``platform_result`` directly, never builds the
+    placeholder list, and never logs the warning below - it is the sanctioned
+    always-silent, never-materializing path (see #1100).
+
+    Materializing rows that contain fabricated placeholders via
+    ``fetchall()``/``fetchone()``/``.rows`` logs a one-time-per-cursor
+    ``logger.warning`` - added after the 2026-07-10 incident where
+    ``assert fetchall() == [(7,)]`` silently became ``[(None,)]`` in a
+    session-isolation test (see ``has_real_rows`` and
+    ``fix-session-isolation-placeholder-rows``). Use ``has_real_rows`` to
+    check placeholder-ness without triggering the warning.
+    """
 
     def __init__(self, platform_result: dict):
         """Initialize with platform adapter result.
@@ -285,6 +326,15 @@ class PlatformAdapterCursor:
         # instead, which reads platform_result directly and never builds this
         # placeholder list at all.
         self._rows: list | None = None
+        # Set by _extract_rows() the first time it runs: True iff the
+        # extracted list contains at least one fabricated (None,) placeholder
+        # element (branch 2 with padding, or branch 3's count-only case).
+        # Distinct from has_real_rows: a first_row-only list (branch 3) has
+        # zero fabricated elements but still reports has_real_rows == False,
+        # since it carries no rows_returned cardinality guarantee.
+        self._has_placeholder_padding: bool = False
+        self._placeholder_kind: str | None = None
+        self._warned_placeholder_materialization: bool = False
 
     def _extract_rows(self):
         """Extract rows (or cardinality-preserving placeholders) from platform result.
@@ -310,6 +360,11 @@ class PlatformAdapterCursor:
           3. ``first_row`` alone, only when no ``rows_returned`` count is present at
              all - the last remaining cardinality signal, so it fabricates a
              single-row list.
+
+        As a side effect, records whether the extracted list contains any
+        fabricated ``(None,)`` placeholder elements (``self._has_placeholder_padding``)
+        and a short ``self._placeholder_kind`` label identifying which branch
+        produced them, for the one-time materialization warning in ``rows``.
         """
         explicit_rows = self.platform_result.get("rows")
         if isinstance(explicit_rows, (list, tuple)):
@@ -321,7 +376,13 @@ class PlatformAdapterCursor:
             if row_count <= 0:
                 return []
             if first_row is not None:
-                return [first_row] + [(None,)] * (row_count - 1)
+                padding = row_count - 1
+                if padding > 0:
+                    self._has_placeholder_padding = True
+                    self._placeholder_kind = "first_row+padding"
+                return [first_row] + [(None,)] * padding
+            self._has_placeholder_padding = True
+            self._placeholder_kind = "rows_returned_only"
             return [(None,)] * row_count
 
         if first_row is not None:
@@ -330,11 +391,49 @@ class PlatformAdapterCursor:
         return []
 
     @property
+    def has_real_rows(self) -> bool:
+        """True only when ``platform_result["rows"]`` is a fully-materialized list.
+
+        This does not force materialization of the placeholder-padded list
+        and never logs the warning - it is a cheap, static check of the same
+        condition ``_extract_rows()`` branch 1 tests, so it is safe to call
+        before deciding whether to trust ``fetchall()``/``fetchone()``/``.rows``.
+
+        False for every other case, including the #1117 first_row-in-slot-0
+        case (element 0 is real but the remaining padding is not) and the
+        first_row-alone case (one real row, but no confirmed cardinality).
+        """
+        return isinstance(self.platform_result.get("rows"), (list, tuple))
+
+    @property
     def rows(self):
-        """Materialized rows, computed lazily on first access."""
+        """Materialized rows, computed lazily on first access.
+
+        Logs a one-time-per-cursor warning the first time this (or
+        ``fetchall()``/``fetchone()``) materializes a list containing
+        fabricated placeholder elements - see the class docstring.
+        """
         if self._rows is None:
             self._rows = self._extract_rows()
+        self._warn_if_placeholder_materialized()
         return self._rows
+
+    def _warn_if_placeholder_materialized(self) -> None:
+        if not self._has_placeholder_padding or self._warned_placeholder_materialization:
+            return
+        self._warned_placeholder_materialization = True
+        query_id = self.platform_result.get("query_id", "unknown")
+        logger.warning(
+            "PlatformAdapterCursor materialized placeholder rows for query_id=%s "
+            "(kind=%s): the platform result carried only a row count (and, in the "
+            "first_row+padding case, one sampled row), so fetchall()/fetchone()/.rows "
+            "fabricated (None,) placeholders to preserve cardinality. These are NOT "
+            "real platform values - check has_real_rows before trusting them, or use "
+            "row_count()/count_query_rows() if only the count is needed. "
+            "(This warning fires once per cursor.)",
+            query_id,
+            self._placeholder_kind,
+        )
 
     def fetchall(self):
         """Return all rows."""
@@ -354,6 +453,9 @@ class PlatformAdapterCursor:
         ``utils < core < platforms < cli`` forbids ``core`` importing from
         ``platforms``. See `benchbox.core.tpch.throughput_test` and
         `benchbox.core.tpcds.throughput_test` for the call sites.
+
+        Always silent: reads ``platform_result`` directly and never builds
+        the placeholder list, so it never logs the materialization warning.
         """
         return count_query_rows(self)
 

--- a/tests/unit/platforms/base/test_connection_wrappers.py
+++ b/tests/unit/platforms/base/test_connection_wrappers.py
@@ -11,18 +11,29 @@ test_streams_share_one_connection_no_new_connections_opened``
 misattributed to unrelated PRs (#1112 blamed #1100 itself; #1115 blamed the
 next unrelated merge, #1113) because the real cursor is populated with
 exactly this ``rows_returned``+``first_row`` shape.
+
+``placeholder-rows-fetch-safety`` (builds on #1117): adds ``has_real_rows``
+and a one-time-per-cursor ``logger.warning`` when fetchall()/fetchone()/
+``.rows`` actually materializes a list containing fabricated ``(None,)``
+placeholders, so a future incident like the one above is loud instead of
+silent. ``row_count()``/``count_query_rows()`` and bare ``has_real_rows``
+access must stay silent and never trigger the warning.
 """
 
 from __future__ import annotations
 
+import logging
+
 import pytest
 
-from benchbox.platforms.base.connection_wrappers import PlatformAdapterCursor
+from benchbox.platforms.base.connection_wrappers import PlatformAdapterCursor, count_query_rows
 
 pytestmark = [
     pytest.mark.unit,
     pytest.mark.fast,
 ]
+
+_LOGGER_NAME = "benchbox.platforms.base.connection_wrappers"
 
 
 def test_preserves_first_row_when_padding_from_rows_returned():
@@ -57,3 +68,114 @@ def test_explicit_rows_list_takes_priority_over_first_row():
 def test_first_row_alone_without_rows_returned():
     cursor = PlatformAdapterCursor({"first_row": (7,)})
     assert cursor.fetchall() == [(7,)]
+
+
+# --- has_real_rows / one-time placeholder-materialization warning matrix ---
+
+
+def test_placeholder_only_fetch_warns_once_and_has_real_rows_is_false(caplog):
+    cursor = PlatformAdapterCursor({"query_id": "q_placeholder", "rows_returned": 2})
+    assert cursor.has_real_rows is False
+
+    with caplog.at_level(logging.WARNING, logger=_LOGGER_NAME):
+        assert cursor.fetchall() == [(None,), (None,)]
+        # A second materializing access must not log a second warning.
+        assert cursor.fetchall() == [(None,), (None,)]
+        assert cursor.rows == [(None,), (None,)]
+
+    warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
+    assert len(warnings) == 1
+    message = warnings[0].getMessage()
+    assert "q_placeholder" in message
+    assert "rows_returned_only" in message
+
+
+def test_explicit_rows_fetch_never_warns_and_has_real_rows_is_true(caplog):
+    cursor = PlatformAdapterCursor({"query_id": "q_explicit", "rows": [(1,), (2,)]})
+    assert cursor.has_real_rows is True
+
+    with caplog.at_level(logging.WARNING, logger=_LOGGER_NAME):
+        assert cursor.fetchall() == [(1,), (2,)]
+        assert cursor.fetchone() == (1,)
+        assert cursor.rows == [(1,), (2,)]
+
+    assert [r for r in caplog.records if r.levelno == logging.WARNING] == []
+
+
+def test_count_only_paths_never_warn_even_with_placeholder_cardinality(caplog):
+    # row_count()/count_query_rows() read platform_result directly and must
+    # never materialize the placeholder list or log the warning, even though
+    # this same platform_result would warn if fetched via fetchall()/.rows.
+    cursor = PlatformAdapterCursor({"query_id": "q_count_only", "rows_returned": 5})
+
+    with caplog.at_level(logging.WARNING, logger=_LOGGER_NAME):
+        assert cursor.row_count() == 5
+        assert count_query_rows(cursor) == 5
+
+    assert [r for r in caplog.records if r.levelno == logging.WARNING] == []
+    # The count-only path must not have materialized anything either.
+    assert cursor._rows is None
+
+
+def test_has_real_rows_access_alone_does_not_warn(caplog):
+    cursor = PlatformAdapterCursor({"query_id": "q_inspect", "rows_returned": 3, "first_row": (7,)})
+
+    with caplog.at_level(logging.WARNING, logger=_LOGGER_NAME):
+        assert cursor.has_real_rows is False
+
+    assert [r for r in caplog.records if r.levelno == logging.WARNING] == []
+
+    # A later real fetch must still warn exactly once - has_real_rows access
+    # is a safe inspection, not a substitute for the materialization warning.
+    with caplog.at_level(logging.WARNING, logger=_LOGGER_NAME):
+        assert cursor.fetchall() == [(7,), (None,), (None,)]
+
+    warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
+    assert len(warnings) == 1
+
+
+def test_first_row_present_case_element_zero_real_but_still_warns_on_padding(caplog):
+    # #1117 nuance: element 0 is the real first_row, but the remaining
+    # cardinality is fabricated padding - has_real_rows is False and the
+    # one-time warning still fires because real padding was fabricated.
+    cursor = PlatformAdapterCursor({"query_id": "q_padded", "rows_returned": 3, "first_row": (7,)})
+    assert cursor.has_real_rows is False
+
+    with caplog.at_level(logging.WARNING, logger=_LOGGER_NAME):
+        rows = cursor.fetchall()
+
+    assert rows == [(7,), (None,), (None,)]
+    assert rows[0] == (7,)  # element 0 is genuinely real
+    warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
+    assert len(warnings) == 1
+    message = warnings[0].getMessage()
+    assert "q_padded" in message
+    assert "first_row+padding" in message
+
+
+def test_first_row_only_single_real_row_does_not_warn_no_padding_fabricated(caplog):
+    # Branch 3 (first_row alone, no rows_returned): the single element is
+    # genuinely real and nothing is padded, so no warning fires even though
+    # has_real_rows is conservatively False (no confirmed cardinality).
+    cursor = PlatformAdapterCursor({"query_id": "q_first_row_only", "first_row": (7,)})
+    assert cursor.has_real_rows is False
+
+    with caplog.at_level(logging.WARNING, logger=_LOGGER_NAME):
+        assert cursor.fetchall() == [(7,)]
+
+    assert [r for r in caplog.records if r.levelno == logging.WARNING] == []
+    assert cursor._has_placeholder_padding is False
+    assert cursor._warned_placeholder_materialization is False
+
+
+def test_no_padding_when_rows_returned_equals_one_with_first_row(caplog):
+    # rows_returned=1 with first_row present pads zero elements - no
+    # fabrication occurred, so no warning should fire.
+    cursor = PlatformAdapterCursor({"query_id": "q_exact_one", "rows_returned": 1, "first_row": (7,)})
+
+    with caplog.at_level(logging.WARNING, logger=_LOGGER_NAME):
+        assert cursor.fetchall() == [(7,)]
+
+    assert [r for r in caplog.records if r.levelno == logging.WARNING] == []
+    assert cursor._has_placeholder_padding is False
+    assert cursor._warned_placeholder_materialization is False

--- a/tests/unit/platforms/base/test_connection_wrappers.py
+++ b/tests/unit/platforms/base/test_connection_wrappers.py
@@ -134,6 +134,25 @@ def test_has_real_rows_access_alone_does_not_warn(caplog):
     assert len(warnings) == 1
 
 
+def test_fetchone_on_placeholder_cursor_warns_once_and_shares_budget_with_fetchall(caplog):
+    # fetchone() routes through the same lazy `rows` property, so it must
+    # trigger the one-time placeholder warning itself - and consume the same
+    # once-per-cursor budget as fetchall(), not a separate one.
+    cursor = PlatformAdapterCursor({"query_id": "q_fetchone", "rows_returned": 2})
+
+    with caplog.at_level(logging.WARNING, logger=_LOGGER_NAME):
+        assert cursor.fetchone() == (None,)
+
+    warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
+    assert len(warnings) == 1
+
+    with caplog.at_level(logging.WARNING, logger=_LOGGER_NAME):
+        assert cursor.fetchall() == [(None,), (None,)]
+
+    warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
+    assert len(warnings) == 1  # still exactly one - shared budget
+
+
 def test_first_row_present_case_element_zero_real_but_still_warns_on_padding(caplog):
     # #1117 nuance: element 0 is the real first_row, but the remaining
     # cardinality is fabricated padding - has_real_rows is False and the


### PR DESCRIPTION
# Pull Request

## Description

Implements TODO `placeholder-rows-fetch-safety` (auto-revert-incident group, #1130) — the design follow-up from the 2026-07-10 develop-red incident, where a test asserting values through `PlatformAdapterCursor.fetchall()` silently received fabricated `[(None,)]` placeholder data.

Additive observability on `PlatformAdapterCursor`, no contract change:

- **`has_real_rows` property** — `True` only when the platform result carries a fully materialized `rows` list; cheap static check, no materialization, no warning side-effect. Conservatively `False` for placeholder-padded results (where element 0 may still be the real `first_row`, per #1117) and `first_row`-only results; the docstring spells out the three-branch contract.
- **Once-per-cursor `logger.warning`** when placeholder-containing rows are actually materialized via `fetchall()`/`fetchone()`/`.rows` — message includes `query_id` and a kind label (`first_row+padding` / `rows_returned_only`). True no-fabrication cases never warn: explicit rows, `first_row` alone, `rows_returned==1` + `first_row` (zero padding), and all count-only usage (`row_count()`/`count_query_rows()` stay silent and lazy — provably unreachable from the warning path).

**Consumer audit (w1)** — every in-repo `fetchall()`/`fetchone()`/`.rows` call site classified; no value-dependent-at-risk consumer found:

| Call site | Usage | Classification |
|---|---|---|
| `tpch/power_test.py:313`, `tpcds/power_test.py:318,584,609` | counts / discarded | count-only |
| `tpch/throughput_test.py:87`, `tpcds/throughput_test.py:108` | `len(fetchall())` fallback for cursors lacking `row_count()` | count-only |
| `tpch/maintenance_test.py` (key reads) | row values | safe — TPC-H maintenance always runs `maintenance_mode=True` (`execution.py:634`), raw DB-API cursor |
| `tpcds/maintenance_operations.py` | row values | safe — multi-row read is parameterized (bypasses the adapter wrapper); single-row MIN/MAX/COUNT reads get the real `first_row`, with an existing `is not None` guard |
| `tpcds/maintenance_test.py` | `fetchone()[0]` on `COUNT(*)` | safe via `first_row` threading |

## Type of Change

- [x] Bug-class prevention / observability
- [x] New tests

## Testing

- `tests/unit/platforms/base/test_connection_wrappers.py` → 14 passed: full warn/no-warn matrix incl. once-per-cursor semantics, `fetchone()` sharing the warning budget, `has_real_rows` inspection safety, count-only laziness (`_rows is None`), and the #1117 first_row+padding nuance.
- `tests/unit/platforms/` full sweep → 7789 passed.
- `tests/integration/test_throughput_real_duckdb.py` + `test_throughput_session_isolation.py` (the #1100/#1117 contract and incident tests, untouched) → green.
- `ruff check` / `ruff format --check` / `ty check` clean.

## Review

Opus-reviewed: **APPROVE**. Both non-blocking findings applied — added the `fetchone()`-warns test (Consider) and single property bind in `fetchone()` (Nit). Reviewer additionally verified `_extract_rows()` return values are byte-identical to pre-change (#1100/#1117 semantics preserved) and independently confirmed all three audit-table safety claims against `execution.py` and both maintenance modules.

## Public Contract Check

- [x] No public contract change: `fetchall()` shape unchanged; `has_real_rows` is a new additive property with no existing references or duck-typing collisions.

## Documentation

- [x] Class docstring documents the three-branch rows contract and the warning semantics.

## Code Quality

- [x] Lint/format/typecheck clean; stdlib logging via the module's existing logger; no new dependencies.

## Artifact Hygiene

- [x] No logs or outputs committed; TODO item moved to DONE (indexes regenerated locally, gitignored).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FKz7FioN7DUZA44PrdQVYC

---
_Generated by [Claude Code](https://claude.ai/code/session_01FKz7FioN7DUZA44PrdQVYC)_