### PR TITLE
chore(todo): 3 close-out TODOs — introspection receipts, registry coverage, policy-generation seam

### DIFF
--- a/_project/TODO/main/planning/tuning-capability-registry-coverage-20260716.yaml
+++ b/_project/TODO/main/planning/tuning-capability-registry-coverage-20260716.yaml
@@ -1,0 +1,56 @@
+id: tuning-capability-registry-coverage-20260716
+title: "Extend the tuning capability registry to the remaining platforms (trino/athena/firebolt/presto/synapse/timescaledb...)"
+worktree: main
+priority: Medium
+status: Not Started
+category: Core Functionality
+
+description: |
+  The capability registry introduced by the renderer consolidation (#1180)
+  covers the 9 legacy compat platforms plus starrocks/doris; platforms with
+  registered DDL generators but no registry entries (trino, presto, athena,
+  firebolt, azure_synapse, timescaledb, pg_duckdb, pg_mooncake, questdb, ...)
+  live as documented allowlist gaps in the capability-source drift test.
+  Add registry entries derived from each platform's real generator +
+  adapter behavior, shrinking the drift-test allowlists to empty as coverage
+  lands. Where a generator exists but the adapter never consumes it, record
+  rendered_via honestly (dry-run-only today) and note the renderer-migration
+  follow-up per platform.
+
+work:
+  - id: w0
+    summary: "Start gate: PR #1180 merged; enumerate the drift-test allowlist entries as the coverage worklist"
+    status: pending
+    needs: []
+  - id: w1
+    summary: "Registry entries for the Trino family (trino/presto/athena) + firebolt + synapse + timescaledb, verified against generators and adapters"
+    status: pending
+    needs: [w0]
+  - id: w2
+    summary: "Registry entries for the pg extensions (pg_duckdb/pg_mooncake) + questdb; shrink allowlists; strictify tests where emptied"
+    status: pending
+    needs: [w0]
+
+deps:
+  needs: []
+
+must_preserve:
+  - "Registry entries record REAL behavior (no aspirational ddl claims for adapter paths that do not consume generators yet)"
+  - "Drift test stays fail-on-new-drift throughout"
+
+scope_limit:
+  only_modify:
+    - "benchbox/core/tuning/**"
+    - "tests/**"
+
+verification:
+  - description: "Drift suite green with shrunken allowlists"
+    command: "uv run -- python -m pytest tests/unit/core/tuning -q -k 'drift or registry'"
+    expected_output: "All passing; allowlists reduced per commit body"
+
+metadata:
+  owners: ["benchbox-team"]
+  tags: [tuning, capability-registry]
+  estimated_effort: Medium
+  created_date: "2026-07-16"
+  source_review: "tuning batch second re-evaluation 2026-07-16"

--- a/_project/TODO/main/planning/tuning-introspection-receipts-20260716.yaml
+++ b/_project/TODO/main/planning/tuning-introspection-receipts-20260716.yaml
@@ -1,0 +1,75 @@
+id: tuning-introspection-receipts-20260716
+title: "Post-load schema introspection receipts: upgrade applied_unverified to applied_verified"
+worktree: main
+priority: Medium-High
+status: Not Started
+category: Core Functionality
+
+description: |
+  The last leg of the ADR-001 trust story (docs/development/
+  tuning-adr-001-trust-and-hash-semantics.md names introspection receipts as
+  the design direction; the applied-ledger work deliberately left
+  applied_verified unclaimable). After tuning application and data load,
+  introspect the live schema (SHOW CREATE TABLE / information_schema /
+  duckdb_constraints) per platform, compare against the ledger's executed DDL
+  intents, and emit a receipt into the .tuning.json companion. When every
+  ledgered DDL intent is corroborated, validation_status upgrades to
+  applied_verified; mismatches downgrade with a diff list. Introspection
+  failure is non-fatal and leaves applied_unverified (never blocks a run).
+
+work:
+  - id: w0
+    summary: "Start gate: applied-ledger PR merged; design note mapping ledger entry kinds to per-platform introspection queries"
+    status: pending
+    needs: []
+  - id: w1
+    summary: "Receipt model + comparison in core/tuning (platform-agnostic; corroboration rules per entry kind)"
+    status: pending
+    needs: [w0]
+  - id: w2
+    summary: "DuckDB + ClickHouse introspectors (constraints/indexes; SHOW CREATE TABLE partition/order clauses)"
+    status: pending
+    needs: [w1]
+  - id: w3
+    summary: "Status upgrade wiring + companion export + explorer receipt display of verified state"
+    status: pending
+    needs: [w2]
+  - id: w4
+    summary: "Tests: corroborated run upgrades to applied_verified; induced mismatch downgrades with diff; introspection failure stays applied_unverified"
+    status: pending
+    needs: [w2]
+
+deps:
+  needs: []
+
+must_preserve:
+  - "Introspection never fails or slows a run materially (bounded queries, non-fatal)"
+  - "applied_verified is claimable ONLY via corroboration - never derived from the ledger alone"
+
+anti_patterns:
+  - "No screen-scraping of engine-specific DDL text where a structured catalog exists"
+
+scope_limit:
+  only_modify:
+    - "benchbox/core/tuning/**"
+    - "benchbox/platforms/**"
+    - "benchbox/core/results/**"
+    - "results-explorer/src/**"
+    - "docs/**"
+    - "tests/**"
+
+verification:
+  - description: "E2E tuned duckdb run reaches applied_verified with a receipt in the companion"
+    command: "uv run -- python -m benchbox.cli.main run --platform duckdb --benchmark tpch --scale 0.01 --tuning tuned --non-interactive --output /tmp/receipt-check"
+    expected_output: "validation_status applied_verified; receipt lists corroborated intents"
+
+prior_art:
+  - "benchbox/core/tuning/applied_ledger.py: entry kinds the receipts corroborate - extend"
+  - "benchbox/platforms/clickhouse/tuning.py validate_session_cache_control: existing settings-readback pattern - reuse"
+
+metadata:
+  owners: ["benchbox-team"]
+  tags: [tuning, trust, introspection, applied-ledger]
+  estimated_effort: Large
+  created_date: "2026-07-16"
+  source_review: "tuning batch second re-evaluation 2026-07-16; ADR-001 future direction"

--- a/_project/TODO/main/planning/tuning-policy-generation-seam-20260716.yaml
+++ b/_project/TODO/main/planning/tuning-policy-generation-seam-20260716.yaml
@@ -1,0 +1,69 @@
+id: tuning-policy-generation-seam-20260716
+title: "Record tuning-policy generation in bundles; explorer warns when comparing across the ADR-003 seam"
+worktree: main
+priority: Medium
+status: Not Started
+category: Core Functionality
+
+description: |
+  ADR-003 changed what "tuned" and "notuning" physically mean on ClickHouse
+  (session pack moved to the tuned path; tuned DDL now actually renders).
+  Bundles record benchbox_version but nothing semantically marks which
+  tuning-policy generation produced a run, so third-party bundles spanning
+  the seam can be compared without any warning. Add a compact
+  tuning_policy_generation marker to the bundle tuning block (e.g. "adr3-v1";
+  emitted by result capture, constant defined beside the ledger vocabulary),
+  ingest it in the explorer, and have ComparabilityReceipt warn when compared
+  runs carry different generations (absent = pre-seam, treated as its own
+  generation). The seed corpus is already clean (pre-seam tuned bundles were
+  dropped in #1185); this protects third-party submissions.
+
+work:
+  - id: w1
+    summary: "Emit tuning_policy_generation in the bundle tuning block + companion; document in result-formats.md"
+    status: pending
+    needs: []
+  - id: w2
+    summary: "Explorer ingest + receipt warning across differing generations (absent = pre-seam generation)"
+    status: pending
+    needs: [w1]
+  - id: w3
+    summary: "Tests both sides; legacy bundles unaffected except the receipt note"
+    status: pending
+    needs: [w1]
+
+deps:
+  needs: []
+
+must_preserve:
+  - "Facet MATCHING unchanged (warning-only, like the mechanisms warning) unless a future ADR says otherwise"
+  - "Legacy bundles load unchanged"
+
+anti_patterns:
+  - "Do not overload benchbox_version parsing as the seam signal - explicit marker only"
+
+scope_limit:
+  only_modify:
+    - "benchbox/core/results/**"
+    - "benchbox/core/tuning/**"
+    - "benchbox/platforms/base/**"
+    - "_project/scripts/explorer_pipeline/**"
+    - "results-explorer/src/**"
+    - "docs/**"
+    - "tests/**"
+
+verification:
+  - description: "New bundle carries the marker; receipt warns on cross-generation tuned pairs"
+    command: "uv run -- python -m pytest tests/unit/core/results tests/unit/scripts/explorer_pipeline -q -k 'generation or seam or policy'"
+    expected_output: "All passing"
+
+prior_art:
+  - "results-explorer/src/components/ComparabilityReceipt.tsx mechanisms warning (#1182): warning-only comparability signal pattern - reuse"
+  - "benchbox/core/tuning/modes.py: vocabulary constants home - extend"
+
+metadata:
+  owners: ["benchbox-team"]
+  tags: [tuning, comparability, explorer]
+  estimated_effort: Medium
+  created_date: "2026-07-16"
+  source_review: "tuning batch second re-evaluation 2026-07-16"


### PR DESCRIPTION
# Pull Request

## Description

Files the three items surfaced by the second re-evaluation that had no tracking:

1. **`tuning-introspection-receipts-20260716`** (Medium-High, gated on the applied-ledger merge) — post-load schema introspection corroborating the ledger, enabling the `applied_unverified` → `applied_verified` upgrade ADR-001 reserves.
2. **`tuning-capability-registry-coverage-20260716`** (Medium, gated on #1180) — registry entries for the platforms living as documented drift-test allowlist gaps (Trino family, firebolt, synapse, timescaledb, pg extensions, questdb), shrinking allowlists as coverage lands.
3. **`tuning-policy-generation-seam-20260716`** (Medium) — explicit `tuning_policy_generation` marker in bundles + a warning-only ComparabilityReceipt signal when compared runs span the ADR-003 semantics change (protects third-party submissions; the seed corpus is already clean via #1185).

## Type of Change

- [x] Refactor / chore

## Testing

- `validate_todo.py` on all 3 — valid; `check-graph` clean (131 items)

## Public Contract Check

- [x] Planning artifacts only.

## Documentation

- [x] N/A.

## Code Quality

- [x] Schema validation in lieu of lint.

## Artifact Hygiene

- [x] No artifacts.

## Notes

Queued as batch-3 in the running remediation ledger; implementation auto-starts as their gates (#1176 → ledger PR, #1180) merge, same implement → Opus review → fix → PR cycle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QTnjb2i44JUL71kmu9sk1t

---
_Generated by [Claude Code](https://claude.ai/code/session_01QTnjb2i44JUL71kmu9sk1t)_