### PR TITLE
fix(ci): green-run-cleanup job missing checkout, silently no-ops on stale auto-revert PRs

### DIFF
--- a/.github/workflows/develop-post-merge.yml
+++ b/.github/workflows/develop-post-merge.yml
@@ -780,6 +780,8 @@ jobs:
       MERGED_SHA: ${{ github.sha }}
       RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
     steps:
+      - uses: actions/checkout@v4
+
       - name: Close stale auto-revert PRs and develop-red incidents
         shell: bash
         run: |


### PR DESCRIPTION
## Description

Root-cause fix for why PR #1197 (an auto-revert PR opened after #1196's merge commit hit a transient CI infra blip) stayed open even after develop went green two commits later.

`develop-post-merge.yml`'s `green-run-cleanup` job exists specifically to auto-close stale `auto-revert/*` PRs and `incident:develop-red` issues once all four gates (lint/fast-test/explorer-tokens/medium-test) pass again — but unlike every other job in this workflow that calls `gh`, it never ran `actions/checkout@v4`. Without a local git remote, `gh pr list`/`gh issue list` fail with `fatal: not a git repository`. That failure happens inside a `mapfile -t x < <(gh ...)` process substitution, which `set -e` does not treat as a pipeline failure, so the job silently logged "No open auto-revert/* PRs to close." and reported success — even when one genuinely was open.

Fix: add the missing `actions/checkout@v4` step, matching the `close-orphaned-prs` and `auto-revert-on-failure` jobs in the same file.

## Root cause of the incident this surfaced

Not a code regression from #1196. All three CI jobs that failed on #1196's merge commit (`fast-test`, `lint`, `medium-test`) died at the identical step — `astral-sh/setup-uv@v4` fetching `latest` version metadata from GitHub's API, which returned an HTML "Unicorn" error page instead of JSON, before any of our code executed. Confirmed:
- `develop-post-merge` run for the merge commit (`82d0ad890`): [failed run](https://github.com/joeharris76/BenchBox/actions/runs/29539857021), identical `##[error]<!DOCTYPE html>...Unicorn! · GitHub` output in all 3 job logs at the `astral-sh/setup-uv@v4` step.
- `develop-post-merge` run for current develop HEAD (`0adcb89e`, which still contains `82d0ad890`'s changes): [passed outright](https://github.com/joeharris76/BenchBox/actions/runs/29545343866) — same code, transient infra blip gone.

Closed #1197 manually (see comment there) since this job's automation couldn't do it. #1196's changes remain on `develop` — no revert needed.

## Type of Change

- [x] Bug fix

## Testing

- `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/develop-post-merge.yml'))"` — parses clean
- `uv run -- python -m pytest tests/unit/workflows/test_develop_post_merge_metrics.py -q` — 11 passed
- `uv run -- ruff check .github` — clean (no Python files under that path; workflow YAML has no dedicated linter in this repo)

## Public Contract Check

- [x] This PR does not change public, beta-public, deprecated, generated, experimental, or repo-only contract surfaces.

## Documentation

- [x] N/A — internal CI workflow fix only.

## Code Quality

- [x] Matches the existing `actions/checkout@v4` pattern used by every other `gh`-calling job in this file.

## Artifact Hygiene

- [x] No raw artifacts committed.

## Notes

`.github/workflows/develop-post-merge.yml` is not a CODEOWNERS-gated path (only `auto-merge-on-open.yml` and `release.yml` are), so this is eligible for standard squash auto-merge.


---
_Generated by [Claude Code](https://claude.ai/code/session_01SKw2UhgHuzYPo3y5MfarD6)_