### PR TITLE
chore(todo): close out Decision B rename (w6 admin flip done) → DONE

### DIFF
--- a/_project/DONE/main/rename-release-branch-main-to-release.yaml
+++ b/_project/DONE/main/rename-release-branch-main-to-release.yaml
@@ -2,7 +2,8 @@ id: rename-release-branch-main-to-release
 title: "Rename the release branch main->release (Decision B of the branching-strategy review)"
 worktree: main
 priority: Medium
-status: "In Progress"
+status: "Completed"
+completed_date: "2026-07-19"
 category: "Release Tooling"
 
 description: |
@@ -100,7 +101,24 @@ work:
   - id: w6
     summary: "ADMIN: rename branch + recreate ruleset"
     needs: [w1, w2, w3]
-    status: pending
+    status: done
+    completion: |
+      DONE 2026-07-19. In-repo work (w1-w5) merged via PR #1114. Admin flip
+      executed by the maintainer:
+      - `branches/main/rename -f new_name=release` — refs/heads/release now
+        exists at the former main HEAD (7550c423); main is gone (GitHub
+        redirect covers old URLs / retargets PRs).
+      - Recreated the ruleset as `release-only` (id 19149459) on
+        refs/heads/release, then deleted the stale `main-release-only`
+        (id 15611783). Verified live-vs-target match: target=branch,
+        ref=[refs/heads/release], enforcement=active, checks=[validate-base,
+        release-required-result], rules=[pull_request, required_status_checks,
+        required_linear_history, non_fast_forward, deletion], bypass_actors=[].
+      - repo-admin-settings.md needed no id edit: the `release-only` section
+        uses a `<release-ruleset-id>` placeholder ("ruleset id varies; list and
+        inspect"), and nothing in Makefile/scripts hard-codes the old id.
+      - Verified-safe unchanged: PyPI trusted publishing (repo + release.yml
+        filename + pypi env), GitHub Pages (deploy-pages).
     notes: |
       `gh api -X POST repos/joeharris76/BenchBox/branches/main/rename
       -f new_name=release` (GitHub redirects old URLs, retargets open PRs).


### PR DESCRIPTION
## Summary

Closes out **Decision B** (rename release branch `main` → `release`). The in-repo half landed via #1114; the maintainer has now executed and verified the admin flip. This marks work-unit **w6 done** and archives the tracked item to `_project/DONE/`.

Docs/TODO only — no code or workflow changes, no CODEOWNERS soundness path.

## Admin flip (executed + verified)

- **Branch rename**: `branches/main/rename -f new_name=release` — `refs/heads/release` now exists at the former `main` HEAD (`7550c423`); `main` is gone (GitHub redirect covers old URLs / retargets PRs).
- **Ruleset recreate**: created `release-only` (id `19149459`) on `refs/heads/release`, then deleted the stale `main-release-only` (id `15611783`). Live state verified against target:
  - `target: branch`, `ref: [refs/heads/release]`, `enforcement: active`
  - `checks: [validate-base, release-required-result]`
  - `rules: [pull_request, required_status_checks, required_linear_history, non_fast_forward, deletion]`
  - `bypass_actors: []`
- **No doc id edit needed**: `repo-admin-settings.md`'s `release-only` section uses a `<release-ruleset-id>` placeholder, and nothing in `Makefile`/`scripts` hard-codes the old id.

## Verified safe / unchanged

- PyPI trusted publishing (repo + `release.yml` filename + `pypi` environment — branch-independent).
- GitHub Pages (`deploy-pages`).

## Testing

- `validate_todo.py` on the archived item: valid.
- `todo_cli.py check-graph`: 127 items, no cycles / no dangling references.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KPPPtRSp95b8JkUJcLEUcn

---
_Generated by [Claude Code](https://claude.ai/code/session_01KPPPtRSp95b8JkUJcLEUcn)_