### PR TITLE
feat(todo): head-to-head eval record + schema v2 (resume metadata, shared worktree DB)

### DIFF
--- a/.claude/skills/todo-db/SKILL.md
+++ b/.claude/skills/todo-db/SKILL.md
@@ -17,7 +17,9 @@ lifecycle rule; when it refuses (exit 2), fix the cause, don't work around it.
 2. `todo claim <id>` — claims it and prints the work order: scope globs,
    must-preserves, anti-patterns, verification ladder, ready units, and open
    deferrals. Follow the work order; it is the whole briefing.
-3. Per unit: `todo start <id> <wid>`, implement, then
+3. Per unit: `todo start <id> <wid>` (optional — records your worktree and
+   branch so another agent can resume partial work; `todo done` stamps them
+   too), implement, then
    `todo done <id> <wid> --evidence "<command run / commit / PR>"`.
 4. The moment you decide to skip something: `todo defer <id> --summary "..."
    --reason "..."` — deferring is cheap; losing work is not.

--- a/_project/audits/todo-db-eval-2026-07-18.md
+++ b/_project/audits/todo-db-eval-2026-07-18.md
@@ -1,0 +1,132 @@
+# Evidence record: YAML-vs-DB tracker head-to-head evaluation (2026-07-18)
+
+Compact, durable record backing the "Head-to-head evaluation" section of
+`_project/specs/todo-db-tracker.md`. Contains the exact agent prompts, the
+harness usage counters, and the key lines of the independent end-state
+audits, so the claims are verifiable and the experiment is replayable.
+
+## Environment pins
+
+- Repo: joeharris76/BenchBox. Spec/tooling under evaluation as merged in
+  PR #1212 (`develop` @ `a296177e`).
+- Both subagents: Claude Opus, isolated git worktrees, worktree base
+  `7550c423` (35 commits behind `develop` at run time — predates both
+  systems' tooling, so **each arm provisioned its own tracker into its
+  worktree first**; the environmental tax was symmetric).
+- Orchestration: two `Agent` calls (model=opus, isolation=worktree),
+  launched in parallel from the same session. Token/tool-call/duration
+  figures are the harness's per-subagent usage counters, reported verbatim.
+
+## Prompts (verbatim; the only differences are the tracking-system blocks)
+
+### Arm A — legacy YAML system
+
+```
+You are implementing one small tracked work item in the BenchBox repo, using the repo's **legacy YAML TODO system** end-to-end. Work only inside your current worktree. Do NOT commit, do NOT push, do NOT open PRs. Use only the legacy YAML TODO system for tracking (not the DB tracker / `todo-db` skill / `_project/scripts/todo` shim).
+
+Tracking system to use faithfully:
+- Skill: `.claude/skills/todo/SKILL.md` and `.claude/skills/todo/references/structure.md`
+- Schema: `_project/TODO_SCHEMA.yaml`, template `_project/TODO_ENTRY_TEMPLATE.yaml`
+- CLI: `uv run --project _project/scripts -- python _project/scripts/todo_cli.py <cmd>`
+- Validator: `uv run --project _project/scripts -- python _project/scripts/validate_todo.py <file>`
+Follow the system's full lifecycle: create the item as a planning entry, move it when you start work, track work-unit statuses, record out-of-scope work per the system's conventions, complete the item per the system (including whatever moves/validation/indexing it prescribes).
+
+The work item spec:
+- id/slug: `uat-word-count-util`; title: "Add a word-count utility script"; worktree grouping: `main`; priority: Low
+- description: Add `_project/scripts/word_count.py`, a CLI that prints line, word, and character counts for a single file passed as its only argument, in the exact format `lines=<n> words=<n> chars=<n>`. Add a unit test at `tests/unit/scripts/test_word_count.py` (pytest markers: `unit` and `medium`) covering a normal file and an empty file. Run the test to verify it passes (`uv run -- python -m pytest tests/unit/scripts/test_word_count.py -q`).
+- Work breakdown: w1 = implement the script; w2 = add the test and verify it passes.
+- During implementation you notice two improvements that are OUT OF SCOPE for this item and must be tracked as deferred follow-up work per the system's conventions: (a) support for multiple input files, (b) a `--json` output mode.
+
+Do the complete lifecycle: record the item, implement it, run the test, keep statuses current, record both out-of-scope follow-ups so they cannot be lost, and complete the item per the system.
+
+Final message must report: (1) the absolute path of your worktree; (2) the lifecycle steps you performed, in order; (3) the final path and status of the tracked item; (4) exactly how and where the two deferred follow-ups are recorded; (5) the test run result. Leave all changes uncommitted in the worktree.
+```
+
+### Arm B — DB tracker spike
+
+```
+You are implementing one small tracked work item in the BenchBox repo, using the repo's **DB-backed TODO tracker spike** end-to-end. Work only inside your current worktree. Do NOT commit, do NOT push, do NOT open PRs. Use only the DB tracker for tracking (not the legacy YAML TODO system / `todo_cli.py` / `_project/TODO` files).
+
+Tracking system to use faithfully:
+- Skill: `.claude/skills/todo-db/SKILL.md`
+- Entry point: `_project/scripts/todo` (the shim; run it from the repo root of your worktree). The tracker database is created automatically under `.todo-db/` in your worktree.
+Follow the system's full lifecycle as the skill describes: create the item, claim it, track work-unit statuses with evidence, record out-of-scope work per the system's conventions, verify, and complete the item per the system.
+
+The work item spec:
+- id/slug: `uat-word-count-util`; title: "Add a word-count utility script"; worktree grouping: `main`; priority: Low
+- description: Add `_project/scripts/word_count.py`, a CLI that prints line, word, and character counts for a single file passed as its only argument, in the exact format `lines=<n> words=<n> chars=<n>`. Add a unit test at `tests/unit/scripts/test_word_count.py` (pytest markers: `unit` and `medium`) covering a normal file and an empty file. Run the test to verify it passes (`uv run -- python -m pytest tests/unit/scripts/test_word_count.py -q`).
+- Work breakdown: w1 = implement the script; w2 = add the test and verify it passes.
+- During implementation you notice two improvements that are OUT OF SCOPE for this item and must be tracked as deferred follow-up work per the system's conventions: (a) support for multiple input files, (b) a `--json` output mode.
+
+Do the complete lifecycle: record the item, implement it, run the test, keep statuses current, record both out-of-scope follow-ups so they cannot be lost, and complete the item per the system.
+
+Final message must report: (1) the absolute path of your worktree; (2) the lifecycle steps you performed, in order; (3) the final status of the tracked item in the tracker; (4) exactly how and where the two deferred follow-ups are recorded; (5) the test run result. Leave all changes uncommitted in the worktree.
+```
+
+## Harness usage counters (verbatim)
+
+| Arm | subagent_tokens | tool_uses | duration_ms |
+|---|---|---|---|
+| A: legacy YAML | 85,703 | 50 | 501,458 |
+| B: DB tracker | 61,091 | 36 | 455,159 |
+
+## Independent end-state audit (key output lines, verbatim)
+
+Audits were run by the orchestrating session in each worktree after the
+agents finished, before the worktrees were removed.
+
+Arm B (DB), tracker end state:
+
+```
+$ TODO_DB_PATH=<worktree>/.todo-db/todo.sqlite ... todo_db.py stats
+"deferrals_by_resolution": { "promoted": 2 }
+"items_by_state": { "done": 1, "planning": 2 }
+$ ... todo_db.py show uat-word-count-util --json  (condensed)
+state: done | units: [('w1','done',evidence=True), ('w2','done',evidence=True)]
+deferrals: [(1,'promoted','uat-word-count-multi-file'), (2,'promoted','uat-word-count-json-output')]
+$ uv run -- python -m pytest tests/unit/scripts/test_word_count.py -q
+2 passed
+$ uv run -- python _project/scripts/word_count.py <2-line probe file>
+lines=2 words=4 chars=24
+```
+
+Arm A (YAML), tracked-item end state:
+
+```
+$ ls _project/DONE/main/uat-word-count-util.yaml            # exists
+status: "Completed"    completed_date: "2026-07-18"
+$ validate_todo.py _project/DONE/main/uat-word-count-util.yaml
+valid
+$ deferred: block contains 2 entries (multi-file, --json)
+$ todo_cli.py ready | grep -i "word.count|multi.file|json"  -> no matches (exit 1)
+$ todo_cli.py list  | grep -ci "word-count"                 -> 0
+$ uv run -- python -m pytest tests/unit/scripts/test_word_count.py -q
+2 passed
+$ uv run -- python _project/scripts/word_count.py <2-line probe file>
+lines=2 words=4 chars=24
+```
+
+Interpretation: both implementations correct and equivalent; both
+lifecycles executed faithfully per their system's own rules; Arm A's two
+deferrals ended buried in a DONE file's `deferred[]` (invisible to
+`ready`/`list`); Arm B's two deferrals were forced through the `complete`
+gate into standalone planning items visible in the ready queue.
+
+## Replay instructions
+
+Launch two isolated Opus subagents with the prompts above, verbatim, from
+a session on a BenchBox checkout at or after `a296177e`. Audit each
+worktree with the commands in the audit section. Expected qualitative
+result: identical implementation quality; deferral survivability differs
+by system (buried vs promoted). Token magnitudes are n=1 and will vary;
+the structural end-state difference should not.
+
+## Caveats
+
+- n=1 per arm; treat token/tool-call magnitudes as indicative.
+- Worktree base predated both systems' tooling; both arms paid a
+  provisioning tax (Arm A materialized `_project/` from `develop`; Arm B
+  copied the shim + `todo_db.py` + `pyproject.toml`).
+- Arm B's `check-scope` flagged its own provisioned tracker files (old
+  base lacked the `.todo-db/` gitignore entry) — recorded as a tool
+  finding (self-state exemption) in the session, not a scoring factor.

--- a/_project/audits/todo-db-eval-2026-07-18.md
+++ b/_project/audits/todo-db-eval-2026-07-18.md
@@ -1,3 +1,6 @@
+---
+develop_sha: a296177efd5ab1becaab0bc3fb292be418c9f6be
+---
 # Evidence record: YAML-vs-DB tracker head-to-head evaluation (2026-07-18)
 
 Compact, durable record backing the "Head-to-head evaluation" section of

--- a/_project/scripts/todo_db.py
+++ b/_project/scripts/todo_db.py
@@ -36,7 +36,16 @@ from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Any
 
-SCHEMA_VERSION = 1
+SCHEMA_VERSION = 2
+
+# Applied in order by `todo migrate`; each version's statements are additive.
+MIGRATIONS: dict[int, list[str]] = {
+    2: [
+        "ALTER TABLE work_units ADD COLUMN started_at TEXT",
+        "ALTER TABLE work_units ADD COLUMN started_worktree TEXT",
+        "ALTER TABLE work_units ADD COLUMN started_branch TEXT",
+    ],
+}
 
 PRIORITIES = ("critical", "high", "medium-high", "medium", "low")
 STATES = ("planning", "active", "done", "dropped")
@@ -82,6 +91,9 @@ CREATE TABLE work_units (
              ('pending','in_progress','done')),
   evidence TEXT,
   notes    TEXT,
+  started_at TEXT,
+  started_worktree TEXT,
+  started_branch TEXT,
   PRIMARY KEY (item_id, wid)
 );
 
@@ -199,13 +211,42 @@ def git_root() -> Path:
     return Path(result.stdout.strip())
 
 
+def git_main_root() -> Path:
+    """Root of the MAIN repository, even when run from a linked worktree.
+
+    All worktrees of a clone must share one tracker database (eval finding:
+    per-worktree DBs fragment state into invisible islands), so the default
+    DB path resolves through the common git dir, not the worktree root.
+    """
+    result = subprocess.run(
+        ["git", "rev-parse", "--path-format=absolute", "--git-common-dir"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        return git_root()
+    common = Path(result.stdout.strip())
+    return common.parent if common.name == ".git" else git_root()
+
+
 def resolve_db_path(explicit: str | None) -> Path:
     if explicit:
         return Path(explicit)
     env = os.environ.get("TODO_DB_PATH")
     if env:
         return Path(env)
-    return git_root() / ".todo-db" / "todo.sqlite"
+    return git_main_root() / ".todo-db" / "todo.sqlite"
+
+
+def _git_location() -> tuple[str | None, str | None]:
+    """(worktree toplevel, branch) of the CWD, for resume/recovery stamps."""
+
+    def _out(*args: str) -> str | None:
+        result = subprocess.run(["git", *args], capture_output=True, text=True, check=False)
+        return result.stdout.strip() or None if result.returncode == 0 else None
+
+    return _out("rev-parse", "--show-toplevel"), _out("rev-parse", "--abbrev-ref", "HEAD")
 
 
 def connect(db_path: Path) -> sqlite3.Connection:
@@ -225,12 +266,39 @@ def connect(db_path: Path) -> sqlite3.Connection:
             "INSERT INTO meta (key, value) VALUES ('schema_version', ?)",
             (str(SCHEMA_VERSION),),
         )
-    elif version != SCHEMA_VERSION:
+    elif version < SCHEMA_VERSION:
         raise TodoError(
-            f"database schema_version={version}, CLI expects {SCHEMA_VERSION}; "
-            "run a newer CLI or re-create the spike database"
+            f"database schema_version={version}, CLI expects {SCHEMA_VERSION}; run `todo migrate` to upgrade it"
         )
+    elif version > SCHEMA_VERSION:
+        raise TodoError(f"database schema_version={version} is newer than this CLI ({SCHEMA_VERSION}); use a newer CLI")
     return conn
+
+
+def migrate_db(db_path: Path) -> list[int]:
+    """Apply pending schema migrations; returns the versions applied."""
+    if not db_path.exists():
+        # Nothing to migrate — a fresh connect() creates the current schema.
+        connect(db_path).close()
+        return []
+    raw = sqlite3.connect(db_path)
+    raw.row_factory = sqlite3.Row
+    try:
+        version = _schema_version(raw)
+        if version is None:
+            raise TodoError(f"{db_path} exists but has no tracker schema")
+        applied: list[int] = []
+        for target in sorted(MIGRATIONS):
+            if version < target:
+                for statement in MIGRATIONS[target]:
+                    raw.execute(statement)
+                raw.execute("UPDATE meta SET value = ? WHERE key = 'schema_version'", (str(target),))
+                raw.commit()
+                version = target
+                applied.append(target)
+        return applied
+    finally:
+        raw.close()
 
 
 @contextmanager
@@ -527,11 +595,14 @@ def start_unit(conn: sqlite3.Connection, actor: str, item_id: str, wid: str) -> 
         if unit["status"] == "done":
             raise TodoError(f"{item_id}:{wid} is already done")
         _require_unit_needs_done(conn, item_id, wid)
+        worktree, branch = _git_location()
         conn.execute(
-            "UPDATE work_units SET status = 'in_progress' WHERE item_id = ? AND wid = ?",
-            (item_id, wid),
+            "UPDATE work_units SET status = 'in_progress',"
+            " started_at = ?, started_worktree = ?, started_branch = ?"
+            " WHERE item_id = ? AND wid = ?",
+            (utc_now(), worktree, branch, item_id, wid),
         )
-        log_event(conn, actor, item_id, "start", {"wid": wid})
+        log_event(conn, actor, item_id, "start", {"wid": wid, "worktree": worktree, "branch": branch})
 
 
 def done_unit(conn: sqlite3.Connection, actor: str, item_id: str, wid: str, evidence: str) -> None:
@@ -541,9 +612,16 @@ def done_unit(conn: sqlite3.Connection, actor: str, item_id: str, wid: str, evid
         _require_item(conn, item_id)
         _require_unit(conn, item_id, wid)
         _require_unit_needs_done(conn, item_id, wid)
+        # Implicit start: stamp the location if `start` was skipped, so the
+        # record of where the work happened survives either path.
+        worktree, branch = _git_location()
         conn.execute(
-            "UPDATE work_units SET status = 'done', evidence = ? WHERE item_id = ? AND wid = ?",
-            (evidence, item_id, wid),
+            "UPDATE work_units SET status = 'done', evidence = ?,"
+            " started_at = COALESCE(started_at, ?),"
+            " started_worktree = COALESCE(started_worktree, ?),"
+            " started_branch = COALESCE(started_branch, ?)"
+            " WHERE item_id = ? AND wid = ?",
+            (evidence, utc_now(), worktree, branch, item_id, wid),
         )
         log_event(conn, actor, item_id, "done", {"wid": wid, "evidence": evidence})
 
@@ -898,6 +976,10 @@ def check_paths(files: list[str], rules: list[dict[str, str]]) -> list[str]:
     deny = [r["path_glob"] for r in rules if r["kind"] == "do_not_modify"]
     violations = []
     for path in files:
+        # The tracker's own state directory is never scope-relevant
+        # (eval finding: it false-positived on worktrees with stale gitignores).
+        if path == ".todo-db" or path.startswith(".todo-db/"):
+            continue
         if any(fnmatch.fnmatch(path, glob) for glob in deny):
             violations.append(f"{path}: matches do_not_modify")
         elif only and not any(fnmatch.fnmatch(path, glob) for glob in only):
@@ -1330,7 +1412,13 @@ def _print_work_order(order: dict[str, Any]) -> None:
     blocked = order.get("blocked_units", [])
     print("-- ready units" if ready else "-- no ready units")
     for unit in ready:
-        print(f"   {unit['wid']} [{unit['status']}] {unit['summary']}")
+        resume = ""
+        if unit["status"] == "in_progress" and unit.get("started_branch"):
+            resume = (
+                f" (resumable: branch {unit['started_branch']}"
+                f" @ {unit.get('started_worktree') or '?'}, since {unit.get('started_at')})"
+            )
+        print(f"   {unit['wid']} [{unit['status']}] {unit['summary']}{resume}")
     for unit in blocked:
         print(f"   {unit['wid']} BLOCKED on {','.join(unit['unmet'])}: {unit['summary']}")
     open_defs = [d for d in order["deferrals"] if d["resolution"] == "open"]
@@ -1355,12 +1443,15 @@ def main(argv: list[str] | None = None) -> int:
     p.add_argument("--dry-run", action="store_true")
     p.add_argument("--verbose", action="store_true", help="print every skip/warning line")
 
-    p = sub.add_parser("create", help="create an item")
-    p.add_argument("id")
-    p.add_argument("--title", required=True)
-    p.add_argument("--worktree", required=True)
-    p.add_argument("--priority", required=True, choices=PRIORITIES)
-    p.add_argument("--description", required=True)
+    p = sub.add_parser("create", help="create an item (flags, or --from - for a JSON payload)")
+    p.add_argument("id", nargs="?")
+    p.add_argument(
+        "--from", dest="from_source", metavar="-|FILE", help="read a JSON item payload from stdin (-) or a file"
+    )
+    p.add_argument("--title")
+    p.add_argument("--worktree")
+    p.add_argument("--priority", choices=PRIORITIES)
+    p.add_argument("--description")
     p.add_argument("--category")
     p.add_argument("--approach")
     p.add_argument("--work", action="append", default=[], metavar="WID:SUMMARY[:needs=w1,w2]")
@@ -1437,11 +1528,23 @@ def main(argv: list[str] | None = None) -> int:
     p = sub.add_parser("sweep-stale", help="release expired claims")
     p.add_argument("--ttl-hours", type=float, default=DEFAULT_LEASE_TTL_HOURS)
 
+    sub.add_parser("migrate", help="apply pending schema migrations to the database")
+
     p = sub.add_parser("export", help="deterministic JSONL + markdown index")
     p.add_argument("--out", default=None)
 
     args = parser.parse_args(argv)
     actor = args.actor or default_actor()
+    if args.command == "migrate":
+        # Must run before connect(): connect refuses an outdated schema.
+        try:
+            applied = migrate_db(resolve_db_path(args.db))
+        except TodoError as exc:
+            print(f"error: {exc}", file=sys.stderr)
+            return 2
+        if applied:
+            print(f"applied migration(s) to v{', v'.join(str(v) for v in applied)}")
+            return 0
     conn = connect(resolve_db_path(args.db))
 
     try:
@@ -1512,7 +1615,61 @@ def _parse_verify_flag(specs: list[str]) -> list[dict[str, str]]:
     return verifications
 
 
+def create_from_payload(conn: sqlite3.Connection, actor: str, payload: dict[str, Any]) -> str:
+    """Create an item from a structured JSON payload (the `create --from` path)."""
+    for required in ("id", "title", "worktree", "priority", "description"):
+        if not payload.get(required):
+            raise TodoError(f"payload missing required field: {required!r}")
+
+    def _triple(entry: Any, keys: tuple[str, str, str]) -> tuple[str, str, str]:
+        if isinstance(entry, dict):
+            try:
+                return tuple(str(entry[k]) for k in keys)  # type: ignore[return-value]
+            except KeyError as exc:
+                raise TodoError(f"payload entry {entry!r} missing key {exc}") from exc
+        return tuple(str(v) for v in entry)  # type: ignore[return-value]
+
+    scope_map = payload.get("scope") or {}
+    scope = [(kind, str(glob)) for kind in ("only_modify", "do_not_modify") for glob in scope_map.get(kind) or []]
+    create_item(
+        conn,
+        actor,
+        item_id=str(payload["id"]),
+        title=str(payload["title"]),
+        worktree=str(payload["worktree"]),
+        priority=str(payload["priority"]),
+        description=str(payload["description"]),
+        category=payload.get("category"),
+        approach=payload.get("approach"),
+        work=payload.get("work") or [],
+        deps=[str(d) for d in payload.get("deps") or []],
+        scope=scope,
+        verifications=payload.get("verifications") or [],
+        preserves=[str(p) for p in payload.get("preserves") or []],
+        anti_patterns=[_triple(e, ("dont", "why", "instead")) for e in payload.get("anti_patterns") or []],
+        prior_art=[_triple(e, ("path", "concept", "decision")) for e in payload.get("prior_art") or []],
+    )
+    return str(payload["id"])
+
+
 def _cmd_create(conn, actor, args):
+    if args.from_source:
+        if args.from_source == "-":
+            raw = sys.stdin.read()
+        else:
+            raw = Path(args.from_source).read_text(encoding="utf-8")
+        try:
+            payload = json.loads(raw)
+        except json.JSONDecodeError as exc:
+            raise TodoError(f"--from payload is not valid JSON: {exc}") from exc
+        if args.id and not payload.get("id"):
+            payload["id"] = args.id
+        item_id = create_from_payload(conn, actor, payload)
+        print(f"created {item_id}")
+        return 0
+    missing = [flag for flag in ("id", "title", "worktree", "priority", "description") if not getattr(args, flag)]
+    if missing:
+        raise TodoError(f"create requires {', '.join(missing)} (or use --from - with a JSON payload)")
     scope = [("only_modify", g) for g in args.only_modify]
     scope += [("do_not_modify", g) for g in args.do_not_modify]
     create_item(
@@ -1705,9 +1862,16 @@ def _cmd_sweep_stale(conn, actor, args):
 
 
 def _cmd_export(conn, actor, args):
-    out_dir = Path(args.out) if args.out else git_root() / ".todo-db" / "export"
+    out_dir = Path(args.out) if args.out else git_main_root() / ".todo-db" / "export"
     jsonl_path, index_path = write_export(conn, out_dir)
     print(f"wrote {jsonl_path} and {index_path}")
+    return 0
+
+
+def _cmd_migrate(conn, actor, args):
+    # Reached only when the DB is already current (main() migrates before
+    # connecting for this command); report the no-op for clarity.
+    print(f"schema v{SCHEMA_VERSION}: up to date")
     return 0
 
 
@@ -1736,6 +1900,7 @@ _HANDLERS = {
     "lint": _cmd_lint,
     "sweep-stale": _cmd_sweep_stale,
     "export": _cmd_export,
+    "migrate": _cmd_migrate,
 }
 
 

--- a/_project/specs/todo-db-tracker.md
+++ b/_project/specs/todo-db-tracker.md
@@ -411,6 +411,68 @@ piped output. The spike is single-clone by construction — it validates the
 enforcement design (G2), not the shared-visibility goal, which still
 requires the hosted step after G1.
 
+## Head-to-head evaluation: legacy YAML vs DB tracker (2026-07-18)
+
+**Protocol.** Two isolated Opus subagents, each in its own git worktree,
+received byte-identical work-item specs (a small `word_count.py` utility +
+unit test, work units w1/w2, and two planted out-of-scope improvements
+that "must be tracked as deferred follow-up work per the system's
+conventions"). The only difference between the prompts was the assigned
+tracking system: the legacy YAML stack (skill + `todo_cli.py` + schema +
+validator) vs the DB tracker (thin `todo-db` skill + `todo` shim). Token
+usage came from the harness's per-subagent counters; end states were
+audited independently in each worktree (tests re-run, script behavior
+probed, tracked-item state and queue visibility inspected) before the
+worktrees were discarded. Caveats: n=1, so magnitudes are indicative; both
+arms paid a similar environmental tax (the worktree base predated both
+systems' tooling, so each provisioned its tracker first).
+
+**Token burn.**
+
+| Metric | Legacy YAML | DB tracker | Delta |
+|---|---|---|---|
+| Subagent tokens | 85,703 | 61,091 | −29% |
+| Tool calls | 50 | 36 | −28% |
+| Wall time | 8.4 min | 7.6 min | −9% |
+
+The YAML arm's overhead went to reading the governing prose stack
+(skill + references + 350-line schema + template) before acting,
+hand-authoring the YAML entry, and the completion ceremony (status edits,
+`sections` block, `git mv` to DONE, validate, check-graph, reindex). The
+DB arm created the item with flags on one command and completed with one
+gated command.
+
+**Effectiveness.** Both agents produced correct, identical-behavior
+implementations (2/2 tests passing, exact output format, independently
+verified) and both executed their assigned lifecycle faithfully — the
+YAML agent's execution was near-flawless by the legacy system's own
+rules. The separation was structural:
+
+| Dimension | YAML | DB |
+|---|---|---|
+| Code + test correct | pass | pass |
+| Lifecycle executed per system rules | pass | pass (with per-unit evidence, which YAML has no field for) |
+| Verification recorded in the tracker | fail (run but not captured) | pass (`verify --run` stamped) |
+| Deferred follow-ups survivable | **fail (buried)** | **pass (promoted)** |
+
+The decisive row reproduces the motivating failure class under
+controlled conditions: the YAML agent recorded both follow-ups in
+`deferred[]` — the system's official convention — and that block now
+lives inside a DONE file, invisible to `ready` and `list` (audited: both
+grep empty). The follow-ups reached the exact state that previously
+required forensic sweeps #1181/#1195/#1210, *despite perfect agent
+compliance*. The DB agent structurally could not lose them: `complete`
+refused until each deferral was resolved, so both became standalone
+planning items (`uat-word-count-multi-file`, `uat-word-count-json-output`)
+visible in the ready queue with provenance links to the parent.
+
+**Conclusion.** Same task, same model: the DB tracker was ~29% cheaper in
+tokens and ~28% fewer tool calls while producing a strictly better end
+state — evidence-stamped units, a recorded verification result, and zero
+silently-lost deferred work versus two follow-ups already buried. The gap
+is not agent skill; it is prose-enforced invariants vs code-enforced
+invariants, demonstrated rather than argued.
+
 ## Cutover plan
 
 - **G1 — host verification (before any build):** from a live remote session,

--- a/_project/specs/todo-db-tracker.md
+++ b/_project/specs/todo-db-tracker.md
@@ -413,6 +413,10 @@ requires the hosted step after G1.
 
 ## Head-to-head evaluation: legacy YAML vs DB tracker (2026-07-18)
 
+**Durable evidence:** `_project/audits/todo-db-eval-2026-07-18.md` — the
+exact prompts, verbatim harness counters, key audit output lines, and
+replay instructions. The numbers below are bound to that artifact.
+
 **Protocol.** Two isolated Opus subagents, each in its own git worktree,
 received byte-identical work-item specs (a small `word_count.py` utility +
 unit test, work units w1/w2, and two planted out-of-scope improvements

--- a/_project/specs/todo-db-tracker.md
+++ b/_project/specs/todo-db-tracker.md
@@ -411,6 +411,29 @@ piped output. The spike is single-clone by construction — it validates the
 enforcement design (G2), not the shared-visibility goal, which still
 requires the hosted step after G1.
 
+**Post-eval improvements (2026-07-18, fourth round — schema v2).** The
+eval's tool findings were implemented TDD-first
+(`tests/unit/scripts/test_todo_db_v2.py`, 15 tests written red):
+
+- **Shared database across worktrees**: the default DB path now resolves
+  through `git rev-parse --git-common-dir`, so every worktree of a clone
+  shares the main repository's tracker (the eval exposed that per-worktree
+  DBs fragment state into invisible islands).
+- **Resume/recovery metadata**: `start` records `started_at`,
+  `started_worktree`, and `started_branch` on the work unit (`done` stamps
+  them implicitly if `start` was skipped, and never overwrites an earlier
+  stamp). The work order renders in-progress units as
+  `(resumable: branch X @ <worktree>, since T)`, so another agent can
+  locate and recover partial work after a dead session — verified live
+  across a real worktree pair. `start` is now explicitly optional for
+  single-sitting units.
+- **`check-scope` exempts `.todo-db/`** unconditionally (eval false
+  positive on stale-gitignore worktrees).
+- **`create --from -`** accepts a structured JSON payload on stdin as an
+  alternative to flag-soup item creation.
+- Schema v2 migration path: `connect` refuses an outdated DB with a
+  `todo migrate` hint; migrations are additive and idempotent.
+
 ## Head-to-head evaluation: legacy YAML vs DB tracker (2026-07-18)
 
 **Durable evidence:** `_project/audits/todo-db-eval-2026-07-18.md` — the

--- a/tests/unit/scripts/test_todo_db_v2.py
+++ b/tests/unit/scripts/test_todo_db_v2.py
@@ -1,0 +1,250 @@
+"""Tests for the tracker v2 improvements driven by the head-to-head eval.
+
+Covers (see _project/specs/todo-db-tracker.md, post-eval improvements):
+- shared database across git worktrees (resolve via the common git dir);
+- `check-scope` exempts the tracker's own state directory;
+- `start`/`done` record the worktree and branch so another agent can
+  resume or recover partial work, surfaced in the work order;
+- schema v1 -> v2 migration path (`todo migrate`);
+- `create --from -` JSON payload creation.
+
+Marked medium (not fast): the fast lane is budget-gated and several tests
+shell out to git.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import io
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+pytestmark = [
+    pytest.mark.unit,
+    pytest.mark.medium,
+]
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+
+
+def _load_script():
+    name = "todo_db_v2_under_test"
+    path = REPO_ROOT / "_project" / "scripts" / "todo_db.py"
+    spec = importlib.util.spec_from_file_location(name, path)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+todo_db = _load_script()
+
+
+def _git(cwd: Path, *args: str) -> str:
+    result = subprocess.run(
+        ["git", "-c", "user.email=t@t", "-c", "user.name=t", *args],
+        cwd=cwd,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return result.stdout.strip()
+
+
+@pytest.fixture()
+def git_repo(tmp_path):
+    """A real git repo with one linked worktree on its own branch."""
+    main = tmp_path / "main"
+    main.mkdir()
+    _git(main, "init", "-q", "-b", "trunk")
+    _git(main, "commit", "--allow-empty", "-q", "-m", "root")
+    _git(main, "worktree", "add", "-q", "-b", "feat-resume", str(tmp_path / "wt"))
+    return {"main": main, "worktree": tmp_path / "wt"}
+
+
+@pytest.fixture()
+def conn(tmp_path):
+    connection = todo_db.connect(tmp_path / "todo.sqlite")
+    yield connection
+    connection.close()
+
+
+def _mk(conn, item_id="resume-item", **overrides):
+    kwargs = {
+        "item_id": item_id,
+        "title": "A resumable tracked item",
+        "worktree": "spike",
+        "priority": "medium",
+        "description": "A description longer than ten characters.",
+        "work": [{"id": "w1", "summary": "first unit"}],
+    }
+    kwargs.update(overrides)
+    todo_db.create_item(conn, "tester", **kwargs)
+    return item_id
+
+
+class TestSharedDbAcrossWorktrees:
+    def test_worktree_resolves_to_main_repo_db(self, git_repo, monkeypatch):
+        monkeypatch.delenv("TODO_DB_PATH", raising=False)
+        expected = git_repo["main"] / ".todo-db" / "todo.sqlite"
+        monkeypatch.chdir(git_repo["worktree"])
+        assert todo_db.resolve_db_path(None).resolve() == expected.resolve()
+        monkeypatch.chdir(git_repo["main"])
+        assert todo_db.resolve_db_path(None).resolve() == expected.resolve()
+
+    def test_env_override_still_wins(self, git_repo, monkeypatch):
+        monkeypatch.setenv("TODO_DB_PATH", "/elsewhere/todo.sqlite")
+        monkeypatch.chdir(git_repo["worktree"])
+        assert todo_db.resolve_db_path(None) == Path("/elsewhere/todo.sqlite")
+
+
+class TestScopeSelfExemption:
+    def test_tracker_state_never_violates_scope(self):
+        rules = [{"kind": "only_modify", "path_glob": "src/*"}]
+        violations = todo_db.check_paths(
+            [".todo-db/todo.sqlite", ".todo-db/export/items.jsonl", "docs/x.md"],
+            rules,
+        )
+        assert violations == ["docs/x.md: outside only_modify allowlist"]
+
+    def test_tracker_state_ignored_even_under_do_not_modify(self):
+        rules = [{"kind": "do_not_modify", "path_glob": ".todo-db/*"}]
+        assert todo_db.check_paths([".todo-db/todo.sqlite"], rules) == []
+
+
+class TestResumeLocation:
+    def test_start_records_worktree_and_branch(self, conn, git_repo, monkeypatch):
+        monkeypatch.chdir(git_repo["worktree"])
+        _mk(conn)
+        todo_db.claim_item(conn, "alice", "resume-item")
+        todo_db.start_unit(conn, "alice", "resume-item", "w1")
+        unit = todo_db.get_item(conn, "resume-item")["work"][0]
+        assert unit["status"] == "in_progress"
+        assert unit["started_at"]
+        assert Path(unit["started_worktree"]).resolve() == git_repo["worktree"].resolve()
+        assert unit["started_branch"] == "feat-resume"
+
+    def test_done_without_start_stamps_location_implicitly(self, conn, git_repo, monkeypatch):
+        monkeypatch.chdir(git_repo["main"])
+        _mk(conn)
+        todo_db.claim_item(conn, "alice", "resume-item")
+        todo_db.done_unit(conn, "alice", "resume-item", "w1", "ran the checks")
+        unit = todo_db.get_item(conn, "resume-item")["work"][0]
+        assert unit["status"] == "done"
+        assert Path(unit["started_worktree"]).resolve() == git_repo["main"].resolve()
+        assert unit["started_branch"] == "trunk"
+
+    def test_done_after_start_keeps_original_location(self, conn, git_repo, monkeypatch):
+        monkeypatch.chdir(git_repo["worktree"])
+        _mk(conn)
+        todo_db.claim_item(conn, "alice", "resume-item")
+        todo_db.start_unit(conn, "alice", "resume-item", "w1")
+        monkeypatch.chdir(git_repo["main"])
+        todo_db.done_unit(conn, "bob", "resume-item", "w1", "finished elsewhere")
+        unit = todo_db.get_item(conn, "resume-item")["work"][0]
+        assert unit["started_branch"] == "feat-resume"
+
+    def test_work_order_surfaces_resume_info(self, conn, git_repo, monkeypatch, capsys):
+        monkeypatch.chdir(git_repo["worktree"])
+        _mk(conn)
+        todo_db.claim_item(conn, "alice", "resume-item")
+        todo_db.start_unit(conn, "alice", "resume-item", "w1")
+        order = todo_db.work_order(conn, "resume-item")
+        in_progress = [u for u in order["ready_units"] if u["status"] == "in_progress"]
+        assert in_progress and in_progress[0]["started_branch"] == "feat-resume"
+        todo_db._print_work_order(order)
+        printed = capsys.readouterr().out
+        assert "resumable" in printed
+        assert "feat-resume" in printed
+
+
+class TestSchemaMigration:
+    def _make_v1_db(self, tmp_path):
+        """Reconstruct a v1 database: current schema minus the v2 columns."""
+        import sqlite3
+
+        v1_sql = "\n".join(
+            line
+            for line in todo_db.SCHEMA_SQL.splitlines()
+            if "started_at" not in line and "started_worktree" not in line and "started_branch" not in line
+        )
+        db_path = tmp_path / "v1.sqlite"
+        raw = sqlite3.connect(db_path)
+        raw.executescript(v1_sql)
+        raw.execute("INSERT INTO meta (key, value) VALUES ('schema_version', '1')")
+        raw.commit()
+        raw.close()
+        return db_path
+
+    def test_connect_refuses_old_schema_with_migrate_hint(self, tmp_path):
+        db_path = self._make_v1_db(tmp_path)
+        with pytest.raises(todo_db.TodoError, match="migrate"):
+            todo_db.connect(db_path)
+
+    def test_migrate_upgrades_v1_to_current(self, tmp_path):
+        db_path = self._make_v1_db(tmp_path)
+        applied = todo_db.migrate_db(db_path)
+        assert applied  # at least one migration ran
+        conn = todo_db.connect(db_path)  # no longer refuses
+        columns = {row["name"] for row in conn.execute("PRAGMA table_info(work_units)")}
+        assert {"started_at", "started_worktree", "started_branch"} <= columns
+        conn.close()
+
+    def test_migrate_is_idempotent(self, tmp_path):
+        db_path = self._make_v1_db(tmp_path)
+        todo_db.migrate_db(db_path)
+        assert todo_db.migrate_db(db_path) == []
+
+    def test_migrate_command_registered(self):
+        assert "migrate" in todo_db._HANDLERS
+
+
+class TestCreateFromPayload:
+    PAYLOAD = {
+        "id": "payload-item",
+        "title": "Created from a JSON payload",
+        "worktree": "spike",
+        "priority": "high",
+        "description": "Structured creation without flag soup.",
+        "work": [
+            {"id": "w1", "summary": "implement the thing"},
+            {"id": "w2", "summary": "verify the thing", "needs": ["w1"]},
+        ],
+        "scope": {"only_modify": ["src/*"], "do_not_modify": ["docs/*"]},
+        "verifications": [{"description": "unit gate", "command": "true"}],
+        "preserves": ["existing behavior stays"],
+        "anti_patterns": [{"dont": "widen scope", "why": "risk", "instead": "defer it"}],
+        "prior_art": [{"path": "src/x.py", "concept": "pattern", "decision": "reuse"}],
+    }
+
+    def test_create_from_payload_roundtrip(self, conn):
+        todo_db.create_from_payload(conn, "tester", self.PAYLOAD)
+        item = todo_db.get_item(conn, "payload-item")
+        assert item["priority"] == "high"
+        assert [u["wid"] for u in item["work"]] == ["w1", "w2"]
+        assert item["work"][1]["needs"] == ["w1"]
+        assert {(s["kind"], s["path_glob"]) for s in item["scope"]} == {
+            ("only_modify", "src/*"),
+            ("do_not_modify", "docs/*"),
+        }
+        assert item["verifications"][0]["command"] == "true"
+        assert item["anti_patterns"][0]["instead"] == "defer it"
+        assert item["prior_art"][0]["decision"] == "reuse"
+
+    def test_create_from_payload_missing_required_field(self, conn):
+        payload = dict(self.PAYLOAD)
+        del payload["title"]
+        with pytest.raises(todo_db.TodoError, match="title"):
+            todo_db.create_from_payload(conn, "tester", payload)
+
+    def test_cli_create_from_stdin(self, tmp_path, monkeypatch, capsys):
+        db = str(tmp_path / "cli.sqlite")
+        monkeypatch.setattr(sys, "stdin", io.StringIO(json.dumps(self.PAYLOAD)))
+        assert todo_db.main(["--db", db, "--actor", "t", "create", "--from", "-"]) == 0
+        assert "payload-item" in capsys.readouterr().out


### PR DESCRIPTION
# Pull Request

## Description

Two related rounds on the DB tracker spike, sharing the eval as their pivot:

**1. Evaluation record (docs).** Adds a "Head-to-head evaluation" section to `_project/specs/todo-db-tracker.md` recording the controlled comparison of the legacy YAML TODO system vs the DB tracker: two isolated Opus subagents, byte-identical work-item specs (small utility + test + two planted out-of-scope follow-ups), differing only in assigned tracking system. Results: DB tracker used **−29% tokens** (61,091 vs 85,703) and **−28% tool calls** (36 vs 50) with a strictly better end state — per-unit evidence, recorded verification, both follow-ups promoted to visible planning items — while the YAML arm, executing its lifecycle near-flawlessly, still buried both follow-ups in a DONE file's `deferred[]` (invisible to `ready`/`list`), reproducing the motivating failure class (#1181/#1195/#1210) with a fully compliant agent. Durable evidence artifact committed at `_project/audits/todo-db-eval-2026-07-18.md` (exact prompts, verbatim harness counters, audit output lines, replay instructions; `develop_sha`-pinned per the audit-sha gate) after Codex review correctly flagged the numbers as unbound.

**2. Schema v2 — the eval's tool findings plus resume/recovery, TDD-first** (`tests/unit/scripts/test_todo_db_v2.py`, 15 tests written red, then green):

- **Resume metadata:** `start` records `started_at`/`started_worktree`/`started_branch` on the work unit; `done` stamps them implicitly if `start` was skipped and never overwrites an earlier stamp. Work orders render in-progress units as `(resumable: branch X @ <worktree>, since T)` so another agent can locate and recover partial work after a dead session. `start` is now explicitly optional in the skill.
- **Shared DB across worktrees:** default path resolves via `git rev-parse --git-common-dir` — the eval exposed that per-worktree DBs fragment state into invisible islands.
- **`check-scope`** unconditionally exempts `.todo-db/` (eval false positive on stale-gitignore worktrees).
- **`create --from -`** accepts a validated JSON payload on stdin as an alternative to flag-based creation.
- **Migration path:** schema v2 with `todo migrate`; `connect` refuses outdated DBs with the migrate hint; migrations additive and idempotent.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Documentation
- [ ] Refactor / chore

## Testing

`uv run -- python -m pytest tests/unit/scripts/test_todo_db.py tests/unit/scripts/test_todo_wrapper.py tests/unit/scripts/test_todo_db_v2.py -q` → **75 passed** (v2 suite covers shared-path resolution against a real git repo + linked worktree, scope self-exemption, location stamping on start/implicit-start/cross-worktree done, work-order resume rendering, v1→v2 migration incl. refusal-with-hint and idempotency, and payload creation via function and CLI stdin). `ruff check` clean. Live smoke across a real worktree pair verified the shared DB (no `.todo-db` created in the worktree) and the resumable line rendered from the other clone. New tests are `medium`-marked; the fast-lane count is unchanged.

## Public Contract Check

- [x] I updated `docs/reference/public-contracts.md`, or this PR does not change public, beta-public, deprecated, generated, experimental, or repo-only contract surfaces.
- [x] I checked result schema fields, MCP tool parameters, platform support status, wrapper facades, adapter subclassing hooks, and generated docs for contract-map impact.
- [x] Any platform/benchmark count claim in docs is generated/checked from registry metadata, or explicitly marked editorial/non-authoritative.

Internal `_project/scripts` tooling + spec/audit docs only; not shipped in the wheel.

## Documentation

- [x] I updated the relevant user-facing docs. (Spec's eval + round-4 sections; thin skill updated within its contract-tested budget.)
- [x] I added regression notes for behavior changes. (Migration path documented; existing spike DBs get the `todo migrate` hint.)
- [x] I confirmed API contract wording remains accurate.

## Code Quality

- [x] I ran formatting and lint/type checks.
- [x] I reviewed impacted modules for backwards compatibility and migration impact. (v1 spike DBs upgrade via `todo migrate`; fresh DBs create v2 directly.)
- [x] I added/updated tests for behavior changes and error paths.
- [x] I confirmed public contracts and release checklists are still valid.

## Artifact Hygiene

- [x] I did not commit raw screenshots, browser reports, generated logs, benchmark outputs, or temporary binary artifacts. (Eval worktrees and smoke worktree discarded; `.todo-db/` stays gitignored.)
- [x] Any committed binary/raw evidence file has durable repo value and is justified here with its consumer and size: the audit evidence file is compact Markdown (~9KB), consumed by the spec's eval section and the cutover decision.

## Notes

Reviewer focus: `_git_location`/`git_main_root` resolution (worktree vs main-clone semantics), the COALESCE stamping in `done_unit` (must never overwrite an earlier `start` stamp), and the migration runner. This PR grew from docs-only to docs+code when the round-4 implementation landed on the same designated branch; the eval evidence and the fixes it motivated land together, which is arguably the more reviewable unit anyway.