### PR TITLE
fix(tuning): register questdb/pg_duckdb/pg_mooncake DDL generators; warn on NoOp fallback

### DIFF
--- a/_project/DONE/main/active/tuning-generator-registry-completeness-20260712.yaml
+++ b/_project/DONE/main/active/tuning-generator-registry-completeness-20260712.yaml
@@ -2,7 +2,8 @@ id: tuning-generator-registry-completeness-20260712
 title: "Register orphaned DDL generators and make NoOp fallback loud + tested"
 worktree: main
 priority: Medium-High
-status: Not Started
+status: Completed
+completed_date: "2026-07-12"
 category: Core Functionality
 
 description: |
@@ -20,15 +21,15 @@ description: |
 work:
   - id: w1
     summary: "Register questdb, pg_duckdb, pg_mooncake in the get_ddl_generator mapping"
-    status: pending
+    status: done
     needs: []
   - id: w2
     summary: "Log a warning when NoOpDDLGenerator is returned for a platform the CLI registry knows (silent fallback only for genuinely tuning-free platforms like sqlite)"
-    status: pending
+    status: done
     needs: [w1]
   - id: w3
     summary: "Add registry-completeness unit test: every module in core/tuning/generators/ exporting a BaseDDLGenerator subclass must be reachable via get_ddl_generator under at least one platform key"
-    status: pending
+    status: done
     needs: [w1]
 
 deferred:

--- a/benchbox/core/tuning/ddl_generator.py
+++ b/benchbox/core/tuning/ddl_generator.py
@@ -622,6 +622,21 @@ class NoOpDDLGenerator(BaseDDLGenerator):
 # Type alias for type hints
 DDLGeneratorType = DDLGenerator | BaseDDLGenerator
 
+# Platforms known to have no physical tuning surface (no partitioning, clustering,
+# distribution, or sort-key clauses to emit) - the NoOp fallback for these is
+# expected and permanent, so get_ddl_generator() does not warn for them.
+_TUNING_FREE_PLATFORMS: frozenset[str] = frozenset(
+    {
+        "sqlite",
+        "sqlite3",
+        "pandas",
+        "modin",
+        "cudf",
+        "dask",
+        "polars",
+    }
+)
+
 
 def get_ddl_generator(platform_type: str) -> BaseDDLGenerator:
     """Get the appropriate DDL generator for a platform.
@@ -642,7 +657,10 @@ def get_ddl_generator(platform_type: str) -> BaseDDLGenerator:
     from benchbox.core.tuning.generators.doris import DorisDDLGenerator
     from benchbox.core.tuning.generators.duckdb import DuckDBDDLGenerator
     from benchbox.core.tuning.generators.firebolt import FireboltDDLGenerator
+    from benchbox.core.tuning.generators.pg_duckdb import PgDuckDBDDLGenerator
+    from benchbox.core.tuning.generators.pg_mooncake import PgMooncakeDDLGenerator
     from benchbox.core.tuning.generators.postgresql import PostgreSQLDDLGenerator
+    from benchbox.core.tuning.generators.questdb import QuestDBDDLGenerator
     from benchbox.core.tuning.generators.redshift import RedshiftDDLGenerator
     from benchbox.core.tuning.generators.snowflake import SnowflakeDDLGenerator
     from benchbox.core.tuning.generators.spark_family import DeltaDDLGenerator
@@ -678,12 +696,39 @@ def get_ddl_generator(platform_type: str) -> BaseDDLGenerator:
         "spark": DeltaDDLGenerator,
         "delta": DeltaDDLGenerator,
         "fabric_warehouse": DeltaDDLGenerator,  # Fabric uses Delta Lake tables
+        # QuestDB
+        "questdb": QuestDBDDLGenerator,
+        # pg_duckdb / pg_mooncake (PostgreSQL extensions). Both the hyphenated CLI
+        # platform key from PlatformRegistry (e.g. "pg-duckdb") and the underscored
+        # form used by the adapters' own platform_name/platform_type (e.g.
+        # "pg_duckdb") are registered so callers using either convention resolve
+        # to the real generator instead of falling through to NoOp.
+        "pg-duckdb": PgDuckDBDDLGenerator,
+        "pg_duckdb": PgDuckDBDDLGenerator,
+        "pg-mooncake": PgMooncakeDDLGenerator,
+        "pg_mooncake": PgMooncakeDDLGenerator,
     }
 
     platform_lower = platform_type.lower()
 
     if platform_lower in generators:
         return generators[platform_lower]()
+
+    # Platforms with no physical tuning surface at all (in-memory/embedded engines
+    # with no indexes, partitioning, or clustering clauses to emit). NoOp is the
+    # correct, permanent answer for these, so the fallback stays silent. Anything
+    # else falling through here is either a platform that should get a real
+    # generator eventually (e.g. StarRocks, deferred pending ADR-3) or a typo'd
+    # platform string - both are worth a warning since dry-run/tuning preview
+    # would otherwise go silently empty.
+    if platform_lower not in _TUNING_FREE_PLATFORMS:
+        logger.warning(
+            "No DDL generator registered for platform %r; tuning clauses will be "
+            "empty (NoOp fallback). If %r supports physical tuning, register it "
+            "in get_ddl_generator().",
+            platform_type,
+            platform_type,
+        )
 
     # Return NoOp generator for platforms without tuning support
     return NoOpDDLGenerator(platform_type)

--- a/tests/unit/core/tuning/test_ddl_generator_registry.py
+++ b/tests/unit/core/tuning/test_ddl_generator_registry.py
@@ -1,0 +1,238 @@
+"""Registry-completeness and NoOp-fallback tests for get_ddl_generator().
+
+Covers the 2026-07-12 tuning review finding R2: questdb, pg_duckdb, and
+pg_mooncake shipped dedicated DDL generators (with their own unit tests) that
+were never wired into get_ddl_generator()'s platform mapping, so callers
+silently got an empty-clauses NoOpDDLGenerator instead. These tests:
+
+1. Pin the fix for the three specific platforms (registration + NoOp
+   fallback is no longer silent for platforms that should have a real
+   generator).
+2. Add a general regression guard so a future generator module can't be
+   added to benchbox/core/tuning/generators/ without being registered in
+   get_ddl_generator(), by statically inspecting the function's own mapping
+   literal rather than re-implementing (and risking drift from) its logic.
+
+Copyright 2026 Joe Harris / BenchBox Project
+
+Licensed under the MIT License. See LICENSE file in the project root for details.
+"""
+
+from __future__ import annotations
+
+import ast
+import inspect
+import logging
+import pkgutil
+from importlib import import_module
+
+import pytest
+
+from benchbox.core.tuning import generators as generators_pkg
+from benchbox.core.tuning.ddl_generator import (
+    BaseDDLGenerator,
+    NoOpDDLGenerator,
+    get_ddl_generator,
+)
+from benchbox.core.tuning.generators.pg_duckdb import PgDuckDBDDLGenerator
+from benchbox.core.tuning.generators.pg_mooncake import PgMooncakeDDLGenerator
+from benchbox.core.tuning.generators.questdb import QuestDBDDLGenerator
+
+pytestmark = [
+    pytest.mark.unit,
+    pytest.mark.fast,
+]
+
+# Generator classes intentionally NOT reachable via get_ddl_generator()'s
+# platform-key dispatch. Keep this empty unless a generator is genuinely
+# selected some other way - document the reason inline when adding an entry.
+#
+# IcebergDDLGenerator / ParquetDDLGenerator / HiveDDLGenerator: these are
+# Spark table-format variants selected via SparkDDLGeneratorMixin's own
+# SparkTableFormat dispatch (benchbox/platforms/base/cloud_spark/mixins.py),
+# not via a get_ddl_generator() platform key. Only the Delta variant is
+# reachable through get_ddl_generator (as "databricks"/"spark"/"delta"/
+# "fabric_warehouse") because it is also usable standalone for dry-run.
+_EXEMPT_GENERATOR_CLASSES: frozenset[str] = frozenset(
+    {
+        "IcebergDDLGenerator",
+        "ParquetDDLGenerator",
+        "HiveDDLGenerator",
+    }
+)
+
+
+def _discover_concrete_generator_classes() -> dict[str, type[BaseDDLGenerator]]:
+    """Find every concrete BaseDDLGenerator subclass defined in a module
+    under benchbox/core/tuning/generators/.
+
+    Walks the actual submodules (not just generators/__init__.py's __all__)
+    so a new generator module is picked up even before anyone remembers to
+    export it. Only classes *defined* in the module (not merely imported,
+    e.g. PostgreSQLDDLGenerator re-used by timescaledb.py) are counted, and
+    abstract classes (e.g. SparkBaseDDLGenerator) are excluded.
+    """
+    discovered: dict[str, type[BaseDDLGenerator]] = {}
+    for module_info in pkgutil.iter_modules(generators_pkg.__path__, prefix=f"{generators_pkg.__name__}."):
+        module = import_module(module_info.name)
+        for name, obj in inspect.getmembers(module, inspect.isclass):
+            if (
+                obj.__module__ == module.__name__
+                and issubclass(obj, BaseDDLGenerator)
+                and obj is not BaseDDLGenerator
+                and not inspect.isabstract(obj)
+            ):
+                discovered[name] = obj
+    return discovered
+
+
+def _registered_generator_class_names() -> set[str]:
+    """Statically extract the class names in get_ddl_generator()'s `generators`
+    mapping literal, by parsing the function's own source with `ast`.
+
+    This deliberately does not re-import/re-declare the mapping (that would
+    just be a second copy that could drift from the real one) - it inspects
+    the actual dict literal inside get_ddl_generator() itself, so this test
+    fails the moment a class stops being referenced there.
+    """
+    source = inspect.getsource(get_ddl_generator)
+    tree = ast.parse(source)
+    function_node = tree.body[0]
+    assert isinstance(function_node, ast.FunctionDef)
+
+    class_names: set[str] = set()
+    for node in ast.walk(function_node):
+        # `generators: dict[str, type[BaseDDLGenerator]] = {...}` is an
+        # annotated assignment (ast.AnnAssign, single `target`), not a plain
+        # ast.Assign (which has a `targets` list) - handle both forms.
+        if (
+            isinstance(node, ast.AnnAssign)
+            and isinstance(node.target, ast.Name)
+            and node.target.id == "generators"
+            or isinstance(node, ast.Assign)
+            and any(isinstance(target, ast.Name) and target.id == "generators" for target in node.targets)
+        ):
+            dict_node = node.value
+        else:
+            continue
+
+        assert isinstance(dict_node, ast.Dict), "Expected `generators` to be assigned a dict literal"
+        for value in dict_node.values:
+            assert isinstance(value, ast.Name), f"Expected a bare class name in generators dict, got {value!r}"
+            class_names.add(value.id)
+        break
+    else:
+        raise AssertionError("Could not find a `generators = {...}` assignment in get_ddl_generator()")
+
+    return class_names
+
+
+class TestDDLGeneratorRegistryCompleteness:
+    """Every concrete generator module must be reachable via get_ddl_generator()."""
+
+    def test_exempt_list_has_no_stale_entries(self) -> None:
+        """Every exemption must correspond to a real, currently-unregistered generator.
+
+        Keeps _EXEMPT_GENERATOR_CLASSES honest: if a class is registered later,
+        its exemption entry must be removed too.
+        """
+        discovered = _discover_concrete_generator_classes()
+        registered = _registered_generator_class_names()
+        unregistered = set(discovered) - registered
+
+        stale = _EXEMPT_GENERATOR_CLASSES - unregistered
+        assert not stale, f"Stale exemptions (already registered or no longer exist): {sorted(stale)}"
+
+    def test_every_generator_module_class_is_registered(self) -> None:
+        """Every exported, concrete DDL generator class must have a platform key.
+
+        Regression guard for review finding R2: questdb.py, pg_duckdb.py, and
+        pg_mooncake.py shipped generator classes with dedicated unit tests but
+        no entry in get_ddl_generator()'s mapping, so get_ddl_generator()
+        silently returned NoOpDDLGenerator for those platforms.
+        """
+        discovered = _discover_concrete_generator_classes()
+        assert discovered, "Expected to discover at least one concrete DDL generator class"
+
+        registered = _registered_generator_class_names()
+        missing = set(discovered) - registered - _EXEMPT_GENERATOR_CLASSES
+
+        assert not missing, (
+            f"Generator classes not reachable via get_ddl_generator(): {sorted(missing)}. "
+            "Add a platform key -> class entry in get_ddl_generator()'s `generators` "
+            "mapping, or add the class to _EXEMPT_GENERATOR_CLASSES with a reason."
+        )
+
+
+class TestNewPlatformGeneratorRegistration:
+    """Pin the specific w1 registrations from review finding R2."""
+
+    def test_questdb_is_registered(self) -> None:
+        generator = get_ddl_generator("questdb")
+        assert isinstance(generator, QuestDBDDLGenerator)
+        assert not isinstance(generator, NoOpDDLGenerator)
+
+    @pytest.mark.parametrize("platform_key", ["pg_duckdb", "pg-duckdb"])
+    def test_pg_duckdb_is_registered(self, platform_key: str) -> None:
+        generator = get_ddl_generator(platform_key)
+        assert isinstance(generator, PgDuckDBDDLGenerator)
+        assert not isinstance(generator, NoOpDDLGenerator)
+
+    @pytest.mark.parametrize("platform_key", ["pg_mooncake", "pg-mooncake"])
+    def test_pg_mooncake_is_registered(self, platform_key: str) -> None:
+        generator = get_ddl_generator(platform_key)
+        assert isinstance(generator, PgMooncakeDDLGenerator)
+        assert not isinstance(generator, NoOpDDLGenerator)
+
+    def test_lookup_is_case_insensitive(self) -> None:
+        assert isinstance(get_ddl_generator("QuestDB"), QuestDBDDLGenerator)
+        assert isinstance(get_ddl_generator("PG-DUCKDB"), PgDuckDBDDLGenerator)
+        assert isinstance(get_ddl_generator("Pg_Mooncake"), PgMooncakeDDLGenerator)
+
+
+class TestNoOpFallbackWarning:
+    """w2: NoOp fallback must warn for platforms that aren't known tuning-free,
+    but must never raise, and must stay silent for genuinely tuning-free
+    platforms.
+    """
+
+    def test_unknown_platform_still_returns_noop_without_raising(self, caplog: pytest.LogCaptureFixture) -> None:
+        with caplog.at_level(logging.WARNING, logger="benchbox.core.tuning.ddl_generator"):
+            generator = get_ddl_generator("totally-unregistered-platform-xyz")
+
+        assert isinstance(generator, NoOpDDLGenerator)
+        assert generator.platform_name == "totally-unregistered-platform-xyz"
+
+    def test_unknown_platform_logs_a_warning(self, caplog: pytest.LogCaptureFixture) -> None:
+        with caplog.at_level(logging.WARNING, logger="benchbox.core.tuning.ddl_generator"):
+            get_ddl_generator("totally-unregistered-platform-xyz")
+
+        assert any(
+            "totally-unregistered-platform-xyz" in record.getMessage() and record.levelno == logging.WARNING
+            for record in caplog.records
+        )
+
+    def test_starrocks_falls_back_loudly(self, caplog: pytest.LogCaptureFixture) -> None:
+        """StarRocks has no generator yet (deferred pending ADR-3) - this is
+        exactly the "silently-empty tuning preview" symptom from review finding
+        R2, so it must now warn rather than stay silent.
+        """
+        with caplog.at_level(logging.WARNING, logger="benchbox.core.tuning.ddl_generator"):
+            generator = get_ddl_generator("starrocks")
+
+        assert isinstance(generator, NoOpDDLGenerator)
+        assert any("starrocks" in record.getMessage() for record in caplog.records)
+
+    @pytest.mark.parametrize("platform_key", ["sqlite", "sqlite3", "pandas", "modin", "cudf", "dask", "polars"])
+    def test_known_tuning_free_platforms_stay_silent(self, platform_key: str, caplog: pytest.LogCaptureFixture) -> None:
+        with caplog.at_level(logging.WARNING, logger="benchbox.core.tuning.ddl_generator"):
+            generator = get_ddl_generator(platform_key)
+
+        assert isinstance(generator, NoOpDDLGenerator)
+        assert caplog.records == []
+
+    def test_registered_platform_never_warns(self, caplog: pytest.LogCaptureFixture) -> None:
+        with caplog.at_level(logging.WARNING, logger="benchbox.core.tuning.ddl_generator"):
+            get_ddl_generator("questdb")
+
+        assert caplog.records == []


### PR DESCRIPTION
# Pull Request

## Description

Implements TODO `tuning-generator-registry-completeness-20260712` (review finding R2). Registers the three orphaned generator classes in `get_ddl_generator()` — `questdb`, and both key forms for the PostgreSQL extensions (`pg-duckdb`/`pg_duckdb`, `pg-mooncake`/`pg_mooncake`, matching the CLI's hyphenated keys and the adapters' underscored names). Unknown platforms outside a known tuning-free set (`sqlite`, DF engines) now log a warning instead of silently receiving `NoOpDDLGenerator`. Adds an AST-based registry-completeness test that fails if a future generator module lands unregistered. Moves the TODO to DONE.

## Type of Change

- [x] Bug fix

## Testing

- `uv run -- python -m pytest tests/unit/core/tuning -q` — 432 passed
- Probe: `get_ddl_generator('questdb'/'pg_mooncake'/'pg-duckdb')` returns the real generators, not NoOp
- Review checks completed: platform keys cross-checked against `benchbox/platforms/__init__.py` (adapters: `.questdb`, `.pg_duckdb`, `.pg_mooncake`) and CLI option tables (`pg-duckdb` hyphenated) — both forms registered; `_TUNING_FREE_PLATFORMS` contains only engines with no DDL-tuning surface

## Public Contract Check

- [x] No public/beta contract surfaces changed (registry is internal; NoOp fallback behavior preserved, plus a log warning).
- [x] Contract-map impact checked — none.
- [x] No count claims.

## Documentation

- [x] No user-facing docs affected (internal registry). No behavior change beyond warning log. API wording unaffected.

## Code Quality

- [x] Tests run (432 passed); registry completeness now pinned by test.
- [x] Backwards compatible: `get_ddl_generator` still never raises.
- [x] New tests added for the fix and the drift guard.
- [x] Contracts unaffected.

## Artifact Hygiene

- [x] No raw artifacts; no binary evidence files.

## Notes

Part of the tuning remediation batch (#1161). The Opus review pass was interrupted by an API usage limit; its two open questions (key correctness, tuning-free list validity) were completed in the main session as recorded above. Unblocks `tuning-soundness-test-coverage-20260712` and `tuning-renderer-consolidation-and-baseline-policy-20260712`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QTnjb2i44JUL71kmu9sk1t

---
_Generated by [Claude Code](https://claude.ai/code/session_01QTnjb2i44JUL71kmu9sk1t)_