### PR TITLE
chore(todo): add guardrails to explorer CI follow-up TODOs (post /todo review)

### DIFF
--- a/_project/TODO/main/planning/chromium-blocking-suite-not-in-required-checks.yaml
+++ b/_project/TODO/main/planning/chromium-blocking-suite-not-in-required-checks.yaml
@@ -15,10 +15,11 @@ description: |
     - The develop ruleset `develop-squash-only` (id 15611785) has exactly ONE
       required status check: `ci-required-result`
       (`gh api repos/joeharris76/BenchBox/rulesets/15611785`).
-    - `ci-required-result` (.github/workflows/pr.yml:949) aggregates only:
-      ci-paths, content-guard, code-lint, code-test, correctness-gate,
-      plan-capture-gate, medium-test, explorer-tokens, audit-sha, package-smoke,
-      dependency-audit, parity-check.
+    - the `ci-required-result:` job in .github/workflows/pr.yml (grep the job
+      key, not a line number — it drifts) aggregates only these via its
+      `needs:` list: ci-paths, content-guard, code-lint, code-test,
+      correctness-gate, plan-capture-gate, medium-test, explorer-tokens,
+      audit-sha, package-smoke, dependency-audit, parity-check.
     - The browser jobs — "Chromium (full suite, blocking)", WebKit @smoke,
       Firefox @smoke — live in a SEPARATE workflow
       (.github/workflows/results-explorer-browser.yml) and are NOT in that
@@ -47,18 +48,34 @@ success_metrics:
   - "The wiring is self-healing / drift-checked so removing Chromium from the gate turns a required job red rather than silently regressing."
 
 work:
-  - id: w1
-    summary: "Confirm the gap live and decide the wiring point (aggregate job vs ruleset required-checks)"
+  - id: w0
+    summary: "Re-validate the gap live and commit a compact evidence summary"
     status: pending
     needs: []
     notes: |
-      Re-read the develop ruleset required_status_checks and ci-required-result's
-      needs list. Decide between: (a) add the Chromium full-suite job to
-      ci-required-result's needs + aggregation with correct skip-as-pass
-      handling (keeps one roll-up check in the ruleset — preferred, matches the
-      existing pattern); or (b) add the Chromium context directly to the ruleset
-      required_status_checks (admin action, and must handle path-skip). Record
-      the choice and why in the PR body.
+      The description's evidence (ruleset id 15611785, the ci-required-result
+      needs list, the browser jobs living in a separate workflow) was captured
+      2026-07-10 and can drift. Before designing, re-capture and record a compact
+      summary (command + result, not raw dumps) in the implementing PR body:
+        gh api repos/joeharris76/BenchBox/rulesets/15611785 \
+          --jq '.rules[]|select(.type=="required_status_checks")|.parameters.required_status_checks[].context'
+        # confirm it still lists only ci-required-result (or note what changed)
+      Then confirm the browser suite is still absent from ci-required-result's
+      needs list in .github/workflows/pr.yml, and that the browser jobs are still
+      in .github/workflows/results-explorer-browser.yml. If the gap is already
+      closed, mark this item Completed with the evidence and stop.
+
+  - id: w1
+    summary: "Decide the wiring point (aggregate job vs ruleset required-checks)"
+    status: pending
+    needs: [w0]
+    notes: |
+      Decide between: (a) add the Chromium full-suite job to ci-required-result's
+      needs + aggregation with correct skip-as-pass handling (keeps one roll-up
+      check in the ruleset — preferred, matches the existing pattern); or (b) add
+      the Chromium context directly to the ruleset required_status_checks (admin
+      action, and must handle path-skip). Record the choice and why in the PR
+      body.
 
   - id: w2
     summary: "Implement the chosen wiring so a red Chromium full suite blocks merge"
@@ -79,6 +96,32 @@ work:
       drift steps) that fails if the Chromium full suite ever falls out of the
       required set. Verify with a throwaway PR that forces a Chromium failure and
       confirm it cannot merge, and that a non-explorer code-only PR still can.
+
+must_preserve:
+  - "A code-only PR that does not trigger the browser workflow must still be able to merge - a correctly-skipped Chromium job counts as pass, never as pending/fail. This is the load-bearing constraint; getting it wrong wedges every non-explorer PR."
+  - "The existing ci-required-result skip-as-pass handling for path-gated jobs (ci-paths gating) is the model; do not regress it while extending it."
+
+anti_patterns:
+  - "Do NOT hard-require the raw 'Chromium (full suite, blocking)' context in the ruleset without skip handling - it turns every path-skipped PR into a permanently-pending required check that can never merge."
+  - "Do NOT make the browser workflow run on every PR just to satisfy the gate - that inflates CI time on Python-only changes; keep it path-gated and handle the skip in the aggregate."
+
+verification:
+  - description: "The aggregate now fails when the Chromium full suite fails (option a)"
+    command: "gh api repos/joeharris76/BenchBox/actions/workflows/pr.yml # inspect ci-required-result needs, or run a throwaway PR with a forced Chromium failure"
+    expected_output: "ci-required-result concludes failure when Chromium (full suite, blocking) fails; PR cannot squash-auto-merge"
+  - description: "A non-explorer, code-only PR still reaches mergeable (skip = pass)"
+    command: "open a docs- or python-only PR and confirm ci-required-result is green with the browser suite skipped"
+    expected_output: "mergeable; ci-required-result green; browser jobs skipped, not pending"
+  - description: "Drift guard fails if the Chromium gate is removed"
+    command: "uv run -- python -m pytest tests/unit/release/ -k 'required_checks or ci_required' -q # (new test added by w3)"
+    expected_output: "asserts Chromium full suite is in the required aggregate; red if it is ever dropped"
+
+scope_limit:
+  only_modify:
+    - ".github/workflows/pr.yml"
+    - ".github/workflows/results-explorer-browser.yml"
+    - "tests/unit/release/"
+    - "docs/"
 
 deferred:
   - summary: "If wiring via the ruleset (option b): apply the develop ruleset required_status_checks change to include the Chromium gate."

--- a/_project/TODO/main/planning/explorer-cold-snapshot-zero-row-race.yaml
+++ b/_project/TODO/main/planning/explorer-cold-snapshot-zero-row-race.yaml
@@ -85,3 +85,39 @@ work:
       Add the w1 repro as a standing regression test. Once green, this unblocks
       (or de-risks) graduate-browser-smoke-to-blocking-gates, whose 10-green
       criterion this flake was defeating on the WebKit lane.
+
+approach: |
+  Fix inside results-explorer/src/db.ts, not in the tests. The e2e "No result
+  found" symptom is downstream of the readiness contract: prefer making the gate
+  keyed (w2 option a) over papering over it with retries, unless a keyed probe is
+  shown to be too slow on cold CDN loads. Reuse the existing transient-retry
+  machinery (isTransientDuckDbSnapshotError, QUERY_RETRY_ATTEMPTS,
+  SNAPSHOT_READY_ATTEMPTS) rather than inventing a second retry path.
+
+must_preserve:
+  - "A genuinely-absent result id still surfaces 'No result found' promptly - the fix must not turn a real not-found into an indefinite spinner or a swallowed error."
+  - "queryRows keeps THROWING on non-transient errors; do not broaden the transient-error classifier to hide real query failures."
+  - "Warm-load latency does not regress: the readiness gate must not add a blocking keyed probe to the steady-state path once the snapshot is hot."
+
+verification:
+  - description: "The new cold-window repro (w1) fails on develop HEAD and passes after the fix"
+    command: "cd results-explorer && npx vitest run src/lib/__tests__/db.test.ts"
+    expected_output: "the cold zero-row keyed-lookup assertion is present and green"
+  - description: "Full explorer e2e is green cold (fresh build, single worker = worst-case cold path)"
+    command: "cd results-explorer && npm run test:e2e:chromium"
+    expected_output: "0 failed; no 'No result found' or heading toBeVisible timeout"
+  - description: "Existing readiness/version-guard unit tests still pass"
+    command: "cd results-explorer && npx vitest run src/lib/__tests__/read-model-version-mismatch.test.ts"
+    expected_output: "all pass"
+
+scope_limit:
+  only_modify:
+    - "results-explorer/src/db.ts"
+    - "results-explorer/src/lib/duckdbQueries.ts"
+    - "results-explorer/src/pages/ResultDetail.tsx"
+    - "results-explorer/src/lib/__tests__/"
+    - "results-explorer/e2e/"
+
+anti_patterns:
+  - "Do NOT 'fix' this by raising Playwright timeouts or adding sleeps in the specs - that hides the readiness defect and leaves real users exposed on cold CDN loads."
+  - "Do NOT mark the id as missing/dangling and regenerate fixtures - the id is present; this is a readiness race, not a corpus bug (see project_explorer_cold_snapshot_race)."


### PR DESCRIPTION
Follow-up to #1217, which merged the two follow-up TODOs before their review
fixes landed. Adds the Required-finding fixes from the five-axis /todo review
(guardrails axis was the weak point on both):

- Both gained a runnable `verification:` block, `scope_limit.only_modify`,
  structured `must_preserve:`, and risk-only `anti_patterns:`.
- explorer-cold-snapshot-zero-row-race: elevated "don't weaken the genuine
  not-found path" from w2 prose to must_preserve; added an `approach:` pointing
  the fix at db.ts's existing retry machinery.
- chromium-blocking-suite-not-in-required-checks: replaced the fragile
  `pr.yml:949` line-number citation with a grep-the-job-key anchor; added a w0
  re-validation unit that re-captures the ruleset/aggregate evidence and commits
  a compact summary (freshness-durability sub-axis).

Both validate; check-graph clean.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
