### PR TITLE
feat(platforms)!: remove bare `clickhouse` alias; retire psycopg3 TODO

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -88,6 +88,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   their platform and command examples from the live registry, so the lists stay
   in sync with actually supported platforms.
 
+### Removed
+
+- **BREAKING: bare `clickhouse` platform alias removed** - The temporary
+  compatibility alias that let `--platform clickhouse` (and `get_adapter(
+  "clickhouse")`) resolve to a first-class platform was added in v0.2.1 as a
+  deprecation shim and has now been removed after its deprecation window
+  (v0.2.1 → v0.3.1). Use `clickhouse-local` (embedded chDB), `clickhouse-server`
+  (self-hosted), or `clickhouse-cloud` (managed); the explicit `clickhouse:local`
+  / `clickhouse:server` / `clickhouse:cloud` selectors also remain available.
+  Passing bare `clickhouse` now raises a `ValueError` naming these replacements
+  instead of silently defaulting to a deployment mode. The `ch` CLI shorthand
+  now resolves to `clickhouse-local`.
+
 ## [0.3.0] - 2026-05-16
 
 ### New

--- a/_project/DONE/main/clickhouse-alias-removal-post-deprecation.yaml
+++ b/_project/DONE/main/clickhouse-alias-removal-post-deprecation.yaml
@@ -2,8 +2,53 @@ id: clickhouse-alias-removal-post-deprecation
 title: "Remove temporary clickhouse→clickhouse-local/server compatibility aliases after deprecation window"
 worktree: main
 priority: Low
-status: Not Started
+status: Completed
+completed_date: "2026-07-16"
 category: Code Quality and Technical Debt
+
+completion_notes: |
+  Bare `clickhouse` alias removed after its deprecation window.
+
+  w0 (window confirmation): the split + bare-alias shim shipped in v0.2.1
+  (2026-04-26, CHANGELOG) and has been live across v0.2.1 → v0.3.0 → v0.3.1
+  (~3 months, 3 releases). Window elapsed.
+
+  w1/w2 (removal + helpful error): `_resolve_clickhouse_legacy` in
+  benchbox/platforms/adapter_factory.py now raises a ValueError naming
+  clickhouse-local / clickhouse-server / clickhouse-cloud (and noting the
+  colon-suffix selectors remain) instead of resolving bare `clickhouse` to a
+  deployment-dependent default. The `ch` CLI shorthand in
+  benchbox/cli/platform.py now maps to `clickhouse-local`. Colon-suffix
+  selectors (`clickhouse:local/server/cloud`) are KEPT (per the approved scope:
+  remove bare only). deployment_mode.py migration-contract docstring updated.
+
+  Tests updated to assert the new error (test_clickhouse_platform_split.py:
+  4 bare-alias tests; test_platform.py: `ch` → clickhouse-local;
+  test_cli_e2e.py: parametrize clickhouse → clickhouse-local). Verified:
+  get_adapter("clickhouse") raises with both replacements named; the sql_compat
+  ClickHouse DIALECT subsystem (platform="clickhouse" in rules/contexts) is
+  unaffected (41 sql_compat clickhouse tests pass); 4310 platform/cli unit
+  tests pass.
+
+  w3 (docs): 24 run-command usages across docs/ + examples/ .md updated to
+  first-class names (clickhouse-local default; clickhouse-server where the
+  context is self-hosted). Example configs/code that would break at runtime
+  fixed: examples/config/clickhouse.yaml (→ clickhouse-server),
+  clickhouse_cloud.yaml (→ clickhouse-cloud), the benchmarking notebook
+  (→ clickhouse-server), and two illustrative py examples. Prose docs that
+  falsely claimed the alias "still works" corrected (clickhouse-migration.md,
+  clickhouse-local-mode.md, deployment-modes.md, comparison-matrix.md). Left
+  as-is: historical docs/blog/*, family-key registry API examples
+  (get_available_deployment_modes("clickhouse") still accepts the family), and
+  dialect usages (dialect="clickhouse", comparison_platform="clickhouse").
+  CHANGELOG [Unreleased] carries a BREAKING "### Removed" entry.
+
+  Verification-command reconciliation: the TODO's first check used
+  `benchbox run --platform clickhouse ...` expecting a clear error — confirmed
+  via get_adapter("clickhouse") raising. The second grep target
+  (benchbox/platforms/ has no unqualified 'clickhouse' registration) holds: the
+  only remaining `"clickhouse"` literal in adapter_factory.py is the removal
+  guard that raises.
 
 description: |
   When ClickHouse support was split into `clickhouse-local` and
@@ -25,7 +70,7 @@ description: |
 work:
   - id: w0
     summary: "Inventory all current clickhouse alias sites and confirm the deprecation window has passed"
-    status: pending
+    status: done
     notes: |
       grep -rn 'clickhouse[^-]' benchbox/ tests/ docs/ --include='*.py' --include='*.yaml' --include='*.md'
       Identify: adapter registration aliases, platform-name normalisation maps,
@@ -36,7 +81,7 @@ work:
   - id: w1
     summary: "Remove the compatibility alias registrations"
     needs: [w0]
-    status: pending
+    status: done
     notes: |
       Remove the platform alias mapping entries from benchbox/platforms/ (likely
       a PLATFORM_ALIASES or similar dict). After removal, benchbox run --platform
@@ -46,7 +91,7 @@ work:
   - id: w2
     summary: "Add a helpful error message for the removed alias"
     needs: [w1]
-    status: pending
+    status: done
     notes: |
       When platform='clickhouse' is passed after alias removal, raise a clear
       error:
@@ -57,7 +102,7 @@ work:
   - id: w3
     summary: "Update docs and remove any remaining clickhouse (unqualified) references"
     needs: [w2]
-    status: pending
+    status: done
     notes: |
       Update docs/platforms/clickhouse.md, README, and any runbook references
       to use the qualified names. Remove any test fixtures that used the

--- a/_project/DONE/main/dependency-migration-psycopg3.yaml
+++ b/_project/DONE/main/dependency-migration-psycopg3.yaml
@@ -2,8 +2,34 @@ id: dependency-migration-psycopg3
 title: "Migrate off psycopg2-binary to psycopg3 (asyncpg-compatible driver modernisation)"
 worktree: main
 priority: Low
-status: Not Started
+status: Completed
+completed_date: "2026-07-16"
 category: Code Quality and Technical Debt
+
+completion_notes: |
+  Already migrated in code — no driver swap needed. The PostgreSQL-family
+  adapters already use psycopg3:
+    - benchbox/platforms/postgresql.py, redshift.py: `import psycopg` (v3),
+      `psycopg.connect(...)`, version guidance points at 3.1+.
+    - pyproject.toml pins `psycopg[binary]>=3.1` (core, and the `postgresql`
+      and `questdb` extras); there is no `psycopg2-binary` dependency.
+    - `benchbox/platforms/base/psycopg2_mixin.py` is a psycopg3 wire-protocol
+      connection mixin (its docstring says "psycopg connection mechanics");
+      only its filename is legacy — it imports no driver.
+  Verified (w0/w3):
+    - `grep -rn 'import psycopg2' benchbox/ | wc -l` -> 0 (the TODO's own
+      acceptance target).
+    - `pytest tests/ -k "postgres or redshift" -m fast` -> 884 passed.
+  w1 (compat assessment) and w2 (swap) were therefore no-ops — the codebase
+  is already on psycopg3. Closing to retire tracking of already-landed work.
+
+  Residual, deferred as cosmetic-only (no behaviour impact): the module
+  filename `base/psycopg2_mixin.py` and a handful of "psycopg2 style" /
+  "psycopg2" comments (e.g. base/phase_tracking.py, tpch/tpcds maintenance
+  paramstyle notes). Corrected the two factually-wrong dependency comments in
+  `benchbox/platforms/__init__.py`; a module rename touches the import in
+  `base/__init__.py` and public `PsycopgConnectionMixin` consumers, so it is
+  left as an optional follow-up rather than bundled here.
 
 description: |
   `psycopg2-binary` is a legacy PostgreSQL driver with known packaging
@@ -25,7 +51,7 @@ description: |
 work:
   - id: w0
     summary: "Audit all psycopg2 import sites and connection usage patterns"
-    status: pending
+    status: done
     notes: |
       grep -rn 'psycopg2\|import psycopg' benchbox/ tests/
       Classify each site: direct import, connection factory, cursor type
@@ -35,7 +61,7 @@ work:
   - id: w1
     summary: "Assess psycopg3 API compatibility at each identified call site"
     needs: [w0]
-    status: pending
+    status: done
     notes: |
       psycopg3 is largely API-compatible with psycopg2 for synchronous use, but
       there are known differences: parameter placeholders (%s vs %(name)s vs ?),
@@ -45,7 +71,7 @@ work:
   - id: w2
     summary: "Swap psycopg2-binary for psycopg[binary] in pyproject.toml and update imports"
     needs: [w1]
-    status: pending
+    status: done
     notes: |
       In pyproject.toml, replace psycopg2-binary with psycopg[binary] (or
       psycopg[c] for the C extension build). Update any `import psycopg2` to
@@ -55,7 +81,7 @@ work:
   - id: w3
     summary: "Run the full Redshift/PostgreSQL test suite and confirm zero regressions"
     needs: [w2]
-    status: pending
+    status: done
     notes: |
       uv run -- python -m pytest tests/ -k 'redshift or postgres or postgresql' -q
       Also run the full unit suite to catch any indirect psycopg2 dependency

--- a/benchbox/cli/platform.py
+++ b/benchbox/cli/platform.py
@@ -37,8 +37,9 @@ PLATFORM_ALIASES: dict[str, str] = {
     # Trino/Presto ecosystem
     "trinodb": "trino",
     "prestodb": "presto",
-    # ClickHouse
-    "ch": "clickhouse",
+    # ClickHouse (bare 'clickhouse' was removed after its deprecation window;
+    # 'ch' shorthand now resolves to the default first-class local platform)
+    "ch": "clickhouse-local",
     # BigQuery
     "bq": "bigquery",
     "gbq": "bigquery",

--- a/benchbox/platforms/__init__.py
+++ b/benchbox/platforms/__init__.py
@@ -56,8 +56,8 @@ from .base.adapter import check_isolation_capability
 #   - SQLiteAdapter (stdlib sqlite3)
 #   - DataFusionAdapter (datafusion - ~68 MB native lib, now lazy)
 #   - PolarsAdapter (polars - ~142 MB native lib, now lazy)
-#   - PostgreSQLAdapter (psycopg2 - core dependency)
-#   - TimescaleDBAdapter (psycopg2 - shares core dependency)
+#   - PostgreSQLAdapter (psycopg (v3) - core dependency)
+#   - TimescaleDBAdapter (psycopg (v3) - shares core dependency)
 # ============================================================================
 
 # Cache for lazily loaded adapters and constants

--- a/benchbox/platforms/adapter_factory.py
+++ b/benchbox/platforms/adapter_factory.py
@@ -16,32 +16,31 @@ from benchbox.core.platform_registry import PlatformRegistry
 from benchbox.platforms.base.adapter import check_isolation_capability
 from benchbox.platforms.clickhouse.deployment_mode import (
     CLICKHOUSE_CANONICAL_PLATFORM_NAMES,
-    CLICKHOUSE_DEFAULT_CANONICAL_PLATFORM,
     CLICKHOUSE_LEGACY_SELECTOR_MAP,
     clickhouse_legacy_selector_warning,
 )
 from benchbox.utils.runtime_env import ensure_driver_version
 
 
-def _resolve_clickhouse_legacy(
-    platform: str,
-    deployment: Optional[str] = None,
-    config: Optional[dict] = None,
-) -> tuple[str, Optional[str]]:
+def _resolve_clickhouse_legacy(platform: str) -> tuple[str, Optional[str]]:
     """Translate legacy ClickHouse selectors to first-class platform names.
 
     Handles the migration from the old mixed-mode ``clickhouse`` platform to the
     explicit first-class names ``clickhouse-local``, ``clickhouse-server``, and
-    ``clickhouse-cloud``.
+    ``clickhouse-cloud``. The bare ``clickhouse`` alias has been removed and now
+    raises; only the colon-suffix selectors remain as deprecating aliases, so no
+    deployment/config context is needed to resolve them.
 
     Args:
         platform: Raw platform name from the caller.
-        deployment: Explicit deployment argument (e.g. from ``get_adapter(..., deployment=...)``)
-        config: Keyword config dict (may contain ``deployment_mode`` or ``mode`` keys).
 
     Returns:
         Tuple of (resolved_platform_name, deprecation_message | None).
         The message is non-None only when a legacy selector was used.
+
+    Raises:
+        ValueError: If bare ``clickhouse`` is passed (removed after its
+            deprecation window); the message names the first-class replacements.
     """
     lp = platform.lower().strip()
 
@@ -49,21 +48,22 @@ def _resolve_clickhouse_legacy(
     if lp in CLICKHOUSE_CANONICAL_PLATFORM_NAMES:
         return platform, None
 
-    # Explicit colon-suffix legacy selectors
+    # Explicit colon-suffix legacy selectors (still supported)
     if lp in CLICKHOUSE_LEGACY_SELECTOR_MAP:
         target = CLICKHOUSE_LEGACY_SELECTOR_MAP[lp]
         return target, clickhouse_legacy_selector_warning(platform, target)
 
-    # Bare 'clickhouse': resolve to first-class name based on explicit deployment context
+    # Bare 'clickhouse' was a temporary compatibility alias for the split into
+    # first-class platforms (shipped v0.2.1). The deprecation window has elapsed,
+    # so it is now a hard error that names the replacements instead of silently
+    # resolving to a deployment-dependent default.
     if lp == "clickhouse":
-        explicit_mode = deployment
-        if not explicit_mode and config:
-            explicit_mode = config.get("deployment_mode") or config.get("mode")
-        if isinstance(explicit_mode, str) and explicit_mode.strip().lower() in ("server", "self-hosted"):
-            target = "clickhouse-server"
-        else:
-            target = CLICKHOUSE_DEFAULT_CANONICAL_PLATFORM  # clickhouse-local
-        return target, clickhouse_legacy_selector_warning(platform, target)
+        raise ValueError(
+            "Platform 'clickhouse' has been removed. Use 'clickhouse-local' "
+            "(embedded chDB), 'clickhouse-server' (self-hosted), or "
+            "'clickhouse-cloud' (managed). The explicit 'clickhouse:local', "
+            "'clickhouse:server', and 'clickhouse:cloud' selectors also remain available."
+        )
 
     return platform, None
 
@@ -148,7 +148,7 @@ def get_adapter(
     """
     # ClickHouse migration: translate legacy selectors to first-class platform names.
     # Must happen before _normalize_platform_name so colon-suffix parsing is bypassed.
-    resolved_platform, migration_warning = _resolve_clickhouse_legacy(platform, deployment, config)
+    resolved_platform, migration_warning = _resolve_clickhouse_legacy(platform)
     if migration_warning:
         warnings.warn(migration_warning, DeprecationWarning, stacklevel=2)
     if resolved_platform != platform:

--- a/benchbox/platforms/clickhouse/deployment_mode.py
+++ b/benchbox/platforms/clickhouse/deployment_mode.py
@@ -6,10 +6,11 @@ Migration Contract (as of 2026-04-11):
     - ``clickhouse-server`` - self-hosted ClickHouse via clickhouse-driver (Docker/dedicated)
     - ``clickhouse-cloud``  - managed ClickHouse Cloud via clickhouse-connect
 
-    Bare ``clickhouse`` and colon-suffix syntax (``clickhouse:local``,
-    ``clickhouse:server``) are accepted as deprecating compatibility aliases.
-    They emit a DeprecationWarning and route to the appropriate first-class name.
-    These aliases will be removed after one deprecation window.
+    Bare ``clickhouse`` was a compatibility alias during the migration window
+    (shipped v0.2.1). That window has elapsed: bare ``clickhouse`` is now a hard
+    error that names the first-class replacements. The colon-suffix selectors
+    (``clickhouse:local``, ``clickhouse:server``, ``clickhouse:cloud``) remain
+    accepted and emit a DeprecationWarning while routing to the first-class name.
 """
 
 from __future__ import annotations

--- a/docs/benchmarks/tpc-havoc.md
+++ b/docs/benchmarks/tpc-havoc.md
@@ -272,7 +272,7 @@ TPC-Havoc inherits all TPC-H infrastructure:
 benchbox run tpchavoc --platform duckdb --scale-factor 1.0
 
 # Run specific query variants
-benchbox run tpchavoc --platform clickhouse --queries Q1_V1,Q1_V2,Q1_V3
+benchbox run tpchavoc --platform clickhouse-local --queries Q1_V1,Q1_V2,Q1_V3
 
 # Run all variants of specific queries
 benchbox run tpchavoc --platform duckdb --query-pattern "Q8_V*"

--- a/docs/concepts/workflow.md
+++ b/docs/concepts/workflow.md
@@ -70,7 +70,7 @@ Compare performance across different database platforms:
 benchbox datagen --benchmark tpch --scale 1 --output ./data/tpch_1
 
 # Run on multiple platforms
-for platform in duckdb clickhouse; do
+for platform in duckdb clickhouse-local; do
   benchbox run --benchmark tpch --platform $platform --scale 1 \
     --data-dir ./data/tpch_1 \
     --output benchmark_runs/tpch_1_${platform}
@@ -79,7 +79,7 @@ done
 # Compare results
 benchbox compare \
   benchmark_runs/tpch_1_duckdb/results.json \
-  benchmark_runs/tpch_1_clickhouse/results.json
+  benchmark_runs/tpch_1_clickhouse-local/results.json
 ```
 
 **Output**:
@@ -255,11 +255,11 @@ Optimizing query performance with platform-specific tunings:
 
 ```bash
 # 1. Baseline run (no tunings)
-benchbox run --benchmark tpcds --platform clickhouse --scale 10 \
+benchbox run --benchmark tpcds --platform clickhouse-local --scale 10 \
   --output baseline/
 
 # 2. Apply tunings (partitioning, sorting, indexes)
-benchbox run --benchmark tpcds --platform clickhouse --scale 10 \
+benchbox run --benchmark tpcds --platform clickhouse-local --scale 10 \
   --tuning tunings/clickhouse_tpcds.yaml \
   --output tuned/
 

--- a/docs/development/benchbox-results-platform-strategy.md
+++ b/docs/development/benchbox-results-platform-strategy.md
@@ -549,7 +549,7 @@ The static build pipeline transforms canonical schema-v2 bundles into:
        }
      ],
      "benchmarks": ["tpch", "tpcds", "ssb"],
-     "platforms": ["duckdb", "datafusion", "clickhouse", "polars-df"],
+     "platforms": ["duckdb", "datafusion", "clickhouse-local", "polars-df"],
      "generated_at": "2026-03-29T00:00:00Z"
    }
    ```

--- a/docs/guides/platform-comparison.md
+++ b/docs/guides/platform-comparison.md
@@ -335,7 +335,7 @@ Run platforms in parallel for faster comparisons:
 benchbox compare \
   -p duckdb \
   -p sqlite \
-  -p clickhouse \
+  -p clickhouse-local \
   --parallel \
   --iterations 3
 ```

--- a/docs/guides/postgresql-extensions.md
+++ b/docs/guides/postgresql-extensions.md
@@ -120,7 +120,7 @@ Compare on real-world analytical query patterns:
 ```bash
 benchbox run --platform pg-mooncake --benchmark clickbench
 benchbox run --platform duckdb --benchmark clickbench
-benchbox run --platform clickhouse --benchmark clickbench
+benchbox run --platform clickhouse-local --benchmark clickbench
 ```
 
 ### Time-Series (TSBS)

--- a/docs/platform-config-audit.md
+++ b/docs/platform-config-audit.md
@@ -66,7 +66,7 @@ behavior and are standard practice for OLAP workloads with long-running queries.
 - ClickHouse - experimental correlated subqueries on by default and aggressive OLAP join/spill tuning
   (`benchbox/platforms/clickhouse/tuning.py:52-118`). Impact if removed: plans revert to safer
   defaults; correlated-subquery TPC-H cases may fail or change results. Tests to confirm: quick TPC-H
-  smoke `benchbox run --platform clickhouse --benchmark tpch --scale 0.01 --phases power --non-interactive`
+  smoke `benchbox run --platform clickhouse-local --benchmark tpch --scale 0.01 --phases power --non-interactive`
   and targeted query validation for Q2/4/17/20/21/22.
 - DataFusion - memory_limit=16G default and identifier normalization flag
   (`benchbox/platforms/datafusion.py:101-169,213-299`). Impact if removed: risk of OOM on large data

--- a/docs/platforms/clickhouse-local-mode.md
+++ b/docs/platforms/clickhouse-local-mode.md
@@ -78,7 +78,7 @@ benchbox run --platform clickhouse-server --benchmark tpch --scale 0.01 \
 - `--platform clickhouse-cloud` - Use ClickHouse Cloud (see [ClickHouse Cloud](clickhouse-cloud.md))
 
 ```{deprecated} v0.2.0
-The legacy colon syntax (`clickhouse:local`, `clickhouse:server`) and bare `clickhouse` selector still work but emit deprecation warnings. Use the first-class names above. See [Migration Guide](clickhouse-migration.md).
+The bare `clickhouse` selector has been removed and now raises an error naming the first-class replacements. The legacy colon syntax (`clickhouse:local`, `clickhouse:server`) still works but emits deprecation warnings. Use the first-class names above. See [Migration Guide](clickhouse-migration.md).
 ```
 
 #### Local Mode Specific Arguments

--- a/docs/platforms/clickhouse-migration.md
+++ b/docs/platforms/clickhouse-migration.md
@@ -56,19 +56,24 @@ during the migration window. They will be removed in a future release.
 | `--platform clickhouse --platform-option deployment_mode=local` | `--platform clickhouse-local` |
 | `--platform clickhouse --platform-option deployment_mode=server` | `--platform clickhouse-server` |
 
-### Bare `clickhouse`
+### Bare `clickhouse` (removed)
 
-Bare `--platform clickhouse` resolves to `clickhouse-local` by default (the
-chDB embedded path). If you relied on `--platform clickhouse` for a real
-server, switch to `--platform clickhouse-server`.
+Bare `--platform clickhouse` has been **removed** after its deprecation window
+(shipped v0.2.1, removed after v0.3.1). It now raises an error naming the
+replacements instead of silently defaulting to `clickhouse-local`. Choose the
+first-class name explicitly: `clickhouse-local` (embedded chDB),
+`clickhouse-server` (self-hosted), or `clickhouse-cloud` (managed). The
+explicit `clickhouse:local` / `clickhouse:server` / `clickhouse:cloud`
+selectors still work (they emit a deprecation warning and route to the
+first-class name).
 
 ### Config Files
 
-YAML configuration files that reference `clickhouse` will continue to work
-during the migration window. To silence the warning, update:
+YAML configuration files that use bare `clickhouse` no longer resolve and must
+be updated to a first-class name:
 
 ```yaml
-# Before (deprecated)
+# Before (removed — now errors)
 platform: clickhouse
 deployment_mode: local
 
@@ -77,7 +82,7 @@ platform: clickhouse-local
 ```
 
 ```yaml
-# Before (deprecated)
+# Before (removed — now errors)
 platform: clickhouse
 deployment_mode: server
 
@@ -98,12 +103,16 @@ until after alias removal.
   platform identifiers in the registry, adapter factory, CLI, DDL generator,
   cost calculator, and dependency surfaces.
 - `clickhouse-cloud` was already a first-class platform and is unchanged.
-- Bare `clickhouse` and colon-suffix syntax are compatibility aliases with
-  explicit `DeprecationWarning` emission.
+- Bare `clickhouse` has been removed and now raises an error naming the
+  first-class replacements. Colon-suffix syntax (`clickhouse:local`, etc.)
+  remains a compatibility alias with explicit `DeprecationWarning` emission.
 - Shared ClickHouse SQL dialect, workload, and tuning logic is unchanged and
   shared across all three platform identifiers.
 
 ## Alias Removal Timeline
 
-Alias removal will happen in a follow-up release after the deprecation window.
-Tracked in: `deferred` items of the `first-class-clickhouse-local-server-cloud-platforms` TODO.
+The bare `clickhouse` alias has now been **removed** (after the v0.2.1 → v0.3.1
+deprecation window); passing it raises an error naming the first-class
+replacements. The colon-suffix selectors (`clickhouse:local` / `:server` /
+`:cloud`) remain as deprecating aliases. Bulk relabeling of historical result
+artifacts that carry the legacy `clickhouse` platform label is still deferred.

--- a/docs/platforms/comparison-matrix.md
+++ b/docs/platforms/comparison-matrix.md
@@ -121,7 +121,7 @@ Zero-infrastructure platforms that run in-process. Ideal for development, testin
 | **SQL Support**    | Full              | Full               | Full               | **DataFrame only** | Full                     |
 
 ```{note}
-**ClickHouse Platforms**: ClickHouse is available as three first-class platforms: `clickhouse-local` (chDB, zero-config), `clickhouse-server` (self-hosted), and `clickhouse-cloud` (managed). The legacy bare `clickhouse` selector still works but is deprecated. See [Migration Guide](clickhouse-migration.md).
+**ClickHouse Platforms**: ClickHouse is available as three first-class platforms: `clickhouse-local` (chDB, zero-config), `clickhouse-server` (self-hosted), and `clickhouse-cloud` (managed). The legacy bare `clickhouse` selector has been removed and now raises an error naming these replacements. See [Migration Guide](clickhouse-migration.md).
 ```
 
 ### Relative Performance Characteristics

--- a/docs/platforms/deployment-modes.md
+++ b/docs/platforms/deployment-modes.md
@@ -103,7 +103,7 @@ This means MotherDuck automatically uses DuckDB's query translator and Starburst
 ClickHouse has three first-class platform names, plus a legacy `clickhouse` selector for backwards compatibility.
 
 ```{note}
-The bare `clickhouse` selector and colon syntax (`clickhouse:local`, `clickhouse:server`) are deprecated. Use the first-class names below. See [Migration Guide](clickhouse-migration.md).
+The bare `clickhouse` selector has been removed (it now raises an error). The colon syntax (`clickhouse:local`, `clickhouse:server`) is deprecated but still works. Use the first-class names below. See [Migration Guide](clickhouse-migration.md).
 ```
 
 ### clickhouse-local (chDB)

--- a/docs/platforms/quick-reference.md
+++ b/docs/platforms/quick-reference.md
@@ -130,7 +130,7 @@ from benchbox import TPCH
 benchmark = TPCH(scale_factor=0.1)
 
 # Test on multiple platforms
-platforms = ["duckdb", "clickhouse"]
+platforms = ["duckdb", "clickhouse-local"]
 
 for platform_name in platforms:
     print(f"Running on {platform_name}...")

--- a/docs/reference/cli/configuration.md
+++ b/docs/reference/cli/configuration.md
@@ -201,7 +201,7 @@ benchbox run --platform athena-spark --benchmark tpch \
 
 Example:
 ```bash
-benchbox run --platform clickhouse --benchmark tpch \
+benchbox run --platform clickhouse-local --benchmark tpch \
   --platform-option mode=local \
   --platform-option secure=true \
   --platform-option port=9440

--- a/docs/reference/cli/run.md
+++ b/docs/reference/cli/run.md
@@ -256,7 +256,7 @@ benchbox run --help-topic benchmarks
 
 ```bash
 # ClickHouse with local mode and TLS
-benchbox run --platform clickhouse --benchmark tpch \
+benchbox run --platform clickhouse-local --benchmark tpch \
   --platform-option mode=local \
   --platform-option secure=true
 

--- a/docs/reference/cli/shell.md
+++ b/docs/reference/cli/shell.md
@@ -92,7 +92,7 @@ benchbox shell --output ./my-benchmarks --benchmark tpcds --scale 10
 
 ```bash
 # ClickHouse connection
-benchbox shell --platform clickhouse --host localhost --port 9000 \
+benchbox shell --platform clickhouse-server --host localhost --port 9000 \
   --user default --database benchbox
 ```
 

--- a/docs/usage/data-generation.md
+++ b/docs/usage/data-generation.md
@@ -475,7 +475,7 @@ Some platforms have special considerations:
 
 ```python
 # ClickHouse - handles large scale factors efficiently
-benchmark = TPCH(scale_factor=100.0, platform="clickhouse")
+benchmark = TPCH(scale_factor=100.0, platform="clickhouse-local")
 
 # DuckDB - configured for analytical workloads
 benchmark = TPCH(scale_factor=10.0, platform="duckdb")

--- a/docs/usage/dry-run.md
+++ b/docs/usage/dry-run.md
@@ -337,7 +337,7 @@ Compare configurations across multiple platforms:
 
 ```bash
 # Preview for multiple platforms
-for platform in duckdb clickhouse databricks; do
+for platform in duckdb clickhouse-local databricks; do
   benchbox run --dry-run ./preview_${platform} \
     --platform ${platform} \
     --benchmark tpch \
@@ -345,7 +345,7 @@ for platform in duckdb clickhouse databricks; do
 done
 
 # Compare extracted queries
-diff ./preview_duckdb/queries/query_1.sql ./preview_clickhouse/queries/query_1.sql
+diff ./preview_duckdb/queries/query_1.sql ./preview_clickhouse-local/queries/query_1.sql
 ```
 
 ### Resource Scaling Analysis
@@ -553,7 +553,7 @@ done
 ```bash
 # Test platform-specific configurations
 benchbox run --dry-run ./platform_test \
-  --platform clickhouse \
+  --platform clickhouse-local \
   --benchmark tpch \
   --scale 0.01
 

--- a/docs/usage/examples.md
+++ b/docs/usage/examples.md
@@ -197,7 +197,7 @@ benchbox run --platform postgres --benchmark tpch --queries "1,6,17" --phases po
 benchbox run --platform duckdb --benchmark tpcds --queries "42" --verbose --phases power
 
 # Test critical production queries only
-benchbox run --platform clickhouse --benchmark tpch --queries "1,6,12,17" --phases power
+benchbox run --platform clickhouse-local --benchmark tpch --queries "1,6,12,17" --phases power
 ```
 
 ### Programmatic Usage

--- a/docs/usage/faq.md
+++ b/docs/usage/faq.md
@@ -219,7 +219,7 @@ See [Performance Optimization](../advanced/performance-optimization.md) for tuni
 ### Can I use BenchBox with self-hosted databases?
 
 Yes! BenchBox currently supports:
-- **ClickHouse**: Fully supported via `--platform clickhouse` (local or remote)
+- **ClickHouse**: Fully supported via `--platform clickhouse-server` (local or remote)
 - **DuckDB**: Fully supported for local/embedded use via `--platform duckdb`
 - **SQLite**: Fully supported for local/embedded use via `--platform sqlite`
 

--- a/examples/PATTERNS.md
+++ b/examples/PATTERNS.md
@@ -535,12 +535,12 @@ python examples/unified_runner.py \
 # Platform 2: ClickHouse (self-hosted)
 echo "=== Running on ClickHouse ==="
 python examples/unified_runner.py \
-  --platform clickhouse \
+  --platform clickhouse-server \
   --benchmark tpch \
   --scale $SCALE_FACTOR \
   --phases power \
   --tuning tuned \
-  --output-dir "$OUTPUT_DIR/clickhouse" \
+  --output-dir "$OUTPUT_DIR/clickhouse-server" \
   --formats json,csv,html
 
 # Platform 3: Databricks (cloud)
@@ -559,7 +559,7 @@ python - <<EOF
 import json
 from pathlib import Path
 
-platforms = ["duckdb", "clickhouse", "databricks"]
+platforms = ["duckdb", "clickhouse-server", "databricks"]
 results = {}
 
 for platform in platforms:

--- a/examples/config/clickhouse.yaml
+++ b/examples/config/clickhouse.yaml
@@ -1,4 +1,4 @@
-type: clickhouse
+type: clickhouse-server
 connection:
   host: localhost
   port: 9000

--- a/examples/config/clickhouse_cloud.yaml
+++ b/examples/config/clickhouse_cloud.yaml
@@ -1,4 +1,4 @@
-type: clickhouse
+type: clickhouse-cloud
 connection:
   host: "your-instance.clickhouse.cloud"
   port: 8443

--- a/examples/features/multi_platform.py
+++ b/examples/features/multi_platform.py
@@ -387,7 +387,7 @@ def main() -> int:
     print()
     print("Next steps:")
     print("  • Use unified_runner.py for platform comparison:")
-    print("    for platform in duckdb clickhouse databricks; do")
+    print("    for platform in duckdb clickhouse-local databricks; do")
     print("      python unified_runner.py --platform $platform \\")
     print("        --benchmark tpch --scale 1.0 --phases power \\")
     print("        --output-dir ./results/$platform")

--- a/examples/notebooks/clickhouse_benchmarking.ipynb
+++ b/examples/notebooks/clickhouse_benchmarking.ipynb
@@ -1,178 +1,148 @@
 {
-  "cells": [
-    {
-      "cell_type": "markdown",
-      "id": "7fb27b941602401d91542211134fc71a",
-      "metadata": {},
-      "source": [
-        "# ClickHouse Benchmarking with BenchBox\n\n",
-        "Run high-performance analytics benchmarks against ClickHouse using BenchBox.\n"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "acae54e37e7d407bbb7b55eff062a284",
-      "metadata": {},
-      "source": [
-        "## Installation & Setup\n"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "5e94305c",
-      "metadata": {},
-      "source": [
-        "Install BenchBox and the ClickHouse Python driver.\n"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "9a63283cbaf04dbcab1f6479b197f3a8",
-      "metadata": {},
-      "outputs": [],
-      "source": [
-        "!pip install benchbox clickhouse-driver"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "8dd0d8092fe74a7c96281538738b07e2",
-      "metadata": {},
-      "source": [
-        "## Quick Start Example\n"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "cc6fc127",
-      "metadata": {},
-      "source": [
-        "Run a TPC-H power test at scale 0.01 against a ClickHouse server.\n"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "72eea5119410473aa328ad9291626812",
-      "metadata": {},
-      "outputs": [],
-      "source": [
-        "import os\n",
-        "\n",
-        "from benchbox.core.config import BenchmarkConfig, DatabaseConfig\n",
-        "from benchbox.core.runner import LifecyclePhases, run_benchmark_lifecycle\n",
-        "\n",
-        "CLICKHOUSE_HOST = os.environ.get(\"CLICKHOUSE_HOST\", \"localhost\")\n",
-        "CLICKHOUSE_PORT = int(os.environ.get(\"CLICKHOUSE_PORT\", \"8443\"))\n",
-        "CLICKHOUSE_USER = os.environ.get(\"CLICKHOUSE_USER\", \"default\")\n",
-        "CLICKHOUSE_PASSWORD = os.environ.get(\"CLICKHOUSE_PASSWORD\", \"\")\n",
-        "CLICKHOUSE_SECURE = os.environ.get(\"CLICKHOUSE_SECURE\", \"true\").lower() == \"true\"\n",
-        "\n",
-        "db_cfg = DatabaseConfig(type=\"clickhouse\", name=\"clickhouse\")\n",
-        "platform_cfg = {\n",
-        "    \"host\": CLICKHOUSE_HOST,\n",
-        "    \"port\": CLICKHOUSE_PORT,\n",
-        "    \"user\": CLICKHOUSE_USER,\n",
-        "    \"password\": CLICKHOUSE_PASSWORD,\n",
-        "    \"secure\": CLICKHOUSE_SECURE,\n",
-        "}\n",
-        "\n",
-        "bench_cfg = BenchmarkConfig(name=\"tpch\", display_name=\"TPC-H\", scale_factor=0.01, test_execution_type=\"power\")\n",
-        "results = run_benchmark_lifecycle(\n",
-        "    benchmark_config=bench_cfg,\n",
-        "    database_config=db_cfg,\n",
-        "    system_profile=None,\n",
-        "    platform_config=platform_cfg,\n",
-        "    phases=LifecyclePhases(generate=True, load=True, execute=True),\n",
-        ")\n",
-        "print(\"Power test completed on ClickHouse\")  # run_benchmark"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "8edb47106e1a46a883d545849b8ab81b",
-      "metadata": {},
-      "source": [
-        "## Advanced Examples\n"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "8a257ac9",
-      "metadata": {},
-      "source": [
-        "- Run ClickBench queries and compare results.\n",
-        "- Use MergeTree settings and partitions for faster loads.\n",
-        "- Experiment with ZSTD compression levels.\n"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "10185d26023b46108eb7d9f57d49d2b3",
-      "metadata": {},
-      "source": [
-        "## Platform-Specific Features\n"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "2ec80a49",
-      "metadata": {},
-      "source": [
-        "- MergeTree table engines and partitioning.\n",
-        "- Materialized views and projections.\n",
-        "- Server settings for concurrency and memory.\n"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "8763a12b2bbd4a93a75aff182afb95dc",
-      "metadata": {},
-      "source": [
-        "## Performance Analysis\n"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "0daf2aa2",
-      "metadata": {},
-      "source": [
-        "- Track query execution profiling and memory usage.\n",
-        "- Compare TPC-H vs ClickBench performance.\n",
-        "- Persist results for longitudinal tracking.\n"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "7623eae2785240b9bd12b16a66d81610",
-      "metadata": {},
-      "source": [
-        "## Troubleshooting\n"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "b828cd3e",
-      "metadata": {},
-      "source": [
-        "- Verify user permissions for DDL and inserts.\n",
-        "- Ensure network access to the ClickHouse server.\n",
-        "- Check server logs for memory limit exceptions.\n"
-      ]
-    }
-  ],
-  "metadata": {
-    "kernelspec": {
-      "display_name": "Python 3",
-      "language": "python",
-      "name": "python3"
-    },
-    "language_info": {
-      "name": "python",
-      "version": "3.10"
-    }
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "7fb27b941602401d91542211134fc71a",
+   "metadata": {},
+   "source": [
+    "# ClickHouse Benchmarking with BenchBox\n\n",
+    "Run high-performance analytics benchmarks against ClickHouse using BenchBox.\n"
+   ]
   },
-  "nbformat": 4,
-  "nbformat_minor": 5
+  {
+   "cell_type": "markdown",
+   "id": "acae54e37e7d407bbb7b55eff062a284",
+   "metadata": {},
+   "source": [
+    "## Installation & Setup\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5e94305c",
+   "metadata": {},
+   "source": [
+    "Install BenchBox and the ClickHouse Python driver.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9a63283cbaf04dbcab1f6479b197f3a8",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!pip install benchbox clickhouse-driver"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8dd0d8092fe74a7c96281538738b07e2",
+   "metadata": {},
+   "source": [
+    "## Quick Start Example\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cc6fc127",
+   "metadata": {},
+   "source": [
+    "Run a TPC-H power test at scale 0.01 against a ClickHouse server.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "72eea5119410473aa328ad9291626812",
+   "metadata": {},
+   "outputs": [],
+   "source": "import os\n\nfrom benchbox.core.config import BenchmarkConfig, DatabaseConfig\nfrom benchbox.core.runner import LifecyclePhases, run_benchmark_lifecycle\n\nCLICKHOUSE_HOST = os.environ.get(\"CLICKHOUSE_HOST\", \"localhost\")\nCLICKHOUSE_PORT = int(os.environ.get(\"CLICKHOUSE_PORT\", \"8443\"))\nCLICKHOUSE_USER = os.environ.get(\"CLICKHOUSE_USER\", \"default\")\nCLICKHOUSE_PASSWORD = os.environ.get(\"CLICKHOUSE_PASSWORD\", \"\")\nCLICKHOUSE_SECURE = os.environ.get(\"CLICKHOUSE_SECURE\", \"true\").lower() == \"true\"\n\ndb_cfg = DatabaseConfig(type=\"clickhouse-server\", name=\"clickhouse-server\")\nplatform_cfg = {\n    \"host\": CLICKHOUSE_HOST,\n    \"port\": CLICKHOUSE_PORT,\n    \"user\": CLICKHOUSE_USER,\n    \"password\": CLICKHOUSE_PASSWORD,\n    \"secure\": CLICKHOUSE_SECURE,\n}\n\nbench_cfg = BenchmarkConfig(name=\"tpch\", display_name=\"TPC-H\", scale_factor=0.01, test_execution_type=\"power\")\nresults = run_benchmark_lifecycle(\n    benchmark_config=bench_cfg,\n    database_config=db_cfg,\n    system_profile=None,\n    platform_config=platform_cfg,\n    phases=LifecyclePhases(generate=True, load=True, execute=True),\n)\nprint(\"Power test completed on ClickHouse\")  # run_benchmark"
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8edb47106e1a46a883d545849b8ab81b",
+   "metadata": {},
+   "source": [
+    "## Advanced Examples\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8a257ac9",
+   "metadata": {},
+   "source": [
+    "- Run ClickBench queries and compare results.\n",
+    "- Use MergeTree settings and partitions for faster loads.\n",
+    "- Experiment with ZSTD compression levels.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "10185d26023b46108eb7d9f57d49d2b3",
+   "metadata": {},
+   "source": [
+    "## Platform-Specific Features\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2ec80a49",
+   "metadata": {},
+   "source": [
+    "- MergeTree table engines and partitioning.\n",
+    "- Materialized views and projections.\n",
+    "- Server settings for concurrency and memory.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8763a12b2bbd4a93a75aff182afb95dc",
+   "metadata": {},
+   "source": [
+    "## Performance Analysis\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0daf2aa2",
+   "metadata": {},
+   "source": [
+    "- Track query execution profiling and memory usage.\n",
+    "- Compare TPC-H vs ClickBench performance.\n",
+    "- Persist results for longitudinal tracking.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7623eae2785240b9bd12b16a66d81610",
+   "metadata": {},
+   "source": [
+    "## Troubleshooting\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b828cd3e",
+   "metadata": {},
+   "source": [
+    "- Verify user permissions for DDL and inserts.\n",
+    "- Ensure network access to the ClickHouse server.\n",
+    "- Check server logs for memory limit exceptions.\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.10"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
 }

--- a/examples/unified_runner_README.md
+++ b/examples/unified_runner_README.md
@@ -231,7 +231,7 @@ Use `--platform` to run on different databases:
 --platform sqlite       # SQLite database
 
 # Self-hosted
---platform clickhouse   # ClickHouse server
+--platform clickhouse-server   # ClickHouse server
 
 # Cloud platforms (requires credentials)
 --platform databricks   # Databricks SQL Warehouse
@@ -395,7 +395,7 @@ python unified_runner.py --platform duckdb --benchmark primitives --scale 0.01 \
 ### Multi-Platform Comparison
 ```bash
 # Run same benchmark on 3 platforms
-for platform in duckdb clickhouse databricks; do
+for platform in duckdb clickhouse-local databricks; do
   python unified_runner.py --platform $platform --benchmark tpch --scale 1.0 \
     --phases power --output-dir ./comparison/$platform
 done

--- a/examples/use_cases/platform_evaluation.py
+++ b/examples/use_cases/platform_evaluation.py
@@ -21,13 +21,13 @@ Evaluation criteria:
 
 Usage:
     # Evaluate multiple platforms
-    python use_cases/platform_evaluation.py --platforms duckdb,sqlite,clickhouse
+    python use_cases/platform_evaluation.py --platforms duckdb,sqlite,clickhouse-local
 
     # Dry-run first (preview without execution)
     python use_cases/platform_evaluation.py --platforms databricks,bigquery --dry-run
 
     # Custom scale factor
-    python use_cases/platform_evaluation.py --platforms duckdb,clickhouse --scale 1.0
+    python use_cases/platform_evaluation.py --platforms duckdb,clickhouse-local --scale 1.0
 """
 
 from __future__ import annotations

--- a/tests/integration/test_cli_e2e.py
+++ b/tests/integration/test_cli_e2e.py
@@ -100,10 +100,10 @@ def _prepare_clickhouse_stub(stub_root: Path) -> Path:
 
 @pytest.mark.integration
 @pytest.mark.platform_smoke
-@pytest.mark.parametrize("database", ["duckdb", "sqlite", "clickhouse"])
+@pytest.mark.parametrize("database", ["duckdb", "sqlite", "clickhouse-local"])
 def test_cli_dry_run_generates_expected_artifacts(tmp_path: Path, database: str):
     # Skip clickhouse test if driver not available
-    if database == "clickhouse" and not CLICKHOUSE_DRIVER_AVAILABLE:
+    if database == "clickhouse-local" and not CLICKHOUSE_DRIVER_AVAILABLE:
         pytest.skip("clickhouse-driver not installed")
     output_dir = tmp_path / f"dry_run_{database}"
     output_dir.mkdir()
@@ -122,13 +122,12 @@ def test_cli_dry_run_generates_expected_artifacts(tmp_path: Path, database: str)
 
     env = {}
 
-    if database == "clickhouse":
+    if database == "clickhouse-local":
         chdb_path = tmp_path / "chdb_store"
         chdb_path.mkdir()
+        # clickhouse-local forces local deployment, so no mode option is needed.
         args.extend(
             [
-                "--platform-option",
-                "mode=local",
                 "--platform-option",
                 f"data_path={chdb_path / 'benchbox.chdb'}",
                 "--platform-option",

--- a/tests/unit/cli/test_platform.py
+++ b/tests/unit/cli/test_platform.py
@@ -105,9 +105,13 @@ class TestPlatformNameNormalization:
         assert normalize_platform_name("PrestoDB") == "presto"
 
     def test_normalize_clickhouse_alias(self):
-        """Test ClickHouse alias."""
-        assert normalize_platform_name("ch") == "clickhouse"
-        assert normalize_platform_name("CH") == "clickhouse"
+        """Test ClickHouse alias resolves to the first-class local platform.
+
+        Bare 'clickhouse' was removed after its deprecation window, so the 'ch'
+        shorthand now normalizes to 'clickhouse-local' (the default canonical).
+        """
+        assert normalize_platform_name("ch") == "clickhouse-local"
+        assert normalize_platform_name("CH") == "clickhouse-local"
 
     def test_normalize_bigquery_aliases(self):
         """Test BigQuery aliases."""

--- a/tests/unit/platforms/test_clickhouse_platform_split.py
+++ b/tests/unit/platforms/test_clickhouse_platform_split.py
@@ -12,7 +12,6 @@ Copyright 2026 Joe Harris / BenchBox Project
 
 from __future__ import annotations
 
-import warnings
 from unittest.mock import patch
 
 import pytest
@@ -228,26 +227,17 @@ class TestAdapterFactoryMigration:
         assert platform == "clickhouse-cloud"
         assert warning is None
 
-    def test_bare_clickhouse_emits_deprecation_and_maps_to_local(self) -> None:
+    def test_bare_clickhouse_is_removed_and_raises_with_replacements(self) -> None:
         from benchbox.platforms.adapter_factory import _resolve_clickhouse_legacy
 
-        platform, warning = _resolve_clickhouse_legacy("clickhouse")
-        assert platform == "clickhouse-local"
-        assert warning is not None
-        assert "deprecated" in warning.lower()
-
-    def test_bare_clickhouse_with_server_mode_maps_to_server(self) -> None:
-        from benchbox.platforms.adapter_factory import _resolve_clickhouse_legacy
-
-        platform, warning = _resolve_clickhouse_legacy("clickhouse", config={"deployment_mode": "server"})
-        assert platform == "clickhouse-server"
-        assert warning is not None
-
-    def test_bare_clickhouse_with_explicit_deployment_server_maps_to_server(self) -> None:
-        from benchbox.platforms.adapter_factory import _resolve_clickhouse_legacy
-
-        platform, warning = _resolve_clickhouse_legacy("clickhouse", deployment="server")
-        assert platform == "clickhouse-server"
+        # Bare 'clickhouse' is now a hard error regardless of any deployment
+        # context (the resolver no longer accepts deployment/config hints for it).
+        with pytest.raises(ValueError) as exc_info:
+            _resolve_clickhouse_legacy("clickhouse")
+        msg = str(exc_info.value)
+        assert "clickhouse-local" in msg
+        assert "clickhouse-server" in msg
+        assert "removed" in msg.lower()
 
     def test_clickhouse_colon_local_maps_to_clickhouse_local(self) -> None:
         from benchbox.platforms.adapter_factory import _resolve_clickhouse_legacy
@@ -280,20 +270,15 @@ class TestAdapterFactoryMigration:
             assert platform == name
             assert warning is None
 
-    def test_get_adapter_emits_deprecation_for_bare_clickhouse(self) -> None:
-        """Integration: get_adapter("clickhouse") emits DeprecationWarning."""
+    def test_get_adapter_rejects_bare_clickhouse_with_helpful_error(self) -> None:
+        """Integration: get_adapter("clickhouse") raises naming the replacements."""
         from benchbox.platforms.adapter_factory import get_adapter
 
-        with warnings.catch_warnings(record=True) as caught:
-            warnings.simplefilter("always")
-            try:
-                get_adapter("clickhouse")
-            except Exception:
-                pass  # May fail if chDB not installed; we only care about the warning
-        deprecation_warnings = [w for w in caught if issubclass(w.category, DeprecationWarning)]
-        assert any("clickhouse" in str(w.message).lower() for w in deprecation_warnings), (
-            f"Expected a DeprecationWarning about 'clickhouse' but got: {[str(w.message) for w in deprecation_warnings]}"
-        )
+        with pytest.raises(ValueError) as exc_info:
+            get_adapter("clickhouse")
+        msg = str(exc_info.value)
+        assert "clickhouse-local" in msg
+        assert "clickhouse-server" in msg
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Description

Second batch of the deferred-gap TODOs (follow-on to #1191). Completes two of
the three remaining items; the third (extras removal) is **held** because
investigation disproved its premise (see Notes).

**clickhouse-alias-removal-post-deprecation (BREAKING):** bare `clickhouse` was
a temporary compatibility alias for the split into first-class platforms
(shipped v0.2.1). Its deprecation window has elapsed (v0.2.1 → v0.3.0 → v0.3.1,
~3 months), so it is removed. `--platform clickhouse` / `get_adapter("clickhouse")`
now raises a `ValueError` naming `clickhouse-local` (embedded chDB),
`clickhouse-server` (self-hosted), and `clickhouse-cloud` (managed) instead of
silently defaulting to a deployment mode. The explicit colon-suffix selectors
(`clickhouse:local` / `:server` / `:cloud`) are **kept** as deprecating aliases
(approved scope: remove bare only). The `ch` CLI shorthand now resolves to
`clickhouse-local`.

**dependency-migration-psycopg3 (already migrated):** the psycopg2-binary →
psycopg3 swap already landed — adapters `import psycopg` (v3), pyproject pins
`psycopg[binary]>=3.1`, zero `psycopg2` imports. Retired to DONE with the two
factually-wrong "psycopg2 - core dependency" comments in `platforms/__init__.py`
corrected.

## Type of Change

- [x] Breaking change (bare `clickhouse` platform alias removed)
- [x] Documentation
- [x] Refactor / chore (2 TODOs moved to `_project/DONE/main/`)

## Testing

- `test_clickhouse_platform_split.py` updated to assert the new error; sql_compat
  ClickHouse **dialect** subsystem unaffected.
- Targeted sweep: `tests/unit/platforms/ tests/unit/cli/ tests/unit/core/sql_compat/
  tests/unit/sql_compat/` → **9620 passed**, 70 skipped, 3 failed.
- The 3 failures (`test_validate_output_directory_local_invalid`,
  `test_dry_run_with_missing_output_dir`, `test_export_with_invalid_output_dir`)
  are **pre-existing and unrelated** — they reproduce identically on the base
  commit `3a27532c` and are environmental (running as root makes
  `/invalid/path/...` creatable, so the expected error doesn't raise). No
  clickhouse/adapter code involved.
- `get_adapter("clickhouse")` raises with both replacements named; `psycopg2`
  imports = 0; postgres/redshift fast tests → 884 passed.
- `validate_todo.py` valid; `check-graph` → 125 items, no cycles/dangling.

This PR changes public platform-selection behavior (bare `clickhouse`), reflected
in the CHANGELOG `### Removed` entry.

## Public Contract Check

- [x] `CHANGELOG.md` records the breaking removal; platform-support surface
      updated (bare `clickhouse` no longer resolvable).
- [x] No result schema / MCP / adapter-subclassing-hook changes; the ClickHouse
      **dialect** and first-class platforms are unaffected.
- [x] No platform/benchmark count claims changed (first-class names already
      counted).

## Documentation

- [x] 24 run-command usages across `docs/` + `examples/` moved to first-class
      names (clickhouse-local default; clickhouse-server for self-hosted context).
- [x] Prose docs that claimed the alias "still works" corrected
      (clickhouse-migration.md, clickhouse-local-mode.md, deployment-modes.md,
      comparison-matrix.md).
- [x] Left historical `docs/blog/*`, family-key registry examples
      (`get_available_deployment_modes("clickhouse")` still accepts the family),
      and `dialect="clickhouse"` usages unchanged.

## Code Quality

- [x] `ruff check` clean on changed sources; dead `deployment`/`config` params
      dropped from `_resolve_clickhouse_legacy` along with the removed branch.
- [x] Reviewed backwards-compat/migration impact — breaking, with a helpful
      error + migration-guide update + kept colon-suffix selectors.
- [x] Tests updated for the new error path; example configs/notebook/py that
      would break at runtime fixed (clickhouse.yaml → server, clickhouse_cloud.yaml
      → cloud, notebook → server).

## Artifact Hygiene

- [x] No screenshots/logs/benchmark-output/binary artifacts. TODO indexes are
      gitignored; batch ledger under git-excluded `scratch/`.

## Notes

**Held — `tighten-dependencies-phase-3-extras-deprecation` is NOT in this PR.**
Investigation disproved the TODO's premise: it (and the older phase-plan)
assumed the plain-name extras (`pandas`, `polars`, …) are the compat *aliases*
to delete. But commit #1124 (2026-07-10) **reversed** this — `pyproject.toml`
now declares plain-name extras as the *preferred* install names and `dataframe-*`
as the aliases, and `docs/platforms/pandas-dataframe.md` documents
`pip install benchbox[pandas]` as canonical. Removing the 6 dataframe plain-name
extras would delete the preferred/documented names. Only `databricks-connect`
remains a genuine deprecated alias (of `cloud-spark-databricks`). This needs a
direction decision before any removal; the TODO stays in planning.

**Deferred (unchanged):** the clickhouse TODO's historical-result-artifact
relabel item remains deferred (out of scope: mutating stored artifacts).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RTJ6YgUNU2uUgWwuDAxwA9

---
_Generated by [Claude Code](https://claude.ai/code/session_01RTJ6YgUNU2uUgWwuDAxwA9)_