### PR TITLE
fix: consolidated bot review follow-up sweep (6 findings across 5 merged PRs)

### DIFF
--- a/_project/TODO/main/planning/tuning-bundle-provenance-and-config-export-20260712.yaml
+++ b/_project/TODO/main/planning/tuning-bundle-provenance-and-config-export-20260712.yaml
@@ -91,7 +91,7 @@ scope_limit:
 
 verification:
   - description: "End-to-end: tuned duckdb run at SF 0.01 produces a bundle whose tuning block contains source enum, template ref, requested_config_hash, and the full requested config"
-    command: "uv run -- python -m benchbox.cli.main run --platform duckdb --benchmark tpch --scale 0.01 --tuning tuned --non-interactive --output /tmp/tuning-export-check && uv run -- python -c \"import json,glob; b=json.load(open(sorted(glob.glob('/tmp/tuning-export-check/*.json'))[-1])); print(json.dumps(b['platform']['tuning'], indent=2))\""
+    command: "BENCHBOX_OUTPUT_DIR=/tmp/tuning-export-check uv run -- python -m benchbox.cli.main run --platform duckdb --benchmark tpch --scale 0.01 --tuning tuned --non-interactive && uv run -- python -c \"import json,glob; b=json.load(open(sorted(glob.glob('/tmp/tuning-export-check/results/*.json'))[-1])); print(json.dumps(b['platform']['tuning'], indent=2))\""
     expected_output: "tuning block with source, template ref/hash, requested_config_hash, and requested config structure"
   - description: "Unit suites green"
     command: "uv run -- python -m pytest tests/unit/core/results tests/unit/core/tuning tests/unit/cli/test_tuning* -q"

--- a/_project/TODO/main/planning/tuning-explorer-ingest-mode-extraction-20260712.yaml
+++ b/_project/TODO/main/planning/tuning-explorer-ingest-mode-extraction-20260712.yaml
@@ -65,8 +65,8 @@ scope_limit:
 
 verification:
   - description: "Corpus re-ingest count check"
-    command: "uv run -- python _project/scripts/explorer_pipeline/pipeline.py --help"
-    expected_output: "Pipeline runs against results-data/bundles; dataset shows 325 tuned and 203 not-recorded rows (exact counts from w0 re-validation)"
+    command: "rm -rf /tmp/explorer-ingest-check && uv run -- python _project/scripts/explorer_publish.py build --data-dir results-data/ --output /tmp/explorer-ingest-check && uv run -- python -c \"import duckdb; print(duckdb.connect('/tmp/explorer-ingest-check/results.duckdb').execute('SELECT tuning_mode, COUNT(*) FROM results GROUP BY tuning_mode ORDER BY 2 DESC').fetchall())\""
+    expected_output: "Real re-ingest via the explorer_publish.py build entrypoint (pipeline.py is import-only, has no CLI); dataset shows 325 tuned and 203 not-recorded rows (exact counts from w0 re-validation) once this TODO's tuning_mode/not-recorded classification work lands -- pre-implementation, tuning_mode reads NULL for all 528 rows (verified 2026-07-12)"
   - description: "Explorer unit tests green"
     command: "cd results-explorer && npm test -- --run 2>&1 | tail -5"
     expected_output: "All passing incl. new not-recorded state tests"

--- a/_project/TODO/scd2-audit-followup/planning/scd2-cleanup-isolation-distinct-effective-ts.yaml
+++ b/_project/TODO/scd2-audit-followup/planning/scd2-cleanup-isolation-distinct-effective-ts.yaml
@@ -35,6 +35,19 @@ description: |
   affect change detection; it does change valid_from/valid_to values, so the
   DuckDB and PostgreSQL SCD2 seed-state assertions and the validation queries that
   filter on effective_ts must be re-checked.
+
+  IMPORTANT correction (review finding, 2026-07-12): per-change_type effective_ts
+  alone does NOT isolate the actually-reproduced basic-after-new_keys_only case.
+  merge_scd_type2_basic and merge_scd_type2_new_keys_only both insert from the
+  SAME 'new' staging rows in scd2_ops_stage_customer - population-time
+  differentiation is a property of the STAGE rows, and both ops read the
+  identical s.effective_ts value from those rows into valid_from, so their
+  inserted rows share the exact same cleanup key regardless of which op did the
+  inserting. Distinguishing "which op consumed this stage row" needs a discriminator
+  applied at INSERT time by each operation's own write_sql (e.g. new_keys_only
+  stamping s.effective_ts + a small op-specific INTERVAL offset, or a new
+  provenance column on the dimension table), not just a per-change_type
+  population value. See the revised w1/w2 scope below.
 impact:
   business_value: "Removes the last latent SCD2 correctness gap: one op's cleanup can no longer corrupt another op's rows even when cleanups are skipped or reordered."
   user_impact: "SCD2 operations become independently cleanable regardless of run order, not just under the current catalog ordering."
@@ -48,19 +61,23 @@ prior_art:
 
 work:
 - id: w1
-  summary: "Assign a distinct effective_ts per change_type group in _get_population_sql (changed/unchanged/new)."
+  summary: "Assign a distinct effective_ts per change_type group in _get_population_sql (changed/unchanged/new). Resolves basic-vs-no_change only; see w2 for basic-vs-new_keys_only."
   status: pending
 - id: w2
-  summary: "Qualify basic and no_change cleanup_sql DELETE/UPDATE subqueries by the op's own change_type(s), now that effective_ts distinguishes groups."
+  summary: "Add an op-specific discriminator to new_keys_only's INSERT (e.g. valid_from = s.effective_ts + an op-tagged offset) so its rows differ from basic's inserts of the same shared 'new' staged keys."
   needs: [w1]
   status: pending
 - id: w3
-  summary: "Audit every SCD2 validation query that filters on effective_ts (no_rows_closed_by_batch, no_rows_closed, the N3 cardinality checks) and re-scope to the correct group(s)."
-  needs: [w1]
+  summary: "Qualify basic and no_change cleanup_sql DELETE/UPDATE subqueries by change_type and, where the group is shared, the w2 discriminator."
+  needs: [w1, w2]
   status: pending
 - id: w4
-  summary: "Re-verify DuckDB + live PostgreSQL seed-state and per-op assertions; add a test proving basic's cleanup no longer deletes new_keys_only's rows in a back-to-back run."
-  needs: [w1, w2, w3]
+  summary: "Audit every SCD2 validation query filtering on effective_ts (no_rows_closed_by_batch, no_rows_closed, the N3 cardinality checks) and re-scope using w1/w2."
+  needs: [w1, w2]
+  status: pending
+- id: w5
+  summary: "Re-verify DuckDB + live PostgreSQL seed-state; add a test proving basic's and new_keys_only's cleanups no longer cross-delete each other's rows, in both run orders."
+  needs: [w1, w2, w3, w4]
   status: pending
 
 must_preserve:
@@ -70,16 +87,24 @@ must_preserve:
 - "The fixed-size 20/20/20 change batch and scale-independence are preserved."
 
 approach: |
-  One population-SQL change (distinct effective_ts per group) unlocks meaningful
-  change_type-scoped cleanup. Sequence: differentiate effective_ts first, then
-  re-scope the cleanups and any effective_ts-filtered validations, then re-verify
-  seed-state on both engines. Keep the dates close (consecutive days) so the
+  A population-SQL change (distinct effective_ts per change_type group) unlocks
+  meaningful cleanup scoping for the two ops with disjoint change_types
+  (basic vs no_change). It does NOT unlock basic-vs-new_keys_only isolation,
+  because both consume the same shared 'new' staging rows and would otherwise
+  insert with the identical valid_from. That pair additionally needs an
+  operation-specific discriminator applied at INSERT time by new_keys_only's
+  own write_sql (w2) - a narrow, scoped change to that one op's body, not a
+  rewrite of the ops' logic. Sequence: differentiate population effective_ts
+  (w1), add the new_keys_only discriminator (w2), re-scope the cleanups and
+  any effective_ts-filtered validations using both (w3/w4), then re-verify
+  seed-state on both engines (w5). Keep the dates/offsets close so the
   "single-batch" framing in docs/blog stays accurate.
 
 anti_patterns:
 - "DO NOT put effective_ts into the row_hash fingerprint - because change detection must stay independent of the batch timestamp - keep it out."
-- "DO NOT scope cleanups by c_custkey - because basic and new_keys_only share the same 'new' custkeys - scope by the now-distinct effective_ts / change_type."
-- "DO NOT widen scope to rewrite the op UPDATE/INSERT bodies - the ops are correct; only population effective_ts and cleanup/validation scoping change."
+- "DO NOT scope cleanups by c_custkey - because basic and new_keys_only share the same 'new' custkeys - scope by effective_ts / change_type / the w2 op discriminator instead."
+- "DO NOT assume per-change_type effective_ts alone separates basic's new-key inserts from new_keys_only's - both read s.effective_ts verbatim from the same shared 'new' stage rows, so their inserted valid_from values are identical without w2's per-operation discriminator (review finding, 2026-07-12)."
+- "DO NOT rewrite basic's or no_change's UPDATE/INSERT bodies - only new_keys_only's INSERT needs the w2 discriminator; the other two ops' logic is correct as-is."
 
 verification:
 - description: "SCD2 DuckDB integration green including a new cross-op cleanup-isolation test."
@@ -98,7 +123,8 @@ scope_limit:
 
 success_metrics:
 - "Each change_type group carries a distinct effective_ts."
-- "basic's cleanup run after new_keys_only's write no longer deletes new_keys_only's rows (proven by test)."
+- "new_keys_only's inserted rows carry a discriminator (w2) distinguishing them from basic's inserts of the same staged 'new' keys."
+- "basic's cleanup run after new_keys_only's write no longer deletes new_keys_only's rows, and vice versa (proven by a back-to-back test in both orders)."
 - "All SCD2 ops still validate green and restore the seed on DuckDB and PostgreSQL."
 
 metadata:

--- a/docs/development/tuning-adr-001-trust-and-hash-semantics.md
+++ b/docs/development/tuning-adr-001-trust-and-hash-semantics.md
@@ -124,11 +124,21 @@ Implementing TODOs must honor these decisions as fixed constraints:
   `applied_ledger_hash` from it, and must not conflate `tunings_applied`
   (requested) with what was physically applied. `tuning_validation_status`
   must be able to express partial application, not just
-  `APPLIED`/`FAILED_TO_SAVE`/`NOT_APPLICABLE`.
+  `APPLIED`/`FAILED_TO_SAVE`/`NOT_APPLICABLE`. Owns populating
+  `applied_ledger_hash` onto the bundle: it depends on
+  `tuning-bundle-provenance-and-config-export-20260712` (the bundle's
+  `requested_config_hash` field and export scaffolding must exist
+  first), so it is this TODO — not bundle-provenance — that completes
+  the "both hashes carried on the bundle" requirement below.
 - **`tuning-bundle-provenance-and-config-export-20260712`** — must
-  populate both `requested_config_hash` and `applied_ledger_hash` on the
-  bundle (replacing the never-set `tuning_config_hash` field), and must
-  carry/display the self-attested trust label alongside them.
+  populate `requested_config_hash` on the bundle (replacing the
+  never-set `tuning_config_hash` field) and carry/display the
+  self-attested trust label alongside it. Does **not** populate
+  `applied_ledger_hash`: this TODO has no dependency on
+  `tuning-applied-ledger-and-validation-status-20260712` (the applied
+  statement ledger does not exist yet at this TODO's build time — the
+  dependency runs the other way), so requiring it here would be
+  unsatisfiable in dependency order (review finding, 2026-07-12).
 - **`tuning-mode-vocabulary-and-facet-implementation-20260712`** — any
   facet or mode-derived data surfaced to evaluators must not imply
   verification beyond self-attestation, and must source hash values from

--- a/scripts/release_readiness_check.py
+++ b/scripts/release_readiness_check.py
@@ -278,8 +278,17 @@ def evaluate_uat_gate_evidence(
             False, f"UAT gate evidence completed_at {completed_raw!r} is unparseable; release is blocked.", summary
         )
     if completed_at.tzinfo is None:
-        # Sweep summaries record operator-local wall-clock time.
-        completed_at = completed_at.astimezone()
+        # A naive timestamp has no recoverable offset here: `.astimezone()`
+        # would reinterpret it against *this process's* local timezone (the
+        # CI runner's, not the operator's who produced the evidence), so
+        # evidence near the max-age cutoff could read stale or fresh purely
+        # based on where the check happens to run (#1162 review). New
+        # evidence is written with an explicit offset (see
+        # orchestrator._write_gate_summary_artifact); a naive timestamp here
+        # means older/hand-authored evidence, so assume UTC -- deterministic
+        # regardless of the evaluating environment, even if not necessarily
+        # the exact original operator offset.
+        completed_at = completed_at.replace(tzinfo=UTC)
     age_days = (now - completed_at).total_seconds() / 86400
     summary.append(f"- uat_age: {age_days:.1f}d")
     if age_days > max_age_days:

--- a/tests/uat/container_cleanup.py
+++ b/tests/uat/container_cleanup.py
@@ -473,7 +473,14 @@ def _list_networks(run: ContainerRunner, project_prefix: str) -> list[ContainerR
 
         if labels.get(_BUILDER_ROLE_LABEL) == "builtin" or name == "default":
             category: ContainerCategory = "system"
-        elif _is_owned(project, project_prefix) or _is_owned_image_name(name, project_prefix):
+        elif _is_owned(project, project_prefix) or _is_owned(name, project_prefix):
+            # Name fallback uses _is_owned (separator-aware: exact match or
+            # `<prefix>-`/`<prefix>_` boundary), not _is_owned_image_name
+            # (bare startswith, meant for image repo names like
+            # "benchbox/foo"). A network without a compose project label
+            # named e.g. "benchbox-uatfoo" must NOT match prefix
+            # "benchbox-uat" -- that's a different, unrelated network, and
+            # `MODE=owned APPLY=1` would otherwise delete it (#1158 review).
             category = "owned"
         else:
             category = "shared"

--- a/tests/uat/gate_summary.py
+++ b/tests/uat/gate_summary.py
@@ -96,7 +96,7 @@ class GateSummary:
     source_commit_sha: str
     source_dirty: bool
     container_engine: str | None
-    completed_at: str  # ISO 8601, tests.uat.orchestrator._dt.datetime.now().isoformat()
+    completed_at: str  # ISO 8601 with UTC offset, tests.uat.orchestrator._dt.datetime.now().astimezone().isoformat()
     dry_run: bool
     aborted: bool
     abort_phase: str | None

--- a/tests/uat/orchestrator.py
+++ b/tests/uat/orchestrator.py
@@ -500,8 +500,12 @@ def run_sweep(  # noqa: C901
     # release-gate aggregation (`make uat-gate-check`) always has a
     # machine-readable per-stage record beside cells.jsonl. Written last:
     # its completed_at is the sweep-completion timestamp the cross-stage
-    # Docker ordering check keys on.
-    completed_at = _dt.datetime.now()
+    # Docker ordering check keys on. `.astimezone()` attaches the operator
+    # machine's real local UTC offset at capture time, so the age check in
+    # release_readiness_check.py (run later, in CI, in a different timezone)
+    # reads the offset embedded in the ISO string instead of reinterpreting
+    # a naive timestamp against the wrong process's local time (#1162 review).
+    completed_at = _dt.datetime.now().astimezone()
     _write_gate_summary_artifact(
         config=config,
         log_dir=log_dir,

--- a/tests/uat/test_container_cleanup.py
+++ b/tests/uat/test_container_cleanup.py
@@ -319,6 +319,39 @@ def test_network_inventory_owned_vs_shared_vs_system():
     assert "default" not in max_networks  # system network is never a target, even at max
 
 
+def test_network_name_extending_prefix_without_separator_is_not_owned():
+    """#1158 review: a network without a compose project label whose name
+    merely extends project_prefix (no `-`/`_` boundary) must be classified
+    `shared`, not `owned` -- otherwise `MODE=owned APPLY=1` deletes an
+    unrelated network. The name fallback must use the same separator-aware
+    matching as the project-label check (_is_owned), not a bare startswith.
+    """
+    networks = [
+        *_NETWORKS,
+        {"id": "lookalike-net", "configuration": {"name": "benchbox-uatfoo_default", "labels": {}}},
+    ]
+
+    def fake(argv, **kwargs):
+        argv_tuple = tuple(argv)
+        if argv_tuple[:4] == ("container", "image", "ls", "--format"):
+            return docker_assets.DockerCommandResult(argv_tuple, 0, json.dumps(_IMAGES), "")
+        if argv_tuple[:3] == ("container", "ls", "-a"):
+            return docker_assets.DockerCommandResult(argv_tuple, 0, json.dumps(_CONTAINERS), "")
+        if argv_tuple[:4] == ("container", "volume", "ls", "--format"):
+            return docker_assets.DockerCommandResult(argv_tuple, 0, json.dumps(_VOLUMES), "")
+        if argv_tuple[:4] == ("container", "network", "ls", "--format"):
+            return docker_assets.DockerCommandResult(argv_tuple, 0, json.dumps(networks), "")
+        if argv_tuple == ("container", "system", "df"):
+            return docker_assets.DockerCommandResult(argv_tuple, 0, _SYSTEM_DF, "")
+        return docker_assets.DockerCommandResult(argv_tuple, 0, "", "")
+
+    owned = container_cleanup.reclaim_container_usage(mode="owned", apply=False, runner=fake)
+    owned_networks = {r.display_name for r in owned.targets if r.kind == "network"}
+    assert "benchbox-uatfoo_default" not in owned_networks
+    retained_networks = {r.display_name for r in owned.retained if r.kind == "network"}
+    assert "benchbox-uatfoo_default" in retained_networks
+
+
 def test_mocker_compose_project_label_is_recognized(monkeypatch):
     """uat-container-engine-routing w4/w0 live-validation finding: a
     `mocker compose up` container/network carries `com.mocker.compose.project`,

--- a/tests/uat/test_orchestrator.py
+++ b/tests/uat/test_orchestrator.py
@@ -1227,6 +1227,23 @@ def test_dry_run_sweep_writes_gate_summary_with_dry_run_verdict(tmp_path: Path):
     assert payload["source_commit_sha"]
 
 
+def test_gate_summary_completed_at_is_offset_aware(tmp_path: Path):
+    """#1162 review: completed_at must carry an explicit UTC offset, not a
+    naive local timestamp -- release_readiness_check.py evaluates the
+    committed evidence in a different process (CI), possibly in a different
+    timezone than the operator who ran the sweep. A naive timestamp there
+    gets reinterpreted against the *evaluating* process's local timezone,
+    which can misjudge freshness near the max-age cutoff.
+    """
+    cfg = validate_config({"name": "gate-tz", "dry_run": True, "phases": ["preflight", "execute", "report"]})
+
+    orchestrator.run_sweep(cfg, log_dir_override=tmp_path)
+
+    payload = _read_gate_summary(tmp_path)
+    completed_at = _dt.datetime.fromisoformat(payload["completed_at"])
+    assert completed_at.tzinfo is not None
+
+
 def test_green_sweep_writes_green_gate_summary_with_accounting(tmp_path: Path):
     cfg = validate_config(
         {

--- a/tests/unit/test_release_infrastructure.py
+++ b/tests/unit/test_release_infrastructure.py
@@ -1439,6 +1439,44 @@ class TestUATGateReleaseEvidence:
         assert not result.ok
         assert "no completed_at" in result.message
 
+    @pytest.mark.skipif(not hasattr(__import__("time"), "tzset"), reason="time.tzset() is POSIX-only")
+    def test_naive_completed_at_treated_as_utc_regardless_of_local_timezone(self, monkeypatch):
+        """#1162 review: a naive completed_at must evaluate identically no
+        matter what timezone the evaluating process happens to be running in.
+        `.astimezone()` previously reinterpreted a naive timestamp against
+        *this process's* local timezone (the CI runner's, not the operator's
+        who produced the evidence) -- so evidence near the max-age cutoff
+        could read stale or fresh purely based on where the check ran.
+        """
+        import os
+        import time
+        from datetime import UTC, datetime
+
+        payload = self._payload(completed_at="2026-07-09T10:00:00")  # naive, no offset
+        now = datetime(2026, 7, 10, 12, tzinfo=UTC)
+
+        def _age_line(result):
+            return next(line for line in result.summary if line.startswith("- uat_age:"))
+
+        original_tz = os.environ.get("TZ")
+        try:
+            results = {}
+            for tz in ("UTC", "Etc/GMT+12", "Etc/GMT-14"):
+                monkeypatch.setenv("TZ", tz)
+                time.tzset()
+                results[tz] = self._evaluate(payload, now=now)
+        finally:
+            if original_tz is not None:
+                os.environ["TZ"] = original_tz
+            else:
+                os.environ.pop("TZ", None)
+            time.tzset()
+
+        oks = {tz: r.ok for tz, r in results.items()}
+        ages = {tz: _age_line(r) for tz, r in results.items()}
+        assert len(set(oks.values())) == 1, oks
+        assert len(set(ages.values())) == 1, ages
+
     def test_uat_failure_blocks_after_green_canary(self, monkeypatch, capsys):
         """main() combines a green canary with UAT evidence; missing UAT blocks."""
         from datetime import UTC, datetime


### PR DESCRIPTION
# Pull Request

## Description

Late-landing `chatgpt-codex-connector` bot review follow-ups. Each PR listed below was already merged before its review completed, so the fixes are consolidated into this one sweep branch off `develop` per the established review-followup pattern.

## Findings fixed

1. **#1158** — `tests/uat/container_cleanup.py`: the network-classification name fallback reused `_is_owned_image_name` (a bare `startswith`, meant for image repo names like `benchbox/foo`), so a network with no compose project label whose name merely extended `project_prefix` without a `-`/`_` boundary (e.g. `benchbox-uatfoo_default` vs prefix `benchbox-uat`) was misclassified as owned — under `MODE=owned APPLY=1` that network would be deleted even though it belongs to a different project. Switched to `_is_owned`, which already implements separator-aware matching.
2. **#1161** — two `_project/TODO/main/planning/*.yaml` verification commands didn't validate what they claimed: (a) `tuning-bundle-provenance-and-config-export`'s command used `--output` to redirect the result bundle, but that flag doesn't control where `_export_run_result` writes JSON (that's `BENCHBOX_OUTPUT_DIR`) — the `glob()` was empty and raised `IndexError`; (b) `tuning-explorer-ingest-mode-extraction`'s command invoked `pipeline.py --help`, but `pipeline.py` is an import-only module with no CLI — the real entrypoint is `explorer_publish.py build`. Both corrected commands were actually run against `develop` HEAD to confirm they work (the semantic content they check — the tuning bundle block, the tuned/not-recorded counts — is understandably absent, since both TODOs are `Not Started` planning items for future work).
3. **#1162** — `scripts/release_readiness_check.py` + `tests/uat/orchestrator.py`: UAT gate evidence's `completed_at` was written as a naive local timestamp, then reinterpreted via `.astimezone()` in `release_readiness_check.py` — which resolves against *that process's* local timezone (the CI runner's), not the operator's who produced the evidence. Evidence near the 21-day max-age cutoff could read stale or fresh purely depending on where the check ran. The writer now stamps an explicit UTC offset at capture time; the reader's naive-timestamp fallback now assumes UTC deterministically instead of reinterpreting per-environment.
4. **#1163** — `_project/TODO/scd2-audit-followup/planning/scd2-cleanup-isolation-distinct-effective-ts.yaml`: the plan's per-change_type `effective_ts` approach doesn't isolate the actually-reproduced `basic`-after-`new_keys_only` case — both ops insert from the same shared `'new'` staging rows and read `s.effective_ts` verbatim, so their inserted rows carry the identical cleanup key regardless of which op did the inserting. Added a new work unit requiring an operation-specific discriminator applied at INSERT time by `new_keys_only`'s own `write_sql`, and corrected the anti-patterns that had ruled out exactly this kind of change. Plan-only fix; implementation stays future work (`status: Not Started`).
5. **#1164** — `docs/development/tuning-adr-001-trust-and-hash-semantics.md`: the ADR required `tuning-bundle-provenance-and-config-export-20260712` to populate both `requested_config_hash` and `applied_ledger_hash`, but that TODO has no dependency on `tuning-applied-ledger-and-validation-status-20260712` (the TODO that builds the applied-statement ledger the hash is computed from) — the dependency runs the other way. Narrowed bundle-provenance's consequence to `requested_config_hash` only and moved `applied_ledger_hash`'s bundle-population ownership to the ledger TODO.

## Testing

Every code-level fix follows the session's standard discipline: added/extended a regression test, verified it fails without the fix (`git stash` the fix, confirm failure, `git stash pop`, confirm pass), lint/format/typecheck, then broader suite runs. The two TODO-file and one ADR fix are documentation/planning corrections (no code), verified by directly executing the corrected verification commands where applicable and running `todo_cli.py check-graph`.

- `tests/uat/test_container_cleanup.py` — new `test_network_name_extending_prefix_without_separator_is_not_owned`; confirmed it fails without the fix.
- `tests/unit/test_release_infrastructure.py` — new `test_naive_completed_at_treated_as_utc_regardless_of_local_timezone` (proves the same naive timestamp evaluated identically across three process-local timezones; previously diverged 1.1d / 0.6d / 1.7d for the same input); `tests/uat/test_orchestrator.py::test_gate_summary_completed_at_is_offset_aware`.
- Ran the corrected `tuning-bundle-provenance-and-config-export` verification command end-to-end against `develop` HEAD (SF 0.01 duckdb run) — it now locates and parses the JSON bundle instead of raising `IndexError`.
- Ran the corrected `tuning-explorer-ingest-mode-extraction` verification command end-to-end against the full `results-data/` corpus (528 bundles, 58 cohorts) — it builds a real `results.duckdb` instead of doing nothing.
- `uv run --project _project/scripts -- python _project/scripts/todo_cli.py check-graph` — 132 items, no cycles, no dangling references.
- `uv run --project _project/scripts -- python _project/scripts/validate_todo.py` on both edited TODO files — valid.
- Full `tests/uat/` + `tests/unit/test_release_infrastructure.py` (`-m fast`) — 523 passed.
- `ruff check` / `ruff format --check` clean on every changed Python file.

## Public Contract Check

- [x] No public contract surface changes — internal UAT tooling, release-gate scripting, and project TODO/docs corrections only.

## Documentation

- [x] This PR's findings 4 and 5 *are* the documentation/planning corrections.
- [x] No user-facing docs affected by findings 1-3.

## Code Quality

- [x] `ruff check` / `ruff format --check` clean on every changed file.
- [x] Regression test added for every code-level finding (1-3); documentation/planning findings (4-5) verified by direct execution and graph validation.

## Artifact Hygiene

- [x] I did not commit raw screenshots, browser reports, generated logs, benchmark outputs, or temporary binary artifacts.

## Notes

No CODEOWNERS-gated paths touched — enabling squash auto-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01SKw2UhgHuzYPo3y5MfarD6)_