### PR TITLE
fix: guard to_dict lookup in platform-options capture; correct ADR-003 caller inventory

### DIFF
--- a/benchbox/core/results/platform_options.py
+++ b/benchbox/core/results/platform_options.py
@@ -148,7 +148,10 @@ def _sanitize_option_value(value: Any, *, exclude_internal: bool = False) -> Any
         return [_sanitize_option_value(item, exclude_internal=exclude_internal) for item in value]
     if isinstance(value, (str, int, float, bool)) or value is None:
         return value
-    to_dict = getattr(value, "to_dict", None)
+    try:
+        to_dict = getattr(value, "to_dict", None)
+    except Exception:
+        return f"<unserializable:{type(value).__name__}>"
     if callable(to_dict):
         try:
             as_dict = to_dict()

--- a/docs/development/tuning-adr-003-baseline-and-single-renderer.md
+++ b/docs/development/tuning-adr-003-baseline-and-single-renderer.md
@@ -40,23 +40,33 @@ ClickHouse pack above, and equivalent StarRocks query settings) are not
 recorded in the tuning bundle in any mode today — there is no ledger entry a
 later run or an auditor can compare against.
 
-### Two parallel rendering universes
+### Three parallel rendering universes
 
-Tuning DDL is rendered by two independent code paths that do not share logic
-and can drift silently:
+Tuning DDL is rendered by three independent code paths that do not share
+logic and can drift silently:
 
 - `benchbox/core/tuning/generators/*` (one module per platform family,
   reachable through `benchbox/core/tuning/ddl_generator.py:get_ddl_generator`).
-  This path is exercised by exactly two callers: the dry-run preview
-  (`benchbox/core/dryrun.py:1066-1091`) and the cloud_spark adapter mixin
-  (`benchbox/platforms/base/cloud_spark/mixins.py:290`, which calls into
-  `TuningClauses` from the generators module directly).
+  This path is exercised by exactly one caller today: the dry-run preview
+  (`benchbox/core/dryrun.py:1066-1091`).
+- `SparkDDLGeneratorMixin.generate_tuning_clauses`
+  (`benchbox/platforms/base/cloud_spark/mixins.py:290-322`), used by the
+  cloud Spark/Onehouse execution path (`benchbox/platforms/onehouse/quanton_adapter.py`).
+  It returns the same `TuningClauses` dataclass as `core/tuning/generators/*`
+  (imported for the type only, at the fallback branch on line 320) but builds
+  it independently through its own `_generate_delta_tuning` /
+  `_generate_iceberg_tuning` / `_generate_hudi_tuning` /
+  `_generate_parquet_tuning` / `_generate_hive_tuning` methods rather than
+  consuming the generators module's per-format logic — it is a third
+  renderer, not an existing generators caller, and needs its own
+  migration/equivalence pass during consolidation, not just deletion of the
+  dead `generate_tuning_clause` methods below.
 - Per-adapter `generate_tuning_clause` mixin methods (singular — one clause
   string, not the generators' `TuningClauses` object), implemented
   independently on ~20 adapters (ClickHouse, Databricks, Redshift, BigQuery,
   Snowflake, Trino, Spark, DuckDB, Firebolt, Azure Synapse, Athena, Presto,
-  and others). This is the only path that touches real database connections
-  during execution.
+  and others). This is the path that touches real database connections
+  during execution for those (non-Spark) platforms.
 
 Because dry-run preview renders through `generators/*` and execution renders
 through the adapter mixins, a preview can show DDL that the real run never

--- a/tests/unit/core/results/test_platform_options_capture.py
+++ b/tests/unit/core/results/test_platform_options_capture.py
@@ -269,6 +269,23 @@ def test_sanitize_never_raises_when_to_dict_itself_fails() -> None:
     assert sanitized["broken"] == "<unserializable:_Broken>"
 
 
+def test_sanitize_never_raises_when_to_dict_lookup_itself_fails() -> None:
+    """A ``to_dict`` descriptor that raises on attribute access (not just on
+    call) must be caught too -- the ``getattr(value, "to_dict", None)`` lookup
+    happens outside the call's try/except, so a raising property previously
+    escaped uncaught."""
+    from benchbox.core.results.platform_options import sanitize_platform_options
+
+    class _BrokenDescriptor:
+        @property
+        def to_dict(self):
+            raise RuntimeError("boom during attribute access")
+
+    sanitized = sanitize_platform_options({"broken": _BrokenDescriptor()})
+
+    assert sanitized["broken"] == "<unserializable:_BrokenDescriptor>"
+
+
 def test_secret_redaction_unaffected_by_internal_key_filtering() -> None:
     """Secret redaction must remain exact regardless of exclude_internal."""
     from benchbox.core.results.platform_options import sanitize_platform_options


### PR DESCRIPTION
## Description

Consolidates two late-landing `chatgpt-codex-connector` review findings on PRs that merged before the sweep could push directly to their branches:

- **#1168** (`benchbox/core/results/platform_options.py`): `_sanitize_option_value`'s `getattr(value, "to_dict", None)` ran outside the `try/except` that guards the subsequent `to_dict()` call. An option value whose `to_dict` is implemented as a raising property/descriptor (not just a method that raises when called) still propagated an exception out of bundle emission instead of returning `<unserializable:TypeName>`. Wrapped the attribute lookup in the same guard.
- **#1166** (`docs/development/tuning-adr-003-baseline-and-single-renderer.md`): the ADR's caller inventory said `SparkDDLGeneratorMixin.generate_tuning_clauses` (`benchbox/platforms/base/cloud_spark/mixins.py:290-322`) "calls into `TuningClauses` from the generators module directly." It doesn't — it imports only the `TuningClauses` dataclass *type* and renders through its own `_generate_delta_tuning`/`_generate_iceberg_tuning`/etc. methods, independent of `core/tuning/generators/*`'s per-format logic. It's a third rendering path (used by the Onehouse Quanton adapter's real execution), not an existing generators caller, so documenting it as one would have left that path out of the renderer-consolidation migration plan. Rewrote the "two parallel rendering universes" section as three, with an accurate caller list.

## Type of Change

- [x] Bug fix
- [x] Documentation

## Testing

- `uv run -- python -m pytest tests/unit/core/results -q` — 728 passed, 3 skipped
- New test `test_sanitize_never_raises_when_to_dict_lookup_itself_fails` added; confirmed it fails without the fix (`git stash` on the source file) and passes with it
- `uv run -- ruff check` / `ruff format --check` / `ty check` on touched files — clean

## Public Contract Check

- [x] No public contract surfaces changed — internal capture-hygiene fix and doc correction.
- [x] Contract-map impact checked — none.
- [x] No count claims.

## Documentation

- [x] Corrected the ADR-003 caller inventory to match the current tree.
- [x] No further regression notes needed.
- [x] API wording unaffected.

## Code Quality

- [x] Format/lint/typecheck run, clean.
- [x] Backwards compatible: `sanitize_platform_options` never raises, same as before, just more completely now.
- [x] Test added for the newly-guarded error path.
- [x] Contracts valid.

## Artifact Hygiene

- [x] No raw artifacts; no binary evidence files.

## Notes

Bot review findings on PRs #1168 and #1166, both merged before this sweep ran, consolidated into one branch per the standing PR-review-followup sweep process. Neither file is under a CODEOWNERS soundness-critical path, so this PR is eligible for squash auto-merge once CI passes.


---
_Generated by [Claude Code](https://claude.ai/code/session_01SKw2UhgHuzYPo3y5MfarD6)_