### PR TITLE
fix(throughput): return from the executor without blocking on a hung stream

### DIFF
--- a/_project/DONE/main/planning/throughput-executor-nonblocking-shutdown.yaml
+++ b/_project/DONE/main/planning/throughput-executor-nonblocking-shutdown.yaml
@@ -2,8 +2,9 @@ id: throughput-executor-nonblocking-shutdown
 title: "Let the throughput executor return without blocking on a hung/leaked stream at shutdown"
 worktree: main
 priority: Medium
-status: Not Started
+status: Completed
 category: Core Functionality
+completed_date: "2026-07-11"
 
 description: |
   throughput-timeout-leak-and-success-gates (#1106) fixed the real timeout bug
@@ -42,20 +43,80 @@ prior_art:
 work:
   - id: w0
     summary: "Reproduce the block: a hung stream (sleep past a tiny stream_timeout, cancellation off) keeps execute() from returning until the sleep ends"
-    status: pending
-    notes: "Add/inspect a timing test proving execute() wall-clock is bounded by the hung stream today, not the timeout. Capture to /tmp/throughput-shutdown-w0.log."
+    status: done
+    notes: |
+      Standalone repro script (fake config/stream_fn, no real DB) with a
+      2.0s hung stream and a 0.1s stream_timeout, cancel_on_timeout=False.
+      Before the fix: execute() wall-clock was 2.011s -- bounded by the
+      hung stream, not the timeout -- while result.errors already correctly
+      recorded the leak (confirming #1106's detection fix was intact and
+      this was purely a shutdown-blocking problem). Captured to
+      /tmp/throughput-shutdown-w0.log (before/after sections).
   - id: w1
     summary: "Manage the pool so execute() returns once the timeout/accounting window closes, abandoning (not killing) a still-running leaked thread"
     needs: [w0]
-    status: pending
+    status: done
+    notes: |
+      Replaced the `with ThreadPoolExecutor(...) as executor:` block with
+      manual lifecycle management: `executor = ThreadPoolExecutor(...)`
+      followed by `try/finally: executor.shutdown(wait=False)`. All
+      existing submission/as_completed/fallback-classification logic is
+      unchanged inside the try block -- only the block's entry/exit
+      mechanism changed. shutdown(wait=False) only stops new submissions;
+      it never touches, joins, or kills a still-running thread. On the
+      healthy path every future is already done() by the time shutdown()
+      runs, so this is a no-op there (verified via the w0 repro re-run:
+      0.107s post-fix vs 2.011s pre-fix, with the leak still surfaced
+      identically).
   - id: w2
     summary: "Decide and document the leaked stream's connection ownership and how TTT/accounting treat a zombie that outlives execute()"
     needs: [w1]
-    status: pending
+    status: done
+    notes: |
+      Documented in docs/development/throughput-result-alignment.md under
+      "Non-Blocking Executor Shutdown": the leaked stream's DB connection
+      is owned by that stream's own _execute_stream implementation (both
+      TPC-H's and TPC-DS's throughput_test.py open/close per-stream
+      connections themselves); StreamRunner.execute() never touched it
+      directly before or after this change, so ownership/closure semantics
+      are unchanged -- only how long execute() waits before returning
+      changes. TTT/accounting: unaffected -- a leaked stream was already
+      excluded from result.stream_results (and therefore TTT and
+      streams_successful) under the old blocking behavior, since
+      _record_completed_future() only runs for done() futures; it only
+      ever contributed to streams_executed and errors, which is unchanged.
+      Documented the residual hazard honestly: execute() returning early
+      means a subsequent phase can now genuinely overlap with a still-
+      running zombie (the old blocking shutdown accidentally provided an
+      unbounded, unreliable de facto serialization that is now gone by
+      design); cancel_on_timeout=True is the recommended mitigation since
+      it bounds the zombie to ~one more query.
   - id: w3
     summary: "Test: execute() returns within ~timeout even with a hung stream; leaked stream still surfaced in result.errors; cooperative-cancel path unaffected"
     needs: [w1, w2]
-    status: pending
+    status: done
+    notes: |
+      Added TestStreamRunnerNonBlockingShutdown to
+      tests/unit/core/throughput/test_runner.py (6 new tests, generous
+      20x+ sleep/timeout margins to avoid CI flake):
+      test_execute_returns_near_timeout_not_after_full_hang (wall-clock
+      bound), test_leaked_stream_from_non_blocking_path_still_surfaced_in_errors
+      (leak surfacing unchanged), test_healthy_all_streams_complete_path_unaffected
+      (no-op on healthy path), test_cooperative_cancel_with_real_set_event_still_cancels
+      (a real timeout-set threading.Event still signals cancellation),
+      test_cooperative_cancel_disabled_by_default_never_cancels (default
+      off never attaches cancel machinery), and
+      test_mock_truthy_config_healthy_path_unaffected (a Mock config's
+      truthy-by-default cancel_on_timeout attribute doesn't disturb a
+      healthy run's accounting; the stricter is-True identity guard
+      against spurious cancellation lives in each spec's
+      _resolve_cancel_event, out of this module's scope, and is exercised
+      by tests/unit/tpch/test_tpch_compliance.py and
+      tests/integration/test_throughput_corrections.py). All 24 unit
+      tests, all 10 slow integration tests in
+      test_throughput_corrections.py, all 7 real-DuckDB oracle tests in
+      test_throughput_real_duckdb.py, and all 9 tests in
+      test_tpch_compliance.py pass.
 
 must_preserve:
   - "The already-shipped leak surfacing: a timed-out/leaked stream is still logged (logger.warning) and recorded in result.errors."
@@ -85,6 +146,12 @@ impact:
     A hung stream should not stall the whole throughput phase (and downstream
     phases) for the full duration of the zombie. Bounding executor return time
     makes long throughput runs and their timeouts actually meaningful.
+
+files_affected:
+  modified:
+    - "benchbox/core/throughput/runner.py"
+    - "docs/development/throughput-result-alignment.md"
+    - "tests/unit/core/throughput/test_runner.py"
 
 metadata:
   tags: [concurrency, throughput, robustness, executor, timeout, follow-up]

--- a/benchbox/core/throughput/runner.py
+++ b/benchbox/core/throughput/runner.py
@@ -43,12 +43,44 @@ exceeds ``config.stream_timeout``:
   ``config.cancel_on_timeout`` directly, so a stale/leftover attribute value
   can never be mistaken for this run's cancellation state.
 
-Even with both enabled, exiting this method's ``with
-ThreadPoolExecutor(...)`` block still blocks (via the implicit
-``shutdown(wait=True)`` in ``__exit__``) until every submitted thread
-returns, including a leaked one -- cooperative cancellation shortens that
-wait to roughly one more query's execution time; without it, the wait is
-unbounded, matching today's behavior except now surfaced instead of silent.
+Non-blocking shutdown (return without joining a leaked thread)
+----------------------------------------------------------------
+``execute()`` manages the ``ThreadPoolExecutor`` manually (no ``with``
+block) so it can call ``executor.shutdown(wait=False)`` in a ``finally``
+instead of relying on the context manager's implicit
+``shutdown(wait=True)``. This means ``execute()`` returns as soon as its
+own timeout/accounting window closes -- bounded by ``config.stream_timeout``
+plus classification overhead -- rather than blocking until every submitted
+thread finishes.
+
+On the healthy path (no timeout fires), every future is already ``done()``
+by the time ``as_completed()`` returns, so ``shutdown(wait=False)`` is a
+no-op: there is nothing left to join, and default-timeout behavior for
+healthy runs is unchanged. On the hung path, any future still not
+``done()`` when the deadline elapses is *abandoned*, not killed -- Python
+cannot forcibly stop a running thread. ``shutdown(wait=False)`` only stops
+the executor from accepting new submissions; it does not touch threads
+already running, so the leaked thread keeps executing in the background
+until ``stream_fn`` itself returns (naturally, or via cooperative
+cancellation if enabled) and exits.
+
+**Zombie connection/accounting semantics** (see also
+``docs/development/throughput-result-alignment.md``): a leaked stream's
+database connection is owned by that stream's own ``stream_fn`` and is
+closed by its own ``finally`` block whenever the thread eventually ends --
+``execute()`` never touches it. Until then, the zombie thread holds an open
+session and may still be issuing queries against the database after
+``execute()`` -- and the whole throughput phase -- has returned; a
+subsequent phase (e.g. data maintenance) that starts immediately after can
+run concurrently with it. This residual hazard is why cooperative
+cancellation (bounding the zombie's remaining lifetime to ~one more query)
+is recommended whenever a hard stream_timeout matters operationally. TTT
+and success-rate accounting are unaffected: a leaked stream was already
+excluded from ``result.stream_results`` (and therefore from TTT and
+``streams_successful``) under the *old* blocking behavior too -- it only
+contributes to ``result.streams_executed`` and ``result.errors``, exactly
+as before. What changes here is only how long ``execute()`` itself blocks
+before returning, not what gets counted.
 """
 
 from __future__ import annotations
@@ -135,7 +167,16 @@ class StreamRunner:
         cooperative_cancel = bool(getattr(config, "cancel_on_timeout", False))
         cancel_events: dict[int, threading.Event] = {}
 
-        with concurrent.futures.ThreadPoolExecutor(max_workers=max_workers) as executor:
+        # Managed manually (no `with` block): the context manager's implicit
+        # `__exit__` calls `shutdown(wait=True)`, which would block this
+        # method's return on every submitted thread -- including a leaked
+        # one that never completes. The `finally` below calls
+        # `shutdown(wait=False)` instead, so a still-running (abandoned, not
+        # killed) thread cannot hold `execute()` hostage. See the module
+        # docstring "Non-blocking shutdown" section for the full rationale
+        # and the zombie connection/accounting semantics this implies.
+        executor = concurrent.futures.ThreadPoolExecutor(max_workers=max_workers)
+        try:
             # Track future -> stream_id mapping for timeout error reporting
             future_to_stream_id: dict[concurrent.futures.Future[ThroughputStreamResult], int] = {}
 
@@ -260,6 +301,16 @@ class StreamRunner:
                     # be silent even in non-verbose runs.
                     logger.warning(error_msg)
                     pending.discard(future)
+        finally:
+            # wait=False: never block this method's return on a still-running
+            # (abandoned, not killed) thread. On the healthy path every
+            # future is already done() by this point, so this is a no-op --
+            # nothing to join, default timeout behavior for healthy runs is
+            # unchanged. On the hung path, any leaked thread keeps running
+            # to completion in the background; its connection is closed by
+            # its own stream_fn's finally whenever that eventually happens.
+            # See the module docstring "Non-blocking shutdown" section.
+            executor.shutdown(wait=False)
 
     @staticmethod
     def compute_metrics(

--- a/docs/development/throughput-result-alignment.md
+++ b/docs/development/throughput-result-alignment.md
@@ -175,11 +175,10 @@ and sets the timed-out stream's event; each spec's `_execute_stream` query
 loop polls its own event between queries and stops early if set, marking
 the stream unsuccessful. This lets a leaked stream actually wind down soon
 after a timeout instead of running unbounded — the only safe mechanism,
-since Python threads cannot be hard-killed. Even with this enabled, exiting
-`execute()`'s `ThreadPoolExecutor` context still blocks until every
-submitted thread returns (`shutdown(wait=True)` on `__exit__`); cooperative
-cancellation shortens that wait to roughly one more query's execution time
-instead of leaving it unbounded.
+since Python threads cannot be hard-killed. **Update (`throughput-executor-
+nonblocking-shutdown`, 2026-07, see below):** `execute()` no longer blocks
+its own return on a leaked thread either way — see "Non-Blocking Executor
+Shutdown" below for how this composes with cooperative cancellation.
 
 **Stale cancel-event leak across reused configs (review follow-up):**
 `config._stream_cancel_events` is set purely by presence, and each spec's
@@ -227,6 +226,91 @@ reported as timed-out before it ever executes a single query.
 mis-configuration is detected (`max_workers < num_streams` and a timeout is
 set); default behavior (unset or `max_workers >= num_streams`) is
 unaffected.
+
+---
+
+## Non-Blocking Executor Shutdown (`throughput-executor-nonblocking-shutdown`, 2026-07)
+
+`throughput-timeout-leak-and-success-gates` (above) fixed timeout
+*detection* (a leaked stream is now always logged and recorded in
+`result.errors`) but explicitly deferred a residual problem: `execute()`
+ran its streams inside a `with concurrent.futures.ThreadPoolExecutor(...)`
+block. The context manager's implicit `__exit__` calls
+`shutdown(wait=True)`, which blocks until *every* submitted thread
+returns — including a leaked one. With cooperative cancellation off (the
+default), a genuinely hung stream therefore still blocked `execute()`
+itself for as long as the stream kept running, and with it the whole
+throughput phase and any subsequent phase (e.g. data maintenance).
+
+**Fix:** `execute()` now manages the `ThreadPoolExecutor` manually (no
+`with` block) and calls `executor.shutdown(wait=False)` in a `finally`.
+`shutdown(wait=False)` only stops the executor from accepting new
+submissions — it does not touch, join, or wait on threads that are already
+running. This is deliberately **not** a thread-kill: Python cannot forcibly
+stop a running thread, and this change does not attempt to. A leaked
+thread is *abandoned*, not killed — it keeps running `stream_fn` to
+completion in the background, entirely decoupled from the caller of
+`execute()`.
+
+**Healthy-path behavior is unchanged.** When every stream completes before
+the timeout (or no timeout is set), every future is already `done()` by
+the time the `as_completed()`/fallback loop finishes, so
+`shutdown(wait=False)` has nothing left to wait for — it is a no-op
+compared to the old `shutdown(wait=True)`. Only the hung-stream shutdown
+path changes; default timeout behavior for healthy runs is unaffected.
+
+### Zombie connection ownership
+
+A leaked stream's database connection is owned and opened by that
+stream's own `_execute_stream` implementation (TPC-H's and TPC-DS's
+`throughput_test.py` each open/close their own connection per stream).
+`StreamRunner.execute()` never held or touched that connection directly,
+and this change does not alter that: the connection is closed by the
+stream's own `finally` block whenever that thread's `stream_fn` call
+eventually returns — naturally, or sooner if cooperative cancellation
+(`cancel_on_timeout=True`) is enabled and the stream notices its cancel
+event between queries. `execute()` returning early does not close, orphan,
+or leak the connection any differently than before; it only stops
+*waiting* for that closure to happen before returning control to the
+caller.
+
+### TTT / accounting semantics for a stream that outlives `execute()`
+
+No accounting behavior changes here — a leaked stream was **already**
+excluded from `result.stream_results` (and therefore from TTT and
+`streams_successful`) under the old, blocking behavior, because
+`_record_completed_future()` is only invoked for futures observed as
+`done()`; a still-pending leaked future never reaches it. It contributes
+only to `result.streams_executed` (incremented in the timeout fallback
+loop) and to `result.errors` (the leak-surfacing message). This item
+changes *when* `execute()` returns, not *what* gets counted — the
+`streams_executed` / `streams_successful` / `errors` contract from
+`throughput-timeout-leak-and-success-gates` is unchanged.
+
+### Residual hazard: overlap with a subsequent phase
+
+This is the hazard `throughput-timeout-leak-and-success-gates` explicitly
+deferred. Because `execute()` (and therefore the whole throughput phase)
+can now return while a leaked stream's thread is still running, a caller
+that immediately proceeds to a subsequent phase (e.g. TPC-DS data
+maintenance) can now genuinely overlap with that zombie thread still
+issuing queries and holding a connection against the same database. This
+was already possible in principle before this change (Python cannot
+forcibly cancel a thread either way), but the old blocking `shutdown(wait=
+True)` accidentally provided a de facto (unbounded, and therefore
+unreliable as a guarantee) serialization between the throughput phase and
+whatever ran next, simply because `execute()` could not return until the
+zombie finished. That accidental serialization is now gone by design.
+
+Mitigating this overlap is the job of `cancel_on_timeout=True`: it bounds
+the zombie's remaining lifetime to roughly one more query instead of
+leaving it unbounded, shrinking (but not eliminating, since Python still
+cannot force a thread to stop mid-query) the window in which a subsequent
+phase can run concurrently with it. Callers whose downstream phases are
+sensitive to this overlap (e.g. connection-pool exhaustion, contention on
+a shared DB) should enable cooperative cancellation and/or leave headroom
+between phases; `StreamRunner.execute()` does not — and, given Python's
+threading constraints, cannot — provide a stronger guarantee than that.
 
 ---
 

--- a/tests/unit/core/throughput/test_runner.py
+++ b/tests/unit/core/throughput/test_runner.py
@@ -2,14 +2,20 @@
 
 Mirrors the mocking style used in ``tests/integration/test_tpch_throughput_test.py``
 (fake benchmark/config objects, no real database or benchmark work) but targets
-``StreamRunner`` directly and stays deterministic - no real multi-threaded
-timing/wall-clock behavior is exercised here. That remains the job of the
-slow-marked integration test.
+``StreamRunner`` directly. Most cases stay fully deterministic; a few
+(``TestStreamRunnerTimeoutDetectionAndLeakSurfacing``,
+``TestStreamRunnerCooperativeCancellation``,
+``TestStreamRunnerNonBlockingShutdown``) use small real sleeps with generous
+margins to exercise genuine multi-threaded timeout/wall-clock behavior
+end-to-end rather than mocking time itself -- the fuller, slower-margin
+real-DuckDB oracle for this remains
+``tests/integration/test_throughput_real_duckdb.py``.
 """
 
 from __future__ import annotations
 
 import logging
+import threading
 import time
 from dataclasses import dataclass
 from typing import Optional
@@ -434,3 +440,163 @@ class TestStreamRunnerCooperativeCancellation:
         assert refreshed_cancel_events is not stale_cancel_events
         assert result2.streams_successful == 1
         assert result2.errors == []
+
+
+class TestStreamRunnerNonBlockingShutdown:
+    """Cover execute()'s non-blocking shutdown (w1/w3): a hung stream must
+    not hold execute() hostage for its own lifetime.
+
+    ``execute()`` used to run inside a ``with ThreadPoolExecutor(...)``
+    block whose implicit ``shutdown(wait=True)`` at ``__exit__`` blocked
+    the method's return until every submitted thread finished -- including
+    a leaked one. It now manages the pool manually and calls
+    ``shutdown(wait=False)`` in a ``finally``, so it returns once its own
+    timeout/accounting window closes, abandoning (never killing) any
+    still-running thread. These tests use a real, but generous margin
+    (hang sleep >> timeout, by 20x+) so wall-clock assertions are not
+    flake-prone on a loaded CI box.
+    """
+
+    TINY_TIMEOUT = 0.05
+    # Deliberately >> TINY_TIMEOUT so a passing assertion that execute()
+    # returned near the timeout (and not near the hang) has a wide margin.
+    HANG_SLEEP = 2.0
+
+    def test_execute_returns_near_timeout_not_after_full_hang(self) -> None:
+        """The headline w1 fix: execute()'s wall-clock is bounded by
+        stream_timeout, not by how long the hung stream actually sleeps."""
+
+        def hung_stream_fn(stream_id: int, seed: int, cfg: _FakeConfig) -> ThroughputStreamResult:
+            time.sleep(self.HANG_SLEEP)
+            return _make_stream_result(stream_id)
+
+        config = _FakeConfig(num_streams=1, stream_timeout=self.TINY_TIMEOUT, cancel_on_timeout=False)
+        result = _make_result()
+        logger = logging.getLogger("test-throughput-runner")
+
+        start = time.monotonic()
+        StreamRunner.execute(hung_stream_fn, config, result, logger)
+        elapsed = time.monotonic() - start
+
+        # Bounded by the timeout window plus classification overhead --
+        # nowhere near the full 2s hang. A generous 1s ceiling still leaves
+        # a 20x margin over TINY_TIMEOUT for CI scheduling jitter while
+        # remaining far short of HANG_SLEEP.
+        assert elapsed < 1.0, f"execute() blocked for {elapsed:.3f}s -- did not return near the timeout"
+
+    def test_leaked_stream_from_non_blocking_path_still_surfaced_in_errors(self) -> None:
+        """The non-blocking shutdown must not regress leak surfacing: the
+        abandoned stream is still logged and recorded in result.errors,
+        exactly as under the old (blocking) behavior."""
+
+        def hung_stream_fn(stream_id: int, seed: int, cfg: _FakeConfig) -> ThroughputStreamResult:
+            time.sleep(self.HANG_SLEEP)
+            return _make_stream_result(stream_id)
+
+        config = _FakeConfig(num_streams=1, stream_timeout=self.TINY_TIMEOUT, cancel_on_timeout=False)
+        result = _make_result()
+        logger = Mock(spec=logging.Logger)
+
+        StreamRunner.execute(hung_stream_fn, config, result, logger)
+
+        assert result.streams_executed == 1
+        assert result.streams_successful == 0
+        assert len(result.errors) == 1
+        assert "timed out" in result.errors[0].lower()
+        assert "leaked" in result.errors[0].lower()
+        logger.warning.assert_called_once_with(result.errors[0])
+
+    def test_healthy_all_streams_complete_path_unaffected(self) -> None:
+        """Non-blocking shutdown must be a pure no-op on the healthy path:
+        every future is already done() before shutdown() runs, so timing
+        and accounting for a normal (no-timeout) run are unchanged."""
+        config = _FakeConfig(num_streams=4, stream_timeout=5)
+        result = _make_result()
+        logger = logging.getLogger("test-throughput-runner")
+        stream_fn = Mock(side_effect=lambda stream_id, seed, cfg: _make_stream_result(stream_id))
+
+        StreamRunner.execute(stream_fn, config, result, logger)
+
+        assert result.streams_executed == 4
+        assert result.streams_successful == 4
+        assert result.errors == []
+        assert stream_fn.call_count == 4
+
+    def test_cooperative_cancel_with_real_set_event_still_cancels(self) -> None:
+        """Composition with #1106: a genuine, timeout-set threading.Event
+        must still signal cancellation under the new non-blocking shutdown
+        -- the executor lifecycle change must not disturb this wiring."""
+
+        def slow_stream_fn(stream_id: int, seed: int, cfg: _FakeConfig) -> ThroughputStreamResult:
+            time.sleep(0.1)
+            return _make_stream_result(stream_id)
+
+        config = _FakeConfig(num_streams=1, stream_timeout=self.TINY_TIMEOUT, cancel_on_timeout=True)
+        result = _make_result()
+        logger = logging.getLogger("test-throughput-runner")
+
+        StreamRunner.execute(slow_stream_fn, config, result, logger)
+
+        cancel_events = getattr(config, "_stream_cancel_events", None)
+        assert cancel_events is not None
+        assert isinstance(cancel_events[0], threading.Event)
+        assert cancel_events[0].is_set()
+
+    def test_cooperative_cancel_disabled_by_default_never_cancels(self) -> None:
+        """Composition with #1106: cancel_on_timeout defaults False, so no
+        cancel-event machinery is attached at all, even on a hung stream,
+        under the new non-blocking shutdown."""
+
+        def hung_stream_fn(stream_id: int, seed: int, cfg: _FakeConfig) -> ThroughputStreamResult:
+            time.sleep(self.HANG_SLEEP)
+            return _make_stream_result(stream_id)
+
+        config = _FakeConfig(num_streams=1, stream_timeout=self.TINY_TIMEOUT)
+        assert config.cancel_on_timeout is False
+        result = _make_result()
+        logger = logging.getLogger("test-throughput-runner")
+
+        StreamRunner.execute(hung_stream_fn, config, result, logger)
+
+        assert getattr(config, "_stream_cancel_events", None) == {}
+
+    def test_mock_truthy_config_healthy_path_unaffected(self) -> None:
+        """Composition with #1106, at the StreamRunner boundary: an
+        unconfigured ``Mock()`` config's ``cancel_on_timeout`` attribute is
+        truthy-by-default (``bool(Mock()) is True``), so ``execute()``'s own
+        ``bool(getattr(config, "cancel_on_timeout", False))`` read treats it
+        as opted-in and *does* populate ``_stream_cancel_events`` -- that
+        alone is harmless bookkeeping. The actual protection against a
+        stale/mock-truthy value causing a *spurious cancellation* is the
+        stricter ``is True`` identity gate in each spec's
+        ``_resolve_cancel_event`` (``benchbox/core/tpch/throughput_test.py``,
+        ``benchbox/core/tpcds/throughput_test.py`` -- out of this module's
+        scope, exercised by ``tests/unit/tpch/test_tpch_compliance.py`` and
+        ``tests/integration/test_throughput_corrections.py``). What this
+        test pins down is that the non-blocking shutdown change does not
+        disturb that composition: on a healthy (no-timeout) run, a
+        Mock-truthy ``cancel_on_timeout`` still yields a normal, fully
+        successful result with no event ever set() -- nothing times out, so
+        no cancellation signal fires regardless of the flag's truthiness.
+        """
+        stream_fn = Mock(side_effect=lambda stream_id, seed, cfg: _make_stream_result(stream_id))
+        result = _make_result()
+        logger = logging.getLogger("test-throughput-runner")
+
+        config = Mock()
+        config.num_streams = 1
+        config.max_workers = None
+        config.base_seed = 1
+        config.stream_timeout = 5
+        config.scale_factor = 1.0
+        config.verbose = False
+        # Deliberately NOT setting cancel_on_timeout -- an unconfigured Mock
+        # attribute access returns a truthy child Mock by default.
+
+        StreamRunner.execute(stream_fn, config, result, logger)
+
+        assert result.streams_successful == 1
+        assert result.errors == []
+        cancel_events = getattr(config, "_stream_cancel_events", None)
+        assert isinstance(cancel_events, dict) and len(cancel_events) == 1
+        assert all(not event.is_set() for event in cancel_events.values())


### PR DESCRIPTION
## Summary

Let `StreamRunner.execute()` return promptly once its timeout/accounting window closes, instead of blocking on a hung stream until the thread finishes.

Implements TODO `throughput-executor-nonblocking-shutdown` (a follow-up deferred by #1106).

## Problem
`execute()` ran its streams inside a `with ThreadPoolExecutor(...)` block, and the context manager's `__exit__` calls `shutdown(wait=True)`. So even though a timed-out stream is correctly **surfaced** (logged + recorded in `result.errors`, from #1106), `execute()` could not **return** until every worker finished. With cooperative cancellation off (the default), a genuinely hung stream blocked the whole throughput phase (and any downstream phase) for the full duration of the hang.

Reproduction (fake stream_fn, no DB): a 2.0s hang with a 0.1s `stream_timeout` and `cancel_on_timeout=False` → pre-fix `execute()` wall-clock **2.011s**, post-fix **0.107s**.

## Change
Manual executor lifecycle: `executor = ThreadPoolExecutor(...)` then `try: … finally: executor.shutdown(wait=False)`. All submission / `as_completed(timeout=…)` / fallback-classification logic (from #1106) is unchanged. `shutdown(wait=False)` only stops new submissions and returns without joining — **no thread is ever killed or interrupted** (Python cannot do so safely); the leaked worker is abandoned to run out in the background.

## Zombie semantics (documented honestly in `throughput-result-alignment.md`)
- **Connection ownership**: the leaked stream's DB connection is owned and closed by its own `_execute_stream` `finally`, whenever the thread eventually ends. `execute()` never held or closed it, so `shutdown(wait=False)` neither leaks nor double-closes it.
- **TTT / accounting are uncorrupted**: a leaked stream never reaches `_record_completed_future()` (called only for `done()` futures), so it never enters `result.stream_results`, TTT, or `streams_successful` — it only bumps `streams_executed` + `errors`, identical to the pre-fix path.
- **Residual (documented)**: the old blocking shutdown provided an *unbounded, unreliable* de-facto serialization (the very stall being fixed). Removing it means a later phase's own timing could see DB contention from a live zombie. `cancel_on_timeout=True` is the mitigation (bounds a zombie to ~one more query). No stronger guarantee is possible at this layer.

## Verification
- `tests/unit/core/throughput/` (`-n 0`) → **24 passed**, incl. `test_execute_returns_near_timeout_not_after_full_hang` (asserts `elapsed < 1.0s` for a 2.0s hang / 0.05s timeout — **non-vacuous**: ~2.0s against the pre-fix `wait=True`).
- `test_throughput_real_duckdb.py -m integration` → **7 passed** (oracle). `tests/unit/tpch/test_tpch_compliance.py` → **9 passed** (the file that caught #1106's mock-config regression — still green).
- `make lint-imports` → 3 kept, 0 broken · `test_marker_strategy.py` → 8 passed · ruff + ty clean.

## Review
Opus 4.8 review: **clean, no findings**. `NO_THREAD_KILL: yes`, `RETURN_BOUNDED: yes` (non-vacuous), `ZOMBIE_HAZARD: acceptable` (accounting provably uncorrupted; residual documented + mitigated), `CONNECTION_SAFE: yes`, `MUST_PRESERVE_OK: yes` (leak surfacing, accounting, cooperative-cancel + #1106 real-Event guard all intact — the guard lives in the out-of-scope `throughput_test.py` files and was correctly left untouched).

## Follow-up (non-blocking, out of scope)
If downstream phases (esp. TPC-DS data maintenance) prove sensitive to zombie overlap in practice, a separate item could add an optional bounded grace-join or a phase-boundary quiescence check at the orchestration layer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
