### PR TITLE
chore(blind-spots): recheck active findings

### DIFF
--- a/_project/blind-spots/2026-05-23-223538-todo-review-misses-spec-the-todo-edits.md
+++ b/_project/blind-spots/2026-05-23-223538-todo-review-misses-spec-the-todo-edits.md
@@ -1,7 +1,7 @@
 ---
 id: 2026-05-23-223538-todo-review-misses-spec-the-todo-edits
 date: 2026-05-23
-status: open
+status: actionable
 finding_kind: framework-gap
 review_context: "/todo review — chore/shrink-review-followup-todos (shrink-campaign follow-ups)"
 related_paths:
@@ -11,20 +11,23 @@ suggested_sweep: "grep active TODO descriptions for 'goal line N' / spec line-nu
 todo_id: null
 ---
 
-# TODO-review freshness axis misses spec/goal docs the TODO itself edits
+# TODO-review freshness does not bind citations to files the TODO itself edits
 
 ## Finding
-A TODO that proposes to edit a living policy/spec document (here
-`_project/goal-shrink-core-code.md`) cited that document's current state as
+The original shrink TODO proposed to edit a living policy/spec document
+(`_project/goal-shrink-core-code.md`) while citing that document's state as
 fixed evidence ("goal line 12", "goal line 19", "still driven by a single
-naive `cloc` metric"). The goal file had since been rewritten to encode the
-very objective function the TODO's w1 was going to author, and the cited line
-numbers no longer held. The TODO scored 3 on clarity, guardrails, prior_art,
-and work breakdown and would have passed a mechanical review; only manually
-reading the goal file revealed w1 was already done and the premise falsified.
-The review rubric's evidence-durability sub-axis enumerates dependency
-versions, harness PASS, and observed external behavior — but not "the
-spec/goal file this TODO proposes to modify may have already moved."
+naive `cloc` metric"). The goal had already been rewritten to encode the
+objective function the TODO's w1 was supposed to author, so the cited lines
+and the premise were stale. Its w0 re-read caught the drift, and the TODO was
+completed and moved to `DONE/` on 2026-05-24.
+
+The current `/todo review` rubric now checks cited upstream evidence such as
+dependency versions, harness PASS, and observed external behavior, but it
+still does not require a fresh read when a TODO's own
+`scope_limit.only_modify` includes a policy/spec/goal file quoted by its
+description. The historical instance is resolved; the review-framework gap
+remains.
 
 ## Why this matters
 TODOs authored from a campaign review often target the campaign's governing
@@ -41,3 +44,7 @@ external dependencies.
       and diffs against the quoted text (score 0 if absent).
 - [ ] Spot-check other active TODOs for spec line-number citations that can
       drift (sql-catalog already corrected to a stable phrase reference here).
+
+## Triage log
+
+- 2026-07-18: actionable — The original shrink TODO is completed in DONE/ as of 2026-05-24, but recheck of the current /todo review rubric shows the own-edit-target freshness gap remains; revised the record to separate the resolved example from the live framework gap.

--- a/_project/blind-spots/2026-07-10-141635-auto-revert-blame-heuristic-misfires.md
+++ b/_project/blind-spots/2026-07-10-141635-auto-revert-blame-heuristic-misfires.md
@@ -57,3 +57,4 @@ would have pointed at #1093, not #1096.
 ## Triage log
 
 - 2026-07-18: actionable — Re-verified at origin/develop 542590b66 on 2026-07-18: signature-aware comparison suppresses persistent-red duplicates, but a latent environment-dependent first failure can still open a revert for the current SHA; retain as a residual attribution gap.
+- 2026-07-18: actionable — Rechecked against origin/develop 8a7ee88e0 on 2026-07-18: signature comparison suppresses persistent-red duplicates, but the workflow still attributes a latent environment-dependent first failure to the current failing SHA without code-under-test ownership; retain as an actionable attribution gap.

--- a/_project/blind-spots/2026-07-10-141635-slow-live-integration-coverage-theater.md
+++ b/_project/blind-spots/2026-07-10-141635-slow-live-integration-coverage-theater.md
@@ -1,7 +1,7 @@
 ---
 id: 2026-07-10-141635-slow-live-integration-coverage-theater
 date: 2026-07-10
-status: open
+status: actionable
 finding_kind: missed-axis
 review_context: "ducklake deep review / CI-lane coverage audit (origin/develop 7b6d1eef4)"
 related_paths:
@@ -13,27 +13,26 @@ suggested_sweep: "for each large integration test module, resolve its module+cla
 todo_id: null
 ---
 
-# A `slow` + `live_integration` marked module can run in ZERO CI lanes while looking covered
+# DuckLake live integration classes can run in ZERO CI lanes while looking covered
 
 ## Finding
-`tests/integration/test_ducklake_integration.py` is ~700 lines across 4 classes,
-presenting as the adapter's live coverage. Resolving markers against every lane:
-- Module marker: `slow`. Class `TestDuckLakeLiveConnection` (core in-process
-  ATTACH: cursor scoping, force-recreate, platform_info) adds `live_integration`;
-  `TestDuckLakePostgresCatalogLive` and `TestDuckLakeS3DataPathLive` add
-  `live_integration` too. Only `TestDuckLakeSqliteCatalogLive` lacks it.
-- Every default lane selects `not (slow or ... or live_integration)` (pr.yml
-  fast, test.yml integration, nightly, develop-post-merge `make test-medium`).
-  The `-m "slow"` jobs in pr.yml are FILE-SCOPED to other files (mutation,
-  tpchavoc), never naming this module. release-canary/validate-main-pr run
-  `-m "(slow or resource_heavy) and not (... live_integration)"`.
-- Net: classes 1/3/4 (in-process ATTACH, Postgres, S3) run in NO lane at all.
-  Class 2 (SQLite CLI e2e) runs ONLY at the main-release gate — never on the
-  develop PR that merged it, nor nightly, nor post-merge. The adapter's core
-  ATTACH/cursor/force-recreate behavior has zero live CI coverage; only the
-  hermetic mock unit test (`tests/unit/platforms/test_ducklake_adapter.py`,
-  `fast`) runs on the PR. #1082 and #1096 both merged via squash auto-merge
-  with no human review and effectively no live-behavior gate.
+`tests/integration/test_ducklake_integration.py` is a large four-class module,
+presenting as the adapter's live coverage. Resolving its current markers against
+the configured lanes:
+- The module is marked `integration` and `slow`. `TestDuckLakeLiveConnection`
+  (core in-process ATTACH: cursor scoping, force-recreate, platform_info),
+  `TestDuckLakePostgresCatalogLive`, and `TestDuckLakeS3DataPathLive` add
+  `live_integration`; only `TestDuckLakeSqliteCatalogLive` lacks it.
+- The develop PR fast/medium lanes, credential-free integration lane, nightly
+  integration lane, and develop-post-merge `make test-medium` all exclude
+  `slow` and/or `live_integration`. The named `-m "slow"` PR steps are
+  file-scoped to other modules and never select this file.
+- Net: 8 of the module's 9 tests (the in-process ATTACH, Postgres, and S3
+  classes) still run in no configured CI lane. The SQLite CLI test is selected
+  only by the release non-fast canary because it lacks `live_integration`; it
+  is not covered by the develop PR, nightly, or post-merge lanes. The
+  adapter's core live ATTACH behavior therefore still has zero live CI
+  coverage; the PR only runs the hermetic mock unit test.
 - Amplifier: `_probe_extension(...)` is cached for the test process. A transient
   extension-repository failure can cache `False` for later tests in that process.
   The probe is deliberately lazy and runs from `setup_method`, so deselected
@@ -53,5 +52,10 @@ evades the "where are the tests?" prompt.
       integration test module is selected by zero configured lanes.
 - [ ] Give the extension-only in-process ATTACH class a marker that a real lane
       runs (it needs no external service), so core adapter behavior is gated.
-- [ ] Make `_probe_extension` failures loud (warn/xfail) rather than a cached
-      silent skip at the release gate.
+- [ ] Make `_probe_extension` failures visible as an explicit skip/health
+      result rather than a cached silent skip in a gate that is meant to prove
+      live coverage.
+
+## Triage log
+
+- 2026-07-18: actionable — Rechecked against origin/develop 8a7ee88e0 on 2026-07-18: current marker collection selects 8 of 9 DuckLake tests in no configured CI lane; only the non-live SQLite test reaches the release non-fast canary; revised the record to match current lane behavior.

--- a/_project/blind-spots/2026-07-16-140939-config-lost-across-serialization-boundary.md
+++ b/_project/blind-spots/2026-07-16-140939-config-lost-across-serialization-boundary.md
@@ -1,7 +1,7 @@
 ---
 id: 2026-07-16-140939-config-lost-across-serialization-boundary
 date: 2026-07-16
-status: open
+status: actionable
 finding_kind: bug-class
 review_context: "tuning remediation batch close-out 2026-07-16 / chore/tuning-residual-cleanups"
 related_paths:
@@ -12,41 +12,46 @@ suggested_sweep: "grep from_config implementations for dropped kwargs classes be
 todo_id: null
 ---
 
-# Config silently lost across a serialization boundary between producer and consumer
+# Producer-added config fields can be silently dropped by hand-picking consumers
 
 ## Finding
-`get_platform_config` (`benchbox/core/platform_config.py`) builds the adapter-facing
-config dict by calling `DatabaseConfig.model_dump(exclude_none=False)` and merging in a
-handful of extra keys (`benchmark`, `scale_factor`, `tuning_config`). Each platform's
-`PlatformAdapter.from_config(cls, config: dict)` then hand-picks the keys it knows about
-out of that flattened dict (as seen in `benchbox/platforms/duckdb.py from_config`, which
-explicitly reads `config.get("tuning_config")`, `config["benchmark"]`,
-`config["scale_factor"]`, etc.). Nothing enforces that every `from_config` override reads
-every kwarg the producer put in -- across the ~48 platform adapters, a kwarg added by the
-producer side that a given adapter's `from_config` doesn't explicitly extract is dropped
-silently: no error, no warning, just absent from the constructed adapter. This is the same
-shape of bug independently proven in #1176 w0 for the tuning-kwarg case, but the
-model_dump-then-hand-pick pattern is generic -- any future field added to `DatabaseConfig`
-or to `get_platform_config`'s merged dict has the same failure mode for any adapter whose
-`from_config` wasn't updated in lockstep.
+`get_platform_config` (`benchbox/core/platform_config.py`) still builds the
+adapter-facing dict from `DatabaseConfig.model_dump(exclude_none=False)`, which
+includes allowed extras, then merges runtime keys such as `benchmark`,
+`scale_factor`, and `tuning_config`. Each platform's
+`PlatformAdapter.from_config(cls, config: dict)` still selects the constructor
+keys it knows about. For example, `DuckDB.from_config` explicitly reads the
+database path, benchmark/scale context, memory/force settings, tuning keys,
+and driver metadata, while other adapters use different hand-maintained
+lists.
+
+The tuning remediation added a shared forwarding list for the known tuning
+keys, but there is still no producer/consumer contract that distinguishes
+intentionally ignored metadata from a semantically required new config field.
+A future field added to `DatabaseConfig` or `get_platform_config` can therefore
+be dropped without an error or warning when an affected adapter's
+`from_config` is not updated in lockstep. The generic class remains; only the
+known tuning instance was fixed.
 
 ## Why this matters
-A serialization/deserialization boundary (dict flattening on the producer side, manual
-key extraction on the consumer side) has no schema contract between the two ends. The
-type system cannot catch a field that one side stops producing or the other side never
-started reading -- the only symptom is a config value quietly not taking effect, which
-looks identical to "the value was never set" from the caller's perspective. This is
-structurally the same class of bug as the platform-identity display-name/canonical-key
-confusion from the 2026-07-12 batch (differently shaped keys silently failing to connect
-producer to consumer), but for config *values* rather than config *keys*.
+A dict-flattening boundary on the producer side and manual key extraction on
+the consumer side has no schema contract for semantically required fields. The
+type system cannot catch a field that one side starts producing while the
+other side never reads; the only symptom is a config value quietly not taking
+effect, which looks identical to "the value was never set" from the caller's
+perspective. This is structurally the same class of bug as the platform-
+identity display-name/canonical-key confusion from the 2026-07-12 batch, but
+for config values rather than config keys.
 
 ## Suggested next steps
-- [ ] Grep all `from_config` implementations under `benchbox/platforms/**` for the set of
-      keys each one reads out of its `config` dict argument; diff against the full set of
-      keys `get_platform_config` can produce (including `DatabaseConfig` extra/optional
-      fields) to find adapters silently dropping producer-supplied config.
-      (suggested_sweep, verbatim: "grep from_config implementations for dropped kwargs
-      classes beyond tuning")
-- [ ] Consider a shared `from_config` base helper (or a post-construction assertion) that
-      surfaces unconsumed keys instead of letting `from_config` overrides silently ignore
-      them.
+- [ ] Inventory all `from_config` implementations under `benchbox/platforms/**` and
+      classify each producer key as consumed, intentionally ignored metadata, or
+      required-but-dropped; do not treat every diagnostic/driver field as a constructor
+      obligation.
+- [ ] Add a contract or focused test for semantically required producer fields so a new
+      field cannot be silently omitted by an adapter override. A shared helper may reduce
+      drift, but it must preserve platform-specific filtering.
+
+## Triage log
+
+- 2026-07-18: actionable — Rechecked against origin/develop 8a7ee88e0 on 2026-07-18: producer flattening and hand-picked from_config consumers remain, while the tuning forwarding helper fixes only the known tuning instance; revised the record to retain the generic semantically-required-field gap.


### PR DESCRIPTION
## Summary

- Rechecked the four active blind-spot records in chronological order against `origin/develop`.
- Revised three records whose historical wording had drifted, separating resolved examples from still-live framework risks.
- Added dated 2026-07-18 actionable triage entries to all four records.

## Why

Keep the blind-spot queue current without erasing historical findings. The oldest TODO-review record's concrete shrink example is resolved, but its own-edit-target freshness gap remains. The auto-revert attribution gap, DuckLake live-CI coverage gap, and producer/consumer config-boundary gap remain applicable.

## Validation

- `uv run --project _project/scripts -- python _project/scripts/validate_blind_spot.py --all` — all 64 files valid.
- `make pr-preflight` — 25,175 passed, 27 skipped, 48 warnings, 4 subtests passed; CI lint and artifact-hygiene checks passed.

Documentation-only blind-spot records were changed; no runtime code was modified.
