### PR TITLE
fix(todo-db): make _HostedRow case-insensitive like sqlite3.Row

### DIFF
--- a/_project/scripts/todo_db.py
+++ b/_project/scripts/todo_db.py
@@ -402,18 +402,28 @@ def connect(db_path: Path) -> sqlite3.Connection:
 
 
 class _HostedRow:
-    """sqlite3.Row stand-in: index + name access, dict(row) via keys()."""
+    """sqlite3.Row stand-in: index + name access, dict(row) via keys().
+
+    libsql's cursor.description reports column names verbatim from the SQL
+    keyword casing that produced them rather than the SELECT-list casing (observed
+    live against Turso: the `anti_patterns.instead` column - "instead" being
+    a keyword via INSTEAD OF triggers - comes back as "INSTEAD"). sqlite3.Row
+    has no such quirk and is case-insensitive on name access besides. Names
+    are lowercased at construction so keys()/dict(row) match local sqlite3.Row
+    output exactly, and __getitem__ additionally lowercases the lookup key as
+    a second line of defense for any future case mismatch.
+    """
 
     __slots__ = ("_names", "_values")
 
     def __init__(self, names: list[str], values: tuple):
-        self._names = names
+        self._names = [name.lower() for name in names]
         self._values = values
 
     def __getitem__(self, key):
         if isinstance(key, str):
             try:
-                return self._values[self._names.index(key)]
+                return self._values[self._names.index(key.lower())]
             except ValueError:
                 raise IndexError(f"no such column: {key}") from None
         return self._values[key]
@@ -1742,12 +1752,12 @@ def export_all(conn: sqlite3.Connection) -> list[dict[str, Any]]:
         items[row["item_id"]]["verifications"].append(dict(row))
     for row in conn.execute("SELECT item_id, behavior FROM preserves ORDER BY item_id, behavior"):
         items[row["item_id"]]["preserves"].append(row["behavior"])
-    # Use dict(row) (as get_item does) rather than by-name access: `instead` is
-    # a SQL keyword and the backends disagree on its result-column name (local
-    # SQLite -> "instead", the libsql cursor -> "INSTEAD"); dict(row) inherits
-    # whatever the cursor reports, keeping export byte-identical with get_item()
-    # on both backends, and avoids the by-name keyword lookup that fails on the
-    # remote cursor.
+    # Use dict(row) (as get_item does), consistent with every other table
+    # here: `instead` is a SQL keyword and the hosted libsql cursor once
+    # reported it back as "INSTEAD" while local sqlite3 preserved the SELECT
+    # casing "instead" - _HostedRow now lowercases column names at
+    # construction (see its docstring) so both backends agree, but dict(row)
+    # remains the right idiom regardless of casing.
     for row in conn.execute("SELECT item_id, dont, why, instead FROM anti_patterns ORDER BY item_id, dont"):
         anti = dict(row)
         items[anti.pop("item_id")]["anti_patterns"].append(anti)

--- a/tests/unit/scripts/test_todo_db.py
+++ b/tests/unit/scripts/test_todo_db.py
@@ -342,6 +342,61 @@ class TestExport:
         assert "second-item" in (first_dir / "index.md").read_text()
 
 
+class TestHostedRow:
+    """_HostedRow is the libsql/Turso stand-in for sqlite3.Row (see its
+    docstring in todo_db.py). libsql's cursor.description has been observed
+    to report a keyword column name ("instead", via INSTEAD OF triggers)
+    back in uppercase, while local sqlite3 preserves the lowercase SELECT
+    casing. sqlite3.Row is case-insensitive on name access, so _HostedRow
+    must be too, or hosted-only KeyErrors sneak past local-only test runs."""
+
+    def test_case_insensitive_access_and_dict_roundtrip(self):
+        r = todo_db._HostedRow(["dont", "why", "INSTEAD"], ("a", "b", "c"))
+        assert r["instead"] == "c"
+        assert r["INSTEAD"] == "c"
+        assert dict(r) == {"dont": "a", "why": "b", "instead": "c"}
+        assert r[2] == "c"
+        assert list(r.keys()) == ["dont", "why", "instead"]
+
+    def test_missing_column_raises_index_error(self):
+        r = todo_db._HostedRow(["dont", "why", "instead"], ("a", "b", "c"))
+        with pytest.raises(IndexError, match="no such column: nope"):
+            r["nope"]
+
+
+class TestPrintWorkOrderHostedRegression:
+    """Regression coverage for the `todo claim` crash on the hosted backend:
+    get_item() builds anti_patterns entries via dict(row); on hosted, an
+    unfixed _HostedRow yielded the key "INSTEAD" (uppercase) instead of
+    "instead", and _print_work_order's `anti['instead']` lookup raised
+    KeyError. The state transition itself succeeded — only the banner print
+    crashed — so this must exercise the print path directly, not just the
+    lifecycle functions (which are backend-agnostic and were never broken)."""
+
+    def test_anti_pattern_from_hosted_row_does_not_raise(self, capsys):
+        hosted_row = todo_db._HostedRow(
+            ["dont", "why", "INSTEAD"],
+            ("skip the fast tests", "flakiness hides real regressions", "run make test-fast locally first"),
+        )
+        order = {
+            "id": "sample-item",
+            "priority": "medium",
+            "title": "A sample tracked item",
+            "state": "active",
+            "worktree": "spike",
+            "claimed_by": "tester",
+            "blocked_reason": None,
+            "scope": [],
+            "preserves": [],
+            "anti_patterns": [dict(hosted_row)],
+            "verifications": [],
+            "deferrals": [],
+        }
+        todo_db._print_work_order(order)  # must not raise KeyError
+        out = capsys.readouterr().out
+        assert "instead: run make test-fast locally first" in out
+
+
 class TestAntiPatternParse:
     def test_full_form(self):
         dont, why, instead = todo_db._parse_anti_pattern(


### PR DESCRIPTION
libsql returns the anti_patterns.instead column as "INSTEAD" (keyword via
INSTEAD OF triggers) while local sqlite3 preserves the lowercase SELECT
casing. _HostedRow did exact-case name lookup, so get_item()'s dict(row)
carried the uppercase key through and _print_work_order's anti['instead']
raised KeyError on the hosted backend only -- crashing `todo claim` after
the state transition had already succeeded.

Fix the adapter, not the call site: _HostedRow now lowercases column names
at construction and lowercases the lookup key in __getitem__, matching
sqlite3.Row's case-insensitive semantics on both axes. This covers every
keyword-column access (only `anti['instead']` was confirmed broken; `value`
in the meta-table lookups was the other keyword-ish candidate) rather than
patching one call site.

Audited the rest of _HostedRow/_HostedCursor against sqlite3.Row/Cursor
behavior actually used by this file (keys(), iteration-over-values, len,
dict(), int/name indexing) -- all faithfully mirrored; row equality/hashing
is not replicated but nothing in the codebase relies on it.
