### PR TITLE
chore(todo): tuning-system remediation plan (14 items) + review blind-spot captures

### DIFF
--- a/_project/TODO/main/planning/tuning-adr-baseline-definition-and-renderer-20260712.yaml
+++ b/_project/TODO/main/planning/tuning-adr-baseline-definition-and-renderer-20260712.yaml
@@ -1,0 +1,75 @@
+id: tuning-adr-baseline-definition-and-renderer-20260712
+title: "DECISION GATE: what 'notuning' promises, and the single tuning-DDL renderer (ADR-3)"
+worktree: main
+priority: High
+status: Not Started
+category: Architecture Decision
+
+description: |
+  Decision gate from the 2026-07-12 tuning-system deep review (evidence pinned to
+  commit acfb8992; findings C5, R2, R3).
+
+  1. BASELINE DEFINITION. "notuning" is not a baseline today: ClickHouse applies
+     its aggressive OLAP session pack (grace-hash join, spill thresholds,
+     aggregation-in-order) ONLY when tuning is disabled
+     (benchbox/platforms/clickhouse/tuning.py:74-100); StarRocks injects
+     DISTRIBUTED BY HASH(first_col) BUCKETS 8 into every table in every mode
+     (benchbox/platforms/starrocks/workload.py:214-221). Decide what baseline
+     promises: platform defaults + engine-mandatory choices only? Where does the
+     ClickHouse pack live (tuned path, recorded harness-defaults block, or
+     removed)? This also settles the warn-vs-fail axis in the blocked
+     databricks-liquid-clustering-tuning-review-20260526 TODO.
+  2. SINGLE RENDERER. Tuning DDL is rendered by two parallel universes:
+     core/tuning/generators/* (used only by dry-run preview and cloud_spark
+     mixins) and per-adapter mixins (the only path touching real databases; some
+     are log-only or dead code - ClickHouse generate_tuning_clause has zero
+     callers). Decide the survivor: adapters consume generators (recommended - the
+     only design dry-run, execution, and a capability registry can share), or
+     generators fold into mixins.
+
+work:
+  - id: w1
+    summary: "Draft ADR: baseline definition options + session-pack relocation options; renderer consolidation options with migration cost sketch per platform"
+    status: pending
+    needs: []
+  - id: w2
+    summary: "Joe decides; record decisions; annotate databricks-liquid TODO open_questions with the settled policy axis"
+    status: pending
+    needs: [w1]
+
+deferred:
+  - summary: "Renderer migration and baseline enforcement"
+    reason: "Owned by tuning-renderer-consolidation-and-baseline-policy-20260712"
+
+deps:
+  needs: []
+
+verification:
+  - description: "Decision record exists defining baseline semantics and naming the surviving renderer"
+    command: "ls docs/development/ | grep -i 'tuning'"
+    expected_output: "Committed decision record with baseline definition and renderer direction"
+
+prior_art:
+  - "docs/development/adapter-refactor-map.md: prior refactor-direction record for the platforms/base split — reuse format"
+  - "benchbox/core/tuning/ddl_generator.py get_ddl_generator: existing registry that would become the single entry point — extend"
+
+open_questions:
+  - question: "Does 'notuning' permit curated session-optimization packs?"
+    gating: true
+    affects: [w2]
+    default: "No - baseline = platform defaults + engine-mandatory schema choices; session packs move to the tuned path or an explicitly recorded harness-defaults block"
+  - question: "Which renderer survives?"
+    gating: true
+    affects: [w2]
+    default: "Generators become the single renderer; adapter mixins consume them"
+
+metadata:
+  owners:
+    - "joe"
+  tags:
+    - tuning
+    - decision-gate
+    - architecture
+  estimated_effort: Small
+  created_date: "2026-07-12"
+  source_review: "tuning-system deep review 2026-07-12 (claude/tuning-system-review-7mzapy)"

--- a/_project/TODO/main/planning/tuning-adr-mode-vocabulary-fallback-facets-20260712.yaml
+++ b/_project/TODO/main/planning/tuning-adr-mode-vocabulary-fallback-facets-20260712.yaml
@@ -1,0 +1,77 @@
+id: tuning-adr-mode-vocabulary-fallback-facets-20260712
+title: "DECISION GATE: tuning mode vocabulary, fallback labeling, and facet semantics (ADR-2)"
+worktree: main
+priority: High
+status: Not Started
+category: Architecture Decision
+
+description: |
+  Decision gate from the 2026-07-12 tuning-system deep review (evidence pinned to
+  commit acfb8992; findings C4-C6).
+
+  Decisions needed before mode/facet implementation work:
+
+  1. FALLBACK LABELING. `--tuning tuned` with no template silently runs a bare
+     default config still labeled "tuned" (benchbox/cli/tuning_resolver.py:295-307,
+     benchbox/cli/commands/run.py:1016-1022) and facet-matches curated-template
+     runs. Options: keep, introduce a distinct mode (e.g. tuned-fallback /
+     constraints), or refuse in non-interactive / --official runs.
+  2. MODE VOCABULARY PIN. Python emits tuned/notuning/auto/<raw path> plus
+     "balanced" (benchbox/cli/tuning.py:52,56); the explorer knows
+     tuned/notuning/auto and defaults missing to "untuned"
+     (results-explorer/src/lib/facetMatching.ts:99). Decide the canonical value
+     set, whether raw file paths are a legal mode value (they leak local paths into
+     bundles), and how absent-vs-baseline must be distinguished.
+  3. CROSS-PLATFORM "TUNED" FACET. Platform X tuned may render 6 physical
+     mechanisms while platform Y renders zero; the facet matches them. Decide
+     whether facet matching stays mode-string-based, incorporates
+     physical_rendering_id / mechanism counts, or adds a receipt-level warning.
+
+work:
+  - id: w1
+    summary: "Draft ADR with options and recommendations for fallback labeling, vocabulary pin, facet rule"
+    notes: "Recommendations from the review: distinct fallback mode + refuse under --official; pinned shared vocabulary artifact consumed by Python and TS; mode stays coarse facet with mechanism-set warning in receipt and physical_rendering_id promoted to matchable facet for TPC."
+    status: pending
+    needs: []
+  - id: w2
+    summary: "Joe decides; record decisions and the pinned vocabulary in a decision record referenced by both Python and TS test suites"
+    status: pending
+    needs: [w1]
+
+deferred:
+  - summary: "Implementation across resolver, schema, explorer"
+    reason: "Owned by tuning-mode-vocabulary-and-facet-implementation-20260712"
+
+deps:
+  needs: []
+
+verification:
+  - description: "Decision record exists with the canonical mode value set and fallback policy"
+    command: "ls docs/development/ | grep -i 'tuning'"
+    expected_output: "Committed decision record enumerating mode values, fallback labeling, and facet-matching rule"
+
+prior_art:
+  - "benchbox/core/schemas.py:497: current free-string tuning_mode contract (comment-only) — supersede with pinned vocabulary"
+  - "results-explorer/src/components/TuningBadge.tsx TUNING_CONFIG: current TS-side value set — reuse as starting vocabulary"
+
+open_questions:
+  - question: "Does a template-less tuned run keep the 'tuned' label?"
+    gating: true
+    affects: [w2]
+    default: "No - distinct mode value; refuse under --official"
+  - question: "Do two 'tuned' runs on different platforms facet-match regardless of physical mechanisms?"
+    gating: true
+    affects: [w2]
+    default: "Coarse facet keeps matching; receipt warns on disjoint mechanism sets; physical_rendering_id becomes a secondary facet for TPC"
+
+metadata:
+  owners:
+    - "joe"
+  tags:
+    - tuning
+    - decision-gate
+    - explorer
+    - comparability
+  estimated_effort: Small
+  created_date: "2026-07-12"
+  source_review: "tuning-system deep review 2026-07-12 (claude/tuning-system-review-7mzapy)"

--- a/_project/TODO/main/planning/tuning-adr-trust-and-hash-semantics-20260712.yaml
+++ b/_project/TODO/main/planning/tuning-adr-trust-and-hash-semantics-20260712.yaml
@@ -1,0 +1,75 @@
+id: tuning-adr-trust-and-hash-semantics-20260712
+title: "DECISION GATE: tuning trust/attestation model and hash semantics (ADR-1)"
+worktree: main
+priority: Critical
+status: Not Started
+category: Architecture Decision
+
+description: |
+  Decision gate from the 2026-07-12 tuning-system deep review (evidence pinned to
+  commit acfb8992; full report delivered in-session, findings C1-C3).
+
+  Two product decisions only Joe can make, blocking the soundness remediation
+  (tuning-applied-ledger-and-validation-status-20260712):
+
+  1. TRUST MODEL for published tuning claims. Today bundles are self-attested and
+     nothing says so: `tunings_applied` is the requested config
+     (benchbox/platforms/base/adapter.py:743-747), APPLIED certifies only a
+     metadata-table write, and no mechanism lets an evaluator verify claims
+     against reality.
+  2. HASH SEMANTICS. The bundle hash field is never populated; four disjoint hash
+     notions exist (interface.py:846-863 full sha256; profile_validation.py:324-333
+     16-char template hash; the never-set bundle tuning_config_hash; the explorer's
+     8-char repr hash in _project/scripts/explorer_pipeline/transformer.py:187-201).
+     Decide what the hash must certify: requested template, effective post-filter
+     config, rendered DDL/applied ledger, or a pair.
+
+  Deliverable is a short ADR-style decision record, not code.
+
+work:
+  - id: w1
+    summary: "Draft ADR with options and recommendation for trust model and hash semantics"
+    notes: "Recommendations from the review: label self-attested now, introspection receipts as design direction, third-party attestation deferred; hashes as a pair (requested-config hash + applied-ledger hash)."
+    status: pending
+    needs: []
+  - id: w2
+    summary: "Joe decides; record decisions, rejected options, and rationale in docs/development/ decision record; update threat-model doc if the self-attested label is adopted"
+    status: pending
+    needs: [w1]
+
+deferred:
+  - summary: "Implementing the decided semantics"
+    reason: "Owned by tuning-applied-ledger-and-validation-status-20260712 and tuning-facet-and-receipt gated items"
+
+deps:
+  needs: []
+
+verification:
+  - description: "Decision record exists and answers both questions unambiguously"
+    command: "ls docs/development/ | grep -i 'tuning'"
+    expected_output: "A committed decision record naming the chosen trust label and the object(s) each hash covers"
+
+prior_art:
+  - "docs/reference/threat-model.md: existing trust-label vocabulary (public-verified reserved) — extend, do not fork"
+  - "docs/development/adapter-refactor-map.md: existing design-record style in docs/development — reuse"
+
+open_questions:
+  - question: "Are published tuning claims labeled self-attested in explorer UI and docs, with verification deferred?"
+    gating: true
+    affects: [w2]
+    default: "Yes - label self-attested now; design post-load introspection receipts later"
+  - question: "What does the bundle tuning hash certify?"
+    gating: true
+    affects: [w2]
+    default: "Two hashes: canonical requested-config hash (platform-independent identity) + applied-ledger hash (physical identity)"
+
+metadata:
+  owners:
+    - "joe"
+  tags:
+    - tuning
+    - decision-gate
+    - soundness
+  estimated_effort: Small
+  created_date: "2026-07-12"
+  source_review: "tuning-system deep review 2026-07-12 (claude/tuning-system-review-7mzapy)"

--- a/_project/TODO/main/planning/tuning-applied-ledger-and-validation-status-20260712.yaml
+++ b/_project/TODO/main/planning/tuning-applied-ledger-and-validation-status-20260712.yaml
@@ -1,0 +1,114 @@
+id: tuning-applied-ledger-and-validation-status-20260712
+title: "Applied-tuning ledger: record what actually executed; honest validation_status; session-settings capture"
+worktree: main
+priority: Critical
+status: Not Started
+category: Core Functionality
+
+description: |
+  From the 2026-07-12 tuning review, findings C1, C5 (capture side), R6
+  (evidence pinned to commit acfb8992). GATED on ADR-1
+  (tuning-adr-trust-and-hash-semantics-20260712).
+
+  Today the bundle records intent as fact: tunings_applied is the requested
+  config's to_dict() and validation_status "APPLIED" certifies only that a
+  metadata-table INSERT succeeded (platforms/base/adapter.py:743-747). The base
+  apply_unified_tuning is a silent no-op (platforms/base/tuning_config.py:45-66).
+  Session-level SETs applied by configure_for_benchmark (ClickHouse OLAP pack,
+  StarRocks query settings) are captured nowhere. Rerun drift-detection is blind
+  to platform optimizations and unique/check constraints
+  (core/tuning/metadata.py:247-256) and never feeds published bundles;
+  FAILED_TO_SAVE surfaces for benign read-only/in-memory conditions.
+
+  Build, per ADR-1's decided semantics:
+  - an applied-statement ledger: every tuning-relevant statement the adapter
+    actually executes (DDL clauses, post-load statements, session SETs) appended
+    during execution and exported alongside the requested config;
+  - the applied-ledger hash (per ADR-1);
+  - honest validation_status semantics (e.g. applied_verified /
+    applied_unverified / noop / failed) replacing the metadata-write proxy, with
+    FAILED_TO_SAVE downgraded to a non-alarming metadata-persistence note;
+  - drift-validation results routed into the bundle where ADR-1 says they belong.
+
+work:
+  - id: w0
+    summary: "Re-validate pinned evidence at current HEAD after upstream TODOs merge (call sites move); note refs in PR"
+    status: pending
+    needs: []
+  - id: w1
+    summary: "Design the ledger data model + capture hooks (adapter records statements at execution time; base no-op records 'noop'); align with ADR-1 record"
+    status: pending
+    needs: [w0]
+  - id: w2
+    summary: "Instrument the SQL adapters with real tuning paths (duckdb, clickhouse, starrocks, databricks, cloud_spark) plus session SETs from configure_for_benchmark in every mode including baseline"
+    status: pending
+    needs: [w1]
+  - id: w3
+    summary: "Export ledger + applied hash into bundle/companion; implement new validation_status semantics; route drift-validation results per ADR-1"
+    status: pending
+    needs: [w1]
+  - id: w4
+    summary: "Surface dropped/unmapped tuning intents as run-time warnings (review finding R4)"
+    notes: "The ledger knows what was requested but not rendered (capability filtering, unregistered generator, log-only path); warn the author at run time and export the dropped list with reasons."
+    status: pending
+    needs: [w2, w3]
+  - id: w5
+    summary: "Tests: recording-connection harness asserts ledger matches executed statements"
+    notes: "Also: a deliberately no-op platform yields status noop, never applied; benign persistence failure does not surface as an alarming status."
+    status: pending
+    needs: [w2, w3]
+
+deferred:
+  - summary: "DataFrame runtime-tuning ledger parity (threads/memory/write-layout as applied observations, not just config blobs)"
+    reason: "Review finding N10; ledger shape must settle on SQL platforms first, then extend to the DF runner in a follow-up"
+
+deps:
+  needs:
+    - tuning-adr-trust-and-hash-semantics-20260712
+    - tuning-bundle-provenance-and-config-export-20260712
+
+must_preserve:
+  - "Requested-config export from tuning-bundle-provenance-and-config-export-20260712 (ledger is additive)"
+  - "Benchmark execution must never fail because ledger capture fails (capture degrades, run continues, degradation recorded)"
+
+approach: |
+  Thread a ledger object through the existing apply_* hook sequence rather than
+  re-architecting adapters; session SETs hook at the connection.execute wrapper
+  where one exists.
+
+anti_patterns:
+  - "No post-hoc reconstruction of the ledger from config - it must be produced by the execution path"
+  - "Do not repurpose the old APPLIED string with new semantics silently; new status vocabulary, documented mapping"
+
+scope_limit:
+  only_modify:
+    - "benchbox/platforms/**"
+    - "benchbox/core/tuning/**"
+    - "benchbox/core/results/**"
+    - "benchbox/base.py"
+    - "docs/**"
+    - "tests/**"
+
+verification:
+  - description: "End-to-end tuned duckdb run: bundle contains requested config, applied ledger with the actual CREATE INDEX statements, matching status"
+    command: "uv run -- python -m benchbox.cli.main run --platform duckdb --benchmark tpch --scale 0.01 --tuning tuned --non-interactive --output /tmp/ledger-check"
+    expected_output: "Ledger lists executed statements; status reflects observation not intent"
+  - description: "Unit suites green"
+    command: "uv run -- python -m pytest tests/unit/core/tuning tests/unit/core/results tests/unit/platforms -q"
+    expected_output: "All passing"
+
+prior_art:
+  - "benchbox/core/results/schema.py .plans.json companion: existing per-run observation companion pattern — reuse for ledger export"
+  - "benchbox/core/tuning/metadata.py TuningMetadataManager: existing in-DB record of applied tunings — supersede as the bundle-facing record (keep for rerun drift detection)"
+  - "benchbox/platforms/clickhouse/tuning.py validate_session_cache_control: existing session-settings readback pattern — extend for capture"
+
+metadata:
+  owners:
+    - "benchbox-team"
+  tags:
+    - tuning
+    - soundness
+    - applied-ledger
+  estimated_effort: Large
+  created_date: "2026-07-12"
+  source_review: "tuning-system deep review 2026-07-12, findings C1/C5/R6"

--- a/_project/TODO/main/planning/tuning-author-experience-honesty-quickfixes-20260712.yaml
+++ b/_project/TODO/main/planning/tuning-author-experience-honesty-quickfixes-20260712.yaml
@@ -1,0 +1,83 @@
+id: tuning-author-experience-honesty-quickfixes-20260712
+title: "Author-facing honesty quickfixes: dry-run preview lookup, misleading displays, CLI footguns"
+worktree: main
+priority: Medium-High
+status: Not Started
+category: Core Functionality
+
+description: |
+  From the 2026-07-12 tuning review, findings R3 (partial), N1, N2, N3
+  (evidence pinned to commit acfb8992). Small, independent, decision-free fixes:
+
+  1. Dry-run tuning preview is silently empty: _extract_ddl_preview
+     (benchbox/core/dryrun.py:1087) does exact-key lookup
+     table_tunings.get(table_name) with lowercase benchmark names vs uppercase
+     template keys (LINEITEM) - verified: tuned duckdb/tpch dry-run rendered 0
+     tuning clauses. Normalize case like profile_validation.extract_template_columns
+     already does (.upper()).
+  2. Dry-run shows "Databricks Clustering Strategy: z_order" under Platform
+     Optimizations for non-Databricks runs (observed on duckdb) - suppress
+     platform-foreign default fields.
+  3. --dry-run takes a required OUTPUT_DIR string and swallows a following flag:
+     `--dry-run --non-interactive` created a directory literally named
+     "--non-interactive" (run.py:2597-2602). Reject values starting with '-'.
+  4. A local file/dir named "tuned" shadows the tuned keyword because path
+     existence is checked before keywords (tuning_resolver.py:200-207). Check
+     keywords first.
+  5. Invalid-value error hint says "--tuning list", itself an invalid value
+     (tuning_resolver.py:316,326); the real command is `benchbox tuning list`.
+
+work:
+  - id: w1
+    summary: "Case-normalize table-key lookup in _extract_ddl_preview (+ regression test using the shipped duckdb tpch template)"
+    status: pending
+    needs: []
+  - id: w2
+    summary: "Suppress platform-foreign optimization rows in dry-run display; only show fields relevant to the target platform"
+    status: pending
+    needs: []
+  - id: w3
+    summary: "Reject option-like values for --dry-run OUTPUT_DIR (leading '-') with a clear error"
+    status: pending
+    needs: []
+  - id: w4
+    summary: "Resolver: check keywords (tuned/notuning/auto) before path existence; fix the '--tuning list' hint to 'benchbox tuning list'"
+    status: pending
+    needs: []
+
+deps:
+  needs: []
+
+must_preserve:
+  - "Explicit file paths (including relative) keep working for --tuning"
+  - "Dry-run remains non-executing and side-effect free apart from its output dir"
+
+anti_patterns:
+  - "Do not rewrite the preview to use adapter mixins here - renderer unification is gated on ADR-3"
+
+scope_limit:
+  only_modify:
+    - "benchbox/core/dryrun.py"
+    - "benchbox/cli/tuning_resolver.py"
+    - "benchbox/cli/commands/run.py"
+    - "tests/unit/**"
+
+verification:
+  - description: "Tuned duckdb dry-run now shows tuning clauses"
+    command: "uv run -- python -m benchbox.cli.main run --platform duckdb --benchmark tpch --scale 0.01 --tuning tuned --dry-run /tmp/dr-check --non-interactive 2>&1 | grep -c 'ORDER BY'"
+    expected_output: ">= 1 tuning clause rendered in preview"
+  - description: "Flag-swallow guard"
+    command: "uv run -- python -m benchbox.cli.main run --platform duckdb --benchmark tpch --scale 0.01 --dry-run --non-interactive 2>&1 | tail -3"
+    expected_output: "Clear error about missing OUTPUT_DIR, no directory named '--non-interactive' created"
+
+metadata:
+  owners:
+    - "benchbox-team"
+  tags:
+    - tuning
+    - dry-run
+    - cli
+    - author-experience
+  estimated_effort: Small
+  created_date: "2026-07-12"
+  source_review: "tuning-system deep review 2026-07-12, findings R3/N1/N2/N3"

--- a/_project/TODO/main/planning/tuning-bundle-provenance-and-config-export-20260712.yaml
+++ b/_project/TODO/main/planning/tuning-bundle-provenance-and-config-export-20260712.yaml
@@ -1,0 +1,114 @@
+id: tuning-bundle-provenance-and-config-export-20260712
+title: "Export tuning provenance, requested config, and requested-config hash into bundles"
+worktree: main
+priority: Critical
+status: Not Started
+category: Core Functionality
+
+description: |
+  From the 2026-07-12 tuning review, findings C2/C3/C4 ungated parts (evidence
+  pinned to commit acfb8992). The evaluator-facing evidence chain is broken:
+
+  - tuning_config_hash and tuning_source_file are read from kwargs no call site
+    passes (benchbox/base.py:757-761; the adapter call at
+    platforms/base/adapter.py:851-881 omits both) -> bundle hash always absent,
+    source always "auto" (core/results/schema.py:1234). Corpus: 0/528 bundles
+    carry a hash.
+  - build_tuning_payload/_build_tuning_summary extract keys
+    (indexes/statistics/configuration) that UnifiedTuningConfiguration.to_dict()
+    never produces (schema.py:1250-1258, 1364-1374) -> clauses always empty and
+    the requested config is dropped at export entirely.
+  - TuningResolution provenance (mode/source enum/config file/searched paths) is
+    display-only (cli/tuning_resolver.py); TuningSource.INTERACTIVE_WIZARD is
+    never assigned.
+
+  Fix (decision-safe under ADR-1, which may later ADD an applied-side hash):
+  thread TuningResolution provenance into run_config -> result capture; export
+  the requested config canonically (to_dict) plus a clearly-named
+  requested-config hash; replace the dead clauses extraction with the real
+  config structure. Record source as the enum value, template as a repo-relative
+  ref or content hash - never a raw local path.
+
+work:
+  - id: w0
+    summary: "Re-validate pinned evidence at current HEAD (grep the kwarg call sites and clauses key extraction; note line refs in PR)"
+    status: pending
+    needs: []
+  - id: w1
+    summary: "Thread provenance (source enum, template ref, requested-config hash) into result capture kwargs"
+    notes: "From run.py through run_config into create_enhanced_benchmark_result kwargs; template ref repo-relative or hashed, never a raw local path; assign INTERACTIVE_WIZARD where the wizard produces the config."
+    status: pending
+    needs: [w0]
+  - id: w2
+    summary: "Rewrite build_tuning_payload/_build_tuning_summary to export the requested config's real structure"
+    notes: "Export constraints, platform_optimizations, table_tunings; drop the dead indexes/statistics/configuration extraction that never matches to_dict() keys."
+    status: pending
+    needs: [w1]
+  - id: w3
+    summary: "Schema/docs: document the new fields as REQUESTED (self-attested) values; bump/annotate bundle schema notes; loader round-trip support"
+    status: pending
+    needs: [w2]
+  - id: w4
+    summary: "Tests: bundle for a template run carries source=yaml + template ref + hash; fallback run carries source=fallback; hash is stable across dict ordering and distinct across differing configs"
+    status: pending
+    needs: [w2]
+
+deferred:
+  - summary: "Applied-side ledger, dual-hash, validation_status overhaul"
+    reason: "Gated on ADR-1; owned by tuning-applied-ledger-and-validation-status-20260712"
+
+deps:
+  needs: []
+
+must_preserve:
+  - "Existing bundle schema keys remain readable by the explorer pipeline (additive change; no key renames)"
+  - "No raw local filesystem paths in exported bundles"
+
+approach: |
+  Name the new hash field explicitly (e.g. requested_config_hash) so ADR-1's
+  later applied-ledger hash can coexist without semantic collision. Reuse
+  BenchmarkTunings-style canonical JSON hashing (sort_keys, separators) but hash
+  the full UnifiedTuningConfiguration.to_dict().
+
+anti_patterns:
+  - "Do not reuse the ambiguous 'hash' key for the new value without qualifying its object"
+  - "Do not export repr() strings anywhere (see tuning-repr-serialization-leak-fix-20260712)"
+
+scope_limit:
+  only_modify:
+    - "benchbox/cli/commands/run.py"
+    - "benchbox/cli/tuning_resolver.py"
+    - "benchbox/platforms/base/adapter.py"
+    - "benchbox/platforms/base/result_capture.py"
+    - "benchbox/base.py"
+    - "benchbox/core/results/schema.py"
+    - "benchbox/core/results/models.py"
+    - "benchbox/core/results/builder.py"
+    - "benchbox/core/results/loader.py"
+    - "benchbox/core/tuning/interface.py"
+    - "docs/**"
+    - "tests/unit/**"
+
+verification:
+  - description: "End-to-end: tuned duckdb run at SF 0.01 produces a bundle whose tuning block contains source enum, template ref, requested_config_hash, and the full requested config"
+    command: "uv run -- python -m benchbox.cli.main run --platform duckdb --benchmark tpch --scale 0.01 --tuning tuned --non-interactive --output /tmp/tuning-export-check && uv run -- python -c \"import json,glob; b=json.load(open(sorted(glob.glob('/tmp/tuning-export-check/*.json'))[-1])); print(json.dumps(b['platform']['tuning'], indent=2))\""
+    expected_output: "tuning block with source, template ref/hash, requested_config_hash, and requested config structure"
+  - description: "Unit suites green"
+    command: "uv run -- python -m pytest tests/unit/core/results tests/unit/core/tuning tests/unit/cli/test_tuning* -q"
+    expected_output: "All passing"
+
+prior_art:
+  - "benchbox/core/results/schema.py build_plan_payload / .plans.json companion: existing companion-file + summary-block pattern — reuse for the tuning companion"
+  - "benchbox/core/tuning/interface.py get_configuration_hash: existing canonical-JSON hash recipe — extend to full unified config"
+
+metadata:
+  owners:
+    - "benchbox-team"
+  tags:
+    - tuning
+    - soundness
+    - results-schema
+    - provenance
+  estimated_effort: Large
+  created_date: "2026-07-12"
+  source_review: "tuning-system deep review 2026-07-12, findings C2/C3/C4"

--- a/_project/TODO/main/planning/tuning-docs-env-contract-fixes-20260712.yaml
+++ b/_project/TODO/main/planning/tuning-docs-env-contract-fixes-20260712.yaml
@@ -1,0 +1,85 @@
+id: tuning-docs-env-contract-fixes-20260712
+title: "Fix broken tuning docs/env contract: dead env var, stale README, undocumented precedence, dishonest auto mode"
+worktree: main
+priority: Medium-High
+status: Not Started
+category: Documentation
+
+description: |
+  From the 2026-07-12 tuning review, finding R5 (evidence pinned to commit acfb8992).
+
+  - BENCHBOX_TUNING_ENABLED sets config key tuning.enabled which NOTHING at
+    runtime reads (only reader is a test); yet docs/usage/configuration.md:91-94
+    and docs/reference/cli/configuration.md:93 claim it activates tuned runs in CI.
+  - examples/tunings/README.md is wholesale stale: documents a --tuning-config
+    flag that does not exist, example scripts that do not exist, stale flat
+    filenames, an env-var recipe that cannot work, and an unqualified "2-10x"
+    performance promise.
+  - The actual precedence order (flag default notuning -> keyword/path -> yaml
+    default_config_file [BENCHBOX_TUNING_CONFIG] -> BENCHBOX_TUNING_PATH ->
+    cwd-relative examples/ -> cwd -> fallback) is documented nowhere.
+  - --tuning auto on SQL platforms prints "using smart defaults based on system
+    profile" but delivers a default-constructed config (run.py:1021-1024);
+    real smart defaults exist only for DataFrame mode (tuning_runtime.py:49-92).
+  - docs/reference/cli/tuning.md: wrong --output default, three subcommands
+    (list/show/platforms) undocumented.
+
+work:
+  - id: w1
+    summary: "Decide-in-PR the env var: remove the doc claims AND either delete BENCHBOX_TUNING_ENABLED handling or emit a deprecation warning when set (recommend delete + release note)"
+    status: pending
+    needs: []
+  - id: w2
+    summary: "Rewrite examples/tunings/README.md against reality: --tuning flag, real template paths, auto-discovery as the primary UX, drop unfalsifiable performance claims"
+    status: pending
+    needs: []
+  - id: w3
+    summary: "Write the precedence table into docs/reference/cli/tuning.md; document tuning list/show/platforms; fix --output default"
+    notes: "Re-check the review's verified rules against HEAD before writing. Explicitly document that examples/ discovery is cwd-relative, so installed-package users hit the fallback unless BENCHBOX_TUNING_PATH is set (review finding N8)."
+    status: pending
+    needs: []
+  - id: w4
+    summary: "Make --tuning auto honest on SQL platforms: warn that smart defaults are DataFrame-only and the run proceeds with basic config (message change only; behavior change gated on ADR-2)"
+    status: pending
+    needs: []
+
+deferred:
+  - summary: "Ship discoverable templates with the installed package (package resources) so --tuning tuned works outside a repo checkout"
+    reason: "Behavior/packaging change beyond a docs fix; needs its own sizing after the precedence doc makes the limitation visible (review finding N8)"
+
+deps:
+  needs: []
+
+must_preserve:
+  - "BENCHBOX_TUNING_CONFIG and BENCHBOX_TUNING_PATH behavior exactly as implemented"
+
+anti_patterns:
+  - "Do not document aspirational behavior; every documented rule must have a file:line anchor at time of writing"
+
+scope_limit:
+  only_modify:
+    - "docs/**"
+    - "examples/tunings/README.md"
+    - "benchbox/cli/config.py"
+    - "benchbox/cli/commands/run.py"
+    - "benchbox/cli/tuning_resolver.py"
+    - "tests/unit/**"
+
+verification:
+  - description: "No doc references to the dead env var remain (or the var actually works)"
+    command: "grep -rn 'BENCHBOX_TUNING_ENABLED' docs/ benchbox/ | grep -v test"
+    expected_output: "Either zero doc hits + removed handling, or a functioning documented code path"
+  - description: "Docs build clean"
+    command: "make lint"
+    expected_output: "Passing"
+
+metadata:
+  owners:
+    - "benchbox-team"
+  tags:
+    - tuning
+    - documentation
+    - cli
+  estimated_effort: Medium
+  created_date: "2026-07-12"
+  source_review: "tuning-system deep review 2026-07-12, finding R5"

--- a/_project/TODO/main/planning/tuning-explorer-ingest-mode-extraction-20260712.yaml
+++ b/_project/TODO/main/planning/tuning-explorer-ingest-mode-extraction-20260712.yaml
@@ -1,0 +1,84 @@
+id: tuning-explorer-ingest-mode-extraction-20260712
+title: "Explorer ingest: read tuning_mode from all bundle generations; stop conflating absent with baseline"
+worktree: main
+priority: High
+status: Not Started
+category: Core Functionality
+
+description: |
+  From the 2026-07-12 tuning review, finding C6 ungated part (evidence pinned to
+  commit acfb8992).
+
+  The explorer pipeline reads only config.tuning_mode
+  (_project/scripts/explorer_pipeline/transformer.py:178-184). All 528
+  seed-corpus bundles store the value at execution.tuning_mode (325) or nowhere
+  (203) -> every corpus run ingests as tuning_mode=None. facetMatching.ts:99 then
+  defaults null to "untuned", a token no producer emits, so "explicitly
+  baseline", "tuned but old schema", and "never recorded" all facet-match each
+  other. ComparabilityReceipt.tsx:177 shows "Not recorded". The explorer's own
+  tuning_hash (transformer.py:187-201) hashes {mode, repr string} - cosmetic repr
+  differences change it.
+
+  Fix the ingest layer (decision-safe): fall back to execution.tuning_mode,
+  ingest a distinct "unknown/not-recorded" state instead of null-coalescing to a
+  fake mode, and stop hashing repr text (hash the canonical config when present,
+  else emit no hash). Facet-matching RULE changes (whether unknown matches
+  baseline) are gated on ADR-2 and owned by the facet implementation TODO.
+
+work:
+  - id: w0
+    summary: "Re-validate pinned evidence at current HEAD: rerun the corpus sweep script (scratchpad tuning_sweep.py logic) and confirm field locations; commit compact counts in PR body"
+    status: pending
+    needs: []
+  - id: w1
+    summary: "transformer.py: read config.tuning_mode with execution.tuning_mode fallback; represent not-recorded explicitly; tuning_hash only from machine-readable config (never repr strings)"
+    status: pending
+    needs: [w0]
+  - id: w2
+    summary: "facetMatching/receipt: surface not-recorded as its own display state (keep current matching rule until ADR-2; remove the invented 'untuned' default token in favor of the explicit state)"
+    status: pending
+    needs: [w1]
+  - id: w3
+    summary: "Re-ingest the seed corpus and verify counts: 325 tuned / 203 not-recorded now visible in the explorer dataset"
+    status: pending
+    needs: [w1]
+
+deps:
+  needs: []
+
+must_preserve:
+  - "Ingest must not fail on any existing corpus bundle generation"
+  - "Existing explorer duckdb dataset column names (additive states, no renames)"
+
+anti_patterns:
+  - "Do not default missing mode to any real mode value"
+  - "Do not change which runs facet-match which (gated on ADR-2)"
+
+scope_limit:
+  only_modify:
+    - "_project/scripts/explorer_pipeline/**"
+    - "results-explorer/src/lib/facetMatching.ts"
+    - "results-explorer/src/components/ComparabilityReceipt.tsx"
+    - "results-explorer/src/components/TuningBadge.tsx"
+    - "results-explorer/src/**/__tests__/**"
+    - "tests/unit/**"
+
+verification:
+  - description: "Corpus re-ingest count check"
+    command: "uv run -- python _project/scripts/explorer_pipeline/pipeline.py --help"
+    expected_output: "Pipeline runs against results-data/bundles; dataset shows 325 tuned and 203 not-recorded rows (exact counts from w0 re-validation)"
+  - description: "Explorer unit tests green"
+    command: "cd results-explorer && npm test -- --run 2>&1 | tail -5"
+    expected_output: "All passing incl. new not-recorded state tests"
+
+metadata:
+  owners:
+    - "benchbox-team"
+  tags:
+    - tuning
+    - explorer
+    - ingest
+    - comparability
+  estimated_effort: Medium
+  created_date: "2026-07-12"
+  source_review: "tuning-system deep review 2026-07-12, finding C6"

--- a/_project/TODO/main/planning/tuning-generator-registry-completeness-20260712.yaml
+++ b/_project/TODO/main/planning/tuning-generator-registry-completeness-20260712.yaml
@@ -1,0 +1,68 @@
+id: tuning-generator-registry-completeness-20260712
+title: "Register orphaned DDL generators and make NoOp fallback loud + tested"
+worktree: main
+priority: Medium-High
+status: Not Started
+category: Core Functionality
+
+description: |
+  From the 2026-07-12 tuning review, finding R2 (evidence pinned to commit acfb8992).
+
+  benchbox/core/tuning/generators/ ships questdb.py, pg_duckdb.py, pg_mooncake.py
+  (exported in generators/__init__.py, each with dedicated unit tests) but
+  get_ddl_generator's mapping (benchbox/core/tuning/ddl_generator.py:653-681)
+  has no entries for them; unknown platforms silently receive NoOpDDLGenerator
+  (line 689). StarRocks has no generator at all. Consumers today: dry-run
+  preview (core/dryrun.py:1066-1101) and cloud_spark mixins - so the symptom is
+  a silently-empty tuning preview on platforms whose generators exist and pass
+  tests.
+
+work:
+  - id: w1
+    summary: "Register questdb, pg_duckdb, pg_mooncake in the get_ddl_generator mapping"
+    status: pending
+    needs: []
+  - id: w2
+    summary: "Log a warning when NoOpDDLGenerator is returned for a platform the CLI registry knows (silent fallback only for genuinely tuning-free platforms like sqlite)"
+    status: pending
+    needs: [w1]
+  - id: w3
+    summary: "Add registry-completeness unit test: every module in core/tuning/generators/ exporting a BaseDDLGenerator subclass must be reachable via get_ddl_generator under at least one platform key"
+    status: pending
+    needs: [w1]
+
+deferred:
+  - summary: "A StarRocks DDL generator"
+    reason: "Renderer direction is gated on ADR-3; writing a new generator before the consolidation decision risks throwaway work"
+
+deps:
+  needs: []
+
+must_preserve:
+  - "NoOp fallback behavior for genuinely unsupported platforms (no exceptions from get_ddl_generator)"
+
+anti_patterns:
+  - "Do not raise for unknown platforms - dry-run must keep working everywhere"
+
+scope_limit:
+  only_modify:
+    - "benchbox/core/tuning/ddl_generator.py"
+    - "tests/unit/core/tuning/**"
+
+verification:
+  - description: "Registry test enforces completeness"
+    command: "uv run -- python -m pytest tests/unit/core/tuning -q -k registry"
+    expected_output: "New completeness test passes; fails if a generator module is added without registration"
+  - description: "Existing generator tests stay green"
+    command: "uv run -- python -m pytest tests/unit/core/tuning -q"
+    expected_output: "All passing"
+
+metadata:
+  owners:
+    - "benchbox-team"
+  tags:
+    - tuning
+    - ddl-generators
+  estimated_effort: Small
+  created_date: "2026-07-12"
+  source_review: "tuning-system deep review 2026-07-12, finding R2"

--- a/_project/TODO/main/planning/tuning-mode-vocabulary-and-facet-implementation-20260712.yaml
+++ b/_project/TODO/main/planning/tuning-mode-vocabulary-and-facet-implementation-20260712.yaml
@@ -1,0 +1,88 @@
+id: tuning-mode-vocabulary-and-facet-implementation-20260712
+title: "Implement decided mode vocabulary, fallback labeling, and facet/receipt semantics end-to-end"
+worktree: main
+priority: High
+status: Not Started
+category: Core Functionality
+
+description: |
+  From the 2026-07-12 tuning review, findings C4/C6 (rule side) and product
+  questions 3-4 (evidence pinned to commit acfb8992). GATED on ADR-2
+  (tuning-adr-mode-vocabulary-fallback-facets-20260712).
+
+  Implements whatever ADR-2 decides across the whole pipeline:
+  - resolver/runner: distinct mode/source for template-less tuned runs; wizard
+    provenance assigned; --official policy; raw file paths replaced by a
+    canonical mode + template ref (no local path leakage via
+    config.tuning_mode - run.py:311, schema.py:854);
+  - schema/loader: pinned vocabulary enforced at emission;
+  - explorer: facet rule per ADR-2 (mechanism-set warning in
+    ComparabilityReceipt, physical_rendering_id as secondary facet for TPC,
+    profile-version visibility), TuningBadge entries for any new mode values,
+    self-attested labeling per ADR-1 if decided;
+  - external-mode guard completeness: reject external+tuning for custom-file
+    mode too, not just the literal string "tuned" (run.py:617,2302).
+
+work:
+  - id: w1
+    summary: "Resolver/runner: implement decided fallback labeling + provenance assignment + official-mode policy; kill raw-path mode values"
+    status: pending
+    needs: []
+  - id: w2
+    summary: "Schema + loader: enforce pinned vocabulary; emit new mode/source values; migration note for old bundles"
+    status: pending
+    needs: [w1]
+  - id: w3
+    summary: "Explorer: facet rule, receipt mechanism warning, badge entries, self-attested label per ADRs"
+    status: pending
+    needs: [w2]
+  - id: w4
+    summary: "Complete the external-table guard for all tuning-bearing modes"
+    status: pending
+    needs: [w1]
+  - id: w5
+    summary: "Cross-language vocabulary tests updated against the shared pin"
+    status: pending
+    needs: [w2, w3]
+
+deps:
+  needs:
+    - tuning-adr-mode-vocabulary-fallback-facets-20260712
+    - tuning-explorer-ingest-mode-extraction-20260712
+
+must_preserve:
+  - "Old-generation bundles keep loading and displaying (not-recorded state)"
+  - "Existing facet behavior for non-tuning facets untouched"
+
+anti_patterns:
+  - "No facet rule changes beyond what ADR-2 records"
+
+scope_limit:
+  only_modify:
+    - "benchbox/cli/**"
+    - "benchbox/core/results/**"
+    - "benchbox/core/schemas.py"
+    - "_project/scripts/explorer_pipeline/**"
+    - "results-explorer/src/**"
+    - "docs/**"
+    - "tests/**"
+
+verification:
+  - description: "Fallback run end-to-end carries the decided distinct labeling into bundle and explorer"
+    command: "uv run -- python -m benchbox.cli.main run --platform duckdb --benchmark ssb --scale 0.01 --tuning tuned --non-interactive --output /tmp/fallback-check"
+    expected_output: "Bundle mode/source reflect fallback per ADR-2 (ssb has no duckdb template only if removed; else use a templateless platform/benchmark pair from w1 analysis)"
+  - description: "Python + TS suites green against shared vocabulary pin"
+    command: "uv run -- python -m pytest tests/unit -q -k tuning && cd results-explorer && npm test -- --run 2>&1 | tail -3"
+    expected_output: "All passing"
+
+metadata:
+  owners:
+    - "benchbox-team"
+  tags:
+    - tuning
+    - explorer
+    - comparability
+    - vocabulary
+  estimated_effort: Large
+  created_date: "2026-07-12"
+  source_review: "tuning-system deep review 2026-07-12, findings C4/C6"

--- a/_project/TODO/main/planning/tuning-platform-identity-canonical-keys-20260712.yaml
+++ b/_project/TODO/main/planning/tuning-platform-identity-canonical-keys-20260712.yaml
@@ -1,0 +1,92 @@
+id: tuning-platform-identity-canonical-keys-20260712
+title: "Use canonical platform type keys (not display names) in tuning validation and metadata"
+worktree: main
+priority: High
+status: Not Started
+category: Core Functionality
+
+description: |
+  From the 2026-07-12 tuning review, finding R1 (evidence pinned to commit acfb8992).
+
+  benchbox/platforms/base/adapter.py:714 calls
+  `validate_for_platform(self.platform_name)` with the human display string
+  ("ClickHouse (Local)", "StarRocks"). TuningType.is_compatible_with_platform
+  (benchbox/core/tuning/interface.py:79-164) lowercases it and looks it up in a
+  map keyed by canonical types ("clickhouse"), so multi-word display names match
+  nothing and every enabled tuning type errors -> ValueError after data
+  generation. Verified empirically: a default-constructed config (constraints
+  default enabled=True) yields 4 errors on StarRocks / "ClickHouse (Local)" /
+  Doris / Trino; even the key "clickhouse" fails on default-enabled
+  foreign_keys/check_constraints. TuningMetadataManager also persists the display
+  name into the metadata table (benchbox/core/tuning/metadata.py:207).
+
+  Fix: introduce a canonical platform-type accessor on adapters (the CLI key,
+  e.g. database_config.type) and route every tuning-capability lookup and
+  metadata persistence through it. Also decide-in-code the unknown-platform
+  behavior explicitly (warn + treat as no-capability, never a crash keyed on
+  string formatting).
+
+work:
+  - id: w0
+    summary: "Re-validate pinned evidence at current HEAD (validate_for_platform probe, line refs)"
+    notes: "Re-run the empirical probe, confirm adapter.py/interface.py line refs; commit a compact summary (command, SHA, PASS/FAIL, key lines) in the PR description."
+    status: pending
+    needs: []
+  - id: w1
+    summary: "Add canonical_platform_type to PlatformAdapter and switch tuning lookups to it"
+    notes: "Sourced from config type; audit all platform_name uses feeding dict lookups / lowercased comparisons / persistence, switch tuning paths to the canonical key."
+    status: pending
+    needs: [w0]
+  - id: w2
+    summary: "Make unknown-platform capability lookups an explicit warning path, not an empty-set hard fail"
+    notes: "Align default-enabled constraints with per-platform reality, or downgrade constraint-compat mismatches to warnings with a recorded drop."
+    status: pending
+    needs: [w1]
+  - id: w3
+    summary: "Regression tests: tuned-mode validation on starrocks/clickhouse/doris display names no longer crashes on name formatting; canonical key persisted in metadata table"
+    status: pending
+    needs: [w2]
+
+deps:
+  needs: []
+
+must_preserve:
+  - "Existing passing validation behavior for duckdb/databricks tuned templates"
+  - "validate_for_platform's public signature (callers exist in cli/config.py and platforms/base/tuning_config.py)"
+
+approach: |
+  Small, mechanical: one new property, call-site substitutions, plus explicit
+  unknown-platform semantics. Do NOT consolidate the capability registries here
+  (gated on ADR-3); this item only makes the existing lookups use the right key.
+
+anti_patterns:
+  - "Do not add starrocks/doris/etc to the hardcoded compat map as a fix - that grows the drift problem this plan later removes"
+  - "Do not normalize display names with string surgery (strip parens); use the config type key"
+
+scope_limit:
+  only_modify:
+    - "benchbox/platforms/base/adapter.py"
+    - "benchbox/platforms/base/tuning_config.py"
+    - "benchbox/core/tuning/interface.py"
+    - "benchbox/core/tuning/metadata.py"
+    - "benchbox/cli/config.py"
+    - "tests/unit/**"
+
+verification:
+  - description: "Empirical probe passes"
+    command: "uv run -- python -c \"from benchbox.core.tuning.interface import UnifiedTuningConfiguration; c=UnifiedTuningConfiguration(); print(c.validate_for_platform('StarRocks'))\""
+    expected_output: "No spurious 'not supported by platform' errors caused purely by display-name formatting"
+  - description: "Tuning unit suites stay green"
+    command: "uv run -- python -m pytest tests/unit/core/tuning tests/unit/cli/test_tuning* -q"
+    expected_output: "All passing"
+
+metadata:
+  owners:
+    - "benchbox-team"
+  tags:
+    - tuning
+    - platform-identity
+    - correctness
+  estimated_effort: Medium
+  created_date: "2026-07-12"
+  source_review: "tuning-system deep review 2026-07-12, finding R1"

--- a/_project/TODO/main/planning/tuning-renderer-consolidation-and-baseline-policy-20260712.yaml
+++ b/_project/TODO/main/planning/tuning-renderer-consolidation-and-baseline-policy-20260712.yaml
@@ -1,0 +1,102 @@
+id: tuning-renderer-consolidation-and-baseline-policy-20260712
+title: "Single tuning renderer + capability registry; enforce decided baseline policy"
+worktree: main
+priority: Medium-High
+status: Not Started
+category: Architecture
+
+description: |
+  From the 2026-07-12 tuning review, findings C5 (policy side), R2/R3 (structural
+  side), architecture assessment (evidence pinned to commit acfb8992). GATED on
+  ADR-3 (tuning-adr-baseline-definition-and-renderer-20260712).
+
+  Implements the decided direction:
+  - ONE capability registry keyed by canonical platform type; the six current
+    sources (interface.py compat map, generator registry,
+    platform_capabilities.py, adapter mixins, `benchbox tuning platforms`
+    tables, coverage matrix) become derivations or lookups of it;
+  - ONE rendering path shared by dry-run preview and execution (per ADR-3,
+    expected: adapters consume core/tuning/generators/*); delete dead renderers
+    (clickhouse generate_tuning_clause has zero callers) and log-only apply
+    paths become real or explicitly declared no-capability;
+  - BASELINE POLICY per ADR-3: relocate/record the ClickHouse OLAP session pack
+    (clickhouse/tuning.py:74-100), label engine-mandatory layout (StarRocks
+    DISTRIBUTED BY injection) in bundle metadata, and align the databricks-liquid
+    warn-vs-fail behavior with the recorded policy axis;
+  - Databricks-specific layout validation moves out of interface.py
+    (_validate_databricks_effective_layout) into the platform layer.
+
+work:
+  - id: w1
+    summary: "Introduce the capability registry; derive interface compat checks and platform_capabilities from it; consistency test flips from allowlist-drift to strict"
+    status: pending
+    needs: []
+  - id: w2
+    summary: "Renderer unification per ADR-3, one platform at a time starting duckdb -> clickhouse -> starrocks -> databricks; dry-run preview calls the same renderer as execution"
+    status: pending
+    needs: [w1]
+  - id: w3
+    summary: "Baseline policy enforcement: session-pack relocation + engine-mandatory layout labeling + `benchbox tuning platforms` output generated from the registry"
+    status: pending
+    needs: [w1]
+  - id: w4
+    summary: "Move Databricks layout validation to the platform layer; slim interface.py to pure data model"
+    status: pending
+    needs: [w1]
+  - id: w5
+    summary: "Retire deprecated CLI shims (create-sample-tuning, df-tuning) with docs/test sweep, or explicitly re-justify keeping them"
+    status: pending
+    needs: []
+
+deps:
+  needs:
+    - tuning-adr-baseline-definition-and-renderer-20260712
+    - tuning-platform-identity-canonical-keys-20260712
+    - tuning-generator-registry-completeness-20260712
+
+must_preserve:
+  - "Physical rendering identity boundaries (zorder vs liquid auto/manual vs duckdb tuned) per the databricks-liquid TODO must_preserve"
+  - "Existing bundle schema compatibility during migration (renderer change must not silently change published metadata semantics without a schema note)"
+
+approach: |
+  Land per-platform in separate PRs under this one TODO's work units; each
+  platform migration ships with a before/after DDL snapshot test proving the
+  rendered statements are intentional (identical, or a documented improvement).
+
+anti_patterns:
+  - "No big-bang rewrite across all platforms in one PR"
+  - "Do not delete a mixin path before its generator replacement has a snapshot test"
+
+scope_limit:
+  only_modify:
+    - "benchbox/core/tuning/**"
+    - "benchbox/platforms/**"
+    - "benchbox/cli/**"
+    - "benchbox/core/dryrun.py"
+    - "docs/**"
+    - "tests/**"
+
+verification:
+  - description: "Dry-run preview and execution render identical tuning DDL for a migrated platform"
+    command: "uv run -- python -m pytest tests/unit -q -k 'renderer or ddl_snapshot'"
+    expected_output: "Snapshot tests pass; preview==execution assertion holds"
+  - description: "Full tuning suites green"
+    command: "uv run -- python -m pytest tests/unit/core/tuning tests/unit/platforms tests/unit/cli/test_tuning* -q"
+    expected_output: "All passing"
+
+prior_art:
+  - "benchbox/core/tuning/ddl_generator.py get_ddl_generator: registry seed — extend into the capability registry"
+  - "benchbox/platforms/base/format_capabilities.py: existing per-platform capability declaration pattern — reuse shape"
+  - "docs/development/adapter-refactor-map.md: prior slice-by-slice platform refactor process — reuse"
+
+metadata:
+  owners:
+    - "benchbox-team"
+  tags:
+    - tuning
+    - architecture
+    - renderer
+    - baseline
+  estimated_effort: Large
+  created_date: "2026-07-12"
+  source_review: "tuning-system deep review 2026-07-12, architecture assessment"

--- a/_project/TODO/main/planning/tuning-repr-serialization-leak-fix-20260712.yaml
+++ b/_project/TODO/main/planning/tuning-repr-serialization-leak-fix-20260712.yaml
@@ -1,0 +1,64 @@
+id: tuning-repr-serialization-leak-fix-20260712
+title: "Stop publishing Python repr() strings in bundle raw_config; make serialization fallbacks loud"
+worktree: main
+priority: Medium-High
+status: Not Started
+category: Core Functionality
+
+description: |
+  From the 2026-07-12 tuning review, finding R9/C2-adjacent (evidence pinned to
+  commit acfb8992).
+
+  sanitize_platform_options (benchbox/core/results/platform_options.py:68-80) is
+  used for platform.raw_config (platforms/base/runtime_metadata.py:105) but does
+  NOT filter _INTERNAL_OPTION_KEYS (only _iter_public_options does), and
+  _sanitize_option_value falls back to str(value) (platform_options.py:138). Net
+  effect: UnifiedTuningConfiguration objects are published as ~900-char Python
+  repr() strings at platform.raw_config.tuning_config - 468 of 528 seed-corpus
+  bundles carry one, and the explorer's tuning hash ends up hashing repr text.
+
+work:
+  - id: w1
+    summary: "Exclude internal option keys from raw_config capture (align sanitize_platform_options call sites with _iter_public_options filtering, or filter at the runtime_metadata call site)"
+    status: pending
+    needs: []
+  - id: w2
+    summary: "Replace the str() fallback for non-JSON-able values on exported paths: use to_dict() when available, else drop the key with a captured warning marker"
+    status: pending
+    needs: [w1]
+  - id: w3
+    summary: "Tests: a config object placed in options never serializes as a repr string in any exported payload; warning marker asserted for unknown objects"
+    status: pending
+    needs: [w2]
+
+deps:
+  needs: []
+
+must_preserve:
+  - "Secret redaction behavior (REDACTED_VALUE) exactly as-is"
+  - "Bundle emission must never raise because an option value is unserializable"
+
+anti_patterns:
+  - "Do not silently drop values with no trace - leave an explicit '<unserializable:TypeName>' marker so capture gaps stay visible"
+
+scope_limit:
+  only_modify:
+    - "benchbox/core/results/platform_options.py"
+    - "benchbox/platforms/base/runtime_metadata.py"
+    - "tests/unit/**"
+
+verification:
+  - description: "Sweep script over a fresh local run shows no repr strings"
+    command: "uv run -- python -m pytest tests/unit/core/results -q -k 'platform_options or raw_config'"
+    expected_output: "All passing incl. new no-repr assertions"
+
+metadata:
+  owners:
+    - "benchbox-team"
+  tags:
+    - tuning
+    - serialization
+    - results-schema
+  estimated_effort: Small
+  created_date: "2026-07-12"
+  source_review: "tuning-system deep review 2026-07-12, finding R9"

--- a/_project/TODO/main/planning/tuning-soundness-test-coverage-20260712.yaml
+++ b/_project/TODO/main/planning/tuning-soundness-test-coverage-20260712.yaml
@@ -1,0 +1,94 @@
+id: tuning-soundness-test-coverage-20260712
+title: "Test coverage for tuning soundness boundaries (registries, statuses, hashes, vocabulary)"
+worktree: main
+priority: High
+status: Not Started
+category: Testing and Quality Assurance
+
+description: |
+  From the 2026-07-12 tuning review, finding R7 (evidence pinned to commit
+  acfb8992). 467 tuning unit tests pass while every soundness boundary has zero
+  coverage:
+
+  - No test covers requested-vs-applied integrity (tunings_applied vs executed
+    statements).
+  - Validation-status tests pin "PASSED" (test_tpc_tuning_template_parity.py:231,270),
+    a value production never emits (real set: NOT_APPLICABLE/APPLIED/
+    FAILED_TO_SAVE/NOT_VALIDATED).
+  - No test calls get_ddl_generator at all; no registry-completeness test.
+  - No cross-consistency test across the capability sources (interface compat
+    map, generator registry, platform_capabilities mapping).
+  - No tests for hash stability/canonicality (get_configuration_hash,
+    hash_tuning_template).
+  - No shared Python<->TypeScript tuning_mode vocabulary pin; Python emits
+    "balanced" (cli/tuning.py:52,56) unknown to the explorer.
+  - Resolver's emitted fallback log marker and coverage.py's parser expectation
+    can drift silently (coverage tests hand-write the strings).
+
+work:
+  - id: w1
+    summary: "Pin the real validation-status vocabulary in tests; remove fictional 'PASSED' fixtures"
+    status: pending
+    needs: []
+  - id: w2
+    summary: "Hash canonicality tests: dict-ordering stability, semantic-equivalence, distinctness across differing configs, truncation posture documented"
+    status: pending
+    needs: []
+  - id: w3
+    summary: "Cross-source consistency test over capability registries (expected-drift allowlist so it fails only on NEW drift until consolidation lands)"
+    status: pending
+    needs: []
+  - id: w4
+    summary: "Resolver marker <-> coverage.py parser round-trip test (resolver emits, parser classifies; no hand-written strings)"
+    status: pending
+    needs: []
+  - id: w5
+    summary: "Shared vocabulary pin: single source (JSON/YAML) asserted by both pytest and vitest for tuning_mode values"
+    status: pending
+    needs: []
+  - id: w6
+    summary: "Requested-vs-applied harness: adapter-level test with a recording connection asserting executed tuning statements are reflected in captured metadata (deepens once the applied ledger lands)"
+    status: pending
+    needs: [w1]
+
+deferred:
+  - summary: "Full applied-ledger integrity assertions"
+    reason: "Ledger shape gated on ADR-1; w6 pins today's requested-side behavior first"
+
+deps:
+  needs:
+    - tuning-platform-identity-canonical-keys-20260712
+    - tuning-generator-registry-completeness-20260712
+
+must_preserve:
+  - "Existing 467 passing tuning tests (modify only the fictional-vocabulary fixtures)"
+
+anti_patterns:
+  - "No tests that merely mirror implementation constants - each must encode an invariant that catches drift"
+
+scope_limit:
+  only_modify:
+    - "tests/**"
+    - "results-explorer/src/**/__tests__/**"
+    - "_project/scripts/tests/**"
+    - "benchbox/core/tuning/coverage.py"
+
+verification:
+  - description: "New suites pass and fail-on-drift is demonstrated (mutate one registry entry locally, observe failure, revert)"
+    command: "uv run -- python -m pytest tests/unit/core/tuning tests/unit/cli/test_tuning* -q"
+    expected_output: "All passing; drift-demo documented in PR body"
+
+prior_art:
+  - "benchbox/core/results/schema_specs.yaml + benchmark_specs.yaml: existing YAML-spec-consumed-by-code pattern — reuse for the shared tuning_mode vocabulary pin"
+  - "tests/uat/data/tuning_coverage.tsv: existing checked-in matrix asserted by tests — same enforcement shape"
+
+metadata:
+  owners:
+    - "benchbox-team"
+  tags:
+    - tuning
+    - testing
+    - soundness
+  estimated_effort: Medium
+  created_date: "2026-07-12"
+  source_review: "tuning-system deep review 2026-07-12, finding R7"

--- a/_project/blind-spots/2026-07-12-164408-display-name-used-as-platform-key.md
+++ b/_project/blind-spots/2026-07-12-164408-display-name-used-as-platform-key.md
@@ -1,0 +1,33 @@
+---
+id: 2026-07-12-164408-display-name-used-as-platform-key
+date: 2026-07-12
+status: open
+finding_kind: assumption
+review_context: "tuning-system deep review / claude/tuning-system-review-7mzapy"
+related_paths:
+  - benchbox/core/tuning/interface.py
+  - benchbox/platforms/base/adapter.py
+  - benchbox/core/tuning/metadata.py
+suggested_sweep: "grep for `platform_name` passed into any dict lookup or .lower() comparison; contrast with database_config.type"
+todo_id: null
+---
+
+# Human display names are silently assumed to be canonical platform keys
+
+## Finding
+`adapter.py` passes `self.platform_name` (a display string like "ClickHouse (Local)" or
+"StarRocks") into `validate_for_platform`, which lowercases it and looks it up in a map keyed
+by canonical types ("clickhouse"). The lookup can never match for multi-word display names, so
+validation semantics flip from "check compatibility" to "reject everything". The same
+display-name value is also persisted into the tuning metadata table (`metadata.py` `platform=`)
+while other layers key on `database_config.type`. Two identity vocabularies exist for platforms
+and code moves between them without conversion.
+
+## Why this matters
+Any map, registry, or persisted record keyed by "platform" is only correct if every producer and
+consumer agrees on which of the two identities is in play. Because both are strings, the type
+system cannot catch a mix-up, and the failure mode is a silent empty lookup rather than an error.
+
+## Suggested next steps
+- [ ] Sweep all `platform_name` uses that feed comparisons, dict lookups, or persistence and classify display-key vs canonical-key.
+- [ ] Consider a `PlatformKey` newtype or a `canonical_platform_type` property on adapters so the two identities cannot be confused.

--- a/_project/blind-spots/2026-07-12-164408-hand-maintained-capability-matrices-drift.md
+++ b/_project/blind-spots/2026-07-12-164408-hand-maintained-capability-matrices-drift.md
@@ -1,0 +1,33 @@
+---
+id: 2026-07-12-164408-hand-maintained-capability-matrices-drift
+date: 2026-07-12
+status: open
+finding_kind: bug-class
+review_context: "tuning-system deep review / claude/tuning-system-review-7mzapy"
+related_paths:
+  - benchbox/core/tuning/interface.py
+  - benchbox/core/tuning/ddl_generator.py
+  - benchbox/core/tuning/platform_capabilities.py
+suggested_sweep: "find other N-way hand-maintained platform matrices (format capabilities, external-table support, dialect features) and check for cross-consistency tests"
+todo_id: null
+---
+
+# Parallel hand-maintained capability matrices drift with no consistency test
+
+## Finding
+"What tuning does platform X support" is answered independently by six artifacts: the hardcoded
+compat map in `interface.py`, the `get_ddl_generator` registry, `platform_capabilities.py`
+mappings, per-adapter mixin implementations, the `benchbox tuning platforms` CLI prose tables,
+and the `examples/tunings/` + coverage.yaml matrix. They disagree today (e.g. generators exist
+for platforms the registry doesn't map; the compat map rejects platforms that ship tuning
+mixins) and no test cross-checks any pair.
+
+## Why this matters
+When capability knowledge is duplicated per consumer, each new platform or tuning type must be
+added in every location, and the failure mode of missing one is silent (NoOp fallback, empty
+set, UNSUPPORTED default) rather than loud. The bug class recurs anywhere the repo keeps
+per-platform feature matrices by hand.
+
+## Suggested next steps
+- [ ] Add a cross-consistency unit test over the existing sources as a stopgap (fails on new drift).
+- [ ] Evaluate a single capability registry that the other five artifacts derive from.

--- a/_project/blind-spots/2026-07-12-164408-intent-recorded-as-applied-fact.md
+++ b/_project/blind-spots/2026-07-12-164408-intent-recorded-as-applied-fact.md
@@ -1,0 +1,33 @@
+---
+id: 2026-07-12-164408-intent-recorded-as-applied-fact
+date: 2026-07-12
+status: open
+finding_kind: bug-class
+review_context: "tuning-system deep review / claude/tuning-system-review-7mzapy"
+related_paths:
+  - benchbox/platforms/base/adapter.py
+  - benchbox/platforms/base/result_capture.py
+  - benchbox/core/results/schema.py
+suggested_sweep: "for each bundle field, ask: is this derived from what we asked the engine to do, or from observing what it did? List the intent-derived ones."
+todo_id: null
+---
+
+# Result-bundle fields record intent and label it as applied fact
+
+## Finding
+`tunings_applied` is `effective_tuning_config.to_dict()` — the requested configuration — and
+`tuning_validation_status = "APPLIED"` is gated on a metadata-table write succeeding, not on any
+observation of the database. The base `apply_unified_tuning` is a silent no-op, so a platform can
+skip the entire tuning while the bundle asserts it was applied. The same intent-as-fact pattern
+plausibly affects other self-reported bundle fields (session settings applied in
+`configure_for_benchmark` are recorded nowhere; sorted-ingestion and constraint enforcement are
+reported from config, not introspection).
+
+## Why this matters
+Published bundles are compared by third parties; every field that is actually "what we intended"
+but reads as "what happened" silently corrupts cross-submission comparison — the same failure
+class as a broken comparator, but invisible to tests that only check serialization round-trips.
+
+## Suggested next steps
+- [ ] Inventory bundle fields by provenance (intent vs observation) and mark intent-only ones in the schema docs.
+- [ ] Design an applied-statement ledger in the adapter execution path so capture can record observations.

--- a/_project/blind-spots/2026-07-12-164408-str-fallback-serialization-leak.md
+++ b/_project/blind-spots/2026-07-12-164408-str-fallback-serialization-leak.md
@@ -1,0 +1,31 @@
+---
+id: 2026-07-12-164408-str-fallback-serialization-leak
+date: 2026-07-12
+status: open
+finding_kind: framework-gap
+review_context: "tuning-system deep review / claude/tuning-system-review-7mzapy"
+related_paths:
+  - benchbox/core/results/platform_options.py
+  - benchbox/platforms/base/runtime_metadata.py
+suggested_sweep: "grep for `return str(value)` / `default=str` fallbacks on any path that ends in a published bundle or companion file"
+todo_id: null
+---
+
+# str() serialization fallbacks silently publish Python reprs into bundles
+
+## Finding
+`_sanitize_option_value` falls back to `str(value)` for any non-JSON-able object, and
+`sanitize_platform_options` (used for `platform.raw_config`) does not filter internal option
+keys. Result: `UnifiedTuningConfiguration` objects are published as 900-char Python `repr()`
+strings in bundles — 468 of 528 seed-corpus bundles carry one — and downstream consumers (the
+explorer's tuning hash) end up hashing repr text. `hash_tuning_template` has the same
+`default=str` escape hatch.
+
+## Why this matters
+A str() fallback converts "we forgot to define serialization for this type" from a loud error
+into a permanent, machine-unreadable artifact in published data. Anything that reaches an
+exported file should either serialize canonically or fail capture visibly.
+
+## Suggested next steps
+- [ ] Audit exported-payload paths for str()/repr fallbacks; replace with explicit to_dict or drop-with-warning.
+- [ ] Decide whether internal option keys should be excluded from raw_config the way _iter_public_options already excludes them elsewhere.

--- a/_project/blind-spots/2026-07-12-164408-unpinned-cross-boundary-enums.md
+++ b/_project/blind-spots/2026-07-12-164408-unpinned-cross-boundary-enums.md
@@ -1,0 +1,33 @@
+---
+id: 2026-07-12-164408-unpinned-cross-boundary-enums
+date: 2026-07-12
+status: open
+finding_kind: bug-class
+review_context: "tuning-system deep review / claude/tuning-system-review-7mzapy"
+related_paths:
+  - benchbox/core/schemas.py
+  - results-explorer/src/lib/facetMatching.ts
+  - _project/scripts/explorer_pipeline/transformer.py
+suggested_sweep: "list every string enum that crosses Python -> bundle JSON -> TypeScript (status, mode, phase names) and check whether both sides pin the same value set"
+todo_id: null
+---
+
+# String enums that cross the Python/JSON/TypeScript boundary are never pinned
+
+## Finding
+`tuning_mode` is a free string on both sides: Python emits `tuned/notuning/auto/<raw path>` plus
+`balanced` from the wizard; the explorer defaults missing values to `untuned` — a token no
+producer emits — and the ingest pipeline reads the field from a different JSON path than older
+bundles wrote it to. Each side has tests using its own literals; no shared artifact pins the
+vocabulary, so producers and consumers drift per-generation and per-language without any test
+failing.
+
+## Why this matters
+Cross-boundary enums are contracts, but as bare strings they are invisible to both type systems.
+The drift failure mode is semantic (facets match wrong things, badges show wrong labels), not a
+crash, so it survives green CI indefinitely. The same class applies to validation statuses,
+phase names, and comparability facets generally.
+
+## Suggested next steps
+- [ ] Pin shared vocabularies in one schema artifact consumed by both Python and TS tests.
+- [ ] Make consumers distinguish "value absent" from "value = baseline" instead of defaulting.


### PR DESCRIPTION
# Pull Request

## Description

Converts the 2026-07-12 tuning-subsystem deep review (read-only; evidence pinned to commit `acfb8992`) into an actionable remediation plan: **14 TODO items** in `_project/TODO/main/planning/` plus the review's **5 blind-spot capture files** in `_project/blind-spots/`.

Plan structure with explicit decision gates:

- **3 ADR decision gates** (Joe decides; each carries `open_questions` with `gating: true` and recommended defaults):
  - ADR-1 trust/attestation model + hash semantics (Critical — gates the soundness work)
  - ADR-2 mode vocabulary, fallback labeling, facet semantics
  - ADR-3 baseline ("notuning") definition + single-renderer direction
- **8 ungated defect fixes** ready to implement now: canonical platform keys (display-name lookup bug), generator-registry completeness, bundle provenance + requested-config export (Critical), repr() serialization leak, explorer ingest mode extraction, author-experience quickfixes (dry-run case bug, flag-swallow, resolver hints), docs/env contract (dead `BENCHBOX_TUNING_ENABLED`), soundness test coverage.
- **3 gated implementation items** wired via `deps.needs`: applied-tuning ledger + honest `validation_status` (needs ADR-1), vocabulary/facet implementation (needs ADR-2), renderer consolidation + baseline policy (needs ADR-3).

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [x] Refactor / chore

## Testing

- `_project/scripts/validate_todo.py` on each of the 14 files — all valid against `TODO_SCHEMA.yaml`
- `todo_cli.py check-graph` — no inter-item cycles, no work-unit cycles, no dangling refs (134 items checked)
- `generate_indexes.py` — indexes regenerated cleanly
- Blind-spot files validated with `validate_blind_spot.py` (all OK)

## Public Contract Check

- [x] I updated `docs/reference/public-contracts.md`, or this PR does not change public, beta-public, deprecated, generated, experimental, or repo-only contract surfaces.
- [x] I checked result schema fields, MCP tool parameters, platform support status, wrapper facades, adapter subclassing hooks, and generated docs for contract-map impact.
- [x] Any platform/benchmark count claim in docs is generated/checked from registry metadata, or explicitly marked editorial/non-authoritative.

(Planning artifacts only — no code, schema, or docs surfaces changed.)

## Documentation

- [x] I updated the relevant user-facing docs. (N/A — no user-facing behavior changed; doc fixes are themselves planned items.)
- [x] I added regression notes for behavior changes. (N/A — no behavior changes.)
- [x] I confirmed API contract wording remains accurate.

## Code Quality

- [x] I ran formatting and lint/type checks. (YAML/markdown planning files; schema validation run instead.)
- [x] I reviewed impacted modules for backwards compatibility and migration impact. (N/A)
- [x] I added/updated tests for behavior changes and error paths. (N/A — test additions are a planned item.)
- [x] I confirmed public contracts and release checklists are still valid.

## Artifact Hygiene

- [x] I did not commit raw screenshots, browser reports, generated logs, benchmark outputs, or temporary binary artifacts.
- [x] Any committed binary/raw evidence file has durable repo value and is justified here with its consumer and size: (none — evidence lives as pinned file:line refs inside the TODO descriptions; raw logs stayed in /tmp.)

## Notes

- Every TODO description pins its evidence to commit `acfb8992`; drift-prone items carry a `w0` re-validation work unit per the freshness/evidence-durability rule.
- The three ADR items are the critical path: nothing gated starts until they're decided. The 8 ungated items can be batch-implemented immediately (suggested order: platform-identity → generator-registry → bundle-provenance → repr-leak → explorer-ingest → quickfixes → docs → tests).
- The blind-spot files (commit `16f9ae10`) ride along from the review session; contents were already reported in-session.
- No CODEOWNERS soundness paths are touched; enabling squash auto-merge per remote-session convention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QTnjb2i44JUL71kmu9sk1t

---
_Generated by [Claude Code](https://claude.ai/code/session_01QTnjb2i44JUL71kmu9sk1t)_