### PR TITLE
fix(write-primitives): evaluate skip checks before the sql_override short-circuit

### DIFF
--- a/_project/DONE/scd2-audit-followup/write-primitives-sql-override-skip-order.yaml
+++ b/_project/DONE/scd2-audit-followup/write-primitives-sql-override-skip-order.yaml
@@ -2,7 +2,8 @@ id: "write-primitives-sql-override-skip-order"
 title: "Apply write-primitives skip checks before sql_override short-circuit"
 worktree: "scd2-audit-followup"
 priority: "Medium"
-status: "Not Started"
+status: "Completed"
+completed_date: "2026-07-11"
 category: "Core Functionality"
 description: |
   SCD2 adversarial audit finding N8 (live defect, broader than SCD2).
@@ -31,15 +32,17 @@ impact:
   user_impact: "DataFusion (and any platform with a preprocess hook) no longer runs ops the catalog marks unsupported."
   technical_debt: "Removes an ordering hazard where adapter preprocessing outranks the entire skip policy."
 prior_art:
-- "benchbox/core/write_primitives/benchmark.py:372-442 _get_effective_write_sql - the ordering to fix (:398-399 early return vs :408-440 skip checks)"
+- "benchbox/core/write_primitives/benchmark.py:372-442 _get_effective_write_sql - the ordering to fix (:398-399 early return
+  vs :408-440 skip checks)"
 - "benchbox/platforms/datafusion.py:170-179 preprocess_operation_sql (returns rewritten SQL for every bulk_load op)"
 - "benchbox/platforms/base/execution.py:1048-1055 where preprocessed SQL becomes sql_override"
-- "benchbox/core/write_primitives/catalog/operations.yaml bulk_load_upsert_mode platform_overrides {datafusion: null, starrocks: null} - the override being bypassed"
+- "benchbox/core/write_primitives/catalog/operations.yaml bulk_load_upsert_mode platform_overrides {datafusion: null, starrocks:
+  null} - the override being bypassed"
 
 work:
 - id: w1
   summary: "Reorder _get_effective_write_sql so all skip checks run before the sql_override short-circuit."
-  status: pending
+  status: done
   notes: |
     Affected checks that currently sit AFTER the :398-399 early return:
     aggregate-state, Postgres skips, DuckDB token gate, platform_overrides null,
@@ -48,16 +51,19 @@ work:
     first and apply the override only if the op is not skipped. Keep
     adapter-preprocessing priority for the SQL body once the op is runnable.
 - id: w2
-  summary: "Regression test: bulk_load_upsert_mode (datafusion:null) is SKIPPED on datafusion even though preprocess_operation_sql returns rewritten SQL."
+  summary: "Regression test: bulk_load_upsert_mode (datafusion:null) is SKIPPED on datafusion even though preprocess_operation_sql
+    returns rewritten SQL."
   needs: [w1]
-  status: pending
+  status: done
 - id: w3
-  summary: "Document that the SCD2 datafusion:null overrides are honored only because category='merge' yields no preprocess override; note the ordering now enforces it structurally."
+  summary: "Document that the SCD2 datafusion:null overrides are honored only because category='merge' yields no preprocess
+    override; note the ordering now enforces it structurally."
   needs: [w1]
-  status: pending
+  status: done
 
 must_preserve:
-- "Legitimate adapter preprocessing (e.g. DataFusion bulk_load COPY -> CREATE EXTERNAL TABLE rewrite) still applies for ops that are NOT skipped."
+- "Legitimate adapter preprocessing (e.g. DataFusion bulk_load COPY -> CREATE EXTERNAL TABLE rewrite) still applies for ops
+  that are NOT skipped."
 - "The staging-population guard, bulk-load file check, and Postgres/DuckDB skips still fire for their ops."
 - "SCD2 ops on DuckDB/Postgres remain runnable and unaffected (they set no sql_override)."
 
@@ -69,8 +75,10 @@ approach: |
   no call-site changes needed.
 
 anti_patterns:
-- "DO NOT drop adapter preprocessing - because DataFusion bulk_load genuinely needs the CREATE EXTERNAL TABLE rewrite - only make skip checks outrank it."
-- "DO NOT special-case bulk_load_upsert_mode - because the ordering bug is general (any preprocess hook + any null override) - fix the ordering."
+- "DO NOT drop adapter preprocessing - because DataFusion bulk_load genuinely needs the CREATE EXTERNAL TABLE rewrite - only
+  make skip checks outrank it."
+- "DO NOT special-case bulk_load_upsert_mode - because the ordering bug is general (any preprocess hook + any null override)
+  - fix the ordering."
 
 verification:
 - description: "Write-primitives unit + DuckDB integration green."
@@ -89,7 +97,8 @@ scope_limit:
   - "benchbox/core/write_primitives/catalog/operations.yaml"
 
 success_metrics:
-- "An operation with platform_overrides {<platform>: null} is skipped on that platform even when a preprocess hook returns rewritten SQL."
+- "An operation with platform_overrides {<platform>: null} is skipped on that platform even when a preprocess hook returns
+  rewritten SQL."
 - "Adapter preprocessing still applies to runnable ops."
 - "SCD2 datafusion:null enforcement is now structural, not category-accidental."
 

--- a/benchbox/core/write_primitives/benchmark.py
+++ b/benchbox/core/write_primitives/benchmark.py
@@ -394,10 +394,14 @@ class WritePrimitivesBenchmark(TransactionalBenchmarkBase["OperationResult"]):
             Tuple of (effective_sql, skip_reason). If skip_reason is not None,
             the operation should be skipped.
         """
-        # Adapter-preprocessed SQL takes priority
-        if sql_override is not None:
-            return sql_override, None
-
+        # Skip decisions depend on (operation, platform_key), NOT on the SQL body,
+        # so they run BEFORE any adapter ``sql_override`` is honored. An override
+        # is a dialect rewrite of the operation body (e.g. a bulk_load COPY ->
+        # CREATE EXTERNAL TABLE rewrite), not a signal that the operation is
+        # supported. Evaluating it first would let an operation marked unsupported
+        # (``platform_overrides {platform: null}``) still execute on that platform
+        # whenever the adapter also returns a preprocessed body - the override
+        # side-channel bypass (audit finding N8).
         if getattr(operation, "aggregate_state", None) is not None:
             platform_label = platform_key or "SQL"
             return None, (
@@ -423,20 +427,33 @@ class WritePrimitivesBenchmark(TransactionalBenchmarkBase["OperationResult"]):
             if duckdb_skip_reason is not None:
                 return None, (f"Operation '{operation.id}' is skipped on DuckDB: {duckdb_skip_reason}")
 
-        effective_sql = operation.write_sql
-
+        # A ``null`` platform override is an unsupported-on-this-platform skip; a
+        # string override is a per-platform SQL body used only when the adapter
+        # did not supply its own ``sql_override`` below.
+        platform_override_sql: str | None = None
         if platform_key and operation.platform_overrides and platform_key in operation.platform_overrides:
             override = operation.platform_overrides[platform_key]
             if override is None:
                 return None, f"Operation '{operation.id}' is unsupported on platform '{platform_key}'."
-            effective_sql = override
+            platform_override_sql = override
 
         if (missing_file := self._check_bulk_load_file_dependencies(operation)) is not None:
             return None, (
                 f"Operation '{operation.id}' is skipped because required bulk-load files are missing: {missing_file}"
             )
 
-        if (empty_reason := self._check_staging_table_population(effective_sql, connection)) is not None:
+        # Body precedence once the operation is confirmed runnable: adapter
+        # ``sql_override`` (preprocessed) wins, then a platform override, then the
+        # catalog default. The staging-population guard uses the catalog default,
+        # which names the logical staging tables regardless of any dialect rewrite.
+        if sql_override is not None:
+            effective_sql = sql_override
+        elif platform_override_sql is not None:
+            effective_sql = platform_override_sql
+        else:
+            effective_sql = operation.write_sql
+
+        if (empty_reason := self._check_staging_table_population(operation.write_sql, connection)) is not None:
             return None, f"Operation '{operation.id}' is skipped because {empty_reason}"
 
         return effective_sql, None

--- a/tests/unit/core/write_primitives/test_benchmark_operations.py
+++ b/tests/unit/core/write_primitives/test_benchmark_operations.py
@@ -218,3 +218,43 @@ class TestOperationManagement:
 
     def test_get_data_source_benchmark_returns_tpch(self, wp: WritePrimitivesBenchmark):
         assert wp.get_data_source_benchmark() == "tpch"
+
+
+# ---------------------------------------------------------------------------
+# _get_effective_write_sql skip-order (audit finding N8)
+# ---------------------------------------------------------------------------
+class TestEffectiveWriteSqlSkipOrder:
+    """Skip decisions must precede the adapter sql_override short-circuit."""
+
+    def test_null_override_skips_even_with_sql_override(self, wp: WritePrimitivesBenchmark):
+        """An op marked unsupported on a platform is skipped even when the adapter
+        returns preprocessed SQL for it (the override side-channel bypass)."""
+        op = wp.get_operation("bulk_load_upsert_mode")
+        assert op.platform_overrides.get("datafusion", "MISSING") is None
+        effective_sql, skip_reason = wp._get_effective_write_sql(
+            op,
+            platform_key="datafusion",
+            sql_override="CREATE EXTERNAL TABLE rewritten AS SELECT 1",
+        )
+        assert effective_sql is None
+        assert skip_reason is not None
+        assert "unsupported on platform 'datafusion'" in skip_reason
+
+    def test_sql_override_wins_when_op_is_runnable(self, wp: WritePrimitivesBenchmark):
+        """When the op is NOT skipped, adapter preprocessing still takes effect."""
+        # An op with no file dependencies and no override for this platform is
+        # runnable, so the supplied sql_override becomes the effective body.
+        op = wp.get_operation("merge_scd_type2_basic")
+        assert not getattr(op, "file_dependencies", None)
+        assert "spark" not in (op.platform_overrides or {})
+        rewritten = "UPDATE rewritten SET a = 1"
+        effective_sql, skip_reason = wp._get_effective_write_sql(op, platform_key="spark", sql_override=rewritten)
+        assert skip_reason is None
+        assert effective_sql == rewritten
+
+    def test_scd2_null_override_skips_on_datafusion(self, wp: WritePrimitivesBenchmark):
+        """SCD2 ops (category merge, no preprocess override) still skip on datafusion."""
+        op = wp.get_operation("merge_scd_type2_basic")
+        effective_sql, skip_reason = wp._get_effective_write_sql(op, platform_key="datafusion")
+        assert effective_sql is None
+        assert skip_reason is not None and "unsupported on platform 'datafusion'" in skip_reason


### PR DESCRIPTION
Audit finding N8: _get_effective_write_sql returned an adapter sql_override
before running any skip check, so an operation marked unsupported on a platform
(platform_overrides {platform: null}) still executed there whenever the adapter
also returned a preprocessed body. bulk_load_upsert_mode carries
{datafusion: null} yet DataFusionAdapter.preprocess_operation_sql rewrites every
bulk_load op, so it ran on DataFusion via the override side-channel.

- All skip decisions (aggregate-state, Postgres, DuckDB token gate,
  platform-override null, bulk-load file dependencies) now run before the body
  is resolved. Body precedence once the op is confirmed runnable: sql_override
  (preprocessed) wins, then a string platform override, then the catalog default.
- The staging-population guard keys on operation.write_sql (the canonical body
  naming the logical staging tables), independent of any dialect rewrite.
- Intended consequence: the bulk-load file-dependency check now also covers
  sql_override cases. In a real run the files exist so nothing over-skips; when
  files are absent the op now skips cleanly instead of running a rewrite that
  would fail.
- The SCD2 datafusion:null overrides were previously honored only by accident of
  category (merge -> no preprocess override); the reorder makes the skip
  structural. Covered by new tests.

TODO: scd2-audit-followup/write-primitives-sql-override-skip-order

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
