### PR TITLE
fix(clickhouse): convert DATETIME/TIMESTAMP and bracketed vector types on server insert

### DIFF
--- a/_project/TODO/main/planning/uat-clickhouse-server-loader-type-coverage.yaml
+++ b/_project/TODO/main/planning/uat-clickhouse-server-loader-type-coverage.yaml
@@ -2,7 +2,7 @@ id: uat-clickhouse-server-loader-type-coverage
 title: "Fix ClickHouse-server client-insert type coverage exposed by corpus UAT"
 worktree: main
 priority: High
-status: Identified
+status: In Progress
 category: Platform Expansion
 
 description: |
@@ -48,7 +48,7 @@ prior_art:
 work:
   - id: w0
     summary: "Re-derive the four loader buckets against current develop and pin compact evidence"
-    status: pending
+    status: done
     notes: |
       Before changing code, drive the conversion/introspection helpers directly
       where possible and preserve a compact command/result summary in this
@@ -56,19 +56,46 @@ work:
       Expected signatures to re-confirm: empty numeric/date handling, raw
       DATETIME/TIMESTAMP string fallthrough, bracketed array/vector parsing,
       and Table-valued schema introspection.
+
+      RE-VALIDATION (2026-07-16, helper boundary, no Docker). The conversion
+      helper is benchbox/platforms/base/data_loading.py:
+      ClickHouseNativeHandler._convert_field_for_clickhouse (landed in the Jul-10
+      import ded0a94b, AFTER this TODO's 2026-06-01 corpus evidence — the
+      "Identified" status was stale). Driving the helper directly:
+        - Bucket A (empty numeric/date -> NULL): ALREADY IMPLEMENTED and matches
+          the ratified policy. `if value == "": return None if
+          needs_non_string_value else value`; empty String stays "". No change
+          needed.
+        - Bucket B (DATETIME/TIMESTAMP): BROKEN. "DATETIME".startswith("DATE") is
+          True so `date.fromisoformat("2020-01-15 12:30:00")` raised; bare
+          "TIMESTAMP" fell through as str -> driver 'str' has no 'tzinfo'.
+        - Bucket C (array/vector): PARTIAL. "Array(...)" parsed, but DuckDB
+          "FLOAT[128]" matched the FLOAT branch -> float("[...]") raised.
+        - Bucket D (Table-valued schema introspection): NOT re-reproduced here;
+          needs the live DataVault schema object. `_get_column_type_names`
+          returns [] for non-dict schemas (silent no-conversion) rather than the
+          observed `'Table' is not iterable`, so the crash site is elsewhere in
+          the DataVault load path. Deferred (see deferred + w2 notes).
   - id: w1
     summary: "Add focused unit coverage for ClickHouse-server value conversion"
     needs: [w0]
-    status: pending
+    status: done
     notes: |
       Cover nullable integer fields with blank/null-like inputs, Date and
       DateTime/DateTime64 values supplied as strings, ClickHouse arrays such
       as `Array(Float32)` from bracketed literals, and schemas represented by
       benchmark `Table` objects instead of simple dicts.
+
+      DONE for Buckets A/B/C in tests/unit/platforms/test_clickhouse_adapter.py:
+      test_empty_numeric_date_fields_become_null_not_default (A),
+      test_datetime_and_timestamp_conversion (B),
+      test_vector_bracket_type_parsed_to_list_not_float (C). The Table-object
+      schema case (Bucket D) is NOT covered yet — it depends on the Bucket D fix
+      site, which is deferred.
   - id: w2
     summary: "Fix the client-batch conversion path without regressing clickhouse-local"
     needs: [w1]
-    status: pending
+    status: in_progress
     notes: |
       Keep server mode on client-side INSERT batches for Docker-host files;
       do not revert to server-side `file()` loading. Preserve shared ClickHouse
@@ -76,6 +103,17 @@ work:
       Resolve the nullable-empty-field policy explicitly: prefer preserving
       NULL when the benchmark schema permits it, and only use type defaults for
       truly non-Nullable columns when that matches the source semantics.
+
+      DONE (Buckets B + C): _convert_field_for_clickhouse now classifies
+      DATETIME/DateTime64/TIMESTAMP before the DATE prefix and parses to Python
+      datetime; DuckDB bracketed vector/list types (FLOAT[128], INTEGER[]) route
+      to array parsing via the new _CLICKHOUSE_VECTOR_TYPE_RE. Bucket A was
+      already correct (nullable-empty -> NULL, ratified policy) and is unchanged.
+      All at the helper boundary per anti_patterns; clickhouse-local path
+      untouched (server-mode-only helper).
+      REMAINING (Bucket D): Table-valued schema introspection for DataVault is
+      NOT fixed — its crash site needs live repro (see deferred). w2 stays
+      in_progress until D lands or is split into its own item.
   - id: w3
     summary: "Verify representative failing cells live against ClickHouse server"
     needs: [w2]
@@ -84,6 +122,31 @@ work:
       Use UAT-managed Docker and the same benchmark output root. Representative
       cells should include TPC-DS SF=0.01, one DateTime-heavy cell, DataVault
       SF=0.01, and Vector Search SF=0.01 before broadening to the corpus.
+
+      NOT RUN in the 2026-07-16 session: no Docker daemon in the remote
+      container, so live cells could not execute. Buckets A/B/C are proven at
+      the unit/helper boundary only; a live run of the TPC-DS, DateTime-heavy,
+      and Vector Search cells is still required to close this. DataVault stays
+      blocked on the Bucket D fix.
+
+      Code-review checkpoints to confirm on the live run (from the w2 review):
+        - tz-AWARE datetime round-trip: a source timestamp with a 'Z'/offset
+          (e.g. TSBS RFC3339) parses to a tz-aware Python datetime;
+          clickhouse-driver converts it to the column timezone. Verify the
+          stored instant is NOT shifted vs the naive-string benchmarks (a
+          non-UTC DateTime column would otherwise corrupt time aggregates). If a
+          shift is observed, normalise to naive-UTC before insert.
+        - Non-ISO/epoch DateTime formats: datetime.fromisoformat parses only
+          ISO-8601, so epoch-seconds or locale timestamps raise (loud, per
+          guardrails). Confirm the actual ClickBench/TSBS/H2O timestamp formats
+          are ISO; if any emit epoch/other, extend the parser (tracked in
+          deferred).
+
+deferred:
+  - summary: "Bucket D: harden Table-valued schema introspection for DataVault"
+    reason: "The observed `'Table' is not iterable` crash is outside _convert_field_for_clickhouse (which safely no-ops on non-dict schemas); pinning the real crash site needs a live DataVault load, unavailable this session. Split candidate if it grows."
+  - summary: "Bucket B follow-up: non-ISO / epoch-integer DateTime source formats"
+    reason: "datetime.fromisoformat covers the observed ISO forms; epoch-seconds or locale formats, if any benchmark emits them, would raise (loud, per guardrails) and can be handled when a real case appears."
 
 deps:
   needs:

--- a/benchbox/platforms/base/data_loading.py
+++ b/benchbox/platforms/base/data_loading.py
@@ -21,7 +21,7 @@ from abc import ABC, abstractmethod
 from collections.abc import Iterator
 from contextlib import contextmanager
 from dataclasses import dataclass
-from datetime import date
+from datetime import date, datetime
 from decimal import Decimal
 from importlib import metadata as importlib_metadata
 from pathlib import Path
@@ -1908,6 +1908,17 @@ class DuckDBVortexHandler(FileFormatHandler):
             return row_count
 
 
+# Matches DuckDB bracketed vector/list type suffixes, e.g. "FLOAT[128]",
+# "DOUBLE[3]", or "INTEGER[]" — used to route these to array parsing rather
+# than scalar numeric conversion during ClickHouse client-side inserts.
+# NOTE: the DDL side rewrites the same fixed-size forms to ClickHouse arrays
+# (workload.py: FLOAT[N] -> Array(Float32), DOUBLE[N] -> Array(Float64)); this
+# value-level detector is the insert-time counterpart and additionally covers
+# bracketless-size lists like "INTEGER[]". Keep the two in sync if a new
+# bracketed vector form is added to either surface.
+_CLICKHOUSE_VECTOR_TYPE_RE = re.compile(r"\[\s*\d*\s*\]")
+
+
 class ClickHouseNativeHandler(FileFormatHandler):
     """Handler for ClickHouse's native file() function.
 
@@ -2113,9 +2124,12 @@ class ClickHouseNativeHandler(FileFormatHandler):
 
         type_upper = type_name.upper()
 
-        # Array types: parse the CSV string representation into a Python list so
-        # clickhouse-driver receives a sequence rather than a raw string.
-        if "ARRAY" in type_upper:
+        # Array/vector types: "Array(...)" or DuckDB bracketed vector/list syntax
+        # such as "FLOAT[128]" (fixed-size vector) or "INTEGER[]" (list). Parse
+        # the bracketed CSV string into a Python list so clickhouse-driver
+        # receives a sequence; otherwise "FLOAT[128]" matches the FLOAT branch
+        # below and float("[0.02,...]") raises (Bucket C).
+        if "ARRAY" in type_upper or _CLICKHOUSE_VECTOR_TYPE_RE.search(type_upper):
             if not value or value.upper() in ("\\N", "NULL"):
                 return None
             try:
@@ -2126,10 +2140,19 @@ class ClickHouseNativeHandler(FileFormatHandler):
                 pass
             return value
 
+        # DateTime/DateTime64/TIMESTAMP must be classified BEFORE the DATE prefix:
+        # "DATETIME".startswith("DATE") is True, so a bare DATE check misroutes
+        # timestamps into date.fromisoformat() (raises on the time component),
+        # and plain "TIMESTAMP" otherwise falls through as a str, which the
+        # driver rejects with "'str' object has no attribute 'tzinfo'" (Bucket B).
+        is_datetime = "DATETIME" in type_upper or "TIMESTAMP" in type_upper
+        is_date = not is_datetime and type_upper.startswith("DATE")
+
         needs_non_string_value = (
             "INT" in type_upper
             or any(token in type_upper for token in ("DECIMAL", "NUMERIC", "DOUBLE", "FLOAT", "REAL"))
-            or type_upper.startswith("DATE")
+            or is_date
+            or is_datetime
         )
         if value == "":
             return None if needs_non_string_value else value
@@ -2140,7 +2163,9 @@ class ClickHouseNativeHandler(FileFormatHandler):
             return Decimal(value)
         if any(token in type_upper for token in ("DOUBLE", "FLOAT", "REAL")):
             return float(value)
-        if type_upper.startswith("DATE"):
+        if is_datetime:
+            return datetime.fromisoformat(value)
+        if is_date:
             return date.fromisoformat(value)
         return value
 

--- a/tests/unit/platforms/test_clickhouse_adapter.py
+++ b/tests/unit/platforms/test_clickhouse_adapter.py
@@ -569,6 +569,68 @@ class TestClickHouseAdapter:
         # NULL sentinels in an array column become None.
         assert handler._convert_field_for_clickhouse("\\N", "Array(Float32)") is None
 
+    def test_vector_bracket_type_parsed_to_list_not_float(self):
+        """DuckDB bracketed vector/list types route to array parsing (Bucket C).
+
+        A fixed-size vector column typed ``FLOAT[128]`` (or list ``INTEGER[]``)
+        must be parsed into a Python sequence, not passed to ``float("[...]")``
+        which raised ``could not convert string to float`` and dropped rows.
+        """
+        from benchbox.platforms.base.data_loading import ClickHouseNativeHandler
+
+        handler = ClickHouseNativeHandler(delimiter=",", adapter=None, benchmark=None)
+
+        assert handler._convert_field_for_clickhouse("[0.02,0.5,0.9]", "FLOAT[3]") == [0.02, 0.5, 0.9]
+        assert handler._convert_field_for_clickhouse("[1,2,3]", "INTEGER[]") == [1, 2, 3]
+        assert handler._convert_field_for_clickhouse("[0.1,0.2]", "DOUBLE[2]") == [0.1, 0.2]
+        # Empty/NULL sentinels in a bracketed vector column become None.
+        assert handler._convert_field_for_clickhouse("", "FLOAT[3]") is None
+        assert handler._convert_field_for_clickhouse("\\N", "FLOAT[3]") is None
+
+    def test_datetime_and_timestamp_conversion(self):
+        """DateTime/TIMESTAMP classify before the DATE prefix (Bucket B).
+
+        ``"DATETIME".startswith("DATE")`` is True, so a naive DATE check
+        misrouted timestamps into ``date.fromisoformat`` (raised on the time
+        component); bare ``TIMESTAMP`` otherwise fell through as a ``str`` that
+        clickhouse-driver rejected with ``'str' object has no attribute
+        'tzinfo'``. Both must become ``datetime`` objects.
+        """
+        from datetime import date as date_cls, datetime as dt
+
+        from benchbox.platforms.base.data_loading import ClickHouseNativeHandler
+
+        handler = ClickHouseNativeHandler(delimiter=",", adapter=None, benchmark=None)
+        conv = handler._convert_field_for_clickhouse
+
+        assert conv("2020-01-15 12:30:00", "DATETIME") == dt(2020, 1, 15, 12, 30, 0)
+        assert conv("2020-01-15 12:30:00", "TIMESTAMP") == dt(2020, 1, 15, 12, 30, 0)
+        # DateTime64 with a "T"/"Z" ISO form parses (and stays tz-aware).
+        assert conv("2016-01-01T00:00:00Z", "DateTime64(3)").year == 2016
+        # A plain DATE column is unaffected — still a date, not a datetime.
+        assert conv("2020-01-15", "DATE") == date_cls(2020, 1, 15)
+        # Empty datetime/timestamp fields become NULL (Bucket A policy).
+        assert conv("", "DATETIME") is None
+        assert conv("", "TIMESTAMP") is None
+
+    def test_empty_numeric_date_fields_become_null_not_default(self):
+        """Empty numeric/date source fields convert to NULL, never a default (Bucket A).
+
+        Ratified policy: an empty value in a nullable numeric/date column is
+        absent -> NULL, never coerced to 0/epoch (which would fabricate joinable
+        values and corrupt answer-sets). Empty String fields stay empty strings.
+        """
+        from benchbox.platforms.base.data_loading import ClickHouseNativeHandler
+
+        handler = ClickHouseNativeHandler(delimiter=",", adapter=None, benchmark=None)
+        conv = handler._convert_field_for_clickhouse
+
+        for type_name in ("INTEGER", "BIGINT", "DECIMAL(10,2)", "DOUBLE", "DATE", "DATETIME"):
+            assert conv("", type_name) is None, f"empty {type_name} must become NULL"
+        # Empty String columns are preserved as empty strings, not turned into NULL.
+        assert conv("", "VARCHAR") == ""
+        assert conv("", "CHAR(16)") == ""
+
     @patch("benchbox.platforms.clickhouse.setup.ClickHouseClient")
     def test_get_platform_metadata(self, mock_client_class):
         """Test platform metadata collection."""


### PR DESCRIPTION
## Description

Implements buckets B and C of `uat-clickhouse-server-loader-type-coverage` (now In Progress). The ClickHouse-server client-side INSERT path (`ClickHouseNativeHandler._convert_field_for_clickhouse`, server-mode only) misconverted two value classes, each dropping whole cells in the 2026-06-01 corpus UAT:

- **Bucket B (DateTime/TIMESTAMP):** `"DATETIME".startswith("DATE")` is `True`, so datetime strings were routed into `date.fromisoformat()` and raised on the time component; bare `TIMESTAMP` fell through as a `str`, which clickhouse-driver rejects with `'str' object has no attribute 'tzinfo'`. Fix: classify datetime-like types **before** the DATE prefix and parse to Python `datetime`.
- **Bucket C (vector/list):** DuckDB `FLOAT[128]` matched the FLOAT substring branch and `float("[0.02,...]")` raised. Fix: route bracketed vector/list types (`FLOAT[N]`, `DOUBLE[N]`, `INTEGER[]`) to array parsing via `_CLICKHOUSE_VECTOR_TYPE_RE`, mirroring `workload.py`'s DDL-side `FLOAT[N]`→`Array(Float32)` rewrite.

**Bucket A** (empty numeric/date → NULL, the policy ratified in #1199) was already correct in-tree and is unchanged. `clickhouse-local` is untouched (helper is server-mode-only). Fix is at the conversion-helper boundary per the item's `anti_patterns`.

### Re-validation (w0)
Driven directly at the helper boundary (no Docker in this environment): A already correct; B raised `Invalid isoformat` / fell through as str; C raised `could not convert string to float`. Fix verified against the same cases.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactor / chore

## Testing

- New unit coverage in `tests/unit/platforms/test_clickhouse_adapter.py`: `test_empty_numeric_date_fields_become_null_not_default` (A), `test_datetime_and_timestamp_conversion` (B, incl. DATE-not-misrouted and DateTime64), `test_vector_bracket_type_parsed_to_list_not_float` (C).
- `pytest tests/unit/platforms/test_clickhouse_adapter.py` → **78 passed**.
- `pytest tests/unit/platforms/ -k "data_loading or clickhouse or loading or convert"` → **833 passed, 8 skipped** (Java-only skips), no regressions.
- `ruff check` clean; `ty check` clean (one pre-existing unrelated `vortex` optional-import warning).
- **Live cells NOT run** — no Docker daemon in this environment (see Notes).

## Public Contract Check

- [x] This PR does not change public, beta-public, deprecated, generated, experimental, or repo-only contract surfaces.
- [x] I checked result schema fields, MCP tool parameters, platform support status, wrapper facades, adapter subclassing hooks, and generated docs for contract-map impact.
- [x] Any platform/benchmark count claim in docs is generated/checked from registry metadata, or explicitly marked editorial/non-authoritative.

_Internal server-mode loader helper; no public contract surface. Not a CODEOWNERS soundness path, but it is data-correctness code — reviewed accordingly (see Notes)._

## Documentation

- [x] I updated the relevant user-facing docs.
- [x] I added regression notes for behavior changes.
- [x] I confirmed API contract wording remains accurate.

_Behavior/regression notes captured in the TODO work-unit notes; no user-facing docs affected._

## Code Quality

- [x] I ran formatting and lint/type checks.
- [x] I reviewed impacted modules for backwards compatibility and migration impact.
- [x] I added/updated tests for behavior changes and error paths.
- [x] I confirmed public contracts and release checklists are still valid.

## Artifact Hygiene

- [x] I did not commit raw screenshots, browser reports, generated logs, benchmark outputs, or temporary binary artifacts.
- [x] Any committed binary/raw evidence file has durable repo value and is justified here with its consumer and size:

_No artifacts._

## Notes

A `/code-review` (medium) pass produced three PLAUSIBLE findings, all handled:
1. **tz-aware datetime shift** (soundness): a `Z`/offset source yields a tz-aware datetime that clickhouse-driver converts to the column tz — a non-UTC DateTime column could shift the stored instant. Cannot confirm without a live server; recorded as an explicit **w3 live-validation checkpoint** (normalise to naive-UTC if a shift is seen). Not triggered by the naive-timestamp benchmarks in scope.
2. **non-ISO/epoch timestamps** would raise (loud, per guardrails) — recorded as a deferred parser-extension + w3 format check.
3. **regex overlap** with `workload.py`/`_spark_helpers` array detection — documented a keep-in-sync note in the code.

**Scope / still open on the TODO:** Bucket D (DataVault `Table`-schema introspection — crash site needs live repro) and the live-cell verification (TPC-DS / DateTime-heavy / Vector Search) both remain, since Docker isn't available here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HMgAPRZwYHAe5D3QeGCoU8

---
_Generated by [Claude Code](https://claude.ai/code/session_01HMgAPRZwYHAe5D3QeGCoU8)_