### PR TITLE
fix(explorer): bump build-contract EXPECTED_READ_MODEL_VERSION 3→4

### DIFF
--- a/results-explorer/scripts/explorer-build-contract.mjs
+++ b/results-explorer/scripts/explorer-build-contract.mjs
@@ -3,7 +3,7 @@ import { resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
 const EXPECTED_CONTRACT_VERSION = "4";
-export const EXPECTED_READ_MODEL_VERSION = 3;
+export const EXPECTED_READ_MODEL_VERSION = 4;
 const REQUIRED_FLAGS = ["--data-dir", "--output", "--trust-label", "--visibility"];
 const REQUIRED_OUTPUTS = ["results.duckdb", "bundles/{result_id}.json"];
 const REMOVED_LEGACY_OUTPUTS = [


### PR DESCRIPTION
## Description

`#1182` bumped `EXPLORER_READ_MODEL_VERSION` to 4 in `_project/scripts/explorer_pipeline/contract.py` and `EXPECTED_READ_MODEL_VERSION` in `results-explorer/src/db.ts` (for `results.physical_rendering_id`), but missed the matching constant in `results-explorer/scripts/explorer-build-contract.mjs`, which was left at 3. That script's own contract check then fails every browser-fixture generation and `Chromium` e2e run with `Explorer read-model version 3 expected, got 4`, since the real build now genuinely emits v4 snapshots. One-line fix: bump the constant to 4 to match.

## Type of Change

- [x] Bug fix

## Testing

- `node results-explorer/scripts/generate-browser-fixtures.mjs && node results-explorer/scripts/verify-browser-fixtures.mjs` — both pass (previously failed with the version-mismatch error).
- `npx vitest run src/lib/__tests__/db-remediation-pin.test.ts src/lib/__tests__/read-model-version-mismatch.test.ts` (from `results-explorer/`) — 10 passed.

## Public Contract Check

- [x] This PR does not change public, beta-public, deprecated, generated, experimental, or repo-only contract surfaces.
- [x] No result schema / MCP / platform-support / adapter-hook impact — internal build-contract constant only.
- [x] No platform/benchmark count claims changed.

## Documentation

- [x] No user-facing docs affected.
- [x] N/A — no behavior change beyond correcting the internal version-check constant to match reality.
- [x] N/A.

## Code Quality

- [x] No lint/type checks apply (plain constant edit); verified via the two commands above.
- [x] No backwards-compatibility impact — internal build tooling only.
- [x] Covered by the existing `read-model-version-mismatch.test.ts` / `db-remediation-pin.test.ts` suite plus the fixture-generation smoke run above.
- [x] N/A.

## Artifact Hygiene

- [x] No raw screenshots, browser reports, generated logs, benchmark outputs, or temporary binary artifacts committed.
- [x] N/A — no binary/raw evidence files.

## Notes

Split out of PR #1114 (branch-rename PR), which had picked up this pre-existing `develop` bug via a normal `develop` merge and carried a stray fix commit for it. No CODEOWNERS-gated paths touched — eligible for standard auto-merge.


---
_Generated by [Claude Code](https://claude.ai/code/session_01D5cPJRHok7vur6jxL3NBdZ)_