### PR TITLE
fix(write-primitives): gate operation status on validation_passed

### DIFF
--- a/_project/DONE/scd2-audit-followup/write-primitives-validation-result-gating.yaml
+++ b/_project/DONE/scd2-audit-followup/write-primitives-validation-result-gating.yaml
@@ -2,7 +2,8 @@ id: "write-primitives-validation-result-gating"
 title: "Gate write/transaction-primitives run status on validation_passed"
 worktree: "scd2-audit-followup"
 priority: "High"
-status: "Not Started"
+status: "Completed"
+completed_date: "2026-07-11"
 category: "Core Functionality"
 description: |
   SCD2 adversarial audit finding N1 (keystone). An operation whose validation
@@ -30,19 +31,23 @@ description: |
   unobservable until a failing validation actually fails the run.
 impact:
   business_value: "A benchmark tool that silently reports incorrect writes as passing is unsound as a measurement instrument."
-  user_impact: "Corrupting or no-op operations surface as green; results and the honesty story depend on this being fixed first."
+  user_impact: "Corrupting or no-op operations surface as green; results and the honesty story depend on this being fixed
+    first."
   technical_debt: "Dead validation-status plumbing (row_count_validation_status) that operations never populate."
 prior_art:
 - "benchbox/core/write_primitives/benchmark.py:1211-1224 OperationResult construction (hardcoded success=True)"
 - "benchbox/core/transaction_primitives/benchmark.py:809-816 identical construction in sibling benchmark"
-- "benchbox/platforms/base/execution.py:1080-1094 _execute_operation_query result dict (writes validation_passed, read by nothing)"
-- "benchbox/platforms/base/execution.py:1103-1126 _log_query_result (keys off unset row_count_validation_status) - extend / supersede"
-- "benchbox/core/write_primitives/benchmark.py:126-130 OperationResult.status field already exists (SUCCESS/SKIPPED/FAILED) - reuse"
+- "benchbox/platforms/base/execution.py:1080-1094 _execute_operation_query result dict (writes validation_passed, read by
+  nothing)"
+- "benchbox/platforms/base/execution.py:1103-1126 _log_query_result (keys off unset row_count_validation_status) - extend
+  / supersede"
+- "benchbox/core/write_primitives/benchmark.py:126-130 OperationResult.status field already exists (SUCCESS/SKIPPED/FAILED)
+  - reuse"
 
 work:
 - id: w0
   summary: "Re-validate blast radius on write + transaction primitives and a second engine before flipping status."
-  status: pending
+  status: done
   notes: |
     Measured on DuckDB SF0.01 (scratchpad blast.py): write_primitives
     SUCCESS=56 SKIPPED=56 FAILED=0, with ZERO ops SUCCESS-but-validation_failed.
@@ -55,7 +60,7 @@ work:
 - id: w1
   summary: "Decision gate: reuse status=FAILED vs add a distinct VALIDATION_FAILED status."
   needs: [w0]
-  status: pending
+  status: done
   notes: |
     Recommend a distinct VALIDATION_FAILED: it separates 'the SQL raised' from
     'the SQL ran and the post-condition is wrong', which matters for a
@@ -64,11 +69,12 @@ work:
 - id: w2
   summary: "Derive success/status from validation_passed in both benchmark.py OperationResult constructions."
   needs: [w1]
-  status: pending
+  status: done
 - id: w3
-  summary: "Propagate status through _execute_operation_query; make _log_query_result and _log_execution_summary reflect validation failure."
+  summary: "Propagate status through _execute_operation_query; make _log_query_result and _log_execution_summary reflect validation
+    failure."
   needs: [w2]
-  status: pending
+  status: done
   notes: |
     _log_query_result currently reads result['row_count_validation_status'],
     never set for operations. Either populate it from validation_passed in
@@ -77,10 +83,11 @@ work:
 - id: w4
   summary: "Regression test: an op with a deliberately failing validation must not report SUCCESS/green."
   needs: [w3]
-  status: pending
+  status: done
 
 must_preserve:
-- "All 56 currently-passing write_primitives ops on DuckDB SF0.01 keep reporting success (w0 confirms zero rely on ignored validation failure)."
+- "All 56 currently-passing write_primitives ops on DuckDB SF0.01 keep reporting success (w0 confirms zero rely on ignored
+  validation failure)."
 - "SKIPPED semantics unchanged: a skipped op still reports success with status=SKIPPED (skip means not-applicable, not failure)."
 - "transaction_primitives operation reporting stays behaviorally consistent with write_primitives after the change."
 
@@ -93,13 +100,16 @@ approach: |
   mechanical and symmetric across write + transaction primitives.
 
 anti_patterns:
-- "DO NOT gate only write_primitives - because transaction_primitives shares the identical hardcoded success=True (benchmark.py:809-816) - fix both."
-- "DO NOT resurrect row_count_validation_status as a second source of truth - because it is unset dead plumbing - drive the console off validation_passed / status instead."
+- "DO NOT gate only write_primitives - because transaction_primitives shares the identical hardcoded success=True (benchmark.py:809-816)
+  - fix both."
+- "DO NOT resurrect row_count_validation_status as a second source of truth - because it is unset dead plumbing - drive the
+  console off validation_passed / status instead."
 - "DO NOT change what counts as SKIPPED - because skip is not failure - only SUCCESS-with-failed-validation changes."
 
 verification:
 - description: "SCD2 unit + DuckDB integration still green (single-threaded to respect the shared test lock)."
-  command: "uv run -- python -m pytest tests/unit/benchmarks/test_write_primitives_core.py tests/integration/test_write_primitives_duckdb.py -k scd2 -n 0 -q"
+  command: "uv run -- python -m pytest tests/unit/benchmarks/test_write_primitives_core.py tests/integration/test_write_primitives_duckdb.py
+    -k scd2 -n 0 -q"
   expected_output: "all pass"
 - description: "New regression: a failing validation flips status away from SUCCESS/green."
   command: "uv run -- python -m pytest tests/integration/test_write_primitives_duckdb.py -n 0 -q -k validation_fail"

--- a/benchbox/core/primitives_benchmark_utils.py
+++ b/benchbox/core/primitives_benchmark_utils.py
@@ -9,6 +9,25 @@ from benchbox.core.connection import DatabaseConnection
 from benchbox.core.tpch.schema import get_create_all_tables_sql as get_tpch_ddl, get_table as get_tpch_table
 
 
+def summarize_validation_failures(validation_results: list[dict[str, Any]]) -> str:
+    """Build a one-line summary of failed (non-skipped) validation queries.
+
+    Shared by both primitives benchmarks as the ``error`` message for a
+    ``VALIDATION_FAILED`` OperationResult, so the console and result payload name
+    which post-conditions the write violated, e.g.
+    "validation failed: at_most_one_current_per_business_key (40 rows)".
+    A result without a ``skipped`` key is treated as not skipped.
+    """
+    parts = []
+    for vr in validation_results:
+        if vr.get("skipped") or vr.get("passed", True):
+            continue
+        parts.append(f"{vr.get('query_id', '?')} ({vr.get('actual_rows', '?')} rows)")
+    if not parts:
+        return "validation failed"
+    return "validation failed: " + ", ".join(parts)
+
+
 def quote_identifier(identifier: str) -> str:
     """Quote a SQL identifier after validating it is safe."""
     if not re.match(r"^[a-zA-Z_][a-zA-Z0-9_]*$", identifier):

--- a/benchbox/core/transaction_primitives/benchmark.py
+++ b/benchbox/core/transaction_primitives/benchmark.py
@@ -21,6 +21,7 @@ from benchbox.core.connection import DatabaseConnection
 from benchbox.core.primitives_benchmark_utils import (
     build_tpch_staging_tables_sql,
     quote_identifier,
+    summarize_validation_failures,
     table_exists,
 )
 from benchbox.core.transaction_primitives.generator import TransactionPrimitivesDataGenerator
@@ -806,9 +807,13 @@ class TransactionPrimitivesBenchmark(TransactionalBenchmarkBase["OperationResult
 
             cleanup_duration_ms = (time.perf_counter() - cleanup_start) * 1000
 
+            # A failed post-condition validation means the operation did not do
+            # what it claims even though the write SQL did not raise. Report it as
+            # VALIDATION_FAILED (distinct from an execution FAILED), mirroring
+            # write_primitives, so it cannot render as a passing operation.
             return OperationResult(
                 operation_id=operation_id,
-                success=True,
+                success=validation_passed,
                 write_duration_ms=write_duration_ms,
                 rows_affected=rows_affected,
                 validation_duration_ms=validation_duration_ms,
@@ -816,6 +821,11 @@ class TransactionPrimitivesBenchmark(TransactionalBenchmarkBase["OperationResult
                 validation_results=validation_results,
                 cleanup_duration_ms=cleanup_duration_ms,
                 cleanup_success=cleanup_success,
+                # Preserve this benchmark's "status None on normal success"
+                # idiom (derived to SUCCESS downstream); only stamp an explicit
+                # status when a post-condition validation fails.
+                status=None if validation_passed else "VALIDATION_FAILED",
+                error=None if validation_passed else summarize_validation_failures(validation_results),
                 cleanup_warning=cleanup_warning,
                 executed_sql=write_sql,
             )

--- a/benchbox/core/write_primitives/benchmark.py
+++ b/benchbox/core/write_primitives/benchmark.py
@@ -25,6 +25,7 @@ from benchbox.core.connection import DatabaseConnection
 from benchbox.core.primitives_benchmark_utils import (
     build_tpch_staging_tables_sql,
     quote_identifier,
+    summarize_validation_failures,
     table_exists,
 )
 from benchbox.core.transactional.benchmark_base import TransactionalBenchmarkBase
@@ -1208,9 +1209,13 @@ class WritePrimitivesBenchmark(TransactionalBenchmarkBase["OperationResult"]):
                 operation, connection, operation_id
             )
 
+            # The write SQL executed without raising, but a failed post-condition
+            # validation means the operation did not do what it claims. Report it
+            # as VALIDATION_FAILED (distinct from an execution FAILED) rather than
+            # SUCCESS, so a corrupting or no-op operation cannot render green.
             return OperationResult(
                 operation_id=operation_id,
-                success=True,
+                success=validation_passed,
                 write_duration_ms=write_duration_ms,
                 rows_affected=rows_affected,
                 validation_duration_ms=validation_duration_ms,
@@ -1218,7 +1223,8 @@ class WritePrimitivesBenchmark(TransactionalBenchmarkBase["OperationResult"]):
                 validation_results=validation_results,
                 cleanup_duration_ms=cleanup_duration_ms,
                 cleanup_success=cleanup_success,
-                status="SUCCESS",
+                status="SUCCESS" if validation_passed else "VALIDATION_FAILED",
+                error=None if validation_passed else summarize_validation_failures(validation_results),
                 cleanup_warning=cleanup_warning,
                 executed_sql=write_sql,
             )

--- a/benchbox/platforms/base/execution.py
+++ b/benchbox/platforms/base/execution.py
@@ -1107,6 +1107,12 @@ class TestDriversMixin:
             error_msg = result.get("error", "Unknown error")
             error_preview = error_msg[:80] + "..." if len(error_msg) > 80 else error_msg
             console.print(f"[red]❌ Query {index}/{total}: {query_id} FAILED - {error_preview}[/red]")
+        elif status == "VALIDATION_FAILED" or result.get("validation_passed") is False:
+            # The operation's write ran but a post-condition validation failed:
+            # surface it as a failure, never a green line.
+            error_msg = result.get("error") or "post-condition validation failed"
+            error_preview = error_msg[:80] + "..." if len(error_msg) > 80 else error_msg
+            console.print(f"[red]❌ Query {index}/{total}: {query_id} VALIDATION FAILED - {error_preview}[/red]")
         elif status == "SKIPPED":
             skip_reason = result.get("skip_reason") or result.get("error") or "Operation not supported on this platform"
             reason_preview = skip_reason[:80] + "..." if len(skip_reason) > 80 else skip_reason
@@ -1137,9 +1143,19 @@ class TestDriversMixin:
             console.print(f"[yellow]Benchmark cancelled. Processed {len(results)}/{total_queries} queries.[/yellow]")
             return
 
-        successful = len([r for r in results if r.get("status") == "SUCCESS"])
+        successful = len(
+            [r for r in results if r.get("status") == "SUCCESS" and r.get("validation_passed") is not False]
+        )
         skipped = len([r for r in results if r.get("status") == "SKIPPED"])
-        failed = len([r for r in results if r.get("status") == "FAILED"])
+        # A VALIDATION_FAILED operation (write ran, post-condition failed) counts
+        # as a failure, not a pass, alongside execution FAILED.
+        failed = len(
+            [
+                r
+                for r in results
+                if r.get("status") in ("FAILED", "VALIDATION_FAILED") or r.get("validation_passed") is False
+            ]
+        )
         if failed > 0:
             console.print(
                 f"[yellow]Completed {total_queries} queries: {successful} passed, {skipped} skipped, {failed} failed.[/yellow]"

--- a/tests/integration/test_write_primitives_duckdb.py
+++ b/tests/integration/test_write_primitives_duckdb.py
@@ -1127,6 +1127,28 @@ class TestWritePrimitivesSCD2DuckDB:
         conn.execute(op.cleanup_sql)
         assert self._current_state(conn) == (50, 50, 0)
 
+    def test_failing_validation_reports_validation_failed_not_success(self, scd2_env):
+        """A post-condition validation failure must not report SUCCESS/green.
+
+        Inject a second current version for an existing business key so the
+        at_most_one_current_per_business_key invariant fails independently of the
+        operation. new_keys_only's cleanup only removes new-key rows, so the
+        planted duplicate survives and the failure is observed at the op level.
+        This guards the N1 regression: validation_passed was computed but never
+        gated success/status.
+        """
+        write_bench, conn = scd2_env
+        # Duplicate current row for existing key 1 (unique surrogate key).
+        conn.execute(
+            "INSERT INTO scd2_ops_dim_customer VALUES "
+            "(999999, 1, 'DUP', 'DUP', 0, 'DUP', 'DUP', true, DATE '1990-01-01', DATE '9999-12-31')"
+        )
+        result = write_bench.execute_operation("merge_scd_type2_new_keys_only", conn)
+        assert result.validation_passed is False
+        assert result.success is False
+        assert result.status == "VALIDATION_FAILED"
+        assert result.error and "at_most_one_current_per_business_key" in result.error
+
 
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])


### PR DESCRIPTION
Audit finding N1: an operation whose post-condition validation FAILED still
reported success. OperationResult was built with a hardcoded success=True /
status="SUCCESS" regardless of validation_passed, and the adapter copied
validation_passed into the result dict but nothing read it: the console keyed
off an unset row_count_validation_status (green line) and the summary counted
only status FAILED. A corrupting or no-op op rendered green. The identical shape
existed in transaction_primitives.

- Both benchmarks now derive success/status from validation_passed: a write that
  runs but fails a post-condition returns status="VALIDATION_FAILED" (distinct
  from an execution FAILED), success=False, and an error naming the failed
  checks. write_primitives keeps its explicit "SUCCESS"; transaction_primitives
  preserves its "status None on normal success" idiom and only stamps a status
  on failure.
- execution.py surfaces VALIDATION_FAILED as a red line and counts it as a
  failure; a validation-failed row is excluded from the passed count so the
  buckets partition cleanly.
- summarize_validation_failures added to the shared primitives_benchmark_utils
  (the DRY home both benchmarks already import) rather than duplicated.
- Regression test: an op with a planted invariant violation reports
  VALIDATION_FAILED, not SUCCESS.

Blast radius w0: on DuckDB SF0.01, 56/56 write_primitives ops pass validation on
the happy path, so no currently-passing op flips; two transaction_primitives
tests asserting the "status None on success" contract stay green because the
success path is unchanged.

Scope note: primitives_benchmark_utils.py was added beyond the TODO's original
scope_limit as the correct shared home for the helper (avoids sibling coupling).

TODO: scd2-audit-followup/write-primitives-validation-result-gating

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
