### PR TITLE
chore: sweep fixes for late-landing bot findings (#1201, #1203)

### DIFF
--- a/_project/TODO/main/planning/fk-aware-drop-ordering-20260717.yaml
+++ b/_project/TODO/main/planning/fk-aware-drop-ordering-20260717.yaml
@@ -8,38 +8,80 @@ category: Core Functionality
 description: |
   Discovered during PR #1176's E2E verification (2026-07-16). A tuned DuckDB
   run with the real checked-in FK-enabled template
-  (examples/tunings/duckdb/tpch_tuned.yaml) fails during schema RE-creation
-  with a table-DROP-ordering error:
+  (examples/tunings/duckdb/tpch_tuned.yaml, which sorts SUPPLIER -- a table
+  with FK-referencing dependents LINEITEM/PARTSUPP) fails with a
+  table-DROP-ordering error:
 
     Cannot drop entry supplier because ... depends on it
 
-  This is the mirror image of the load-ordering defect fixed by #1189
-  (fk-load-ordering): #1189 made table CREATE/LOAD respect FK topology via
-  get_fk_ordered_table_names(), but the DROP path used when a schema already
-  exists still iterates in schema-declaration order, so parent tables are
-  dropped while dependents still reference them. The defect only bites once
-  tuning constraints are physically applied (post-#1176), which is why it
-  was latent: pre-provenance runs never delivered FK config to the adapter.
+  NOT a schema-recreation issue (a second CLI run into the same database
+  either reuses it wholesale or deletes the whole file, per w0's notes --
+  neither path does a per-table DROP). The real failure is inside a SINGLE
+  run: schema creation declares all tables and FK constraints up front, then
+  DataLoader._load_file_based_data() loads tables in FK-safe order and calls
+  PlatformAdapter.apply_ctas_sort() (CREATE OR REPLACE TABLE ... AS SELECT)
+  immediately after each table's raw load. CREATE OR REPLACE implicitly
+  drops the existing table first; sorting SUPPLIER this way fails once a
+  dependent's FK constraint already references it (declared at
+  schema-creation time, before any data loads), even though SUPPLIER loads
+  first in FK order. This is the mirror image of the load-ordering defect
+  fixed by #1189 (fk-load-ordering): #1189 made table CREATE/LOAD respect FK
+  topology via get_fk_ordered_table_names(), but the CTAS-sort's implicit
+  DROP has no equivalent FK awareness. The defect only bites once tuning
+  constraints are physically applied (post-#1176), which is why it was
+  latent: pre-provenance runs never delivered FK config to the adapter.
 
-  Fix: drop in reverse FK-topological order (reuse
-  get_fk_ordered_table_names() reversed), or drop with dependency awareness
-  per platform where CASCADE semantics differ. Audit the same recreation
-  path on other FK-enforcing platforms (postgres family at minimum) — the
-  bug class is platform-generic even though the repro is DuckDB.
+  Fix: make the CTAS-sort's implicit DROP FK-aware -- e.g. drop/recreate FK
+  constraints referencing the table being sorted before the CTAS and
+  re-add them after, or reorder so a table is never CTAS-sorted while a
+  live FK still references it. Audit the same apply_ctas_sort path on other
+  FK-enforcing platforms (postgres family at minimum) — the bug class is
+  platform-generic even though the repro is DuckDB.
 
 work:
   - id: w0
-    summary: "Reproduce at HEAD: tuned duckdb tpch run twice into the same database file; second run must fail with the DROP-ordering error; pin exact code path"
+    summary: "Reproduce at HEAD: a SINGLE tuned duckdb tpch run with sort tuning applied to a table that has FK-referencing dependents; pin the exact CTAS-sort code path, not a second CLI invocation"
     status: pending
     needs: []
+    notes: |
+      A second full CLI run into the same database file does NOT reach this
+      defect: ConnectionLifecycleMixin.handle_existing_database() either
+      reuses a compatible database wholesale (skipping schema
+      creation/loading entirely, PlatformAdapter._setup_reused_database_phases)
+      or deletes the whole database file/directory outright when
+      incompatible (_remove_database) -- neither path does a per-table DROP
+      inside an existing schema, so it can never hit a DROP-ordering error.
+      The real failure is within the FIRST/only run: schema creation
+      declares all tables (and their FK constraints) up front, then
+      DataLoader._load_file_based_data() loads tables in FK-safe order and
+      calls PlatformAdapter.apply_ctas_sort() (CREATE OR REPLACE TABLE ...
+      AS SELECT, duckdb.py:_build_duckdb_ctas_sort_sql) immediately after
+      each table's raw load. Sorting a parent table (e.g. supplier) via
+      CREATE OR REPLACE after a dependent's FK constraint already exists
+      (e.g. lineitem/partsupp referencing supplier, declared at schema-
+      creation time) triggers exactly this error, even though supplier
+      loads first in FK order. Reproduce by loading a single tuned run
+      whose sort tuning targets a table with FK dependents.
   - id: w1
-    summary: "Route schema-recreation DROPs through reverse FK-topological order (shared helper, not per-adapter copies); handle cycles the same way get_fk_ordered_table_names does"
+    summary: "Make the CTAS-sort's implicit DROP FK-aware (shared helper, not per-adapter copies); handle cycles the same way get_fk_ordered_table_names does"
     status: pending
     needs: [w0]
+    notes: |
+      The fix target is apply_ctas_sort's CREATE OR REPLACE TABLE, not a
+      schema-recreation DROP path (see w0 notes) -- it must not conflict
+      with FK constraints a dependent table already declares against the
+      table being sorted.
   - id: w2
-    summary: "Regression tests: recreation with FK constraints applied succeeds on duckdb (real adapter); unit test pins reverse-topo order for tpch/ssb/coffeeshop schemas"
+    summary: "Regression tests: tuned single-run load with FK+sort tuning on a referenced parent succeeds AND the FK constraint is still enforced afterward; unit test pins reverse-topo order for tpch/ssb/coffeeshop"
     status: pending
     needs: [w1]
+    notes: |
+      Two invariants, not one: (1) the load completes without the
+      DROP-ordering error, and (2) the FK constraint the CTAS rewrite
+      touched is still actually enforced afterward -- a violating INSERT
+      must be rejected, not silently dropped by the rewrite. Mirror
+      test_fk_constraint_is_actually_enforced_after_load's assertion
+      shape rather than only checking that recreation succeeds.
   - id: w3
     summary: "Audit other FK-enforcing adapters' recreation paths for the same declaration-order DROP; fix or record honest per-platform notes"
     status: pending
@@ -62,9 +104,9 @@ scope_limit:
     - "tests/**"
 
 verification:
-  - description: "Second tuned run into an existing database succeeds"
-    command: "uv run -- python -m benchbox.cli.main run --platform duckdb --benchmark tpch --scale 0.01 --tuning tuned --non-interactive --output /tmp/drop-order-check && uv run -- python -m benchbox.cli.main run --platform duckdb --benchmark tpch --scale 0.01 --tuning tuned --non-interactive --output /tmp/drop-order-check"
-    expected_output: "Both runs complete; no 'Cannot drop entry' error"
+  - description: "A single tuned run whose sort tuning targets a table with FK dependents (the checked-in template sorts SUPPLIER, referenced by LINEITEM/PARTSUPP) completes without the DROP-ordering error"
+    command: "rm -rf /tmp/drop-order-check && uv run -- python -m benchbox.cli.main run --platform duckdb --benchmark tpch --scale 0.01 --tuning examples/tunings/duckdb/tpch_tuned.yaml --non-interactive --output /tmp/drop-order-check"
+    expected_output: "Run completes; no 'Cannot drop entry' error"
   - description: "Unit suites green"
     command: "uv run -- python -m pytest tests/unit/core tests/unit/platforms -q"
     expected_output: "All passing"

--- a/benchbox/platforms/base/data_loading.py
+++ b/benchbox/platforms/base/data_loading.py
@@ -2164,7 +2164,13 @@ class ClickHouseNativeHandler(FileFormatHandler):
         if any(token in type_upper for token in ("DOUBLE", "FLOAT", "REAL")):
             return float(value)
         if is_datetime:
-            return datetime.fromisoformat(value)
+            # datetime.fromisoformat() only accepts a trailing "Z" (RFC 3339
+            # UTC shorthand) starting in Python 3.11; on the supported 3.10
+            # runtime (requires-python >=3.10) it raises ValueError.
+            # Normalize to the explicit "+00:00" offset fromisoformat has
+            # always accepted, matching the pattern used elsewhere in this
+            # codebase (e.g. core/tpc_validation.py, mcp/tools/analytics.py).
+            return datetime.fromisoformat(value.replace("Z", "+00:00"))
         if is_date:
             return date.fromisoformat(value)
         return value

--- a/tests/unit/platforms/test_clickhouse_adapter.py
+++ b/tests/unit/platforms/test_clickhouse_adapter.py
@@ -613,6 +613,27 @@ class TestClickHouseAdapter:
         assert conv("", "DATETIME") is None
         assert conv("", "TIMESTAMP") is None
 
+    def test_datetime_z_suffix_parses_on_python_3_10(self):
+        """Regression for #1201's follow-up: datetime.fromisoformat() only
+        accepts a trailing "Z" (RFC 3339 UTC shorthand) starting in Python
+        3.11; the repo's minimum supported runtime is 3.10
+        (requires-python >=3.10), where the same call raises ValueError.
+        Verified directly against a real Python 3.10 interpreter
+        (/usr/bin/python3.10): `datetime.fromisoformat("2016-01-01T00:00:00Z")`
+        raises "Invalid isoformat string", while `.replace("Z", "+00:00")`
+        first fixes it -- confirming this is a real cross-version bug this
+        (3.11+) test process cannot reproduce on its own.
+        """
+        from datetime import datetime as dt, timezone
+
+        from benchbox.platforms.base.data_loading import ClickHouseNativeHandler
+
+        handler = ClickHouseNativeHandler(delimiter=",", adapter=None, benchmark=None)
+        conv = handler._convert_field_for_clickhouse
+
+        assert conv("2016-01-01T00:00:00Z", "DATETIME") == dt(2016, 1, 1, 0, 0, 0, tzinfo=timezone.utc)
+        assert conv("2016-01-01T00:00:00Z", "TIMESTAMP") == dt(2016, 1, 1, 0, 0, 0, tzinfo=timezone.utc)
+
     def test_empty_numeric_date_fields_become_null_not_default(self):
         """Empty numeric/date source fields convert to NULL, never a default (Bucket A).
 


### PR DESCRIPTION
## Description

Consolidated fixes for `chatgpt-codex-connector` review findings that landed on already-merged PRs:

- **#1201**: `datetime.fromisoformat()` only accepts a trailing `Z` (RFC 3339 UTC shorthand) starting in Python 3.11; on the repo's minimum supported runtime (`requires-python >=3.10`) it raises `ValueError`, so a ClickHouse-server load containing an RFC 3339 UTC value like `2016-01-01T00:00:00Z` would abort its insert batch. Normalized `Z` to `+00:00` before parsing, matching the established pattern already used elsewhere in this codebase (`core/tpc_validation.py`, `mcp/tools/analytics.py`, etc). Verified directly against a real Python 3.10 interpreter (`/usr/bin/python3.10`): the bare call raises `Invalid isoformat string` pre-fix and parses correctly post-fix — the pytest-level test can't reproduce this locally since this sandbox's test runner is 3.11+, where `fromisoformat` already accepts `Z` natively (documented in the new test's docstring).
- **#1203** (2 findings on `fk-aware-drop-ordering-20260717.yaml`, still `Not Started`): the TODO's reproduction plan described running the tuned CLI twice into the same database, but that can't reach the claimed DROP-ordering defect — `ConnectionLifecycleMixin.handle_existing_database()` either reuses a compatible database wholesale (skipping schema creation/loading entirely) or deletes the whole database file outright when incompatible, neither of which does a per-table DROP inside an existing schema. The real failure is within a *single* run: schema creation declares all tables and FK constraints up front, then `DataLoader._load_file_based_data()` calls `apply_ctas_sort()` (`CREATE OR REPLACE TABLE ... AS SELECT`) right after each table's raw load — sorting `SUPPLIER` this way fails once `LINEITEM`/`PARTSUPP`'s FK constraints already reference it, even though `SUPPLIER` loads first in FK order. Rewrote the description, `w0`'s reproduction plan, and the verification command to match (a single run against the checked-in `tpch_tuned.yaml` template, which already sorts `SUPPLIER`). Also strengthened `w1`/`w2`: the fix target is the CTAS-sort's implicit DROP (not a schema-recreation DROP path), and the regression test must prove the FK constraint is still actually enforced after the CTAS rewrite, not just that recreation succeeds.

## Type of Change

- [x] Bug fix
- [x] Refactor / chore

## Testing

- Direct Python 3.10 interpreter verification (`/usr/bin/python3.10`) for the `fromisoformat` fix — see commit message
- `uv run -- python -m pytest tests/unit/platforms/test_clickhouse_adapter.py -q` — 79 passed
- `uv run --project _project/scripts -- python _project/scripts/validate_todo.py _project/TODO/main/planning/fk-aware-drop-ordering-20260717.yaml` — valid
- `uv run --project _project/scripts -- python _project/scripts/todo_cli.py check-graph` — 127 items, no cycles/dangling refs
- `uv run -- ruff check` / `ruff format --check` on all changed files — clean

## Public Contract Check

- [x] I updated `docs/reference/public-contracts.md`, or this PR does not change public, beta-public, deprecated, generated, experimental, or repo-only contract surfaces.
- [x] I checked result schema fields, MCP tool parameters, platform support status, wrapper facades, adapter subclassing hooks, and generated docs for contract-map impact.
- [x] Any platform/benchmark count claim in docs is generated/checked from registry metadata, or explicitly marked editorial/non-authoritative.

## Documentation

- [x] I updated the relevant user-facing docs.
- [x] I added regression notes for behavior changes.
- [x] I confirmed API contract wording remains accurate.

## Code Quality

- [x] I ran formatting and lint/type checks.
- [x] I reviewed impacted modules for backwards compatibility and migration impact.
- [x] I added/updated tests for behavior changes and error paths.
- [x] I confirmed public contracts and release checklists are still valid.

## Artifact Hygiene

- [x] I did not commit raw screenshots, browser reports, generated logs, benchmark outputs, or temporary binary artifacts.
- [x] N/A — no binary/raw evidence files committed.

## Notes

None of the touched paths fall under CODEOWNERS soundness-critical prefixes (`benchbox/core/**/validation.py`, `benchbox/core/equivalence/**`, `benchbox/core/query_plans/parsers/**`, `benchbox/core/expected_results/**`, etc.), so this is eligible for standard squash auto-merge.


---
_Generated by [Claude Code](https://claude.ai/code/session_01SKw2UhgHuzYPo3y5MfarD6)_