### PR TITLE
todo: track the 5 deferred holistic-review follow-ups as actionable TODOs

### DIFF
--- a/_project/TODO/main/planning/cross-surface-baseline-stale-entry-autodetect.yaml
+++ b/_project/TODO/main/planning/cross-surface-baseline-stale-entry-autodetect.yaml
@@ -1,0 +1,85 @@
+id: cross-surface-baseline-stale-entry-autodetect
+title: "Auto-detect and PR resolved cross-surface known-divergence baseline entries on a schedule"
+worktree: main
+priority: Low
+status: Not Started
+category: Developer Tooling
+
+description: |
+  Follow-up to cross-surface-baseline-update-flag (#935), which shipped the manual
+  `--update-baseline` maintenance affordance (a YAML baseline in
+  cross_surface_baseline.yaml, pruned by known_divergences_baseline.py via the
+  `make cross-surface-update-baseline` target). That item deferred the automation:
+  detection and pruning are still operator-initiated, so a resolved (no-longer-
+  reproducing) known-divergence entry can linger between manual sweeps.
+
+  Add a scheduled job that runs the enforced cross-surface gates, detects resolved
+  entries (the gate already reports "previously-known divergences now equivalent"),
+  runs the existing `--update-baseline` writer, and opens a PR with the pruned
+  baseline. Removal stays explicit and reviewable (a PR), never a side effect of a
+  blocking gate run.
+
+prior_art:
+  - ref: "benchbox/core/equivalence/known_divergences_baseline.py + Makefile cross-surface-update-baseline"
+    note: "The load/prune/dump writer and Make target shipped by #935; the scheduled job invokes these, does not reimplement pruning."
+  - ref: ".github/workflows/release-canary.yml"
+    note: "Existing scheduled-workflow + RULESET_DRIFT_TOKEN pattern to model the cadence and bot-PR mechanics on."
+  - ref: "benchbox/core/equivalence/cross_surface.py (run_gate resolved-key reporting)"
+    note: "The gate already computes resolved keys; the scheduler reads them rather than re-deriving."
+
+work:
+  - id: w1
+    summary: "Scheduled job runs the enforced gates and collects resolved baseline entries per gate"
+    status: pending
+    needs: []
+    notes: |
+      A scheduled workflow (or an extension of an existing canary) that runs each
+      enforced gate and captures the resolved-entry report. No-op when nothing
+      resolved.
+  - id: w2
+    summary: "When resolved entries exist, run --update-baseline and open a PR with the pruned baseline"
+    status: pending
+    needs: [w1]
+    notes: |
+      Invoke `make cross-surface-update-baseline BENCHMARK=<gate>` for each affected
+      gate, then open a bot-authored, labeled PR with the pruned cross_surface_
+      baseline.yaml. Idempotent: no PR when nothing changed.
+  - id: w3
+    summary: "Guardrails: never auto-merge the prune PR; it touches a soundness path"
+    status: pending
+    needs: [w2]
+    notes: |
+      cross_surface.py / the baseline are CODEOWNERS soundness paths, so the prune PR
+      must leave auto-merge OFF and route to Code Owner review (reuse
+      auto_merge_soundness_paths.py).
+
+must_preserve:
+  - "The blocking gate run never prunes; pruning happens only in the scheduled PR path (as #935 established)."
+  - "A still-reproducing divergence is never removed; only resolved entries are dropped; idempotent."
+
+anti_patterns:
+  - "DO NOT auto-merge the prune PR — soundness path, Code Owner review required."
+  - "DO NOT reimplement the pruning logic; invoke the #935 writer/target."
+
+verification:
+  - description: "Dry-run detects a seeded resolved entry and produces the expected prune diff"
+    command: "seed a resolved entry, run the detection step -> it identifies exactly that entry and the writer's diff drops only it"
+    expected_output: "resolved entry surfaced and pruned; no live entry touched; no-op when none resolved"
+
+scope_limit:
+  only_modify:
+    - ".github/workflows/"
+    - "_project/scripts/"
+    - "benchbox/core/equivalence/"
+    - "Makefile"
+    - "tests/"
+
+success_metrics:
+  - "A resolved cross-surface baseline entry is surfaced and PR'd automatically within one schedule cycle, no manual initiation."
+  - "The automation never opens a PR when nothing is resolved and never auto-merges a soundness-path prune."
+
+metadata:
+  tags: [cross-surface, equivalence, baseline, automation, developer-tooling, holistic-review-followup]
+  estimated_effort: "Medium"
+  created_date: "2026-07-17"
+  last_updated: "2026-07-17T00:00:00"

--- a/_project/TODO/main/planning/dataframe-csv-coercion-single-shared-step.yaml
+++ b/_project/TODO/main/planning/dataframe-csv-coercion-single-shared-step.yaml
@@ -1,0 +1,80 @@
+id: dataframe-csv-coercion-single-shared-step
+title: "Consolidate per-adapter empty-string/null CSV coercion into one shared step"
+worktree: main
+priority: Medium
+status: Not Started
+category: Code Quality and Technical Debt
+
+description: |
+  Follow-up to dataframe-csv-empty-string-null-uniform (#904) and its coverage
+  follow-up dataframe-csv-empty-string-parity-coverage (#936). #904 landed the
+  empty-string-vs-null CSV coercion PER ADAPTER rather than as the single shared
+  step the original YAML specified. It is functionally equivalent today, but it
+  means each DataFrame adapter carries its own copy of the contract — each is an
+  independent risk surface that can drift.
+
+  Consolidate the coercion into one shared step in the common DataFrame CSV load
+  path so the empty-string/null contract has a single source of truth. This is now
+  a safe refactor because #936 pins the contract across every installed adapter
+  (datafusion/pyspark/pandas/polars/dask, plus the SQL<->DataFrame parity case), so
+  the parity tests are the behavior-preservation net.
+
+prior_art:
+  - ref: "benchbox/platforms/dataframe/polars_df.py (missing_utf8_is_empty_string) and the sibling per-adapter coercion sites"
+    note: "The per-adapter coercion this item consolidates; enumerate every site before extracting."
+  - ref: "benchbox/platforms/dataframe/benchmark_mixin.py (DataFrame CSV load path)"
+    note: "The common load path where the single shared coercion step should live."
+  - ref: "tests/integration/test_dataframe_csv_empty_string_null_semantics.py (#936)"
+    note: "The cross-adapter parity net that must stay byte-identical-green through the refactor."
+
+work:
+  - id: w1
+    summary: "Map every per-adapter empty-string/null CSV coercion site"
+    status: pending
+    needs: []
+    notes: |
+      Enumerate where each adapter implements the empty-field -> "" vs null rule
+      (null_marker semantics). Record file:line for each.
+  - id: w2
+    summary: "Extract the coercion to one shared step in the common DataFrame CSV load path"
+    status: pending
+    needs: [w1]
+    notes: |
+      Move the contract into a single shared step each adapter defers to; remove the
+      per-adapter special-casing. Behavior-preserving move only.
+  - id: w3
+    summary: "Confirm byte-identical behavior via the #936 parity tests"
+    status: pending
+    needs: [w2]
+    notes: |
+      The #936 parametrized parity tests (per-adapter + SQL<->DataFrame CSV-path)
+      must stay green unchanged; add a test asserting no per-adapter coercion path
+      remains if useful.
+
+must_preserve:
+  - "The empty-string vs null CSV contract is unchanged for every adapter — proven by the #936 parity tests staying green."
+  - "Behavior-preserving refactor: no adapter's observable CSV-loading semantics change."
+
+anti_patterns:
+  - "DO NOT change any adapter's empty-string/null outcome while consolidating — this is a structural move only."
+
+verification:
+  - description: "Cross-adapter parity holds through the refactor"
+    command: "uv run -- python -m pytest tests/integration/test_dataframe_csv_empty_string_null_semantics.py -q"
+    expected_output: "all per-adapter + cross-surface parity cells pass unchanged; coercion now lives in one shared step"
+
+scope_limit:
+  only_modify:
+    - "benchbox/platforms/dataframe/"
+    - "benchbox/platforms/base/"
+    - "tests/"
+
+success_metrics:
+  - "Empty-string/null CSV coercion lives in exactly one shared step; no per-adapter special-casing of the contract remains."
+  - "The #936 parity suite passes unchanged, confirming the refactor is behavior-preserving."
+
+metadata:
+  tags: [dataframe, csv, refactor, technical-debt, holistic-review-followup]
+  estimated_effort: "Medium"
+  created_date: "2026-07-17"
+  last_updated: "2026-07-17T00:00:00"

--- a/_project/TODO/main/planning/done-item-metric-truthfulness-audit.yaml
+++ b/_project/TODO/main/planning/done-item-metric-truthfulness-audit.yaml
@@ -1,0 +1,81 @@
+id: done-item-metric-truthfulness-audit
+title: "Audit metric/scope truthfulness across all historical DONE items and add a recurrence guard"
+worktree: main
+priority: Medium
+status: Not Started
+category: Documentation
+
+description: |
+  Follow-up to holistic-review-followup-metadata-truth (#938), which corrected metric
+  and scope truth defects (overstated success_metrics, scope_limit omissions, stale
+  Makefile comments) for the specific DONE items the holistic review examined. That
+  item scoped itself to the holistic-review effort and deferred the broad sweep.
+
+  Do the full audit: for every historical DONE item, verify its success_metrics,
+  scope_limit.only_modify, and any counts against the item's actually-merged diff, and
+  correct any that overstate, understate, or omit. Then systematize it so future
+  close-outs cannot silently drift — a lightweight check that flags a DONE item whose
+  scope_limit does not cover its merged diff, or whose metric claims a state its diff
+  did not deliver. Metadata-only; no source-code behavior change.
+
+prior_art:
+  - ref: "_project/DONE/main/planning/holistic-review-followup-metadata-truth.yaml (#938)"
+    note: "The pattern to generalize: reword overstated metrics to the accurate scoped claim, add omitted scope_limit paths, refresh stale comments; metadata-only."
+  - ref: "_project/scripts/validate_todo.py"
+    note: "Where a recurrence guard (scope_limit-vs-diff / metric-vs-diff check) could live or be invoked from."
+  - ref: "AGENTS.md (Default write-task close-out, guard+wiring rule added by #938)"
+    note: "House-rules home for any new close-out discipline this audit surfaces."
+
+work:
+  - id: w1
+    summary: "Enumerate DONE items and diff each item's success_metrics / scope_limit / counts vs its merged PR diff"
+    status: pending
+    needs: []
+    notes: |
+      For each DONE item, resolve the merging PR and compare the recorded metrics,
+      scope_limit.only_modify, and any counts against the diff --name-only / content.
+      Record mismatches (overstated / understated / omitted).
+  - id: w2
+    summary: "Correct the mismatches (metadata-only), like #938 did for the holistic-review subset"
+    status: pending
+    needs: [w1]
+    notes: |
+      Reword metrics to the accurate claim, add omitted scope paths, fix stale
+      counts/comments. No source or behavior change; re-run validate_todo on each.
+  - id: w3
+    summary: "Add a recurrence guard that flags a DONE item whose scope_limit doesn't cover its diff"
+    status: pending
+    needs: [w2]
+    notes: |
+      A lightweight script/guardrail (invoked from validate_todo or the todo review
+      action) that catches scope_limit-vs-diff and metric-vs-diff drift on close-out,
+      so this cannot silently recur.
+
+must_preserve:
+  - "Metadata/documentation only — no source-code behavior change."
+  - "Validator and TODO graph stay green after the DONE-YAML edits."
+
+anti_patterns:
+  - "DO NOT reopen or re-run the merged items; correct their recorded metadata only."
+  - "DO NOT invert or weaken a merged item's actual guarantees — only align the recorded text with the merged diff."
+
+verification:
+  - description: "Amended DONE YAMLs validate and the graph is intact"
+    command: "uv run --project _project/scripts -- python _project/scripts/validate_todo.py --all && uv run --project _project/scripts -- python _project/scripts/todo_cli.py check-graph"
+    expected_output: "all files valid; no cycles/dangling refs; sampled DONE metrics match their merged diffs"
+
+scope_limit:
+  only_modify:
+    - "_project/DONE/"
+    - "_project/scripts/"
+    - "AGENTS.md"
+
+success_metrics:
+  - "No DONE item carries a success_metric, scope_limit, or count that contradicts its merged diff."
+  - "A recurrence guard flags scope_limit-vs-diff (or metric-vs-diff) drift so close-out truth cannot silently regress."
+
+metadata:
+  tags: [documentation, metadata, todo-hygiene, holistic-review-followup]
+  estimated_effort: "Medium"
+  created_date: "2026-07-17"
+  last_updated: "2026-07-17T00:00:00"

--- a/_project/TODO/main/planning/generalize-multiphase-harness-registry-non-tpc.yaml
+++ b/_project/TODO/main/planning/generalize-multiphase-harness-registry-non-tpc.yaml
@@ -1,0 +1,90 @@
+id: generalize-multiphase-harness-registry-non-tpc
+title: "Generalize the multi-phase harness registry so a non-TPC family can register its harnesses"
+worktree: main
+priority: Low
+status: Not Started
+category: Code Quality and Technical Debt
+
+description: |
+  Follow-up to execution-harness-extraction-throughput-maintenance-combined (#937),
+  which routed all four TPC dispatch methods (power/throughput/maintenance/combined)
+  in platforms/base/execution.py through the power_harnesses capability registry, so
+  execution.py carries no literal TPC benchmark names in any dispatch method.
+
+  Today the registry only maps the two TPC families (tpch, tpcds). Generalize the
+  registration API so a NON-TPC benchmark family with multi-phase shapes can register
+  its power/throughput/maintenance/combined harnesses declaratively, without editing
+  execution.py's dispatch.
+
+  Readiness gate (why this is not started immediately): TPC is currently the only
+  benchmark family with multi-phase power/throughput/maintenance shapes, so there is
+  no second consumer to validate the generalized API against. This item is tracked as
+  actionable work that ACTIVATES when a second multi-phase family is introduced —
+  designing the abstraction against a single consumer risks the wrong shape. Do the
+  generalization together with (or immediately before) that second family, using it
+  as the second consumer that proves the API.
+
+prior_art:
+  - ref: "benchbox/core/power_harnesses.py (#937 registry: resolve_power/throughput/maintenance/combined_harness)"
+    note: "The registry to generalize; keep the single-registry design, extend it to register a family's harnesses as data."
+  - ref: "benchbox/platforms/base/execution.py (the four dispatch methods)"
+    note: "Dispatch must stay family-agnostic (no literal family names) for every registered family, not just TPC."
+
+work:
+  - id: w1
+    summary: "Define the generalized family-registration API against the incoming second multi-phase family"
+    status: pending
+    needs: []
+    notes: |
+      When a second multi-phase family lands, define how a family registers its phase
+      harness methods (power/throughput/maintenance + combined label/methods) as data,
+      so both TPC and the new family register uniformly.
+  - id: w2
+    summary: "Migrate TPC and the new family onto the generalized registry"
+    status: pending
+    needs: [w1]
+    notes: |
+      execution.py dispatch resolves harnesses purely by registry lookup for any
+      registered family; no per-family branch remains.
+  - id: w3
+    summary: "Broaden the dispatch-literal guard test to assert no literal family names for ANY registered family"
+    status: pending
+    needs: [w2]
+    notes: |
+      Extend test_dispatch_paths_have_no_literal_tpc_benchmark_names (or a sibling) so
+      the metric holds for the generalized registry, not just TPC.
+
+must_preserve:
+  - "Byte-identical benchmark execution for TPC families through the generalization (the #937 guarantee is not regressed)."
+  - "execution.py dispatch stays family-agnostic — no literal family names for any registered family."
+
+anti_patterns:
+  - "DO NOT design the generalized API against a single (TPC-only) consumer — activate this with the second family as the second consumer."
+  - "DO NOT add a parallel dispatch mechanism; extend the existing power_harnesses registry."
+
+verification:
+  - description: "No literal family names remain in dispatch for any registered family"
+    command: "uv run -- python -m pytest tests/unit/platforms/ -k literal_tpc_benchmark_names -q"
+    expected_output: "the guard asserts family-agnostic dispatch across all registered families"
+
+scope_limit:
+  only_modify:
+    - "benchbox/core/power_harnesses.py"
+    - "benchbox/platforms/base/execution.py"
+    - "benchbox/core/"
+    - "tests/unit/platforms/"
+    - "tests/"
+
+success_metrics:
+  - "A non-TPC multi-phase family can register its harnesses without editing execution.py dispatch."
+  - "The dispatch-literal guard holds for every registered family, not only TPC."
+
+deferred:
+  - summary: "Building the generalized API before a second multi-phase family exists."
+    reason: "No second consumer to validate the abstraction against; activate this together with the second family."
+
+metadata:
+  tags: [refactor, execution, tpc, structural-debt, holistic-review-followup]
+  estimated_effort: "Medium"
+  created_date: "2026-07-17"
+  last_updated: "2026-07-17T00:00:00"

--- a/_project/TODO/main/planning/promote-non-required-regression-reproducers-suite-audit.yaml
+++ b/_project/TODO/main/planning/promote-non-required-regression-reproducers-suite-audit.yaml
@@ -1,0 +1,83 @@
+id: promote-non-required-regression-reproducers-suite-audit
+title: "Audit the whole suite for regression reproducers parked outside required develop CI"
+worktree: main
+priority: Medium
+status: Not Started
+category: Testing and Quality Assurance
+
+description: |
+  Systemic follow-up to required-ci-coverage-deepest-reproducers (#932), which
+  promoted three specific holistic-review reproducers (#900 plan-capture planted
+  defect, #901 mutation catch, #909 plan-capture-phase) into the required
+  develop-PR gate. That item deliberately scoped itself to those three instances
+  and deferred the suite-wide sweep.
+
+  The systemic gap: a regression reproducer that proves a fix but is parked in a
+  non-required lane (an env-var gate, a `slow`/`integration`/`medium` marker, or a
+  test.yml-only job) does NOT run in the develop required gate `ci-required-result`,
+  so the PR that introduced the fix can self-merge without ever running its own
+  deepest guard — the reproducer only fires one ring out, at the main-release
+  boundary. Audit the whole test suite for this pattern and promote the
+  load-bearing cells into the required gate via bounded explicit-node steps, the
+  same mechanism #932 used.
+
+prior_art:
+  - ref: "_project/DONE/main/planning/required-ci-coverage-deepest-reproducers.yaml"
+    note: "The pattern this generalizes: explicit-node `-m <marker> -n 0 -k <cell>` steps added to a job already in ci-required-result.needs, each proven load-bearing by reverting its fix."
+  - ref: ".github/workflows/pr.yml"
+    note: "ci-required-result.needs and the existing explicit-node drift-guard steps in code-test; reuse the mechanism, do not add continue-on-error jobs."
+
+work:
+  - id: w1
+    summary: "Enumerate regression reproducers excluded from the required develop gate"
+    status: pending
+    needs: []
+    notes: |
+      Grep for env-var-gated tests, module/function slow|integration|medium marks,
+      and tests that run only in test.yml, and cross-reference which prove a
+      specific merged fix. Produce the candidate list (test id, marker/gate, which
+      fix it protects, current lane).
+  - id: w2
+    summary: "Classify each candidate as load-bearing vs redundant and select the cells to promote"
+    status: pending
+    needs: [w1]
+    notes: |
+      A reproducer is load-bearing if reverting its fix would turn it red. Select
+      only those; keep wall-clock bounded (specific cells, never whole slow matrices).
+  - id: w3
+    summary: "Promote the selected cells via explicit-node steps in a required job and prove each load-bearing"
+    status: pending
+    needs: [w2]
+    notes: |
+      Add explicit-node steps to a job already in ci-required-result.needs. For each,
+      revert its underlying fix locally, confirm the required step goes red, restore;
+      record the break/restore evidence in the PR body. No continue-on-error.
+
+must_preserve:
+  - "No new always-on slow/integration matrix in required CI — promote only the load-bearing cells; keep wall-clock bounded."
+  - "Every added step lives in a job already in ci-required-result.needs and is not continue-on-error."
+
+anti_patterns:
+  - "DO NOT promote entire slow/integration suites — promote the specific cells that prove the fixes."
+  - "DO NOT add a required step without proving it goes red when the fix is reverted."
+
+verification:
+  - description: "Each promoted step is load-bearing"
+    command: "revert the underlying fix locally -> the required develop-PR check goes red -> restore (record in PR body)"
+    expected_output: "every promoted cell fails required CI when its fix is reverted"
+
+scope_limit:
+  only_modify:
+    - ".github/workflows/pr.yml"
+    - "Makefile"
+    - "tests/"
+
+success_metrics:
+  - "No regression reproducer that proves a merged fix runs ONLY outside the required develop-PR gate."
+  - "Promoted steps add bounded wall-clock (selected cells), not full slow/integration matrices."
+
+metadata:
+  tags: [ci, testing, regression-guard, holistic-review-followup]
+  estimated_effort: "Medium"
+  created_date: "2026-07-17"
+  last_updated: "2026-07-17T00:00:00"


### PR DESCRIPTION
Each of the six holistic-review-remediation items carried a `deferred:` note scoping a concrete follow-up. Five of those items are now DONE, so their deferred notes were buried inside DONE items — recorded, but not surfaced in the ready queue. These are **actionable, scoped work — not aspirational research** — so this promotes each to a dedicated open TODO with work units, guardrails, verification, `scope_limit`, and `prior_art` provenance back to its source finding.

## New TODOs
| New TODO | From | Actionable now? |
|---|---|---|
| `promote-non-required-regression-reproducers-suite-audit` | #932 | Yes — suite-wide sweep for reproducers parked outside the required develop gate; promote load-bearing cells |
| `cross-surface-baseline-stale-entry-autodetect` | #935 | Yes — scheduled detect + `--update-baseline` + PR for resolved known-divergence entries (never auto-merge; soundness path) |
| `dataframe-csv-coercion-single-shared-step` | #904/#936 | Yes — consolidate the per-adapter empty-string/null coercion into one shared step (the #936 parity suite is the behavior-preservation net) |
| `generalize-multiphase-harness-registry-non-tpc` | #937 | Tracked; **readiness gated on a second multi-phase benchmark family existing** — documented prominently in-item (not buried), so the abstraction is designed against a real second consumer |
| `done-item-metric-truthfulness-audit` | #938 | Yes — audit metric/scope truth across all DONE items + add a recurrence guard |

I deliberately did **not** file these under `future-ideas-backlog.yaml` — that item is explicitly for aspirational, research-stage work, which these are not.

## Validation
- Each of the five validates against `TODO_SCHEMA.yaml` (`validate_todo.py`).
- `todo_cli.py check-graph` → green, 130 items, no duplicate ids / dangling refs.

No source or behavior change — planning TODOs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Jb4WFFT3SBDJF57MP4GXYZ)_