### PR TITLE
chore(todo): add 4 second-pass follow-up TODO items from 2026-06-08 audit

### DIFF
--- a/_project/TODO/main/planning/todo-dep-graph-unblocking-sweep.yaml
+++ b/_project/TODO/main/planning/todo-dep-graph-unblocking-sweep.yaml
@@ -1,0 +1,81 @@
+id: todo-dep-graph-unblocking-sweep
+title: "Sweep TODO dep graph after each release batch to surface items whose blockers are now in DONE"
+worktree: main
+priority: Medium-High
+status: Not Started
+category: Process and Workflow
+
+description: |
+  After PR #759 moved `benchmark-runs-output-root-propagation` and
+  `benchmark-runs-local-artifact-guardrails` to DONE, the item
+  `benchmark-runs-duplicate-artifact-cleanup` (Medium-High) still has
+  `status: Not Started` with `deps.needs` pointing to both of those now-done
+  items. It is fully unblocked but nothing flagged it as ready to work.
+
+  This is a systemic gap: the TODO system has no automated step that detects
+  when a `deps.needs` item transitions to DONE and re-evaluates the downstream
+  item's readiness. The result is hidden unblocked work sitting in the backlog
+  looking like it's blocked.
+
+  Two deliverables:
+  1. An immediate fix — manually update `benchmark-runs-duplicate-artifact-cleanup`
+     to reflect its newly-unblocked state.
+  2. A process fix — `todo_cli.py` already has a `ready` command (line ~486).
+     Document its use in `_project/TODO/README.md` as a post-merge checklist
+     step so the command is discoverable and unblocking transitions are caught
+     automatically going forward.
+
+work:
+  - id: w1
+    summary: "Update benchmark-runs-duplicate-artifact-cleanup: change status to Not Started (unblocked)"
+    status: pending
+    notes: |
+      File: _project/TODO/main/planning/benchmark-runs-duplicate-artifact-cleanup.yaml
+      Verify deps are satisfied: both benchmark-runs-output-root-propagation and
+      benchmark-runs-local-artifact-guardrails are now in _project/DONE/.
+      Change status from the effective Blocked state to Not Started.
+      The item is now the first actionable step in its chain.
+
+  - id: w2
+    summary: "Document todo_cli.py ready in TODO/README.md as a post-merge checklist step"
+    status: pending
+    notes: |
+      The ready command already exists in todo_cli.py (~line 486). Add a
+      "Post-merge checklist" section (or extend the existing CLI Tool section)
+      in _project/TODO/README.md:
+        uv run _project/scripts/todo_cli.py ready
+        # Lists items whose deps.needs are all in the DONE tree — run after
+        # each batch of PRs to surface newly-unblocked work.
+
+prior_art:
+  - "_project/scripts/todo_cli.py:ready — check if command exists before adding"
+  - "_project/TODO/main/planning/benchmark-runs-duplicate-artifact-cleanup.yaml: immediate case to fix"
+
+must_preserve:
+  - "benchmark-runs-duplicate-artifact-cleanup.yaml deps.needs entries remain (they document history)"
+  - "Items that are genuinely still blocked (deps not yet in DONE) remain at Blocked status"
+
+verification:
+  - description: "benchmark-runs-duplicate-artifact-cleanup no longer appears in blocked list"
+    command: "uv run --project _project/scripts -- python _project/scripts/todo_cli.py list --status=Blocked"
+    expected_output: "benchmark-runs-duplicate-artifact-cleanup absent from output"
+  - description: "todo_cli.py ready runs and shows benchmark-runs-duplicate-artifact-cleanup as ready"
+    command: "uv run --project _project/scripts -- python _project/scripts/todo_cli.py ready"
+    expected_output: "benchmark-runs-duplicate-artifact-cleanup listed as ready to start"
+
+metadata:
+  created_date: "2026-06-08"
+  estimated_effort: "Small"
+  tags:
+    - process
+    - dep-graph
+    - todo-system
+    - housekeeping
+
+impact:
+  business_value: |
+    benchmark-runs-duplicate-artifact-cleanup (Medium-High) is currently the
+    only confirmed hidden-unblocked item, but the gap is systemic: every
+    completed dep silently unblocks downstream work that stays invisible
+    until someone manually traces the graph. A one-time sweep + recurring
+    check surfaces this class of work automatically.

--- a/_project/TODO/main/planning/todo-done-tree-location-convention.yaml
+++ b/_project/TODO/main/planning/todo-done-tree-location-convention.yaml
@@ -1,0 +1,90 @@
+id: todo-done-tree-location-convention
+title: "Document and enforce a consistent location convention for items moved to the DONE tree"
+worktree: main
+priority: Low
+status: Not Started
+category: Repository Maintenance
+
+description: |
+  `_project/DONE/README.md` documents the canonical placement convention:
+  `DONE/{worktree}/{lifecycle-phase}/{slug}.yaml`, preserving the `planning/`
+  or `active/` subdirectory from the source TODO tree.
+
+  At least one file violates this convention as of 2026-06-08:
+
+  - `DONE/main/benchmark-runs-output-root-propagation.yaml` — placed flat
+    under `DONE/main/` with no lifecycle subdirectory. Per the README it
+    should be `DONE/main/planning/benchmark-runs-output-root-propagation.yaml`.
+
+  `todo-sweep-completed-items-from-open-tree` needs the convention to be
+  consistently enforced before it can reliably move items. `todo_cli.py` may
+  also miscount items if some live outside the documented path structure.
+
+  Audit the DONE tree for all flat-placed items, normalize them to the
+  documented convention, and confirm `todo_cli.py` still resolves them
+  correctly after the move.
+
+work:
+  - id: w0
+    summary: "Audit DONE tree for all flat-placed items (not in planning/ or active/)"
+    status: pending
+    notes: |
+      Run: find _project/DONE -name "*.yaml" | grep -vE "/(planning|active|_indexes)/" | grep -v README
+      Known violator: DONE/main/benchmark-runs-output-root-propagation.yaml
+      Check all worktree subdirs for additional flat items.
+
+  - id: w1
+    summary: "Verify todo_cli.py path assumptions before moving files"
+    needs: [w0]
+    status: pending
+    notes: |
+      grep -n "DONE\|planning\|active" _project/scripts/todo_cli.py | head -20
+      Confirm the CLI uses the documented {worktree}/{phase}/ structure and
+      will find items after they are moved.
+
+  - id: w2
+    summary: "Move all flat-placed items to their correct {worktree}/{phase}/ location"
+    needs: [w1]
+    status: pending
+    notes: |
+      Known case:
+        git mv _project/DONE/main/benchmark-runs-output-root-propagation.yaml \
+               _project/DONE/main/planning/benchmark-runs-output-root-propagation.yaml
+      Use git mv so history is preserved. Repeat for any additional violators
+      found in w0.
+
+  - id: w3
+    summary: "Run validate_todo.py --all and todo_cli.py check-graph; regenerate indexes"
+    needs: [w2]
+    status: pending
+    notes: |
+      uv run --project _project/scripts -- python _project/scripts/validate_todo.py --all
+      uv run --project _project/scripts -- python _project/scripts/todo_cli.py check-graph
+      make todo-reindex
+
+prior_art:
+  - "_project/DONE/README.md: already documents the {worktree}/{phase}/{slug} convention"
+  - "_project/scripts/todo_cli.py: check path assumptions before moving any files"
+
+must_preserve:
+  - "Existing DONE items remain findable by todo_cli.py after any renaming"
+  - "Cross-item deps.needs references that point to DONE items remain resolvable"
+
+verification:
+  - description: "No flat-placed .yaml items remain directly under a worktree directory"
+    command: "find _project/DONE -name '*.yaml' | grep -vE '/(planning|active|_indexes)/' | grep -v README"
+    expected_output: "Empty (all items in planning/ or active/ subdirectories)"
+
+metadata:
+  created_date: "2026-06-08"
+  estimated_effort: "Small"
+  tags:
+    - housekeeping
+    - todo-system
+    - conventions
+
+impact:
+  technical_debt: |
+    Without a documented convention, every sweep or migration places items
+    inconsistently, making the DONE tree unreliable as a historical record
+    and potentially breaking CLI path resolution for completed items.

--- a/_project/TODO/main/planning/todo-priority-criteria-in-agents-md.yaml
+++ b/_project/TODO/main/planning/todo-priority-criteria-in-agents-md.yaml
@@ -1,0 +1,75 @@
+id: todo-priority-criteria-in-agents-md
+title: "Add priority-level criteria to AGENTS.md so automated agents can apply them consistently"
+worktree: main
+priority: Low
+status: Not Started
+category: Process and Workflow
+
+description: |
+  `todo-priority-criteria-definition` (filed in the 2026-06-08 batch) targets
+  `_project/TODO/README.md` and `TODO_ENTRY_TEMPLATE.yaml`. Those files are
+  read by humans authoring TODOs.
+
+  AGENTS.md (at the repo root) is the behavioral guidance file read by
+  automated agents at session start. Without priority criteria in AGENTS.md,
+  agents performing prioritization or triage cannot apply the agreed-upon
+  definitions — they fall back to implicit heuristics that differ from the
+  documented criteria.
+
+  Once `todo-priority-criteria-definition` is done and the criteria are in
+  README.md, add a concise cross-reference or summary section to AGENTS.md
+  so agents have the same definitions available.
+
+deps:
+  needs:
+    - todo-priority-criteria-definition
+
+work:
+  - id: w1
+    summary: "Read AGENTS.md to find the right insertion point"
+    status: pending
+    notes: |
+      Look for an existing section about TODO/backlog management, task
+      prioritization, or agent decision-making. The criteria should live
+      near any existing guidance about how agents should approach TODO items.
+
+  - id: w2
+    summary: "Add a Priority Definitions summary or cross-reference to AGENTS.md"
+    needs: [w1]
+    status: pending
+    notes: |
+      Options in order of preference:
+        1. Short inline table (5 rows, one per level) with the key
+           distinguishing question — avoids agents having to read README.md.
+        2. One-paragraph summary + pointer to _project/TODO/README.md.
+      Do not duplicate the full criteria verbatim; maintain a single source
+      of truth in TODO/README.md.
+
+prior_art:
+  - "AGENTS.md: root-level agent guidance file — extend, do not replace"
+  - "_project/TODO/README.md: source of truth for priority criteria (added by todo-priority-criteria-definition)"
+
+must_preserve:
+  - "AGENTS.md existing sections and their ordering remain intact"
+  - "Criteria in AGENTS.md stay in sync with TODO/README.md (one drives, the other references)"
+
+verification:
+  - description: "AGENTS.md contains a priority-level reference legible without reading README.md"
+    command: "grep -A 10 'Priority' AGENTS.md"
+    expected_output: "Criteria or pointer visible for Critical, High, Medium-High, Medium, Low"
+
+metadata:
+  created_date: "2026-06-08"
+  estimated_effort: "Small"
+  tags:
+    - agents
+    - documentation
+    - process
+    - todo-system
+
+impact:
+  technical_debt: |
+    Without priority criteria in AGENTS.md, automated prioritization passes
+    produce inconsistent results because each agent session starts from
+    different implicit assumptions. A single clear definition in the file
+    agents always read eliminates the divergence.

--- a/_project/TODO/main/planning/todo-schema-require-id-field.yaml
+++ b/_project/TODO/main/planning/todo-schema-require-id-field.yaml
@@ -1,0 +1,88 @@
+id: todo-schema-require-id-field
+title: "Add id to TODO_SCHEMA.yaml required fields so missing IDs are caught at validation time"
+worktree: main
+priority: Medium
+status: Not Started
+category: Developer Tooling
+
+description: |
+  The `id` field is the stable cross-reference key used in `deps.needs`,
+  `todo_cli.py show`, and index generation. It must match the filename slug
+  exactly. Yet `id` is NOT in the `required:` list in `TODO_SCHEMA.yaml` —
+  it is only defined under `properties:` with a regex pattern.
+
+  Consequence: `validate_todo.py` silently accepts a TODO file with no `id`
+  field. Any `deps.needs` reference to that item then silently fails at
+  dep-graph resolution time rather than at validation time, making the graph
+  check unreliable as a quality gate.
+
+  Add `id` to the `required:` list. This is a one-line schema change but
+  requires confirming all existing TODO/DONE files already carry the field
+  before the gate goes live.
+
+work:
+  - id: w0
+    summary: "Audit all TODO and DONE files for missing id field"
+    status: pending
+    notes: |
+      Run: uv run --project _project/scripts -- python _project/scripts/validate_todo.py --all
+      Then also: grep -rL "^id:" _project/TODO _project/DONE --include="*.yaml"
+      Expected: 0 files missing id (but must confirm before making id required).
+
+  - id: w1
+    summary: "Add id to required: list in TODO_SCHEMA.yaml"
+    needs: [w0]
+    status: pending
+    notes: |
+      In _project/TODO_SCHEMA.yaml, add "- id" to the required: list alongside
+      title, worktree, priority, status, description.
+      The id property definition and pattern already exist under properties: —
+      no changes needed there.
+
+  - id: w2
+    summary: "Run validate_todo.py --all and confirm 0 new failures"
+    needs: [w1]
+    status: pending
+    notes: |
+      uv run --project _project/scripts -- python _project/scripts/validate_todo.py --all
+      Any newly-failing file has a missing id and must be fixed before this
+      change lands.
+
+  - id: w3
+    summary: "Update TODO_ENTRY_TEMPLATE.yaml comment to note id is required"
+    needs: [w1]
+    status: pending
+    notes: |
+      The template already has id: "<filename-slug>" at the top. Add a comment
+      noting it is required and must match the filename without .yaml extension.
+
+prior_art:
+  - "_project/TODO_SCHEMA.yaml: required: list at line ~15 — add id here"
+  - "_project/TODO_ENTRY_TEMPLATE.yaml: id field already at top — add required annotation"
+  - "_project/scripts/validate_todo.py: --all flag to sweep all files"
+
+must_preserve:
+  - "All currently-valid TODO/DONE files must still pass validate_todo.py after the change"
+  - "The id pattern regex (^[a-z0-9][a-z0-9-]*[a-z0-9]$) is unchanged"
+
+verification:
+  - description: "validate_todo.py rejects a file with no id field"
+    command: "uv run --project _project/scripts -- python _project/scripts/validate_todo.py /tmp/test-no-id.yaml"
+    expected_output: "root: 'id' is a required property"
+  - description: "All existing files still pass after adding id to required"
+    command: "uv run --project _project/scripts -- python _project/scripts/validate_todo.py --all"
+    expected_output: "0 errors"
+
+metadata:
+  created_date: "2026-06-08"
+  estimated_effort: "Small"
+  tags:
+    - schema
+    - tooling
+    - todo-system
+
+impact:
+  technical_debt: |
+    Without id in required, the dep-graph check (todo_cli.py check-graph) can
+    reference items that have no queryable ID, making cross-item dependencies
+    silently unresolvable. One-line schema fix closes the gap permanently.


### PR DESCRIPTION
## Summary

Second iteration of the TODO system self-improvement loop — gaps found by reviewing the first batch (PR #761).

- **`todo-schema-require-id-field`** (Medium) — `id` is not in `TODO_SCHEMA.yaml`'s `required:` list. A file with no `id` field passes validation but silently breaks `deps.needs` resolution. Fix: add `id` to `required:` after a pre-flight `--all` audit confirms all existing files already carry it.

- **`todo-priority-criteria-in-agents-md`** (Low) — PR #761's `todo-priority-criteria-definition` targets only `_project/TODO/README.md`. `AGENTS.md` (root-level, read by automated agents at session start) is where priority criteria must also live. Depends on `todo-priority-criteria-definition`.

- **`todo-done-tree-location-convention`** (Low) — `_project/DONE/README.md` already documents the `{worktree}/{phase}/{slug}.yaml` convention, but `benchmark-runs-output-root-propagation.yaml` was placed flat at `DONE/main/` (no `planning/` subdirectory), violating it. Audit for all flat-placed items and normalize with `git mv`.

- **`todo-dep-graph-unblocking-sweep`** (Medium-High) — `benchmark-runs-duplicate-artifact-cleanup` (Medium-High) has both its `deps.needs` satisfied (`benchmark-runs-output-root-propagation` and `benchmark-runs-local-artifact-guardrails` both now in DONE via PR #759), but still shows as effectively blocked. Fix it immediately and document `todo_cli.py ready` in `TODO/README.md` as the recurring post-merge unblocking check.

## Test plan

- [x] All 4 files pass `validate_todo.py` schema validation
- [x] Pre-commit hooks passed (codespell, check-yaml, fix-eol, trim-whitespace)
- [x] Content-only change — Python fast tests not required
- [x] Review findings corrected: error message format in verification, DONE README premise, `ready` command altitude

https://claude.ai/code/session_013FzK1DZiUTQRgWWRgtbegX

---
_Generated by [Claude Code](https://claude.ai/code/session_013FzK1DZiUTQRgWWRgtbegX)_