### PR TITLE
feat(todo): portability round — per-DB config, harness-neutral actors, self-teaching gate errors

### DIFF
--- a/_project/scripts/todo_db.py
+++ b/_project/scripts/todo_db.py
@@ -191,12 +191,42 @@ def utc_now() -> str:
     return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
 
 
+# Harness-neutral actor resolution: TODO_ACTOR is the universal override any
+# agent harness can set; the session vars cover known harnesses.
+ACTOR_ENV_VARS = ("TODO_ACTOR", "CLAUDE_SESSION_ID", "CODEX_SESSION_ID", "AGENT_SESSION_ID")
+
+
 def default_actor() -> str:
-    for var in ("TODO_ACTOR", "CLAUDE_SESSION_ID"):
+    for var in ACTOR_ENV_VARS:
         value = os.environ.get(var)
         if value:
             return value
     return f"{getpass.getuser()}@{socket.gethostname()}"
+
+
+# Per-database configuration, stored in `meta`. Convention-flavored lint rules
+# are opt-out so the tracker stays generic outside this project.
+CONFIG_KEYS: dict[str, tuple[str, ...]] = {
+    "lint.require_w0_revalidation": ("on", "off"),
+    "lint.require_scope_rules": ("on", "off"),
+}
+
+
+def get_config(conn: sqlite3.Connection, key: str) -> str:
+    if key not in CONFIG_KEYS:
+        raise TodoError(f"unknown config key {key!r}; known: {', '.join(sorted(CONFIG_KEYS))}")
+    row = conn.execute("SELECT value FROM meta WHERE key = ?", (key,)).fetchone()
+    return row["value"] if row else "on"
+
+
+def set_config(conn: sqlite3.Connection, actor: str, key: str, value: str) -> None:
+    if key not in CONFIG_KEYS:
+        raise TodoError(f"unknown config key {key!r}; known: {', '.join(sorted(CONFIG_KEYS))}")
+    if value not in CONFIG_KEYS[key]:
+        raise TodoError(f"config {key} accepts 'on' or 'off', got {value!r}")
+    with _write_txn(conn):
+        conn.execute("INSERT OR REPLACE INTO meta (key, value) VALUES (?, ?)", (key, value))
+        log_event(conn, actor, None, "config", {"key": key, "value": value})
 
 
 def git_root() -> Path:
@@ -398,7 +428,10 @@ def _lease_expired(claimed_at: str | None, ttl_hours: float) -> bool:
 
 def _transition(conn: sqlite3.Connection, item: sqlite3.Row, new_state: str) -> None:
     if (item["state"], new_state) not in TRANSITIONS:
-        raise TodoError(f"illegal transition {item['state']!r} -> {new_state!r} for {item['id']!r}")
+        hint = ""
+        if item["state"] == "planning" and new_state == "done":
+            hint = f"; claim it first via `todo claim {item['id']}`"
+        raise TodoError(f"illegal transition {item['state']!r} -> {new_state!r} for {item['id']!r}{hint}")
     conn.execute("UPDATE items SET state = ? WHERE id = ?", (new_state, item["id"]))
 
 
@@ -550,7 +583,11 @@ def claim_item(
             raise TodoError(f"{item_id!r} is {item['state']}; cannot claim")
         holder = item["claimed_by"]
         if holder and holder != actor and not _lease_expired(item["claimed_at"], ttl_hours):
-            raise TodoError(f"{item_id!r} is claimed by {holder!r} since {item['claimed_at']}")
+            raise TodoError(
+                f"{item_id!r} is claimed by {holder!r} since {item['claimed_at']};"
+                " expired leases release via `todo sweep-stale`,"
+                " or pick another item from `todo ready`"
+            )
         unmet = [
             row["needs_item"]
             for row in conn.execute(
@@ -560,7 +597,10 @@ def claim_item(
             )
         ]
         if unmet:
-            raise TodoError(f"{item_id!r} has unmet dependencies: {', '.join(unmet)}")
+            raise TodoError(
+                f"{item_id!r} has unmet dependencies: {', '.join(unmet)};"
+                " finish those first, or pick another item from `todo ready`"
+            )
         # BEGIN IMMEDIATE already serializes this block; the conditional
         # predicate + rowcount check is defense-in-depth so a future caller
         # that skips the txn still cannot silently overwrite a live claim.
@@ -607,7 +647,7 @@ def start_unit(conn: sqlite3.Connection, actor: str, item_id: str, wid: str) -> 
 
 def done_unit(conn: sqlite3.Connection, actor: str, item_id: str, wid: str, evidence: str) -> None:
     if not evidence or not evidence.strip():
-        raise TodoError("evidence is required to mark a work unit done")
+        raise TodoError('evidence is required to mark a work unit done; pass --evidence "<command run / commit / PR>"')
     with _write_txn(conn):
         _require_item(conn, item_id)
         _require_unit(conn, item_id, wid)
@@ -644,7 +684,10 @@ def _require_unit_needs_done(conn: sqlite3.Connection, item_id: str, wid: str) -
         )
     ]
     if unmet:
-        raise TodoError(f"{item_id}:{wid} needs unfinished units: {', '.join(unmet)}")
+        raise TodoError(
+            f"{item_id}:{wid} needs unfinished units: {', '.join(unmet)};"
+            f" finish them first via `todo done {item_id} <wid> --evidence ...`"
+        )
 
 
 def defer_work(
@@ -747,6 +790,11 @@ def _require_deferral(conn: sqlite3.Connection, deferral_id: int) -> sqlite3.Row
 def complete_item(conn: sqlite3.Connection, actor: str, item_id: str, pr: int | None) -> None:
     with _write_txn(conn):
         item = _require_item(conn, item_id)
+        # State legality first: "claim it" is more fundamental guidance than
+        # any unit-level detail on an item that was never started.
+        if item["state"] != "active":
+            hint = f"; claim it first via `todo claim {item_id}`" if item["state"] == "planning" else ""
+            raise TodoError(f"illegal transition {item['state']!r} -> 'done' for {item_id!r}{hint}")
         undone = [
             row["wid"]
             for row in conn.execute(
@@ -755,7 +803,10 @@ def complete_item(conn: sqlite3.Connection, actor: str, item_id: str, pr: int | 
             )
         ]
         if undone:
-            raise TodoError(f"cannot complete {item_id!r}: work units not done: {', '.join(undone)}")
+            raise TodoError(
+                f"cannot complete {item_id!r}: work units not done: {', '.join(undone)};"
+                f" mark each via `todo done {item_id} <wid> --evidence ...`"
+            )
         open_deferrals = [
             f"#{row['id']} {row['summary']}"
             for row in conn.execute(
@@ -765,11 +816,15 @@ def complete_item(conn: sqlite3.Connection, actor: str, item_id: str, pr: int | 
         ]
         if open_deferrals:
             raise TodoError(
-                f"cannot complete {item_id!r}: unresolved deferrals — promote or dismiss"
-                f" first: {'; '.join(open_deferrals)}"
+                f"cannot complete {item_id!r}: unresolved deferrals: {'; '.join(open_deferrals)};"
+                " resolve each via `todo promote <deferral-id> --to-item <slug>`"
+                ' or `todo dismiss <deferral-id> --reason "..."`'
             )
         if item["blocked_reason"]:
-            raise TodoError(f"cannot complete {item_id!r} while blocked: {item['blocked_reason']}")
+            raise TodoError(
+                f"cannot complete {item_id!r} while blocked: {item['blocked_reason']};"
+                f" clear it via `todo unblock {item_id}`"
+            )
         _transition(conn, item, "done")
         conn.execute(
             "UPDATE items SET completed_at = ?, completed_pr = ?, claimed_by = NULL, claimed_at = NULL WHERE id = ?",
@@ -788,7 +843,11 @@ def drop_item(conn: sqlite3.Connection, actor: str, item_id: str, reason: str) -
             (item_id,),
         ).fetchone()["n"]
         if open_deferrals:
-            raise TodoError(f"cannot drop {item_id!r}: {open_deferrals} unresolved deferral(s)")
+            raise TodoError(
+                f"cannot drop {item_id!r}: {open_deferrals} unresolved deferral(s);"
+                " resolve each via `todo promote <deferral-id> --to-item <slug>`"
+                ' or `todo dismiss <deferral-id> --reason "..."`'
+            )
         _transition(conn, item, "dropped")
         conn.execute("UPDATE items SET claimed_by = NULL, claimed_at = NULL WHERE id = ?", (item_id,))
         log_event(conn, actor, item_id, "drop", {"reason": reason})
@@ -1040,9 +1099,13 @@ def lint_item(conn: sqlite3.Connection, item_id: str) -> list[str]:
         findings.append("no verification steps recorded")
     elif not any(v["command"] for v in item["verifications"]):
         findings.append("verification steps exist but none has a runnable command")
-    if item["work"] and not item["scope"]:
+    if get_config(conn, "lint.require_scope_rules") == "on" and item["work"] and not item["scope"]:
         findings.append("has work units but no scope rules (only_modify/do_not_modify)")
-    if EVIDENCE_PIN_RE.search(item["description"] or "") and not any(unit["wid"] == "w0" for unit in item["work"]):
+    if (
+        get_config(conn, "lint.require_w0_revalidation") == "on"
+        and EVIDENCE_PIN_RE.search(item["description"] or "")
+        and not any(unit["wid"] == "w0" for unit in item["work"])
+    ):
         findings.append("description cites point-in-time evidence but has no w0 re-validation unit")
     if not item["work"] and item["state"] in ("planning", "active"):
         findings.append("no work breakdown")
@@ -1530,6 +1593,10 @@ def main(argv: list[str] | None = None) -> int:
 
     sub.add_parser("migrate", help="apply pending schema migrations to the database")
 
+    p = sub.add_parser("config", help="list, get, or set per-database configuration")
+    p.add_argument("key", nargs="?")
+    p.add_argument("value", nargs="?")
+
     p = sub.add_parser("export", help="deterministic JSONL + markdown index")
     p.add_argument("--out", default=None)
 
@@ -1868,6 +1935,18 @@ def _cmd_export(conn, actor, args):
     return 0
 
 
+def _cmd_config(conn, actor, args):
+    if args.key is None:
+        for key in sorted(CONFIG_KEYS):
+            print(f"{key}={get_config(conn, key)}")
+    elif args.value is None:
+        print(get_config(conn, args.key))
+    else:
+        set_config(conn, actor, args.key, args.value)
+        print(f"{args.key}={args.value}")
+    return 0
+
+
 def _cmd_migrate(conn, actor, args):
     # Reached only when the DB is already current (main() migrates before
     # connecting for this command); report the no-op for clarity.
@@ -1901,6 +1980,7 @@ _HANDLERS = {
     "sweep-stale": _cmd_sweep_stale,
     "export": _cmd_export,
     "migrate": _cmd_migrate,
+    "config": _cmd_config,
 }
 
 

--- a/_project/specs/todo-db-tracker.md
+++ b/_project/specs/todo-db-tracker.md
@@ -434,6 +434,23 @@ eval's tool findings were implemented TDD-first
 - Schema v2 migration path: `connect` refuses an outdated DB with a
   `todo migrate` hint; migrations are additive and idempotent.
 
+**Portability round (same day, TDD):** groundwork for using the tracker
+outside BenchBox and under non-Claude harnesses (Codex, etc.):
+
+- **Per-database config** (`todo config [key] [value]`, stored in `meta`):
+  the two BenchBox-convention lint rules (`lint.require_w0_revalidation`,
+  `lint.require_scope_rules`) are now opt-out per project, defaulting on.
+- **Harness-neutral actor chain**: `TODO_ACTOR` (universal override) →
+  `CLAUDE_SESSION_ID` → `CODEX_SESSION_ID` → `AGENT_SESSION_ID` →
+  `user@host`. Lease/claim mechanics are actor-based and harness-blind.
+- **Self-teaching gate errors**: every refusal now names its recovery
+  command (`todo done ... --evidence`, `todo promote`/`todo dismiss`,
+  `todo unblock`, `todo claim`, `todo sweep-stale`/`todo ready`), pinned
+  by tests — the error messages are the harness-portable instruction
+  layer, so an agent with no skill loaded is still steered by the CLI
+  itself. Gate ordering fixed so "claim it first" precedes unit-level
+  detail on never-started items.
+
 ## Head-to-head evaluation: legacy YAML vs DB tracker (2026-07-18)
 
 **Durable evidence:** `_project/audits/todo-db-eval-2026-07-18.md` — the

--- a/tests/unit/scripts/test_todo_db_v2.py
+++ b/tests/unit/scripts/test_todo_db_v2.py
@@ -248,3 +248,154 @@ class TestCreateFromPayload:
         monkeypatch.setattr(sys, "stdin", io.StringIO(json.dumps(self.PAYLOAD)))
         assert todo_db.main(["--db", db, "--actor", "t", "create", "--from", "-"]) == 0
         assert "payload-item" in capsys.readouterr().out
+
+
+class TestActorChain:
+    """The actor identity must be resolvable from any agent harness."""
+
+    def test_todo_actor_wins_over_harness_vars(self, monkeypatch):
+        monkeypatch.setenv("TODO_ACTOR", "neutral-actor")
+        monkeypatch.setenv("CLAUDE_SESSION_ID", "claude-session")
+        assert todo_db.default_actor() == "neutral-actor"
+
+    def test_non_claude_harness_session_var_is_recognized(self, monkeypatch):
+        for var in todo_db.ACTOR_ENV_VARS:
+            monkeypatch.delenv(var, raising=False)
+        monkeypatch.setenv("CODEX_SESSION_ID", "codex-session")
+        assert todo_db.default_actor() == "codex-session"
+
+    def test_fallback_is_user_at_host(self, monkeypatch):
+        for var in todo_db.ACTOR_ENV_VARS:
+            monkeypatch.delenv(var, raising=False)
+        assert "@" in todo_db.default_actor()
+
+
+class TestLintConfigGating:
+    """Project-convention lint rules must be per-database configuration."""
+
+    def _mk_pinned(self, conn):
+        todo_db.create_item(
+            conn,
+            "tester",
+            item_id="pinned-item",
+            title="Item citing point-in-time evidence",
+            worktree="spike",
+            priority="medium",
+            description="Behavior verified on develop @ fc31f3604 with a PASS run.",
+            work=[{"id": "w1", "summary": "first unit"}],
+        )
+
+    def test_convention_rules_default_on(self, conn):
+        self._mk_pinned(conn)
+        findings = todo_db.lint_item(conn, "pinned-item")
+        assert any("w0" in f for f in findings)
+        assert any("scope rules" in f for f in findings)
+
+    def test_rules_can_be_disabled_per_db(self, conn):
+        self._mk_pinned(conn)
+        todo_db.set_config(conn, "tester", "lint.require_w0_revalidation", "off")
+        todo_db.set_config(conn, "tester", "lint.require_scope_rules", "off")
+        findings = todo_db.lint_item(conn, "pinned-item")
+        assert not any("w0" in f for f in findings)
+        assert not any("scope rules" in f for f in findings)
+
+    def test_unknown_config_key_rejected(self, conn):
+        with pytest.raises(todo_db.TodoError, match="unknown config key"):
+            todo_db.set_config(conn, "tester", "lint.no_such_rule", "off")
+
+    def test_schema_version_not_settable_via_config(self, conn):
+        with pytest.raises(todo_db.TodoError, match="unknown config key"):
+            todo_db.set_config(conn, "tester", "schema_version", "99")
+
+    def test_invalid_value_rejected(self, conn):
+        with pytest.raises(todo_db.TodoError, match="on.*off|off.*on"):
+            todo_db.set_config(conn, "tester", "lint.require_w0_revalidation", "maybe")
+
+    def test_config_command_registered(self):
+        assert "config" in todo_db._HANDLERS
+
+
+class TestInstructiveGateErrors:
+    """Every gate refusal must name its recovery command — the error messages
+    are the harness-portable instruction layer."""
+
+    def _mk_flow(self, conn):
+        todo_db.create_item(
+            conn,
+            "tester",
+            item_id="gate-item",
+            title="Gate error message item",
+            worktree="spike",
+            priority="medium",
+            description="A description longer than ten characters.",
+            work=[
+                {"id": "w1", "summary": "first unit"},
+                {"id": "w2", "summary": "second unit", "needs": ["w1"]},
+            ],
+        )
+
+    def _err(self, fn, *args, **kwargs) -> str:
+        with pytest.raises(todo_db.TodoError) as excinfo:
+            fn(*args, **kwargs)
+        return str(excinfo.value)
+
+    def test_missing_evidence_names_flag(self, conn):
+        self._mk_flow(conn)
+        assert "--evidence" in self._err(todo_db.done_unit, conn, "t", "gate-item", "w1", " ")
+
+    def test_unfinished_needs_names_done_command(self, conn):
+        self._mk_flow(conn)
+        message = self._err(todo_db.done_unit, conn, "t", "gate-item", "w2", "evidence")
+        assert "todo done" in message
+
+    def test_complete_with_undone_units_names_done_command(self, conn):
+        self._mk_flow(conn)
+        todo_db.claim_item(conn, "t", "gate-item")
+        assert "todo done" in self._err(todo_db.complete_item, conn, "t", "gate-item", None)
+
+    def test_complete_with_open_deferral_names_both_commands(self, conn):
+        self._mk_flow(conn)
+        todo_db.claim_item(conn, "t", "gate-item")
+        todo_db.done_unit(conn, "t", "gate-item", "w1", "ok")
+        todo_db.done_unit(conn, "t", "gate-item", "w2", "ok")
+        todo_db.defer_work(conn, "t", "gate-item", "later", "reason")
+        message = self._err(todo_db.complete_item, conn, "t", "gate-item", None)
+        assert "todo promote" in message and "todo dismiss" in message
+
+    def test_drop_with_open_deferral_names_both_commands(self, conn):
+        self._mk_flow(conn)
+        todo_db.defer_work(conn, "t", "gate-item", "later", "reason")
+        message = self._err(todo_db.drop_item, conn, "t", "gate-item", "not needed")
+        assert "todo promote" in message and "todo dismiss" in message
+
+    def test_blocked_complete_names_unblock(self, conn):
+        self._mk_flow(conn)
+        todo_db.claim_item(conn, "t", "gate-item")
+        todo_db.done_unit(conn, "t", "gate-item", "w1", "ok")
+        todo_db.done_unit(conn, "t", "gate-item", "w2", "ok")
+        todo_db.block_item(conn, "t", "gate-item", "waiting")
+        assert "todo unblock" in self._err(todo_db.complete_item, conn, "t", "gate-item", None)
+
+    def test_live_claim_conflict_names_sweep_and_ready(self, conn):
+        self._mk_flow(conn)
+        todo_db.claim_item(conn, "alice", "gate-item")
+        message = self._err(todo_db.claim_item, conn, "bob", "gate-item")
+        assert "todo sweep-stale" in message and "todo ready" in message
+
+    def test_unmet_dependency_names_ready(self, conn):
+        self._mk_flow(conn)
+        todo_db.create_item(
+            conn,
+            "tester",
+            item_id="downstream-item",
+            title="Depends on the gate item",
+            worktree="spike",
+            priority="medium",
+            description="A description longer than ten characters.",
+            deps=["gate-item"],
+        )
+        assert "todo ready" in self._err(todo_db.claim_item, conn, "t", "downstream-item")
+
+    def test_complete_from_planning_names_claim(self, conn):
+        self._mk_flow(conn)
+        assert "todo claim" in self._err(todo_db.complete_item, conn, "t", "gate-item", None)


### PR DESCRIPTION
# Pull Request

## Description

Generalization groundwork so the DB tracker spike can be extracted for other projects and driven by non-Claude agent harnesses (Codex etc.), per the portability assessment recorded in the spec:

- **Per-database configuration**: `todo config [key] [value]`, stored in the existing `meta` table. The two BenchBox-convention lint rules (`lint.require_w0_revalidation`, `lint.require_scope_rules`) become opt-out per project, defaulting on; unknown keys and invalid values are rejected, and `schema_version` is not settable through this path.
- **Harness-neutral actor chain**: `TODO_ACTOR` (universal override) → `CLAUDE_SESSION_ID` → `CODEX_SESSION_ID` → `AGENT_SESSION_ID` → `user@host`. Lease/claim mechanics remain actor-based and harness-blind.
- **Self-teaching gate errors**: every lifecycle refusal now names its recovery command (`todo done … --evidence`, `todo promote`/`todo dismiss`, `todo unblock`, `todo claim`, `todo sweep-stale`/`todo ready`), pinned by tests — the error messages are the harness-portable instruction layer, so an agent with no skill loaded is still steered by the CLI itself.
- **Gate-order fix**: `complete` on a never-started item now says "claim it first" before any unit-level detail.

Spec updated with a "Portability round" subsection.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactor / chore

## Testing

TDD: 16 tests written red in `tests/unit/scripts/test_todo_db_v2.py` (actor chain, config gating incl. rejection paths, one instructive-error test per gate), all green after implementation. Full tracker/wrapper regression: `uv run -- python -m pytest tests/unit/scripts/ -k todo -q` → **101 passed** on current `develop`. `ruff check` clean. New tests are `medium`-marked (fast lane untouched).

## Public Contract Check

- [x] I updated `docs/reference/public-contracts.md`, or this PR does not change public, beta-public, deprecated, generated, experimental, or repo-only contract surfaces.
- [x] I checked result schema fields, MCP tool parameters, platform support status, wrapper facades, adapter subclassing hooks, and generated docs for contract-map impact.
- [x] Any platform/benchmark count claim in docs is generated/checked from registry metadata, or explicitly marked editorial/non-authoritative.

Internal `_project/scripts` tooling only; not shipped in the wheel.

## Documentation

- [x] I updated the relevant user-facing docs. (Spec's portability subsection; no user-facing product docs affected.)
- [x] I added regression notes for behavior changes. (Gate messages extended, one gate reordered — additive guidance; no behavioral contract broken, existing tests updated in place.)
- [x] I confirmed API contract wording remains accurate.

## Code Quality

- [x] I ran formatting and lint/type checks.
- [x] I reviewed impacted modules for backwards compatibility and migration impact. (No schema change; config keys live in the existing `meta` table.)
- [x] I added/updated tests for behavior changes and error paths.
- [x] I confirmed public contracts and release checklists are still valid.

## Artifact Hygiene

- [x] I did not commit raw screenshots, browser reports, generated logs, benchmark outputs, or temporary binary artifacts.
- [x] Any committed binary/raw evidence file has durable repo value and is justified here with its consumer and size: none.

## Notes

Reviewer focus: the gate-error wording (these strings are now load-bearing for harness portability and pinned by `TestInstructiveGateErrors`), and the `complete` gate reordering. Next portability step per the spec is extraction into a standalone package (needs a target repo) and per-harness instruction mirrors via skill-sync at G5.

---
_Generated by [Claude Code](https://claude.ai/code/session_01SVRhfdUVr5vgUfCZBKHaeb)_