### PR TITLE
fix: close todo-db review follow-ups

### DIFF
--- a/_project/scripts/todo_db.py
+++ b/_project/scripts/todo_db.py
@@ -2181,7 +2181,8 @@ def _print_work_order(order: dict[str, Any]) -> None:
         print("-- verification ladder (narrowest first)")
         for ver in order["verifications"]:
             cmd = f" :: {ver['command']}" if ver["command"] else ""
-            print(f"   {ver['seq']}. {ver['description']}{cmd}")
+            expected = f" — expected: {ver['expected']}" if ver.get("expected") else ""
+            print(f"   {ver['seq']}. {ver['description']}{cmd}{expected}")
     ready = order.get("ready_units", [])
     blocked = order.get("blocked_units", [])
     print("-- ready units" if ready else "-- no ready units")
@@ -2686,7 +2687,9 @@ def _cmd_verify(conn, actor, args):
     item = get_item(conn, args.id)
     for ver in item["verifications"]:
         status = f" [{ver['last_result']} @ {ver['last_run']}]" if ver["last_result"] else ""
-        print(f"{ver['seq']}. {ver['description']}" + (f" :: {ver['command']}" if ver["command"] else "") + status)
+        cmd = f" :: {ver['command']}" if ver["command"] else ""
+        expected = f" — expected: {ver['expected']}" if ver.get("expected") else ""
+        print(f"{ver['seq']}. {ver['description']}{cmd}{expected}{status}")
     return 0
 
 

--- a/_project/scripts/todo_db_standalone_compat.py
+++ b/_project/scripts/todo_db_standalone_compat.py
@@ -87,6 +87,10 @@ def _has_option(argv: Iterable[str], name: str) -> bool:
     return any(value == name or value.startswith(f"{name}=") for value in argv)
 
 
+def _has_database_environment() -> bool:
+    return any(os.environ.get(name) for name in ("TODO_DB_PATH", "TODO_DB_URL"))
+
+
 def _with_identity(argv: list[str], command_index: int) -> list[str]:
     before = argv[:command_index]
     after = argv[command_index:]
@@ -287,7 +291,7 @@ def _main(argv: list[str] | None = None) -> int:
         return result.returncode
     command_index, command = located
     root = _repo_root()
-    if not _has_option(args, "--db"):
+    if not _has_option(args, "--db") and not _has_database_environment():
         args[command_index:command_index] = ["--db", str(root / ".todo-db" / "todo.sqlite")]
         command_index += 2
     if command == "export":

--- a/tests/unit/scripts/test_todo_db.py
+++ b/tests/unit/scripts/test_todo_db.py
@@ -6,6 +6,7 @@ import importlib.util
 import sys
 import textwrap
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 
@@ -334,6 +335,18 @@ class TestVerifyRun:
         )
         assert todo_db.run_verification(conn, "tester", "sample-item", 1)[0] == "pass"
         assert todo_db.run_verification(conn, "tester", "sample-item", 2)[0] == "fail"
+
+    def test_verify_expected_is_rendered_in_work_order_and_listing(self, conn, capsys):
+        _mk(
+            conn,
+            verifications=[{"description": "passes", "command": "true", "expected": "human-readable criterion"}],
+        )
+
+        todo_db._print_work_order(todo_db.work_order(conn, "sample-item"))
+        assert "expected: human-readable criterion" in capsys.readouterr().out
+
+        todo_db._cmd_verify(conn, "tester", SimpleNamespace(id="sample-item", run=None))
+        assert "expected: human-readable criterion" in capsys.readouterr().out
 
 
 class TestExport:

--- a/tests/unit/scripts/test_todo_db_standalone_compat.py
+++ b/tests/unit/scripts/test_todo_db_standalone_compat.py
@@ -164,8 +164,31 @@ def test_missing_db_is_pinned_to_benchbox_database(monkeypatch: pytest.MonkeyPat
 
     monkeypatch.setattr(compat, "_delegate", fake_delegate)
     monkeypatch.setenv("BENCHBOX_REPO_ROOT", str(tmp_path))
+    monkeypatch.delenv("TODO_DB_PATH", raising=False)
+    monkeypatch.delenv("TODO_DB_URL", raising=False)
     assert compat.main(["show", "item"]) == 0
     assert calls[0][:2] == ["--db", str(tmp_path / ".todo-db" / "todo.sqlite")]
+
+
+@pytest.mark.parametrize(
+    ("variable", "value"),
+    [("TODO_DB_PATH", "/tmp/pinned.sqlite"), ("TODO_DB_URL", "libsql://tracker.example")],
+)
+def test_database_environment_is_left_for_standalone_cli(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, variable: str, value: str
+) -> None:
+    calls: list[list[str]] = []
+
+    def fake_delegate(argv: list[str], *, command: str, cwd: Path, capture: bool = True) -> CompletedProcess[str]:
+        calls.append(argv)
+        return CompletedProcess(argv, 0, stdout="", stderr="")
+
+    monkeypatch.setattr(compat, "_delegate", fake_delegate)
+    monkeypatch.setenv("BENCHBOX_REPO_ROOT", str(tmp_path))
+    monkeypatch.setenv(variable, value)
+
+    assert compat.main(["show", "item"]) == 0
+    assert "--db" not in calls[0]
 
 
 def test_missing_binary_fails_cleanly(monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys) -> None:


### PR DESCRIPTION
## Summary

Follow-up fixes for the two unresolved review threads found while sweeping the 30 most recently merged PRs:

- Preserve standalone todo-db environment backend selection by only injecting the BenchBox local fallback when neither --db nor TODO_DB_PATH/TODO_DB_URL is configured.
- Surface verification expected-output guidance in both the work order and verify listing without changing exit-status semantics.

## Source threads

- #1239 `_project/scripts/todo_db_standalone_compat.py`
- #1240 `_project/scripts/todo_db.py`

## Verification

- `uv run -- python -m pytest tests/unit/ -x -q` — 24,891 passed, 22 skipped
- Focused todo-db suite — 159 passed
- Ruff check/format — passed
- `make pr-preflight` — 25,274 passed, 27 skipped
- Commit hooks and pre-push checks — passed