### PR TITLE
fix: close merged PR review follow-up findings

### DIFF
--- a/GEMINI.md
+++ b/GEMINI.md
@@ -78,7 +78,7 @@ Gemini can run these without permission:
 
 ### TODO Management
 - `_project/scripts/todo` is the DB-backed tracker entry point; global `--db`/`--actor` flags come before the subcommand.
-- Read: `_project/scripts/todo ready|list|show|stats|deps|lint|export|check-scope`
+- Read-only: `_project/scripts/todo ready|list|show|stats|deps|lint|export|check-scope`
 - Lifecycle writes: `_project/scripts/todo create|claim|start|done|defer|promote|dismiss|complete|drop|block|unblock|verify`
 
 ### Timing & Audit
@@ -90,9 +90,10 @@ Gemini can run these without permission:
 
 ## TODO Workflow
 - State lives in the shared DB; there is no `_project/TODO` tree. `_project/scripts/todo` is the only write path.
-- `todo claim <id>` prints scope, preserves, anti-patterns, the verification ladder, ready units, and deferrals.
+- `todo claim <id>` prints scope, preserves, anti-patterns, the verification ladder, dependencies, ready units, and deferrals; follow that work order.
 - Per unit: `todo start ...` (optional) then `todo done ... --evidence ...`; use `todo defer` when skipping; `todo complete ... --pr ...` is gated.
 - `todo export` is the deterministic JSONL/Markdown snapshot; never hand-edit tracker state.
+- `todo lint <id>` runs the mechanical quality checks. Never hand-write tracker state into repository files.
 
 ## CLI Options & Phases
 - **Basic Run**: `benchbox run --platform {plat} --benchmark {bm} --scale {sf}`

--- a/_project/scripts/todo_db.py
+++ b/_project/scripts/todo_db.py
@@ -1715,7 +1715,23 @@ def lint_item(conn: sqlite3.Connection, item_id: str) -> list[str]:
 # Export
 
 
-def export_all(conn: sqlite3.Connection) -> list[dict[str, Any]]:
+@contextmanager
+def _read_txn(conn: Any):
+    """Hold one consistent read snapshot across the complete export bundle."""
+    conn.execute("BEGIN")
+    try:
+        yield
+    except BaseException:
+        try:
+            conn.rollback()
+        except Exception:  # noqa: S110 - never mask the original failure
+            pass
+        raise
+    else:
+        conn.commit()
+
+
+def _export_all_unlocked(conn: sqlite3.Connection) -> list[dict[str, Any]]:
     # Bulk read: one SELECT per table, assembled in Python. Produces output
     # byte-identical to per-item get_item() but with ~11 round-trips instead of
     # thousands, so a remote (no-embedded-replica) read-only connection stays
@@ -1771,18 +1787,26 @@ def export_all(conn: sqlite3.Connection) -> list[dict[str, Any]]:
     return [items[i] for i in order]
 
 
+def export_all(conn: sqlite3.Connection) -> list[dict[str, Any]]:
+    with _read_txn(conn):
+        return _export_all_unlocked(conn)
+
+
 def write_export(conn: sqlite3.Connection, out_dir: Path) -> tuple[Path, Path]:
     out_dir.mkdir(parents=True, exist_ok=True)
+    items = export_all(conn)
     jsonl_path = out_dir / "items.jsonl"
     with open(jsonl_path, "w", encoding="utf-8") as handle:
-        for item in export_all(conn):
+        for item in items:
             handle.write(json.dumps(item, sort_keys=True) + "\n")
     index_path = out_dir / "index.md"
     with open(index_path, "w", encoding="utf-8") as handle:
         handle.write("# TODO export\n\n| id | state | priority | worktree | title |\n")
         handle.write("|---|---|---|---|---|\n")
-        for row in conn.execute("SELECT id, state, priority, worktree, title FROM items ORDER BY id"):
-            handle.write(f"| {row['id']} | {row['state']} | {row['priority']} | {row['worktree']} | {row['title']} |\n")
+        for item in items:
+            handle.write(
+                f"| {item['id']} | {item['state']} | {item['priority']} | {item['worktree']} | {item['title']} |\n"
+            )
     return jsonl_path, index_path
 
 

--- a/docs/operations/uat-framework.md
+++ b/docs/operations/uat-framework.md
@@ -47,13 +47,13 @@ worktree.
 
 Two ways to change the root, in precedence order: an explicit
 `output.benchmark_runs_dir_template` (and/or `output.logs_dir_template`,
-`output.submissions_dir_template`) in the config always wins. If a config
-leaves those at their schema defaults (every checked-in config does),
-setting `BENCHBOX_OUTPUT_DIR` before the sweep overrides the
-`~/Developer/benchmark_runs` base for both the runs dir and the log dir —
+`output.submissions_dir_template`) in the config always wins. The three
+release-gate configs intentionally leave those keys unset, so setting
+`BENCHBOX_OUTPUT_DIR` before a stage overrides the
+`~/Developer/benchmark_runs` base for runs, logs, and local-stage submissions;
 this also matches bare `make uat-cell` (which has always read the env var).
-A config with an explicit template ignores `BENCHBOX_OUTPUT_DIR` entirely —
-no silent root switching for a configured sweep.
+A config with an explicit template ignores `BENCHBOX_OUTPUT_DIR` for that
+path — no silent root switching for a configured sweep.
 
 ## Local-artifact hygiene (external-root invariant)
 
@@ -450,8 +450,8 @@ dataframe — in a single Docker-free sweep; stages 2 and 3 are the Docker tiers
 Run rules:
 
 - Use a **fresh run root** under `BENCHBOX_OUTPUT_DIR=~/Developer/benchmark_runs`
-  (the three configs use the default output templates, so the env var sets the
-  base — see "Output artefacts"); never resume into the failed 2026-05-28/29
+  (the three configs leave their output templates unset, so the env var sets
+  the base — see "Output artefacts"); never resume into the failed 2026-05-28/29
   dirs (they are non-evidentiary).
 - One platform / one Docker stack at a time (`execute.parallel_platforms` is
   hard-rejected). A single Docker stack's compose-up failure records FAIL and

--- a/tests/uat/config.py
+++ b/tests/uat/config.py
@@ -101,6 +101,11 @@ class ScalesConfig:
     rungs: tuple[float, ...] = (0.01,)
     override: float | None = None
 
+    @property
+    def requested_rungs(self) -> tuple[float, ...]:
+        """Return the effective ladder after any one-scale override."""
+        return (self.override,) if self.override is not None else self.rungs
+
 
 @dataclass(frozen=True)
 class ValidateConfig:
@@ -313,7 +318,19 @@ def _validate_scales(payload: dict[str, Any] | None) -> ScalesConfig:
     if not isinstance(payload, dict):
         raise ConfigError("`scales:` must be a mapping")
     _reject_unknown_fields(payload, frozenset({"rungs", "override"}), "scales")
-    rungs_raw = payload.get("rungs", [0.01])
+    override = payload.get("override")
+    if isinstance(override, bool):
+        raise ConfigError("`scales.override` must be a number, got bool")
+    try:
+        override_value = float(override) if override is not None else None
+    except (TypeError, ValueError) as exc:
+        raise ConfigError("`scales.override` must be a number") from exc
+
+    # Keep the report-facing rung list aligned with the single-scale override.
+    # Enumeration already prefers `override`, but report/aggregation consumers
+    # read `rungs`; leaving the schema default here makes an override run report
+    # against the wrong scale ladder.
+    rungs_raw = payload.get("rungs", [override_value] if override_value is not None else [0.01])
     if isinstance(rungs_raw, (str, bytes)) or not isinstance(rungs_raw, (list, tuple)):
         raise ConfigError("`scales.rungs` must be a list of numbers")
     if any(isinstance(value, bool) for value in rungs_raw):
@@ -326,13 +343,6 @@ def _validate_scales(payload: dict[str, Any] | None) -> ScalesConfig:
         raise ConfigError("`scales.rungs` must be a list of numbers") from exc
     if not rungs:
         raise ConfigError("`scales.rungs` must be non-empty")
-    override = payload.get("override")
-    if isinstance(override, bool):
-        raise ConfigError("`scales.override` must be a number, got bool")
-    try:
-        override_value = float(override) if override is not None else None
-    except (TypeError, ValueError) as exc:
-        raise ConfigError("`scales.override` must be a number") from exc
     if "rungs" in payload and override_value is not None:
         raise ConfigError(
             "`scales.rungs` and `scales.override` are mutually exclusive -- "

--- a/tests/uat/configs/release-gate-01-native-dataframe.yaml
+++ b/tests/uat/configs/release-gate-01-native-dataframe.yaml
@@ -45,7 +45,6 @@ execute:
 
 preflight:
   free_space_min_gib: 5
-  free_space_path: "~/Developer/benchmark_runs"
 
 cleanup:
   preserve_datagen: true
@@ -79,8 +78,3 @@ report:
   # environment variance without letting a mass regression sign off; never set
   # this to the eligible count exactly.
   cross_scale_coverage_min_pairs: 122
-
-output:
-  benchmark_runs_dir_template: "~/Developer/benchmark_runs"
-  logs_dir_template: "~/Developer/benchmark_runs/logs/release_gate_01_native_dataframe_{date}"
-  submissions_dir_template: "~/Developer/benchmark_runs/submissions/{name}"

--- a/tests/uat/configs/release-gate-02-docker-nonoltp.yaml
+++ b/tests/uat/configs/release-gate-02-docker-nonoltp.yaml
@@ -43,7 +43,6 @@ execute:
 
 preflight:
   free_space_min_gib: 5
-  free_space_path: "~/Developer/benchmark_runs"
   docker_required: true
 
 cleanup:
@@ -79,8 +78,3 @@ report:
   # absorbs a down docker stack without letting a mass regression sign off;
   # never set this to the eligible count exactly.
   cross_scale_coverage_min_pairs: 51
-
-output:
-  benchmark_runs_dir_template: "~/Developer/benchmark_runs"
-  logs_dir_template: "~/Developer/benchmark_runs/logs/release_gate_02_docker_nonoltp_{date}"
-  submissions_dir_template: "~/Developer/benchmark_runs/submissions/{name}"

--- a/tests/uat/configs/release-gate-03-docker-oltp.yaml
+++ b/tests/uat/configs/release-gate-03-docker-oltp.yaml
@@ -37,7 +37,6 @@ execute:
 
 preflight:
   free_space_min_gib: 5
-  free_space_path: "~/Developer/benchmark_runs"
   docker_required: true
 
 cleanup:
@@ -71,8 +70,3 @@ report:
   # docker stack without letting a mass regression sign off; never set this
   # to the eligible count exactly.
   cross_scale_coverage_min_pairs: 162
-
-output:
-  benchmark_runs_dir_template: "~/Developer/benchmark_runs"
-  logs_dir_template: "~/Developer/benchmark_runs/logs/release_gate_03_docker_oltp_{date}"
-  submissions_dir_template: "~/Developer/benchmark_runs/submissions/{name}"

--- a/tests/uat/orchestrator.py
+++ b/tests/uat/orchestrator.py
@@ -363,11 +363,7 @@ def run_sweep(  # noqa: C901
             # regardless of exit code), but packaging/submitting it would
             # present a known-bad run as a candidate submission.
             result_paths = [r.result_path for r in execute_outcome.results if r.result_path and r.status == "passed"]
-            submissions_dir = Path(
-                config.output.submissions_dir_template.replace("{date}", now.strftime("%Y%m%d")).replace(
-                    "{name}", config.name
-                )
-            ).expanduser()
+            submissions_dir = exec_phase.default_submissions_dir(config, now=now)
             pr = run_package(
                 config,
                 result_paths=result_paths,
@@ -483,7 +479,7 @@ def run_sweep(  # noqa: C901
             summary = report_phase.write_report(
                 cells,
                 output_path=tsv_path,
-                rungs=list(config.scales.rungs),
+                rungs=list(config.scales.requested_rungs),
                 cross_scale_floor=config.report.cross_scale_coverage_min_pairs,
                 validator_status_by_path=validator_status_by_path,
                 compatibility_pruned_count=len(getattr(execute_outcome, "compatibility_pruned", ())),
@@ -586,7 +582,7 @@ def _emit_abort_artifacts(
     return report_phase.write_report(
         cells,
         output_path=_partial_report_path(log_dir / config.report.matrix_summary_tsv),
-        rungs=list(config.scales.rungs),
+        rungs=list(config.scales.requested_rungs),
         cross_scale_floor=config.report.cross_scale_coverage_min_pairs,
         compatibility_pruned_count=len(compatibility_pruned),
         early_stop_pruned_count=early_stop_pruned_count,

--- a/tests/uat/phases/enumerate.py
+++ b/tests/uat/phases/enumerate.py
@@ -97,23 +97,29 @@ def enumerate_cells_with_pruning(
         benchmarks=benchmarks,
     )
 
-    if config.scales.override is not None:
-        requested = [config.scales.override]
-    else:
-        requested = list(config.scales.rungs)
+    # `requested_rungs` centralizes the effective values from
+    # `config.scales.rungs` and `config.scales.override` for every consumer.
+    requested = list(config.scales.requested_rungs)
 
     cells: list[Cell] = []
     compatibility_pruned: list[CompatibilityPrunedCell] = []
     include_release_gate_runtime_envelopes = config.compatibility.release_gate_runtime_envelopes
 
+    missing_benchmarks = missing_benchmarks_from_include(config.benchmarks.include, benchmarks)
+    missing_platforms = missing_platforms_from_include(config.platforms.include)
     # `resolve_benchmarks` silently drops `benchmarks.include` entries absent
     # from the registry (see `missing_benchmarks_from_include`'s docstring) -
     # so a typo'd/removed benchmark id never reaches `benchmark_list` below.
     # Surface it here as a visible accounting row instead of a zero-signal
     # drop, one row per platform x requested scale (mirrors the shape
     # `_pruned_rows_for_rule` already uses for compatibility-rule prunes).
-    for missing_benchmark in missing_benchmarks_from_include(config.benchmarks.include, benchmarks):
-        for platform in platform_list:
+    # Include missing ids as accounting dimensions too. This preserves a
+    # diagnostic row when both explicit include lists contain only unknown
+    # ids, rather than letting each side's empty resolved list hide the other.
+    accounting_platforms = [*platform_list, *missing_platforms]
+    accounting_benchmarks = [*benchmark_list, *missing_benchmarks]
+    for missing_benchmark in missing_benchmarks:
+        for platform in accounting_platforms:
             compatibility_pruned.extend(
                 _registry_absent_rows(platform=platform, benchmark=missing_benchmark, requested=requested)
             )
@@ -125,8 +131,8 @@ def enumerate_cells_with_pruning(
     # platform id never reaches `platform_list`. Surface it as a visible
     # accounting row per missing platform x resolved benchmark, instead of an
     # execute-time surprise.
-    for missing_platform in missing_platforms_from_include(config.platforms.include):
-        for benchmark in benchmark_list:
+    for missing_platform in missing_platforms:
+        for benchmark in accounting_benchmarks:
             compatibility_pruned.extend(
                 _registry_absent_platform_rows(platform=missing_platform, benchmark=benchmark, requested=requested)
             )

--- a/tests/uat/phases/execute.py
+++ b/tests/uat/phases/execute.py
@@ -983,3 +983,15 @@ def default_benchmark_runs_dir(config: UATConfig, now: _dt.datetime | None = Non
     )
     rendered = template.replace("{date}", now.strftime("%Y%m%d")).replace("{name}", config.name)
     return Path(rendered).expanduser()
+
+
+def default_submissions_dir(config: UATConfig, now: _dt.datetime | None = None) -> Path:
+    """Resolve the package submissions directory using the same output root."""
+    now = now or _dt.datetime.now()
+    template = _resolve_output_base(
+        config.output.submissions_dir_template,
+        _DEFAULT_OUTPUT.submissions_dir_template,
+        explicit="submissions_dir_template" in config.output.explicitly_set,
+    )
+    rendered = template.replace("{date}", now.strftime("%Y%m%d")).replace("{name}", config.name)
+    return Path(rendered).expanduser()

--- a/tests/uat/test_config.py
+++ b/tests/uat/test_config.py
@@ -263,7 +263,7 @@ def test_stress_default_fields_have_reader_or_reserved_contract():
         "report.matrix_summary_tsv": ("tests/uat/orchestrator.py", "config.report.matrix_summary_tsv"),
         "output.logs_dir_template": ("tests/uat/phases/execute.py", "config.output.logs_dir_template"),
         "output.submissions_dir_template": (
-            "tests/uat/orchestrator.py",
+            "tests/uat/phases/execute.py",
             "config.output.submissions_dir_template",
         ),
     }
@@ -300,6 +300,7 @@ def test_stress_override_scale_sets_override_without_mutating_rungs():
     overridden = replace(cfg, scales=replace(cfg.scales, override=0.1))
     assert overridden.scales.rungs == (0.01, 0.1, 1.0)
     assert overridden.scales.override == 0.1
+    assert overridden.scales.requested_rungs == (0.1,)
 
 
 # ---------------------------------------------------------------------------
@@ -403,6 +404,13 @@ def test_validate_config_accepts_canonical_phase_subsequence():
 def test_validate_config_rejects_rungs_and_override_together():
     with pytest.raises(config.ConfigError, match="mutually exclusive"):
         config.validate_config({"name": "smoke", "phases": ["execute"], "scales": {"rungs": [0.1], "override": 1.0}})
+
+
+def test_validate_config_uses_override_as_report_rung():
+    cfg = config.validate_config({"name": "official", "scales": {"override": 1.0}})
+
+    assert cfg.scales.override == 1.0
+    assert cfg.scales.rungs == (1.0,)
 
 
 def test_validate_config_rejects_bool_rung():

--- a/tests/uat/test_matrix.py
+++ b/tests/uat/test_matrix.py
@@ -324,6 +324,22 @@ def test_enumerate_with_pruning_records_registry_missing_platform():
     assert result.candidate_count == len(result.cells) + len(result.compatibility_pruned)
 
 
+def test_enumerate_with_pruning_records_both_unknown_include_dimensions():
+    raw = {
+        "platforms": {"include": ["totally_bogus_platform_xyz"]},
+        "benchmarks": {"include": ["totally_bogus_benchmark_xyz"]},
+        "scales": {"rungs": [0.01]},
+    }
+
+    result = enum_phase.enumerate_cells_with_pruning(_registry_cfg(raw))
+
+    assert result.cells == ()
+    assert {(row.rule_id, row.platform, row.benchmark, row.scale) for row in result.compatibility_pruned} == {
+        ("platform-not-in-registry", "totally_bogus_platform_xyz", "totally_bogus_benchmark_xyz", 0.01),
+        ("benchmark-not-in-registry", "totally_bogus_platform_xyz", "totally_bogus_benchmark_xyz", 0.01),
+    }
+
+
 def test_enumerate_with_pruning_records_ladder_pruned_scales():
     raw = {
         "platforms": {"include": ["duckdb"]},

--- a/tests/uat/test_phases.py
+++ b/tests/uat/test_phases.py
@@ -1423,6 +1423,15 @@ def test_default_log_dir_honors_env_var_when_template_is_default(monkeypatch, tm
     assert out == tmp_path / "external-root" / "logs" / "uat_20260505_090000"
 
 
+def test_default_submissions_dir_honors_env_var_when_template_is_default(monkeypatch, tmp_path):
+    monkeypatch.setenv("BENCHBOX_OUTPUT_DIR", str(tmp_path / "external-root"))
+    cfg = validate_config({"name": "uat-smoke"})
+
+    out = exec_phase.default_submissions_dir(cfg, now=_dt.datetime(2026, 5, 5))
+
+    assert out == tmp_path / "external-root" / "submissions" / "uat-smoke"
+
+
 def test_default_benchmark_runs_dir_explicit_template_wins_over_env_var(monkeypatch, tmp_path):
     """An explicit YAML template must never be silently overridden by the env var."""
     monkeypatch.setenv("BENCHBOX_OUTPUT_DIR", str(tmp_path / "external-root"))

--- a/tests/unit/scripts/test_todo_db_hosted.py
+++ b/tests/unit/scripts/test_todo_db_hosted.py
@@ -1000,6 +1000,26 @@ def test_export_all_bulk_matches_per_item(tmp_path):
     assert ap.get("instead", ap.get("INSTEAD")) == "do it properly"
 
 
+def test_export_all_uses_one_read_transaction(tmp_path):
+    conn = todo_db.connect(tmp_path / "t.sqlite")
+    todo_db.create_item(
+        conn,
+        "tester",
+        item_id="snapshot-item",
+        title="Snapshot item",
+        worktree="spike",
+        priority="low",
+        description="transaction test",
+    )
+    statements: list[str] = []
+    conn.set_trace_callback(statements.append)
+
+    todo_db.write_export(conn, tmp_path / "export")
+
+    assert statements[0] == "BEGIN"
+    assert statements[-1] == "COMMIT"
+
+
 def test_export_command_uses_read_only_connect(monkeypatch):
     """The export command must connect read-only (remote-only, no embedded
     replica) so a read-only hosted token works."""


### PR DESCRIPTION
## Summary

Follow-up sweep for unresolved review threads across the last 30 merged PRs.

- Make `scales.override` authoritative for report-facing rungs, including programmatic overrides.
- Preserve registry accounting when both explicit platform and benchmark includes are unknown.
- Make release-gate configs honor `BENCHBOX_OUTPUT_DIR` for runs, logs, preflight, and submissions.
- Make hosted TODO export bundles use one read snapshot and keep `index.md` consistent with `items.jsonl`.
- Refresh the remaining stale Gemini TODO instructions.

Already-fixed/superseded threads are closed with replies referencing the later merged cutover/snapshot fixes.

## Verification

- `uv run -- python -m pytest tests/unit/ -x -q` — 24,823 passed, 22 skipped
- Targeted UAT/export/wrapper suite — 371 passed
- `make pr-preflight` — passed
- Ruff check/format and pre-commit hooks — passed

Source threads: #1226, #1227, #1229, #1232, #1233, #1234, #1235.