### PR TITLE
fix(todo-db): make `export` truly read-only so the G6 export job works with a read-only token

### DIFF
--- a/_project/scripts/todo_db.py
+++ b/_project/scripts/todo_db.py
@@ -541,6 +541,14 @@ def _replica_setup_lock(replica: Path):
         os.close(fd)
 
 
+def _import_libsql():
+    try:
+        import libsql  # deferred: only hosted mode needs it
+    except ImportError as exc:
+        raise TodoError("hosted tracker requires the `libsql` package; run `uv sync` in _project/scripts") from exc
+    return libsql
+
+
 def _hosted_raw_connect(url: str, sync_required: bool) -> _HostedConnection:
     # Use the normalized return (trimmed whitespace, lowercased scheme) for the
     # actual connect, not just the security check: direct helper callers do not
@@ -550,10 +558,7 @@ def _hosted_raw_connect(url: str, sync_required: bool) -> _HostedConnection:
     token = os.environ.get("TODO_DB_AUTH_TOKEN") or ""
     if not token:
         raise TodoError("hosted tracker: set TODO_DB_AUTH_TOKEN when TODO_DB_URL points at a remote database")
-    try:
-        import libsql  # deferred: only hosted mode needs it
-    except ImportError as exc:
-        raise TodoError("hosted tracker requires the `libsql` package; run `uv sync` in _project/scripts") from exc
+    libsql = _import_libsql()
     replica = hosted_replica_path()
     replica.parent.mkdir(parents=True, exist_ok=True)
     with _replica_setup_lock(replica):
@@ -577,7 +582,36 @@ def _hosted_raw_connect(url: str, sync_required: bool) -> _HostedConnection:
     return conn
 
 
-def connect_hosted(url: str) -> _HostedConnection:
+def _hosted_read_connect(url: str) -> _HostedConnection:
+    """Remote-only connection (no embedded replica) for read-only commands.
+
+    Queries go straight to the primary over HTTP, so a read-only auth token
+    works and no schema-bootstrap write is ever attempted (a read-only token
+    cannot drive embedded-replica sync, which would leave an empty replica and
+    trip the bootstrap write). Slower per query than the local replica, so read
+    paths that use this must be bulk — see export_all().
+    """
+    url = _require_secure_url(url)
+    token = os.environ.get("TODO_DB_AUTH_TOKEN") or ""
+    if not token:
+        raise TodoError("hosted tracker: set TODO_DB_AUTH_TOKEN when TODO_DB_URL points at a remote database")
+    libsql = _import_libsql()
+    return _HostedConnection(libsql.connect(url, auth_token=token))
+
+
+def connect_hosted(url: str, *, read_only: bool = False) -> _HostedConnection:
+    if read_only:
+        conn = _hosted_read_connect(url)
+        version = _schema_version(conn)
+        if version is None:
+            conn.close()
+            raise TodoError("hosted tracker: no schema found on the primary")
+        if version != SCHEMA_VERSION:
+            conn.close()
+            raise TodoError(
+                f"database schema_version={version}, CLI expects {SCHEMA_VERSION}; run `todo migrate` to upgrade it"
+            )
+        return conn
     conn = _hosted_raw_connect(url, sync_required=False)
     if conn.stale and _schema_version(conn) is None:
         # A never-synced replica cannot bootstrap the schema while the
@@ -787,10 +821,17 @@ def bulk_transfer(
     return {"rows": rows_total, "batches": len(batches) + 2}
 
 
-def connect_backend(backend: Path | str) -> sqlite3.Connection | _HostedConnection:
+# Commands that only read: connected remote-only (no embedded replica) so a
+# read-only hosted token works. Kept minimal — `export` is the automated
+# read-only-token consumer and its reader is bulk; interactive reads keep the
+# fast embedded replica (which needs a read-write token anyway).
+READ_ONLY_COMMANDS = frozenset({"export"})
+
+
+def connect_backend(backend: Path | str, *, read_only: bool = False) -> sqlite3.Connection | _HostedConnection:
     if isinstance(backend, Path):
         return connect(backend)
-    return connect_hosted(backend)
+    return connect_hosted(backend, read_only=read_only)
 
 
 def migrate_backend(backend: Path | str) -> list[int]:
@@ -1665,7 +1706,59 @@ def lint_item(conn: sqlite3.Connection, item_id: str) -> list[str]:
 
 
 def export_all(conn: sqlite3.Connection) -> list[dict[str, Any]]:
-    return [get_item(conn, row["id"]) for row in conn.execute("SELECT id FROM items ORDER BY id")]
+    # Bulk read: one SELECT per table, assembled in Python. Produces output
+    # byte-identical to per-item get_item() but with ~11 round-trips instead of
+    # thousands, so a remote (no-embedded-replica) read-only connection stays
+    # fast enough for the export job. Ordering within every child list mirrors
+    # get_item()'s per-item ORDER BY exactly.
+    items: dict[str, dict[str, Any]] = {}
+    order: list[str] = []
+    for row in conn.execute("SELECT * FROM items ORDER BY id"):
+        d = dict(row)
+        d["work"] = []
+        d["deps"] = []
+        d["scope"] = []
+        d["verifications"] = []
+        d["preserves"] = []
+        d["anti_patterns"] = []
+        d["prior_art"] = []
+        d["deferrals"] = []
+        items[d["id"]] = d
+        order.append(d["id"])
+
+    work_index: dict[tuple[str, str], dict[str, Any]] = {}
+    for row in conn.execute("SELECT * FROM work_units ORDER BY item_id, wid"):
+        w = dict(row)
+        w["needs"] = []
+        items[w["item_id"]]["work"].append(w)
+        work_index[(w["item_id"], w["wid"])] = w
+    for row in conn.execute("SELECT item_id, wid, needs_wid FROM work_needs ORDER BY item_id, wid, needs_wid"):
+        work_index[(row["item_id"], row["wid"])]["needs"].append(row["needs_wid"])
+    for row in conn.execute("SELECT item_id, needs_item FROM item_deps ORDER BY item_id, needs_item"):
+        items[row["item_id"]]["deps"].append(row["needs_item"])
+    for row in conn.execute("SELECT item_id, kind, path_glob FROM scope_rules ORDER BY item_id, kind, path_glob"):
+        items[row["item_id"]]["scope"].append({"kind": row["kind"], "path_glob": row["path_glob"]})
+    for row in conn.execute("SELECT * FROM verifications ORDER BY item_id, seq"):
+        items[row["item_id"]]["verifications"].append(dict(row))
+    for row in conn.execute("SELECT item_id, behavior FROM preserves ORDER BY item_id, behavior"):
+        items[row["item_id"]]["preserves"].append(row["behavior"])
+    # Use dict(row) (as get_item does) rather than by-name access: `instead` is
+    # a SQL keyword and the backends disagree on its result-column name (local
+    # SQLite -> "instead", the libsql cursor -> "INSTEAD"); dict(row) inherits
+    # whatever the cursor reports, keeping export byte-identical with get_item()
+    # on both backends, and avoids the by-name keyword lookup that fails on the
+    # remote cursor.
+    for row in conn.execute("SELECT item_id, dont, why, instead FROM anti_patterns ORDER BY item_id, dont"):
+        anti = dict(row)
+        items[anti.pop("item_id")]["anti_patterns"].append(anti)
+    for row in conn.execute("SELECT item_id, path, concept, decision FROM prior_art ORDER BY item_id, path, concept"):
+        items[row["item_id"]]["prior_art"].append(
+            {"path": row["path"], "concept": row["concept"], "decision": row["decision"]}
+        )
+    for row in conn.execute("SELECT * FROM deferrals ORDER BY from_item, id"):
+        items[row["from_item"]]["deferrals"].append(dict(row))
+
+    return [items[i] for i in order]
 
 
 def write_export(conn: sqlite3.Connection, out_dir: Path) -> tuple[Path, Path]:
@@ -2174,7 +2267,7 @@ def main(argv: list[str] | None = None) -> int:
             print(f"applied migration(s) to v{', v'.join(str(v) for v in applied)}")
             return 0
     try:
-        conn = connect_backend(backend)
+        conn = connect_backend(backend, read_only=args.command in READ_ONLY_COMMANDS)
     except TodoError as exc:
         print(f"error: {exc}", file=sys.stderr)
         return 2

--- a/tests/unit/scripts/test_todo_db_hosted.py
+++ b/tests/unit/scripts/test_todo_db_hosted.py
@@ -18,6 +18,7 @@ Marked medium (not fast) deliberately: the fast lane is budget-gated.
 from __future__ import annotations
 
 import importlib.util
+import json
 import sqlite3
 import sys
 import types
@@ -888,3 +889,71 @@ class TestHostedMigrate:
         conn = todo_db.connect_backend(HOSTED_URL)
         cols = [row[1] for row in conn.execute("PRAGMA table_info(work_units)").fetchall()]
         assert "started_at" in cols
+
+
+# ---------------------------------------------------------------------------
+# Read-only export path (bulk reader + remote-only connect)
+
+
+def test_export_all_bulk_matches_per_item(tmp_path):
+    """Bulk export_all() must be byte-identical to per-item get_item() assembly
+    across every child table (work+needs, deps, scope, verifications, preserves,
+    anti_patterns incl. the INSTEAD keyword column, prior_art, deferrals)."""
+    conn = todo_db.connect(tmp_path / "t.sqlite")
+    todo_db.create_item(
+        conn,
+        "tester",
+        item_id="item-b",
+        title="Item B target",
+        worktree="spike",
+        priority="low",
+        description="dep target item",
+    )
+    todo_db.create_item(
+        conn,
+        "tester",
+        item_id="item-a",
+        title="Item A rich",
+        worktree="spike",
+        priority="high",
+        description="rich item body",
+        work=[{"id": "w0", "summary": "first"}, {"id": "w1", "summary": "second", "needs": ["w0"]}],
+        deps=["item-b"],
+        scope=[("only_modify", "src/**"), ("do_not_modify", "gen/**")],
+        verifications=[{"description": "check", "command": "make x", "expected": "ok"}],
+        preserves=["keep the public API"],
+        anti_patterns=[("do not hack", "it breaks", "do it properly")],
+        prior_art=[("docs/x.md", "concept", "reuse")],
+    )
+    todo_db.defer_work(conn, "tester", "item-a", "later work", "out of scope")
+
+    per_item = [todo_db.get_item(conn, row["id"]) for row in conn.execute("SELECT id FROM items ORDER BY id")]
+    bulk = todo_db.export_all(conn)
+    assert bulk == per_item
+    # and the serialized form export writes is identical too
+    dump = lambda rows: [json.dumps(r, sort_keys=True) for r in rows]
+    assert dump(bulk) == dump(per_item)
+    # the keyword `instead` column round-trips (its result-column name is
+    # backend-dependent: "instead" on local SQLite, "INSTEAD" on libsql), so
+    # check the value under either key.
+    a = next(r for r in bulk if r["id"] == "item-a")
+    ap = a["anti_patterns"][0]
+    assert ap["dont"] == "do not hack" and ap["why"] == "it breaks"
+    assert ap.get("instead", ap.get("INSTEAD")) == "do it properly"
+
+
+def test_export_command_uses_read_only_connect(monkeypatch):
+    """The export command must connect read-only (remote-only, no embedded
+    replica) so a read-only hosted token works."""
+    assert "export" in todo_db.READ_ONLY_COMMANDS
+    seen = {}
+
+    def spy(url, *, read_only=False):
+        seen["read_only"] = read_only
+        raise todo_db.TodoError("stop after connect")  # short-circuit; we only assert the flag
+
+    monkeypatch.setattr(todo_db, "connect_hosted", spy)
+    monkeypatch.setenv("TODO_DB_URL", HOSTED_URL)
+    monkeypatch.delenv("TODO_DB_PATH", raising=False)
+    todo_db.main(["export", "--out", "/tmp/does-not-matter"])
+    assert seen == {"read_only": True}


### PR DESCRIPTION
## Description

The G6 weekly export job (merged in #1223) **failed on its first real run** against the hosted DB with the read-only token: `SQL write operations are forbidden (current session doesn't have write permission)` (run [29686734866](https://github.com/joeharris76/BenchBox/actions/runs/29686734866)).

**Root cause:** `export` connected through the **embedded replica**, which a **read-only token cannot sync** (the sync needs write access to the primary). The replica came up empty → the CLI read `schema_version = None` → assumed a fresh DB → attempted a schema **bootstrap write** → correctly blocked by the RO token. Local runs masked this by using the read-write token.

**Fix (two parts):**
1. **Read-only connect path** — `connect_hosted(url, read_only=True)` connects **remote-only** (no embedded replica, no sync, no `_ensure_schema` bootstrap) and validates the schema by *reading only*. `export` is the sole member of a new `READ_ONLY_COMMANDS` set; interactive reads keep the fast embedded replica (which needs a RW token anyway). Deduped the deferred `import libsql` into `_import_libsql()`.
2. **Bulk export reader** — `export_all` now issues ~11 bulk `SELECT`s assembled in Python instead of per-item `get_item()`, because remote-only per-item reads are thousands of round-trips (**measured >2 min timeout**). Output is **byte-identical** to the per-item path.

## Type of Change

- [x] Bug fix

## Testing

- **Full hosted export via the new read-only path is byte-identical** to the per-item embedded-replica export (1493 items, sha match) and runs in **~3s**.
- New local test `test_export_all_bulk_matches_per_item` pins `export_all == get_item` assembly across every child table — including the `instead`/`INSTEAD` **backend-dependent keyword-column casing** (local SQLite vs libsql), which `dict(row)` inherits correctly.
- New `test_export_command_uses_read_only_connect` pins that `export` connects read-only.
- `148` tracker tests pass (`test_todo_db{,_v2,_hosted,_hardening}.py`, `test_todo_wrapper.py`); `ruff` clean; `ty` unchanged from baseline.
- The **real RO-token Actions path** will be re-verified by re-dispatching the export workflow once this lands (I'll report the result).

## Public Contract Check

- [x] No public/beta/generated contract surfaces changed (tracker-internal CLI); export output format is preserved byte-for-byte.

## Documentation

- [x] Behavior change (read path) documented inline; export format unchanged.

## Code Quality

- [x] `ruff check` / `ruff format --check` / `ty` clean (no new diagnostics).
- [x] Added regression tests for the bulk reader and the read-only connect.

## Artifact Hygiene

- [x] No artifacts committed.

## Notes

Incident issue **#1224** (opened by the failed run — the alerting working as designed) will auto-clear on the first green export run after this lands.

---
_Generated by [Claude Code](https://claude.ai/code/session_01GNjjJehFtKyK7fSibNYUqc)_