### PR TITLE
feat(todo-db): G6 weekly export job + PR #1219/#1222 review follow-ups

### DIFF
--- a/.github/path-filters.yml
+++ b/.github/path-filters.yml
@@ -15,6 +15,12 @@ safe-content:
   - "_project/notes/**"
   - "_project/research/**"
   - "_project/planning/**"
+  # Deterministic machine-generated tracker export snapshot (written weekly by
+  # .github/workflows/todo-db-export.yml). Data, not authored prose, so it is
+  # deliberately safe-content but NOT content-guard: routing generated files
+  # through markdownlint --fix would let a future generated table stick the
+  # weekly auto-merge PR with no author to fix it.
+  - "_project/todo-db-export/**"
   - "_blog/**.md"
   - "_blog/**.rst"
   - "_blog/**.png"

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -510,6 +510,32 @@ jobs:
               print(f"::error::GitHub API unreachable after retries for {url}: {last_err}")
               sys.exit(1)
 
+          def workflow_registered_at(workflow_file: str):
+              """When Actions first registered this workflow (~when its file
+              first landed on the default branch), or None if unknown. Used to
+              grace a freshly-added scheduled workflow whose first cron fire is
+              still pending -- it has zero scheduled runs not because it is dead
+              but because it has not had a chance to fire yet."""
+              url = f"{api}/repos/{repo}/actions/workflows/{workflow_file}"
+              headers = {
+                  "Accept": "application/vnd.github+json",
+                  "User-Agent": "benchbox-scheduled-workflow-liveness",
+              }
+              if token:
+                  headers["Authorization"] = f"Bearer {token}"
+              # Any failure here (HTTP error, unreachable, non-JSON body, or an
+              # unparseable timestamp) returns None so the caller falls through
+              # to the normal dead-path: this grace must never crash the liveness
+              # job, only relax it.
+              try:
+                  with urllib.request.urlopen(urllib.request.Request(url, headers=headers), timeout=30) as resp:
+                      created = json.load(resp).get("created_at")
+                  if not created:
+                      return None
+                  return datetime.fromisoformat(created.replace("Z", "+00:00"))
+              except (urllib.error.HTTPError, urllib.error.URLError, ValueError):
+                  return None
+
           dead: list[str] = []
           checked = 0
           for path in sorted(wf_dir.glob("*.yml")) + sorted(wf_dir.glob("*.yaml")):
@@ -521,6 +547,19 @@ jobs:
               window_days = cadence_window_days(cron_re.findall(on_block.group(1)))
               runs = latest_scheduled_run(path.name)
               if not runs:
+                  # Activation grace: a workflow added within its own cadence
+                  # window has not had a scheduled fire yet, so "no runs" is
+                  # expected, not dead. This grace only RELAXES the check (it can
+                  # never turn a live schedule red); worst case it tolerates a
+                  # genuinely-dead brand-new workflow for one cadence window,
+                  # after which the missing run trips the check normally.
+                  registered = workflow_registered_at(path.name)
+                  if registered is not None and datetime.now(timezone.utc) - registered <= timedelta(days=window_days):
+                      print(
+                          f"{path.name}: registered {registered.date()}, no scheduled "
+                          f"run yet -- within its {window_days}-day activation grace."
+                      )
+                      continue
                   dead.append(
                       f"{path.name}: no scheduled runs at all -- absent from the "
                       "default branch, or its cron is disabled/never fires"

--- a/.github/workflows/todo-db-export.yml
+++ b/.github/workflows/todo-db-export.yml
@@ -1,0 +1,223 @@
+name: TODO DB weekly export
+
+# Sanctioned exception to the DB-free-CI rule (_project/specs/todo-db-tracker.md,
+# "CI stays DB-free"): this is the ONLY workflow that connects to the hosted
+# TODO tracker database. It runs `todo export` weekly with a READ-ONLY Turso
+# token and lands the deterministic JSONL + markdown snapshot on develop through
+# an auto-merging, path-scoped PR, so the repo carries a reviewable provenance
+# trail and a vendor-lock escape hatch that contains full tracker state. The job
+# is load-bearing for provenance, so it ALERTS ON FAILURE (upserts an
+# incident:todo-export-failed issue) and clears that incident on the next
+# success.
+#
+# Provisioning (maintainer, one-time -- an agent session cannot do either step;
+# minting needs the logged-in `turso` CLI and secrets need repo admin):
+#   1. Mint a READ-ONLY token -- never the read-write session token:
+#        turso db tokens create benchbox-todo --read-only --expiration none
+#      (or a long expiry you commit to rotating; --read-only is mandatory).
+#   2. Add two repository secrets:
+#        TODO_DB_URL           = libsql://benchbox-todo-<...>.turso.io
+#        TODO_DB_RO_AUTH_TOKEN = <the read-only token from step 1>
+# Until both secrets exist the scheduled run fails loudly and opens the incident
+# issue -- intentional: a silently non-exporting provenance job is worse than a
+# noisy one.
+
+on:
+  schedule:
+    # Weekly, Sunday 09:00 UTC. Isolated from the daily 03/06/08 jobs and the
+    # Monday 06:00/07:00 cluster to avoid runner contention. Weekly (not nightly)
+    # per the maintainer: the snapshot is a provenance trail, not a live mirror.
+    - cron: '0 9 * * 0'
+  workflow_dispatch: {}
+
+permissions:
+  contents: write
+  pull-requests: write
+  issues: write
+
+concurrency:
+  group: todo-db-export
+  cancel-in-progress: false
+
+jobs:
+  export:
+    name: Export tracker DB and land snapshot
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    env:
+      GH_TOKEN: ${{ github.token }}
+      EXPORT_DIR: _project/todo-db-export
+      SNAPSHOT_BRANCH: chore/todo-db-export-snapshot
+      INCIDENT_LABEL: incident:todo-export-failed
+      RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+    steps:
+      - name: Checkout develop
+        uses: actions/checkout@v4
+        with:
+          ref: develop
+          fetch-depth: 0
+
+      - name: Require DB secrets
+        env:
+          SECRET_TODO_DB_URL: ${{ secrets.TODO_DB_URL }}
+          SECRET_TODO_DB_RO_AUTH_TOKEN: ${{ secrets.TODO_DB_RO_AUTH_TOKEN }}
+        run: |
+          set -euo pipefail
+          missing=()
+          [ -n "${SECRET_TODO_DB_URL:-}" ] || missing+=("TODO_DB_URL")
+          [ -n "${SECRET_TODO_DB_RO_AUTH_TOKEN:-}" ] || missing+=("TODO_DB_RO_AUTH_TOKEN")
+          if [ "${#missing[@]}" -gt 0 ]; then
+            echo "::error::Missing required repository secret(s): ${missing[*]}. See this workflow's header comment for provisioning steps." >&2
+            exit 1
+          fi
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v4
+
+      - name: Run todo export (read-only token)
+        env:
+          # The CLI reads TODO_DB_AUTH_TOKEN; feed it the READ-ONLY token so the
+          # export path can never mutate the shared tracker DB.
+          TODO_DB_URL: ${{ secrets.TODO_DB_URL }}
+          TODO_DB_AUTH_TOKEN: ${{ secrets.TODO_DB_RO_AUTH_TOKEN }}
+        run: |
+          set -euo pipefail
+          uv run --project _project/scripts -- \
+            python _project/scripts/todo_db.py export --out "${EXPORT_DIR}"
+
+      - name: Write directory README
+        run: |
+          set -euo pipefail
+          # Self-document the generated directory. Written here (not committed in
+          # the workflow-adding PR) so the .gitignore negation that makes this
+          # tree trackable never lands in the same PR as a tracked file under it
+          # -- gitignore-lint flags a negation pattern that matches a tracked
+          # path, even though a negation un-ignores rather than ignores.
+          cat > "${EXPORT_DIR}/README.md" <<'MD'
+          # TODO tracker export snapshot
+
+          **Auto-generated — do not hand-edit.**
+
+          Deterministic weekly snapshot of the hosted TODO tracker database
+          (`_project/specs/todo-db-tracker.md`), written by
+          `.github/workflows/todo-db-export.yml` with a read-only token.
+
+          - `items.jsonl` — one JSON object per item, keys sorted, ordered by
+            `id`, timestamps from row data (not wall-clock). Full-state
+            vendor-lock escape hatch: the tracker reconstructs from it.
+          - `index.md` — rendered `id / state / priority / worktree / title`.
+
+          This directory's git history is the tracker's provenance trail — the
+          single sanctioned exception to the repo's DB-free-CI rule.
+          MD
+
+      - name: Detect snapshot changes
+        id: diff
+        run: |
+          set -euo pipefail
+          git add "${EXPORT_DIR}"
+          if git diff --staged --quiet; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+            echo "No tracker changes since the last snapshot -- nothing to commit."
+          else
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Commit and push snapshot branch
+        if: steps.diff.outputs.changed == 'true'
+        run: |
+          set -euo pipefail
+          git config user.name  "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          # Fetch the snapshot branch's current remote state (if any) so
+          # --force-with-lease below has a real remote-tracking ref to lease
+          # against. The checkout only fetched develop, and the branch name is
+          # fixed (reused every week), so without this the second-and-later push
+          # would be rejected as stale. Harmless on the first run (no branch yet).
+          git fetch --no-tags origin "${SNAPSHOT_BRANCH}:refs/remotes/origin/${SNAPSHOT_BRANCH}" 2>/dev/null || true
+          # Reset the workflow-owned snapshot branch to the develop tip, then
+          # carry the staged export onto it, so the PR diff is exactly this
+          # week's tracker delta against develop. The branch is only ever
+          # managed here, so --force-with-lease is safe (matches the
+          # sync-results-data-to-published convention).
+          git checkout -B "${SNAPSHOT_BRANCH}"
+          git commit -m "chore(todo-db): weekly tracker export snapshot" \
+            -m "Auto-generated by .github/workflows/todo-db-export.yml. Deterministic ${EXPORT_DIR}/ snapshot (stable ordering + row-data timestamps => clean diffs). Provenance trail and vendor-lock escape hatch; do not hand-edit."
+          git push --force-with-lease origin "${SNAPSHOT_BRANCH}"
+
+      - name: Open or reuse auto-merging PR
+        if: steps.diff.outputs.changed == 'true'
+        run: |
+          set -euo pipefail
+          existing="$(gh pr list --base develop --head "${SNAPSHOT_BRANCH}" --state open --json number --jq '.[0].number // empty')"
+          body_file="$(mktemp)"
+          {
+            echo "Auto-generated weekly snapshot of the hosted TODO tracker DB (\`${EXPORT_DIR}/\`)."
+            echo ""
+            echo "The export is deterministic, so this diff is the week's tracker delta."
+            echo "It is the provenance trail (residual-risk mitigation in the todo-db spec)"
+            echo "and the vendor-lock escape hatch -- it contains full tracker state."
+            echo ""
+            echo "Run: ${RUN_URL}"
+          } > "${body_file}"
+          if [ -z "${existing}" ]; then
+            url="$(gh pr create --base develop --head "${SNAPSHOT_BRANCH}" \
+              --title "chore(todo-db): weekly tracker export snapshot" \
+              --body-file "${body_file}")"
+            echo "Opened ${url}"
+          else
+            url="$(gh pr view "${existing}" --json url --jq .url)"
+            gh pr edit "${existing}" --body-file "${body_file}"
+            echo "Reusing PR #${existing} (${url})"
+          fi
+          # Backstop for auto-merge-on-open.yml (this path is not soundness-critical).
+          gh pr merge --auto --squash "${url}" \
+            || echo "auto-merge enablement deferred to auto-merge-on-open.yml"
+
+      - name: Alert on failure
+        if: failure()
+        run: |
+          set -euo pipefail
+          gh label create "${INCIDENT_LABEL}" \
+            --description "Weekly TODO tracker export workflow failed" \
+            --color B60205 >/dev/null 2>&1 || true
+          # One open incident per outage: reuse the existing issue instead of
+          # opening a fresh one every failed run.
+          existing="$(gh issue list --state open --label "${INCIDENT_LABEL}" --json url --jq '.[0].url // empty')"
+          body_file="$(mktemp)"
+          {
+            echo "The weekly TODO tracker export workflow failed."
+            echo ""
+            echo "Run: ${RUN_URL}"
+            echo ""
+            echo "This job is load-bearing for tracker provenance (the export is the"
+            echo "vendor-lock escape hatch). Likely causes: a missing or rotated"
+            echo "TODO_DB_URL / TODO_DB_RO_AUTH_TOKEN secret, the hosted DB being"
+            echo "unreachable, or a schema-version mismatch. See the header of"
+            echo ".github/workflows/todo-db-export.yml for provisioning and rotation."
+          } > "${body_file}"
+          if [ -n "${existing}" ]; then
+            gh issue comment "${existing}" --body-file "${body_file}"
+            echo "Commented on existing incident: ${existing}"
+          else
+            url="$(gh issue create --title "TODO tracker weekly export failed" \
+              --body-file "${body_file}" --label "${INCIDENT_LABEL}")"
+            echo "Opened incident: ${url}"
+          fi
+
+      - name: Clear stale incident on success
+        if: success()
+        run: |
+          set -euo pipefail
+          mapfile -t nums < <(gh issue list --state open --label "${INCIDENT_LABEL}" --json number --jq '.[].number')
+          for n in "${nums[@]:-}"; do
+            [ -n "${n}" ] || continue
+            gh issue close "${n}" \
+              --comment "Weekly export succeeded again at ${RUN_URL}; closing stale incident." \
+              || echo "Failed to close incident #${n}; leaving open." >&2
+          done

--- a/.github/workflows/todo-db-export.yml
+++ b/.github/workflows/todo-db-export.yml
@@ -21,6 +21,19 @@ name: TODO DB weekly export
 # Until both secrets exist the scheduled run fails loudly and opens the incident
 # issue -- intentional: a silently non-exporting provenance job is worse than a
 # noisy one.
+#
+# Auto-merge requires a THIRD secret (optional but needed for hands-free weekly
+# landings):
+#   3. TODO_EXPORT_PR_TOKEN = a fine-grained PAT (this repo; contents +
+#      pull-requests: write) or a GitHub App installation token.
+# Rationale: GitHub deliberately does NOT trigger workflows for events raised by
+# the built-in GITHUB_TOKEN, so a PR opened/pushed with it never runs pr.yml and
+# its required `ci-required-result` check never reports -- auto-merge would wait
+# forever. A non-GITHUB_TOKEN identity makes pr.yml run so the check reports and
+# auto-merge completes. Without this secret the workflow still runs and opens the
+# snapshot PR, but leaves it for MANUAL merge (and says so) instead of enabling a
+# stuck auto-merge. This mirrors why sync-results-data-to-published uses a
+# human-merged PR rather than GITHUB_TOKEN auto-merge.
 
 on:
   schedule:
@@ -45,7 +58,13 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     env:
+      # Issue/label/incident steps use the built-in token (it has issues:write
+      # via `permissions` below; a fine-grained PR token may not). PR creation +
+      # branch push use TODO_EXPORT_PR_TOKEN when set (checkout `token:` and a
+      # step-level GH_TOKEN override) so pr.yml fires and ci-required-result
+      # reports -- see header.
       GH_TOKEN: ${{ github.token }}
+      PR_TOKEN_SET: ${{ secrets.TODO_EXPORT_PR_TOKEN != '' }}
       EXPORT_DIR: _project/todo-db-export
       SNAPSHOT_BRANCH: chore/todo-db-export-snapshot
       INCIDENT_LABEL: incident:todo-export-failed
@@ -56,6 +75,10 @@ jobs:
         with:
           ref: develop
           fetch-depth: 0
+          # Persist this token for the branch push: a push authored by the
+          # built-in token would not trigger pr.yml on the PR's synchronize
+          # event either, so the reuse path needs the same identity as creation.
+          token: ${{ secrets.TODO_EXPORT_PR_TOKEN || github.token }}
 
       - name: Require DB secrets
         env:
@@ -152,6 +175,9 @@ jobs:
 
       - name: Open or reuse auto-merging PR
         if: steps.diff.outputs.changed == 'true'
+        env:
+          # Author the PR as the PR token (when set) so pr.yml runs for it.
+          GH_TOKEN: ${{ secrets.TODO_EXPORT_PR_TOKEN || github.token }}
         run: |
           set -euo pipefail
           existing="$(gh pr list --base develop --head "${SNAPSHOT_BRANCH}" --state open --json number --jq '.[0].number // empty')"
@@ -175,9 +201,16 @@ jobs:
             gh pr edit "${existing}" --body-file "${body_file}"
             echo "Reusing PR #${existing} (${url})"
           fi
-          # Backstop for auto-merge-on-open.yml (this path is not soundness-critical).
-          gh pr merge --auto --squash "${url}" \
-            || echo "auto-merge enablement deferred to auto-merge-on-open.yml"
+          # Only enable auto-merge when the PR was authored by a token that
+          # triggers pr.yml. With the built-in GITHUB_TOKEN, ci-required-result
+          # never runs, so enabling auto-merge would leave the PR stuck
+          # "waiting for status" forever; leave it for manual merge and say so.
+          if [ "${PR_TOKEN_SET}" = "true" ]; then
+            gh pr merge --auto --squash "${url}" \
+              || echo "::warning::auto-merge enable failed; merge ${url} manually"
+          else
+            echo "::warning::TODO_EXPORT_PR_TOKEN not set — ${url} was authored by GITHUB_TOKEN, so pr.yml/ci-required-result will not run and auto-merge cannot complete. Merge it manually, or provision TODO_EXPORT_PR_TOKEN (see workflow header) for hands-free weekly landings."
+          fi
 
       - name: Alert on failure
         if: failure()

--- a/.gitignore
+++ b/.gitignore
@@ -99,6 +99,10 @@ _project/*
 !_project/LAUNCH_*.md
 !_project/CONTENT_*.md
 !_project/SOCIAL_*.md
+# Committed TODO-tracker export snapshot (written weekly by
+# .github/workflows/todo-db-export.yml) -- provenance trail, must be tracked.
+!_project/todo-db-export/
+!_project/todo-db-export/**
 
 # Include pre-compiled TPC binaries for distribution
 !_binaries/

--- a/_project/scripts/todo_db.py
+++ b/_project/scripts/todo_db.py
@@ -542,7 +542,11 @@ def _replica_setup_lock(replica: Path):
 
 
 def _hosted_raw_connect(url: str, sync_required: bool) -> _HostedConnection:
-    _require_secure_url(url)
+    # Use the normalized return (trimmed whitespace, lowercased scheme) for the
+    # actual connect, not just the security check: direct helper callers do not
+    # pass through resolve_backend(), so without this a whitespace-padded or
+    # uppercase-scheme URL would reach libsql.connect() un-normalized.
+    url = _require_secure_url(url)
     token = os.environ.get("TODO_DB_AUTH_TOKEN") or ""
     if not token:
         raise TodoError("hosted tracker: set TODO_DB_AUTH_TOKEN when TODO_DB_URL points at a remote database")

--- a/_project/specs/todo-db-tracker.md
+++ b/_project/specs/todo-db-tracker.md
@@ -558,6 +558,41 @@ tracker suite (93 tests: `test_todo_db.py`, `test_todo_db_v2.py`,
 passes unchanged. Replayable acceptance protocol:
 `_project/audits/todo-db-hosted-acceptance-2026-07-18.md`.
 
+### Pilot status & readiness (2026-07-19, PR #1222 review follow-up)
+
+Current readiness: **ready for controlled agent use via the explicit
+`todo-db` skill, one process per worktree, with hosted credentials
+configured** — NOT the default project-wide TODO process.
+
+- **Cutover contract (opt-in pilot, not migrated).** Generic TODO routing
+  still points at the YAML tree: `AGENTS.md` "Planning & TODOs" and the
+  skill-synced `todo` skill direct agents to `_project/TODO/**` +
+  `todo_cli.py`; `todo-db` is an unmanaged, opt-in sibling. The routing/docs
+  cutover is **G5** (deferred, maintainer-gated). Until G5, describe this as
+  an opt-in DB-backend pilot — do not claim the project-wide TODO process has
+  migrated.
+- **Same-worktree replica concurrency (one process per worktree).** The
+  `_replica_setup_lock()` advisory flock serializes replica open+sync across
+  processes but is released while the connection stays open, so it does not
+  make two processes *sharing one replica file* provably safe. The supported
+  operating model is therefore **one active process per worktree** — already
+  enforced by the `worktree-claim` workflow (one agent per worktree). The
+  design also already supports **per-process replica isolation** via
+  `TODO_DB_REPLICA` (the live acceptance test drives two concurrent actors
+  with distinct replica paths); any concurrent-same-worktree use should give
+  each process its own `TODO_DB_REPLICA`. Full-connection-lifetime
+  serialization is deliberately not taken on now (tracker commands are
+  single-round-trip; it would risk self-deadlock for a command opening two
+  same-worktree connections).
+- **Hosted acceptance boundary (manual, not in PR CI).** Ordinary PR CI runs
+  the hosted suite against fakes only; the live Turso test
+  (`tests/integration/test_todo_db_hosted_live.py`) is gated on a **dedicated**
+  `TODO_TEST_DB_URL` (never the production tracker) and is skipped otherwise.
+  Hosted **write-path** production readiness is thus a manual acceptance step
+  (run the acceptance protocol above against a dedicated test DB). The hosted
+  **read path** is verified live: the G6 export ran against the production
+  primary on 2026-07-19 (deterministic across two runs, 1366 items).
+
 **Shared-visibility proof (live, two processes × two replicas × two
 actors).** The one property the local spike could not demonstrate, run
 against the real Turso primary through the shim only:

--- a/tests/unit/scripts/test_todo_db_hosted.py
+++ b/tests/unit/scripts/test_todo_db_hosted.py
@@ -243,6 +243,16 @@ class TestHostedConnect:
             todo_db.SCHEMA_VERSION
         )
 
+    def test_direct_helper_normalizes_url_before_connect(self, fake_libsql):
+        # _hosted_raw_connect is reachable without resolve_backend()'s
+        # normalization (direct helper callers). A whitespace-padded,
+        # uppercase-scheme URL must still reach libsql.connect() normalized.
+        conn = todo_db._hosted_raw_connect(f"  LIBSQL://{HOSTED_URL.split('://', 1)[1]}  ", sync_required=True)
+        try:
+            assert fake_libsql.connect_calls[0]["sync_url"] == HOSTED_URL
+        finally:
+            conn.close()
+
     def test_default_replica_path_is_per_worktree(self, monkeypatch, tmp_path):
         # Per-worktree deliberately (NOT git_main_root): every process syncing
         # one shared replica file is a cross-process corruption hazard; the


### PR DESCRIPTION
## Description

Closes **G6** of the DB-backed TODO tracker migration (`_project/specs/todo-db-tracker.md`) and folds in the PR #1219/#1222 review follow-ups.

**G6 — weekly hosted-tracker export job** (`.github/workflows/todo-db-export.yml`): the single sanctioned exception to the DB-free-CI rule. Runs `todo export` weekly (Sun 09:00 UTC) with a **read-only** Turso token and lands the deterministic `items.jsonl` + `index.md` snapshot on develop via an **auto-merging, content-classified PR**, giving the repo a reviewable provenance trail + full-state vendor-lock escape hatch. Alerts on failure (deduped `incident:todo-export-failed` issue) and clears the incident on the next success.

**Supporting changes:**
- **Nightly liveness activation grace** (`nightly.yml`): a scheduled workflow registered within its cadence window has no first fire yet, so "zero scheduled runs" is expected, not dead — without this, adding *any* new scheduled workflow reds the nightly liveness job until its first fire. The grace only *relaxes* the check (never turns a live schedule red; any lookup hiccup falls through to the dead-path).
- **CI classifier** (`path-filters.yml`): classify `_project/todo-db-export/**` as `safe-content` (generated data, not authored prose) so the weekly export PR skips the ~30-min code suite and `ci-required-result` greenlights it cheaply. Deliberately **not** in `content-guard` (routing generated files through `markdownlint --fix` could stick the weekly PR with no author to fix a future table).
- **`.gitignore`**: negation so the export tree is trackable under the `_project/*` blanket ignore (files land via the weekly PR, not this one — avoids a `gitignore-lint` false-positive on the negation pattern).
- **PR #1222 follow-up (`todo_db.py`)**: `_hosted_raw_connect()` now uses `_require_secure_url()`'s normalized return instead of the raw URL (direct-helper callers no longer hand `libsql.connect()` a whitespace/uppercase-scheme URL). Regression test added.
- **Spec**: a "Pilot status & readiness" contract — opt-in DB pilot (not project-wide migrated until G5), one-process-per-worktree operating model (+ `TODO_DB_REPLICA` per-process isolation), and the manual hosted-write-path acceptance boundary.

## Type of Change

- [x] New feature
- [x] Bug fix
- [x] Documentation
- [x] Refactor / chore

## Testing

- `uv run -- python -m pytest tests/unit/scripts/test_todo_db_hosted.py tests/unit/scripts/test_todo_db_hardening.py -q` → **53 passed** (the +1 is `test_direct_helper_normalizes_url_before_connect`, confirmed to **fail** on the pre-fix code).
- `uv run -- python -m pytest tests/integration/test_todo_db_hosted_live.py -m live_integration -q` → **skipped** (dedicated `TODO_TEST_DB_URL` required — hosted write-path acceptance is a manual step by design).
- Path classifier suites (`test_path_filter_decision.py`, `test_pr_workflow_path_classifier.py`) → **35 passed**; verified an export-only changeset resolves `safe-content-only` and a mixed one `needs-code-ci`.
- `make pr-preflight` → passed (CI lint + fast tests).
- Nightly liveness grace exercised against the *actual* edited YAML block (graces new workflows; still flags genuinely-dead ones; safe fallthrough on malformed JSON / bad timestamp).
- Export data path verified **live** against the hosted primary (deterministic across two runs, 1366 items); git commit/branch/no-op/incremental-diff flow replayed in a throwaway repo.

## Public Contract Check

- [x] This PR does not change public, beta-public, deprecated, generated, experimental, or repo-only contract surfaces (tracker-internal tooling + CI infra).
- [x] No result schema / MCP param / platform-support / wrapper / adapter-hook impact.
- [x] No platform/benchmark count claims added.

## Documentation

- [x] Updated the spec's "Pilot status & readiness" contract; workflow header documents provisioning and the auto-merge token rationale.
- [x] Added regression notes for the URL-normalization behavior change.
- [x] API contract wording unchanged.

## Code Quality

- [x] Ran `ruff check` / `ruff format --check` / `ty` (no new diagnostics; `todo_db.py`'s 4 pre-existing `ty` findings are unchanged).
- [x] Reviewed for backwards compatibility (no CLI/API change; `_hosted_raw_connect` fix is transparent).
- [x] Added a regression test for the URL-normalization path.
- [x] Public contracts / release checklists unaffected.

## Artifact Hygiene

- [x] No raw screenshots/reports/logs/binary artifacts committed. The export directory carries **no** data files in this PR — the 9.4 MB `items.jsonl` snapshot is generated and committed by the weekly workflow, not here.

## Notes

**Reviewer focus — this PR modifies shared CI infra** (`nightly.yml` liveness guard + `path-filters.yml` classifier). Both are tested, but if you'd rather eyeball them before landing, disable auto-merge.

**Provisioning required for G6 to run (maintainer; an agent session can't do these):**
1. Mint a **read-only** Turso token (`turso db tokens create benchbox-todo --read-only`).
2. Add secrets `TODO_DB_URL` + `TODO_DB_RO_AUTH_TOKEN`.
3. *(For hands-free auto-merge)* add `TODO_EXPORT_PR_TOKEN` (fine-grained PAT / App token) — the built-in `GITHUB_TOKEN` does not trigger `pr.yml`, so a PR it authors never gets `ci-required-result` and can't auto-merge. Without it the weekly PR is opened but left for manual merge.

Once secrets land I can trigger `workflow_dispatch` to verify one real end-to-end cycle.

**Deferred (not in this PR):** G4 deferred-debt sweep (plan proposed, awaiting sign-off + timing — 629 open deferrals across 310 source items), G5 freeze & delete (awaiting explicit authorization). Left open per spec: G4 timing, G5 execution, standalone-package target repo, `todo lint` hard-gate.

---
_Generated by [Claude Code](https://claude.ai/code/session_01GNjjJehFtKyK7fSibNYUqc)_