### PR TITLE
chore(todo): file 2 confirmed-defect TODOs + promote 2 documented deferrals

### DIFF
--- a/_project/TODO/main/planning/fk-aware-drop-ordering-20260717.yaml
+++ b/_project/TODO/main/planning/fk-aware-drop-ordering-20260717.yaml
@@ -1,0 +1,85 @@
+id: fk-aware-drop-ordering-20260717
+title: "FK-aware table DROP ordering: schema recreation fails on DuckDB when FK constraints were applied"
+worktree: main
+priority: Medium-High
+status: Not Started
+category: Core Functionality
+
+description: |
+  Discovered during PR #1176's E2E verification (2026-07-16). A tuned DuckDB
+  run with the real checked-in FK-enabled template
+  (examples/tunings/duckdb/tpch_tuned.yaml) fails during schema RE-creation
+  with a table-DROP-ordering error:
+
+    Cannot drop entry supplier because ... depends on it
+
+  This is the mirror image of the load-ordering defect fixed by #1189
+  (fk-load-ordering): #1189 made table CREATE/LOAD respect FK topology via
+  get_fk_ordered_table_names(), but the DROP path used when a schema already
+  exists still iterates in schema-declaration order, so parent tables are
+  dropped while dependents still reference them. The defect only bites once
+  tuning constraints are physically applied (post-#1176), which is why it
+  was latent: pre-provenance runs never delivered FK config to the adapter.
+
+  Fix: drop in reverse FK-topological order (reuse
+  get_fk_ordered_table_names() reversed), or drop with dependency awareness
+  per platform where CASCADE semantics differ. Audit the same recreation
+  path on other FK-enforcing platforms (postgres family at minimum) — the
+  bug class is platform-generic even though the repro is DuckDB.
+
+work:
+  - id: w0
+    summary: "Reproduce at HEAD: tuned duckdb tpch run twice into the same database file; second run must fail with the DROP-ordering error; pin exact code path"
+    status: pending
+    needs: []
+  - id: w1
+    summary: "Route schema-recreation DROPs through reverse FK-topological order (shared helper, not per-adapter copies); handle cycles the same way get_fk_ordered_table_names does"
+    status: pending
+    needs: [w0]
+  - id: w2
+    summary: "Regression tests: recreation with FK constraints applied succeeds on duckdb (real adapter); unit test pins reverse-topo order for tpch/ssb/coffeeshop schemas"
+    status: pending
+    needs: [w1]
+  - id: w3
+    summary: "Audit other FK-enforcing adapters' recreation paths for the same declaration-order DROP; fix or record honest per-platform notes"
+    status: pending
+    needs: [w1]
+
+deps:
+  needs: []
+
+must_preserve:
+  - "#1189 load-ordering behavior (get_fk_ordered_table_names) unchanged"
+  - "Recreation of schemas without FK constraints unchanged"
+
+anti_patterns:
+  - "No blanket DROP ... CASCADE as the fix on platforms where it silently widens the blast radius; ordering is the fix, CASCADE only where semantics are already destructive-safe"
+
+scope_limit:
+  only_modify:
+    - "benchbox/core/schema_primitives.py"
+    - "benchbox/platforms/**"
+    - "tests/**"
+
+verification:
+  - description: "Second tuned run into an existing database succeeds"
+    command: "uv run -- python -m benchbox.cli.main run --platform duckdb --benchmark tpch --scale 0.01 --tuning tuned --non-interactive --output /tmp/drop-order-check && uv run -- python -m benchbox.cli.main run --platform duckdb --benchmark tpch --scale 0.01 --tuning tuned --non-interactive --output /tmp/drop-order-check"
+    expected_output: "Both runs complete; no 'Cannot drop entry' error"
+  - description: "Unit suites green"
+    command: "uv run -- python -m pytest tests/unit/core tests/unit/platforms -q"
+    expected_output: "All passing"
+
+prior_art:
+  - "benchbox/core/schema_primitives.py get_fk_ordered_table_names: the #1189 topo sort - reverse it for drops"
+  - "_project/DONE/main/planning/tuning-fk-load-ordering-fix-20260716.yaml: the load-side fix this mirrors"
+
+metadata:
+  owners:
+    - "benchbox-team"
+  tags:
+    - tuning
+    - constraints
+    - schema-management
+  estimated_effort: Small-Medium
+  created_date: "2026-07-17"
+  source_review: "PR #1176 E2E verification follow-up, 2026-07-16"

--- a/_project/TODO/main/planning/tuning-registry-mixin-honesty-20260717.yaml
+++ b/_project/TODO/main/planning/tuning-registry-mixin-honesty-20260717.yaml
@@ -1,0 +1,81 @@
+id: tuning-registry-mixin-honesty-20260717
+title: "Correct capability-registry entries resting on the dead generate_tuning_clause adapter mixin (postgresql, snowflake, redshift, bigquery, mysql)"
+worktree: main
+priority: Medium
+status: Not Started
+category: Core Functionality
+
+description: |
+  Confirmed during PR #1198's implementation and its Opus review (2026-07-17).
+  A repo-wide search finds ZERO production call sites for any adapter's
+  generate_tuning_clause (singular) mixin — every hit is in tests. Production
+  rendering flows through the DDL generators' generate_tuning_clauses
+  (plural; core/dryrun.py, duckdb.py) or #1180's registry-driven paths.
+
+  Yet five pre-existing #1180-era registry entries claim physical DDL
+  rendering via that dead mixin (rendered_via="ddl",
+  mechanism "adapter_mixin:<Platform>Adapter.generate_tuning_clause"):
+  postgresql, snowflake, redshift, bigquery, mysql. For postgresql it is
+  affirmatively false (PostgreSQLAdapter.generate_tuning_clause
+  unconditionally returns "" - postgresql.py:898-903 - and
+  apply_table_tunings is a no-op). The others follow the same pattern and
+  need individual verification. An evaluator consulting the registry (or
+  `benchbox tuning platforms`, now generated from it) would believe tuned
+  runs on these platforms physically render tuning DDL when they may not.
+
+  Fix: verify each of the five against its real execution path; correct each
+  entry to honest rendered_via (likely "none" with per-platform notes, or
+  "ddl" only where a generator is actually consumed at execution); extend
+  the capability-source drift test so a mechanism claim naming a dead
+  code path fails (e.g. assert claimed adapter_mixin symbols have
+  production call sites, or retire the adapter_mixin mechanism vocabulary
+  entirely in favor of generator-backed mechanisms).
+
+work:
+  - id: w0
+    summary: "Verify each of the five platforms' execution paths; table of claim vs reality with file:line evidence"
+    status: pending
+    needs: []
+  - id: w1
+    summary: "Correct the five registry entries to honest rendered_via/mechanism; keep is_compatible_with_platform behavior unchanged unless the honest entry requires otherwise (document any behavior delta)"
+    status: pending
+    needs: [w0]
+  - id: w2
+    summary: "Drift-test hardening: dead-mechanism claims must fail (call-site existence check or mechanism vocabulary retirement)"
+    status: pending
+    needs: [w1]
+
+deps:
+  needs: []
+
+must_preserve:
+  - "PR #1198's 9 rendered_via=none entries and the emptied allowlist"
+  - "validate_for_platform behavior for platforms with real tuned rendering (duckdb, clickhouse per #1180)"
+
+anti_patterns:
+  - "Do not delete the dead generate_tuning_clause mixins in this item without checking the applied-ledger TODO's instrumentation plans - coordinate, don't race"
+
+scope_limit:
+  only_modify:
+    - "benchbox/core/tuning/**"
+    - "tests/**"
+
+verification:
+  - description: "Registry suite green; corrected entries pinned"
+    command: "uv run -- python -m pytest tests/unit/core/tuning -q -k 'drift or registry'"
+    expected_output: "All passing; per-platform corrections listed in PR body"
+
+prior_art:
+  - "benchbox/core/tuning/capability_registry.py pg-duckdb entry notes: documents the postgresql discrepancy accurately - the pattern for honest notes"
+  - "PR #1198: same verify-against-source method applied to the 9 gap platforms"
+
+metadata:
+  owners:
+    - "benchbox-team"
+  tags:
+    - tuning
+    - capability-registry
+    - soundness
+  estimated_effort: Small-Medium
+  created_date: "2026-07-17"
+  source_review: "PR #1198 implementation + Opus review, 2026-07-17"


### PR DESCRIPTION
# Pull Request

## Description

Records four items from this week's tuning-batch verification as tracked TODOs — the two confirmed defects that existed only in PR-body notes, plus two documented deferrals promoted by maintainer direction:

**Confirmed defects:**
1. **`fk-aware-drop-ordering-20260717`** (Medium-High) — schema **re**creation DROPs tables in declaration order, so a second tuned DuckDB run into an existing database fails with "Cannot drop entry supplier because ... depends on it" once FK constraints are physically applied. Discovered in PR #1176's E2E; latent until #1176 made tuning config actually reach adapters. Mirror image of #1189's load-side topological fix.
2. **`tuning-registry-mixin-honesty-20260717`** (Medium) — five #1180-era capability-registry entries (postgresql, snowflake, redshift, bigquery, mysql) claim DDL rendering via the `generate_tuning_clause` adapter mixin, which has **zero production call sites** repo-wide (postgresql confirmed affirmatively false in PR #1198's review). Verifies each, corrects entries, and hardens the drift test so dead-mechanism claims fail.

**Promoted deferrals:**
3. **`explorer-physical-rendering-facet-chip-20260717`** (Medium) — the `physical_rendering_id` facet chip UI deferred in #1182 (predicate + data layer are done; nothing surfaces the facet visually).
4. **`tuning-renderer-migration-remaining-platforms-20260717`** (Medium, Large effort) — schedules the per-platform migrations from `rendered_via="none"` to real execution-path tuned rendering, per the follow-up notes embedded in registry entries by #1180/#1198. Gated on the applied-ledger merge + the registry-honesty verification; one platform per PR; excludes starrocks/databricks (own TODOs) and the mixin-honesty five (pending verification).

## Type of Change

- [x] Refactor / chore (TODO bookkeeping only)

## Testing

- All four files pass `validate_todo.py`; `todo_cli.py check-graph` clean (129 items, no dangling references); index generation clean.

## Public Contract Check

- [x] No code changes.

## Notes

Part of the tuning remediation batch close-out (#1161 / #1183 / #1192). No CODEOWNERS paths — squash auto-merge enabled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QTnjb2i44JUL71kmu9sk1t