### PR TITLE
chore(todo): re-prioritize 2 open TODO items (2026-07-16 pass)

### DIFF
--- a/_project/TODO/main/active/tag-and-pypi-environment-admin-hardening.yaml
+++ b/_project/TODO/main/active/tag-and-pypi-environment-admin-hardening.yaml
@@ -1,7 +1,7 @@
 id: tag-and-pypi-environment-admin-hardening
 title: "Apply the two remaining publish-path admin protections: v* tag-creation ruleset and pypi environment required reviewers"
 worktree: main
-priority: Medium
+priority: High
 status: "In Progress"
 category: "Release Tooling"
 

--- a/_project/TODO/main/planning/lxml-cve-pysec-2026-87-blocked-by-redshift-connector.yaml
+++ b/_project/TODO/main/planning/lxml-cve-pysec-2026-87-blocked-by-redshift-connector.yaml
@@ -1,7 +1,7 @@
 id: lxml-cve-pysec-2026-87-blocked-by-redshift-connector
 title: "Unblock lxml PYSEC-2026-87 fix once redshift-connector relaxes its lxml pin"
 worktree: main
-priority: Low
+priority: Medium
 status: Blocked
 category: Code Quality and Technical Debt
 description: |


### PR DESCRIPTION
## Summary

Second full-backlog prioritization pass (~105 open items across `main/active`, `main/planning`, `benchmark-expansion`, and `platform-expansion`). Two adjustments:

- **`tag-and-pypi-environment-admin-hardening`**: Medium → **High** — In-progress publish-path admin controls: v* tag-creation ruleset and PyPI environment required reviewers. These gaps allow unauthorized package publishes until closed; that's a High-severity release-security gap.

- **`lxml-cve-pysec-2026-87-blocked-by-redshift-connector`**: Low → **Medium** — Tracked CVE (PYSEC-2026-87) blocked by upstream redshift-connector lxml pin. Low for a named CVE understates urgency; Medium ensures it's acted on promptly when the upstream pin relaxes.

Notable observations (no priority changes, but flagged for follow-up):
- 7 items in `main/planning/` have `status: Completed` and belong in the DONE tree (covered by `todo-sweep-completed-items-from-open-tree`)
- `cross-surface-oracle-remediation` in `main/active/` is also `Completed` — should be swept
- The 12-item tuning cluster filed 2026-07-16 (2 Critical, 5 High) appears deliberately calibrated by its author and was left untouched

## Test plan

- [x] Both changed files pass `validate_todo.py` schema validation
- [x] Pre-commit hooks passed (codespell, check-yaml, fix-eol, trim-whitespace)
- [x] Content-only change — Python fast tests not required

https://claude.ai/code/session_013FzK1DZiUTQRgWWRgtbegX

---
_Generated by [Claude Code](https://claude.ai/code/session_013FzK1DZiUTQRgWWRgtbegX)_