### PR TITLE
feat(postgresql): isolate concurrent stream sessions

### DIFF
--- a/benchbox/cli/commands/run_official.py
+++ b/benchbox/cli/commands/run_official.py
@@ -7,7 +7,7 @@ from collections.abc import Iterator
 
 import click
 
-from benchbox.cli.commands.run import run
+from benchbox.cli.commands.run import PlatformOptionParamType, run
 from benchbox.cli.composite_params import ValidationConfig
 from benchbox.cli.orchestrator import BenchmarkOrchestrator
 from benchbox.cli.shared import console
@@ -68,12 +68,31 @@ def _forward_requested_streams(streams: int | None) -> Iterator[None]:
 @click.option("--scale", type=float, required=True, help="TPC scale factor")
 @click.option("--phases", type=str, required=True, help="Test phases, comma-separated")
 @click.option("--streams", type=int, help="Concurrent streams for throughput")
+@click.option(
+    "--platform-option",
+    "platform_option_pairs",
+    type=PlatformOptionParamType(),
+    multiple=True,
+    help="Platform option in KEY=VALUE form (repeatable).",
+)
 @click.option("--seed", type=int, help="Random seed for reproducible official runs")
 @click.option("--output", "output_dir", type=click.Path(), help="Output directory")
 @click.option("--verbose", "-v", is_flag=True, help="Enable verbose logging")
 @click.option("--validate-results", is_flag=True, help="Enable result validation")
 @click.pass_context
-def run_official(ctx, benchmark, platform, scale, phases, streams, seed, output_dir, verbose, validate_results):
+def run_official(
+    ctx,
+    benchmark,
+    platform,
+    scale,
+    phases,
+    streams,
+    platform_option_pairs,
+    seed,
+    output_dir,
+    verbose,
+    validate_results,
+):
     """Run TPC-compliant official benchmark tests. Deprecated; use `benchbox run --official`."""
     if scale not in TPC_ALLOWED_SCALE_FACTORS:
         console.print(f"[red]Error: Scale factor {scale} is not TPC-compliant[/red]")
@@ -137,6 +156,7 @@ def run_official(ctx, benchmark, platform, scale, phases, streams, seed, output_
                 output=output_dir,
                 verbose=verbose,
                 validation=ValidationConfig.parse("full") if validate_results else None,
+                platform_option_pairs=platform_option_pairs,
             )
     except Exception as e:
         console.print(f"[red]Benchmark execution failed: {e}[/red]")

--- a/benchbox/platforms/base/execution.py
+++ b/benchbox/platforms/base/execution.py
@@ -540,12 +540,17 @@ class TestDriversMixin:
 
             console.print(f"[green]Running TPC-DS Maintenance Test (Scale Factor: {scale_factor})[/green]")
 
-            # Create connection factory that wraps the platform adapter connection
+            # Create connection factory that wraps the platform adapter connection.
+            # Routed through new_stream_connection() (see the throughput
+            # connection_factory above): SHARED_CURSOR (default) returns a
+            # thread-safe cursor of this one shared connection - unchanged for
+            # embedded engines like DuckDB. INDEPENDENT_CONNECTION opens a
+            # fresh connection/session per RF1/RF2 maintenance stream, so a
+            # server engine's refresh stream no longer shares the query
+            # stream's session.
             def connection_factory():
-                # Create thread-safe cursor for concurrent stream execution
-                # See: https://duckdb.org/docs/stable/guides/python/multiple_threads
-                stream_cursor = _make_stream_cursor(connection)
-                conn_wrapper = PlatformAdapterConnection(stream_cursor, self)
+                stream_connection = self.new_stream_connection(connection)
+                conn_wrapper = PlatformAdapterConnection(stream_connection, self)
                 # Configure benchmark context for query validation
                 conn_wrapper.benchmark_type = "tpcds"
                 conn_wrapper.scale_factor = scale_factor
@@ -635,13 +640,18 @@ class TestDriversMixin:
 
             console.print(f"[green]Running TPC-H Maintenance Test (Scale Factor: {scale_factor})[/green]")
 
+            # Routed through new_stream_connection() (see the throughput
+            # connection_factory in _execute_tpch_throughput_test): SHARED_CURSOR
+            # (default) returns a thread-safe cursor of this one shared
+            # connection - unchanged for embedded engines like DuckDB.
+            # INDEPENDENT_CONNECTION opens a fresh connection/session per
+            # RF1/RF2 maintenance stream, so a server engine's refresh stream
+            # no longer shares the query stream's session.
             def connection_factory():
-                # Create thread-safe cursor for maintenance operations
-                # See: https://duckdb.org/docs/stable/guides/python/multiple_threads
-                stream_cursor = _make_stream_cursor(connection)
+                stream_connection = self.new_stream_connection(connection)
                 # Use maintenance_mode=True to execute all queries directly on the connection
                 # (RF1/RF2 operations need real data, not validation-wrapped results)
-                conn_wrapper = PlatformAdapterConnection(stream_cursor, self, maintenance_mode=True)
+                conn_wrapper = PlatformAdapterConnection(stream_connection, self, maintenance_mode=True)
                 conn_wrapper.benchmark_type = "tpch"
                 conn_wrapper.scale_factor = scale_factor
                 return conn_wrapper

--- a/benchbox/platforms/postgresql.py
+++ b/benchbox/platforms/postgresql.py
@@ -41,6 +41,7 @@ from .base.config_utils import (
     POSTGRES_FAMILY_PLATFORM_FIELDS,
     make_platform_config_builder,
 )
+from .base.connection_wrappers import StreamConnectionCapability
 from .base.data_loading import (
     CsvDialect,
     DataSourceResolver,
@@ -262,6 +263,14 @@ class PostgreSQLAdapter(PsycopgConnectionMixin, PlatformAdapter):
 
     driver_isolation_capability = DriverIsolationCapability.FEASIBLE_CLIENT_ONLY
     plan_capture_phase_eligible = True
+    # psycopg connections do not support true concurrent statement execution
+    # across cursors of one connection (server-side session state --
+    # transactions, SET, prepared statements -- lives on the connection, and
+    # concurrent cursor use serializes or raises). Each throughput/pool-test
+    # stream therefore gets its own independent connection/session; see
+    # new_stream_connection() below and
+    # benchbox/platforms/base/connection_wrappers.py:StreamConnectionCapability.
+    stream_connection_capability = StreamConnectionCapability.INDEPENDENT_CONNECTION
 
     @property
     def platform_name(self) -> str:
@@ -511,6 +520,63 @@ class PostgreSQLAdapter(PsycopgConnectionMixin, PlatformAdapter):
 
         self.log_operation_complete("PostgreSQL connection", details=f"Applied: {', '.join(settings_applied)}")
         return conn
+
+    def new_stream_connection(self, connection: Any) -> Any:
+        """Open an independent PostgreSQL connection for one throughput stream.
+
+        Overrides the base ``SHARED_CURSOR`` implementation: psycopg
+        connections carry server-side session state (transactions, ``SET``
+        GUCs, prepared statements) and do not support true concurrent
+        statement execution across cursors of one connection, so sharing
+        ``connection`` across concurrent throughput streams would either
+        serialize on it or corrupt session-local state between streams. Each
+        stream instead gets a brand-new connection built from this adapter's
+        existing connection parameters, with the same session GUCs applied as
+        ``create_connection`` (schema/database creation is a one-time setup
+        step already done on the shared ``connection`` and is not repeated
+        here). The returned connection is closed by the caller (the
+        throughput/maintenance stream driver's ``finally`` block) -- see
+        ``PlatformAdapter.new_stream_connection()`` for the full contract.
+
+        Args:
+            connection: The adapter's shared platform connection. Not reused
+                here -- a fresh connection/session is always opened.
+
+        Returns:
+            A new, independent psycopg connection for this stream.
+        """
+        del connection  # not reused: INDEPENDENT_CONNECTION always opens a fresh session
+        params = self._get_connection_params()
+        conn = psycopg.connect(**params)
+
+        cursor = None
+        try:
+            cursor = conn.cursor()
+            guc_statements = [
+                f"SET work_mem = '{self.work_mem}'",
+                f"SET maintenance_work_mem = '{self.maintenance_work_mem}'",
+                f"SET effective_cache_size = '{self.effective_cache_size}'",
+                f"SET max_parallel_workers_per_gather = {self.max_parallel_workers_per_gather}",
+            ]
+            for sql in guc_statements:
+                try:
+                    cursor.execute(sql)
+                except Exception as e:
+                    conn.rollback()
+                    self.logger.debug(f"Could not apply stream session setting ({sql}): {e}")
+
+            # Safety: self.schema validated by _validate_identifier() before use in f-string
+            if self.schema != "public" and self._validate_identifier(self.schema):
+                cursor.execute(f'SET search_path TO "{self.schema}", public')
+
+            conn.commit()
+            return conn
+        except Exception:
+            conn.close()
+            raise
+        finally:
+            if cursor is not None:
+                cursor.close()
 
     def create_schema(self, benchmark, connection: Any) -> float:
         """Create schema using benchmark's SQL definitions."""

--- a/tests/integration/test_throughput_session_isolation.py
+++ b/tests/integration/test_throughput_session_isolation.py
@@ -43,16 +43,27 @@ engines (real DuckDB, real sqlite3) rather than mocks:
   Postgres-style ``SET`` session variable) made by one stream is invisible to
   another.
 
-SQLite is used instead of Postgres/docker per the TODO's own guidance
-(``throughput-independent-sessions-per-stream-per-stream.yaml`` work item
-w3): a stand-in server-style engine models the connection-is-a-session
-property just as faithfully, with no docker dependency and no network I/O -
-much faster and more reliable for CI.
+SQLite is used for the stand-in above per the original
+``throughput-independent-sessions-per-stream`` TODO's guidance (no docker
+dependency, faster/more reliable for CI). ``server-adapter-independent-
+connection-optin`` (the follow-up that makes a real server adapter opt into
+the capability) adds one more class below:
+
+- ``TestPostgreSQLIndependentConnectionIsolatesSessions``: proves the same
+  session-isolation property against the real ``PostgreSQLAdapter``
+  (``benchbox/platforms/postgresql.py``), which now declares
+  ``INDEPENDENT_CONNECTION`` and overrides ``new_stream_connection()`` to
+  open a fresh psycopg connection per stream. A session-local ``SET`` made on
+  one stream's connection must not leak into another stream's connection -
+  the real-engine analog of the SQLite ``TEMP TABLE`` check above. Requires a
+  local PostgreSQL Docker/mocker service (``make test-docker-up-postgresql``)
+  and is skipped cleanly (not failed) when one isn't reachable.
 """
 
 from __future__ import annotations
 
 import sqlite3
+import threading
 from typing import Any
 
 import pytest
@@ -63,6 +74,10 @@ from benchbox.platforms.base.connection_wrappers import (
     StreamConnectionCapability,
 )
 from benchbox.platforms.duckdb import DuckDBAdapter
+from benchbox.platforms.postgresql import PostgreSQLAdapter
+from benchbox.utils.clock import elapsed_seconds, mono_time
+
+from .platforms.conftest import skip_unless_docker_service
 
 pytestmark = [
     pytest.mark.integration,
@@ -248,5 +263,125 @@ class TestSharedCursorCapabilityIsDuckDBDefault:
             # finally block).
             stream_a.close()
             assert stream_b.execute("SELECT value FROM shared_state").fetchall() == [(7,)]
+        finally:
+            shared_connection.close()
+
+
+class TestPostgreSQLIndependentConnectionIsolatesSessions:
+    """Real PostgreSQL (``server-adapter-independent-connection-optin``): the
+    first production server adapter to opt into ``INDEPENDENT_CONNECTION``.
+
+    Proves the same session-isolation property as
+    ``TestIndependentConnectionCapabilityIsolatesSessions`` above, but
+    against the real ``PostgreSQLAdapter`` and a real psycopg connection
+    instead of the SQLite stand-in - closing the gap the TODO's
+    ``verification`` section calls for. Requires a local PostgreSQL
+    Docker/mocker service (``make test-docker-up-postgresql``); skipped
+    cleanly (not failed) when one isn't reachable, mirroring
+    ``tests/integration/platforms/test_postgresql_live.py``'s
+    ``skip_unless_docker_service`` gate.
+    """
+
+    pytestmark = [
+        pytest.mark.docker_integration,
+        pytest.mark.live_integration,
+        pytest.mark.live_postgresql,
+        pytest.mark.slow,
+    ]
+
+    @pytest.fixture
+    def postgresql_adapter(self):
+        skip_unless_docker_service("localhost", 5432, platform="PostgreSQL")
+        adapter = PostgreSQLAdapter(
+            host="localhost",
+            port=5432,
+            username="benchbox",
+            password="benchbox",
+            database="benchbox_test",
+        )
+        adapter.skip_database_management = True
+        return adapter
+
+    def test_declares_independent_connection(self, postgresql_adapter) -> None:
+        """PostgreSQLAdapter must declare INDEPENDENT_CONNECTION and provide
+        its own new_stream_connection() override (not the base hook, which
+        would raise NotImplementedError for this capability value)."""
+        assert postgresql_adapter.stream_connection_capability is StreamConnectionCapability.INDEPENDENT_CONNECTION
+        assert type(postgresql_adapter).new_stream_connection is not PlatformAdapter.new_stream_connection
+
+    def test_session_local_set_does_not_leak_across_streams(self, postgresql_adapter) -> None:
+        """A session-local SET (``application_name`` - connection-scoped in
+        PostgreSQL) made by one stream must be invisible to another stream -
+        proving each stream has its OWN connection/session, not a cursor of
+        one shared connection (the real-engine analog of the SQLite TEMP
+        TABLE check above)."""
+        shared_connection = postgresql_adapter.create_connection()
+        try:
+            stream_a = _stream_wrapper(postgresql_adapter, shared_connection)
+            stream_b = _stream_wrapper(postgresql_adapter, shared_connection)
+            try:
+                # Sanity: each stream really did get its own connection
+                # object, distinct from each other AND from the shared
+                # connection - zero cursor sharing.
+                assert stream_a.connection is not stream_b.connection
+                assert stream_a.connection is not shared_connection
+                assert stream_b.connection is not shared_connection
+
+                stream_a.connection.execute("SET application_name = 'stream_a_marker'")
+                own_name = stream_a.connection.execute("SHOW application_name").fetchone()[0]
+                assert own_name == "stream_a_marker"
+
+                other_name = stream_b.connection.execute("SHOW application_name").fetchone()[0]
+                assert other_name != "stream_a_marker"
+            finally:
+                stream_a.close()
+                stream_b.close()
+        finally:
+            shared_connection.close()
+
+    def test_concurrent_statements_do_not_serialize_on_one_connection(self, postgresql_adapter) -> None:
+        """Two streams issuing ``pg_sleep(1)`` concurrently on their
+        independent connections must overlap in wall-clock time. psycopg
+        connections do not support true concurrent statement execution
+        across cursors of ONE connection (the failure mode this capability
+        exists to avoid), so two 1-second sleeps sharing a connection would
+        run sequentially (~2s total); on independent connections they
+        overlap (~1s total)."""
+        shared_connection = postgresql_adapter.create_connection()
+        try:
+            stream_a = _stream_wrapper(postgresql_adapter, shared_connection)
+            stream_b = _stream_wrapper(postgresql_adapter, shared_connection)
+            try:
+                results: dict[str, float] = {}
+                errors: dict[str, BaseException] = {}
+
+                def run(name: str, wrapper: PlatformAdapterConnection) -> None:
+                    start = mono_time()
+                    try:
+                        wrapper.connection.execute("SELECT pg_sleep(1)")
+                        results[name] = elapsed_seconds(start)
+                    except BaseException as exc:  # noqa: BLE001 - surfaced via errors dict below
+                        errors[name] = exc
+
+                thread_a = threading.Thread(target=run, args=("a", stream_a))
+                thread_b = threading.Thread(target=run, args=("b", stream_b))
+                overall_start = mono_time()
+                thread_a.start()
+                thread_b.start()
+                thread_a.join(timeout=15)
+                thread_b.join(timeout=15)
+                overall_duration = elapsed_seconds(overall_start)
+
+                assert not errors, f"concurrent pg_sleep() on independent connections raised: {errors}"
+                assert "a" in results and "b" in results, "one or both streams did not complete in time"
+                # Sequential (shared-connection) execution of two 1s sleeps
+                # would take ~2s; independent connections overlap, so total
+                # wall time stays well under that.
+                assert overall_duration < 1.8, (
+                    f"streams appear serialized on one connection: {overall_duration:.2f}s for two 1s sleeps"
+                )
+            finally:
+                stream_a.close()
+                stream_b.close()
         finally:
             shared_connection.close()

--- a/tests/uat/configs/uat-throughput-postgresql-nightly.yaml
+++ b/tests/uat/configs/uat-throughput-postgresql-nightly.yaml
@@ -1,0 +1,94 @@
+# TEMPLATE — canonical nightly-CI PostgreSQL throughput config; edited in
+# place, not cloned per sweep. See _project/specs/uat-framework.md Section 9.
+#
+# Nightly-only real acceptance coverage for the throughput/concurrent phase
+# on a real server-style (client/server) engine (server-adapter-independent-
+# connection-optin). The DuckDB throughput cell
+# (uat-throughput-duckdb-nightly.yaml, throughput-uat-and-ci-coverage) proves
+# the throughput driver honors a requested stream count, but DuckDB stays on
+# the SHARED_CURSOR fast path (one connection, cursor-per-stream) — it never
+# exercises the INDEPENDENT_CONNECTION capability (a fresh connection/session
+# per stream) that PostgreSQL now opts into. This cell is the deferred w4 from
+# throughput-uat-and-ci-coverage: a docker Postgres throughput cell that
+# actually drives N concurrent independent PostgreSQL sessions end to end via
+# the production CLI, not just the integration-test harness
+# (tests/integration/test_throughput_session_isolation.py).
+#
+# `benchbox run` has no `--streams` option; `benchbox run-official --streams N`
+# is, today, the only CLI surface that forwards a requested stream count to
+# the throughput driver (see tests/uat/throughput.py and the
+# throughput-stream-count-wiring-defect TODO). `run-official` requires a
+# TPC-compliant scale factor, so SF=1 (the smallest allowed rung) is used
+# here rather than the usual SF=0.01 smoke scale.
+#
+# `streams: 3` is intentionally > the driver's 2-stream floor
+# (`_resolve_requested_stream_count` in
+# benchbox/platforms/base/execution.py floors any requested count < 2 up to
+# 2) so this cell exercises "was my N-stream request honored, with N real
+# independent PostgreSQL connections?" rather than "did the floor's default
+# of 2 happen to match?".
+#
+# Not run in the PR fast lane: invoke via `make uat-sweep
+# CONFIG=tests/uat/configs/uat-throughput-postgresql-nightly.yaml` from a
+# nightly workflow, after bringing up the Postgres compose stack (`make
+# test-docker-up-postgresql`) or letting this cell's `cleanup.docker_manage_
+# platforms: true` bring it up itself.
+#
+# `run-official` accepts and forwards the repeatable `--platform-option`
+# arguments emitted by `tests.uat.matrix.benchbox_run_official_argv`, so this
+# cell supplies the compose credentials alongside `--streams 3`. The
+# underlying PostgreSQL session-isolation tests remain the focused PR gate;
+# this config is the nightly end-to-end acceptance path.
+name: "uat-throughput-postgresql-nightly"
+description: "Nightly: real multi-stream throughput phase on PostgreSQL TPC-H SF1 (run-official --streams 3, INDEPENDENT_CONNECTION)"
+
+phases:
+  - preflight
+  - execute
+  - validate
+  - report
+
+platforms:
+  include: ["postgresql"]
+
+benchmarks:
+  include: ["tpch"]
+
+scales:
+  rungs: [1]
+
+execute:
+  per_cell_timeout_s: 1200
+  early_stop_after_s: 1200
+  early_stop_on_failure: false
+  phases_arg: "load,throughput"
+  skip_unreachable: true
+  parallel_platforms: false
+  official: true
+  streams: 3
+  seed: 20260711
+
+preflight:
+  free_space_min_gib: 5
+  free_space_path: "~/Developer/benchmark_runs"
+  docker_required: true
+
+cleanup:
+  preserve_datagen: true
+  prune_databases: true
+  docker_manage_platforms: true
+  docker_platform_switch: "volumes"
+  docker_project_prefix: "benchbox-uat-throughput-pg"
+  docker_start_timeout_s: 300
+  docker_fixed_container_name_policy: "fail"
+
+validate:
+  validator_clean_rate_floor: 1.0
+
+report:
+  matrix_summary_tsv: "matrix_summary.tsv"
+
+output:
+  benchmark_runs_dir_template: "~/Developer/benchmark_runs"
+  logs_dir_template: "~/Developer/benchmark_runs/logs/uat_throughput_postgresql_nightly_{date}"
+  submissions_dir_template: "~/Developer/benchmark_runs/submissions/{name}"

--- a/tests/uat/docker_assets.py
+++ b/tests/uat/docker_assets.py
@@ -295,12 +295,21 @@ _PLATFORM_INJECT_SPARK_CONNECT_ENDPOINT_OPT: frozenset[str] = frozenset({"lakesa
 # Local managed-Docker credentials, appended only when UAT manages the stack
 # (kept separate because PLATFORM options apply even for externally managed
 # local platforms).
+#
+# postgresql's compose stack (docker/postgresql/docker-compose.yml) sets
+# POSTGRES_USER=benchbox, which makes `benchbox` the ONLY superuser role the
+# official postgres image creates (POSTGRES_USER replaces the default
+# `postgres` role rather than adding alongside it) -- the adapter's own
+# `username` default ("postgres") does not exist in this container and
+# authentication fails outright. `username=benchbox` must be injected here
+# alongside `password=benchbox` for any docker-managed postgresql cell (e.g.
+# the throughput UAT cell) to connect at all.
 _PLATFORM_LOCAL_MANAGED_OPTS: dict[str, list[str]] = {
     "clickhouse-server": ["--platform-option", "password=benchbox"],
     "pg-duckdb": ["--platform-option", "password=benchbox"],
     "pg-mooncake": ["--platform-option", "password=benchbox"],
     "timescaledb": ["--platform-option", "password=benchbox"],
-    "postgresql": ["--platform-option", "password=benchbox"],
+    "postgresql": ["--platform-option", "username=benchbox", "--platform-option", "password=benchbox"],
 }
 
 # A compose `ports:` entry: "[ip:]host:container", host may be ${VAR:-default}.

--- a/tests/uat/test_config.py
+++ b/tests/uat/test_config.py
@@ -601,4 +601,4 @@ def test_top_level_config_paths_exclude_generated_rerun_shards():
     this parametrized set."""
     shard_dir = _CORPUS_CONFIGS_ROOT / "generated-rerun-shards"
     assert all(shard_dir not in p.parents for p in _top_level_config_paths())
-    assert len(_top_level_config_paths()) == 15
+    assert len(_top_level_config_paths()) == 16

--- a/tests/unit/cli/commands/test_run_official.py
+++ b/tests/unit/cli/commands/test_run_official.py
@@ -1,0 +1,46 @@
+"""Fast coverage for the deprecated ``run-official`` compatibility command."""
+
+from __future__ import annotations
+
+import click
+import pytest
+from click.testing import CliRunner
+
+import benchbox.cli.commands.run_official as run_official_module
+
+pytestmark = [pytest.mark.unit, pytest.mark.fast]
+
+
+def test_run_official_accepts_and_forwards_platform_options(monkeypatch):
+    """The throughput UAT command must accept credentials with ``--streams``."""
+    captured: dict[str, object] = {}
+
+    def fake_run(**kwargs):
+        captured.update(kwargs)
+
+    monkeypatch.setattr(run_official_module, "run", click.Command("run", callback=fake_run))
+
+    result = CliRunner().invoke(
+        run_official_module.run_official,
+        [
+            "tpch",
+            "--platform",
+            "postgresql",
+            "--scale",
+            "1",
+            "--phases",
+            "throughput",
+            "--streams",
+            "3",
+            "--platform-option",
+            "username=benchbox",
+            "--platform-option",
+            "password=benchbox",
+            "--seed",
+            "42",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert captured["platform"] == "postgresql"
+    assert captured["platform_option_pairs"] == (("username", "benchbox"), ("password", "benchbox"))

--- a/tests/unit/platforms/test_postgresql_adapter.py
+++ b/tests/unit/platforms/test_postgresql_adapter.py
@@ -102,6 +102,37 @@ class TestPostgreSQLAdapter:
 
         assert params["dbname"] == "override_db"
 
+    def test_new_stream_connection_opens_independent_session(self, postgres_stubs):
+        """Each stream gets a fresh psycopg session with adapter GUCs applied."""
+        stream_connection = Mock()
+        stream_cursor = Mock()
+        stream_connection.cursor.return_value = stream_cursor
+        postgres_stubs.connect.return_value = stream_connection
+        adapter = PostgreSQLAdapter(
+            host="pg.example.com",
+            port=5433,
+            database="testdb",
+            username="testuser",
+            password="testpass",
+            schema="analytics",
+        )
+        shared_connection = Mock()
+
+        result = adapter.new_stream_connection(shared_connection)
+
+        assert result is stream_connection
+        postgres_stubs.connect.assert_called_once_with(**adapter._get_connection_params())
+        assert stream_cursor.execute.call_args_list == [
+            (("SET work_mem = '256MB'",), {}),
+            (("SET maintenance_work_mem = '512MB'",), {}),
+            (("SET effective_cache_size = '1GB'",), {}),
+            (("SET max_parallel_workers_per_gather = 2",), {}),
+            (('SET search_path TO "analytics", public',), {}),
+        ]
+        stream_connection.commit.assert_called_once_with()
+        stream_cursor.close.assert_called_once_with()
+        shared_connection.cursor.assert_not_called()
+
     def test_add_cli_arguments_registers_postgres_compatible_flags(self, postgres_stubs):
         """CLI parser should expose shared PostgreSQL-compatible arguments."""
         parser = argparse.ArgumentParser()


### PR DESCRIPTION
## Summary

- Make PostgreSQL throughput and maintenance streams use independent psycopg connections and sessions.
- Preserve the shared-cursor path for embedded adapters while applying the new capability to both TPC-H and TPC-DS maintenance factories.
- Add real PostgreSQL session-isolation and concurrency coverage, plus unit coverage for stream-session setup.
- Inject the compose PostgreSQL username and password into managed UAT cells.
- Resolve the CLI blocker by adding repeatable `--platform-option KEY=VALUE` forwarding to deprecated `run-official`, so UAT can pass credentials together with `--streams`.
- Add the nightly PostgreSQL TPC-H SF1 throughput UAT config.

## Validation

- Focused suite: 141 passed.
- Real PostgreSQL via local mocker compose: 3 new session-isolation/concurrency tests passed; existing PostgreSQL live adapter suite: 8 passed.
- UAT config corpus/lifecycle checks: 51 passed.
- Fast suite: 25,296 passed, 27 skipped, 48 warnings, 4 subtests passed.
- `make pr-preflight`: 25,281 passed, 27 skipped, 48 warnings, 4 subtests passed; artifact hygiene and timing checks passed.

The SF1 nightly UAT cell is intentionally not run in the PR lane; it is the checked-in end-to-end acceptance path for the nightly workflow.
