### PR TITLE
chore(todo): ratify ClickHouse empty-value nullability decision; resolve parent open_question

### DIFF
--- a/_project/DONE/main/planning/uat-clickhouse-loader-empty-value-nullability.yaml
+++ b/_project/DONE/main/planning/uat-clickhouse-loader-empty-value-nullability.yaml
@@ -2,7 +2,7 @@ id: uat-clickhouse-loader-empty-value-nullability
 title: "Decide ClickHouse-server loader empty-value nullability policy: Nullable(...) DDL vs default coercion"
 worktree: main
 priority: High
-status: Not Started
+status: Completed
 category: Testing and Quality Assurance
 
 description: |
@@ -26,15 +26,46 @@ description: |
   deferred so the parent's w2 is unambiguous.
 
 recommended_resolution: |
-  Carried from the parent's documented default, pending ratification:
-  "Emit or preserve Nullable(T) where the benchmark schema marks a column
-  nullable; only coerce to a type default for genuinely non-Nullable fields
-  when source semantics require it." Rationale: benchmark answer-sets are
-  defined against the reference schema's nullability; silently coercing a
-  nullable-empty to a default can shift aggregates/counts and corrupt
-  comparability. This preserves soundness; the coercion path trades soundness
-  for DDL simplicity and should only apply where the schema itself is
-  non-Nullable.
+  RATIFIED (2026-07-16, repo owner). Policy: an empty numeric/date source field
+  becomes NULL, and the column emits Nullable(T) DDL where the reference schema
+  marks it nullable. Do NOT coerce empties to a type default (0 / epoch). When
+  an empty value lands in a column the reference schema marks NOT NULL, FAIL
+  LOUDLY and treat it as a benchmark data defect (split into a benchmark-specific
+  TODO per the parent's approach), rather than fabricating a default.
+
+  This is effectively pre-decided by the schema data + the parent's own
+  guardrails, not a free choice:
+
+    1. The columns that actually fail Bucket A are nullable in BenchBox's own
+       TPC-DS schema (benchbox/core/tpcds/schema/table_specs.yaml; Column tuple
+       field 4 = nullable, per schema/models.py):
+         c_current_cdemo_sk   INTEGER  nullable=true
+         c_current_hdemo_sk   INTEGER  nullable=true
+         c_current_addr_sk    INTEGER  nullable=true
+         s_rec_start_date     DATE     nullable=true
+         s_rec_end_date       DATE     nullable=true
+       So an empty there genuinely means absent -> NULL. Coercing to 0/epoch
+       fabricates a real-looking surrogate key / date that then joins, counts,
+       and aggregates as if real, corrupting query answers (comparability).
+
+    2. The parent already forbids the coercion path:
+       must_preserve "Do not silently coerce invalid data to zero... nullability
+       and parse failures must stay visible", and anti_patterns "DO NOT fabricate
+       default numeric/date values for fields that are genuinely nullable".
+
+    3. DDL is mechanical: emit Nullable(T) where the schema's nullable bit is
+       set; the existing benchbox/sql_compat/rules/ddl_optimize/
+       clickhouse_ddl_rewrites.py already normalises Nullable(T) NOT NULL.
+
+  Empirical note: because every observed failing column is nullable, the
+  NOT-NULL edge (option requiring the fail-loud policy) does not fire for the
+  current corpus. The parent's w0 must re-confirm no genuinely-NOT-NULL column
+  receives empties; if one appears, it is a benchmark data defect, handled by
+  fail-loud, not by silent defaulting.
+
+  IMPLEMENTATION GATE: this ratifies the POLICY only (a TODO-doc change). The
+  loader/DDL code that applies it lives in the parent (loader-type-coverage:w2)
+  and still passes through CODEOWNERS review when that PR is opened.
 
 work:
   - id: w0
@@ -67,22 +98,32 @@ work:
       territory and needs Code Owner sign-off; see anti_patterns.
   - id: w1
     summary: "Ratify Nullable-preserve vs default-coerce against benchmark schema nullability"
-    status: pending
+    status: done
     needs: [w0]
     notes: |
       Decide per the recommended_resolution unless w0 surfaces a schema column
       where preserving Nullable breaks the reference answer-set. This is the
       decision work unit; it needs Code Owner / soundness review because it
       touches comparator-relevant behaviour (see anti_patterns).
+
+      RATIFIED 2026-07-16 by the repo owner: Nullable-preserve (send NULL, emit
+      Nullable(T)); no default coercion; fail loudly on empty-into-NOT-NULL.
+      w0 confirmed every observed failing column is nullable in the reference
+      schema, so preserving Nullable cannot break their answer-sets. Policy-only
+      ratification; the loader code (parent w2) still gets CODEOWNERS review.
   - id: w2
     summary: "Record the decision in the parent and defer the rejected path"
-    status: pending
+    status: done
     needs: [w1]
     notes: |
       Write the ratified policy into
       uat-clickhouse-server-loader-type-coverage (resolve its open_question,
       point w2 at the decision) and record the unchosen path as deferred here.
       No loader code changes in this item — implementation stays in the parent.
+
+      DONE: parent open_question marked resolved with the ratified decision +
+      back-reference to this item; the coercion path and the parent's
+      implementation are recorded as deferred below.
 
 deferred:
   - summary: "Implement the chosen policy in the ClickHouse-server loader/DDL"
@@ -118,4 +159,15 @@ metadata:
   tags: [uat, clickhouse-server, loader, schema-decision, soundness, deeper-question]
   estimated_effort: Small
   created_date: "2026-07-16"
+  last_updated: "2026-07-16T00:00:00-04:00"
+  completed_date: "2026-07-16"
+  completion_note: |
+    Decision item resolved. Policy ratified by the repo owner: empty
+    numeric/date -> NULL with Nullable(T) DDL where the reference schema is
+    nullable; no default coercion; fail loudly on empty-into-NOT-NULL. Grounded
+    in BenchBox's own TPC-DS schema (all observed failing columns are nullable)
+    and the parent's existing soundness guardrails. Parent open_question
+    resolved and pointed at this decision. Policy-only; the loader implementation
+    (uat-clickhouse-server-loader-type-coverage:w2) still passes CODEOWNERS
+    review when its PR opens.
   source: "UAT-effort assessment 2026-07-16 (deeper-questions promotion); parent uat-clickhouse-server-loader-type-coverage open_question"

--- a/_project/TODO/main/planning/uat-clickhouse-server-loader-type-coverage.yaml
+++ b/_project/TODO/main/planning/uat-clickhouse-server-loader-type-coverage.yaml
@@ -146,10 +146,10 @@ success_metrics:
 
 open_questions:
   - question: "For Bucket A, should empty numeric/date values drive Nullable(...) DDL or default coercion for non-Nullable columns?"
-    gating: true
+    gating: false
+    resolved: true
     affects: ["w2", "success_metrics"]
-    default: "Emit or preserve Nullable where benchmark schema marks a column nullable; only coerce to defaults for genuinely non-Nullable fields when source semantics require that."
-    promoted_to: "[[uat-clickhouse-loader-empty-value-nullability]] (2026-07-16) — the decision item that ratifies this default against benchmark schema nullability before w2 implements it."
+    decision: "RESOLVED 2026-07-16 (repo owner, via [[uat-clickhouse-loader-empty-value-nullability]]): empty numeric/date -> NULL with Nullable(T) DDL where the reference schema marks the column nullable; do NOT coerce to a type default; fail loudly on empty-into-genuinely-NOT-NULL (treat as a benchmark data defect). Grounded in this benchmark's own schema (c_current_cdemo_sk/hdemo_sk/addr_sk and s_rec_start/end_date are nullable:true) and this item's must_preserve/anti_patterns. w2 implements this policy; the code change carries CODEOWNERS review."
 
 metadata:
   tags: [clickhouse-server, uat, loader, type-conversion]


### PR DESCRIPTION
## Description

Follow-up to #1195 (merged). The repo owner ratified the Bucket A nullability decision for `uat-clickhouse-server-loader-type-coverage`, so this PR records the decision and resolves the parent's gating open-question.

**Ratified policy:** an empty numeric/date source field becomes **NULL** with `Nullable(T)` DDL where the reference schema marks the column nullable; **no** coercion to a type default (`0` / epoch); **fail loudly** when an empty lands in a genuinely NOT-NULL column (treat as a benchmark data defect, not a loader default).

**Why it was effectively pre-decided** (folded into the decision item's `recommended_resolution`):
- Every observed failing column is `nullable: true` in BenchBox's own TPC-DS schema (`benchbox/core/tpcds/schema/table_specs.yaml`): `c_current_cdemo_sk` / `c_current_hdemo_sk` / `c_current_addr_sk` (INTEGER) and `s_rec_start_date` / `s_rec_end_date` (DATE). Empty there = absent = NULL; defaulting to `0`/epoch fabricates real-looking keys/dates that join, count, and aggregate as real → corrupts answer-sets.
- The parent already forbids coercion (`must_preserve` "Do not silently coerce invalid data to zero"; `anti_patterns` "DO NOT fabricate default numeric/date values for genuinely nullable fields").

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [x] Refactor / chore

## Testing

TODO-tracking change only (no product code touched). Verified with:
- `validate_todo.py` on the decision item + parent → valid.
- `todo_cli.py check-graph` → passes (126 items, no dangling refs/cycles; the `[[…]]` reference to the now-DONE decision item still resolves).

## Public Contract Check

- [x] This PR does not change public, beta-public, deprecated, generated, experimental, or repo-only contract surfaces.
- [x] I checked result schema fields, MCP tool parameters, platform support status, wrapper facades, adapter subclassing hooks, and generated docs for contract-map impact.
- [x] Any platform/benchmark count claim in docs is generated/checked from registry metadata, or explicitly marked editorial/non-authoritative.

_TODO planning files only. The decision is **policy-only**; the loader/DDL code that applies it lives in `uat-clickhouse-server-loader-type-coverage:w2` and still carries CODEOWNERS review when that PR opens._

## Documentation

- [x] I updated the relevant user-facing docs.
- [x] I added regression notes for behavior changes.
- [x] I confirmed API contract wording remains accurate.

_No user-facing docs; TODO/DONE planning yamls only._

## Code Quality

- [x] I ran formatting and lint/type checks.
- [x] I reviewed impacted modules for backwards compatibility and migration impact.
- [x] I added/updated tests for behavior changes and error paths.
- [x] I confirmed public contracts and release checklists are still valid.

_No code changed; validated via the TODO schema validator + graph check above._

## Artifact Hygiene

- [x] I did not commit raw screenshots, browser reports, generated logs, benchmark outputs, or temporary binary artifacts.
- [x] Any committed binary/raw evidence file has durable repo value and is justified here with its consumer and size:

_No binary/raw artifacts. `_indexes/` gitignored; batch ledger in git-excluded `.todo-batch/`._

## Notes

- Decision item `uat-clickhouse-loader-empty-value-nullability` is marked `Completed` and moved to DONE; the parent's `open_question` is now `resolved: true` with the decision recorded and back-referenced.
- This does **not** implement the loader fix — that stays in the parent item (`w2`), now unblocked from a decision standpoint but still requiring implementation + CODEOWNERS review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HMgAPRZwYHAe5D3QeGCoU8

---
_Generated by [Claude Code](https://claude.ai/code/session_01HMgAPRZwYHAe5D3QeGCoU8)_