### PR TITLE
feat(todo-db): hosted backend (Turso/libsql embedded replica) — close G1/G3

### DIFF
--- a/_project/scripts/pyproject.toml
+++ b/_project/scripts/pyproject.toml
@@ -20,6 +20,7 @@ dependencies = [
     # regardless of writer version (kept in sync with the root manifest).
     "duckdb>=1.0.0,<2.0.0",
     "jsonschema>=4.25.1", # validate_todo.py: Draft7Validator
+    "libsql>=0.1.11", # todo_db.py: hosted backend (Turso embedded replica)
     "pyyaml>=6.0.0", # todo_cli.py + validate_todo.py: yaml.safe_load
     "ruamel-yaml>=0.19.1", # todo_cli.py: YAML() for structure-preserving edits (done command)
     "sqlglot>=25.6.0,<31.0.0",

--- a/_project/scripts/todo_db.py
+++ b/_project/scripts/todo_db.py
@@ -1,22 +1,32 @@
 #!/usr/bin/env python3
-"""todo_db.py - Local-SQLite spike of the DB-backed TODO tracker.
+"""todo_db.py - DB-backed TODO tracker (local SQLite or hosted libsql/Turso).
 
-Implements the G2 gate of _project/specs/todo-db-tracker.md against a local
-SQLite file so the approach can be evaluated end-to-end without provisioning
-a hosted database. The CLI is the only sanctioned write path; every
-lifecycle invariant lives in code here, not in skill prose.
+Implements the G2 gate of _project/specs/todo-db-tracker.md. The CLI is the
+only sanctioned write path; every lifecycle invariant lives in code here, not
+in skill prose.
 
 Usage:
     uv run --project _project/scripts -- python _project/scripts/todo_db.py <command> ...
 
-Default database path: <git root>/.todo-db/todo.sqlite (gitignored).
-Override with --db PATH or the TODO_DB_PATH environment variable.
+Backend selection (first match wins):
+- --db PATH_OR_URL          explicit; libsql:// or https:// selects hosted
+- TODO_DB_PATH              local SQLite file (also what tests use)
+- TODO_DB_URL               hosted libsql database (Turso); requires
+                            TODO_DB_AUTH_TOKEN; embedded replica at
+                            <git main root>/.todo-db/replica.db
+                            (override: TODO_DB_REPLICA)
+- default                   <git main root>/.todo-db/todo.sqlite (gitignored)
+
+Hosted mode keeps the exact write-transaction discipline of local mode:
+BEGIN IMMEDIATE write transactions are delegated statement-by-statement to
+the primary, so check-then-act gates serialize against every other writer.
+On sync failure, reads degrade to the stale replica with a banner; writes
+fail loudly (no offline queue, by design).
 
 Spike deviations from the spec DDL (recorded in the spec's spike section):
 - `items.category` column added (nullable) so the importer is lossless.
 - scope-rule matching uses fnmatch semantics ('*' crosses '/'), which is
   slightly more permissive than the final glob contract.
-- No network/degraded-mode layer: the database is a local file.
 """
 
 from __future__ import annotations
@@ -269,6 +279,33 @@ def resolve_db_path(explicit: str | None) -> Path:
     return git_main_root() / ".todo-db" / "todo.sqlite"
 
 
+def _is_hosted_url(value: str) -> bool:
+    return value.startswith(("libsql://", "https://", "http://"))
+
+
+def resolve_backend(explicit: str | None) -> Path | str:
+    """Pick the database backend: a Path (local SQLite) or a URL (hosted).
+
+    Precedence: --db > TODO_DB_PATH > TODO_DB_URL > default local path.
+    TODO_DB_PATH outranks TODO_DB_URL deliberately: a test or tool that pins
+    a local file must never be silently redirected at the shared database.
+    """
+    if explicit:
+        return explicit if _is_hosted_url(explicit) else Path(explicit)
+    env_path = os.environ.get("TODO_DB_PATH")
+    if env_path:
+        return Path(env_path)
+    env_url = os.environ.get("TODO_DB_URL")
+    if env_url:
+        return env_url
+    return git_main_root() / ".todo-db" / "todo.sqlite"
+
+
+def hosted_replica_path() -> Path:
+    env = os.environ.get("TODO_DB_REPLICA")
+    return Path(env) if env else git_main_root() / ".todo-db" / "replica.db"
+
+
 def _git_location() -> tuple[str | None, str | None]:
     """(worktree toplevel, branch) of the CWD, for resume/recovery stamps."""
 
@@ -279,16 +316,7 @@ def _git_location() -> tuple[str | None, str | None]:
     return _out("rev-parse", "--show-toplevel"), _out("rev-parse", "--abbrev-ref", "HEAD")
 
 
-def connect(db_path: Path) -> sqlite3.Connection:
-    db_path.parent.mkdir(parents=True, exist_ok=True)
-    conn = sqlite3.connect(db_path)
-    conn.row_factory = sqlite3.Row
-    # Autocommit mode: every multi-statement write goes through _write_txn,
-    # which takes the write lock up front (BEGIN IMMEDIATE) so check-then-act
-    # gates cannot race a concurrent writer.
-    conn.isolation_level = None
-    conn.execute("PRAGMA foreign_keys = ON")
-    conn.execute("PRAGMA busy_timeout = 5000")
+def _ensure_schema(conn: sqlite3.Connection) -> None:
     version = _schema_version(conn)
     if version is None:
         conn.executescript(SCHEMA_SQL)
@@ -302,7 +330,333 @@ def connect(db_path: Path) -> sqlite3.Connection:
         )
     elif version > SCHEMA_VERSION:
         raise TodoError(f"database schema_version={version} is newer than this CLI ({SCHEMA_VERSION}); use a newer CLI")
+
+
+def connect(db_path: Path) -> sqlite3.Connection:
+    db_path.parent.mkdir(parents=True, exist_ok=True)
+    conn = sqlite3.connect(db_path)
+    conn.row_factory = sqlite3.Row
+    # Autocommit mode: every multi-statement write goes through _write_txn,
+    # which takes the write lock up front (BEGIN IMMEDIATE) so check-then-act
+    # gates cannot race a concurrent writer.
+    conn.isolation_level = None
+    conn.execute("PRAGMA foreign_keys = ON")
+    conn.execute("PRAGMA busy_timeout = 5000")
+    _ensure_schema(conn)
     return conn
+
+
+# ---------------------------------------------------------------------------
+# Hosted backend (Turso / libsql embedded replica)
+#
+# The libsql Python client is close to sqlite3 but not close enough (observed
+# live against Turso, libsql==0.1.11): rows are plain tuples with no
+# row_factory, cursors are not iterable, and constraint violations surface as
+# ValueError (locally "UNIQUE constraint failed: ...", remotely wrapped in
+# Hrana text with code SQLITE_CONSTRAINT). The adapter below closes exactly
+# those gaps so every code path above runs unchanged on either backend.
+
+
+class _HostedRow:
+    """sqlite3.Row stand-in: index + name access, dict(row) via keys()."""
+
+    __slots__ = ("_names", "_values")
+
+    def __init__(self, names: list[str], values: tuple):
+        self._names = names
+        self._values = values
+
+    def __getitem__(self, key):
+        if isinstance(key, str):
+            try:
+                return self._values[self._names.index(key)]
+            except ValueError:
+                raise IndexError(f"no such column: {key}") from None
+        return self._values[key]
+
+    def keys(self) -> list[str]:
+        return list(self._names)
+
+    def __iter__(self):
+        return iter(self._values)
+
+    def __len__(self) -> int:
+        return len(self._values)
+
+    def __repr__(self) -> str:
+        return f"_HostedRow({dict(zip(self._names, self._values))!r})"
+
+
+def _map_hosted_error(exc: BaseException) -> sqlite3.Error | None:
+    """Translate libsql's ValueError surface back onto sqlite3 exceptions."""
+    message = str(exc)
+    if "constraint" in message.lower():
+        return sqlite3.IntegrityError(message)
+    return None
+
+
+class _HostedCursor:
+    def __init__(self, raw):
+        self._raw = raw
+
+    def _wrap(self, values) -> _HostedRow | None:
+        if values is None:
+            return None
+        names = [column[0] for column in (self._raw.description or [])]
+        return _HostedRow(names, tuple(values))
+
+    def fetchone(self) -> _HostedRow | None:
+        return self._wrap(self._raw.fetchone())
+
+    def fetchall(self) -> list[_HostedRow]:
+        return [self._wrap(values) for values in self._raw.fetchall()]
+
+    def __iter__(self):
+        while True:
+            row = self.fetchone()
+            if row is None:
+                return
+            yield row
+
+    @property
+    def lastrowid(self):
+        return self._raw.lastrowid
+
+    @property
+    def rowcount(self):
+        return self._raw.rowcount
+
+
+class _HostedConnection:
+    """Duck-typed subset of sqlite3.Connection over the libsql client."""
+
+    def __init__(self, raw):
+        self._raw = raw
+
+    def execute(self, sql: str, params=()) -> _HostedCursor:
+        try:
+            return _HostedCursor(self._raw.execute(sql, tuple(params)))
+        except ValueError as exc:
+            mapped = _map_hosted_error(exc)
+            if mapped is not None:
+                raise mapped from exc
+            raise
+
+    def executescript(self, sql: str) -> None:
+        try:
+            self._raw.executescript(sql)
+        except ValueError as exc:
+            mapped = _map_hosted_error(exc)
+            if mapped is not None:
+                raise mapped from exc
+            raise
+
+    def commit(self) -> None:
+        self._raw.commit()
+
+    def rollback(self) -> None:
+        self._raw.rollback()
+
+    def close(self) -> None:
+        self._raw.close()
+
+    def sync(self) -> None:
+        self._raw.sync()
+
+
+def _redacted(exc: BaseException, secret: str) -> str:
+    return str(exc).replace(secret, "<redacted>") if secret else str(exc)
+
+
+def _hosted_raw_connect(url: str, sync_required: bool) -> _HostedConnection:
+    token = os.environ.get("TODO_DB_AUTH_TOKEN") or ""
+    if not token:
+        raise TodoError("hosted tracker: set TODO_DB_AUTH_TOKEN when TODO_DB_URL points at a remote database")
+    try:
+        import libsql  # deferred: only hosted mode needs it
+    except ImportError as exc:
+        raise TodoError("hosted tracker requires the `libsql` package; run `uv sync` in _project/scripts") from exc
+    replica = hosted_replica_path()
+    replica.parent.mkdir(parents=True, exist_ok=True)
+    raw = libsql.connect(str(replica), sync_url=url, auth_token=token, isolation_level=None)
+    conn = _HostedConnection(raw)
+    try:
+        conn.sync()
+    except Exception as exc:
+        if sync_required:
+            raise TodoError(f"hosted tracker: cannot sync with the primary: {_redacted(exc, token)}") from exc
+        # Degraded mode per spec: reads serve the stale replica with a banner;
+        # writes will fail loudly at the primary (no offline write queue).
+        print(
+            f"warning: STALE replica — sync with the primary failed ({_redacted(exc, token)}); "
+            "reads may be outdated and writes will fail",
+            file=sys.stderr,
+        )
+    conn.execute("PRAGMA foreign_keys = ON")
+    conn.execute("PRAGMA busy_timeout = 5000")
+    return conn
+
+
+def connect_hosted(url: str) -> _HostedConnection:
+    conn = _hosted_raw_connect(url, sync_required=False)
+    _ensure_schema(conn)
+    return conn
+
+
+# ---------------------------------------------------------------------------
+# Hosted bulk transfer (Hrana pipeline)
+#
+# Interactive write transactions round-trip per statement (~0.15s RTT), which
+# is correct for CLI-scale writes but hopeless for the one-shot YAML import:
+# measured live, the row-by-row path ran at ~10 items/min (≈2.5h for the full
+# tree). The importer therefore stages into a temp local SQLite through the
+# exact same gated code, then bulk-copies rows to the primary with batched
+# parameterized statements over the Hrana HTTP pipeline — one round-trip per
+# few hundred statements, all inside a single baton-chained transaction.
+
+# Insert order respects foreign keys; DELETE (--replace) runs in reverse.
+TRANSFER_TABLES = (
+    "items",
+    "work_units",
+    "work_needs",
+    "item_deps",
+    "scope_rules",
+    "verifications",
+    "preserves",
+    "anti_patterns",
+    "prior_art",
+    "deferrals",
+    "events",
+)
+
+
+def _hrana_endpoint(url: str) -> str:
+    if url.startswith("libsql://"):
+        url = "https://" + url[len("libsql://") :]
+    return url.rstrip("/") + "/v2/pipeline"
+
+
+def _hrana_value(value: Any) -> dict[str, Any]:
+    if value is None:
+        return {"type": "null"}
+    if isinstance(value, bool) or isinstance(value, int):
+        return {"type": "integer", "value": str(int(value))}
+    if isinstance(value, float):
+        return {"type": "float", "value": value}
+    if isinstance(value, (bytes, bytearray)):
+        import base64
+
+        return {"type": "blob", "base64": base64.b64encode(bytes(value)).decode("ascii")}
+    return {"type": "text", "value": str(value)}
+
+
+def _post_pipeline(endpoint: str, token: str, payload: dict[str, Any]) -> dict[str, Any]:
+    import urllib.error
+    import urllib.request
+
+    request = urllib.request.Request(
+        endpoint,
+        data=json.dumps(payload).encode("utf-8"),
+        headers={"Authorization": f"Bearer {token}", "Content-Type": "application/json"},
+    )
+    try:
+        with urllib.request.urlopen(request, timeout=60) as response:
+            return json.loads(response.read())
+    except urllib.error.URLError as exc:
+        raise TodoError(f"hosted pipeline request failed: {_redacted(exc, token)}") from exc
+
+
+def _pipeline_execute(
+    url: str,
+    token: str,
+    stmts: list[tuple[str, list[Any]]],
+    *,
+    baton: str | None = None,
+    close: bool = False,
+    post=None,
+) -> dict[str, Any]:
+    post = post or _post_pipeline
+    requests_payload: list[dict[str, Any]] = [
+        {"type": "execute", "stmt": {"sql": sql, "args": [_hrana_value(arg) for arg in args]}} for sql, args in stmts
+    ]
+    if close:
+        requests_payload.append({"type": "close"})
+    response = post(_hrana_endpoint(url), token, {"baton": baton, "requests": requests_payload})
+    for result in response.get("results", []):
+        if result.get("type") == "error":
+            message = result.get("error", {}).get("message", "unknown error")
+            raise TodoError(f"hosted pipeline error: {message}")
+    return response
+
+
+def hosted_item_count(url: str, token: str, post=None) -> int:
+    response = _pipeline_execute(url, token, [("SELECT count(*) FROM items", [])], close=True, post=post)
+    cell = response["results"][0]["response"]["result"]["rows"][0][0]
+    return int(cell["value"])
+
+
+def bulk_transfer(
+    staging: sqlite3.Connection,
+    url: str,
+    token: str,
+    *,
+    replace: bool = False,
+    post=None,
+    batch_size: int = 400,
+) -> dict[str, int]:
+    """Copy all tracker rows from a staged local database to the primary,
+    atomically (one baton-chained transaction; the stream closing without
+    COMMIT rolls the whole transfer back)."""
+    stmts: list[tuple[str, list[Any]]] = [("BEGIN", [])]
+    if replace:
+        for table in reversed(TRANSFER_TABLES):
+            stmts.append((f"DELETE FROM {table}", []))
+    rows_total = 0
+    for table in TRANSFER_TABLES:
+        columns = [row["name"] for row in staging.execute(f"PRAGMA table_info({table})")]
+        insert = f"INSERT INTO {table} ({', '.join(columns)}) VALUES ({', '.join('?' for _ in columns)})"
+        for row in staging.execute(f"SELECT {', '.join(columns)} FROM {table}"):
+            stmts.append((insert, list(row)))
+            rows_total += 1
+    stmts.append(("COMMIT", []))
+    batches = [stmts[i : i + batch_size] for i in range(0, len(stmts), batch_size)]
+    baton: str | None = None
+    for index, batch in enumerate(batches):
+        response = _pipeline_execute(url, token, batch, baton=baton, close=index == len(batches) - 1, post=post)
+        baton = response.get("baton")
+    return {"rows": rows_total, "batches": len(batches)}
+
+
+def connect_backend(backend: Path | str) -> sqlite3.Connection | _HostedConnection:
+    if isinstance(backend, Path):
+        return connect(backend)
+    return connect_hosted(backend)
+
+
+def migrate_backend(backend: Path | str) -> list[int]:
+    """Apply pending schema migrations on either backend; returns versions applied."""
+    if isinstance(backend, Path):
+        return migrate_db(backend)
+    # Hosted: a fresh sync is a hard requirement — migrating a stale replica
+    # against an already-migrated primary would corrupt the version record.
+    conn = _hosted_raw_connect(backend, sync_required=True)
+    try:
+        version = _schema_version(conn)
+        if version is None:
+            _ensure_schema(conn)  # fresh database: created at the current version
+            return []
+        applied: list[int] = []
+        for target in sorted(MIGRATIONS):
+            if version < target:
+                with _write_txn(conn):
+                    for statement in MIGRATIONS[target]:
+                        conn.execute(statement)
+                    conn.execute("UPDATE meta SET value = ? WHERE key = 'schema_version'", (str(target),))
+                version = target
+                applied.append(target)
+        return applied
+    finally:
+        conn.close()
 
 
 def migrate_db(db_path: Path) -> list[int]:
@@ -1493,7 +1847,11 @@ def _print_work_order(order: dict[str, Any]) -> None:
 
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description="Local-SQLite TODO tracker (spike)")
-    parser.add_argument("--db", help="database path (default: <git root>/.todo-db/todo.sqlite)")
+    parser.add_argument(
+        "--db",
+        help="database path, or libsql://... / https://... URL for the hosted backend"
+        " (default: <git main root>/.todo-db/todo.sqlite, or TODO_DB_URL when set)",
+    )
     parser.add_argument("--actor", help="override actor identity for the audit log")
     sub = parser.add_subparsers(dest="command", required=True)
 
@@ -1505,6 +1863,11 @@ def main(argv: list[str] | None = None) -> int:
     p.add_argument("--skip-done", action="store_true", help="import only the open TODO tree")
     p.add_argument("--dry-run", action="store_true")
     p.add_argument("--verbose", action="store_true", help="print every skip/warning line")
+    p.add_argument(
+        "--replace",
+        action="store_true",
+        help="hosted backend only: clear the tracker tables before importing (same transaction)",
+    )
 
     p = sub.add_parser("create", help="create an item (flags, or --from - for a JSON payload)")
     p.add_argument("id", nargs="?")
@@ -1602,17 +1965,22 @@ def main(argv: list[str] | None = None) -> int:
 
     args = parser.parse_args(argv)
     actor = args.actor or default_actor()
+    backend = resolve_backend(args.db)
     if args.command == "migrate":
         # Must run before connect(): connect refuses an outdated schema.
         try:
-            applied = migrate_db(resolve_db_path(args.db))
+            applied = migrate_backend(backend)
         except TodoError as exc:
             print(f"error: {exc}", file=sys.stderr)
             return 2
         if applied:
             print(f"applied migration(s) to v{', v'.join(str(v) for v in applied)}")
             return 0
-    conn = connect(resolve_db_path(args.db))
+    try:
+        conn = connect_backend(backend)
+    except TodoError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 2
 
     try:
         return _dispatch(conn, actor, args)
@@ -1641,18 +2009,49 @@ def _print_capped(label: str, lines: list[str], verbose: bool, cap: int = 25) ->
         print(f"  {label}: ... +{len(lines) - len(shown)} more (use --verbose)")
 
 
+def _print_import_report(report: dict[str, Any], verbose: bool) -> None:
+    print(
+        f"imported: {len(report['imported'])}  skipped: {len(report['skipped'])}  warnings: {len(report['warnings'])}"
+    )
+    print(f"  counts: {json.dumps(report['counts'], sort_keys=True)}")
+    _print_capped("skip", report["skipped"], verbose)
+    _print_capped("warn", report["warnings"], verbose)
+
+
 def _cmd_import_yaml(conn, actor, args):
     todo_dir = Path(args.todo_dir) if args.todo_dir else git_root() / "_project" / "TODO"
     done_dir = None
     if not args.skip_done:
         done_dir = Path(args.done_dir) if args.done_dir else git_root() / "_project" / "DONE"
+    backend = resolve_backend(args.db)
+    hosted = isinstance(backend, str)
+    if args.replace and not (hosted and not args.dry_run):
+        raise TodoError("--replace only applies to a live import into the hosted backend")
+    if hosted and not args.dry_run:
+        # Bulk path: stage through the exact same gated code into a temp local
+        # database, then copy rows to the primary in one batched transaction.
+        # The row-by-row path is ~2.5h over the network; this is seconds.
+        token = os.environ.get("TODO_DB_AUTH_TOKEN") or ""
+        existing = hosted_item_count(backend, token)
+        if existing and not args.replace:
+            raise TodoError(
+                f"hosted database already holds {existing} item(s);"
+                " rerun with --replace to clear the tracker tables and re-import"
+            )
+        import tempfile
+
+        with tempfile.TemporaryDirectory() as tmp:
+            staging = connect(Path(tmp) / "staging.sqlite")
+            try:
+                report = import_yaml_tree(staging, actor, todo_dir, done_dir=done_dir, dry_run=False)
+                summary = bulk_transfer(staging, backend, token, replace=args.replace)
+            finally:
+                staging.close()
+        _print_import_report(report, args.verbose)
+        print(f"  bulk transfer: {summary['rows']} row(s) in {summary['batches']} batch(es)")
+        return 0
     report = import_yaml_tree(conn, actor, todo_dir, done_dir=done_dir, dry_run=args.dry_run)
-    print(
-        f"imported: {len(report['imported'])}  skipped: {len(report['skipped'])}  warnings: {len(report['warnings'])}"
-    )
-    print(f"  counts: {json.dumps(report['counts'], sort_keys=True)}")
-    _print_capped("skip", report["skipped"], args.verbose)
-    _print_capped("warn", report["warnings"], args.verbose)
+    _print_import_report(report, args.verbose)
     return 0
 
 

--- a/_project/specs/todo-db-tracker.md
+++ b/_project/specs/todo-db-tracker.md
@@ -517,6 +517,107 @@ silently-lost deferred work versus two follow-ups already buried. The gap
 is not agent skill; it is prose-enforced invariants vs code-enforced
 invariants, demonstrated rather than argued.
 
+## Hosted backend (2026-07-18, fifth round — Turso/libsql, TDD)
+
+With G1 closed, `connect()` grew a second mode (PR: see below). Backend
+selection, first match wins: `--db` (a `libsql://`/`https://` value selects
+hosted) → `TODO_DB_PATH` (local file) → `TODO_DB_URL` (hosted; requires
+`TODO_DB_AUTH_TOKEN`) → default local path. `TODO_DB_PATH` deliberately
+outranks `TODO_DB_URL` so a test or tool that pins a local file can never be
+silently redirected at the shared database.
+
+Hosted mode uses the `libsql` Python client (0.1.11) with an **embedded
+replica** at `<git main root>/.todo-db/replica.db` (override:
+`TODO_DB_REPLICA`): reads serve from the local replica after one freshness
+`sync()` at connect; writes — including every `BEGIN IMMEDIATE` interactive
+transaction — are delegated statement-by-statement to the primary, so the
+check-then-act gates serialize against all other writers exactly as they do
+against the local file. On sync failure, reads degrade to the stale replica
+with a `STALE` banner and writes fail loudly (no offline queue, per design).
+
+The client is close to sqlite3 but not close enough (verified live): rows
+are plain tuples with no `row_factory`, cursors are not iterable, and
+constraint violations raise `ValueError` (remotely wrapped in Hrana text
+with `SQLITE_CONSTRAINT`). A ~100-line adapter closes exactly those gaps —
+named-row access, cursor iteration, constraint→`sqlite3.IntegrityError`
+mapping — so every gate, query, and transaction above it runs unchanged on
+either backend. FK enforcement was verified live through write delegation
+(dangling insert refused by the primary). `todo migrate` is backend-aware;
+the hosted path hard-requires a fresh sync before touching the version
+record. TDD: 22 new tests (`tests/unit/scripts/test_todo_db_hosted.py`,
+medium-marked, written red first) pin backend resolution, wiring, adapter
+semantics, `BEGIN IMMEDIATE` discipline, rollback-on-failed-gate, the full
+gated lifecycle, and hosted migration against a fake libsql module that
+reproduces the real client's quirks; the pre-existing tracker suite (93
+tests across `test_todo_db*.py` + `test_todo_wrapper.py`) passes unchanged.
+
+**Shared-visibility proof (live, two processes × two replicas × two
+actors).** The one property the local spike could not demonstrate, run
+against the real Turso primary through the shim only:
+
+| Step | Result |
+|---|---|
+| A creates item (replica A) | created, 4.3s (first sync + schema pull) |
+| B `ready` (replica B) | item visible cross-replica, 1.7s |
+| A claims | work order printed |
+| B claims | **refused, exit 2** — "claimed by 'actor-a'", 1.5s |
+| A `done w1`, A defers | recorded, 1.9–2.4s |
+| B `complete` | **refused, exit 2** — deferral gate held cross-process, 1.9s |
+| B dismisses A's deferral, A completes | both succeed; B reads final state `done`/`dismissed` |
+
+Claim contention and the deferral gate are enforced by the primary for
+every actor regardless of process, worktree, or replica — the
+shared-visibility objective (success criterion 6) is met. (The probe
+item's rows were later cleared by the G3 `--replace` import; this table
+is the durable record of the proof.)
+
+**Command latency vs. local baseline** (same machine, same tree):
+local-SQLite `todo stats`/`ready` ≈ **0.04s**; hosted ≈ **0.7–4.1s** per
+command — reads (`ready` over the full 1,366-item database: 0.7–0.8s)
+pay uv startup + one sync round-trip; writes add per-statement
+delegation at ~0.15s RTT (single-gate writes 1.5–2.6s; claim/promote/
+complete with their larger transactions 2.3–3.3s). Interactive-scale
+acceptable per the latency budget.
+
+**Bulk import path (measured necessity).** The row-by-row importer over
+per-statement write delegation ran at ~10 items/min against the live
+primary (≈2.5h projected for the full tree — unfit). `import-yaml` on a
+hosted backend therefore stages into a temp local SQLite **through the
+exact same gated code**, then copies all rows to the primary as batched
+parameterized statements over the Hrana HTTP pipeline, inside a single
+baton-chained transaction (stream close without COMMIT = full rollback).
+`--replace` (hosted-only flag) clears the tracker tables in that same
+transaction; a non-empty target without `--replace` is refused. Covered
+by the same TDD round (fake-primary replay asserts row-for-row parity
+between staging and target).
+
+**G3 CLOSED (2026-07-18, live).** `todo import-yaml --replace` against
+the hosted primary: **imported 1,364 / skipped 0 / warnings 18; 539 deps
+resolved, 1 dangling; 629 open deferrals; 32,595 rows in 82 batches,
+44s wall** — report-identical to a same-tree local-SQLite control run
+(4s wall). Counts drifted from the recorded 1,362/538 of the earlier
+rounds because five PRs (#1114, #1142, #1194, #1215, #1217) added/moved
+TODO/DONE files on `develop` in between; warnings (18), skipped (0),
+dangling (1), and open deferrals (629) are unchanged. Post-import hosted
+`stats` matches the local control exactly (done 1,247 / active 31 /
+planning 86 — the +11 over `done_items=1,236` are the known
+Completed-in-planning drift files, imported as done).
+
+**Hosted UAT (2026-07-18, live, shim only).** The
+`TestWrapperUatLifecycle` protocol executed end-to-end against the
+imported hosted database (actor `uat-hosted-session`): create with work
+graph/scope/preserve/verify ladder → `ready` shows it (0.7s) → claim
+prints the full work order → out-of-order `done w2` refused (exit 2) →
+start/done with evidence → `verify --run 1` pass recorded → defer
+(deferral **#630** — the counter itself demonstrates full-scale
+operation) → `complete` refused on the open deferral (exit 2) → promote
+→ complete → `export` twice over all 1,366 items **byte-identical** →
+late defer on the done item refused (exit 2). Every gate fired
+identically to local mode. Final stats coherent: open deferrals 629
+(unchanged), promoted 1, done 1,248. Cleanup: the promoted follow-up
+(`uat-hosted-item-followup`) was dropped with reason "UAT artifact";
+the UAT parent remains as `done` audit trail.
+
 ## Cutover plan
 
 - **G1 — host verification (before any build):** from a live remote session,
@@ -538,12 +639,40 @@ invariants, demonstrated rather than argued.
     token into the environment config — both are account-holder actions an
     agent session cannot perform. Re-run the reachability probe afterwards
     to close G1.
+
+  **G1 CLOSED (2026-07-18, local session).** Both maintainer prerequisites
+  landed and the round-trip is verified end to end against the provisioned
+  database `libsql://benchbox-todo-joeharris76.aws-us-east-1.turso.io`:
+
+  - **Remote allowlist:** `*.turso.io`, `*.aws-us-east-1.turso.io`, and
+    `api.turso.tech` are on the remote environment's network allowlist;
+    unauthenticated HTTPS probes through the proxy returned 401 from both
+    the DB endpoint and `api.turso.tech` on 2026-07-18 (auth required —
+    the 403 policy denial is gone).
+  - **Local round-trip (this session):** unauthenticated control
+    `POST /v2/pipeline` → **401** in 0.15s; authenticated
+    `CREATE TABLE` + `INSERT ... RETURNING` → **200** with `rows_written`
+    confirmed server-side and `last_insert_rowid=1`; read-back
+    `count(*)=1`; probe table dropped. Authenticated `SELECT 1` latency
+    over five fresh connections: **0.15–0.16s** each (server-side
+    `query_duration_ms` < 1ms — the cost is the network round-trip).
+  - **Credential provisioning deviation:** `TODO_DB_URL` /
+    `TODO_DB_AUTH_TOKEN` are provisioned in the *remote* environment
+    config only; they were verified **absent** from this local session's
+    environment. Local access authenticated via the maintainer's
+    logged-in `turso` CLI, minting short-lived DB tokens per invocation
+    (`turso db tokens create benchbox-todo`), never stored or echoed.
+    Open provisioning item for the maintainer: add the two variables to
+    local `.env` (per the Credentials bullet above) so local sessions
+    don't depend on the turso CLI login.
 - **G2 — CLI MVP:** schema DDL + `create/show/claim/start/done/defer/
   promote/dismiss/complete/ready/list/stats/export` + tests. No repo changes
   to the YAML system yet.
 - **G3 — import:** script maps the 129 open TODO YAMLs onto the tables
   (fields → columns/rows; `tasks:`/`dependencies:` legacy forms handled by
   the importer, one-off). Dry-run report → maintainer eyeball → import.
+  **CLOSED 2026-07-18** — full-history import (open + archive) executed
+  against the hosted primary; results in the "Hosted backend" round above.
 - **G4 — deferred-debt sweep (one-time):** walk all 278 archived DONE
   `deferred:` blocks + 34 open-item blocks through `defer` then
   `promote`/`dismiss`, deduping against existing items. This is the last

--- a/tests/unit/scripts/test_todo_db_hosted.py
+++ b/tests/unit/scripts/test_todo_db_hosted.py
@@ -1,0 +1,613 @@
+"""Hosted-mode (Turso/libsql embedded replica) tests for todo_db.py.
+
+The hosted backend must be behaviorally identical to the local-SQLite path:
+same write-transaction discipline (BEGIN IMMEDIATE around every check-then-act
+write), same lifecycle gates, same error surfaces. These tests pin that via a
+fake `libsql` module that reproduces the real client's API quirks observed
+live against Turso (libsql==0.1.11):
+
+- rows come back as plain tuples (no row_factory support);
+- cursors are not iterable;
+- constraint violations raise ValueError, remotely wrapped in Hrana text
+  (`... "SQLite error: FOREIGN KEY constraint failed", code: "SQLITE_CONSTRAINT" ...`);
+- the connection exposes sync() and accepts sync_url/auth_token/isolation_level.
+
+Marked medium (not fast) deliberately: the fast lane is budget-gated.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sqlite3
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+pytestmark = [
+    pytest.mark.unit,
+    pytest.mark.medium,
+]
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+
+HOSTED_URL = "libsql://example-db.aws-us-east-1.turso.io"
+
+
+def _load_script():
+    name = "todo_db"
+    path = REPO_ROOT / "_project" / "scripts" / f"{name}.py"
+    spec = importlib.util.spec_from_file_location(name, path)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+todo_db = _load_script()
+
+
+# ---------------------------------------------------------------------------
+# Fake libsql client, faithful to the real API surface
+
+
+class FakeRawCursor:
+    """Mimics libsql's cursor: tuple rows, NOT iterable, has description."""
+
+    def __init__(self, cur: sqlite3.Cursor):
+        self._cur = cur
+
+    def fetchone(self):
+        return self._cur.fetchone()
+
+    def fetchall(self):
+        return self._cur.fetchall()
+
+    @property
+    def description(self):
+        return self._cur.description
+
+    @property
+    def lastrowid(self):
+        return self._cur.lastrowid
+
+    @property
+    def rowcount(self):
+        return self._cur.rowcount
+
+
+def _hrana_wrap(exc: sqlite3.Error) -> ValueError:
+    return ValueError(f'Hrana: `stream error: `Error {{ message: "SQLite error: {exc}", code: "SQLITE_CONSTRAINT" }}``')
+
+
+class FakeRawConnection:
+    """Mimics libsql.Connection over a real local SQLite file."""
+
+    def __init__(self, database: str, sync_fails: bool = False):
+        self._conn = sqlite3.connect(database)
+        self._conn.isolation_level = None  # autocommit, like isolation_level=None
+        self.statements: list[str] = []
+        self.sync_calls = 0
+        self.commit_calls = 0
+        self._sync_fails = sync_fails
+
+    def execute(self, sql, params=()):
+        self.statements.append(sql if isinstance(sql, str) else str(sql))
+        try:
+            return FakeRawCursor(self._conn.execute(sql, tuple(params)))
+        except sqlite3.IntegrityError as exc:
+            raise _hrana_wrap(exc) from None
+
+    def executescript(self, sql):
+        self.statements.append("<script>")
+        self._conn.executescript(sql)
+
+    def commit(self):
+        self.commit_calls += 1
+        self._conn.commit()
+
+    def rollback(self):
+        self._conn.rollback()
+
+    def close(self):
+        self._conn.close()
+
+    def sync(self):
+        self.sync_calls += 1
+        if self._sync_fails:
+            raise ValueError("Hrana: `api error: `connection refused``")
+
+
+class FakeLibsql(types.ModuleType):
+    def __init__(self, sync_fails: bool = False):
+        super().__init__("libsql")
+        self.connect_calls: list[dict] = []
+        self.connections: list[FakeRawConnection] = []
+        self._sync_fails = sync_fails
+
+    def connect(self, database, **kwargs):
+        self.connect_calls.append({"database": database, **kwargs})
+        conn = FakeRawConnection(str(database), sync_fails=self._sync_fails)
+        self.connections.append(conn)
+        return conn
+
+
+@pytest.fixture()
+def fake_libsql(monkeypatch, tmp_path):
+    fake = FakeLibsql()
+    monkeypatch.setitem(sys.modules, "libsql", fake)
+    monkeypatch.setenv("TODO_DB_AUTH_TOKEN", "test-token-value")
+    monkeypatch.setenv("TODO_DB_REPLICA", str(tmp_path / "replica" / "replica.db"))
+    monkeypatch.delenv("TODO_DB_PATH", raising=False)
+    return fake
+
+
+def _hosted_conn(fake: FakeLibsql):
+    return todo_db.connect_backend(HOSTED_URL)
+
+
+def _make_item(conn, item_id="hosted-item", work=None):
+    todo_db.create_item(
+        conn,
+        "tester",
+        item_id=item_id,
+        title="Hosted-mode lifecycle item",
+        worktree="spike",
+        priority="high",
+        description="Exercises hosted-mode gate behavior.",
+        work=work,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Backend resolution
+
+
+class TestBackendResolution:
+    def test_explicit_db_path_stays_local_even_with_url_env(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("TODO_DB_URL", HOSTED_URL)
+        backend = todo_db.resolve_backend(str(tmp_path / "todo.sqlite"))
+        assert isinstance(backend, Path)
+
+    def test_env_db_path_wins_over_env_url(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("TODO_DB_URL", HOSTED_URL)
+        monkeypatch.setenv("TODO_DB_PATH", str(tmp_path / "todo.sqlite"))
+        backend = todo_db.resolve_backend(None)
+        assert isinstance(backend, Path)
+
+    def test_env_url_selects_hosted(self, monkeypatch):
+        monkeypatch.delenv("TODO_DB_PATH", raising=False)
+        monkeypatch.setenv("TODO_DB_URL", HOSTED_URL)
+        assert todo_db.resolve_backend(None) == HOSTED_URL
+
+    def test_explicit_url_selects_hosted(self, monkeypatch):
+        monkeypatch.delenv("TODO_DB_URL", raising=False)
+        assert todo_db.resolve_backend(HOSTED_URL) == HOSTED_URL
+        assert todo_db.resolve_backend("https://example-db.turso.io") == ("https://example-db.turso.io")
+
+    def test_no_env_defaults_to_local_path(self, monkeypatch):
+        monkeypatch.delenv("TODO_DB_URL", raising=False)
+        monkeypatch.delenv("TODO_DB_PATH", raising=False)
+        assert isinstance(todo_db.resolve_backend(None), Path)
+
+
+# ---------------------------------------------------------------------------
+# Hosted connection wiring
+
+
+class TestHostedConnect:
+    def test_requires_auth_token(self, monkeypatch, tmp_path):
+        fake = FakeLibsql()
+        monkeypatch.setitem(sys.modules, "libsql", fake)
+        monkeypatch.delenv("TODO_DB_AUTH_TOKEN", raising=False)
+        monkeypatch.setenv("TODO_DB_REPLICA", str(tmp_path / "replica.db"))
+        with pytest.raises(todo_db.TodoError, match="TODO_DB_AUTH_TOKEN"):
+            todo_db.connect_backend(HOSTED_URL)
+        assert not fake.connect_calls
+
+    def test_wires_replica_sync_url_auth_and_autocommit(self, fake_libsql, tmp_path):
+        conn = _hosted_conn(fake_libsql)
+        call = fake_libsql.connect_calls[0]
+        assert call["database"].endswith("replica.db")
+        assert call["sync_url"] == HOSTED_URL
+        assert call["auth_token"] == "test-token-value"
+        assert call["isolation_level"] is None
+        # replica parent directory is created
+        assert Path(call["database"]).parent.is_dir()
+        # one freshness sync at connect; schema bootstrap happened
+        raw = fake_libsql.connections[0]
+        assert raw.sync_calls == 1
+        assert conn.execute("SELECT value FROM meta WHERE key='schema_version'").fetchone()[0] == str(
+            todo_db.SCHEMA_VERSION
+        )
+
+    def test_default_replica_path_is_todo_db_dir(self, monkeypatch, tmp_path):
+        fake = FakeLibsql()
+        monkeypatch.setitem(sys.modules, "libsql", fake)
+        monkeypatch.setenv("TODO_DB_AUTH_TOKEN", "test-token-value")
+        monkeypatch.delenv("TODO_DB_REPLICA", raising=False)
+        monkeypatch.setattr(todo_db, "git_main_root", lambda: tmp_path)
+        todo_db.connect_backend(HOSTED_URL)
+        assert fake.connect_calls[0]["database"] == str(tmp_path / ".todo-db" / "replica.db")
+
+    def test_error_message_never_contains_the_token(self, monkeypatch, tmp_path):
+        fake = FakeLibsql(sync_fails=True)
+        monkeypatch.setitem(sys.modules, "libsql", fake)
+        monkeypatch.setenv("TODO_DB_AUTH_TOKEN", "sekrit-token-abc123")
+        monkeypatch.setenv("TODO_DB_REPLICA", str(tmp_path / "replica.db"))
+        # sync failure degrades to the stale replica with a warning, not a crash
+        conn = todo_db.connect_backend(HOSTED_URL)
+        assert conn.execute("SELECT 1").fetchone()[0] == 1
+
+    def test_sync_failure_warns_and_serves_stale_reads(self, monkeypatch, tmp_path, capsys):
+        fake = FakeLibsql(sync_fails=True)
+        monkeypatch.setitem(sys.modules, "libsql", fake)
+        monkeypatch.setenv("TODO_DB_AUTH_TOKEN", "test-token-value")
+        monkeypatch.setenv("TODO_DB_REPLICA", str(tmp_path / "replica.db"))
+        conn = todo_db.connect_backend(HOSTED_URL)
+        err = capsys.readouterr().err
+        assert "STALE" in err
+        assert "sekrit" not in err and "test-token-value" not in err
+        assert conn.execute("SELECT 1").fetchone()[0] == 1
+
+    def test_local_connect_is_unchanged(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("TODO_DB_URL", HOSTED_URL)
+        conn = todo_db.connect(tmp_path / "todo.sqlite")
+        assert isinstance(conn, sqlite3.Connection)
+
+
+# ---------------------------------------------------------------------------
+# Adapter semantics
+
+
+class TestHostedAdapter:
+    def test_rows_support_name_access_index_access_and_dict(self, fake_libsql):
+        conn = _hosted_conn(fake_libsql)
+        _make_item(conn)
+        row = conn.execute("SELECT id, state FROM items").fetchone()
+        assert row["id"] == "hosted-item"
+        assert row[1] == "planning"
+        as_dict = dict(conn.execute("SELECT id, state FROM items").fetchone())
+        assert as_dict == {"id": "hosted-item", "state": "planning"}
+
+    def test_cursor_is_iterable(self, fake_libsql):
+        conn = _hosted_conn(fake_libsql)
+        _make_item(conn, item_id="iter-one")
+        _make_item(conn, item_id="iter-two")
+        ids = [row["id"] for row in conn.execute("SELECT id FROM items ORDER BY id")]
+        assert ids == ["iter-one", "iter-two"]
+
+    def test_fetchone_returns_none_on_empty(self, fake_libsql):
+        conn = _hosted_conn(fake_libsql)
+        assert conn.execute("SELECT id FROM items").fetchone() is None
+
+    def test_unique_violation_maps_to_integrity_error(self, fake_libsql):
+        conn = _hosted_conn(fake_libsql)
+        _make_item(conn)
+        with pytest.raises(todo_db.TodoError, match="cannot create"):
+            _make_item(conn)
+
+    def test_fk_violation_maps_to_integrity_error(self, fake_libsql):
+        conn = _hosted_conn(fake_libsql)
+        _make_item(conn)
+        conn.execute("PRAGMA foreign_keys = ON")
+        with pytest.raises(todo_db.TodoError, match="missing item"):
+            with todo_db._write_txn(conn):
+                todo_db.add_item_dep(conn, "hosted-item", "does-not-exist")
+
+    def test_lastrowid_survives_the_adapter(self, fake_libsql):
+        conn = _hosted_conn(fake_libsql)
+        _make_item(conn)
+        deferral_id = todo_db.defer_work(conn, "tester", "hosted-item", "follow-up", "later")
+        assert deferral_id == 1
+
+
+# ---------------------------------------------------------------------------
+# Write-transaction discipline
+
+
+class TestHostedWriteDiscipline:
+    def test_writes_run_under_begin_immediate(self, fake_libsql):
+        conn = _hosted_conn(fake_libsql)
+        raw = fake_libsql.connections[0]
+        before = raw.commit_calls
+        raw.statements.clear()
+        _make_item(conn)
+        assert raw.statements[0] == "BEGIN IMMEDIATE"
+        insert_pos = next(i for i, s in enumerate(raw.statements) if s.startswith("INSERT INTO items"))
+        assert insert_pos > raw.statements.index("BEGIN IMMEDIATE")
+        assert raw.commit_calls == before + 1
+
+    def test_failed_gate_rolls_back(self, fake_libsql):
+        conn = _hosted_conn(fake_libsql)
+        _make_item(conn, work=[{"id": "w1", "summary": "only unit here"}])
+        with pytest.raises(todo_db.TodoError):
+            todo_db.complete_item(conn, "tester", "hosted-item", None)
+        # nothing half-committed: item still planning, no completed_at
+        row = conn.execute("SELECT state, completed_at FROM items").fetchone()
+        assert row["state"] == "planning"
+        assert row["completed_at"] is None
+
+
+# ---------------------------------------------------------------------------
+# Lifecycle gates behave identically in hosted mode
+
+
+class TestHostedLifecycleGates:
+    def test_full_gated_lifecycle(self, fake_libsql):
+        conn = _hosted_conn(fake_libsql)
+        _make_item(
+            conn,
+            work=[
+                {"id": "w1", "summary": "implement the thing"},
+                {"id": "w2", "summary": "verify the thing", "needs": ["w1"]},
+            ],
+        )
+        # claim contention: second actor refused while the lease is live
+        todo_db.claim_item(conn, "actor-a", "hosted-item")
+        with pytest.raises(todo_db.TodoError, match="claimed by 'actor-a'"):
+            todo_db.claim_item(conn, "actor-b", "hosted-item")
+        # unit ordering gate
+        with pytest.raises(todo_db.TodoError, match="needs unfinished units"):
+            todo_db.done_unit(conn, "actor-a", "hosted-item", "w2", "premature")
+        # evidence gate
+        with pytest.raises(todo_db.TodoError, match="evidence is required"):
+            todo_db.done_unit(conn, "actor-a", "hosted-item", "w1", "  ")
+        todo_db.done_unit(conn, "actor-a", "hosted-item", "w1", "pytest passed")
+        todo_db.done_unit(conn, "actor-a", "hosted-item", "w2", "ladder pass")
+        # deferral gate blocks completion until promoted/dismissed
+        deferral_id = todo_db.defer_work(conn, "actor-a", "hosted-item", "polish", "out of scope")
+        with pytest.raises(todo_db.TodoError, match="unresolved deferrals"):
+            todo_db.complete_item(conn, "actor-a", "hosted-item", 999)
+        todo_db.promote_deferral(conn, "actor-a", deferral_id, new_item_id="hosted-item-followup")
+        todo_db.complete_item(conn, "actor-a", "hosted-item", 999)
+        # terminal-defer guard
+        with pytest.raises(todo_db.TodoError, match="terminal items"):
+            todo_db.defer_work(conn, "actor-a", "hosted-item", "too late", "nope")
+        # end state is coherent
+        got = todo_db.stats(conn)
+        assert got["items_by_state"] == {"done": 1, "planning": 1}
+        assert got["deferrals_by_resolution"] == {"promoted": 1}
+
+    def test_cli_main_routes_hosted_via_env(self, fake_libsql, monkeypatch, capsys):
+        monkeypatch.setenv("TODO_DB_URL", HOSTED_URL)
+        rc = todo_db.main(["--actor", "tester", "stats"])
+        assert rc == 0
+        assert fake_libsql.connect_calls, "main() did not open the hosted backend"
+        assert "items_by_state" in capsys.readouterr().out
+
+
+# ---------------------------------------------------------------------------
+# Hosted migrations
+
+
+class FakePrimary:
+    """Hrana-pipeline stand-in: executes posted statements on a local SQLite
+    file so bulk-transfer fidelity is testable end to end without a network.
+    Mimics the wire contract: parameterized statements, baton chaining, and
+    Hrana-typed result rows."""
+
+    def __init__(self, path: Path):
+        self.path = path
+        self.requests: list[dict] = []
+        self._conn = sqlite3.connect(path)
+        self._conn.isolation_level = None
+        self._baton = 0
+
+    def post(self, endpoint: str, token: str, payload: dict) -> dict:
+        assert token, "post called without an auth token"
+        self.requests.append({"endpoint": endpoint, "payload": payload})
+        results = []
+        for request in payload["requests"]:
+            if request["type"] == "close":
+                results.append({"type": "ok", "response": {"type": "close"}})
+                continue
+            stmt = request["stmt"]
+            args = [self._decode(a) for a in stmt.get("args", [])]
+            try:
+                cur = self._conn.execute(stmt["sql"], args)
+                rows = [[self._encode(v) for v in row] for row in cur.fetchall()]
+                results.append(
+                    {
+                        "type": "ok",
+                        "response": {"type": "execute", "result": {"rows": rows, "affected_row_count": cur.rowcount}},
+                    }
+                )
+            except sqlite3.Error as exc:
+                results.append({"type": "error", "error": {"message": str(exc)}})
+        self._baton += 1
+        return {"baton": f"baton-{self._baton}", "results": results}
+
+    @staticmethod
+    def _decode(arg: dict):
+        kind = arg["type"]
+        if kind == "null":
+            return None
+        if kind == "integer":
+            return int(arg["value"])
+        if kind == "float":
+            return float(arg["value"])
+        return arg["value"]
+
+    @staticmethod
+    def _encode(value) -> dict:
+        if value is None:
+            return {"type": "null"}
+        if isinstance(value, int):
+            return {"type": "integer", "value": str(value)}
+        if isinstance(value, float):
+            return {"type": "float", "value": value}
+        return {"type": "text", "value": str(value)}
+
+
+def _dump(path: Path) -> dict[str, list]:
+    conn = sqlite3.connect(path)
+    tables = [
+        row[0]
+        for row in conn.execute("SELECT name FROM sqlite_master WHERE type='table' AND name != 'meta' ORDER BY name")
+    ]
+    out = {t: conn.execute(f"SELECT * FROM {t} ORDER BY rowid").fetchall() for t in tables}
+    conn.close()
+    return out
+
+
+class TestHostedBulkImport:
+    @pytest.fixture()
+    def staging(self, tmp_path):
+        conn = todo_db.connect(tmp_path / "staging.sqlite")
+        _make_item(
+            conn,
+            item_id="bulk-one",
+            work=[{"id": "w1", "summary": "first unit"}, {"id": "w2", "summary": "second unit", "needs": ["w1"]}],
+        )
+        _make_item(conn, item_id="bulk-two")
+        todo_db.defer_work(conn, "tester", "bulk-two", "deferred bit", "later")
+        with todo_db._write_txn(conn):
+            todo_db.add_item_dep(conn, "bulk-two", "bulk-one")
+        return conn
+
+    def test_hrana_value_encoding(self):
+        assert todo_db._hrana_value(None) == {"type": "null"}
+        assert todo_db._hrana_value(7) == {"type": "integer", "value": "7"}
+        assert todo_db._hrana_value(1.5) == {"type": "float", "value": 1.5}
+        assert todo_db._hrana_value("x") == {"type": "text", "value": "x"}
+
+    def test_hrana_endpoint_translation(self):
+        assert todo_db._hrana_endpoint(HOSTED_URL) == ("https://example-db.aws-us-east-1.turso.io/v2/pipeline")
+        assert todo_db._hrana_endpoint("https://x.turso.io") == "https://x.turso.io/v2/pipeline"
+
+    def test_bulk_transfer_row_parity(self, staging, tmp_path):
+        primary = FakePrimary(tmp_path / "primary.sqlite")
+        sqlite3.connect(primary.path).executescript(todo_db.SCHEMA_SQL)
+        summary = todo_db.bulk_transfer(staging, HOSTED_URL, "tok", post=primary.post)
+        assert _dump(tmp_path / "staging.sqlite") == _dump(primary.path)
+        assert summary["rows"] > 0
+        assert summary["batches"] >= 1
+
+    def test_bulk_transfer_wraps_in_one_transaction_with_baton(self, staging, tmp_path):
+        primary = FakePrimary(tmp_path / "primary.sqlite")
+        sqlite3.connect(primary.path).executescript(todo_db.SCHEMA_SQL)
+        todo_db.bulk_transfer(staging, HOSTED_URL, "tok", post=primary.post, batch_size=5)
+        assert len(primary.requests) > 2, "batch_size=5 must split into several requests"
+        first_sqls = [r["stmt"]["sql"] for r in primary.requests[0]["payload"]["requests"] if r["type"] == "execute"]
+        assert first_sqls[0] == "BEGIN"
+        last_payload = primary.requests[-1]["payload"]
+        last_sqls = [r["stmt"]["sql"] for r in last_payload["requests"] if r["type"] == "execute"]
+        assert last_sqls[-1] == "COMMIT"
+        assert last_payload["requests"][-1]["type"] == "close"
+        # every request after the first chains the previous baton
+        for i, request in enumerate(primary.requests[1:], start=1):
+            assert request["payload"]["baton"] == f"baton-{i}"
+
+    def test_import_yaml_hosted_stages_locally_and_bulk_transfers(self, fake_libsql, monkeypatch, tmp_path, capsys):
+        todo_dir = tmp_path / "TODO" / "area" / "planning"
+        todo_dir.mkdir(parents=True)
+        (todo_dir / "bulk-import-item.yaml").write_text(
+            "id: bulk-import-item\n"
+            "title: Bulk import end-to-end item\n"
+            "priority: medium\n"
+            "status: Not Started\n"
+            "description: Hosted bulk import path exercise.\n",
+            encoding="utf-8",
+        )
+        primary = FakePrimary(tmp_path / "primary.sqlite")
+        sqlite3.connect(primary.path).executescript(todo_db.SCHEMA_SQL)
+        monkeypatch.setattr(todo_db, "_post_pipeline", primary.post)
+        monkeypatch.setenv("TODO_DB_URL", HOSTED_URL)
+        rc = todo_db.main(["import-yaml", "--todo-dir", str(tmp_path / "TODO"), "--skip-done"])
+        out = capsys.readouterr().out
+        assert rc == 0, out
+        assert "imported: 1" in out
+        assert "bulk transfer" in out
+        row = sqlite3.connect(primary.path).execute("SELECT id, state FROM items").fetchone()
+        assert row == ("bulk-import-item", "planning")
+
+    def test_import_yaml_hosted_refuses_nonempty_target_without_replace(
+        self, fake_libsql, monkeypatch, tmp_path, capsys
+    ):
+        todo_dir = tmp_path / "TODO"
+        todo_dir.mkdir()
+        primary = FakePrimary(tmp_path / "primary.sqlite")
+        sqlite3.connect(primary.path).executescript(todo_db.SCHEMA_SQL)
+        seed = sqlite3.connect(primary.path)
+        seed.execute(
+            "INSERT INTO items (id, title, worktree, priority, description, created_at)"
+            " VALUES ('leftover', 'Leftover row here', 'spike', 'low', 'pre-existing row', '2026-07-18T00:00:00Z')"
+        )
+        seed.commit()
+        monkeypatch.setattr(todo_db, "_post_pipeline", primary.post)
+        monkeypatch.setenv("TODO_DB_URL", HOSTED_URL)
+        rc = todo_db.main(["import-yaml", "--todo-dir", str(todo_dir), "--skip-done"])
+        assert rc == 2
+        assert "--replace" in capsys.readouterr().err
+
+    def test_import_yaml_hosted_replace_clears_target_first(self, fake_libsql, monkeypatch, tmp_path, capsys):
+        todo_dir = tmp_path / "TODO" / "area" / "planning"
+        todo_dir.mkdir(parents=True)
+        (todo_dir / "fresh-item.yaml").write_text(
+            "id: fresh-item\n"
+            "title: Fresh item after replace\n"
+            "priority: low\n"
+            "status: Not Started\n"
+            "description: Replaces the leftover rows.\n",
+            encoding="utf-8",
+        )
+        primary = FakePrimary(tmp_path / "primary.sqlite")
+        sqlite3.connect(primary.path).executescript(todo_db.SCHEMA_SQL)
+        seed = sqlite3.connect(primary.path)
+        seed.execute(
+            "INSERT INTO items (id, title, worktree, priority, description, created_at)"
+            " VALUES ('leftover', 'Leftover row here', 'spike', 'low', 'pre-existing row', '2026-07-18T00:00:00Z')"
+        )
+        seed.execute("INSERT INTO events (at, actor, item_id, action) VALUES ('t', 'a', 'leftover', 'create')")
+        seed.commit()
+        monkeypatch.setattr(todo_db, "_post_pipeline", primary.post)
+        monkeypatch.setenv("TODO_DB_URL", HOSTED_URL)
+        rc = todo_db.main(["import-yaml", "--todo-dir", str(tmp_path / "TODO"), "--skip-done", "--replace"])
+        assert rc == 0
+        ids = [r[0] for r in sqlite3.connect(primary.path).execute("SELECT id FROM items").fetchall()]
+        assert ids == ["fresh-item"]
+        # replaced events too: only the fresh import's audit trail remains
+        actions = {r[0] for r in sqlite3.connect(primary.path).execute("SELECT item_id FROM events").fetchall()}
+        assert "leftover" not in actions
+
+    def test_dry_run_never_posts(self, fake_libsql, monkeypatch, tmp_path, capsys):
+        todo_dir = tmp_path / "TODO"
+        todo_dir.mkdir()
+        calls = []
+        monkeypatch.setattr(todo_db, "_post_pipeline", lambda *a, **k: calls.append(a))
+        monkeypatch.setenv("TODO_DB_URL", HOSTED_URL)
+        rc = todo_db.main(["import-yaml", "--todo-dir", str(todo_dir), "--skip-done", "--dry-run"])
+        assert rc == 0
+        assert not calls
+
+
+class TestHostedMigrate:
+    def _v1_schema(self) -> str:
+        script = todo_db.SCHEMA_SQL
+        for column in ("started_at TEXT", "started_worktree TEXT", "started_branch TEXT"):
+            script = script.replace(f"  {column},\n", "")
+        assert "started_at" not in script
+        return script
+
+    def test_migrate_backend_upgrades_hosted_schema(self, fake_libsql, monkeypatch, tmp_path):
+        # Build a v1 database behind the fake, as if created by an old CLI.
+        replica = tmp_path / "replica" / "replica.db"
+        replica.parent.mkdir(parents=True, exist_ok=True)
+        seed = sqlite3.connect(replica)
+        seed.executescript(self._v1_schema())
+        seed.execute("INSERT INTO meta (key, value) VALUES ('schema_version', '1')")
+        seed.commit()
+        seed.close()
+        # current CLI must refuse it ...
+        with pytest.raises(todo_db.TodoError, match="todo migrate"):
+            todo_db.connect_backend(HOSTED_URL)
+        # ... and migrate must fix it in place
+        applied = todo_db.migrate_backend(HOSTED_URL)
+        assert applied == [2]
+        conn = todo_db.connect_backend(HOSTED_URL)
+        cols = [row[1] for row in conn.execute("PRAGMA table_info(work_units)").fetchall()]
+        assert "started_at" in cols


### PR DESCRIPTION
Teach the DB-backed TODO tracker a second backend behind the same code:
when TODO_DB_URL is set (or --db is given a libsql:// URL), connect via a
libsql embedded replica at .todo-db/replica.db with auth from
TODO_DB_AUTH_TOKEN; the local-SQLite path is unchanged and still outranked
by --db/TODO_DB_PATH so pinned-file tests can never hit the shared DB.

- ~100-line adapter closes the exact sqlite3 gaps the libsql client has
  (named rows, cursor iteration, constraint ValueError -> IntegrityError),
  so every BEGIN IMMEDIATE write transaction and lifecycle gate runs
  unchanged on either backend; degraded mode serves stale replica reads
  with a STALE banner and lets writes fail loudly.
- Hosted bulk-import path: row-by-row write delegation measured at
  ~10 items/min live (2.5h projected), so import-yaml stages through the
  same gated code into a temp local DB and bulk-copies rows over the
  Hrana pipeline in one baton-chained transaction (44s live, 32,595 rows);
  --replace clears tracker tables in the same transaction.
- TDD: 30 new medium-marked tests (fake libsql client + fake Hrana
  primary with replay-parity checks); full scripts suite 800 green.
- Spec: G1 recorded CLOSED with round-trip evidence; live two-process /
  two-replica shared-visibility proof (claim contention exit 2,
  cross-process deferral gate); G3 import + full shim UAT against the
  hosted primary recorded, latency vs local baseline included.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
