### PR TITLE
ci(pr): run the medium test tier pre-merge on code PRs

### DIFF
--- a/.github/workflows/develop-post-merge.yml
+++ b/.github/workflows/develop-post-merge.yml
@@ -173,6 +173,17 @@ jobs:
     # dropped). The 44 tpch-extension "errors" reported earlier were
     # sandbox-only (egress proxy 403 on the extension download) and do not
     # occur on the runner.
+    #
+    # PR-LANE CONSUMER ADDED 2026-07-11 (medium-tier-pre-merge-lane): the tier
+    # now also runs pre-merge as pr.yml's `medium-test` job, path-gated on
+    # ci-paths' needs-code-ci output so docs/TODO-only PRs skip it. That job
+    # is a plain `make test-medium` run with no signature/junit emission (the
+    # PR lane does not feed auto-revert). This post-merge job stays the
+    # blocking safety net for the residual gap the PR lane cannot see: a
+    # stale-base squash race, where a PR's own merge-tree CI passes but the
+    # eventual develop tip has a semantic conflict with another PR merged in
+    # between (see the TODO description for the #1093/#1095/#1100 incident
+    # this closes half of).
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -461,6 +461,30 @@ jobs:
           fail_ci_if_error: false  # Don't fail CI if Codecov upload fails (token may not be configured)
           token: ${{ secrets.CODECOV_TOKEN }}
 
+  medium-test:
+    name: medium-test
+    needs: ci-paths
+    if: ${{ needs.ci-paths.outputs.needs-code-ci == 'true' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Python 3.12
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v4
+
+      - name: Install dependencies
+        run: uv sync --group dev
+
+      - name: Run medium speed tier
+        run: make test-medium
+
   correctness-gate:
     name: correctness-gate
     needs: ci-paths
@@ -924,7 +948,7 @@ jobs:
 
   ci-required-result:
     name: ci-required-result
-    needs: [ci-paths, content-guard, code-lint, code-test, correctness-gate, plan-capture-gate, explorer-tokens, audit-sha, package-smoke, dependency-audit, parity-check]
+    needs: [ci-paths, content-guard, code-lint, code-test, correctness-gate, plan-capture-gate, medium-test, explorer-tokens, audit-sha, package-smoke, dependency-audit, parity-check]
     if: always()
     runs-on: ubuntu-latest
     steps:
@@ -936,6 +960,7 @@ jobs:
           TEST_RESULT: ${{ needs.code-test.result }}
           CORRECTNESS_RESULT: ${{ needs.correctness-gate.result }}
           PLAN_CAPTURE_RESULT: ${{ needs.plan-capture-gate.result }}
+          MEDIUM_TEST_RESULT: ${{ needs.medium-test.result }}
           EXPLORER_TOKENS_RESULT: ${{ needs.explorer-tokens.result }}
           AUDIT_SHA_RESULT: ${{ needs.audit-sha.result }}
           PACKAGE_SMOKE_RESULT: ${{ needs.package-smoke.result }}
@@ -1011,10 +1036,11 @@ jobs:
           if [ "$LINT_RESULT" = "success" ] \
               && [ "$TEST_RESULT" = "success" ] \
               && [ "$CORRECTNESS_RESULT" = "success" ] \
-              && [ "$PLAN_CAPTURE_RESULT" = "success" ]; then
-            echo "Code/infra PR; lint, fast tests, correctness gate, and plan-capture gate passed."
+              && [ "$PLAN_CAPTURE_RESULT" = "success" ] \
+              && [ "$MEDIUM_TEST_RESULT" = "success" ]; then
+            echo "Code/infra PR; lint, fast tests, correctness gate, plan-capture gate, and medium tier passed."
             exit 0
           fi
 
-          echo "code-lint=$LINT_RESULT code-test=$TEST_RESULT correctness-gate=$CORRECTNESS_RESULT plan-capture-gate=$PLAN_CAPTURE_RESULT"
+          echo "code-lint=$LINT_RESULT code-test=$TEST_RESULT correctness-gate=$CORRECTNESS_RESULT plan-capture-gate=$PLAN_CAPTURE_RESULT medium-test=$MEDIUM_TEST_RESULT"
           exit 1

--- a/_project/DONE/auto-revert-incident/active/medium-tier-pre-merge-lane.yaml
+++ b/_project/DONE/auto-revert-incident/active/medium-tier-pre-merge-lane.yaml
@@ -2,7 +2,8 @@ id: "medium-tier-pre-merge-lane"
 title: "Run the medium test tier pre-merge on code PRs so medium breakage cannot land unexecuted"
 worktree: "auto-revert-incident"
 priority: "High"
-status: "Not Started"
+status: "Completed"
+completed_date: "2026-07-11"
 category: "Testing and Quality Assurance"
 description: |
   The medium tier (`make test-medium`, Makefile:90-91, ~18-27 min on the
@@ -40,16 +41,24 @@ prior_art:
 work:
 - id: w1
   summary: "Add the medium-test job to pr.yml: needs ci-paths, if needs-code-ci == 'true' (mirror code-test's gate at pr.yml:393), make test-medium, timeout-minutes 30."
-  status: pending
+  status: done
   notes: |
     Steps: checkout + setup-python 3.12 + setup-uv + uv sync --group dev +
     make test-medium. Confirm pr.yml's concurrency block cancels superseded
     runs so force-push storms do not stack 30-minute jobs; add
     cancel-in-progress if absent.
+
+    Done: job added to pr.yml (mirrors develop-post-merge's medium-test
+    steps, minus the signature/junit emission - the PR lane does not feed
+    auto-revert). Wired into ci-required-result's `needs:` list and its
+    MEDIUM_TEST_RESULT success check, same pattern as
+    correctness-gate/plan-capture-gate. pr.yml's concurrency block
+    (group: develop-pr-${{ github.ref }}, cancel-in-progress: true) already
+    existed pre-TODO - no change needed.
 - id: w2
   summary: "Update the develop-post-merge medium-test job comment to record the new PR-lane consumer; post-merge stays as the squash-race safety net."
   needs: [w1]
-  status: pending
+  status: done
   notes: |
     The original decision record already moved to
     _project/DONE/main/medium-tier-ci-home.yaml - leave the DONE record
@@ -57,10 +66,29 @@ work:
     Coordination: auto-revert-signature-attribution rewrites
     develop-post-merge.yml heavily; this TODO lands AFTER it (deps.needs)
     so this comment tweak rebases trivially.
+
+    Done: appended a "PR-LANE CONSUMER ADDED 2026-07-11" paragraph to the
+    medium-test job's promotion-history comment block, comment-only (no
+    #1136 signature/auto-revert machinery touched). Confirmed
+    _project/TODO/main/planning/medium-tier-ci-home.yaml no longer exists
+    (moved to _project/DONE/main/medium-tier-ci-home.yaml before this TODO
+    started); left it untouched.
 - id: w3
   summary: "Validate on this TODO's own PR: the job must trigger (workflow files count as code paths or adjust the classifier lists accordingly) and pass; capture the run link in the PR body."
   needs: [w1]
-  status: pending
+  status: done
+  notes: |
+    Local check confirmed .github/workflows/** is already an explicit
+    code-ci pattern in .github/path-filters.yml, so this PR's own diff
+    (touching pr.yml and develop-post-merge.yml) sets needs-code-ci=true;
+    no classifier change was needed. Verified via
+    `path_filter_decision.py --changed-file <workflow-path-list> --check
+    needs-code-ci` (exit 0) vs a docs-only path list (exit 1).
+
+    The live PR-run validation (confirming medium-test actually executes
+    and passes on this TODO's own PR, and capturing the run link in the PR
+    body) is executed by the coordinator once the PR is opened - not run
+    from this worktree.
 deferred:
 - summary: "Make the new job a required status check in the develop ruleset"
   reason: "Branch-protection/ruleset change is admin/settings work, not repo code; without it auto-merge does not wait for this job - flag to the repo owner in the PR body."

--- a/tests/unit/workflows/test_pr_workflow_path_classifier.py
+++ b/tests/unit/workflows/test_pr_workflow_path_classifier.py
@@ -65,6 +65,7 @@ def _run_ci_required_result(**env_overrides: str) -> subprocess.CompletedProcess
         "TEST_RESULT": "skipped",
         "CORRECTNESS_RESULT": "skipped",
         "PLAN_CAPTURE_RESULT": "skipped",
+        "MEDIUM_TEST_RESULT": "skipped",
         "EXPLORER_TOKENS_RESULT": "skipped",
         "AUDIT_SHA_RESULT": "skipped",
         "PACKAGE_SMOKE_RESULT": "skipped",
@@ -121,6 +122,7 @@ def test_ci_required_result_fails_on_explorer_tokens_failure() -> None:
         TEST_RESULT="success",
         CORRECTNESS_RESULT="success",
         PLAN_CAPTURE_RESULT="success",
+        MEDIUM_TEST_RESULT="success",
         EXPLORER_TOKENS_RESULT="failure",
     )
 
@@ -148,11 +150,14 @@ def test_ci_required_result_treats_explorer_tokens_skipped_as_success() -> None:
         TEST_RESULT="success",
         CORRECTNESS_RESULT="success",
         PLAN_CAPTURE_RESULT="success",
+        MEDIUM_TEST_RESULT="success",
         EXPLORER_TOKENS_RESULT="skipped",
     )
 
     assert result.returncode == 0
-    assert "Code/infra PR; lint, fast tests, correctness gate, and plan-capture gate passed." in result.stdout
+    assert (
+        "Code/infra PR; lint, fast tests, correctness gate, plan-capture gate, and medium tier passed." in result.stdout
+    )
 
 
 def test_ci_required_result_passes_on_explorer_tokens_success() -> None:
@@ -165,11 +170,14 @@ def test_ci_required_result_passes_on_explorer_tokens_success() -> None:
         TEST_RESULT="success",
         CORRECTNESS_RESULT="success",
         PLAN_CAPTURE_RESULT="success",
+        MEDIUM_TEST_RESULT="success",
         EXPLORER_TOKENS_RESULT="success",
     )
 
     assert result.returncode == 0
-    assert "Code/infra PR; lint, fast tests, correctness gate, and plan-capture gate passed." in result.stdout
+    assert (
+        "Code/infra PR; lint, fast tests, correctness gate, plan-capture gate, and medium tier passed." in result.stdout
+    )
 
 
 def test_ci_required_result_fails_on_plan_capture_gate_failure() -> None:
@@ -185,6 +193,22 @@ def test_ci_required_result_fails_on_plan_capture_gate_failure() -> None:
 
     assert result.returncode == 1
     assert "plan-capture-gate=failure" in result.stdout
+
+
+def test_ci_required_result_fails_on_medium_test_failure() -> None:
+    result = _run_ci_required_result(
+        NEEDS_CODE_CI="true",
+        SAFE_CONTENT_ONLY="false",
+        LINT_RESULT="success",
+        TEST_RESULT="success",
+        CORRECTNESS_RESULT="success",
+        PLAN_CAPTURE_RESULT="success",
+        MEDIUM_TEST_RESULT="failure",
+        EXPLORER_TOKENS_RESULT="success",
+    )
+
+    assert result.returncode == 1
+    assert "medium-test=failure" in result.stdout
 
 
 def test_ci_required_result_required_jobs_in_needs() -> None:
@@ -345,6 +369,7 @@ def test_ci_required_result_passes_when_packaging_jobs_skip() -> None:
         TEST_RESULT="success",
         CORRECTNESS_RESULT="success",
         PLAN_CAPTURE_RESULT="success",
+        MEDIUM_TEST_RESULT="success",
         EXPLORER_TOKENS_RESULT="success",
     )
     assert result.returncode == 0
@@ -360,6 +385,7 @@ def test_ci_required_result_fails_on_parity_check_failure() -> None:
         TEST_RESULT="success",
         CORRECTNESS_RESULT="success",
         PLAN_CAPTURE_RESULT="success",
+        MEDIUM_TEST_RESULT="success",
         EXPLORER_TOKENS_RESULT="success",
         PARITY_CHECK_RESULT="failure",
     )
@@ -376,6 +402,7 @@ def test_ci_required_result_passes_when_parity_check_skips() -> None:
         TEST_RESULT="success",
         CORRECTNESS_RESULT="success",
         PLAN_CAPTURE_RESULT="success",
+        MEDIUM_TEST_RESULT="success",
         EXPLORER_TOKENS_RESULT="success",
         PARITY_CHECK_RESULT="skipped",
     )


### PR DESCRIPTION
# Pull Request

## Description

Implements TODO `medium-tier-pre-merge-lane` (auto-revert-incident group, #1130) — the coverage-gap fix from the 2026-07-10 incident: the medium tier (`make test-medium`, ~18–27 min) ran only post-merge, so both breakages (#1093's preflight misalignment and #1095×#1100's semantic conflict) landed without the tier ever executing pre-merge.

- New `medium-test` job in `.github/workflows/pr.yml`, gated on the existing `ci-paths` classifier (`needs-code-ci == 'true'`) exactly like `code-lint`/`code-test` — docs/TODO-only PRs skip it entirely. Python 3.12, `uv sync --group dev`, `make test-medium` (no inlined pytest — the PR lane and post-merge lane cannot drift), `timeout-minutes: 30`. No junit/signature emit steps: that machinery (#1136) is post-merge-only, feeding auto-revert.
- Wired into the `ci-required-result` rollup: added to `needs:` and the success conjunction. Since the rollup has `if: always()` and its docs-only early-exit uses the same `needs-code-ci` condition as the job's gate, a skipped medium-test never falsely compares and a failed/cancelled one deterministically reddens the required aggregate — blocking auto-merge on code PRs.
- `tests/unit/workflows/test_pr_workflow_path_classifier.py`: the extracted-script harness that pins the rollup logic now sets `MEDIUM_TEST_RESULT` (base env + code-PR scenarios), asserts the updated success message, and adds an explicit medium-test-failure case (exit 1, `medium-test=failure` in the summary). This file is a deliberate, required extension of the TODO's original `scope_limit` — the first CI run of this PR failed exactly here (`unbound variable` under `set -u`), which is the harness doing its job.
- `develop-post-merge.yml`: comment-only update to the medium-test job's promotion history (the tier now has a PR-lane consumer; the post-merge lane remains the safety net for stale-base squash races, which PR CI structurally cannot see). The #1136 signature machinery is byte-identical.
- `_project/TODO/main/planning/medium-tier-ci-home.yaml` had already moved to DONE before this TODO; that record is untouched.

**Note for the repo owner (from review):** the TODO deferred "make the new job a required status check (ruleset change)". Per the reviewer's trace, that is likely already satisfied transitively — `medium-test` gates `ci-required-result`, and if that aggregate is the ruleset's required check (as the design implies), auto-merge already waits on medium-test with no ruleset change. Worth a one-time confirmation that `ci-required-result` is indeed the required check; if so the deferred item can be closed.

Residual gap intentionally not addressed here (recorded in the TODO): stale-base squash races still need the post-merge safety net; the structural fix (merge queue) is deferred as an admin/settings decision.

## Type of Change

- [x] CI coverage improvement

## Testing

- Both workflows parse (`yaml.safe_load`); `pre-commit run check-yaml` passed.
- Path classifier exercised both ways: docs-only list → `needs_code_ci=false` (job skips); workflow-file list → `needs_code_ci=true` (this PR's own diff triggers the job).
- Rollup harness: `tests/unit/workflows/test_pr_workflow_path_classifier.py` → 16 passed (was 5 failed on the first CI run before the harness update).
- **Live validation (TODO w3): confirmed** — this PR's first CI run executed the new `medium-test` job and it passed (1311 items, ~23 min): https://github.com/joeharris76/BenchBox/actions/runs/29152198003/job/86543369237

## Review

Opus-reviewed: **APPROVE**, no Critical/Required findings. All four rollup scenarios traced (docs-only skip → pass; code+green → pass; code+fail → red; code+cancelled/timeout → red). Review-acknowledged, no change: the `uv venv` step present in some sibling pr.yml jobs is omitted here to mirror the post-merge source job (`uv sync` creates the venv itself — behavior identical); the deferred-ruleset clarification is the owner note above.

## Public Contract Check

- [x] No public contract surfaces — CI workflows, rollup-harness tests, and TODO bookkeeping only.

## Documentation

- [x] Workflow comments record the promotion history and lane roles.

## Code Quality

- [x] YAML validated; job mirrors the established gated-job pattern; ruff check/format clean on the test file.

## Artifact Hygiene

- [x] No logs or outputs committed; TODO item moved to DONE (indexes gitignored).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FKz7FioN7DUZA44PrdQVYC