### PR TITLE
chore(todo): complete + archive T7/T8 UAT-hardening TODOs to DONE

### DIFF
--- a/_project/DONE/uat-hardening/planning/nightly-throughput-gate-restoration.yaml
+++ b/_project/DONE/uat-hardening/planning/nightly-throughput-gate-restoration.yaml
@@ -2,7 +2,8 @@ id: nightly-throughput-gate-restoration
 title: "Remove continue-on-error from the nightly throughput UAT sweep and strengthen stream-count semantics"
 worktree: uat-hardening
 priority: Medium-High
-status: Not Started
+status: Completed
+completed_date: "2026-07-19"
 category: "Testing and Quality Assurance"
 
 description: |
@@ -33,26 +34,86 @@ prior_art:
 work:
   - id: w0
     summary: "Confirm tpch-throughput-seed-validation-fix landed and the sweep passes clean locally (make uat-sweep CONFIG=tests/uat/configs/uat-throughput-duckdb-nightly.yaml exits 0); record SHA + exit code"
-    status: pending
+    status: done
     needs: []
+    notes: >
+      Confirmed the #1142 seed fix on develop. Ran `make uat-sweep
+      CONFIG=tests/uat/configs/uat-throughput-duckdb-nightly.yaml` clean
+      locally against origin/develop@b0bce89b2: 66/66 queries SUCCESS
+      across 3 streams, Throughput@Size=290820.07,
+      validator_status=clean, exit 0.
   - id: w1
     summary: "Add strict per-stream success semantics: each counted stream needs >=1 successful query; unit tests cover the all-queries-failed stream case"
-    status: pending
+    status: done
     needs: []
+    notes: >
+      Added validate_stream_success() -- every stream present in
+      queries[] must have >=1 query with status == "SUCCESS"
+      (case-insensitive); wired into validate_throughput_result
+      (count -> success -> metric composition order). Kept
+      validate_stream_count status-blind so the wiring-defect check
+      stays a pure, outcome-independent concurrency signal. 10 new
+      tests: all-queries-failed-stream rejection, multi-failed-stream,
+      mixed-pass/fail-passes, case-insensitivity, missing stream id,
+      empty-queries, and composition-ordering coverage.
   - id: w2
     summary: "Remove continue-on-error from the sweep step; delete the stale known-defect comment block (nightly.yml:580-595); keep the independent stream-count assert step (now also strict) as defense-in-depth"
-    status: pending
+    status: done
     needs: [w0, w1]
+    notes: >
+      Removed continue-on-error: true from the nightly sweep step and
+      deleted the stale Q11/16/18/20 known-defect comment block. The
+      cell exit code + validator_clean_rate_floor: 1.0 + strict report
+      exit policy now gate the job. Kept the independent stream-count
+      assert step (defense-in-depth), made it strict (now runs both
+      validate_stream_count and validate_stream_success). Review found
+      a Critical here: with continue-on-error removed, GitHub Actions'
+      default success() step-condition would have SKIPPED the separate
+      assert step on a sweep FAILURE -- breaking its must_preserve
+      "runs regardless of the sweep outcome" contract. Fixed by adding
+      if: ${{ !cancelled() }} to the assert step so it gates on both a
+      passing and a failing sweep (only cancellation skips it); no
+      continue-on-error re-added anywhere. See review_response below.
   - id: w3
     summary: "Trigger a workflow_dispatch nightly run and verify the job passes with gating enabled; record the run URL (operator-verified: needs gh auth + CI dispatch; batch agents record as waiting)"
     status: pending
     needs: [w2]
+    notes: >
+      WAITING / deferred-to-operator: not achievable from a batch
+      agent session (needs gh auth + a dispatched/scheduled CI run,
+      per this work unit's own operator-verified framing). w0-w2
+      merged as PR #1231 (2026-07-19); a maintainer-dispatched
+      workflow_dispatch nightly run confirming green gating with the
+      restored gate still needs to happen post-merge and its run URL
+      recorded here.
 
 deferred:
   - summary: "Throughput performance-regression thresholds (Throughput@Size floor per platform/scale)"
     reason: "Needs baseline data from several green nightly runs before a floor is defensible; premature thresholds create flake. Promoted to [[uat-throughput-regression-threshold-policy]] (2026-07-16), which needs this item."
   - summary: "Widening nightly throughput coverage beyond DuckDB TPC-H SF1"
     reason: "Runtime budget: the job has a 20-minute timeout; adding platforms belongs to a capacity decision, not this gate fix."
+
+review_response:
+  date: "2026-07-19"
+  summary: >
+    Merged as PR #1231. Adversarial review of the shipped implementation
+    found one merge-blocking Critical (assert-step independence) plus a
+    cross-cutting fast-lane headroom note; both applied before merge.
+  required_fix: >
+    With continue-on-error removed from the sweep step (w2), the
+    separate defense-in-depth stream-count/success assert step would
+    have been SKIPPED on a sweep FAILURE under GitHub Actions' default
+    success() step-condition -- breaking its must_preserve "runs
+    regardless of the sweep outcome" contract. Fixed by adding
+    if: ${{ !cancelled() }} to the assert step so it gates on both a
+    passing and a failing sweep (only a cancellation skips it), and
+    aligned the step comment to the !cancelled() behavior. No
+    continue-on-error re-added anywhere.
+  considers_applied:
+    - "The 10 new strict per-stream-success unit tests (w1) brought the fast lane to exactly the then-current ceiling with zero headroom. Bumped max_fast_tests in _project/config/fast_test_lane_policy.json (+5) with a dated _ceiling_note entry -- outside this TODO's scope_limit but the allowed cross-cutting fast-lane gate, same pattern as uat-throughput-result-resolution-hardening's policy bump."
+  considers_deferred:
+    - summary: "w3 workflow_dispatch nightly run verifying green gating"
+      reason: "Operator-verified: requires gh auth + a dispatched/scheduled CI run, not achievable from a batch agent session. Recorded as pending in work (see w3 notes); the maintainer dispatches post-merge and records the run URL."
 
 deps:
   needs: [tpch-throughput-seed-validation-fix, uat-throughput-result-resolution-hardening]
@@ -92,3 +153,10 @@ metadata:
   estimated_effort: Small
   created_date: "2026-07-11"
   source: "UAT infrastructure review 2026-07-10 (develop @ fc31f3604), gate-wiring findings + throughput agent risk"
+
+files_affected:
+  modified:
+  - .github/workflows/nightly.yml
+  - _project/config/fast_test_lane_policy.json
+  - tests/uat/test_throughput.py
+  - tests/uat/throughput.py

--- a/_project/DONE/uat-hardening/planning/uat-throughput-result-resolution-hardening.yaml
+++ b/_project/DONE/uat-hardening/planning/uat-throughput-result-resolution-hardening.yaml
@@ -2,7 +2,8 @@ id: uat-throughput-result-resolution-hardening
 title: "Harden the throughput result-path resolver: exact platform token, scale token, deterministic tie-break, narrower nightly window"
 worktree: uat-hardening
 priority: Medium-High
-status: Not Started
+status: Completed
+completed_date: "2026-07-19"
 category: "Bug Fix / Data Pipeline"
 
 description: |
@@ -40,24 +41,89 @@ prior_art:
 work:
   - id: w1
     summary: "Pin the filename grammar: locate the exporter that writes result filenames, document the token order (benchmark, sf, platform, mode, date) in the resolver docstring"
-    status: pending
+    status: done
     needs: []
+    notes: >
+      Pinned the exporter's filename grammar
+      (benchbox.core.results.filenames.build_result_filename_base) in the
+      resolver docstring:
+      {benchmark...}_{sf<N>}_{platform...}_{mode}_{timestamp}[_{execution_id}].json,
+      with benchmark and platform each documented as variable-length
+      underscore-token runs (not fixed indices).
   - id: w2
     summary: "Exact-token platform matching: split filename on underscores and require the platform token sequence to match exactly (pg_duckdb no longer matches duckdb); add the collision-direction regression test"
-    status: pending
+    status: done
     needs: [w1]
+    notes: >
+      Split filename on underscores and require the platform token
+      SEQUENCE to match exactly, so platform="duckdb" no longer
+      substring-matches a pg_duckdb result file (old glob was
+      f"{benchmark}_*{platform}*.json"). Added both-direction collision
+      regression tests. Review (Opus) found and fixed a Critical here: the
+      first-pass matcher hardcoded fixed token indices
+      (benchmark=token[0], scale=token[1], platform_start=2), which
+      regressed the ~10 registered benchmark ids containing underscores
+      (tpcds_obt, tsbs_devops, tpch_skew, *_primitives, ...) to
+      false-negative None -- a real tpcds_obt_sf1_duckdb_sql_*.json would
+      have downgraded a passing official cell to FAILED. Fixed by matching
+      the benchmark as a token PREFIX SEQUENCE and deriving scale_idx =
+      len(benchmark_tokens) / platform_start = scale_idx + 1; added
+      tpcds_obt + tsbs_devops regression tests (incl. the pg_duckdb
+      non-collision) and confirmed the reverted single-token code returns
+      None on the new fixture. See review_response below.
   - id: w3
     summary: "Add a scale token to the filter (scale param threaded from run_cell, which knows it); tie-break by (mtime, filename) so equal-mtime resolution is deterministic"
-    status: pending
+    status: done
     needs: [w2]
+    notes: >
+      Added an optional keyword-only scale filter threaded from run_cell
+      (which already knows the scale) and a deterministic (mtime,
+      filename) tie-break for equal-mtime candidates. Backward-compatible:
+      resolve_official_result_path's signature keeps scale
+      optional/keyword-only. Review found the run_cell -> resolver scale
+      forwarding was untested (every other official test mocked the
+      resolver without checking kwargs, so deleting the wiring would have
+      passed silently); added a forwarding-assert test.
   - id: w4
     summary: "Narrow the nightly assert window: capture a start timestamp before the sweep step and pass it through instead of now()-1h (nightly.yml)"
-    status: pending
+    status: done
     needs: [w3]
+    notes: >
+      Narrowed the nightly assert window: capture a UTC start timestamp
+      (via $GITHUB_ENV, written with `date -u`) before the sweep step
+      instead of a now()-1h lookback over a shared results dir. Review
+      found the captured timestamp was parsed as a naive/local datetime
+      rather than UTC; fixed by anchoring the parsed value with
+      .replace(tzinfo=timezone.utc) so resolution is runner-timezone
+      independent.
 
 deferred:
   - summary: "Replace glob resolution entirely with a result-path manifest emitted by run-official"
     reason: "Requires a benchbox CLI surface change (run-official output contract) which the no-CLI-surface-drift constraint makes a bigger conversation; the hardened glob is sufficient for sequential UAT. Promoted to [[uat-throughput-result-path-manifest]] (2026-07-16), which needs this item."
+
+review_response:
+  date: "2026-07-19"
+  summary: >
+    Merged as PR #1228. Adversarial review of the shipped implementation
+    found one merge-blocking Critical (multi-token benchmark ids
+    regressed to false-negatives) plus two Considers; all three fixed
+    before merge.
+  required_fix: >
+    The first-pass exact-token matcher (w2) hardcoded
+    benchmark=token[0], scale=token[1], platform_start=2, which shifts
+    every index for the ~10 registered benchmark ids that contain
+    underscores (tpcds_obt, tsbs_devops, tpch_skew, *_primitives, ...). A
+    real tpcds_obt_sf1_duckdb_sql_*.json then resolved to None ->
+    run_cell downgrades a passing official cell to FAILED -- a
+    false-negative worse than the substring false-positive it replaced.
+    Fixed by matching the benchmark as a token PREFIX SEQUENCE and
+    deriving scale_idx = len(benchmark_tokens) / platform_start =
+    scale_idx + 1. Added tpcds_obt + tsbs_devops regression tests (incl.
+    the pg_duckdb non-collision), and confirmed the reverted
+    single-token code returns None on the new fixture.
+  considers_applied:
+    - "run_cell forwarding scale= into resolve_official_result_path was untested (every other official test mocked the resolver without checking kwargs, so deleting the wiring would have passed silently) -- added a forwarding-assert test."
+    - "The nightly assert step wrote the start timestamp with `date -u` (UTC) but consumed it as a naive datetime whose .timestamp() reads as local -- anchored the parsed value to UTC (.replace(tzinfo=timezone.utc)) so resolution is runner-timezone independent."
 
 deps:
   needs: [uat-status-taxonomy-exit-code-fixes, tpch-throughput-seed-validation-fix]
@@ -94,3 +160,12 @@ metadata:
   estimated_effort: Small
   created_date: "2026-07-11"
   source: "UAT infrastructure review 2026-07-10 (develop @ fc31f3604), finding R4"
+
+files_affected:
+  modified:
+  - .github/workflows/nightly.yml
+  - _project/config/fast_test_lane_policy.json
+  - tests/uat/runner.py
+  - tests/uat/test_runner.py
+  - tests/uat/test_throughput.py
+  - tests/uat/throughput.py


### PR DESCRIPTION
uat-throughput-result-resolution-hardening (T7, PR #1228) and
nightly-throughput-gate-restoration (T8, PR #1231) merged to develop
but their TODO files were never archived. Add completion metadata
(status, completed_date, per-work-unit notes, review_response,
files_affected) and move both into _project/DONE/uat-hardening/planning/.

T8's w3 (operator-dispatched nightly run confirming green gating)
stays pending -- not achievable from a batch session; recorded as
waiting on the maintainer.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
