### PR TITLE
docs(tuning): ADR-003 baseline definition and single renderer

### DIFF
--- a/_project/DONE/main/active/tuning-adr-baseline-definition-and-renderer-20260712.yaml
+++ b/_project/DONE/main/active/tuning-adr-baseline-definition-and-renderer-20260712.yaml
@@ -2,7 +2,8 @@ id: tuning-adr-baseline-definition-and-renderer-20260712
 title: "DECISION GATE: what 'notuning' promises, and the single tuning-DDL renderer (ADR-3)"
 worktree: main
 priority: High
-status: Not Started
+status: Completed
+completed_date: "2026-07-12"
 category: Architecture Decision
 
 description: |
@@ -30,12 +31,29 @@ description: |
 work:
   - id: w1
     summary: "Draft ADR: baseline definition options + session-pack relocation options; renderer consolidation options with migration cost sketch per platform"
-    status: pending
+    status: done
     needs: []
+    notes: |
+      Done 2026-07-12: docs/development/tuning-adr-003-baseline-and-single-renderer.md
+      drafted with Context (ClickHouse inverted OLAP pack at
+      platforms/clickhouse/tuning.py:74-100, StarRocks unconditional
+      DISTRIBUTED BY injection at platforms/starrocks/workload.py:214-221, the
+      two parallel rendering universes with generators reachable only from
+      dry-run preview and the cloud_spark mixin), a two-bullet Decision, and
+      Rejected Options (record-only status quo; consolidate into adapter
+      mixins instead of generators).
   - id: w2
     summary: "Joe decides; record decisions; annotate databricks-liquid TODO open_questions with the settled policy axis"
-    status: pending
+    status: done
     needs: [w1]
+    notes: |
+      Done 2026-07-12: Joe adopted the recommended defaults for both open
+      questions (baseline = platform defaults + engine-mandatory schema
+      choices only; generators become the single renderer). ADR Status set to
+      Accepted. Both open_questions entries in
+      databricks-liquid-clustering-tuning-review-20260526.yaml annotated with
+      resolved_with pointing at this ADR (warn-first / block only explicit
+      unsafe combinations).
 
 deferred:
   - summary: "Renderer migration and baseline enforcement"
@@ -58,10 +76,12 @@ open_questions:
     gating: true
     affects: [w2]
     default: "No - baseline = platform defaults + engine-mandatory schema choices; session packs move to the tuned path or an explicitly recorded harness-defaults block"
+    resolved_with: "Joe decided 2026-07-12: adopted the recommended default as-is. Recorded in docs/development/tuning-adr-003-baseline-and-single-renderer.md (Decision 1)."
   - question: "Which renderer survives?"
     gating: true
     affects: [w2]
     default: "Generators become the single renderer; adapter mixins consume them"
+    resolved_with: "Joe decided 2026-07-12: adopted the recommended default as-is. Recorded in docs/development/tuning-adr-003-baseline-and-single-renderer.md (Decision 2)."
 
 metadata:
   owners:

--- a/_project/TODO/main/active/databricks-liquid-clustering-tuning-review-20260526.yaml
+++ b/_project/TODO/main/active/databricks-liquid-clustering-tuning-review-20260526.yaml
@@ -168,10 +168,12 @@ open_questions:
     gating: true
     affects: [w3]
     default: "warn-first, block by default only for explicit unsafe runtimes"
+    resolved_with: "Policy axis settled by tuning-adr-003 (2026-07-12): warn-first, block only explicit unsafe runtimes / hard-fail for explicit >4 keys stands. See docs/development/tuning-adr-003-baseline-and-single-renderer.md."
   - question: "Should manual mode >4 explicit liquid columns always fail or auto-fallback to auto strategy?"
     gating: true
     affects: [w2]
     default: "hard-fail for explicit >4, preserve deterministic behavior"
+    resolved_with: "Policy axis settled by tuning-adr-003 (2026-07-12): warn-first, block only explicit unsafe runtimes / hard-fail for explicit >4 keys stands. See docs/development/tuning-adr-003-baseline-and-single-renderer.md."
 
 commits:
   - "b56457e17"

--- a/docs/development/tuning-adr-003-baseline-and-single-renderer.md
+++ b/docs/development/tuning-adr-003-baseline-and-single-renderer.md
@@ -1,0 +1,146 @@
+# ADR-3: Baseline Definition and the Single Tuning-DDL Renderer
+
+## Status
+
+Accepted, 2026-07-12. Decided by Joe.
+
+## Date
+
+2026-07-12
+
+## Context
+
+This is the decision gate for TODO `tuning-adr-baseline-definition-and-renderer-20260712`,
+drawn from the 2026-07-12 tuning-system deep review (evidence pinned to commit
+`acfb8992`; findings C5, R2, R3).
+
+### `notuning` is not a baseline today
+
+"notuning" is supposed to mean platform defaults plus whatever an engine
+mandates for a working schema. In practice two platforms attach behavior to
+the *absence* of tuning, or unconditionally, rather than to the tuned path:
+
+- **ClickHouse inverts the pack.** `benchbox/platforms/clickhouse/tuning.py:74-100`
+  applies an aggressive OLAP session pack — `join_algorithm=grace_hash`,
+  `grace_hash_join_initial_buckets=8`, `optimize_aggregation_in_order=1`,
+  `group_by_two_level_threshold=100000`, and 50%-of-memory spill thresholds
+  for external group-by/sort — **only when `self.tuning_enabled` is
+  `False`**. A user who explicitly asks for tuning gets none of this; a user
+  who explicitly asks for no tuning gets a curated performance profile. The
+  label and the behavior are backwards.
+- **StarRocks injects unconditionally.** `benchbox/platforms/starrocks/workload.py:214-221`
+  appends `DISTRIBUTED BY HASH(`col`) BUCKETS 8` to every `CREATE TABLE` that
+  doesn't already declare a distribution clause, in every tuning mode. This is
+  schema-shape physical layout the engine requires to have a working table,
+  not an optimization choice — but nothing in bundle metadata currently
+  labels it as engine-mandatory versus a tuning decision.
+
+The same review also found that session-level `SET` statements (the
+ClickHouse pack above, and equivalent StarRocks query settings) are not
+recorded in the tuning bundle in any mode today — there is no ledger entry a
+later run or an auditor can compare against.
+
+### Two parallel rendering universes
+
+Tuning DDL is rendered by two independent code paths that do not share logic
+and can drift silently:
+
+- `benchbox/core/tuning/generators/*` (one module per platform family,
+  reachable through `benchbox/core/tuning/ddl_generator.py:get_ddl_generator`).
+  This path is exercised by exactly two callers: the dry-run preview
+  (`benchbox/core/dryrun.py:1066-1091`) and the cloud_spark adapter mixin
+  (`benchbox/platforms/base/cloud_spark/mixins.py:290`, which calls into
+  `TuningClauses` from the generators module directly).
+- Per-adapter `generate_tuning_clause` mixin methods (singular — one clause
+  string, not the generators' `TuningClauses` object), implemented
+  independently on ~20 adapters (ClickHouse, Databricks, Redshift, BigQuery,
+  Snowflake, Trino, Spark, DuckDB, Firebolt, Azure Synapse, Athena, Presto,
+  and others). This is the only path that touches real database connections
+  during execution.
+
+Because dry-run preview renders through `generators/*` and execution renders
+through the adapter mixins, a preview can show DDL that the real run never
+issues. Some adapter implementations are dead: `ClickHouse.generate_tuning_clause`
+(`benchbox/platforms/clickhouse/tuning.py:354`) has zero production callers —
+`rg -n "\.generate_tuning_clause\(" benchbox --include=*.py` (excluding the
+`def` lines) returns nothing; it is exercised only by unit tests that call
+the adapter method directly.
+
+### Linked open question
+
+The blocked TODO `databricks-liquid-clustering-tuning-review-20260526` has
+two open questions (DBR-compatibility hard-error vs. warning; manual-mode
+`liquid_clustering_columns` over 4 keys) that are instances of the same
+policy axis this ADR settles: when does an engine-specific tuning constraint
+block a run outright, versus warn and proceed? See Consequences.
+
+## Decision
+
+1. **Baseline definition.** `notuning` means platform defaults plus
+   engine-mandatory schema choices only — nothing else. Curated
+   session-optimization packs (e.g. the ClickHouse OLAP pack at
+   `benchbox/platforms/clickhouse/tuning.py:74-100`) move to the tuned path,
+   or to an explicitly recorded harness-defaults block if they must apply
+   regardless of tuning mode; they must never apply silently only when
+   tuning is disabled. Engine-mandatory physical layout that a working table
+   requires (e.g. StarRocks `DISTRIBUTED BY HASH` injection at
+   `benchbox/platforms/starrocks/workload.py:214-221`) is permitted in
+   baseline, but must be labeled as engine-mandatory in bundle metadata so it
+   is never mistaken for an applied tuning. Session-level `SET` statements
+   are recorded in the bundle in every mode, not only when tuning is
+   enabled. This settles the warn-vs-fail direction for the
+   `databricks-liquid-clustering-tuning-review-20260526` open questions:
+   compatibility checks warn first; a run is blocked only for explicit,
+   named unsafe combinations, not by default.
+
+2. **Single renderer.** `core/tuning/generators/*` becomes the single
+   tuning-DDL renderer. Adapter mixins are migrated to consume the
+   generators rather than maintaining independent `generate_tuning_clause`
+   implementations, so dry-run preview and real execution call the same
+   rendering function and cannot drift. Renderers with zero production
+   callers (e.g. `ClickHouse.generate_tuning_clause`) are deleted during
+   consolidation rather than migrated. Migration proceeds per platform, each
+   with a before/after DDL snapshot test proving the adapter-mixin output and
+   the generator output are equivalent prior to cutover.
+
+## Consequences
+
+- `tuning-renderer-consolidation-and-baseline-policy-20260712` implements
+  decision 2 (and the labeling/recording half of decision 1): one capability
+  registry, per-platform migration to the generators with before/after DDL
+  snapshot tests, and deletion of dead renderers such as
+  `ClickHouse.generate_tuning_clause`.
+- `tuning-applied-ledger-and-validation-status-20260712` implements the
+  recording half of decision 1: session-level `SET` statements (ClickHouse
+  OLAP pack, StarRocks query settings) get bundle ledger entries in every
+  mode, and `validation_status` stops certifying only that a metadata-table
+  `INSERT` succeeded.
+- `databricks-liquid-clustering-tuning-review-20260526` (blocked, w3's open
+  question on DBR-compatibility hard-error vs. warning) is unblocked on this
+  axis: warn-first, block only for explicit unsafe runtimes. Its second open
+  question (hard-fail for explicit `>4` manual `liquid_clustering_columns`)
+  already matches this ADR's "block only explicit unsafe combinations"
+  direction and stands unchanged. Annotated directly on the TODO via
+  `resolved_with`.
+- The ClickHouse OLAP session pack and any similar per-platform pack must be
+  re-homed (tuned path or harness-defaults block) as part of the renderer
+  consolidation work, not left in place with a comment.
+
+## Rejected Options
+
+1. **Keep session packs where they are, add recording only.** Record the
+   ClickHouse pack's `SET` statements in the bundle ledger but leave them
+   firing only when tuning is disabled. Rejected: this fixes the
+   observability gap (a reader now knows what ran) but not the semantic bug
+   (baseline still promises "no tuning" while shipping a curated OLAP
+   profile). "notuning" would remain a false label with better paperwork.
+2. **Consolidate into adapter mixins instead of generators.** Make each
+   adapter's `generate_tuning_clause` the source of truth and have dry-run
+   preview call adapter instances instead of the standalone generators.
+   Rejected: dry-run preview needs to render DDL without a live connection
+   or fully constructed adapter instance, which the generators already
+   support and most adapter mixins do not; a capability registry keyed by
+   platform type is also cleaner to build against a stateless generator
+   interface than against ~20 adapter classes with mixed constructor
+   requirements. Generators additionally already cover more platforms
+   (17 modules) than adapters currently delegate to.


### PR DESCRIPTION
# Pull Request

## Description

Records the ADR-3 decision gate (TODO `tuning-adr-baseline-definition-and-renderer-20260712`, decided by Joe 2026-07-12): `notuning` = platform defaults + engine-mandatory schema choices only (ClickHouse OLAP session pack leaves the baseline; engine-mandatory layout like StarRocks DISTRIBUTED BY stays but gets labeled; session SETs recorded in every mode; warn-first compatibility policy), and `core/tuning/generators/*` become the single DDL renderer consumed by adapter mixins, shared by dry-run and execution. Adds `docs/development/tuning-adr-003-baseline-and-single-renderer.md`, annotates the blocked databricks-liquid TODO's open questions with `resolved_with`, and moves the ADR TODO to DONE.

## Type of Change

- [x] Documentation

## Testing

- `validate_todo.py` on both touched YAML files — valid; indexes regenerate clean
- Review: citations (clickhouse/tuning.py:74-100 inverted session pack; starrocks/workload.py:214-221 unconditional injection; zero production callers of `ClickHouse.generate_tuning_clause`) verified independently twice — once during the original review session, once by the implementing agent via grep

## Public Contract Check

- [x] No public contract surfaces changed (decision record + TODO bookkeeping).
- [x] Contract-map impact checked — none.
- [x] No count claims added.

## Documentation

- [x] The ADR is the doc. No behavior changes. API wording unaffected.

## Code Quality

- [x] Schema validation on TODO files; no code changed; N/A tests; contracts unaffected.

## Artifact Hygiene

- [x] No raw artifacts; no binary evidence files.

## Notes

Part of the tuning remediation batch (#1161). Unblocks `tuning-renderer-consolidation-and-baseline-policy-20260712`. The Opus review pass for this branch was interrupted by an API usage limit after verifying all citations; the one remaining check (no adapter consumes the dead renderer under another name) was verified in the main session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QTnjb2i44JUL71kmu9sk1t

---
_Generated by [Claude Code](https://claude.ai/code/session_01QTnjb2i44JUL71kmu9sk1t)_