### PR TITLE
docs(runbook): record medium-test in the ci-required-result umbrella; close both deferred medium-lane items

### DIFF
--- a/_project/DONE/auto-revert-incident/active/medium-tier-pre-merge-lane.yaml
+++ b/_project/DONE/auto-revert-incident/active/medium-tier-pre-merge-lane.yaml
@@ -91,9 +91,9 @@ work:
     from this worktree.
 deferred:
 - summary: "Make the new job a required status check in the develop ruleset"
-  reason: "Branch-protection/ruleset change is admin/settings work, not repo code; without it auto-merge does not wait for this job - flag to the repo owner in the PR body."
+  reason: "RESOLVED 2026-07-11: no ruleset change needed. The develop-squash-only ruleset's sole required check is the ci-required-result umbrella (docs/operations/repo-admin-settings.md, pinned by the release-canary drift job), and #1139 wired medium-test into that umbrella's needs+conjunction - auto-merge already waits on it transitively."
 - summary: "GitHub merge queue for develop"
-  reason: "The structural fix for stale-base squash races, but requires repo-settings evaluation (queue latency, runner budget); record as its own decision item if pursued."
+  reason: "RESOLVED 2026-07-11 as not-available: merge queues require organization-owned repos; BenchBox is user-owned. The ruleset also deliberately preserves strict_required_status_checks_policy=false (runbook: properties to preserve), so the strict-checks alternative is rejected by design. Accepted mitigation: the signature-aware develop-post-merge safety net (#1136)."
 must_preserve:
 - "Docs/TODO/markdown-only PRs must not start the medium job (ci-paths gating)"
 - "develop-post-merge medium-test job stays blocking and wired to auto-revert (it is the safety net for stale-base races PR CI cannot see)"

--- a/docs/operations/repo-admin-settings.md
+++ b/docs/operations/repo-admin-settings.md
@@ -58,6 +58,8 @@ Required status checks:
 `ci-required-result` is the umbrella job in `.github/workflows/pr.yml`
 that aggregates the required-lane jobs: `ci-paths`, `content-guard`,
 `code-lint`, `code-test`, `correctness-gate`, `plan-capture-gate`,
+`medium-test` (added 2026-07-11, #1139 — the medium tier now gates code
+PRs pre-merge via the same umbrella, no ruleset change needed),
 `explorer-tokens`, `audit-sha`, `package-smoke`, and `dependency-audit`.
 Branch protection deliberately keys off the umbrella so the path-aware
 classifier can skip subordinate jobs without making the protected check


### PR DESCRIPTION
# Pull Request

## Description

Closes out the two items #1139 flagged for owner decision, with evidence from the repo's own ruleset documentation (kept live-accurate by the release-canary ruleset-drift job):

1. **"Make medium-test a required status check" → resolved, no action needed.** The `develop-squash-only` ruleset's sole required check is the `ci-required-result` umbrella (`docs/operations/repo-admin-settings.md`), and #1139 wired `medium-test` into that umbrella's `needs:` + success conjunction — auto-merge already waits on it transitively. The runbook's list of jobs the umbrella aggregates was stale; `medium-test` is now recorded there with the promotion date.
2. **"GitHub merge queue for develop" → resolved as not available.** Merge queues require organization-owned repositories; BenchBox is user-owned. The ruleset also deliberately preserves `strict_required_status_checks_policy: false` (runbook "properties to preserve"), so the strict-checks alternative is rejected by design. The accepted mitigation for stale-base squash races remains the signature-aware develop-post-merge safety net (#1136).

Both deferred entries on the DONE TODO record (`_project/DONE/auto-revert-incident/active/medium-tier-pre-merge-lane.yaml`) now carry their resolutions, so the incident batch has no dangling decisions.

## Type of Change

- [x] Documentation / TODO bookkeeping only

## Testing

- `validate_todo.py` on the updated DONE record: valid.
- No code or workflow changes.

## Public Contract Check

- [x] No contract surfaces touched.

## Documentation

- [x] This PR is the documentation update.

## Code Quality

- [x] N/A — docs and TODO metadata only.

## Artifact Hygiene

- [x] Nothing generated committed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FKz7FioN7DUZA44PrdQVYC

---
_Generated by [Claude Code](https://claude.ai/code/session_01FKz7FioN7DUZA44PrdQVYC)_