### PR TITLE
feat(uat): incremental cells.jsonl durability + SIGTERM teardown parity

### DIFF
--- a/docs/operations/uat-framework.md
+++ b/docs/operations/uat-framework.md
@@ -280,6 +280,35 @@ write) in place instead of a torn file. `cells.jsonl` is written before its
 accounting sidecar, so a crash between the two writes cannot leave a fresh
 sidecar next to a stale (or absent) cell stream.
 
+### Incremental durability and killed-run detection
+
+During the execute phase each cell's `cells.jsonl` row is appended and
+`fsync`'d the moment that cell completes, so a sweep that dies mid-run keeps
+every row it had already earned instead of losing the whole batch. Two
+sentinel files beside `cells.jsonl` record the run's lifecycle:
+
+- `cells.jsonl.inprogress` — written when streaming begins.
+- `cells.jsonl.finalized` — written last, at an orderly sweep end (normal
+  completion *or* a controlled abort), which also clears `.inprogress`.
+
+A run interrupted by a signal (see below) or a hard crash leaves `.inprogress`
+without `.finalized`. `make uat-report` treats such a run as `INCOMPLETE` and
+exits nonzero — a partial stream of all-passed rows never reads as a clean
+sweep. A legacy artifact that carries *neither* sentinel (it predates this
+machinery) still regenerates exactly as before.
+
+### Signal teardown (SIGTERM behaves like Ctrl-C)
+
+For the duration of a sweep the process installs a SIGTERM handler that raises
+a cancellation, so an operator `kill` (or a CI cancellation) unwinds through
+the same path Ctrl-C already took: the per-platform `finally` tears the
+managed Docker stack down, no finalize marker is written (the run stays
+`INCOMPLETE`), and the process exits nonzero. The cancellation — signal name,
+phase in flight, and timestamp — is recorded to `uat_lifecycle.log` as a
+`[cancel]` line. The shim is scoped to the sweep process only; cell
+subprocesses keep their own timeout/process-group kill semantics, and the
+previous SIGTERM handler is always restored when the sweep returns.
+
 ## Disk-budget estimate
 
 Preflight prints a disk-budget line and a per-root free-space report before

--- a/tests/uat/_cli.py
+++ b/tests/uat/_cli.py
@@ -147,10 +147,22 @@ def _handle_preflight(args: argparse.Namespace) -> int:
 
 def _handle_report(args: argparse.Namespace) -> int:
     """Implements `make uat-report`. Reads cells from a JSON-lines stream."""
-    from tests.uat.cells_io import coerce_accounting_count, read_accounting_sidecar, read_cells_jsonl
+    from tests.uat.cells_io import (
+        cells_run_incomplete,
+        coerce_accounting_count,
+        read_accounting_sidecar,
+        read_cells_jsonl,
+    )
     from tests.uat.phases.report import write_report
 
     cells = read_cells_jsonl(Path(args.cells_jsonl))
+    # A cells.jsonl whose durable sweep began but never finalized (its
+    # `.inprogress` marker still lingers with no `.finalized`) came from a
+    # sweep killed mid-run (uat-sweep-durability-and-signal-teardown w1): the
+    # rows present are durable but partial, so the report must not read green.
+    # A legacy artifact with neither marker is unaffected -- it still
+    # regenerates exactly as before.
+    finalized = not cells_run_incomplete(Path(args.cells_jsonl))
     # Skipped-unreachable and startup-failed cells are not JSONL rows; the
     # durable sweep writes their counts to a sidecar next to cells.jsonl.
     # Read the sidecar ONCE and take both counts from the same payload so a
@@ -175,6 +187,7 @@ def _handle_report(args: argparse.Namespace) -> int:
         skipped_unreachable_count=skipped_unreachable_count,
         startup_failed_count=startup_failed_count,
         unreachable_count_is_estimated=not sidecar_present,
+        finalized=finalized,
     )
     print(
         json.dumps(
@@ -192,6 +205,7 @@ def _handle_report(args: argparse.Namespace) -> int:
                 "passed": summary.pass_count,
                 "failed": summary.fail_count,
                 "timed_out": summary.timeout_count,
+                "finalized": finalized,
                 "cross_scale_clean_pairs": summary.cross_scale_clean_pairs,
                 "cross_scale_floor": summary.cross_scale_floor,
                 "cross_scale_floor_breached": summary.cross_scale_floor_breached,

--- a/tests/uat/cells_io.py
+++ b/tests/uat/cells_io.py
@@ -28,7 +28,9 @@ uat-resume-retirement-artifact-durability w4.
 
 from __future__ import annotations
 
+import datetime as _dt
 import json
+import os
 from collections import deque
 from collections.abc import Iterable
 from pathlib import Path
@@ -39,6 +41,27 @@ from tests.uat.runner import CellResult
 
 FAILURE_TAIL_LINES = 50
 FAILURE_TAIL_CHARS = 12_000
+
+# Sweep lifecycle markers (uat-sweep-durability-and-signal-teardown w1).
+#
+# Both are *separate* sentinel artifacts beside cells.jsonl -- deliberately not
+# trailing rows inside cells.jsonl, so the row schema report/gate consumers
+# parse stays byte-for-byte unchanged.
+#
+# The durable sweep writes the ``.inprogress`` marker the moment it starts
+# streaming rows, and a complete ``write_cells_jsonl`` clears it and writes the
+# ``.finalized`` marker at orderly end. The two together let a reader tell
+# three cases apart WITHOUT changing how a marker-less legacy artifact reads:
+#   * finalized present            -> sweep completed (positive signal).
+#   * inprogress present, no final -> sweep was KILLED mid-run: its streamed
+#                                     rows are durable but partial, so report
+#                                     must reject it as green.
+#   * neither marker               -> a legacy/hand-written artifact predating
+#                                     the markers -- treated exactly as before
+#                                     (the pinned "regenerate old artifacts"
+#                                     contract, test_report_cli_without_sidecar_*).
+CELLS_FINALIZED_SUFFIX = ".finalized"
+CELLS_INPROGRESS_SUFFIX = ".inprogress"
 
 
 class SourceInfo(Protocol):
@@ -52,6 +75,153 @@ def cells_accounting_path(cells_jsonl: Path) -> Path:
     return cells_jsonl.with_name(cells_jsonl.name + ".accounting.json")
 
 
+def cells_finalized_path(cells_jsonl: Path) -> Path:
+    """Path of the finalize-marker sentinel beside a given cells.jsonl (w1)."""
+    return cells_jsonl.with_name(cells_jsonl.name + CELLS_FINALIZED_SUFFIX)
+
+
+def cells_inprogress_path(cells_jsonl: Path) -> Path:
+    """Path of the in-progress marker sentinel beside a given cells.jsonl (w1)."""
+    return cells_jsonl.with_name(cells_jsonl.name + CELLS_INPROGRESS_SUFFIX)
+
+
+def _render_cell_row(cell: CellResult, *, source_info: SourceInfo) -> str:
+    """Render one cells.jsonl row (with trailing newline) and persist its log failure context.
+
+    The single owner of the cells.jsonl row schema, shared by the complete
+    `write_cells_jsonl` writer and the incremental `CellStreamWriter` so a
+    streamed row and a batch-written row are byte-for-byte identical -- the
+    final atomic `write_cells_jsonl` at orderly sweep end can then replace the
+    incrementally-appended file without changing a single row's bytes.
+    `_persist_cell_failure_context` is idempotent per cell log (guarded by
+    `_cell_log_has_marker`), so calling it once while streaming and again at
+    the batch write does not double-append the failure tail.
+    """
+    cell_terminal_state = terminal_state(cell)
+    failure_tail = _persist_cell_failure_context(cell, terminal_state=cell_terminal_state)
+    return (
+        json.dumps(
+            {
+                "platform": cell.platform,
+                "benchmark": cell.benchmark,
+                "scale": cell.scale,
+                "status": cell.status,
+                "terminal_state": cell_terminal_state,
+                "submit_terminal_state": cell.submit_terminal_state,
+                "timed_out": cell.status == "timed-out",
+                "exit_code": cell.exit_code,
+                "elapsed_s": cell.elapsed_s,
+                "log_path": str(cell.log_path),
+                "result_path": (str(cell.result_path) if cell.result_path else None),
+                "throughput_check": cell.throughput_check,
+                "failure_tail": failure_tail,
+                "source_commit_sha": source_info.commit_sha,
+                "source_commit_short_sha": source_info.commit_short_sha,
+                "source_dirty": source_info.dirty,
+            }
+        )
+        + "\n"
+    )
+
+
+class CellStreamWriter:
+    """Incrementally append cells.jsonl rows, flushing + fsync'ing each row.
+
+    Durability contract (uat-sweep-durability-and-signal-teardown w1): a sweep
+    killed mid-run keeps every *completed* cell's row on disk, because each row
+    is flushed and fsync'd at cell completion instead of being buffered in
+    memory until the sweep's end (the pre-existing failure mode -- the whole
+    result set was written in one batch after the last cell, so a mid-sweep
+    process death lost every row). It reopens the file per append rather than
+    holding a handle across the sweep: cells complete seconds-to-minutes apart
+    in a serial sweep, so the open cost is negligible, and no open handle has
+    to be reasoned about across the SIGTERM teardown path (w2).
+
+    It deliberately does NOT write the finalize marker -- only a complete
+    `write_cells_jsonl` does. On construction it drops the ``.inprogress``
+    marker, the positive signal that a durable stream began; if the sweep is
+    killed before `write_cells_jsonl` clears it, that lingering marker is how
+    report tells this partial run apart from a marker-less legacy artifact.
+    """
+
+    def __init__(self, path: Path, *, source_info: SourceInfo) -> None:
+        self._path = path
+        self._source_info = source_info
+        self.count = 0
+        write_cells_inprogress_marker(path)
+
+    def append(self, cell: CellResult) -> None:
+        line = _render_cell_row(cell, source_info=self._source_info)
+        self._path.parent.mkdir(parents=True, exist_ok=True)
+        with self._path.open("a", encoding="utf-8") as fh:
+            fh.write(line)
+            fh.flush()
+            os.fsync(fh.fileno())
+        self.count += 1
+
+
+def write_cells_inprogress_marker(cells_jsonl: Path) -> Path:
+    """Write the atomic in-progress marker when a durable stream begins (w1)."""
+    marker = cells_inprogress_path(cells_jsonl)
+    atomic_write_text(
+        marker,
+        json.dumps({"started_at": _dt.datetime.now().astimezone().isoformat(timespec="seconds")}) + "\n",
+    )
+    return marker
+
+
+def write_cells_finalized_marker(cells_jsonl: Path, *, row_count: int) -> Path:
+    """Write the atomic finalize marker for a completed cells.jsonl and clear the in-progress one (w1).
+
+    Called from a complete `write_cells_jsonl` (and directly by tests modeling
+    a finished sweep). Records the row count and an offset-aware completion
+    timestamp, then removes any `.inprogress` marker so an orderly-completed run
+    is never mistaken for a killed one.
+    """
+    marker = cells_finalized_path(cells_jsonl)
+    atomic_write_text(
+        marker,
+        json.dumps(
+            {
+                "finalized_at": _dt.datetime.now().astimezone().isoformat(timespec="seconds"),
+                "row_count": int(row_count),
+            }
+        )
+        + "\n",
+    )
+    cells_inprogress_path(cells_jsonl).unlink(missing_ok=True)
+    return marker
+
+
+def cells_are_finalized(cells_jsonl: Path) -> bool:
+    """True when the finalize marker beside `cells_jsonl` exists (positive completion signal)."""
+    return cells_finalized_path(cells_jsonl).exists()
+
+
+def cells_run_incomplete(cells_jsonl: Path) -> bool:
+    """True when a durable sweep began (`.inprogress`) but never finalized -- i.e. it was killed mid-run.
+
+    False for a legacy/hand-written artifact that carries neither marker, so
+    `make uat-report` keeps regenerating old artifacts exactly as before
+    (test_report_cli_without_sidecar_defaults_unreachable_zero) -- only a
+    genuinely interrupted durable run is flagged.
+    """
+    return cells_inprogress_path(cells_jsonl).exists() and not cells_finalized_path(cells_jsonl).exists()
+
+
+def read_cells_finalized_marker(cells_jsonl: Path) -> dict[str, object] | None:
+    """Return the finalize marker payload, or None when absent/unreadable."""
+    marker = cells_finalized_path(cells_jsonl)
+    if not marker.exists():
+        return None
+    try:
+        with marker.open(encoding="utf-8") as fh:
+            payload = json.load(fh)
+    except (OSError, ValueError, TypeError):
+        return None
+    return payload if isinstance(payload, dict) else None
+
+
 def write_cells_jsonl(
     path: Path,
     cells: Iterable[CellResult],
@@ -61,35 +231,20 @@ def write_cells_jsonl(
     startup_failed_count: int = 0,
     disk_gate_disabled: bool = False,
     container_engine: str | None = None,
+    finalize: bool = True,
 ) -> None:
-    """Write the durable per-cell result stream plus its accounting sidecar."""
-    lines: list[str] = []
-    for cell in cells:
-        cell_terminal_state = terminal_state(cell)
-        failure_tail = _persist_cell_failure_context(cell, terminal_state=cell_terminal_state)
-        lines.append(
-            json.dumps(
-                {
-                    "platform": cell.platform,
-                    "benchmark": cell.benchmark,
-                    "scale": cell.scale,
-                    "status": cell.status,
-                    "terminal_state": cell_terminal_state,
-                    "submit_terminal_state": cell.submit_terminal_state,
-                    "timed_out": cell.status == "timed-out",
-                    "exit_code": cell.exit_code,
-                    "elapsed_s": cell.elapsed_s,
-                    "log_path": str(cell.log_path),
-                    "result_path": (str(cell.result_path) if cell.result_path else None),
-                    "throughput_check": cell.throughput_check,
-                    "failure_tail": failure_tail,
-                    "source_commit_sha": source_info.commit_sha,
-                    "source_commit_short_sha": source_info.commit_short_sha,
-                    "source_dirty": source_info.dirty,
-                }
-            )
-            + "\n"
-        )
+    """Write the durable per-cell result stream plus its accounting sidecar.
+
+    This is the *complete* writer: it is called with the full result set at an
+    orderly sweep end (or by a test modeling a finished sweep), so by default
+    it also writes the finalize marker (`finalize=True`) that report/gate use
+    to tell a finished sweep from a killed one. During a live sweep the
+    orchestrator streams rows via `CellStreamWriter` first, then calls this to
+    atomically replace the incrementally-written file with the identical
+    authoritative content and drop the marker. Pass `finalize=False` only to
+    model an unfinalized/partial run in a test.
+    """
+    lines = [_render_cell_row(cell, source_info=source_info) for cell in cells]
     # cells.jsonl before its sidecar -- see module docstring "Write ordering".
     atomic_write_text(path, "".join(lines))
 
@@ -114,6 +269,12 @@ def write_cells_jsonl(
         + "\n"
     )
     atomic_write_text(accounting_path, accounting_text)
+
+    # Finalize marker last: rows and sidecar are on disk before the sweep is
+    # declared complete, so a reader that sees the marker is guaranteed the
+    # full stream + sidecar preceded it (uat-sweep-durability-and-signal-teardown w1).
+    if finalize:
+        write_cells_finalized_marker(path, row_count=len(lines))
 
 
 def read_cells_jsonl(path: Path) -> list[CellResult]:

--- a/tests/uat/orchestrator.py
+++ b/tests/uat/orchestrator.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 
 import datetime as _dt
 import json
+import signal
 import subprocess
 import sys
 from collections.abc import Callable, Iterable
@@ -69,6 +70,74 @@ class DiskFloorAbort(RuntimeError):
         self.reason = reason
 
 
+class SweepCancelled(KeyboardInterrupt):
+    """A sweep-process SIGTERM upgraded to a Ctrl-C-equivalent cancellation.
+
+    Subclasses `KeyboardInterrupt` so it rides the exact same unwinding path a
+    real Ctrl-C already took: the per-platform `finally` in `run_execute` tears
+    the Docker stack down, no finalize marker is written (so report/gate treat
+    the run as unfinished, not green), and the process exits nonzero
+    (uat-sweep-durability-and-signal-teardown w2).
+    """
+
+    def __init__(self, signal_name: str) -> None:
+        super().__init__(signal_name)
+        self.signal_name = signal_name
+
+
+# Sentinel distinct from a real previous handler of None (SIG_DFL is not None,
+# but signal.getsignal can legitimately return None for a handler set outside
+# Python); used to mean "shim was never installed, do not restore".
+_SHIM_NOT_INSTALLED = object()
+
+
+def _install_sweep_sigterm_shim(log_dir: Path, phase_holder: list[str | None]) -> object | None:
+    """Convert SIGTERM to `SweepCancelled` for the sweep process only (w2/w3).
+
+    Returns the previous SIGTERM handler to restore, or the not-installed
+    sentinel when the shim could not be installed (not running in the main
+    thread -- `signal.signal` raises there). Installing in the sweep's own
+    process does not touch cell subprocesses: `timeouts.py` owns their
+    process-group kill semantics, and those subprocesses never import this
+    shim. Returning the sentinel (rather than raising) keeps a sweep driven
+    from a worker thread working with default SIGTERM behavior; row durability
+    does not depend on the shim, only the orderly-teardown upgrade does.
+
+    The handler records the cancellation (signal name, phase in flight,
+    timestamp) to uat_lifecycle.log before raising (w3), so a killed sweep
+    leaves a durable breadcrumb of when and where it was cancelled -- written
+    from the handler because the phase loop never returns to do it.
+    """
+
+    def _raise_cancelled(signum: int, _frame: object) -> None:
+        signal_name = signal.Signals(signum).name
+        exec_phase.append_lifecycle_log(
+            log_dir,
+            f"[cancel] signal={signal_name} phase={phase_holder[0]} "
+            "status=tearing-down unfinalized (no finalize marker will be written)",
+        )
+        raise SweepCancelled(signal_name)
+
+    try:
+        return signal.signal(signal.SIGTERM, _raise_cancelled)
+    except (ValueError, OSError):
+        return _SHIM_NOT_INSTALLED
+
+
+def _restore_sweep_sigterm_shim(previous: object | None) -> None:
+    if previous is _SHIM_NOT_INSTALLED:
+        return
+    # A previous handler of None means SIGTERM was last set outside Python;
+    # `signal.signal(sig, None)` rejects that, so fall back to SIG_DFL rather
+    # than silently leaving our SweepCancelled-raising shim installed past the
+    # sweep. Restoring the default is the honest "no Python handler" state.
+    restore_to = signal.SIG_DFL if previous is None else previous
+    try:
+        signal.signal(signal.SIGTERM, restore_to)  # type: ignore[arg-type]
+    except (ValueError, OSError, TypeError):
+        pass
+
+
 def capture_run_source_info(repo_root: Path | None = None) -> RunSourceInfo:
     """Capture source provenance once per sweep."""
     root = repo_root or Path(__file__).resolve().parents[2]
@@ -105,12 +174,23 @@ def _build_disk_floor_runner(
     watch_disk_floor: bool,
     free_space_path: str | Path,
     free_space_min_gib: float,
+    cell_stream: Callable[[CellResult], None] | None = None,
 ) -> CellRunner:
-    """Wrap a cell runner with attempted-cell capture and mid-sweep disk checks."""
+    """Wrap a cell runner with attempted-cell capture, incremental durability, and mid-sweep disk checks.
+
+    `cell_stream`, when provided, is called with each cell's result the moment
+    it completes -- the hook the durable sweep uses to append + fsync that row
+    to cells.jsonl immediately (uat-sweep-durability-and-signal-teardown w1),
+    so a mid-sweep process death keeps every completed cell's row instead of
+    losing the whole batch. It fires before the disk-floor check so a row is
+    on disk even when the very next check aborts the sweep.
+    """
 
     def runner(platform: str, benchmark: str, scale: float, **kwargs) -> CellResult:
         result = base_runner(platform, benchmark, scale, **kwargs)
         attempted_cells.append(result)
+        if cell_stream is not None:
+            cell_stream(result)
         if watch_disk_floor:
             free_gib = preflight_budget.free_space_gib(free_space_path)
             if free_gib < free_space_min_gib:
@@ -141,13 +221,21 @@ def _record_container_engine_identity(log_dir: Path) -> str | None:
     return binary
 
 
-def run_sweep(  # noqa: C901
+def run_sweep(
     config: UATConfig,
     *,
     log_dir_override: Path | None = None,
     databases_root: Path | None = None,
 ) -> SweepResult:
-    """Orchestrate the YAML's `phases:` list. Returns SweepResult."""
+    """Orchestrate the YAML's `phases:` list. Returns SweepResult.
+
+    Installs a sweep-process SIGTERM shim (uat-sweep-durability-and-signal-teardown
+    w2) so an operator `kill` (or a CI cancellation) tears the Docker stack
+    down, records the cancellation (w3), and exits nonzero exactly like Ctrl-C,
+    then always restores the previous handler. The phase loop itself lives in
+    `_run_sweep_phases`; the split keeps that restore in a single, obvious
+    try/finally instead of threading it through every `break`.
+    """
     now = _dt.datetime.now()
     log_dir = log_dir_override or exec_phase.default_log_dir(config, now=now)
     benchmark_runs_dir = exec_phase.default_benchmark_runs_dir(config, now=now)
@@ -157,10 +245,41 @@ def run_sweep(  # noqa: C901
     if databases_root is None:
         databases_root = benchmark_runs_dir / "databases"
 
+    source_info = capture_run_source_info()
+    phase_holder: list[str | None] = [None]
+    sigterm_prev = _install_sweep_sigterm_shim(log_dir, phase_holder)
+    try:
+        return _run_sweep_phases(
+            config,
+            now=now,
+            log_dir=log_dir,
+            benchmark_runs_dir=benchmark_runs_dir,
+            databases_root=databases_root,
+            container_engine=container_engine,
+            source_info=source_info,
+            phase_holder=phase_holder,
+        )
+    finally:
+        _restore_sweep_sigterm_shim(sigterm_prev)
+
+
+def _run_sweep_phases(  # noqa: C901
+    config: UATConfig,
+    *,
+    now: _dt.datetime,
+    log_dir: Path,
+    benchmark_runs_dir: Path,
+    databases_root: Path,
+    container_engine: str | None,
+    source_info: RunSourceInfo,
+    phase_holder: list[str | None],
+) -> SweepResult:
+    """Walk the YAML `phases:` list. Split out of `run_sweep` so the SIGTERM
+    shim's restore lives in one try/finally there; this body is unchanged from
+    the pre-split loop except for recording the in-flight phase for w3."""
     phase_exit_codes: dict[str, int] = {}
     aborted_phase: str | None = None
     abort_reason: str | None = None
-    source_info = capture_run_source_info()
 
     cells_jsonl = log_dir / "cells.jsonl"
     compatibility_pruned_jsonl = log_dir / "compatibility_pruned.jsonl"
@@ -178,6 +297,7 @@ def run_sweep(  # noqa: C901
             print(gate_warning, file=sys.stderr)
 
     for phase in config.phases:
+        phase_holder[0] = phase
         if config.dry_run:
             phase_exit_codes[phase] = 0
             continue
@@ -210,6 +330,12 @@ def run_sweep(  # noqa: C901
                 break
         elif phase == "execute":
             attempted_cells: list[CellResult] = []
+            # Stream each cell's row to cells.jsonl as it completes so a
+            # mid-sweep kill keeps the rows already earned (w1). The final
+            # atomic write_cells_jsonl below replaces this incrementally-grown
+            # file with identical authoritative content and adds the finalize
+            # marker; a kill before that leaves the streamed rows unfinalized.
+            cell_stream_writer = cells_io.CellStreamWriter(cells_jsonl, source_info=source_info)
             execute_kwargs: dict[str, Any] = {
                 "log_dir": log_dir,
                 "benchmark_runs_dir": benchmark_runs_dir,
@@ -222,6 +348,7 @@ def run_sweep(  # noqa: C901
                     watch_disk_floor=config.disk_gate_enabled,
                     free_space_path=config.preflight.free_space_path or str(benchmark_runs_dir),
                     free_space_min_gib=config.preflight.free_space_min_gib,
+                    cell_stream=cell_stream_writer.append,
                 ),
             }
             try:

--- a/tests/uat/phases/report.py
+++ b/tests/uat/phases/report.py
@@ -117,9 +117,14 @@ class ReportSummary(PhaseResult):
     # fail_count or unreachable_count would misrepresent an environment
     # condition as a cell failure.
     startup_failed_count: int = 0
+    # The sweep that produced these cells never wrote its finalize marker --
+    # it was killed mid-run (uat-sweep-durability-and-signal-teardown w1). A
+    # partial cells.jsonl must never read as a clean sweep, so this forces a
+    # nonzero exit regardless of what the rows-so-far happen to say.
+    unfinalized: bool = False
 
     def exit_code(self) -> int:
-        if self.aborted:
+        if self.aborted or self.unfinalized:
             return 2
         has_uncleared_cells = (
             self.fail_count > 0 or self.timeout_count > 0 or self.unreachable_count > 0 or self.startup_failed_count > 0
@@ -228,6 +233,7 @@ def write_report(
     run_status: str = "COMPLETED",
     abort_phase: str | None = None,
     abort_reason: str | None = None,
+    finalized: bool = True,
 ) -> ReportSummary:
     """Write the matrix summary TSV; optionally enforce a cross-scale floor.
 
@@ -254,6 +260,11 @@ def write_report(
     `unreachable_count` does, but is reported under its own counter -- see
     uat-fail-advance-consistency w3.
     """
+    # A run whose sweep never finalized (killed mid-stream) is INCOMPLETE and
+    # must not read as a clean COMPLETED run, whatever the rows-so-far say. An
+    # already-ABORTED run stays ABORTED (it reached an orderly, finalized end).
+    if not finalized and run_status == "COMPLETED":
+        run_status = "INCOMPLETE"
     rows = list(cells)
     executed_count = len(rows)
 
@@ -349,6 +360,7 @@ def write_report(
         startup_failed_count=startup_failed_count,
         aborted=run_status in {"ABORTED", "BLOCKED"},
         abort_reason=abort_reason,
+        unfinalized=not finalized,
     )
 
 

--- a/tests/uat/test_orchestrator.py
+++ b/tests/uat/test_orchestrator.py
@@ -968,12 +968,14 @@ def test_write_cells_jsonl_persists_skipped_unreachable_sidecar(tmp_path: Path):
 
 
 def test_write_cells_jsonl_writes_cell_stream_before_accounting_sidecar(tmp_path: Path):
-    """cells.jsonl must land before its accounting sidecar (w4).
+    """cells.jsonl, then its accounting sidecar, then the finalize marker (w1/w4).
 
-    A crash between the two writes must never leave a fresh sidecar beside a
-    stale (or absent) cell stream -- see
-    uat-resume-retirement-artifact-durability w4. Record the path order
-    `atomic_write_text` is called in and assert cells.jsonl comes first.
+    A crash between the row and sidecar writes must never leave a fresh sidecar
+    beside a stale (or absent) cell stream -- see
+    uat-resume-retirement-artifact-durability w4. The finalize marker is
+    written strictly last (uat-sweep-durability-and-signal-teardown w1) so its
+    presence guarantees both the rows and the sidecar preceded it. Record the
+    path order `atomic_write_text` is called in and assert that ordering.
     """
     cells_jsonl = tmp_path / "cells.jsonl"
     written_paths: list[Path] = []
@@ -992,7 +994,8 @@ def test_write_cells_jsonl_writes_cell_stream_before_accounting_sidecar(tmp_path
         )
 
     sidecar = cells_jsonl.with_name("cells.jsonl.accounting.json")
-    assert written_paths == [cells_jsonl, sidecar]
+    finalized = cells_jsonl.with_name("cells.jsonl.finalized")
+    assert written_paths == [cells_jsonl, sidecar, finalized]
 
 
 def test_abort_artifacts_thread_skipped_unreachable_when_outcome_missing(tmp_path: Path):

--- a/tests/uat/test_sweep_durability.py
+++ b/tests/uat/test_sweep_durability.py
@@ -14,7 +14,10 @@ from __future__ import annotations
 
 import json
 import signal
+from collections.abc import Callable
 from pathlib import Path
+from types import FrameType
+from typing import cast
 from unittest.mock import patch
 
 import pytest
@@ -175,8 +178,11 @@ def test_sigterm_shim_raises_sweepcancelled_and_records_cancellation(tmp_path: P
     try:
         handler = signal.getsignal(signal.SIGTERM)
         assert callable(handler)
+        # signal.getsignal returns an opaque callable union; give it the real
+        # handler signature so the call type-checks (ty call-top-callable).
+        typed_handler = cast(Callable[[int, FrameType | None], None], handler)
         with pytest.raises(orchestrator.SweepCancelled) as excinfo:
-            handler(int(signal.SIGTERM), None)
+            typed_handler(int(signal.SIGTERM), None)
         assert excinfo.value.signal_name == "SIGTERM"
         assert isinstance(excinfo.value, KeyboardInterrupt)
     finally:

--- a/tests/uat/test_sweep_durability.py
+++ b/tests/uat/test_sweep_durability.py
@@ -1,0 +1,245 @@
+"""Durability + SIGTERM teardown coverage for UAT sweeps.
+
+uat-sweep-durability-and-signal-teardown:
+  w1 -- incremental cells.jsonl append + atomic finalize marker; a report on an
+        unfinalized (killed) run must never read green, while a marker-less
+        legacy artifact still regenerates unchanged.
+  w2 -- a sweep-process SIGTERM is upgraded to a Ctrl-C-equivalent cancellation
+        so the platform `finally` teardown runs and the process exits nonzero.
+  w3 -- the cancellation (signal name, phase, timestamp) is recorded in
+        uat_lifecycle.log.
+"""
+
+from __future__ import annotations
+
+import json
+import signal
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from tests.uat import _cli as uat_cli, cells_io, docker_assets, orchestrator
+from tests.uat.config import validate_config
+from tests.uat.phases import execute as exec_phase
+from tests.uat.runner import CellResult
+
+pytestmark = pytest.mark.fast
+
+
+def _source_info() -> orchestrator.RunSourceInfo:
+    return orchestrator.RunSourceInfo(commit_sha="deadbeef", commit_short_sha="deadbee", dirty=False)
+
+
+def _passed_cell(platform: str, benchmark: str, scale: float, log_dir: Path) -> CellResult:
+    return CellResult(
+        platform=platform,
+        benchmark=benchmark,
+        scale=scale,
+        status="passed",
+        exit_code=0,
+        elapsed_s=1.0,
+        log_path=log_dir / f"{platform}_{benchmark}_{scale}.log",
+        result_path=None,
+    )
+
+
+# --------------------------------------------------------------------------- w1
+
+
+def test_disk_floor_runner_streams_each_row_before_a_mid_sweep_death(tmp_path: Path):
+    """Incremental durability: a row is flushed to cells.jsonl the instant its
+    cell completes, so a process death mid-sweep keeps every earned row instead
+    of losing the whole in-memory batch. The lingering `.inprogress` marker (no
+    `.finalized`) is how the run is later recognized as killed."""
+    cells_jsonl = tmp_path / "cells.jsonl"
+    writer = cells_io.CellStreamWriter(cells_jsonl, source_info=_source_info())
+    attempted: list[CellResult] = []
+    calls = {"n": 0}
+
+    def base_runner(platform: str, benchmark: str, scale: float, **_kwargs) -> CellResult:
+        calls["n"] += 1
+        if calls["n"] == 2:
+            raise RuntimeError("boom: process dies mid-sweep")
+        return _passed_cell(platform, benchmark, scale, tmp_path)
+
+    runner = orchestrator._build_disk_floor_runner(
+        base_runner,
+        attempted_cells=attempted,
+        watch_disk_floor=False,
+        free_space_path=str(tmp_path),
+        free_space_min_gib=0.0,
+        cell_stream=writer.append,
+    )
+
+    runner("duckdb", "tpch", 0.01)
+    with pytest.raises(RuntimeError):
+        runner("duckdb", "tpch", 0.1)
+
+    rows = cells_io.read_cells_jsonl(cells_jsonl)
+    assert [(r.platform, r.scale) for r in rows] == [("duckdb", 0.01)]
+    assert cells_io.cells_run_incomplete(cells_jsonl) is True
+    assert cells_io.cells_are_finalized(cells_jsonl) is False
+
+
+def test_write_cells_jsonl_finalizes_and_clears_inprogress(tmp_path: Path):
+    """An orderly complete write drops the finalize marker and clears the
+    in-progress one, so the run is unambiguously finished."""
+    cells_jsonl = tmp_path / "cells.jsonl"
+    cells_io.write_cells_inprogress_marker(cells_jsonl)
+    assert cells_io.cells_inprogress_path(cells_jsonl).exists()
+
+    cells_io.write_cells_jsonl(
+        cells_jsonl,
+        [_passed_cell("duckdb", "tpch", 0.01, tmp_path)],
+        source_info=_source_info(),
+    )
+
+    assert cells_io.cells_are_finalized(cells_jsonl) is True
+    assert cells_io.cells_inprogress_path(cells_jsonl).exists() is False
+    assert cells_io.cells_run_incomplete(cells_jsonl) is False
+    marker = cells_io.read_cells_finalized_marker(cells_jsonl)
+    assert marker is not None and marker["row_count"] == 1
+
+
+def test_report_rejects_unfinalized_killed_run_as_nonzero(tmp_path: Path, capsys: pytest.CaptureFixture[str]):
+    """make uat-report on a killed run (rows + lingering `.inprogress`, no
+    `.finalized`) must exit nonzero and mark the run INCOMPLETE -- a partial
+    stream of all-passed rows must never read as a clean sweep."""
+    cells_jsonl = tmp_path / "cells.jsonl"
+    cells_jsonl.write_text(
+        json.dumps(
+            {
+                "platform": "duckdb",
+                "benchmark": "tpch",
+                "scale": 0.01,
+                "status": "passed",
+                "exit_code": 0,
+                "elapsed_s": 1.0,
+                "log_path": "/tmp/a.log",
+                "result_path": "/tmp/a.json",
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    cells_io.write_cells_inprogress_marker(cells_jsonl)  # killed: never finalized
+    output_tsv = tmp_path / "matrix_summary.tsv"
+
+    exit_code = uat_cli.main(["report", "--cells-jsonl", str(cells_jsonl), "--output-tsv", str(output_tsv)])
+
+    assert exit_code == 2
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["finalized"] is False
+    assert "run_status=INCOMPLETE" in output_tsv.read_text(encoding="utf-8")
+
+
+def test_report_regenerates_marker_less_legacy_artifact_unchanged(tmp_path: Path, capsys: pytest.CaptureFixture[str]):
+    """A legacy cells.jsonl carrying NEITHER marker predates the finalize
+    machinery; the report must still regenerate it green, not conflate
+    "no marker" with "killed"."""
+    cells_jsonl = tmp_path / "cells.jsonl"
+    cells_jsonl.write_text(
+        json.dumps(
+            {
+                "platform": "duckdb",
+                "benchmark": "tpch",
+                "scale": 0.01,
+                "status": "passed",
+                "exit_code": 0,
+                "elapsed_s": 1.0,
+                "log_path": "/tmp/a.log",
+                "result_path": "/tmp/a.json",
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    output_tsv = tmp_path / "matrix_summary.tsv"
+
+    exit_code = uat_cli.main(["report", "--cells-jsonl", str(cells_jsonl), "--output-tsv", str(output_tsv)])
+
+    assert exit_code == 0
+    assert json.loads(capsys.readouterr().out)["finalized"] is True
+
+
+# ------------------------------------------------------------------------ w2/w3
+
+
+def test_sigterm_shim_raises_sweepcancelled_and_records_cancellation(tmp_path: Path):
+    """The installed SIGTERM handler raises SweepCancelled (a KeyboardInterrupt
+    subclass) and records the cancellation with signal name + phase to
+    uat_lifecycle.log before unwinding."""
+    phase_holder: list[str | None] = ["execute"]
+    previous = orchestrator._install_sweep_sigterm_shim(tmp_path, phase_holder)
+    try:
+        handler = signal.getsignal(signal.SIGTERM)
+        assert callable(handler)
+        with pytest.raises(orchestrator.SweepCancelled) as excinfo:
+            handler(int(signal.SIGTERM), None)
+        assert excinfo.value.signal_name == "SIGTERM"
+        assert isinstance(excinfo.value, KeyboardInterrupt)
+    finally:
+        orchestrator._restore_sweep_sigterm_shim(previous)
+
+    log_text = (tmp_path / "uat_lifecycle.log").read_text(encoding="utf-8")
+    assert "[cancel] signal=SIGTERM phase=execute" in log_text
+    # Handler restored so the shim does not leak across sweeps / tests.
+    assert signal.getsignal(signal.SIGTERM) == previous
+
+
+def test_run_sweep_restores_previous_sigterm_handler(tmp_path: Path):
+    """run_sweep installs its shim for the run and always restores the prior
+    handler, even on the (dry-run) happy path."""
+    before = signal.getsignal(signal.SIGTERM)
+    cfg = validate_config(
+        {
+            "name": "dry-run-shim",
+            "phases": ["execute", "report"],
+            "platforms": {"include": ["duckdb"]},
+            "benchmarks": {"include": ["tpch"]},
+            "scales": {"rungs": [0.01]},
+            "dry_run": True,
+        }
+    )
+    orchestrator.run_sweep(cfg, log_dir_override=tmp_path / "logs")
+    assert signal.getsignal(signal.SIGTERM) == before
+
+
+def test_interrupt_mid_cell_still_tears_down_docker_stack(tmp_path: Path):
+    """A Ctrl-C / SIGTERM landing mid-cell must still run the platform
+    `finally` teardown (compose down) before the interrupt propagates -- the
+    exact behavior the SIGTERM shim upgrades a `kill` to."""
+    cfg = validate_config(
+        {
+            "name": "interrupt-teardown",
+            "platforms": {"include": ["clickhouse-server"]},
+            "benchmarks": {"include": ["tpch"]},
+            "scales": {"rungs": [0.01]},
+            "cleanup": {"docker_manage_platforms": True, "docker_platform_switch": "volumes"},
+        }
+    )
+    sequence: list[str] = []
+
+    def fake_docker(argv, **_kwargs):
+        action = "up" if "up" in argv else "down"
+        sequence.append(action)
+        return docker_assets.DockerCommandResult(tuple(argv), 0, "", "")
+
+    def interrupting_runner(platform, benchmark, scale, **_kwargs):
+        sequence.append("cell")
+        raise KeyboardInterrupt
+
+    with patch("tests.uat.phases.execute.platform_is_reachable", return_value=True):
+        with pytest.raises(KeyboardInterrupt):
+            exec_phase.run_execute(
+                cfg,
+                log_dir=tmp_path,
+                databases_root=tmp_path / "databases",
+                runner=interrupting_runner,
+                docker_runner=fake_docker,
+                free_space_checks_enabled=False,
+            )
+
+    assert "cell" in sequence and "down" in sequence
+    assert sequence.index("down") > sequence.index("cell")


### PR DESCRIPTION
Sweeps buffered every cells.jsonl row in memory and wrote them in one
batch after the last cell, so a process death mid-sweep lost every row,
and a partial run could later read as green.

w1: stream each cell's row to cells.jsonl (append + fsync at cell
completion) via a CellStreamWriter hooked into the existing disk-floor
runner. A complete write_cells_jsonl now writes an atomic `.finalized`
marker last and clears the `.inprogress` marker dropped when streaming
began. `make uat-report` treats a run with a lingering `.inprogress`
and no `.finalized` (a killed sweep) as INCOMPLETE and exits nonzero;
a marker-less legacy artifact still regenerates unchanged.

w2: install a sweep-process-only SIGTERM->SweepCancelled shim so an
operator `kill` unwinds exactly like Ctrl-C -- the per-platform finally
tears the Docker stack down, no finalize marker is written, and the
process exits nonzero. The previous handler is always restored.

w3: the SIGTERM handler records the cancellation (signal, phase,
timestamp) to uat_lifecycle.log before raising.

Row schema, exit codes, and the atomic-write/sidecar ordering are
unchanged; the finalize marker is a separate sentinel artifact. Adds
tests/uat/test_sweep_durability.py; full tests/uat lane (569) green.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
