### PR TITLE
fix(todo-db): hosted-backend hardening (PR #1219 review follow-up)

### DIFF
--- a/_project/audits/todo-db-hosted-acceptance-2026-07-18.md
+++ b/_project/audits/todo-db-hosted-acceptance-2026-07-18.md
@@ -28,9 +28,13 @@ DB=https://benchbox-todo-joeharris76.aws-us-east-1.turso.io/v2/pipeline
 curl -s -o /dev/null -w '%{http_code}\n' -X POST "$DB" \
   -H 'Content-Type: application/json' \
   -d '{"requests":[{"type":"execute","stmt":{"sql":"SELECT 1"}},{"type":"close"}]}'
-# authenticated -> HTTP 200; observed 0.15-0.16s per fresh connection
-curl -s -o /dev/null -w '%{http_code} %{time_total}s\n' -X POST "$DB" \
-  -H "Authorization: Bearer $TODO_DB_AUTH_TOKEN" -H 'Content-Type: application/json' \
+# authenticated -> HTTP 200; observed 0.15-0.16s per fresh connection.
+# The auth header goes through curl's stdin config (-K-), NOT argv: argv is
+# world-readable via ps on shared hosts. printf is a shell builtin, so the
+# token never appears in any process's argv.
+printf 'header = "Authorization: Bearer %s"\n' "$TODO_DB_AUTH_TOKEN" | \
+  curl -s -K- -o /dev/null -w '%{http_code} %{time_total}s\n' -X POST "$DB" \
+  -H 'Content-Type: application/json' \
   -d '{"requests":[{"type":"execute","stmt":{"sql":"SELECT 1"}},{"type":"close"}]}'
 ```
 
@@ -41,8 +45,10 @@ default; `TODO_DB_REPLICA` forces distinct paths when replaying from one
 worktree). Expected exit codes in comments.
 
 ```bash
-A() { TODO_DB_REPLICA=/tmp/replicaA/replica.db TODO_ACTOR=actor-a _project/scripts/todo "$@"; }
-B() { TODO_DB_REPLICA=/tmp/replicaB/replica.db TODO_ACTOR=actor-b _project/scripts/todo "$@"; }
+# Repo-local replica dirs (never world-writable /tmp: the lock/replica
+# paths would be symlink-attackable there).
+A() { TODO_DB_REPLICA="$PWD/.todo-db/replay-A/replica.db" TODO_ACTOR=actor-a _project/scripts/todo "$@"; }
+B() { TODO_DB_REPLICA="$PWD/.todo-db/replay-B/replica.db" TODO_ACTOR=actor-b _project/scripts/todo "$@"; }
 A create vis-probe-$(date +%s) --title "Cross-process visibility probe" \
   --worktree spike --priority low --description "Two-replica proof." \
   --work "w1:probe unit"                                   # rc=0
@@ -96,5 +102,15 @@ Failure paths are pinned by `tests/unit/scripts/test_todo_db_hosted.py`
 COMMIT isolated from data batches and withheld on any statement error,
 stream close (rollback) on mid-transfer failure, `base_url` carried across
 baton-chained requests, atomic emptiness guard, network/JSON error mapping
-to exit 2, replica setup flock. Replay: `uv run -- python -m pytest
-tests/unit/scripts/test_todo_db_hosted.py -q`.
+to exit 2, replica setup flock. Second wave: redirect refusal (urllib
+carries Authorization across redirects), transactional `promote` with a
+concurrent-connection lock probe, degraded-mode fresh-replica refusal,
+atomic schema bootstrap, broadened busy/network error mapping with
+redaction at the CLI boundary, whole-tracker import guard, conditional
+`sweep-stale`, migrate re-check under lock, `O_NOFOLLOW` on the lock.
+Replay: `uv run -- python -m pytest
+tests/unit/scripts/test_todo_db_hosted.py
+tests/unit/scripts/test_todo_db_hardening.py -q`. Live counterpart (needs
+`TODO_TEST_DB_URL` + `TODO_DB_AUTH_TOKEN`, a dedicated test database):
+`uv run -- python -m pytest tests/integration/test_todo_db_hosted_live.py
+-m live_integration -q`.

--- a/_project/audits/todo-db-hosted-acceptance-2026-07-18.md
+++ b/_project/audits/todo-db-hosted-acceptance-2026-07-18.md
@@ -64,11 +64,15 @@ imported/skipped/warnings counts without writing. Full replay
 non-empty target without `--replace`, atomically (the emptiness guard runs
 inside the transfer's `BEGIN IMMEDIATE` transaction).
 
-Recorded result at this SHA's tree (drifts as TODO/DONE files land):
+Recorded result (drifts as TODO/DONE files land):
 `imported: 1364  skipped: 0  warnings: 18`,
-`deps_resolved 539, deps_dangling 1`, stats `open` deferrals 629;
-32,595 rows, 44s wall via the Hrana bulk path (vs 4s local-SQLite control,
-vs ~2.5h projected for row-by-row delegation). Verify hosted == local by
+`deps_resolved 539, deps_dangling 1`, stats `open` deferrals 629 — these
+reproduce exactly at this file's pinned SHA. The live run's row total,
+32,595 in 82 data batches / 44s wall via the Hrana bulk path (vs 4s
+local-SQLite control, vs ~2.5h projected for row-by-row delegation), came
+from the PR #1219 head tree; a replay at the pinned SHA yields 32,621
+rows (intervening TODO/DONE edits), and the hardened CLI reports pipeline
+requests (data batches + guard + commit), so a replay prints 84. Verify hosted == local by
 running the same import into a scratch local file
 (`TODO_DB_PATH=/tmp/ctl.sqlite`) and diffing the report lines and `stats`.
 
@@ -87,7 +91,8 @@ promoted 1). Command latency observed: reads 0.7–0.8s warm; writes
 ## E. Hardening regressions (post-merge review)
 
 Failure paths are pinned by `tests/unit/scripts/test_todo_db_hosted.py`
-(fake libsql client + fake Hrana primary): plaintext `http://` refusal,
+(fake libsql client + fake Hrana primary): plaintext `http://` refusal
+(scheme-normalized: `HTTP://`/whitespace variants are caught too),
 COMMIT isolated from data batches and withheld on any statement error,
 stream close (rollback) on mid-transfer failure, `base_url` carried across
 baton-chained requests, atomic emptiness guard, network/JSON error mapping

--- a/_project/audits/todo-db-hosted-acceptance-2026-07-18.md
+++ b/_project/audits/todo-db-hosted-acceptance-2026-07-18.md
@@ -1,0 +1,95 @@
+---
+develop_sha: 253e6a810307ba169f331986420d70c38db6a244
+---
+# Evidence record: hosted TODO tracker acceptance (2026-07-18)
+
+Replayable harness backing the "Hosted backend" round and the G1/G3 closures
+in `_project/specs/todo-db-tracker.md` (landed in PR #1219, hardened in the
+follow-up PR that adds this file). The spec carries the observed numbers;
+this file carries the exact commands to reproduce them.
+
+## Prerequisites
+
+- Turso database `benchbox-todo`
+  (`libsql://benchbox-todo-joeharris76.aws-us-east-1.turso.io`).
+- Credentials: `TODO_DB_URL` + `TODO_DB_AUTH_TOKEN` in the environment.
+  Remote sessions get them from the environment config; local sessions can
+  mint a short-lived token inline via the maintainer's authenticated CLI:
+  `TODO_DB_AUTH_TOKEN=$(turso db tokens create benchbox-todo)`. Never store
+  or echo the token.
+- All commands below run through the shim `_project/scripts/todo`. Global
+  flags (`--db`, `--actor`) go before the subcommand.
+
+## A. Reachability (G1)
+
+```bash
+DB=https://benchbox-todo-joeharris76.aws-us-east-1.turso.io/v2/pipeline
+# unauthenticated control -> HTTP 401 (auth required, not policy-blocked)
+curl -s -o /dev/null -w '%{http_code}\n' -X POST "$DB" \
+  -H 'Content-Type: application/json' \
+  -d '{"requests":[{"type":"execute","stmt":{"sql":"SELECT 1"}},{"type":"close"}]}'
+# authenticated -> HTTP 200; observed 0.15-0.16s per fresh connection
+curl -s -o /dev/null -w '%{http_code} %{time_total}s\n' -X POST "$DB" \
+  -H "Authorization: Bearer $TODO_DB_AUTH_TOKEN" -H 'Content-Type: application/json' \
+  -d '{"requests":[{"type":"execute","stmt":{"sql":"SELECT 1"}},{"type":"close"}]}'
+```
+
+## B. Two-process shared-visibility proof
+
+Two shells, distinct replicas and actors (replicas are per-worktree by
+default; `TODO_DB_REPLICA` forces distinct paths when replaying from one
+worktree). Expected exit codes in comments.
+
+```bash
+A() { TODO_DB_REPLICA=/tmp/replicaA/replica.db TODO_ACTOR=actor-a _project/scripts/todo "$@"; }
+B() { TODO_DB_REPLICA=/tmp/replicaB/replica.db TODO_ACTOR=actor-b _project/scripts/todo "$@"; }
+A create vis-probe-$(date +%s) --title "Cross-process visibility probe" \
+  --worktree spike --priority low --description "Two-replica proof." \
+  --work "w1:probe unit"                                   # rc=0
+B ready | grep vis-probe                                   # visible cross-replica
+A claim <id>                                               # rc=0, prints work order
+B claim <id>                                               # rc=2 "claimed by 'actor-a'"
+A done <id> w1 --evidence "live probe"                     # rc=0
+A defer <id> --summary "gate probe" --reason "proof"       # rc=0
+B complete <id>                                            # rc=2 "unresolved deferrals"
+B dismiss <deferral-id> --reason "probe complete"          # rc=0 (cross-process resolution)
+A complete <id>                                            # rc=0
+```
+
+## C. Import (G3)
+
+Non-destructive replay: `todo import-yaml --dry-run` prints the same
+imported/skipped/warnings counts without writing. Full replay
+(`--replace`) clears the tracker tables and re-imports; it refuses a
+non-empty target without `--replace`, atomically (the emptiness guard runs
+inside the transfer's `BEGIN IMMEDIATE` transaction).
+
+Recorded result at this SHA's tree (drifts as TODO/DONE files land):
+`imported: 1364  skipped: 0  warnings: 18`,
+`deps_resolved 539, deps_dangling 1`, stats `open` deferrals 629;
+32,595 rows, 44s wall via the Hrana bulk path (vs 4s local-SQLite control,
+vs ~2.5h projected for row-by-row delegation). Verify hosted == local by
+running the same import into a scratch local file
+(`TODO_DB_PATH=/tmp/ctl.sqlite`) and diffing the report lines and `stats`.
+
+## D. Shim UAT lifecycle
+
+The `TestWrapperUatLifecycle` sequence executed live against the hosted
+database (create → ready → claim → out-of-order done rc=2 → start/done with
+evidence → verify --run pass → defer → complete rc=2 → promote → complete →
+export ×2 byte-identical → late defer rc=2). Cleanup: `todo drop` the
+promoted follow-up with reason "UAT artifact". Recorded run: deferral #630,
+export over 1,366 items identical, final stats coherent (open 629 /
+promoted 1). Command latency observed: reads 0.7–0.8s warm; writes
+1.5–3.3s; first connect per worktree pays a cold replica sync (~3.4s at
+12.8MB).
+
+## E. Hardening regressions (post-merge review)
+
+Failure paths are pinned by `tests/unit/scripts/test_todo_db_hosted.py`
+(fake libsql client + fake Hrana primary): plaintext `http://` refusal,
+COMMIT isolated from data batches and withheld on any statement error,
+stream close (rollback) on mid-transfer failure, `base_url` carried across
+baton-chained requests, atomic emptiness guard, network/JSON error mapping
+to exit 2, replica setup flock. Replay: `uv run -- python -m pytest
+tests/unit/scripts/test_todo_db_hosted.py -q`.

--- a/_project/scripts/todo_db.py
+++ b/_project/scripts/todo_db.py
@@ -280,14 +280,23 @@ def resolve_db_path(explicit: str | None) -> Path:
     return git_main_root() / ".todo-db" / "todo.sqlite"
 
 
+def _normalize_url(value: str) -> str:
+    """Trim whitespace and lowercase the scheme (schemes are case-insensitive
+    per RFC 3986, so HTTP:// must not bypass scheme checks)."""
+    value = value.strip()
+    scheme, sep, rest = value.partition("://")
+    return scheme.lower() + sep + rest if sep else value
+
+
 def _is_hosted_url(value: str) -> bool:
     # http:// is recognized so it can be REJECTED with a clear error at
     # connect time (a Bearer token must never travel over plaintext), rather
     # than silently treated as a local file path.
-    return value.startswith(("libsql://", "https://", "http://"))
+    return _normalize_url(value).startswith(("libsql://", "https://", "http://"))
 
 
 def _require_secure_url(url: str) -> str:
+    url = _normalize_url(url)
     if url.startswith("http://"):
         raise TodoError(
             "refusing plaintext http:// for the hosted backend (the auth token would"
@@ -304,13 +313,13 @@ def resolve_backend(explicit: str | None) -> Path | str:
     a local file must never be silently redirected at the shared database.
     """
     if explicit:
-        return explicit if _is_hosted_url(explicit) else Path(explicit)
+        return _normalize_url(explicit) if _is_hosted_url(explicit) else Path(explicit)
     env_path = os.environ.get("TODO_DB_PATH")
     if env_path:
         return Path(env_path)
     env_url = os.environ.get("TODO_DB_URL")
     if env_url:
-        return env_url
+        return _normalize_url(env_url)
     return git_main_root() / ".todo-db" / "todo.sqlite"
 
 
@@ -576,7 +585,7 @@ TRANSFER_TABLES = (
 
 
 def _hrana_endpoint(url: str) -> str:
-    _require_secure_url(url)
+    url = _require_secure_url(url)
     if url.startswith("libsql://"):
         url = "https://" + url[len("libsql://") :]
     return url.rstrip("/") + "/v2/pipeline"

--- a/_project/scripts/todo_db.py
+++ b/_project/scripts/todo_db.py
@@ -345,15 +345,30 @@ def _git_location() -> tuple[str | None, str | None]:
     return _out("rev-parse", "--show-toplevel"), _out("rev-parse", "--abbrev-ref", "HEAD")
 
 
+def _schema_statements() -> list[str]:
+    # SCHEMA_SQL is our own controlled DDL: no string literals containing ';'.
+    return [statement.strip() for statement in SCHEMA_SQL.split(";") if statement.strip()]
+
+
 def _ensure_schema(conn: sqlite3.Connection) -> None:
     version = _schema_version(conn)
     if version is None:
-        conn.executescript(SCHEMA_SQL)
-        conn.execute(
-            "INSERT INTO meta (key, value) VALUES ('schema_version', ?)",
-            (str(SCHEMA_VERSION),),
-        )
-    elif version < SCHEMA_VERSION:
+        # Atomic bootstrap: per-statement inside one write transaction, so a
+        # mid-DDL failure (network drop on a hosted primary, a racing
+        # first-connect) rolls back completely instead of leaving partial
+        # tables without `meta` that wedge every later connect. Not
+        # executescript: it auto-commits, and some libsql client builds
+        # document it unimplemented.
+        with _write_txn(conn):
+            if _schema_version(conn) is None:  # re-check under the write lock
+                for statement in _schema_statements():
+                    conn.execute(statement)
+                conn.execute(
+                    "INSERT INTO meta (key, value) VALUES ('schema_version', ?)",
+                    (str(SCHEMA_VERSION),),
+                )
+        version = _schema_version(conn)
+    if version < SCHEMA_VERSION:
         raise TodoError(
             f"database schema_version={version}, CLI expects {SCHEMA_VERSION}; run `todo migrate` to upgrade it"
         )
@@ -416,12 +431,17 @@ class _HostedRow:
         return f"_HostedRow({dict(zip(self._names, self._values))!r})"
 
 
-def _map_hosted_error(exc: BaseException) -> sqlite3.Error | None:
-    """Translate libsql's ValueError surface back onto sqlite3 exceptions."""
+def _map_hosted_error(exc: BaseException) -> sqlite3.Error:
+    """Translate libsql's ValueError surface back onto sqlite3 exceptions.
+
+    Constraint violations keep their IntegrityError identity (gates depend on
+    it); everything else — SQLITE_BUSY, network drops mid-statement — becomes
+    OperationalError so main()'s sqlite3.Error boundary turns it into a clean
+    exit 2 instead of a traceback."""
     message = str(exc)
     if "constraint" in message.lower():
         return sqlite3.IntegrityError(message)
-    return None
+    return sqlite3.OperationalError(message)
 
 
 class _HostedCursor:
@@ -461,24 +481,13 @@ class _HostedConnection:
 
     def __init__(self, raw):
         self._raw = raw
+        self.stale = False  # set when the freshness sync at connect failed
 
     def execute(self, sql: str, params=()) -> _HostedCursor:
         try:
             return _HostedCursor(self._raw.execute(sql, tuple(params)))
         except ValueError as exc:
-            mapped = _map_hosted_error(exc)
-            if mapped is not None:
-                raise mapped from exc
-            raise
-
-    def executescript(self, sql: str) -> None:
-        try:
-            self._raw.executescript(sql)
-        except ValueError as exc:
-            mapped = _map_hosted_error(exc)
-            if mapped is not None:
-                raise mapped from exc
-            raise
+            raise _map_hosted_error(exc) from exc
 
     def commit(self) -> None:
         self._raw.commit()
@@ -497,6 +506,10 @@ def _redacted(exc: BaseException, secret: str) -> str:
     return str(exc).replace(secret, "<redacted>") if secret else str(exc)
 
 
+def _auth_token() -> str:
+    return os.environ.get("TODO_DB_AUTH_TOKEN") or ""
+
+
 @contextmanager
 def _replica_setup_lock(replica: Path):
     """Serialize replica open+sync across processes of the same worktree.
@@ -512,12 +525,20 @@ def _replica_setup_lock(replica: Path):
         yield
         return
     lock_path = replica.with_suffix(".db.lock")
-    with open(lock_path, "w", encoding="utf-8") as handle:
-        fcntl.flock(handle, fcntl.LOCK_EX)
+    try:
+        # O_NOFOLLOW: a planted symlink at the lock path must fail loudly,
+        # never truncate its target (lock dirs may live on shared hosts).
+        fd = os.open(lock_path, os.O_CREAT | os.O_RDWR | getattr(os, "O_NOFOLLOW", 0), 0o600)
+    except OSError as exc:
+        raise TodoError(f"cannot open replica lock {lock_path}: {exc}") from exc
+    try:
+        fcntl.flock(fd, fcntl.LOCK_EX)
         try:
             yield
         finally:
-            fcntl.flock(handle, fcntl.LOCK_UN)
+            fcntl.flock(fd, fcntl.LOCK_UN)
+    finally:
+        os.close(fd)
 
 
 def _hosted_raw_connect(url: str, sync_required: bool) -> _HostedConnection:
@@ -541,6 +562,7 @@ def _hosted_raw_connect(url: str, sync_required: bool) -> _HostedConnection:
                 raise TodoError(f"hosted tracker: cannot sync with the primary: {_redacted(exc, token)}") from exc
             # Degraded mode per spec: reads serve the stale replica with a banner;
             # writes will fail loudly at the primary (no offline write queue).
+            conn.stale = True
             print(
                 f"warning: STALE replica — sync with the primary failed ({_redacted(exc, token)}); "
                 "reads may be outdated and writes will fail",
@@ -553,6 +575,14 @@ def _hosted_raw_connect(url: str, sync_required: bool) -> _HostedConnection:
 
 def connect_hosted(url: str) -> _HostedConnection:
     conn = _hosted_raw_connect(url, sync_required=False)
+    if conn.stale and _schema_version(conn) is None:
+        # A never-synced replica cannot bootstrap the schema while the
+        # primary is down — that would be a delegated write. Fail cleanly.
+        conn.close()
+        raise TodoError(
+            "hosted tracker: the primary is unreachable and this worktree's replica"
+            " has no schema yet; retry when the network is back"
+        )
     _ensure_schema(conn)
     return conn
 
@@ -605,6 +635,29 @@ def _hrana_value(value: Any) -> dict[str, Any]:
     return {"type": "text", "value": str(value)}
 
 
+def _build_no_redirect_opener():
+    """Opener that refuses ALL redirects: urllib preserves the Authorization
+    header across them (even an https->http downgrade), so following one
+    would replay the Bearer token at a response-chosen URL."""
+    import urllib.request
+
+    class _RefuseRedirects(urllib.request.HTTPRedirectHandler):
+        def redirect_request(self, req, fp, code, msg, headers, newurl):
+            return None
+
+    return urllib.request.build_opener(_RefuseRedirects)
+
+
+_HTTP_OPENER = None
+
+
+def _http_post_response(request, timeout: float):
+    global _HTTP_OPENER
+    if _HTTP_OPENER is None:
+        _HTTP_OPENER = _build_no_redirect_opener()
+    return _HTTP_OPENER.open(request, timeout=timeout)
+
+
 def _post_pipeline(endpoint: str, token: str, payload: dict[str, Any]) -> dict[str, Any]:
     import http.client
     import urllib.request
@@ -615,7 +668,7 @@ def _post_pipeline(endpoint: str, token: str, payload: dict[str, Any]) -> dict[s
         headers={"Authorization": f"Bearer {token}", "Content-Type": "application/json"},
     )
     try:
-        with urllib.request.urlopen(request, timeout=60) as response:
+        with _http_post_response(request, timeout=60) as response:
             body = response.read()
     # OSError covers URLError, TimeoutError/socket.timeout, and connection
     # resets; HTTPException covers mid-response protocol failures. All must
@@ -704,17 +757,21 @@ def bulk_transfer(
             pass
 
     try:
+        total_sql = "SELECT " + " + ".join(f"(SELECT count(*) FROM {table})" for table in TRANSFER_TABLES)
         guard = _pipeline_execute(
             url,
             token,
-            [("BEGIN IMMEDIATE", []), ("SELECT count(*) FROM items", [])],
+            [("BEGIN IMMEDIATE", []), (total_sql, [])],
             stream=stream,
             post=post,
         )
+        # Counts EVERY transfer table, not just items: an itemless events row
+        # (e.g. from `todo config`) would otherwise pass the guard and abort
+        # mid-transfer on an events.seq collision with a cryptic error.
         existing = int(guard["results"][1]["response"]["result"]["rows"][0][0]["value"])
         if existing and require_empty:
             raise TodoError(
-                f"hosted database already holds {existing} item(s);"
+                f"hosted database is not empty ({existing} tracker row(s));"
                 " rerun with --replace to clear the tracker tables and re-import"
             )
         for batch in batches:
@@ -748,6 +805,11 @@ def migrate_backend(backend: Path | str) -> list[int]:
         for target in sorted(MIGRATIONS):
             if version < target:
                 with _write_txn(conn):
+                    current = _schema_version(conn)
+                    if current is not None and current >= target:
+                        # a concurrent migrator won the race; not an error
+                        version = current
+                        continue
                     for statement in MIGRATIONS[target]:
                         conn.execute(statement)
                     conn.execute("UPDATE meta SET value = ? WHERE key = 'schema_version'", (str(target),))
@@ -793,7 +855,10 @@ def _write_txn(conn: sqlite3.Connection):
     try:
         yield
     except BaseException:
-        conn.rollback()
+        try:
+            conn.rollback()
+        except Exception:  # noqa: S110 - never mask the original failure
+            pass
         raise
     else:
         conn.commit()
@@ -911,6 +976,7 @@ def create_item(
     prior_art: list[tuple[str, str, str]] | None = None,
     completed_at: str | None = None,
     completed_pr: int | None = None,
+    _in_txn: bool = False,
 ) -> None:
     if not SLUG_RE.match(item_id):
         raise TodoError(f"invalid item id (slug) {item_id!r}")
@@ -923,7 +989,8 @@ def create_item(
         raise TodoError(f"new items must start planning, active, or done (import), not {state!r}")
     if state != "done" and (completed_at or completed_pr):
         raise TodoError("completed_at/completed_pr are only valid with state='done' (import)")
-    with _write_txn(conn):
+
+    def _write_rows() -> None:
         try:
             conn.execute(
                 "INSERT INTO items (id, title, worktree, priority, state, blocked_reason,"
@@ -982,6 +1049,14 @@ def create_item(
                 (item_id, path, concept, decision),
             )
         log_event(conn, actor, item_id, "create", {"title": title, "state": state})
+
+    if _in_txn:
+        # Caller (promote_deferral) already holds the write transaction, so
+        # the whole promote — gate, item creation, resolution — is one txn.
+        _write_rows()
+    else:
+        with _write_txn(conn):
+            _write_rows()
 
 
 def _insert_work_unit(conn: sqlite3.Connection, item_id: str, unit: dict[str, Any]) -> None:
@@ -1182,28 +1257,36 @@ def promote_deferral(
     worktree: str | None = None,
     description: str | None = None,
 ) -> None:
-    row = _require_deferral(conn, deferral_id)
-    if row["resolution"] != "open":
-        raise TodoError(f"deferral {deferral_id} is already {row['resolution']}")
-    parent = _require_item(conn, row["from_item"])
-    create_item(
-        conn,
-        actor,
-        item_id=new_item_id,
-        title=title or row["summary"][:200],
-        worktree=worktree or parent["worktree"],
-        priority=priority,
-        description=description
-        or (
-            f"Promoted from deferral #{deferral_id} of {parent['id']}.\n"
-            f"Deferred: {row['summary']}\nReason deferred: {row['reason']}"
-        ),
-    )
+    # One transaction end to end: the gate read, the item creation, and the
+    # resolution update. Split phases let two actors promote one deferral
+    # (or a promote overwrite a concurrent dismiss) — found by adversarial
+    # review; the conditional UPDATE is the same defense-in-depth pattern as
+    # claim_item.
     with _write_txn(conn):
-        conn.execute(
-            "UPDATE deferrals SET resolution = 'promoted', resolved_item = ? WHERE id = ?",
+        row = _require_deferral(conn, deferral_id)
+        if row["resolution"] != "open":
+            raise TodoError(f"deferral {deferral_id} is already {row['resolution']}")
+        parent = _require_item(conn, row["from_item"])
+        create_item(
+            conn,
+            actor,
+            item_id=new_item_id,
+            title=title or row["summary"][:200],
+            worktree=worktree or parent["worktree"],
+            priority=priority,
+            description=description
+            or (
+                f"Promoted from deferral #{deferral_id} of {parent['id']}.\n"
+                f"Deferred: {row['summary']}\nReason deferred: {row['reason']}"
+            ),
+            _in_txn=True,
+        )
+        resolved = conn.execute(
+            "UPDATE deferrals SET resolution = 'promoted', resolved_item = ? WHERE id = ? AND resolution = 'open'",
             (new_item_id, deferral_id),
         )
+        if resolved.rowcount != 1:
+            raise TodoError(f"deferral {deferral_id} was resolved concurrently")
         log_event(
             conn,
             actor,
@@ -1327,12 +1410,20 @@ def unblock_item(conn: sqlite3.Connection, actor: str, item_id: str) -> None:
 def sweep_stale(conn: sqlite3.Connection, actor: str, ttl_hours: float = DEFAULT_LEASE_TTL_HOURS) -> list[str]:
     released = []
     with _write_txn(conn):
-        for row in conn.execute("SELECT id, claimed_by, claimed_at FROM items WHERE claimed_by IS NOT NULL"):
+        rows = conn.execute("SELECT id, claimed_by, claimed_at FROM items WHERE claimed_by IS NOT NULL").fetchall()
+        for row in rows:
             if _lease_expired(row["claimed_at"], ttl_hours):
-                conn.execute(
-                    "UPDATE items SET claimed_by = NULL, claimed_at = NULL WHERE id = ?",
-                    (row["id"],),
+                # Conditional on the exact lease observed (same defense as
+                # claim_item): if the lease changed hands since the read —
+                # e.g. a renewal the sweeping replica had not seen — the
+                # release must not fire on the live claim.
+                swept = conn.execute(
+                    "UPDATE items SET claimed_by = NULL, claimed_at = NULL"
+                    " WHERE id = ? AND claimed_by = ? AND claimed_at IS ?",
+                    (row["id"], row["claimed_by"], row["claimed_at"]),
                 )
+                if swept.rowcount != 1:
+                    continue
                 log_event(
                     conn,
                     actor,
@@ -2072,6 +2163,9 @@ def main(argv: list[str] | None = None) -> int:
         except TodoError as exc:
             print(f"error: {exc}", file=sys.stderr)
             return 2
+        except sqlite3.Error as exc:
+            print(f"error: database failure: {_redacted(exc, _auth_token())}", file=sys.stderr)
+            return 2
         if applied:
             print(f"applied migration(s) to v{', v'.join(str(v) for v in applied)}")
             return 0
@@ -2080,11 +2174,19 @@ def main(argv: list[str] | None = None) -> int:
     except TodoError as exc:
         print(f"error: {exc}", file=sys.stderr)
         return 2
+    except sqlite3.Error as exc:
+        print(f"error: database failure: {_redacted(exc, _auth_token())}", file=sys.stderr)
+        return 2
 
     try:
         return _dispatch(conn, actor, args)
     except TodoError as exc:
         print(f"error: {exc}", file=sys.stderr)
+        return 2
+    except sqlite3.Error as exc:
+        # SQLITE_BUSY, lock contention, network drops mid-statement: a clean
+        # exit 2 with the token redacted, never a traceback.
+        print(f"error: database failure: {_redacted(exc, _auth_token())}", file=sys.stderr)
         return 2
     except BrokenPipeError:
         # Downstream pipe closed early (e.g. `todo ready | head`); not an error.

--- a/_project/scripts/todo_db.py
+++ b/_project/scripts/todo_db.py
@@ -12,9 +12,10 @@ Backend selection (first match wins):
 - --db PATH_OR_URL          explicit; libsql:// or https:// selects hosted
 - TODO_DB_PATH              local SQLite file (also what tests use)
 - TODO_DB_URL               hosted libsql database (Turso); requires
-                            TODO_DB_AUTH_TOKEN; embedded replica at
-                            <git main root>/.todo-db/replica.db
-                            (override: TODO_DB_REPLICA)
+                            TODO_DB_AUTH_TOKEN; per-worktree embedded
+                            replica at <git root>/.todo-db/replica.db
+                            (override: TODO_DB_REPLICA); plaintext
+                            http:// is refused
 - default                   <git main root>/.todo-db/todo.sqlite (gitignored)
 
 Hosted mode keeps the exact write-transaction discipline of local mode:
@@ -280,7 +281,19 @@ def resolve_db_path(explicit: str | None) -> Path:
 
 
 def _is_hosted_url(value: str) -> bool:
+    # http:// is recognized so it can be REJECTED with a clear error at
+    # connect time (a Bearer token must never travel over plaintext), rather
+    # than silently treated as a local file path.
     return value.startswith(("libsql://", "https://", "http://"))
+
+
+def _require_secure_url(url: str) -> str:
+    if url.startswith("http://"):
+        raise TodoError(
+            "refusing plaintext http:// for the hosted backend (the auth token would"
+            " be sent unencrypted); use https:// or libsql://"
+        )
+    return url
 
 
 def resolve_backend(explicit: str | None) -> Path | str:
@@ -302,8 +315,15 @@ def resolve_backend(explicit: str | None) -> Path | str:
 
 
 def hosted_replica_path() -> Path:
+    """Per-worktree embedded-replica location (override: TODO_DB_REPLICA).
+
+    Deliberately git_root(), not git_main_root(): the replica is a cache of
+    the shared primary, and many processes syncing one shared replica file
+    concurrently is a corruption hazard. Cross-worktree sharing happens at
+    the primary, not the cache.
+    """
     env = os.environ.get("TODO_DB_REPLICA")
-    return Path(env) if env else git_main_root() / ".todo-db" / "replica.db"
+    return Path(env) if env else git_root() / ".todo-db" / "replica.db"
 
 
 def _git_location() -> tuple[str | None, str | None]:
@@ -468,7 +488,31 @@ def _redacted(exc: BaseException, secret: str) -> str:
     return str(exc).replace(secret, "<redacted>") if secret else str(exc)
 
 
+@contextmanager
+def _replica_setup_lock(replica: Path):
+    """Serialize replica open+sync across processes of the same worktree.
+
+    libsql's embedded replica does not document concurrent multi-process
+    sync safety, so setup is guarded by an advisory flock; it is released
+    once the connection is established (post-setup reads are plain SQLite).
+    No-op on platforms without fcntl.
+    """
+    try:
+        import fcntl
+    except ImportError:  # pragma: no cover - non-POSIX
+        yield
+        return
+    lock_path = replica.with_suffix(".db.lock")
+    with open(lock_path, "w", encoding="utf-8") as handle:
+        fcntl.flock(handle, fcntl.LOCK_EX)
+        try:
+            yield
+        finally:
+            fcntl.flock(handle, fcntl.LOCK_UN)
+
+
 def _hosted_raw_connect(url: str, sync_required: bool) -> _HostedConnection:
+    _require_secure_url(url)
     token = os.environ.get("TODO_DB_AUTH_TOKEN") or ""
     if not token:
         raise TodoError("hosted tracker: set TODO_DB_AUTH_TOKEN when TODO_DB_URL points at a remote database")
@@ -478,20 +522,21 @@ def _hosted_raw_connect(url: str, sync_required: bool) -> _HostedConnection:
         raise TodoError("hosted tracker requires the `libsql` package; run `uv sync` in _project/scripts") from exc
     replica = hosted_replica_path()
     replica.parent.mkdir(parents=True, exist_ok=True)
-    raw = libsql.connect(str(replica), sync_url=url, auth_token=token, isolation_level=None)
-    conn = _HostedConnection(raw)
-    try:
-        conn.sync()
-    except Exception as exc:
-        if sync_required:
-            raise TodoError(f"hosted tracker: cannot sync with the primary: {_redacted(exc, token)}") from exc
-        # Degraded mode per spec: reads serve the stale replica with a banner;
-        # writes will fail loudly at the primary (no offline write queue).
-        print(
-            f"warning: STALE replica — sync with the primary failed ({_redacted(exc, token)}); "
-            "reads may be outdated and writes will fail",
-            file=sys.stderr,
-        )
+    with _replica_setup_lock(replica):
+        raw = libsql.connect(str(replica), sync_url=url, auth_token=token, isolation_level=None)
+        conn = _HostedConnection(raw)
+        try:
+            conn.sync()
+        except Exception as exc:
+            if sync_required:
+                raise TodoError(f"hosted tracker: cannot sync with the primary: {_redacted(exc, token)}") from exc
+            # Degraded mode per spec: reads serve the stale replica with a banner;
+            # writes will fail loudly at the primary (no offline write queue).
+            print(
+                f"warning: STALE replica — sync with the primary failed ({_redacted(exc, token)}); "
+                "reads may be outdated and writes will fail",
+                file=sys.stderr,
+            )
     conn.execute("PRAGMA foreign_keys = ON")
     conn.execute("PRAGMA busy_timeout = 5000")
     return conn
@@ -531,6 +576,7 @@ TRANSFER_TABLES = (
 
 
 def _hrana_endpoint(url: str) -> str:
+    _require_secure_url(url)
     if url.startswith("libsql://"):
         url = "https://" + url[len("libsql://") :]
     return url.rstrip("/") + "/v2/pipeline"
@@ -539,7 +585,7 @@ def _hrana_endpoint(url: str) -> str:
 def _hrana_value(value: Any) -> dict[str, Any]:
     if value is None:
         return {"type": "null"}
-    if isinstance(value, bool) or isinstance(value, int):
+    if isinstance(value, int):  # covers bool
         return {"type": "integer", "value": str(int(value))}
     if isinstance(value, float):
         return {"type": "float", "value": value}
@@ -551,7 +597,7 @@ def _hrana_value(value: Any) -> dict[str, Any]:
 
 
 def _post_pipeline(endpoint: str, token: str, payload: dict[str, Any]) -> dict[str, Any]:
-    import urllib.error
+    import http.client
     import urllib.request
 
     request = urllib.request.Request(
@@ -561,9 +607,16 @@ def _post_pipeline(endpoint: str, token: str, payload: dict[str, Any]) -> dict[s
     )
     try:
         with urllib.request.urlopen(request, timeout=60) as response:
-            return json.loads(response.read())
-    except urllib.error.URLError as exc:
+            body = response.read()
+    # OSError covers URLError, TimeoutError/socket.timeout, and connection
+    # resets; HTTPException covers mid-response protocol failures. All must
+    # surface as TodoError so the CLI exits 2 instead of tracebacking.
+    except (OSError, http.client.HTTPException) as exc:
         raise TodoError(f"hosted pipeline request failed: {_redacted(exc, token)}") from exc
+    try:
+        return json.loads(body)
+    except ValueError as exc:
+        raise TodoError(f"hosted pipeline returned a non-JSON response: {_redacted(exc, token)}") from exc
 
 
 def _pipeline_execute(
@@ -571,28 +624,33 @@ def _pipeline_execute(
     token: str,
     stmts: list[tuple[str, list[Any]]],
     *,
-    baton: str | None = None,
+    stream: dict[str, Any] | None = None,
     close: bool = False,
     post=None,
 ) -> dict[str, Any]:
+    """Run one pipeline request; `stream` carries baton + base_url between
+    requests on the same Hrana stream (the spec allows the server to move a
+    stream to another host via base_url)."""
     post = post or _post_pipeline
     requests_payload: list[dict[str, Any]] = [
         {"type": "execute", "stmt": {"sql": sql, "args": [_hrana_value(arg) for arg in args]}} for sql, args in stmts
     ]
     if close:
         requests_payload.append({"type": "close"})
-    response = post(_hrana_endpoint(url), token, {"baton": baton, "requests": requests_payload})
+    baton = stream.get("baton") if stream else None
+    base = (stream.get("base_url") if stream else None) or url
+    response = post(_hrana_endpoint(base), token, {"baton": baton, "requests": requests_payload})
+    # Update stream state BEFORE scanning for errors so a cleanup close after
+    # a raise still targets the right stream on the right host.
+    if stream is not None:
+        stream["baton"] = response.get("baton")
+        if response.get("base_url"):
+            stream["base_url"] = response["base_url"]
     for result in response.get("results", []):
         if result.get("type") == "error":
             message = result.get("error", {}).get("message", "unknown error")
             raise TodoError(f"hosted pipeline error: {message}")
     return response
-
-
-def hosted_item_count(url: str, token: str, post=None) -> int:
-    response = _pipeline_execute(url, token, [("SELECT count(*) FROM items", [])], close=True, post=post)
-    cell = response["results"][0]["response"]["result"]["rows"][0][0]
-    return int(cell["value"])
 
 
 def bulk_transfer(
@@ -601,13 +659,22 @@ def bulk_transfer(
     token: str,
     *,
     replace: bool = False,
+    require_empty: bool = False,
     post=None,
     batch_size: int = 400,
 ) -> dict[str, int]:
     """Copy all tracker rows from a staged local database to the primary,
-    atomically (one baton-chained transaction; the stream closing without
-    COMMIT rolls the whole transfer back)."""
-    stmts: list[tuple[str, list[Any]]] = [("BEGIN", [])]
+    atomically, in one baton-chained transaction.
+
+    Failure discipline (Hrana keeps executing later requests in a pipeline
+    after a statement error, and SQLite statement errors do not abort the
+    transaction): COMMIT is sent alone, in its own final request, only after
+    every data batch's results came back clean; on any error the stream is
+    explicitly closed, which rolls the whole transfer back. The
+    `require_empty` guard runs inside the same BEGIN IMMEDIATE transaction,
+    so no other writer can populate the target between check and transfer.
+    """
+    stmts: list[tuple[str, list[Any]]] = []
     if replace:
         for table in reversed(TRANSFER_TABLES):
             stmts.append((f"DELETE FROM {table}", []))
@@ -618,13 +685,36 @@ def bulk_transfer(
         for row in staging.execute(f"SELECT {', '.join(columns)} FROM {table}"):
             stmts.append((insert, list(row)))
             rows_total += 1
-    stmts.append(("COMMIT", []))
     batches = [stmts[i : i + batch_size] for i in range(0, len(stmts), batch_size)]
-    baton: str | None = None
-    for index, batch in enumerate(batches):
-        response = _pipeline_execute(url, token, batch, baton=baton, close=index == len(batches) - 1, post=post)
-        baton = response.get("baton")
-    return {"rows": rows_total, "batches": len(batches)}
+    stream: dict[str, Any] = {"baton": None, "base_url": None}
+
+    def _close_stream() -> None:
+        try:
+            _pipeline_execute(url, token, [], stream=stream, close=True, post=post)
+        except Exception:  # best effort; the server also rolls back on stream timeout
+            pass
+
+    try:
+        guard = _pipeline_execute(
+            url,
+            token,
+            [("BEGIN IMMEDIATE", []), ("SELECT count(*) FROM items", [])],
+            stream=stream,
+            post=post,
+        )
+        existing = int(guard["results"][1]["response"]["result"]["rows"][0][0]["value"])
+        if existing and require_empty:
+            raise TodoError(
+                f"hosted database already holds {existing} item(s);"
+                " rerun with --replace to clear the tracker tables and re-import"
+            )
+        for batch in batches:
+            _pipeline_execute(url, token, batch, stream=stream, post=post)
+        _pipeline_execute(url, token, [("COMMIT", [])], stream=stream, close=True, post=post)
+    except BaseException:
+        _close_stream()
+        raise
+    return {"rows": rows_total, "batches": len(batches) + 2}
 
 
 def connect_backend(backend: Path | str) -> sqlite3.Connection | _HostedConnection:
@@ -2031,20 +2121,23 @@ def _cmd_import_yaml(conn, actor, args):
         # Bulk path: stage through the exact same gated code into a temp local
         # database, then copy rows to the primary in one batched transaction.
         # The row-by-row path is ~2.5h over the network; this is seconds.
+        # Target-state enforcement (empty unless --replace) happens INSIDE the
+        # transfer's BEGIN IMMEDIATE transaction, so no concurrent writer can
+        # slip rows in between a pre-check and the transfer.
         token = os.environ.get("TODO_DB_AUTH_TOKEN") or ""
-        existing = hosted_item_count(backend, token)
-        if existing and not args.replace:
-            raise TodoError(
-                f"hosted database already holds {existing} item(s);"
-                " rerun with --replace to clear the tracker tables and re-import"
-            )
         import tempfile
 
         with tempfile.TemporaryDirectory() as tmp:
             staging = connect(Path(tmp) / "staging.sqlite")
             try:
                 report = import_yaml_tree(staging, actor, todo_dir, done_dir=done_dir, dry_run=False)
-                summary = bulk_transfer(staging, backend, token, replace=args.replace)
+                summary = bulk_transfer(
+                    staging,
+                    backend,
+                    token,
+                    replace=args.replace,
+                    require_empty=not args.replace,
+                )
             finally:
                 staging.close()
         _print_import_report(report, args.verbose)

--- a/_project/specs/todo-db-tracker.md
+++ b/_project/specs/todo-db-tracker.md
@@ -547,7 +547,8 @@ either backend. FK enforcement was verified live through write delegation
 (dangling insert refused by the primary). `todo migrate` is backend-aware;
 the hosted path hard-requires a fresh sync before touching the version
 record. TDD: `tests/unit/scripts/test_todo_db_hosted.py` (medium-marked,
-written red first; 40 tests as of PR #1222) pins backend
+written red first; count deliberately unpinned — the file is the record)
+pins backend
 resolution, wiring, adapter semantics, `BEGIN IMMEDIATE` discipline,
 rollback-on-failed-gate, the full gated lifecycle, hosted migration, and
 the bulk-transfer failure paths against a fake libsql module and a fake
@@ -652,6 +653,56 @@ failure injection):
   per worktree (~3.4s at 12.8MB), warm reads unchanged.
 - **Error surfaces:** pipeline network failures (timeouts, resets) and
   non-JSON responses map to the CLI's normal exit-2 error path.
+
+**Hardening round, second wave (2026-07-18, full adversarial review).** A
+deeper review (three independent adversarial passes + live Hrana probes
+that confirmed rollback-on-close and error-continues-pipeline semantics on
+the real primary) surfaced and fixed, TDD:
+
+- **Redirect refusal (security):** urllib preserves the `Authorization`
+  header across redirects — including an https→http downgrade — so the
+  pipeline now uses an opener that refuses all redirects; a redirecting
+  endpoint fails loudly instead of replaying the token.
+- **Transactional `promote` (pre-existing spike defect):** the gate read,
+  item creation, and resolution update now run in ONE `BEGIN IMMEDIATE`
+  transaction with a conditional resolution update — two actors can no
+  longer double-promote one deferral, and a promote can no longer
+  overwrite a concurrent dismiss (pinned by a concurrent-connection test
+  that probes the write lock at the gate read).
+- **Degraded-mode fresh replica:** a never-synced replica with the primary
+  unreachable now fails with a clean exit-2 error instead of attempting a
+  delegated schema write and tracebacking.
+- **Atomic schema bootstrap:** per-statement DDL inside one write
+  transaction (with an under-lock re-check) replaces `executescript` — a
+  mid-bootstrap failure rolls back completely instead of wedging the
+  shared database with partial tables; also removes the client's
+  documented-unimplemented `executescript` from the hosted path entirely.
+- **Broadened error mapping:** non-constraint libsql failures
+  (`SQLITE_BUSY`, network drops mid-statement) map to
+  `sqlite3.OperationalError` and a redacted `database failure` exit 2 at
+  the CLI boundary — previously an unredacted traceback; `_write_txn`'s
+  rollback can no longer mask the original error.
+- **Whole-tracker import guard:** the emptiness check counts every
+  transfer table, so an itemless `events` row (e.g. from `todo config`)
+  trips the friendly `--replace` refusal instead of a cryptic mid-transfer
+  `events.seq` collision.
+- **Conditional `sweep-stale`:** lease release now carries the same
+  observed-lease predicate as `claim` — a renewal the sweeping process had
+  not seen can no longer be clobbered.
+- **Concurrent-migrate safety:** the hosted migrator re-checks the schema
+  version under the write lock; a racing migrator no-ops cleanly.
+- **Lock hardening:** the replica setup lock opens with `O_NOFOLLOW`
+  (0600) — a planted symlink fails loudly instead of truncating its
+  target.
+- **Live coverage:** `tests/integration/test_todo_db_hosted_live.py`
+  (env-gated on `TODO_TEST_DB_URL`, `live_integration`-marked) executes
+  the two-actor lifecycle against a real primary through the shim, so the
+  claim/lastrowid/contention semantics are no longer session testimony.
+
+Threat-model note (recorded, accepted): `todo verify --run` executes
+repo-authored verification commands via the shell — the repository is the
+trust root, the same boundary as `make` or pre-commit hooks. Importing a
+TODO tree from an untrusted source would plant shell commands; do not.
 
 ## Cutover plan
 

--- a/_project/specs/todo-db-tracker.md
+++ b/_project/specs/todo-db-tracker.md
@@ -526,9 +526,10 @@ hosted) → `TODO_DB_PATH` (local file) → `TODO_DB_URL` (hosted; requires
 outranks `TODO_DB_URL` so a test or tool that pins a local file can never be
 silently redirected at the shared database.
 
-Hosted mode uses the `libsql` Python client (0.1.11) with an **embedded
-replica** at `<git main root>/.todo-db/replica.db` (override:
-`TODO_DB_REPLICA`): reads serve from the local replica after one freshness
+Hosted mode uses the `libsql` Python client (0.1.11) with a **per-worktree
+embedded replica** at `<git root>/.todo-db/replica.db` (override:
+`TODO_DB_REPLICA`; originally the main-root path, moved per-worktree in the
+hardening round below): reads serve from the local replica after one freshness
 `sync()` at connect; writes — including every `BEGIN IMMEDIATE` interactive
 transaction — are delegated statement-by-statement to the primary, so the
 check-then-act gates serialize against all other writers exactly as they do
@@ -544,12 +545,15 @@ mapping — so every gate, query, and transaction above it runs unchanged on
 either backend. FK enforcement was verified live through write delegation
 (dangling insert refused by the primary). `todo migrate` is backend-aware;
 the hosted path hard-requires a fresh sync before touching the version
-record. TDD: 22 new tests (`tests/unit/scripts/test_todo_db_hosted.py`,
-medium-marked, written red first) pin backend resolution, wiring, adapter
-semantics, `BEGIN IMMEDIATE` discipline, rollback-on-failed-gate, the full
-gated lifecycle, and hosted migration against a fake libsql module that
-reproduces the real client's quirks; the pre-existing tracker suite (93
-tests across `test_todo_db*.py` + `test_todo_wrapper.py`) passes unchanged.
+record. TDD: `tests/unit/scripts/test_todo_db_hosted.py` (medium-marked,
+written red first; 38 tests after the hardening round below) pins backend
+resolution, wiring, adapter semantics, `BEGIN IMMEDIATE` discipline,
+rollback-on-failed-gate, the full gated lifecycle, hosted migration, and
+the bulk-transfer failure paths against a fake libsql module and a fake
+Hrana primary that reproduce the real client's quirks; the pre-existing
+tracker suite (93 tests across `test_todo_db*.py` + `test_todo_wrapper.py`)
+passes unchanged. Replayable acceptance protocol:
+`_project/audits/todo-db-hosted-acceptance-2026-07-18.md`.
 
 **Shared-visibility proof (live, two processes × two replicas × two
 actors).** The one property the local spike could not demonstrate, run
@@ -617,6 +621,31 @@ identically to local mode. Final stats coherent: open deferrals 629
 (unchanged), promoted 1, done 1,248. Cleanup: the promoted follow-up
 (`uat-hosted-item-followup`) was dropped with reason "UAT artifact";
 the UAT parent remains as `done` audit trail.
+
+**Hardening round (2026-07-18, post-merge review follow-up).** Confirmed
+findings from the PR #1219 review, fixed TDD (red first, fake-primary
+failure injection):
+
+- **Plaintext refusal:** `http://` hosted URLs are rejected at connect and
+  at the pipeline layer — the Bearer token never travels unencrypted.
+- **Commit discipline:** Hrana keeps executing later requests in a
+  pipeline after a statement error, so `COMMIT` no longer rides with data
+  batches; it is sent alone, only after every batch's results came back
+  clean, and any failure explicitly closes the stream (server-side
+  rollback). Regression-tested with injected statement errors in final and
+  non-final batches.
+- **Atomic import guard:** the target-must-be-empty check (without
+  `--replace`) moved inside the transfer's `BEGIN IMMEDIATE` transaction —
+  no writer can populate the database between check and transfer.
+- **Protocol correctness:** the response `base_url` is carried alongside
+  the baton across batched requests, per the Hrana HTTP v2 spec.
+- **Replica concurrency:** the embedded replica moved from the shared
+  main-root path to per-worktree (`<git root>/.todo-db/replica.db`), and
+  replica open+sync is serialized by an advisory flock — concurrent
+  processes no longer sync one shared replica file. Cost: one cold sync
+  per worktree (~3.4s at 12.8MB), warm reads unchanged.
+- **Error surfaces:** pipeline network failures (timeouts, resets) and
+  non-JSON responses map to the CLI's normal exit-2 error path.
 
 ## Cutover plan
 

--- a/_project/specs/todo-db-tracker.md
+++ b/_project/specs/todo-db-tracker.md
@@ -519,7 +519,8 @@ invariants, demonstrated rather than argued.
 
 ## Hosted backend (2026-07-18, fifth round — Turso/libsql, TDD)
 
-With G1 closed, `connect()` grew a second mode (PR: see below). Backend
+With G1 closed, `connect()` grew a second mode (PR #1219; hardened in
+PR #1222). Backend
 selection, first match wins: `--db` (a `libsql://`/`https://` value selects
 hosted) → `TODO_DB_PATH` (local file) → `TODO_DB_URL` (hosted; requires
 `TODO_DB_AUTH_TOKEN`) → default local path. `TODO_DB_PATH` deliberately
@@ -546,12 +547,13 @@ either backend. FK enforcement was verified live through write delegation
 (dangling insert refused by the primary). `todo migrate` is backend-aware;
 the hosted path hard-requires a fresh sync before touching the version
 record. TDD: `tests/unit/scripts/test_todo_db_hosted.py` (medium-marked,
-written red first; 38 tests after the hardening round below) pins backend
+written red first; 40 tests as of PR #1222) pins backend
 resolution, wiring, adapter semantics, `BEGIN IMMEDIATE` discipline,
 rollback-on-failed-gate, the full gated lifecycle, hosted migration, and
 the bulk-transfer failure paths against a fake libsql module and a fake
 Hrana primary that reproduce the real client's quirks; the pre-existing
-tracker suite (93 tests across `test_todo_db*.py` + `test_todo_wrapper.py`)
+tracker suite (93 tests: `test_todo_db.py`, `test_todo_db_v2.py`,
+`test_todo_wrapper.py`)
 passes unchanged. Replayable acceptance protocol:
 `_project/audits/todo-db-hosted-acceptance-2026-07-18.md`.
 
@@ -597,9 +599,10 @@ between staging and target).
 
 **G3 CLOSED (2026-07-18, live).** `todo import-yaml --replace` against
 the hosted primary: **imported 1,364 / skipped 0 / warnings 18; 539 deps
-resolved, 1 dangling; 629 open deferrals; 32,595 rows in 82 batches,
-44s wall** — report-identical to a same-tree local-SQLite control run
-(4s wall). Counts drifted from the recorded 1,362/538 of the earlier
+resolved, 1 dangling; 629 open deferrals; 32,595 rows in 82 data
+batches, 44s wall** — report-identical to a same-tree local-SQLite
+control run (4s wall); recorded from the PR #1219 head tree (the
+hardened CLI reports pipeline requests: data batches + guard + commit). Counts drifted from the recorded 1,362/538 of the earlier
 rounds because five PRs (#1114, #1142, #1194, #1215, #1217) added/moved
 TODO/DONE files on `develop` in between; warnings (18), skipped (0),
 dangling (1), and open deferrals (629) are unchanged. Post-import hosted
@@ -628,6 +631,9 @@ failure injection):
 
 - **Plaintext refusal:** `http://` hosted URLs are rejected at connect and
   at the pipeline layer — the Bearer token never travels unencrypted.
+  Extended post-review: schemes are normalized (strip + lowercase scheme)
+  first, so `HTTP://`/whitespace variants cannot bypass the check via
+  `--db`, `TODO_DB_URL`, or a response `base_url`.
 - **Commit discipline:** Hrana keeps executing later requests in a
   pipeline after a statement error, so `COMMIT` no longer rides with data
   batches; it is sent alone, only after every batch's results came back

--- a/tests/integration/test_todo_db_hosted_live.py
+++ b/tests/integration/test_todo_db_hosted_live.py
@@ -1,0 +1,123 @@
+"""Live integration test for the hosted (Turso/libsql) TODO tracker backend.
+
+Everything else in the hosted suite runs against fakes that *encode* the real
+client's observed quirks; this module is the checked-in counterpart of the
+live acceptance protocol (`_project/audits/todo-db-hosted-acceptance-2026-07-18.md`),
+so the claims stop being session testimony. It exercises, against a real
+libsql primary: connect + sync, the claim path (cursor.rowcount semantics),
+deferral creation (cursor.lastrowid semantics), cross-actor claim contention,
+the deferral gate, and terminal cleanup — all through the shim, exactly as
+agents use it.
+
+Gated: runs only when TODO_TEST_DB_URL and TODO_DB_AUTH_TOKEN are set (a
+dedicated test database, never the production tracker — see the spec's
+Testing bullet). Deselected from the default lane by `live_integration`.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import time
+import uuid
+from pathlib import Path
+
+import pytest
+
+pytestmark = [
+    pytest.mark.integration,
+    pytest.mark.live_integration,
+]
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SHIM = REPO_ROOT / "_project" / "scripts" / "todo"
+
+TEST_URL = os.environ.get("TODO_TEST_DB_URL", "")
+AUTH_TOKEN = os.environ.get("TODO_DB_AUTH_TOKEN", "")
+
+requires_live_db = pytest.mark.skipif(
+    not (TEST_URL and AUTH_TOKEN),
+    reason="TODO_TEST_DB_URL and TODO_DB_AUTH_TOKEN not set (dedicated hosted test DB required)",
+)
+
+
+def _run(args: list[str], actor: str, replica_dir: Path) -> subprocess.CompletedProcess[str]:
+    env = {
+        "PATH": os.environ["PATH"],
+        "HOME": str(Path.home()),
+        "TODO_DB_URL": TEST_URL,
+        "TODO_DB_AUTH_TOKEN": AUTH_TOKEN,
+        "TODO_DB_REPLICA": str(replica_dir / "replica.db"),
+        "TODO_ACTOR": actor,
+    }
+    return subprocess.run(
+        [str(SHIM), *args],
+        capture_output=True,
+        text=True,
+        cwd=REPO_ROOT,
+        env=env,
+        check=False,
+        timeout=180,
+    )
+
+
+@requires_live_db
+class TestHostedLiveLifecycle:
+    def test_two_actor_lifecycle_against_real_primary(self, tmp_path):
+        item = f"live-uat-{time.strftime('%Y%m%d%H%M%S')}-{uuid.uuid4().hex[:6]}"
+        replica_a = tmp_path / "replica-a"
+        replica_b = tmp_path / "replica-b"
+
+        create = _run(
+            [
+                "create",
+                item,
+                "--title",
+                "Live hosted integration item",
+                "--worktree",
+                "spike",
+                "--priority",
+                "low",
+                "--description",
+                "Checked-in live counterpart of the acceptance protocol.",
+                "--work",
+                "w1:live probe unit",
+            ],
+            "live-actor-a",
+            replica_a,
+        )
+        assert create.returncode == 0, create.stderr
+
+        # claim succeeds for A (real-client cursor.rowcount must be 1 here —
+        # a rowcount-lying client would refuse even an uncontended claim)
+        claim_a = _run(["claim", item], "live-actor-a", replica_a)
+        assert claim_a.returncode == 0, claim_a.stderr
+
+        # separate replica + actor: contention must refuse with exit 2
+        claim_b = _run(["claim", item], "live-actor-b", replica_b)
+        assert claim_b.returncode == 2
+        assert "claimed by 'live-actor-a'" in claim_b.stderr
+
+        done = _run(["done", item, "w1", "--evidence", "live integration run"], "live-actor-a", replica_a)
+        assert done.returncode == 0, done.stderr
+
+        # deferral id comes from cursor.lastrowid on the real client
+        defer = _run(["defer", item, "--summary", "live gate probe", "--reason", "proof"], "live-actor-a", replica_a)
+        assert defer.returncode == 0, defer.stderr
+        assert "deferral #" in defer.stdout
+        deferral_id = defer.stdout.split("#")[1].split()[0]
+
+        # cross-replica deferral gate
+        blocked = _run(["complete", item], "live-actor-b", replica_b)
+        assert blocked.returncode == 2
+        assert "unresolved deferrals" in blocked.stderr
+
+        dismiss = _run(["dismiss", deferral_id, "--reason", "live probe artifact"], "live-actor-b", replica_b)
+        assert dismiss.returncode == 0, dismiss.stderr
+        complete = _run(["complete", item], "live-actor-a", replica_a)
+        assert complete.returncode == 0, complete.stderr
+
+        # terminal-defer guard, live
+        late = _run(["defer", item, "--summary", "too late", "--reason", "nope"], "live-actor-a", replica_a)
+        assert late.returncode == 2
+        assert "terminal items" in late.stderr

--- a/tests/unit/scripts/test_todo_db_hardening.py
+++ b/tests/unit/scripts/test_todo_db_hardening.py
@@ -1,0 +1,174 @@
+"""Backend-agnostic gate-hardening tests for todo_db.py.
+
+Adversarial review of the hosted-backend work surfaced two check-then-act
+writers that were weaker than the module's own `_write_txn` discipline:
+`promote_deferral` (gate read outside any transaction, unconditional UPDATE)
+and `sweep_stale` (unconditional lease release). These tests pin the
+hardened behavior against real concurrent SQLite connections.
+
+Marked medium (not fast) deliberately: the fast lane is budget-gated.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sqlite3
+import sys
+from pathlib import Path
+
+import pytest
+
+pytestmark = [
+    pytest.mark.unit,
+    pytest.mark.medium,
+]
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+
+
+def _load_script():
+    name = "todo_db"
+    path = REPO_ROOT / "_project" / "scripts" / f"{name}.py"
+    spec = importlib.util.spec_from_file_location(name, path)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+todo_db = _load_script()
+
+
+def _make_parent(conn, item_id="parent-item"):
+    todo_db.create_item(
+        conn,
+        "tester",
+        item_id=item_id,
+        title="Hardening parent item",
+        worktree="spike",
+        priority="low",
+        description="Parent for deferral-gate hardening tests.",
+    )
+
+
+class TestPromoteAtomicity:
+    def test_double_promotion_refused(self, tmp_path):
+        db = tmp_path / "t.sqlite"
+        conn = todo_db.connect(db)
+        _make_parent(conn)
+        deferral_id = todo_db.defer_work(conn, "tester", "parent-item", "follow-up", "later")
+        todo_db.promote_deferral(conn, "actor-a", deferral_id, new_item_id="child-a")
+        with pytest.raises(todo_db.TodoError, match="already|concurrently"):
+            todo_db.promote_deferral(conn, "actor-b", deferral_id, new_item_id="child-b")
+        # exactly one child exists; provenance points at the winner
+        ids = [r["id"] for r in conn.execute("SELECT id FROM items WHERE id LIKE 'child-%'")]
+        assert ids == ["child-a"]
+        row = conn.execute("SELECT resolution, resolved_item FROM deferrals WHERE id = ?", (deferral_id,)).fetchone()
+        assert (row["resolution"], row["resolved_item"]) == ("promoted", "child-a")
+
+    def test_promote_after_dismiss_refused(self, tmp_path):
+        conn = todo_db.connect(tmp_path / "t.sqlite")
+        _make_parent(conn)
+        deferral_id = todo_db.defer_work(conn, "tester", "parent-item", "follow-up", "later")
+        todo_db.dismiss_deferral(conn, "actor-a", deferral_id, "not needed")
+        with pytest.raises(todo_db.TodoError, match="already"):
+            todo_db.promote_deferral(conn, "actor-b", deferral_id, new_item_id="child-x")
+        assert conn.execute("SELECT count(*) FROM items WHERE id = 'child-x'").fetchone()[0] == 0
+
+    def test_failed_promotion_leaves_deferral_open(self, tmp_path):
+        conn = todo_db.connect(tmp_path / "t.sqlite")
+        _make_parent(conn)
+        deferral_id = todo_db.defer_work(conn, "tester", "parent-item", "follow-up", "later")
+        # promoting onto an existing item id fails; the deferral must stay
+        # open and no half-committed state may survive (single transaction)
+        with pytest.raises(todo_db.TodoError, match="cannot create"):
+            todo_db.promote_deferral(conn, "actor-a", deferral_id, new_item_id="parent-item")
+        row = conn.execute("SELECT resolution FROM deferrals WHERE id = ?", (deferral_id,)).fetchone()
+        assert row["resolution"] == "open"
+
+    def test_promote_holds_the_write_lock_for_its_whole_span(self, tmp_path, monkeypatch):
+        """A concurrent writer must be locked out between the gate read and
+        the resolution update — the exact window the pre-hardening code left
+        open (gate outside the transaction, unconditional UPDATE)."""
+        db = tmp_path / "t.sqlite"
+        conn_a = todo_db.connect(db)
+        conn_b = todo_db.connect(db)
+        conn_b.execute("PRAGMA busy_timeout = 100")
+        _make_parent(conn_a)
+        deferral_id = todo_db.defer_work(conn_a, "tester", "parent-item", "follow-up", "later")
+        original_gate = todo_db._require_deferral
+        probe: dict[str, bool] = {}
+
+        def hooked(conn, deferral_id_arg):
+            row = original_gate(conn, deferral_id_arg)
+            if "fired" not in probe:
+                probe["fired"] = True
+                # AT THE GATE READ another connection must already be locked
+                # out — the pre-hardening code read the gate with no
+                # transaction at all, so this write would have succeeded and
+                # the unconditional UPDATE would then have overwritten it.
+                with pytest.raises(sqlite3.OperationalError):
+                    conn_b.execute("UPDATE deferrals SET resolution = 'dismissed' WHERE id = ?", (deferral_id,))
+            return row
+
+        monkeypatch.setattr(todo_db, "_require_deferral", hooked)
+        todo_db.promote_deferral(conn_a, "actor-a", deferral_id, new_item_id="child-locked")
+        assert probe.get("fired"), "the promote event hook never fired"
+        row = conn_a.execute("SELECT resolution FROM deferrals WHERE id = ?", (deferral_id,)).fetchone()
+        assert row["resolution"] == "promoted"
+
+
+class TestSweepStalePredicate:
+    def test_sweep_releases_only_stale_leases(self, tmp_path):
+        conn = todo_db.connect(tmp_path / "t.sqlite")
+        _make_parent(conn, item_id="stale-item")
+        _make_parent(conn, item_id="fresh-item")
+        todo_db.claim_item(conn, "old-actor", "stale-item")
+        todo_db.claim_item(conn, "live-actor", "fresh-item")
+        with todo_db._write_txn(conn):
+            conn.execute(
+                "UPDATE items SET claimed_at = '2020-01-01T00:00:00Z' WHERE id = 'stale-item'",
+            )
+        released = todo_db.sweep_stale(conn, "sweeper")
+        assert released == ["stale-item"]
+        holder = conn.execute("SELECT claimed_by FROM items WHERE id = 'fresh-item'").fetchone()
+        assert holder["claimed_by"] == "live-actor"
+
+    def test_sweep_release_is_conditional_on_the_observed_lease(self, tmp_path, monkeypatch):
+        """If the lease changes hands between the sweep's read and its write,
+        the release must not fire (conditional UPDATE, like claim_item)."""
+        db = tmp_path / "t.sqlite"
+        conn = todo_db.connect(db)
+        interloper = todo_db.connect(db)
+        _make_parent(conn, item_id="contested-item")
+        todo_db.claim_item(conn, "old-actor", "contested-item")
+        with todo_db._write_txn(conn):
+            conn.execute("UPDATE items SET claimed_at = '2020-01-01T00:00:00Z' WHERE id = 'contested-item'")
+
+        original_expired = todo_db._lease_expired
+        state: dict[str, bool] = {}
+
+        def hooked(claimed_at, ttl_hours):
+            # After the sweep has read the stale lease but before it writes,
+            # the lease is renewed by another actor on a second connection.
+            # (Runs outside the sweep's txn window in local SQLite only if the
+            # sweep is not serialized; with BEGIN IMMEDIATE this write blocks,
+            # so emulate the hosted stale-replica read instead: mutate through
+            # the SAME connection the sweep holds, simulating that the row it
+            # read no longer matches primary state.)
+            if "renewed" not in state:
+                state["renewed"] = True
+                conn.execute(
+                    "UPDATE items SET claimed_by = 'new-actor', claimed_at = ? WHERE id = 'contested-item'",
+                    (todo_db.utc_now(),),
+                )
+            return original_expired(claimed_at, ttl_hours)
+
+        monkeypatch.setattr(todo_db, "_lease_expired", hooked)
+        released = todo_db.sweep_stale(conn, "sweeper")
+        assert released == [], "a renewed lease must not be swept"
+        row = conn.execute("SELECT claimed_by FROM items WHERE id = 'contested-item'").fetchone()
+        assert row["claimed_by"] == "new-actor"
+        interloper.close()

--- a/tests/unit/scripts/test_todo_db_hosted.py
+++ b/tests/unit/scripts/test_todo_db_hosted.py
@@ -86,16 +86,21 @@ def _hrana_wrap(exc: sqlite3.Error) -> ValueError:
 class FakeRawConnection:
     """Mimics libsql.Connection over a real local SQLite file."""
 
-    def __init__(self, database: str, sync_fails: bool = False):
+    def __init__(self, database: str, sync_fails: bool = False, execute_error: str | None = None):
         self._conn = sqlite3.connect(database)
         self._conn.isolation_level = None  # autocommit, like isolation_level=None
         self.statements: list[str] = []
         self.sync_calls = 0
         self.commit_calls = 0
         self._sync_fails = sync_fails
+        self.execute_error = execute_error  # substring: matching statements raise like a busy/network error
 
     def execute(self, sql, params=()):
         self.statements.append(sql if isinstance(sql, str) else str(sql))
+        if self.execute_error and self.execute_error in sql:
+            raise ValueError(
+                'Hrana: `stream error: `Error { message: "SQLite error: database is locked", code: "SQLITE_BUSY" }``'
+            )
         try:
             return FakeRawCursor(self._conn.execute(sql, tuple(params)))
         except sqlite3.IntegrityError as exc:
@@ -122,15 +127,16 @@ class FakeRawConnection:
 
 
 class FakeLibsql(types.ModuleType):
-    def __init__(self, sync_fails: bool = False):
+    def __init__(self, sync_fails: bool = False, execute_error: str | None = None):
         super().__init__("libsql")
         self.connect_calls: list[dict] = []
         self.connections: list[FakeRawConnection] = []
         self._sync_fails = sync_fails
+        self._execute_error = execute_error
 
     def connect(self, database, **kwargs):
         self.connect_calls.append({"database": database, **kwargs})
-        conn = FakeRawConnection(str(database), sync_fails=self._sync_fails)
+        conn = FakeRawConnection(str(database), sync_fails=self._sync_fails, execute_error=self._execute_error)
         self.connections.append(conn)
         return conn
 
@@ -143,6 +149,19 @@ def fake_libsql(monkeypatch, tmp_path):
     monkeypatch.setenv("TODO_DB_REPLICA", str(tmp_path / "replica" / "replica.db"))
     monkeypatch.delenv("TODO_DB_PATH", raising=False)
     return fake
+
+
+def _seed_replica_schema(replica_path):
+    """Simulate an existing (previously synced) replica with the tracker schema."""
+    import pathlib
+
+    p = pathlib.Path(replica_path)
+    p.parent.mkdir(parents=True, exist_ok=True)
+    seed = sqlite3.connect(p)
+    seed.executescript(todo_db.SCHEMA_SQL)
+    seed.execute("INSERT INTO meta (key, value) VALUES ('schema_version', ?)", (str(todo_db.SCHEMA_VERSION),))
+    seed.commit()
+    seed.close()
 
 
 def _hosted_conn(fake: FakeLibsql):
@@ -280,6 +299,7 @@ class TestHostedConnect:
         monkeypatch.setitem(sys.modules, "libsql", fake)
         monkeypatch.setenv("TODO_DB_AUTH_TOKEN", "sekrit-token-abc123")
         monkeypatch.setenv("TODO_DB_REPLICA", str(tmp_path / "replica.db"))
+        _seed_replica_schema(tmp_path / "replica.db")
         # sync failure degrades to the stale replica with a warning, not a crash
         conn = todo_db.connect_backend(HOSTED_URL)
         assert conn.execute("SELECT 1").fetchone()[0] == 1
@@ -289,11 +309,91 @@ class TestHostedConnect:
         monkeypatch.setitem(sys.modules, "libsql", fake)
         monkeypatch.setenv("TODO_DB_AUTH_TOKEN", "test-token-value")
         monkeypatch.setenv("TODO_DB_REPLICA", str(tmp_path / "replica.db"))
+        _seed_replica_schema(tmp_path / "replica.db")
         conn = todo_db.connect_backend(HOSTED_URL)
         err = capsys.readouterr().err
         assert "STALE" in err
         assert "sekrit" not in err and "test-token-value" not in err
         assert conn.execute("SELECT 1").fetchone()[0] == 1
+
+    def test_degraded_fresh_replica_raises_clean_error(self, monkeypatch, tmp_path):
+        # A replica that has NEVER synced cannot bootstrap the schema while
+        # the primary is down (that would be a delegated write): must be a
+        # clean TodoError, not a raw libsql traceback.
+        fake = FakeLibsql(sync_fails=True)
+        monkeypatch.setitem(sys.modules, "libsql", fake)
+        monkeypatch.setenv("TODO_DB_AUTH_TOKEN", "test-token-value")
+        monkeypatch.setenv("TODO_DB_REPLICA", str(tmp_path / "fresh" / "replica.db"))
+        with pytest.raises(todo_db.TodoError, match="unreachable"):
+            todo_db.connect_backend(HOSTED_URL)
+
+    def test_busy_error_maps_to_sqlite_error_and_exit_2(self, monkeypatch, tmp_path, capsys):
+        # Non-constraint libsql failures (SQLITE_BUSY, network drop) must map
+        # onto sqlite3 errors and reach the CLI as exit 2, never a traceback.
+        fake = FakeLibsql(execute_error="INSERT INTO items")
+        monkeypatch.setitem(sys.modules, "libsql", fake)
+        monkeypatch.setenv("TODO_DB_AUTH_TOKEN", "sekrit-token-abc123")
+        monkeypatch.setenv("TODO_DB_REPLICA", str(tmp_path / "replica.db"))
+        monkeypatch.delenv("TODO_DB_PATH", raising=False)
+        conn = todo_db.connect_backend(HOSTED_URL)
+        with pytest.raises(sqlite3.OperationalError, match="SQLITE_BUSY"):
+            _make_item(conn)
+        monkeypatch.setenv("TODO_DB_URL", HOSTED_URL)
+        rc = todo_db.main(
+            [
+                "--actor",
+                "tester",
+                "create",
+                "busy-item",
+                "--title",
+                "Busy mapping check",
+                "--worktree",
+                "spike",
+                "--priority",
+                "low",
+                "--description",
+                "Exercise busy-error mapping.",
+            ]
+        )
+        assert rc == 2
+        err = capsys.readouterr().err
+        assert "database failure" in err
+        assert "sekrit" not in err
+
+    def test_schema_bootstrap_is_atomic(self, monkeypatch, tmp_path):
+        # A mid-bootstrap failure must roll back completely so a retry works
+        # (previously partial tables without `meta` wedged the database).
+        replica = tmp_path / "replica.db"
+        fake = FakeLibsql(execute_error="CREATE TABLE meta")
+        monkeypatch.setitem(sys.modules, "libsql", fake)
+        monkeypatch.setenv("TODO_DB_AUTH_TOKEN", "test-token-value")
+        monkeypatch.setenv("TODO_DB_REPLICA", str(replica))
+        with pytest.raises(sqlite3.Error):
+            todo_db.connect_backend(HOSTED_URL)
+        leftover = (
+            sqlite3.connect(replica).execute("SELECT count(*) FROM sqlite_master WHERE type='table'").fetchone()[0]
+        )
+        assert leftover == 0, "failed bootstrap must not leave partial tables"
+        healthy = FakeLibsql()
+        monkeypatch.setitem(sys.modules, "libsql", healthy)
+        conn = todo_db.connect_backend(HOSTED_URL)
+        assert conn.execute("SELECT value FROM meta WHERE key='schema_version'").fetchone()[0] == str(
+            todo_db.SCHEMA_VERSION
+        )
+
+    def test_replica_lock_refuses_symlink(self, monkeypatch, tmp_path):
+        fake = FakeLibsql()
+        monkeypatch.setitem(sys.modules, "libsql", fake)
+        monkeypatch.setenv("TODO_DB_AUTH_TOKEN", "test-token-value")
+        replica_dir = tmp_path / "replica-dir"
+        replica_dir.mkdir()
+        victim = tmp_path / "victim.txt"
+        victim.write_text("precious", encoding="utf-8")
+        (replica_dir / "replica.db.lock").symlink_to(victim)
+        monkeypatch.setenv("TODO_DB_REPLICA", str(replica_dir / "replica.db"))
+        with pytest.raises(todo_db.TodoError, match="lock"):
+            todo_db.connect_backend(HOSTED_URL)
+        assert victim.read_text(encoding="utf-8") == "precious", "symlink target must not be truncated"
 
     def test_local_connect_is_unchanged(self, monkeypatch, tmp_path):
         monkeypatch.setenv("TODO_DB_URL", HOSTED_URL)
@@ -546,25 +646,22 @@ class TestHostedBulkImport:
             todo_db._hrana_endpoint("http://x.turso.io")
 
     def test_post_pipeline_maps_network_errors_to_todo_error(self, monkeypatch):
-        import urllib.request
-
         def _raise_timeout(*args, **kwargs):
             raise TimeoutError("timed out")
 
-        monkeypatch.setattr(urllib.request, "urlopen", _raise_timeout)
+        monkeypatch.setattr(todo_db, "_http_post_response", _raise_timeout)
         with pytest.raises(todo_db.TodoError, match="pipeline request failed"):
             todo_db._post_pipeline("https://x.turso.io/v2/pipeline", "tok", {"requests": []})
 
         def _raise_reset(*args, **kwargs):
             raise ConnectionResetError("peer reset")
 
-        monkeypatch.setattr(urllib.request, "urlopen", _raise_reset)
+        monkeypatch.setattr(todo_db, "_http_post_response", _raise_reset)
         with pytest.raises(todo_db.TodoError, match="pipeline request failed"):
             todo_db._post_pipeline("https://x.turso.io/v2/pipeline", "tok", {"requests": []})
 
     def test_post_pipeline_maps_bad_json_to_todo_error(self, monkeypatch):
         import io
-        import urllib.request
 
         class _FakeResponse(io.BytesIO):
             def __enter__(self):
@@ -573,9 +670,43 @@ class TestHostedBulkImport:
             def __exit__(self, *exc):
                 return False
 
-        monkeypatch.setattr(urllib.request, "urlopen", lambda *a, **k: _FakeResponse(b"<html>gateway error</html>"))
+        monkeypatch.setattr(
+            todo_db, "_http_post_response", lambda *a, **k: _FakeResponse(b"<html>gateway error</html>")
+        )
         with pytest.raises(todo_db.TodoError, match="pipeline"):
             todo_db._post_pipeline("https://x.turso.io/v2/pipeline", "tok", {"requests": []})
+
+    def test_pipeline_refuses_redirects(self):
+        # urllib preserves the Authorization header across redirects (even an
+        # https->http downgrade), so the pipeline opener must refuse them all.
+        import urllib.request
+
+        opener = todo_db._build_no_redirect_opener()
+        handlers = [h for h in opener.handlers if isinstance(h, urllib.request.HTTPRedirectHandler)]
+        assert handlers, "opener must carry a redirect-refusing handler"
+        for handler in handlers:
+            assert handler.redirect_request(None, None, 302, "Found", {}, "http://attacker.example/") is None, (
+                "redirect_request must refuse (return None) so urllib raises instead of re-sending the token"
+            )
+
+    def test_import_guard_counts_all_tracker_tables(self, fake_libsql, monkeypatch, tmp_path, capsys):
+        # An itemless events row (e.g. from `todo config`) must still trip the
+        # emptiness guard with the friendly --replace hint, not a cryptic
+        # events.seq collision mid-transfer.
+        todo_dir = tmp_path / "TODO"
+        todo_dir.mkdir()
+        primary = FakePrimary(tmp_path / "primary.sqlite")
+        sqlite3.connect(primary.path).executescript(todo_db.SCHEMA_SQL)
+        seed = sqlite3.connect(primary.path)
+        seed.execute("INSERT INTO events (at, actor, item_id, action) VALUES ('t', 'a', NULL, 'config')")
+        seed.commit()
+        monkeypatch.setattr(todo_db, "_post_pipeline", primary.post)
+        monkeypatch.setenv("TODO_DB_URL", HOSTED_URL)
+        rc = todo_db.main(["import-yaml", "--todo-dir", str(todo_dir), "--skip-done"])
+        assert rc == 2
+        err = capsys.readouterr().err
+        assert "--replace" in err
+        assert "UNIQUE" not in err
 
     def test_bulk_transfer_row_parity(self, staging, tmp_path):
         primary = FakePrimary(tmp_path / "primary.sqlite")
@@ -592,8 +723,10 @@ class TestHostedBulkImport:
         assert len(primary.requests) > 3, "batch_size=5 must split into several requests"
         sqls = primary.sqls()
         # guard request: take the write lock and check the target atomically
+        # (a combined count over every tracker table, not just items)
         assert sqls[0][0] == "BEGIN IMMEDIATE"
-        assert "SELECT count(*) FROM items" in sqls[0]
+        assert any("SELECT count(*) FROM items" in sql for sql in sqls[0])
+        assert any("count(*) FROM events" in sql for sql in sqls[0])
         # COMMIT is isolated in its own final request, sent only after every
         # data batch's results were verified clean (Hrana keeps executing
         # later requests in a pipeline after a statement error, so a COMMIT

--- a/tests/unit/scripts/test_todo_db_hosted.py
+++ b/tests/unit/scripts/test_todo_db_hosted.py
@@ -255,6 +255,26 @@ class TestHostedConnect:
         assert rc == 2
         assert "https" in capsys.readouterr().err
 
+    def test_plaintext_refusal_is_scheme_case_insensitive(self, fake_libsql, monkeypatch):
+        # URL schemes are case-insensitive; HTTP:// must not bypass the check,
+        # via --db, TODO_DB_URL, or a response base_url.
+        for variant in ("HTTP://example-db.turso.io", "Http://example-db.turso.io", "  http://example-db.turso.io"):
+            backend = todo_db.resolve_backend(variant)
+            assert isinstance(backend, str), f"{variant!r} must be recognized as a hosted URL, not a file path"
+            with pytest.raises(todo_db.TodoError, match="https"):
+                todo_db.connect_backend(backend)
+        monkeypatch.delenv("TODO_DB_PATH", raising=False)
+        monkeypatch.setenv("TODO_DB_URL", "HTTP://example-db.turso.io")
+        with pytest.raises(todo_db.TodoError, match="https"):
+            todo_db.connect_backend(todo_db.resolve_backend(None))
+        assert not fake_libsql.connect_calls
+
+    def test_uppercase_scheme_normalizes_for_pipeline(self):
+        assert todo_db._hrana_endpoint("LIBSQL://x.turso.io") == "https://x.turso.io/v2/pipeline"
+        assert todo_db._hrana_endpoint(" https://x.turso.io ") == "https://x.turso.io/v2/pipeline"
+        with pytest.raises(todo_db.TodoError, match="https"):
+            todo_db._hrana_endpoint("HTTP://x.turso.io")
+
     def test_error_message_never_contains_the_token(self, monkeypatch, tmp_path):
         fake = FakeLibsql(sync_fails=True)
         monkeypatch.setitem(sys.modules, "libsql", fake)

--- a/tests/unit/scripts/test_todo_db_hosted.py
+++ b/tests/unit/scripts/test_todo_db_hosted.py
@@ -224,14 +224,36 @@ class TestHostedConnect:
             todo_db.SCHEMA_VERSION
         )
 
-    def test_default_replica_path_is_todo_db_dir(self, monkeypatch, tmp_path):
+    def test_default_replica_path_is_per_worktree(self, monkeypatch, tmp_path):
+        # Per-worktree deliberately (NOT git_main_root): every process syncing
+        # one shared replica file is a cross-process corruption hazard; the
+        # shared state lives on the primary, the replica is only a cache.
         fake = FakeLibsql()
         monkeypatch.setitem(sys.modules, "libsql", fake)
         monkeypatch.setenv("TODO_DB_AUTH_TOKEN", "test-token-value")
         monkeypatch.delenv("TODO_DB_REPLICA", raising=False)
-        monkeypatch.setattr(todo_db, "git_main_root", lambda: tmp_path)
+        monkeypatch.setattr(todo_db, "git_root", lambda: tmp_path)
         todo_db.connect_backend(HOSTED_URL)
         assert fake.connect_calls[0]["database"] == str(tmp_path / ".todo-db" / "replica.db")
+
+    def test_replica_setup_lock_taken_and_released(self, fake_libsql, tmp_path):
+        todo_db.connect_backend(HOSTED_URL)
+        lock_path = Path(todo_db.hosted_replica_path()).with_suffix(".db.lock")
+        assert lock_path.exists(), "connect must serialize replica setup via a lock file"
+        import fcntl
+
+        with open(lock_path, "w", encoding="utf-8") as handle:
+            # non-blocking acquire succeeds only if connect released the lock
+            fcntl.flock(handle, fcntl.LOCK_EX | fcntl.LOCK_NB)
+            fcntl.flock(handle, fcntl.LOCK_UN)
+
+    def test_plaintext_http_url_is_refused(self, fake_libsql, capsys):
+        with pytest.raises(todo_db.TodoError, match="https"):
+            todo_db.connect_backend("http://example-db.turso.io")
+        assert not fake_libsql.connect_calls
+        rc = todo_db.main(["--db", "http://example-db.turso.io", "stats"])
+        assert rc == 2
+        assert "https" in capsys.readouterr().err
 
     def test_error_message_never_contains_the_token(self, monkeypatch, tmp_path):
         fake = FakeLibsql(sync_fails=True)
@@ -390,12 +412,14 @@ class FakePrimary:
     Mimics the wire contract: parameterized statements, baton chaining, and
     Hrana-typed result rows."""
 
-    def __init__(self, path: Path):
+    def __init__(self, path: Path, base_url: str | None = None, fail_on: str | None = None):
         self.path = path
         self.requests: list[dict] = []
         self._conn = sqlite3.connect(path)
         self._conn.isolation_level = None
         self._baton = 0
+        self.base_url = base_url
+        self.fail_on = fail_on  # substring: statements matching it return an error result
 
     def post(self, endpoint: str, token: str, payload: dict) -> dict:
         assert token, "post called without an auth token"
@@ -403,10 +427,17 @@ class FakePrimary:
         results = []
         for request in payload["requests"]:
             if request["type"] == "close":
+                # Hrana semantics: closing a stream with an open transaction
+                # rolls it back.
+                if self._conn.in_transaction:
+                    self._conn.rollback()
                 results.append({"type": "ok", "response": {"type": "close"}})
                 continue
             stmt = request["stmt"]
             args = [self._decode(a) for a in stmt.get("args", [])]
+            if self.fail_on and self.fail_on in stmt["sql"]:
+                results.append({"type": "error", "error": {"message": f"injected failure for {self.fail_on!r}"}})
+                continue
             try:
                 cur = self._conn.execute(stmt["sql"], args)
                 rows = [[self._encode(v) for v in row] for row in cur.fetchall()]
@@ -419,7 +450,17 @@ class FakePrimary:
             except sqlite3.Error as exc:
                 results.append({"type": "error", "error": {"message": str(exc)}})
         self._baton += 1
-        return {"baton": f"baton-{self._baton}", "results": results}
+        response = {"baton": f"baton-{self._baton}", "results": results}
+        if self.base_url:
+            response["base_url"] = self.base_url
+        return response
+
+    def sqls(self) -> list[list[str]]:
+        """Per-request executed SQL, for assertions."""
+        return [
+            [r["stmt"]["sql"] for r in request["payload"]["requests"] if r["type"] == "execute"]
+            for request in self.requests
+        ]
 
     @staticmethod
     def _decode(arg: dict):
@@ -479,6 +520,43 @@ class TestHostedBulkImport:
         assert todo_db._hrana_endpoint(HOSTED_URL) == ("https://example-db.aws-us-east-1.turso.io/v2/pipeline")
         assert todo_db._hrana_endpoint("https://x.turso.io") == "https://x.turso.io/v2/pipeline"
 
+    def test_hrana_endpoint_refuses_plaintext_http(self):
+        # a Bearer token must never travel over plaintext
+        with pytest.raises(todo_db.TodoError, match="https"):
+            todo_db._hrana_endpoint("http://x.turso.io")
+
+    def test_post_pipeline_maps_network_errors_to_todo_error(self, monkeypatch):
+        import urllib.request
+
+        def _raise_timeout(*args, **kwargs):
+            raise TimeoutError("timed out")
+
+        monkeypatch.setattr(urllib.request, "urlopen", _raise_timeout)
+        with pytest.raises(todo_db.TodoError, match="pipeline request failed"):
+            todo_db._post_pipeline("https://x.turso.io/v2/pipeline", "tok", {"requests": []})
+
+        def _raise_reset(*args, **kwargs):
+            raise ConnectionResetError("peer reset")
+
+        monkeypatch.setattr(urllib.request, "urlopen", _raise_reset)
+        with pytest.raises(todo_db.TodoError, match="pipeline request failed"):
+            todo_db._post_pipeline("https://x.turso.io/v2/pipeline", "tok", {"requests": []})
+
+    def test_post_pipeline_maps_bad_json_to_todo_error(self, monkeypatch):
+        import io
+        import urllib.request
+
+        class _FakeResponse(io.BytesIO):
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *exc):
+                return False
+
+        monkeypatch.setattr(urllib.request, "urlopen", lambda *a, **k: _FakeResponse(b"<html>gateway error</html>"))
+        with pytest.raises(todo_db.TodoError, match="pipeline"):
+            todo_db._post_pipeline("https://x.turso.io/v2/pipeline", "tok", {"requests": []})
+
     def test_bulk_transfer_row_parity(self, staging, tmp_path):
         primary = FakePrimary(tmp_path / "primary.sqlite")
         sqlite3.connect(primary.path).executescript(todo_db.SCHEMA_SQL)
@@ -491,16 +569,52 @@ class TestHostedBulkImport:
         primary = FakePrimary(tmp_path / "primary.sqlite")
         sqlite3.connect(primary.path).executescript(todo_db.SCHEMA_SQL)
         todo_db.bulk_transfer(staging, HOSTED_URL, "tok", post=primary.post, batch_size=5)
-        assert len(primary.requests) > 2, "batch_size=5 must split into several requests"
-        first_sqls = [r["stmt"]["sql"] for r in primary.requests[0]["payload"]["requests"] if r["type"] == "execute"]
-        assert first_sqls[0] == "BEGIN"
-        last_payload = primary.requests[-1]["payload"]
-        last_sqls = [r["stmt"]["sql"] for r in last_payload["requests"] if r["type"] == "execute"]
-        assert last_sqls[-1] == "COMMIT"
-        assert last_payload["requests"][-1]["type"] == "close"
+        assert len(primary.requests) > 3, "batch_size=5 must split into several requests"
+        sqls = primary.sqls()
+        # guard request: take the write lock and check the target atomically
+        assert sqls[0][0] == "BEGIN IMMEDIATE"
+        assert "SELECT count(*) FROM items" in sqls[0]
+        # COMMIT is isolated in its own final request, sent only after every
+        # data batch's results were verified clean (Hrana keeps executing
+        # later requests in a pipeline after a statement error, so a COMMIT
+        # riding with data could commit a partial transfer)
+        assert sqls[-1] == ["COMMIT"]
+        assert primary.requests[-1]["payload"]["requests"][-1]["type"] == "close"
+        assert all("COMMIT" not in batch for batch in sqls[:-1])
         # every request after the first chains the previous baton
         for i, request in enumerate(primary.requests[1:], start=1):
             assert request["payload"]["baton"] == f"baton-{i}"
+
+    def test_statement_error_rolls_back_and_never_commits(self, staging, tmp_path):
+        primary = FakePrimary(tmp_path / "primary.sqlite", fail_on="INSERT INTO deferrals")
+        sqlite3.connect(primary.path).executescript(todo_db.SCHEMA_SQL)
+        with pytest.raises(todo_db.TodoError, match="injected failure"):
+            todo_db.bulk_transfer(staging, HOSTED_URL, "tok", post=primary.post, batch_size=5)
+        sqls = primary.sqls()
+        assert all("COMMIT" not in batch for batch in sqls), "a failed transfer must never COMMIT"
+        # the stream is explicitly closed so the primary rolls back promptly
+        assert primary.requests[-1]["payload"]["requests"][-1]["type"] == "close"
+        # nothing survived on the target
+        remaining = sqlite3.connect(primary.path).execute("SELECT count(*) FROM items").fetchone()[0]
+        assert remaining == 0
+
+    def test_nonfinal_batch_error_also_closes_the_stream(self, staging, tmp_path):
+        # fail early (items is the first transferred table) with small batches,
+        # so the error lands well before the final batch
+        primary = FakePrimary(tmp_path / "primary.sqlite", fail_on="INSERT INTO items")
+        sqlite3.connect(primary.path).executescript(todo_db.SCHEMA_SQL)
+        with pytest.raises(todo_db.TodoError, match="injected failure"):
+            todo_db.bulk_transfer(staging, HOSTED_URL, "tok", post=primary.post, batch_size=3)
+        assert primary.requests[-1]["payload"]["requests"][-1]["type"] == "close"
+        assert all("COMMIT" not in batch for batch in primary.sqls())
+
+    def test_base_url_from_response_is_used_for_subsequent_requests(self, staging, tmp_path):
+        primary = FakePrimary(tmp_path / "primary.sqlite", base_url="https://shard-7.example.turso.io")
+        sqlite3.connect(primary.path).executescript(todo_db.SCHEMA_SQL)
+        todo_db.bulk_transfer(staging, HOSTED_URL, "tok", post=primary.post, batch_size=5)
+        endpoints = [request["endpoint"] for request in primary.requests]
+        assert endpoints[0] == todo_db._hrana_endpoint(HOSTED_URL)
+        assert all(e == "https://shard-7.example.turso.io/v2/pipeline" for e in endpoints[1:]), endpoints
 
     def test_import_yaml_hosted_stages_locally_and_bulk_transfers(self, fake_libsql, monkeypatch, tmp_path, capsys):
         todo_dir = tmp_path / "TODO" / "area" / "planning"


### PR DESCRIPTION
Confirmed findings from the post-merge review of the Turso/libsql backend,
fixed TDD (fake-primary failure injection; 38 hosted tests, suite 808):

- Security: refuse plaintext http:// hosted URLs at connect and at the
  Hrana pipeline layer — the Bearer token never travels unencrypted.
- Data integrity: COMMIT no longer rides in the same pipeline request as
  data (Hrana keeps executing later requests after a statement error, so a
  trailing COMMIT could commit a partial transfer); it is sent alone after
  all batch results verify clean, and any failure explicitly closes the
  stream for prompt server-side rollback.
- Import race: the target-must-be-empty guard moved inside the transfer's
  BEGIN IMMEDIATE transaction (replaces the separate pre-check), so no
  concurrent writer can populate the target between check and transfer.
- Protocol: carry the Hrana response base_url alongside the baton across
  batched requests per the HTTP v2 spec.
- Concurrency: per-worktree embedded replica (git_root, was git_main_root)
  plus an advisory flock around replica open+sync — multiple processes no
  longer sync one shared replica file.
- Error surfaces: pipeline timeouts/resets/non-JSON responses map to the
  CLI's exit-2 TodoError path instead of tracebacks; SIM101 cleanup.
- Verification: replayable acceptance harness checked in at
  _project/audits/todo-db-hosted-acceptance-2026-07-18.md; spec test-count
  corrected and the hardening round recorded.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
