### PR TITLE
docs(scd2): fix residual ClickHouse overclaim and README count contradictions

### DIFF
--- a/_blog/platform-deep-dives/outlines/apply-changes-into-vs-standard-sql.md
+++ b/_blog/platform-deep-dives/outlines/apply-changes-into-vs-standard-sql.md
@@ -54,9 +54,11 @@ em-dashes or en-dashes, define terms, footnote external facts.
   invocable from a SQL warehouse via standalone streaming tables, but always on
   Databricks/serverless pipelines, never on other engines, and not a standalone
   statement (A3, with the 2026 correction, stated carefully).
-- The portable form runs unchanged across DuckDB, PostgreSQL, Snowflake, BigQuery,
-  ClickHouse. Concrete proof: DuckDB rejects MERGE INTO entirely, yet runs the
-  portable UPDATE+INSERT SCD2 op (C1).
+- The portable form runs unchanged on standard-DML engines: DuckDB, PostgreSQL,
+  Snowflake, BigQuery. ClickHouse is the exception (no standard UPDATE; only the
+  insert-only op is portable there, the close-old step needs a mutation rewrite),
+  and DataFusion is marked unsupported in the catalog. Concrete proof: DuckDB
+  rejects MERGE INTO entirely, yet runs the portable UPDATE+INSERT SCD2 op (C1).
 
 ## 5. What we measured (results, BenchBox, portable form only)
 - Methodology: DuckDB 1.3.2, Apple M4, real TPC-H via dbgen, operation API (explain

--- a/_project/DONE/scd2-audit-followup/scd2-docs-and-count-hygiene-followup.yaml
+++ b/_project/DONE/scd2-audit-followup/scd2-docs-and-count-hygiene-followup.yaml
@@ -2,7 +2,8 @@ id: "scd2-docs-and-count-hygiene-followup"
 title: "Fix residual SCD2 doc overclaim, README count contradictions, and op-vs-setup portability note"
 worktree: "scd2-audit-followup"
 priority: "Low"
-status: "Not Started"
+status: "Completed"
+completed_date: "2026-07-11"
 category: "Documentation"
 description: |
   SCD2 adversarial audit findings N9, N10, N12 - tracked-file doc defects the
@@ -39,36 +40,46 @@ description: |
   built HTML; tracked files only. House rule: no em-dash/en-dash in _blog/
   content (currently 0; keep it 0).
 impact:
-  business_value: "Removes the last surviving pre-#1061 ClickHouse overclaim and the self-contradicting README counts, keeping the published honesty story consistent."
+  business_value: "Removes the last surviving pre-#1061 ClickHouse overclaim and the self-contradicting README counts, keeping
+    the published honesty story consistent."
   user_impact: "Readers of the outline/README no longer see contradictory portability and count claims."
-  technical_debt: "Closes the incomplete edges of two prior Completed remediations (#1057/#1061 outline miss, #923 README counts)."
+  technical_debt: "Closes the incomplete edges of two prior Completed remediations (#1057/#1061 outline miss, #923 README
+    counts)."
 prior_art:
-- "_blog/platform-deep-dives/drafts/apply-changes-into-vs-standard-sql.md:104-117,169-170 - the corrected wording to mirror into the outline"
+- "_blog/platform-deep-dives/drafts/apply-changes-into-vs-standard-sql.md:104-117,169-170 - the corrected wording to mirror
+  into the outline"
 - "docs/benchmarks/write-primitives.md:129-136 SCD2 paragraph - add the op-vs-setup distinction from draft:112-117"
-- "benchbox/core/write_primitives/README.md:27-28 correct totals (136 = 112 user-facing + 24 sketch) - reconcile :59 and :112 against these"
-- "_project/DONE/write-primitives-scd2-followup/scd2-portability-claim-accuracy.yaml - the Completed TODO that missed the outline"
+- "benchbox/core/write_primitives/README.md:27-28 correct totals (136 = 112 user-facing + 24 sketch) - reconcile :59 and :112
+  against these"
+- "_project/DONE/write-primitives-scd2-followup/scd2-portability-claim-accuracy.yaml - the Completed TODO that missed the
+  outline"
 
 work:
 - id: w1
-  summary: "N9: rescope outline:57-58 to standard-DML engines with the ClickHouse mutation-rewrite caveat, matching the draft and docs."
-  status: pending
+  summary: "N9: rescope outline:57-58 to standard-DML engines with the ClickHouse mutation-rewrite caveat, matching the draft
+    and docs."
+  status: done
 - id: w2
-  summary: "N10: fix README:59 'DELETE (12)' -> 14 and remove/annotate the stale TRANSACTION (8) section at :112. Do NOT change the 112 figure."
-  status: pending
+  summary: "N10: fix README:59 'DELETE (12)' -> 14 and remove/annotate the stale TRANSACTION (8) section at :112. Do NOT change
+    the 112 figure."
+  status: done
   notes: |
     Confirm the section sum reconciles to 136 raw / 112 user-facing after the
     edit. The 24 sketch ops are user-hidden; docs' 112 is correct.
 - id: w3
-  summary: "Add the operation-vs-setup SQL portability distinction to docs/benchmarks/write-primitives.md:132-136 (setup population SQL's ||/CAST floor)."
-  status: pending
+  summary: "Add the operation-vs-setup SQL portability distinction to docs/benchmarks/write-primitives.md:132-136 (setup population
+    SQL's ||/CAST floor)."
+  status: done
 - id: w4
-  summary: "Re-grep: 0 em/en-dashes in _blog/ SCD2 files; no remaining 'runs unchanged ... ClickHouse' overclaim in any tracked file."
+  summary: "Re-grep: 0 em/en-dashes in _blog/ SCD2 files; no remaining 'runs unchanged ... ClickHouse' overclaim in any tracked
+    file."
   needs: [w1, w2, w3]
-  status: pending
+  status: done
 
 deferred:
 - summary: "N12: add the SF1 basic row to the blog scale discussion (draft table) for balance."
-  reason: "The blog draft is owned by scd2-basic-idempotency-and-cleanup-scoping, which re-measures and may rewrite that table. Editing the draft here would collide. Fold the SF1 row into that TODO's w4 re-measurement instead."
+  reason: "The blog draft is owned by scd2-basic-idempotency-and-cleanup-scoping, which re-measures and may rewrite that table.
+    Editing the draft here would collide. Fold the SF1 row into that TODO's w4 re-measurement instead."
 
 must_preserve:
 - "The '112 operations' figure in docs and README stays (it is correct for user-facing ops)."
@@ -84,7 +95,8 @@ approach: |
   edit with the idempotency TODO if that one re-measured the tables.
 
 anti_patterns:
-- "DO NOT 'correct' 112 to 136 - because 112 is the user-facing count (24 sketch ops are hidden) and is right - only fix the self-contradicting per-category numbers."
+- "DO NOT 'correct' 112 to 136 - because 112 is the user-facing count (24 sketch ops are hidden) and is right - only fix the
+  self-contradicting per-category numbers."
 - "DO NOT edit docs/_build/ - because it is untracked build output - tracked sources only."
 - "DO NOT introduce em/en-dashes into _blog/ - because the house rule forbids them - use hyphens/rewordings."
 

--- a/benchbox/core/write_primitives/README.md
+++ b/benchbox/core/write_primitives/README.md
@@ -56,7 +56,7 @@ Tests selective and bulk updates with various predicates:
 - Conditional updates
 - UPDATE...RETURNING
 
-### 3. DELETE Operations (12 operations)
+### 3. DELETE Operations (14 operations)
 
 Tests deletion patterns from single row to bulk deletes:
 - Single row by primary key
@@ -66,6 +66,7 @@ Tests deletion patterns from single row to bulk deletes:
 - DELETE...RETURNING
 - Cascade simulation
 - DELETE vs TRUNCATE comparison
+- GDPR deletion by supplier list (1%, 5%)
 
 ### 4. BULK_LOAD Operations (36 operations)
 
@@ -109,15 +110,7 @@ Tests schema evolution and table management:
 - DROP TABLE
 - TRUNCATE TABLE (small, large datasets)
 
-### 7. TRANSACTION Operations (8 operations)
-
-Tests transaction control and isolation levels:
-- COMMIT (small/10 writes, medium/100 writes, large/1000 writes)
-- ROLLBACK (small/3 writes, medium/100 writes)
-- Nested SAVEPOINTs with partial rollback
-- Isolation levels (READ COMMITTED, SERIALIZABLE)
-
-### Sketch persistence operations (24 operations)
+### 7. SKETCH Operations (24 operations)
 
 Tests the **persist + merge + requery** lifecycle for Apache DataSketches
 sketch artifacts — the differentiated half of the modern approximate-

--- a/docs/benchmarks/write-primitives.md
+++ b/docs/benchmarks/write-primitives.md
@@ -133,7 +133,11 @@ The benchmark includes **112 write operations** across 6 categories:
   (no `APPLY CHANGES INTO` / declarative-pipeline syntax, so it runs unchanged on
   standard-DML engines). The catalog marks only DataFusion unsupported; ClickHouse
   has no standard UPDATE, so only the insert-only op is portable there and the
-  close-old ops would need a mutation rewrite (they are not auto-skipped today)
+  close-old ops would need a mutation rewrite (they are not auto-skipped today).
+  The standard-DML scoping covers the harness setup too, not just the operation
+  SQL: the dimension/stage population uses `||` concatenation and
+  `CAST(... AS VARCHAR)` to build the change-detection fingerprint, so an engine
+  where `||` is not string concatenation would need the setup rewritten as well
 
 **Purpose**: Test UPSERT/MERGE operations for CDC, ETL, slowly-changing
 dimension maintenance, and incremental data loading scenarios.


### PR DESCRIPTION
Audit findings N9/N10, closing the incomplete edges of #1057/#1061 and #923.

- N9: the blog OUTLINE still claimed the portable SCD2 form "runs unchanged
  across DuckDB, PostgreSQL, Snowflake, BigQuery, ClickHouse" - the pre-#1061
  overclaim the corrected draft and docs had already dropped. Rescoped to
  standard-DML engines with the ClickHouse mutation-rewrite exception and the
  DataFusion-unsupported note, matching the draft.
- N10: README self-contradicted on counts. DELETE said 12 (its own category
  table and the catalog say 14); added the GDPR-delete bullet. Removed the stale
  "TRANSACTION Operations (8)" section (those ops moved to transaction_primitives,
  as the Benchmark Statistics line already notes) and renumbered Sketch to the
  7th category. Sections now sum to 136 (12+15+14+36+23+12+24). The user-facing
  112 figure is correct and untouched.
- Added the operation-vs-setup portability distinction to
  docs/benchmarks/write-primitives.md: the standard-DML scoping covers the
  harness population SQL (|| / CAST(... AS VARCHAR)), not just the operation SQL.

The blog draft is owned by scd2-basic-idempotency-and-cleanup-scoping and is not
touched here. No em/en-dashes in blog content.

TODO: scd2-audit-followup/scd2-docs-and-count-hygiene-followup

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
