### PR TITLE
fix: consolidated bot review follow-up sweep (2 findings across 2 merged PRs)

### DIFF
--- a/tests/uat/_cli.py
+++ b/tests/uat/_cli.py
@@ -384,6 +384,7 @@ def _handle_execute(args: argparse.Namespace) -> int:
         # NOT land here: run_sweep synthesizes an ExecuteOutcome from the
         # attempted cells for that case, so it flows through the normal
         # summary path below.) There are no per-cell counts to report.
+        aborted = result.aborted_phase is not None
         summary = {
             "name": config.name,
             "log_dir": str(result.log_dir),
@@ -394,12 +395,13 @@ def _handle_execute(args: argparse.Namespace) -> int:
             "compatibility_pruned": 0,
             "skipped_unreachable": 0,
             "docker_events": 0,
-            "aborted": True,
+            "aborted": aborted,
             "abort_reason": result.abort_reason,
         }
         print(json.dumps(summary, indent=2))
-        print(f"[execute] ABORT: {result.abort_reason}", file=sys.stderr)
-        return 2
+        if aborted:
+            print(f"[execute] ABORT: {result.abort_reason}", file=sys.stderr)
+        return result.exit_code()
 
     summary = {
         "name": config.name,

--- a/tests/uat/phases/execute.py
+++ b/tests/uat/phases/execute.py
@@ -808,6 +808,12 @@ def default_log_dir(config: UATConfig, now: _dt.datetime | None = None) -> Path:
     render unchanged: `str.replace` is a no-op when the placeholder is
     absent, so existing explicit `logs_dir_template` values keep working
     verbatim.
+
+    HHMMSS alone still collides when two sweeps using a {time} template
+    start in the same second (e.g. automation kicking off multiple configs
+    at once); since the log dir is now the durable record (no resume
+    machinery to merge into it), a resolved path that already exists gets a
+    numeric suffix appended until it names a fresh directory.
     """
     now = now or _dt.datetime.now()
     template = config.output.logs_dir_template
@@ -816,7 +822,13 @@ def default_log_dir(config: UATConfig, now: _dt.datetime | None = None) -> Path:
         .replace("{time}", now.strftime("%H%M%S"))
         .replace("{name}", config.name)
     )
-    return Path(rendered).expanduser()
+    path = Path(rendered).expanduser()
+    if "{time}" in template:
+        suffix = 2
+        while path.exists():
+            path = path.with_name(f"{path.name}-{suffix}")
+            suffix += 1
+    return path
 
 
 def default_benchmark_runs_dir(config: UATConfig, now: _dt.datetime | None = None) -> Path:

--- a/tests/uat/test_cli_dispatch.py
+++ b/tests/uat/test_cli_dispatch.py
@@ -444,3 +444,43 @@ def test_uat_execute_and_execute_only_sweep_produce_identical_cells_jsonl(tmp_pa
     execute_sidecar = (execute_log_dir / "cells.jsonl.accounting.json").read_text(encoding="utf-8")
     sweep_sidecar = (sweep_log_dir / "cells.jsonl.accounting.json").read_text(encoding="utf-8")
     assert execute_sidecar == sweep_sidecar
+
+
+def test_execute_main_reports_success_for_dry_run_config(tmp_path, monkeypatch, capsys):
+    """#1146 review: a `dry_run: true` config never invokes run_execute, so
+    `result.execute_outcome` stays None -- but that's not an abort. Before
+    this fix, `_handle_execute` treated a None outcome as *always* an abort
+    and hardcoded exit 2, so `make uat-execute` on a dry-run config failed
+    even though the (no-op) phase loop succeeded.
+    """
+    config_path = tmp_path / "uat.yaml"
+    config_path.write_text(
+        "\n".join(
+            [
+                'name: "dry-run-smoke"',
+                "dry_run: true",
+                "phases: [execute]",
+                "platforms:",
+                '  include: ["duckdb"]',
+                "benchmarks:",
+                '  include: ["tpch"]',
+                "scales:",
+                "  rungs: [0.01]",
+                "output:",
+                f'  logs_dir_template: "{tmp_path / "dry-run-execute"}"',
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    def fail_run_execute(config, **kwargs):
+        raise AssertionError("dry_run: true must not invoke run_execute")
+
+    monkeypatch.setattr("tests.uat.phases.execute.run_execute", fail_run_execute)
+
+    rc = _cli.main(["execute", "--config", str(config_path)])
+
+    summary = json.loads(capsys.readouterr().out)
+    assert summary["aborted"] is False
+    assert summary["abort_reason"] is None
+    assert rc == 0

--- a/tests/uat/test_phases.py
+++ b/tests/uat/test_phases.py
@@ -1064,6 +1064,28 @@ def test_default_log_dir_time_avoids_same_day_collision():
     assert first != second
 
 
+def test_default_log_dir_same_second_collision_gets_disambiguated(tmp_path: Path):
+    """#1143 review: {time} truncates to HHMMSS, so two sweeps starting in the
+    same second (e.g. automation kicking off multiple configs at once)
+    resolved to the same directory pre-fix, silently combining/overwriting
+    durable artifacts. A path that already exists on disk now gets a
+    numeric suffix instead.
+    """
+    cfg = validate_config(
+        {
+            "name": "collision-smoke",
+            "output": {"logs_dir_template": str(tmp_path / "uat_{date}_{time}")},
+        }
+    )
+    now = _dt.datetime(2026, 5, 5, 9, 0, 0)
+    first = exec_phase.default_log_dir(cfg, now=now)
+    first.mkdir(parents=True)
+    second = exec_phase.default_log_dir(cfg, now=now)
+
+    assert first != second
+    assert second.name == f"{first.name}-2"
+
+
 def test_default_log_dir_explicit_date_only_template_still_works():
     """Existing configs with an explicit {date}-only template keep working verbatim."""
     cfg = validate_config(


### PR DESCRIPTION
# Pull Request

## Description

Late-landing `chatgpt-codex-connector` bot review follow-ups. Each PR listed below was already merged before its review completed, so the fixes are consolidated into this one sweep branch off `develop` per the established review-followup pattern. (A third finding, on PR #1145, was found already fixed by concurrent work in #1146 — verified adequate and replied+resolved there directly, not duplicated here.)

## Findings fixed

1. **#1146** — `tests/uat/_cli.py::_handle_execute`: when a config sets `dry_run: true`, `run_sweep`'s execute phase never actually invokes `run_execute`, so `result.execute_outcome` stays `None`. `_handle_execute` treated *any* `None` outcome as an abort and hardcoded exit 2, so `make uat-execute CONFIG=<dry-run yaml>` failed even though the (no-op) phase loop succeeded. Now defers to `SweepResult.exit_code()` / `aborted_phase`, which already distinguish a real abort from dry-run/no-op success.
2. **#1143** — `tests/uat/phases/execute.py::default_log_dir`: the default `logs_dir_template`'s `{time}` placeholder only carries second (HHMMSS) granularity, so two sweeps starting in the same second (e.g. automation kicking off multiple configs at once) resolved to the identical log directory and could silently combine/overwrite each other's durable `cells.jsonl`/accounting-sidecar artifacts. A rendered path that already exists on disk now gets a numeric suffix (`-2`, `-3`, ...) appended until it names a fresh directory.

## Testing

Both fixes follow the session's standard discipline: added a regression test, verified it fails without the fix (`git stash` the fix, confirm failure, `git stash pop`, confirm pass), lint/format/typecheck, then broader suite run.

- `tests/uat/test_cli_dispatch.py::test_execute_main_reports_success_for_dry_run_config` — new test asserting a dry-run config exits 0 and reports `aborted: false`; confirmed it fails (`aborted: True`, exit 2) without the fix.
- `tests/uat/test_phases.py::test_default_log_dir_same_second_collision_gets_disambiguated` — new test asserting a second `default_log_dir()` call at the identical timestamp against an already-existing directory returns a disambiguated path; confirmed it fails (paths equal) without the fix.
- `tests/uat/test_cli_dispatch.py tests/uat/test_phases.py` — 66 passed.
- Full `tests/uat/ -m fast` — 379 passed.
- `ruff check` / `ruff format --check` / `ty check` clean on all four changed files.

## Public Contract Check

- [x] No public contract surface changes — internal UAT tooling fixes and test corrections only.

## Documentation

- [x] N/A — no user-facing docs affected; behavior corrections match existing documented intent (dry-run should report success; log dirs should be collision-free).

## Code Quality

- [x] `ruff check` / `ruff format --check` / `ty check` clean on every changed file.
- [x] Regression test added for both code-level findings.

## Artifact Hygiene

- [x] I did not commit raw screenshots, browser reports, generated logs, benchmark outputs, or temporary binary artifacts.

## Notes

No CODEOWNERS-gated paths touched — enabling squash auto-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01SKw2UhgHuzYPo3y5MfarD6)_