### PR TITLE
chore(todo): log explorer cold-snapshot race + Chromium-blocking-gate gaps

### DIFF
--- a/_project/TODO/main/planning/chromium-blocking-suite-not-in-required-checks.yaml
+++ b/_project/TODO/main/planning/chromium-blocking-suite-not-in-required-checks.yaml
@@ -1,0 +1,85 @@
+id: "chromium-blocking-suite-not-in-required-checks"
+title: "Wire the Chromium full-suite e2e into the required merge gate — its job says 'blocking' but nothing enforces it"
+worktree: main
+priority: High
+status: Not Started
+category: Release Tooling
+
+description: |
+  Surfaced during the funding-chip work: PR #1091's "Chromium (full suite,
+  blocking)" job concluded `failure` at 12:24, and the PR squash-auto-merged at
+  12:29 anyway, landing a red browser suite on develop. The job name advertises
+  "blocking" but it is not wired into the required merge gate.
+
+  Evidence (read-only, captured 2026-07-10):
+    - The develop ruleset `develop-squash-only` (id 15611785) has exactly ONE
+      required status check: `ci-required-result`
+      (`gh api repos/joeharris76/BenchBox/rulesets/15611785`).
+    - `ci-required-result` (.github/workflows/pr.yml:949) aggregates only:
+      ci-paths, content-guard, code-lint, code-test, correctness-gate,
+      plan-capture-gate, medium-test, explorer-tokens, audit-sha, package-smoke,
+      dependency-audit, parity-check.
+    - The browser jobs — "Chromium (full suite, blocking)", WebKit @smoke,
+      Firefox @smoke — live in a SEPARATE workflow
+      (.github/workflows/results-explorer-browser.yml) and are NOT in that
+      aggregate's `needs:` list. So `ci-required-result` can be green while
+      Chromium is red, and auto-merge proceeds.
+
+  Scope note: WebKit and Firefox @smoke are INTENTIONALLY advisory today
+  (`continue-on-error: true`), tracked separately by
+  graduate-browser-smoke-to-blocking-gates. This item is specifically about the
+  Chromium FULL suite, which is named "blocking" and is meant to gate merges but
+  does not. Shared root cause with auto-merge-review-gate-admin-enforcement (the
+  develop ruleset is under-configured), but a distinct remediation: that item
+  targets require_code_owner_review for soundness paths and deliberately
+  excludes status-check wiring; this item targets the required status-check set.
+
+  Caveat to design around: the browser workflow is path-gated, so it does not
+  run on every PR. Whatever wiring is chosen must make a code-only PR that does
+  not touch explorer paths still able to merge (the aggregate must treat a
+  correctly-skipped Chromium job as pass, not pending/fail) — mirror the
+  existing `ci-required-result` skip-handling for path-gated jobs rather than
+  hard-requiring the raw job in the ruleset.
+
+success_metrics:
+  - "A PR whose 'Chromium (full suite, blocking)' job concludes failure cannot squash-auto-merge (verified with a throwaway red PR)."
+  - "A code-only PR that does not trigger the browser workflow still merges on CI-pass (correct skip = pass, not a stuck-pending gate)."
+  - "The wiring is self-healing / drift-checked so removing Chromium from the gate turns a required job red rather than silently regressing."
+
+work:
+  - id: w1
+    summary: "Confirm the gap live and decide the wiring point (aggregate job vs ruleset required-checks)"
+    status: pending
+    needs: []
+    notes: |
+      Re-read the develop ruleset required_status_checks and ci-required-result's
+      needs list. Decide between: (a) add the Chromium full-suite job to
+      ci-required-result's needs + aggregation with correct skip-as-pass
+      handling (keeps one roll-up check in the ruleset — preferred, matches the
+      existing pattern); or (b) add the Chromium context directly to the ruleset
+      required_status_checks (admin action, and must handle path-skip). Record
+      the choice and why in the PR body.
+
+  - id: w2
+    summary: "Implement the chosen wiring so a red Chromium full suite blocks merge"
+    status: pending
+    needs: [w1]
+    notes: |
+      If (a): extend .github/workflows/pr.yml ci-required-result to consume the
+      Chromium full-suite result across workflows (workflow_run or a reusable
+      job), treating 'skipped' (path-gated off) as pass and 'failure' as fail.
+      If (b): the ruleset PUT is a deferred admin action (see deferred).
+
+  - id: w3
+    summary: "Regression/drift guard + verify end-to-end"
+    status: pending
+    needs: [w2]
+    notes: |
+      Add a drift check (model on the existing pr.yml gh-api ruleset/aggregate
+      drift steps) that fails if the Chromium full suite ever falls out of the
+      required set. Verify with a throwaway PR that forces a Chromium failure and
+      confirm it cannot merge, and that a non-explorer code-only PR still can.
+
+deferred:
+  - summary: "If wiring via the ruleset (option b): apply the develop ruleset required_status_checks change to include the Chromium gate."
+    reason: "Requires a repo admin (gh api PUT on the ruleset); an agent PR cannot change branch protection. Only needed if w1 chooses option (b) over the aggregate-job approach."

--- a/_project/TODO/main/planning/explorer-cold-snapshot-zero-row-race.yaml
+++ b/_project/TODO/main/planning/explorer-cold-snapshot-zero-row-race.yaml
@@ -1,0 +1,87 @@
+id: "explorer-cold-snapshot-zero-row-race"
+title: "Fix results-explorer cold-snapshot zero-row race (keyed lookups return empty on a cold HTTP-backed DuckDB snapshot)"
+worktree: main
+priority: Medium
+status: Not Started
+category: Testing and Quality Assurance
+
+description: |
+  Surfaced during the funding-chip work (PRs #1091, #1105). Results-explorer
+  e2e tests intermittently fail with `No result found for "<real-id>"` (or a
+  heading like `TPC-H Results` / `TPC-H - DuckDB` never becoming visible) on a
+  result id that genuinely exists in the corpus.
+
+  Root cause (verified, NOT an id-churn / fixture bug):
+    - The id is present. Regenerating the corpus with
+      `npm run test:e2e:fixtures` and querying the snapshot shows the row in
+      both `bench.results` and `bench.result_detail_metrics`.
+    - `queryRows` (results-explorer/src/db.ts) does NOT swallow errors, so this
+      is a genuine ZERO-ROW read, not a masked exception, and the snapshot HTTP
+      fetch is 200 OK (confirmed from the CI Playwright trace's network log).
+    - `getResultDetailMetrics` / the index queries run `WHERE result_id = ?`
+      against a cold, partially-fetched HTTP-backed `results.duckdb`. The
+      readiness probe `waitForSnapshotRows` / `validateAttachedSnapshot`
+      (src/db.ts) only does `SELECT <col> FROM <view> LIMIT 1` per required
+      view, which a cold snapshot can satisfy while a keyed lookup on the same
+      view still returns nothing.
+    - A zero-row detail result is then rendered as a TERMINAL "No result found"
+      with no retry (ResultDetail.tsx: `if (data === null) setError(...)`).
+
+  Where it bites: the FIRST page load after a fresh build (local ~40s cold vs
+  ~9s warm; warm re-runs 3/3 clean). CI is always cold, so CI is where it shows
+  — especially the WebKit `@smoke` lane (slowest engine, smoke-only, so its
+  first test always eats the cold start) and the first snapshot-hitting spec in
+  the Chromium full suite. Re-running the identical commit passes. A real user
+  deep-linking a detail URL against a cold CDN cache can hit the same thing.
+
+  Key files:
+    - results-explorer/src/db.ts — waitForSnapshotRows / SNAPSHOT_READY_SCANS
+      (probe is existence-only, not keyed); queryRows (retry wrapper, only
+      retries isTransientDuckDbSnapshotError, not a cold zero-row read).
+    - results-explorer/src/lib/duckdbQueries.ts — getResultDetailMetrics,
+      getPlatformIndexRows (the keyed lookups that come back empty).
+    - results-explorer/src/pages/ResultDetail.tsx — renders null as a terminal
+      "No result found" with no retry.
+
+  Related project memory: project_explorer_cold_snapshot_race. Same
+  develop-red-from-flakes churn family as the auto-revert misattribution note.
+
+success_metrics:
+  - "results-explorer e2e (all engines, cold first-load in CI) is green across 10 consecutive runs with no 'No result found' / heading-timeout flake"
+  - "A cold zero-row keyed lookup is either prevented by the readiness gate or retried, never rendered as a terminal 'No result found' for an id that exists in the snapshot"
+
+work:
+  - id: w1
+    summary: "Reproduce deterministically: force a cold snapshot and assert the keyed-lookup zero-row window"
+    status: pending
+    needs: []
+    notes: |
+      Add a focused test (or a throttled-fetch harness) that attaches a cold
+      HTTP-backed snapshot and shows `SELECT ... LIMIT 1` on a required view
+      succeeding while `WHERE result_id = ?` on the same view returns 0 rows in
+      the same window. This pins the defect independently of wall-clock timing.
+
+  - id: w2
+    summary: "Make the readiness gate keyed, or make a cold zero-row read retryable"
+    status: pending
+    needs: [w1]
+    notes: |
+      Two candidate fixes (pick one, document why in the PR):
+      (a) Strengthen waitForSnapshotRows to do a keyed probe (or a COUNT that
+          cannot be satisfied from metadata) so the DB instance is not exposed
+          until keyed lookups resolve; or
+      (b) Treat a cold zero-row keyed read as transient in getDetailResult /
+          getResultDetailMetrics and retry a bounded number of times before
+          concluding null, so a real id is never rendered as "No result found"
+          during the cold window.
+      Do NOT weaken the genuine not-found path — an id that truly is absent must
+      still surface "No result found" promptly.
+
+  - id: w3
+    summary: "Regression coverage + reassess graduating WebKit/Firefox smoke to blocking"
+    status: pending
+    needs: [w2]
+    notes: |
+      Add the w1 repro as a standing regression test. Once green, this unblocks
+      (or de-risks) graduate-browser-smoke-to-blocking-gates, whose 10-green
+      criterion this flake was defeating on the WebKit lane.


### PR DESCRIPTION
Two deferred follow-ups surfaced during the funding-chip work (PRs #1091,
#1105), neither previously tracked:

- explorer-cold-snapshot-zero-row-race: results-explorer e2e intermittently
  reports "No result found" for a real id. Root-caused to a cold HTTP-backed
  DuckDB snapshot returning zero rows on a keyed lookup while the existence-only
  readiness probe passes; rendered as a terminal not-found with no retry. Bites
  cold first-load (CI, WebKit @smoke). Not an id-churn/fixture bug.

- chromium-blocking-suite-not-in-required-checks: the "Chromium (full suite,
  blocking)" job is not wired into the required merge gate. The develop ruleset
  requires only ci-required-result, whose aggregation (pr.yml:949) omits the
  browser workflow, so #1091 auto-merged with Chromium red. Distinct remediation
  from auto-merge-review-gate-admin-enforcement (which scopes to code-owner
  review); cross-referenced.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
