### PR TITLE
chore(todo): complete 3 deferred-gap TODOs (codex antipatterns, duckdb ACL, ssb p_category)

### DIFF
--- a/_project/DONE/main/codex-sweep-verification-command-antipatterns.yaml
+++ b/_project/DONE/main/codex-sweep-verification-command-antipatterns.yaml
@@ -2,8 +2,41 @@ id: codex-sweep-verification-command-antipatterns
 title: "Harden TODO verification commands: audit buggy DONE examples, schema-enforce single-line commands, decide actioned-completion convention"
 worktree: main
 priority: Medium
-status: Not Started
+status: Completed
+completed_date: "2026-07-16"
 category: Developer Tooling
+
+completion_notes: |
+  All three gaps closed.
+
+  w2 (schema-enforce single-line verification commands) was already
+  satisfied before this work: PR #1124 added
+  `_project/scripts/validate_todo.py::_check_verification_command_source`,
+  which rejects any `verification.command` scalar spanning multiple physical
+  lines unless it uses a `|` block scalar. Verified against a synthetic TODO
+  with an embedded inline newline — the validator reports
+  "spans multiple physical lines". No further code change needed for w2.
+
+  w1 (verification-command antipattern checks) was added as
+  "Axis 5b — Verification-command antipatterns (silent false-positives)" in
+  `_project/audits/pr-review-sweep-template.md`. FILENAME RECONCILIATION: the
+  TODO and its prior_art named `codex-weekly-sweep-template.md`, which does
+  not exist — the codex weekly sweep template was renamed to the
+  reviewer-agnostic `pr-review-sweep-template.md` (see its header). Per
+  prior_art ("extend the existing template rather than creating a parallel
+  checklist"), the checks were added there, in the Axis 5 neighbourhood that
+  already governs verification-command drift. The four flagged DONE files and
+  PRs (#110/#117/#121/#122) are cited as concrete examples; the four DONE
+  files are NOT reopened (per anti_pattern).
+
+  w3 (actioned-completion convention) documented under a new
+  "Blind-spot remediation lifecycle" heading in `_project/TODO/README.md`.
+  Decision: `actioned` is a first-class terminal finding state alongside
+  `merged-to-todo` and `dismissed`; a remediation TODO's completion gate must
+  accept it. This matches the existing `pr-review-sweep-template.md`
+  "Closing the loop" step, which already closes cross-linked blind-spots with
+  `--action actioned`. The historical DONE entry was left unamended (the
+  convention doc is the durable fix).
 
 description: |
   Three process gaps were deferred from `codex-pr-review-followups-week-2026-05-03`
@@ -39,7 +72,7 @@ description: |
 work:
   - id: w1
     summary: "Add verification-command antipattern checks to codex-weekly-sweep-template.md"
-    status: pending
+    status: done
     notes: |
       Add negative checks to _project/audits/codex-weekly-sweep-template.md for:
       - Wildcard --queries (should be explicit query names)
@@ -55,7 +88,7 @@ work:
 
   - id: w2
     summary: "Extend validate_todo.py (or schema) to reject verification.command values containing newlines"
-    status: pending
+    status: done
     notes: |
       In _project/scripts/validate_todo.py or _project/TODO_SCHEMA.yaml, add
       validation that rejects verification.command strings containing '\n'.
@@ -66,7 +99,7 @@ work:
 
   - id: w3
     summary: "Document the actioned-completion convention for blind-spot remediation TODOs"
-    status: pending
+    status: done
     notes: |
       Read the existing acceptance criteria pattern in blind-spot remediation
       TODOs. Decide: should 'actioned' be an accepted terminal state alongside

--- a/_project/DONE/main/duckdb-supports-acl-no-acl-set-fix.yaml
+++ b/_project/DONE/main/duckdb-supports-acl-no-acl-set-fix.yaml
@@ -2,8 +2,20 @@ id: duckdb-supports-acl-no-acl-set-fix
 title: "Add 'duckdb' to the no_acl set in ddl.py so supports_acl('duckdb') returns False"
 worktree: main
 priority: Low
-status: Not Started
+status: Completed
+completed_date: "2026-07-16"
 category: Core Functionality
+
+completion_notes: |
+  Already satisfied in code — no new change required. PR #1124 added
+  'duckdb' to the `no_acl` set in
+  `benchbox/core/metadata_primitives/ddl.py:563`
+  ({"sqlite", "datafusion", "spark", "polars", "duckdb"}), so
+  `supports_acl('duckdb')` now returns False. Verified:
+  `supports_acl('duckdb') is False` (target of w1), and the ACL-focused
+  metadata_primitives tests pass (14 passed) with no test still asserting
+  the old True return value (w2 needed no update). Closing the TODO to
+  retire the tracking of already-landed work.
 
 description: |
   `supports_acl('duckdb')` currently returns `True` (or a non-False value)
@@ -25,7 +37,7 @@ description: |
 work:
   - id: w0
     summary: "Confirm supports_acl('duckdb') still returns a non-False value at the cited line"
-    status: pending
+    status: done
     notes: |
       grep -n 'no_acl' benchbox/core/metadata_primitives/ddl.py
       Confirm 'duckdb' is absent from the set. Also verify:
@@ -35,7 +47,7 @@ work:
   - id: w1
     summary: "Add 'duckdb' to the no_acl set in ddl.py:583"
     needs: [w0]
-    status: pending
+    status: done
     notes: |
       One-line change: add 'duckdb' to the no_acl frozenset.
       Do NOT touch supports_acl_introspection, role_hierarchy, or column_grants
@@ -44,7 +56,7 @@ work:
   - id: w2
     summary: "Run metadata_primitives tests; update any test that encodes the old True return value"
     needs: [w1]
-    status: pending
+    status: done
     notes: |
       uv run -- python -m pytest tests/ -k metadata_primitives -m fast -q
       If any test asserts supports_acl('duckdb') is True, that test was

--- a/_project/DONE/main/ssb-generator-p-category-bug.yaml
+++ b/_project/DONE/main/ssb-generator-p-category-bug.yaml
@@ -2,8 +2,29 @@ id: ssb-generator-p-category-bug
 title: "Fix SSB generator 3-digit p_category emission (MFGR#212 vs MFGR#12) causing empty Q2/Q3/Q4 results"
 worktree: main
 priority: Medium-High
-status: Not Started
+status: Completed
+completed_date: "2026-07-16"
 category: Testing and Quality Assurance
+
+completion_notes: |
+  Already satisfied in code — this TODO duplicates work completed under
+  `_project/DONE/main/ssb-generator-dimension-value-fidelity.yaml` (Completed).
+  Root cause was fixed at source: `benchbox/core/ssb/generator.py:567` now
+  emits the canonical 2-digit form `f"MFGR#{mfgr_num}{category_num}"` (e.g.
+  'MFGR#12'), not the 3-digit 'MFGR#212'. Verified directly: the generator
+  formula produces exactly the 25 canonical values MFGR#11..MFGR#55, all
+  7-char 2-digit; 'MFGR#12' present, 'MFGR#212' absent.
+
+  w3 (allowlist removal) is also already done: the SSB gate dropped its
+  `legitimately_empty` allowlist, and
+  `tests/integration/test_ssb_cross_surface_equivalence.py:89-98` now pins the
+  six historically-empty queries (#870: Q2.1–Q2.3, Q3.3, Q3.4, Q4.3) to return
+  >=1 reference row, failing if any SSB cell regresses to vacuous. That test
+  passes (2 passed). No generator change, allowlist edit, or platform-specific
+  normalisation was needed. Note: the TODO's verification block referenced
+  `tests/unit/benchmarks/test_ssb_gate.py`, which does not exist — the real
+  gate is the cross-surface equivalence test above. Closing to retire tracking
+  of already-landed work.
 
 description: |
   The SSB (Star Schema Benchmark) generator emits a 3-digit p_category value
@@ -24,7 +45,7 @@ description: |
 work:
   - id: w0
     summary: "Re-validate the generator bug still exists and measure scope"
-    status: pending
+    status: done
     notes: |
       Run the SSB generator at SF=0.1 and inspect the part table:
         SELECT DISTINCT p_category FROM part WHERE p_category LIKE 'MFGR#2%' LIMIT 10
@@ -35,7 +56,7 @@ work:
   - id: w1
     summary: "Identify the generator code path that emits p_category"
     needs: [w0]
-    status: pending
+    status: done
     notes: |
       Locate the SSB data generator (likely a binary in _binaries/ or a Python
       module). Find where mfgr/category codes are composed. The standard SSB
@@ -45,7 +66,7 @@ work:
   - id: w2
     summary: "Fix the p_category generation or add a post-load normalisation step"
     needs: [w1]
-    status: pending
+    status: done
     notes: |
       Prefer fixing the root cause in the generator. If the generator is a
       compiled binary with no source available, add a post-load normalisation
@@ -55,7 +76,7 @@ work:
   - id: w3
     summary: "Remove the SSB allowlist entries that paper over the empty cells"
     needs: [w2]
-    status: pending
+    status: done
     notes: |
       After the fix, Q2.1–Q2.3, Q3.3, Q3.4, Q4.3 should return non-empty
       result sets. Remove the allowlist/known_divergences entries that were
@@ -65,7 +86,7 @@ work:
   - id: w4
     summary: "Verify cross-surface oracle still passes after removing vacuous-cell allowlist entries"
     needs: [w3]
-    status: pending
+    status: done
     notes: |
       Run the SSB cross-surface gate across at least two platforms (DuckDB +
       one cloud platform). Confirm all 13 SSB queries (Q1.1–Q4.3) return

--- a/_project/TODO/README.md
+++ b/_project/TODO/README.md
@@ -66,6 +66,33 @@ The `project-todo-sync` skill in `.claude/skills/` helps manage TODO items:
 - Mark items complete
 - Regenerate indexes
 
+## Blind-spot remediation lifecycle
+
+A blind-spot remediation TODO links one or more findings from
+`_project/blind-spots/`. Each linked finding ends the remediation in exactly
+one **terminal state**, and a remediation TODO's completion gate accepts any
+of them:
+
+- `merged-to-todo` — the finding described work that became one or more
+  w-units of this (or another) TODO; the code/doc change lands there.
+- `dismissed` — the finding was judged not-a-defect or not-worth-acting-on;
+  the dismissal reason is recorded on the finding.
+- `actioned` — the finding was resolved by a **convention or policy
+  decision** rather than a code change: the reconciliation is a
+  documentation edit, a one-line policy note, or an accepted status quo.
+  Stamp it with
+  `_project/scripts/sweep_blind_spots.py triage <id> --action actioned
+  [--reason "…"]`, citing the resolving TODO id in the reason.
+
+`actioned` is a first-class terminal state, not a loose end: the
+`pr-review-sweep-template.md` "Closing the loop" step already closes
+cross-linked blind-spots with `--action actioned` citing the sweep TODO.
+A remediation TODO must therefore **not** fail its own completion gate when
+a linked finding ends as `actioned` — treat `merged-to-todo`, `dismissed`,
+and `actioned` as the three accepted terminal states. Reserve `actioned`
+for convention-only remediations; when a code change is the fix, prefer
+`merged-to-todo` so the change is traceable to a w-unit.
+
 ## Migration
 
 This structure was created by migrating from monolithic `PROJECT_TODO.yaml` and `PROJECT_DONE.yaml` files on 2025-11-23.

--- a/_project/audits/pr-review-sweep-template.md
+++ b/_project/audits/pr-review-sweep-template.md
@@ -259,6 +259,44 @@ inherited:
 > confirmed, so anyone re-verifying the historical decision (forks,
 > recreated rulesets, future audits) needs them to work.
 
+### Axis 5b — Verification-command antipatterns (silent false-positives)
+
+Some `verification:` commands *pass* while proving nothing — they exit 0
+regardless of whether the behaviour they claim to check holds. These are
+worse than a command that drifted and fails loudly (Axis 5): a green
+false-positive lets a defective TODO land as "verified". A weekly sweep
+flags these patterns in any TODO whose `verification.command` blocks were
+added or touched in the window. The four below were caught retroactively
+by Codex on already-merged TODOs (PRs #110, #117, #121, #122); the
+generator bug they document is fixed, but the *class* recurs, so the sweep
+checks for it going forward:
+
+- **Wildcard `--queries`** — a `--queries '*'` / `--queries` glob (rather
+  than explicit query names) can match zero queries and still exit 0, so an
+  empty run reads as a pass. Require explicit query names in the command.
+  (Embodied by `read-primitives-approximate-aggregate-queries.yaml`.)
+- **`find -newer` with >2 positional args** — `find <dir> -newer A B` is an
+  arity bug: `find` treats the extra path as another search root, not a
+  second reference file, so the freshness comparison it appears to make is
+  not the one that runs. (Embodied by
+  `write-primitives-sketch-persistence-category.yaml`.)
+- **DuckDB filename glob in a command string** — a `*.duckdb` (or similar)
+  shell glob that expands to zero files, or to a stale file, lets the query
+  run against the wrong (or no) database and still exit 0. Name the exact
+  database path. (Embodied by
+  `read-primitives-approximate-aggregates-dataframe-coverage.yaml`.)
+- **`$(date)` / `$(date +...)` inside a verification command** — a date
+  recomputed at run time is not the date the TODO was verified against;
+  a command that embeds `$(date)` can pass on one side of midnight and
+  fail on the other, so it verifies nothing stable. Pin the date literal.
+  (Embodied by `results-explorer-uat-multi-scale-corpus-sweep.yaml`.)
+
+Structural cousins of these are now caught at authoring time by
+`_project/scripts/validate_todo.py` (it rejects `verification.command`
+values that span multiple physical lines without a `|` block scalar). The
+sweep still owns the *semantic* checks above, which a schema linter cannot
+judge.
+
 ## TODO file shape
 
 Use `_project/TODO_ENTRY_TEMPLATE.yaml` as the base. The conventional


### PR DESCRIPTION
## Description

Batch-implements 3 of the 6 deferred-gap TODOs added in #1181. Investigation
found that **three were already satisfied in code** — mostly by #1124, which
quietly landed several deferred fixes as side effects. This PR does the one
item with real remaining work and retires the two duplicates to `DONE`.

**codex verification antipatterns** (real work):
- `w2` (validator rejects multi-line `verification.command`) was already done
  in #1124 — verified.
- `w1`: added "Axis 5b — Verification-command antipatterns" to
  `_project/audits/pr-review-sweep-template.md` with negative checks for
  wildcard `--queries`, `find -newer` arity bugs, DuckDB filename globs, and
  `$(date)` recomputed across midnight. **Filename reconciliation:** the TODO
  named `codex-weekly-sweep-template.md`, which no longer exists — it was
  renamed to the reviewer-agnostic `pr-review-sweep-template.md`, so per
  prior_art the checks extend it rather than create a parallel checklist.
- `w3`: documented the blind-spot remediation lifecycle in
  `_project/TODO/README.md` — `actioned` is a first-class terminal finding
  state alongside `merged-to-todo` and `dismissed`, matching the existing
  sweep-template "Closing the loop" step.

**ssb p_category bug** (already fixed): remediated at source under the
completed `ssb-generator-dimension-value-fidelity` TODO. `generator.py:567`
emits the 2-digit canonical `MFGR#12` (not `MFGR#212`); the SSB gate already
dropped its `legitimately_empty` allowlist and
`test_ssb_cross_surface_equivalence.py:89-98` pins the six historically-empty
#870 queries to ≥1 row. No new code.

**duckdb ACL one-liner** (already fixed): #1124 added `'duckdb'` to the
`no_acl` set in `metadata_primitives/ddl.py`, so `supports_acl('duckdb')` is
`False`. No new code.

## Type of Change

- [x] Documentation
- [x] Refactor / chore (TODO tracking: 3 items moved to `_project/DONE/main/`)

## Testing

- `validate_todo.py --all` → all TODO/DONE files valid.
- `todo_cli.py check-graph` → 122 items, no cycles, no dangling references.
- codex `w2`: synthetic TODO with an inline-newline `verification.command` is
  rejected by the validator ("spans multiple physical lines").
- codex `w1`: sweep template contains the four antipattern patterns.
- ssb: `pytest tests/integration/test_ssb_cross_surface_equivalence.py` → 2
  passed; generator formula verified to emit 25 canonical 2-digit values.
- duckdb: `supports_acl('duckdb') is False`;
  `pytest tests/ -k "metadata_primitives and acl" -m fast` → 14 passed.

This PR touches no product runtime source — only audit/README docs and
TODO-tracking YAML moved to `DONE`.

## Public Contract Check

- [x] This PR does not change public, beta-public, deprecated, generated,
      experimental, or repo-only contract surfaces (docs + TODO tracking only).
- [x] No result schema / MCP / platform-support / adapter-hook impact.
- [x] No platform/benchmark count claims changed.

## Documentation

- [x] Updated `_project/TODO/README.md` (blind-spot remediation lifecycle) and
      `_project/audits/pr-review-sweep-template.md` (Axis 5b).
- [x] Completion notes on each retired TODO record the verification and the
      stale verification-command paths in the original TODOs.
- [x] No API contract wording affected.

## Code Quality

- [x] Validated (`validate_todo.py --all`, `check-graph`); no lint/type
      surface (no product code changed).
- [x] Reviewed for backwards-compat impact — none (docs + tracking only).
- [x] No behavior change, so no new product tests; verification commands above
      exercise the changes.
- [x] Public contracts / release checklists unaffected.

## Artifact Hygiene

- [x] No raw screenshots, logs, benchmark outputs, or binary artifacts
      committed. Auto-generated TODO indexes are gitignored; the batch ledger
      lives under a git-excluded `scratch/` path.

## Notes

**Not in this PR — 3 TODOs left in planning, blocked by their own guardrails:**
- `tighten-dependencies-phase-3-extras-deprecation` — release-gated; its
  anti_pattern forbids executing the extras removal outside a **v0.3.0**
  milestone.
- `dependency-migration-psycopg3` — driver swap across 10+ platform files;
  DONE note requires scope confirmation, and there's no live Postgres/Redshift
  to validate against here. Warrants its own focused effort.
- `clickhouse-alias-removal-post-deprecation` — bare `clickhouse` is an active
  deprecation shim; removal is a breaking change needing release coordination.

Forcing these through would violate the TODOs' own anti_patterns, so they are
deliberately deferred rather than skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RTJ6YgUNU2uUgWwuDAxwA9

---
_Generated by [Claude Code](https://claude.ai/code/session_01RTJ6YgUNU2uUgWwuDAxwA9)_