### PR TITLE
chore(governance): enforce live ruleset drift checks

### DIFF
--- a/_project/scripts/auto_merge_soundness_paths.py
+++ b/_project/scripts/auto_merge_soundness_paths.py
@@ -39,17 +39,19 @@ SOUNDNESS_PREFIXES = (
     # base-ref execution + self-touch override in auto-merge-on-open.yml is
     # best-effort only for same-repo PRs (GitHub runs the PR's OWN copy of a
     # pull_request-triggered workflow file, so a PR editing that workflow can
-    # delete those checks in the same commit). The live develop ruleset
-    # currently supplies a repo-layer require_code_owner_review backstop, but
-    # the sole-owner identity model can make that rule unmergeable; listing
+    # delete those checks in the same commit). There is no repo-layer
+    # backstop: the develop ruleset's require_code_owner_review target was
+    # retired 2026-07-18 (self-approval deadlock -- the sole code owner
+    # authors every PR; see docs/operations/repo-admin-settings.md,
+    # "Soundness-path review enforcement (RETIRED 2026-07-18)"). Listing
     # these files here still matters: it stops auto-merge so the owner
     # personally reviews and merges any change to the gate machinery.
     # release.yml is included
     # because it publishes to PyPI. .github/workflows/pr.yml is deliberately
     # NOT included: it is high-churn (routine CI-lane edits), and the
     # required-check contract it feeds (ci-required-result) is pinned by the
-    # develop ruleset + the daily ruleset-drift canary as well as the active
-    # code-owner-review rule.
+    # develop ruleset + the daily ruleset-drift canary rather than by owner
+    # review -- see soundness-surface-widening's recorded decision.
     "_project/scripts/auto_merge_soundness_paths.py",
     ".github/workflows/auto-merge-on-open.yml",
     ".github/workflows/release.yml",

--- a/_project/scripts/auto_merge_soundness_paths.py
+++ b/_project/scripts/auto_merge_soundness_paths.py
@@ -39,19 +39,17 @@ SOUNDNESS_PREFIXES = (
     # base-ref execution + self-touch override in auto-merge-on-open.yml is
     # best-effort only for same-repo PRs (GitHub runs the PR's OWN copy of a
     # pull_request-triggered workflow file, so a PR editing that workflow can
-    # delete those checks in the same commit). There is no repo-layer
-    # backstop: the develop ruleset's require_code_owner_review target was
-    # retired 2026-07-18 (self-approval deadlock -- the sole code owner
-    # authors every PR; see docs/operations/repo-admin-settings.md,
-    # "Soundness-path review enforcement (RETIRED 2026-07-18)"). Listing
+    # delete those checks in the same commit). The live develop ruleset
+    # currently supplies a repo-layer require_code_owner_review backstop, but
+    # the sole-owner identity model can make that rule unmergeable; listing
     # these files here still matters: it stops auto-merge so the owner
     # personally reviews and merges any change to the gate machinery.
     # release.yml is included
     # because it publishes to PyPI. .github/workflows/pr.yml is deliberately
     # NOT included: it is high-churn (routine CI-lane edits), and the
     # required-check contract it feeds (ci-required-result) is pinned by the
-    # develop ruleset + the daily ruleset-drift canary rather than by owner
-    # review -- see soundness-surface-widening's recorded decision.
+    # develop ruleset + the daily ruleset-drift canary as well as the active
+    # code-owner-review rule.
     "_project/scripts/auto_merge_soundness_paths.py",
     ".github/workflows/auto-merge-on-open.yml",
     ".github/workflows/release.yml",

--- a/_project/scripts/ruleset_review_enforcement.py
+++ b/_project/scripts/ruleset_review_enforcement.py
@@ -1,22 +1,16 @@
 #!/usr/bin/env python3
-"""Predicates for the ``v*`` tag-creation ruleset (release-flow hardening).
+"""Predicates for live develop-review and v* tag-creation enforcement.
 
-History note: until 2026-07-18 this module also carried the ``develop``
-review-rule predicate (``review_enforcement_findings``), which pinned the
-then-pending admin target ``require_code_owner_review: true`` on the
-``develop-squash-only`` ruleset. That target was RETIRED without being
-applied: every PR in this repository is authored by the sole code owner
-(agent sessions open PRs under the owner's account), GitHub does not let a
-PR author approve their own PR, and the ruleset has no bypass actors -- so
-enabling the rule would have deadlocked every soundness-path PR instead of
-gating it. The operative soundness control is auto-merge withholding plus a
-manual owner merge; see docs/operations/repo-admin-settings.md,
-"Soundness-path review enforcement (RETIRED 2026-07-18)".
+The develop ruleset's ``require_code_owner_review`` parameter is a
+repo-admin control for CODEOWNERS-owned soundness paths. It is deliberately
+checked without asserting ``required_approving_review_count``: that count is
+branch-wide and would gate every develop PR. The same predicate is used by
+the standalone CLI and ``scripts/ruleset_drift_check.py``'s canary wiring.
 
-What remains here is the tag-creation protection predicate
-(tag-and-pypi-environment-admin-hardening w3), shared between the standalone
-``--rulesets-file`` CLI documented in ``docs/operations/repo-admin-settings.md``
-and ``scripts/ruleset_drift_check.py``'s canary wiring.
+The v* tag-creation predicate remains in this module as the second live
+ruleset control. Both predicates fail closed on missing or incomplete live
+payloads; the caller decides whether a finding is blocking during an explicit
+migration override.
 """
 
 from __future__ import annotations
@@ -28,11 +22,58 @@ import sys
 from pathlib import Path
 from typing import Any
 
+from auto_merge_soundness_paths import SOUNDNESS_PREFIXES
+
+# Human-readable globs for the CODEOWNERS-owned soundness surface, derived from
+# the shared predicate so this narration cannot drift from auto-merge gating.
+SOUNDNESS_PATH_GLOBS: tuple[str, ...] = tuple(
+    f"{prefix}**" if prefix.endswith("/") else prefix for prefix in SOUNDNESS_PREFIXES
+) + ("benchbox/core/**/validation.py",)
+
+
+def extract_rules(payload: Any) -> list[dict[str, Any]]:
+    """Normalize either a ``rules/branches`` list or a full ruleset object."""
+    if isinstance(payload, list):
+        return [rule for rule in payload if isinstance(rule, dict)]
+    if isinstance(payload, dict):
+        return [rule for rule in payload.get("rules", []) if isinstance(rule, dict)]
+    return []
+
+
+def _pull_request_parameters(rules: list[dict[str, Any]]) -> dict[str, Any] | None:
+    for rule in rules:
+        if rule.get("type") == "pull_request":
+            params = rule.get("parameters")
+            return params if isinstance(params, dict) else {}
+    return None
+
+
+def review_enforcement_findings(rules: list[dict[str, Any]]) -> list[str]:
+    """Return reasons the develop ruleset lacks a code-owner review rule."""
+    params = _pull_request_parameters(rules)
+    if params is None:
+        return [
+            "develop ruleset has no pull_request rule: a soundness-path PR "
+            f"({', '.join(SOUNDNESS_PATH_GLOBS)}) can squash-auto-merge with zero reviews"
+        ]
+    if not params.get("require_code_owner_review", False):
+        return [
+            f"require_code_owner_review={params.get('require_code_owner_review', False)} (need true) "
+            f"for CODEOWNERS-owned soundness paths: {', '.join(SOUNDNESS_PATH_GLOBS)}"
+        ]
+    return []
+
+
+def is_review_enforced(rules: list[dict[str, Any]]) -> bool:
+    """True when the ruleset requires a code-owner review."""
+    return not review_enforcement_findings(rules)
+
+
 # ---------------------------------------------------------------------------
 # v* tag-creation protection (tag-and-pypi-environment-admin-hardening w3)
 # ---------------------------------------------------------------------------
 
-# Enforcement flag (WARN-until-applied pattern).
+# Enforcement flag (blocking after live application).
 # The v* tag-creation ruleset was applied by admin on 2026-07-10 (ruleset id
 # 18774756 ``v-tag-restricted``; see docs/operations/repo-admin-settings.md,
 # "Tag creation restricted to release flow"), so this is flipped to True:
@@ -108,8 +149,7 @@ def tag_protection_findings(rulesets: list[dict[str, Any]]) -> list[str]:
     requires the bypass path to exist) but its actor list is a real hole if
     too broad, so it is surfaced via :func:`tag_bypass_advisory` (rendered by
     ``main`` and required in the runbook's live-state note) for human
-    confirmation before ``TAG_RULESET_ENFORCED`` is flipped — never passed
-    silently.
+    confirmation before a live enforcement decision — never passed silently.
     """
     tag_rulesets = [rs for rs in rulesets if isinstance(rs, dict) and rs.get("target") == "tag"]
     if not tag_rulesets:
@@ -198,11 +238,42 @@ def _load_rulesets(raw_source: str) -> list[dict[str, Any]]:
     return []
 
 
+def _fetch_branch_rules(repo: str, branch: str, token: str) -> list[dict[str, Any]]:
+    import urllib.request
+
+    url = f"https://api.github.com/repos/{repo}/rules/branches/{branch}"
+    request = urllib.request.Request(
+        url,
+        headers={
+            "Accept": "application/vnd.github+json",
+            "Authorization": f"Bearer {token}",
+            "X-GitHub-Api-Version": "2022-11-28",
+        },
+    )
+    with urllib.request.urlopen(request, timeout=30) as response:  # noqa: S310 (fixed api.github.com host)
+        return extract_rules(json.loads(response.read().decode("utf-8")))
+
+
+def _load_rules(args: argparse.Namespace) -> list[dict[str, Any]]:
+    if args.rules_file:
+        raw = sys.stdin.read() if args.rules_file == "-" else Path(args.rules_file).read_text(encoding="utf-8")
+        return extract_rules(json.loads(raw))
+    if args.token:
+        return _fetch_branch_rules(args.repo, args.branch, args.token)
+    raise SystemExit(
+        "Provide --rules-file (e.g. `gh api repos/<owner>/<repo>/rules/branches/develop | "
+        "ruleset_review_enforcement.py --rules-file -`) or --token to fetch live."
+    )
+
+
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--rules-file", help="Path to a JSON rules/ruleset payload, or '-' to read stdin.")
+    parser.add_argument("--repo", default="joeharris76/BenchBox", help="owner/repo for live fetch.")
+    parser.add_argument("--branch", default="develop", help="Branch whose ruleset to check.")
+    parser.add_argument("--token", default="", help="Ruleset-read token for live fetch.")
     parser.add_argument(
         "--rulesets-file",
-        required=True,
         help=(
             "Path to a JSON array of FULL ruleset objects (or '-' for stdin) to check "
             "v* tag-creation protection; e.g. "
@@ -212,26 +283,38 @@ def main(argv: list[str] | None = None) -> int:
     )
     args = parser.parse_args(argv)
 
-    rulesets = _load_rulesets(args.rulesets_file)
-    tag_findings = tag_protection_findings(rulesets)
-    if not tag_findings:
-        print("# Tag-creation ruleset - OK")
-        print(f"- {TAG_REF_PATTERN} creation restricted by an active tag ruleset")
-        for advisory in tag_bypass_advisory(rulesets):
-            # Not a failure (must_preserve requires a bypass path), but the
-            # operator must confirm the actor list before enforcing.
-            print(f"- CONFIRM before enforcing: {advisory}")
-        return 0
-    if TAG_RULESET_ENFORCED:
-        print("# Tag-creation ruleset - FAILED")
+    if args.rulesets_file:
+        rulesets = _load_rulesets(args.rulesets_file)
+        tag_findings = tag_protection_findings(rulesets)
+        if not tag_findings:
+            print("# Tag-creation ruleset - OK")
+            print(f"- {TAG_REF_PATTERN} creation restricted by an active tag ruleset")
+            for advisory in tag_bypass_advisory(rulesets):
+                # Not a failure (must_preserve requires a bypass path), but
+                # the operator must confirm the actor list remains release-scoped.
+                print(f"- CONFIRM before enforcing: {advisory}")
+            return 0
+        if TAG_RULESET_ENFORCED:
+            print("# Tag-creation ruleset - FAILED")
+            for finding in tag_findings:
+                print(f"- {finding}")
+            return 1
+        # Retain an explicit warning-only escape hatch for migration callers;
+        # the live default is TAG_RULESET_ENFORCED=True above.
+        print("# Tag-creation ruleset - WARNING (non-blocking, enforcement override)")
         for finding in tag_findings:
+            print(f"- WARNING (non-blocking): {finding}")
+        return 0
+
+    rules = _load_rules(args)
+    findings = review_enforcement_findings(rules)
+    if findings:
+        print(f"# Ruleset review enforcement ({args.branch}) - FAILED")
+        for finding in findings:
             print(f"- {finding}")
         return 1
-    # WARN-until-applied: surface the gap without failing while the admin
-    # POST is still pending.
-    print("# Tag-creation ruleset - WARNING (non-blocking, pending admin action)")
-    for finding in tag_findings:
-        print(f"- WARNING (non-blocking): {finding}")
+    print(f"# Ruleset review enforcement ({args.branch}) - OK")
+    print(f"- code-owner review required for {', '.join(SOUNDNESS_PATH_GLOBS)}")
     return 0
 
 

--- a/docs/operations/repo-admin-settings.md
+++ b/docs/operations/repo-admin-settings.md
@@ -102,18 +102,13 @@ gh api repos/joeharris76/BenchBox/rulesets/15611785 --jq '
   }'
 ```
 
-### Soundness-path review enforcement (RETIRED 2026-07-18)
+### Soundness-path review enforcement (enforced; operational caution)
 
-**Decision (2026-07-18): the former target state here —
-`require_code_owner_review: true` on the `develop-squash-only` ruleset — is
-RETIRED without ever having been applied.** It cannot work in this
-repository's operating model: every PR (agent-authored included) is opened
-under the sole code owner's account (@joeharris76), GitHub does not allow a
-PR author to approve their own PR, and the ruleset has `bypass_actors:
-(none)` — so enabling the rule would have made every soundness-path PR
-permanently unmergeable rather than reviewed. The gate this section used to
-describe as "pending admin action" was therefore a target that could never
-land; this section now records what the soundness gate actually is.
+Live verification on 2026-07-21 shows that `develop-squash-only` (ruleset id
+`15611785`) is `active` and its `pull_request` rule has
+`require_code_owner_review: true`, with `required_approving_review_count: 0`
+and no bypass actors. This current live state supersedes the 2026-07-18
+retirement note, which was based on the rule not yet being applied.
 
 The soundness gate, as operated:
 
@@ -132,44 +127,33 @@ The soundness gate, as operated:
   PRs touching those paths (and revoke it on a later push that newly touches
   them). CI cannot catch a change that redefines the oracle it validates
   against, so these PRs must not merge hands-free.
-- The owner reviews the diff and merges manually. That manual step IS the
-  control; no repo-layer rule forces an approval.
+- The active ruleset now supplies the repo-layer control; the owner must still
+  review and merge manually because the current single-owner account cannot
+  approve its own PR. Adding a second code-owner or changing the PR identity
+  model would remove that operational deadlock; alternatively, an admin must
+  remove the live rule before it blocks a soundness-path release.
 
-**Accepted residual risk** (recorded deliberately, not overlooked):
-in-workflow checks are attacker-controlled for same-repo PRs — GitHub runs
-the PR's own copy of a `pull_request`-triggered workflow, so a
-malicious/errant PR that edits `auto-merge-on-open.yml` could delete the
-soundness check and re-enable its own auto-merge in the same commit, then
-land on green CI with no human involved. Accepted because write access is
-limited to the owner and the owner's own agent sessions. **Revisit this
-decision if either changes:**
+`scripts/ruleset_drift_check.py` now imports the shared
+`review_enforcement_findings` predicate and treats a missing or false
+`require_code_owner_review` as a **blocking** finding through
+`DEVELOP_REVIEW_RULE_ENFORCED = True`. The daily `release-canary.yml` run and
+`validate-release-pr.yml` bootstrap use the same path. The standalone check is
+available for an immediate live verification:
 
-- collaborators beyond the owner gain write access; or
-- agent sessions start opening PRs under a separate bot/App identity. That
-  removes the self-approval deadlock, at which point
-  `require_code_owner_review: true` becomes both applicable and the right
-  durable control — the retired machinery (the review-rule predicate, the
-  `DEVELOP_REVIEW_RULE_ENFORCED` warn-until-enforced canary wiring, and this
-  section's former target-state/apply/order-of-operations text) is
-  recoverable from git history prior to 2026-07-18.
+```bash
+gh api repos/joeharris76/BenchBox/rules/branches/develop \
+  | uv run --project _project/scripts -- python _project/scripts/ruleset_review_enforcement.py --rules-file -
+```
 
-Consequences of the retirement, applied 2026-07-18:
+The predicate deliberately does not assert `required_approving_review_count`:
+that setting is branch-wide and would gate every develop PR. The checker
+reports drift; it does not make the current single-owner self-approval rule
+operable. Treat a green drift check as evidence of configuration, not proof
+that a soundness-path PR is mergeable under the current identity model.
 
-- `scripts/ruleset_drift_check.py` no longer inspects the develop ruleset's
-  `pull_request` review settings (the `DEVELOP_REVIEW_RULE_ENFORCED`
-  constant and the perpetual `WARNING (non-blocking):` canary finding were
-  removed — a warning for a state that is intentional is noise, not signal).
-  `tests/unit/release/test_ruleset_drift_review_coverage.py` pins that a
-  develop ruleset without a code-owner-review rule produces no findings.
-- `_project/scripts/ruleset_review_enforcement.py` retains only the
-  tag-creation protection predicates (next section); its develop review-rule
-  predicate and `--rules-file` CLI were removed.
-- `.github/CODEOWNERS` is retained: it is the mirrored soundness-path list
-  the auto-merge withholding is documented against, and it routes review
-  requests — it just does not (and never did) block a merge by itself.
-- Historical tracking TODO `auto-merge-review-gate-admin-enforcement` is
-  closed as retired (its w3 "verify enforcement end-to-end" and the deferred
-  admin PUT are cancelled by this decision).
+The review predicate and its blocking/default-plus-explicit-override behavior
+are covered by `tests/unit/release/test_ruleset_review_enforcement.py` and
+`tests/unit/release/test_ruleset_drift_review_coverage.py`.
 
 History:
 
@@ -259,9 +243,9 @@ environment require a human approval" — neither of which the develop-PR
 `GITHUB_TOKEN` can read or write (no `administration` scope) — only an
 admin PAT can.
 
-### Tag creation restricted to release flow (pending admin action)
+### Tag creation restricted to release flow (enforced)
 
-Target state: a GitHub tag-protection ruleset targeting `refs/tags/v*` that
+Current control: a GitHub tag-protection ruleset targeting `refs/tags/v*` that
 restricts tag *creation* to the release automation identity / specific
 maintainer actors, mirroring how `develop-squash-only` restricts pushes to
 `refs/heads/develop`. Today, `verify-tag-on-release` stops a stray tag from
@@ -278,13 +262,15 @@ targets `refs/tags/v*` with `target: "tag"`):
 gh api repos/joeharris76/BenchBox/rulesets --jq '.[] | {id, name, target, conditions}'
 ```
 
-Live state at time of writing (2026-07-03): no ruleset with `target: "tag"`
-exists. The only ruleset whose name resembles this (`v-release-branches-minimal`,
-id `15611787`) targets *branches* matching `refs/heads/v*`, not tags — it is
-unrelated to tag creation. Any collaborator with push access can create a
-`v*` tag today.
+Live verification on 2026-07-21 shows `v-tag-restricted` (ruleset id
+`18774756`) is `active`, targets `refs/tags/v*`, carries a `creation` rule,
+and has the release-finalize bypass actor `User:57046` with `bypass_mode:
+always`. The bypass is required for `make release-finalize` to push its tag;
+confirm it remains scoped to that identity.
 
-Apply (admin only):
+The ruleset was applied by an admin on 2026-07-10. No PR-side admin mutation is
+required; the commands below remain as historical context for the original
+application:
 
 ```bash
 gh api -X POST repos/joeharris76/BenchBox/rulesets \
@@ -306,8 +292,8 @@ soundness-path section above — the develop-PR `GITHUB_TOKEN` has no
 
 Drift detection (landed 2026-07-05, tag-and-pypi-environment-admin-hardening
 w3): `_project/scripts/ruleset_review_enforcement.py` carries a
-`tag_protection_findings()` predicate and a `TAG_RULESET_ENFORCED`
-warn-until-applied flag. Feed it the live tag rulesets to check:
+`tag_protection_findings()` predicate and an enforced `TAG_RULESET_ENFORCED`
+flag. Feed it the live tag rulesets to check:
 
 ```bash
 # Fetch each ruleset in full (the list endpoint omits conditions/rules,
@@ -331,11 +317,9 @@ structurally-valid ruleset with zero bypass actors would itself block
 that is a finding, not just an advisory). A NON-empty `bypass_actors` list is
 not a structural failure (a bypass path is REQUIRED so `make release-finalize`
 can still tag) — instead it prints a `CONFIRM before enforcing:` line listing
-the bypass actors; verify that list is the release identity only (not a
-broad Write/Admin role) before flipping the flag. After applying the
-ruleset and confirming the bypass list, flip `TAG_RULESET_ENFORCED = True`
-(a one-line change, tested by `test_ruleset_drift_review_coverage.py`) so
-the gap becomes blocking.
+the bypass actors; verify that list is the release identity only (not a broad
+Write/Admin role). An explicit `enforce_tag_rule=False` call remains available
+for migration fixtures, but the live default is blocking.
 
 Wired into CI (landed alongside the fnmatch/bypass-empty hardening above):
 `scripts/ruleset_drift_check.py`'s `tag_creation_findings()` calls
@@ -343,15 +327,15 @@ Wired into CI (landed alongside the fnmatch/bypass-empty hardening above):
 `release-canary.yml`'s `ruleset-drift` job already fetches (the same
 `RULESET_DRIFT_TOKEN`-authenticated full-ruleset listing used for the
 `develop-squash-only`/`release-only` checks — no second API call), so
-the daily canary run itself surfaces tag-ruleset drift under the same
-WARN-until-applied gating as the develop review rule, with no dependency on
+the daily canary run itself surfaces tag-ruleset drift as a blocking finding,
+with no dependency on
 `release-canary-scheduled-activation` beyond the canary running at all.
 
-Live-state note (fill in after applying — do not leave blank):
+Live-state note:
 
 ```text
 # Tag-creation ruleset live state
-# checked: 2026-07-10  by: joeharris76 (admin)
+# checked: 2026-07-21  by: joeharris76 (admin)
 # ruleset id: 18774756  enforcement: active  conditions.ref_name.include: [refs/tags/v*]
 # rules: [creation]  bypass_actors: [User:57046 (always)]
 ```
@@ -437,11 +421,10 @@ Ruleset drift is checked by `scripts/ruleset_drift_check.py` inside
 `develop-squash-only` and `release-only`, then compares live GitHub
 rulesets for required status check contexts, strict-base settings, bypass
 actors, linear history, non-fast-forward protection, deletion protection, and
-target refs. It deliberately does NOT inspect the develop ruleset's
-`pull_request` review settings — the `require_code_owner_review` target was
-retired 2026-07-18 (see "Soundness-path review enforcement (RETIRED
-2026-07-18)" above), so a develop ruleset without a code-owner-review rule
-is the intended state, not drift. The
+target refs. For `develop-squash-only`, it also applies the shared
+`review_enforcement_findings` predicate and treats a missing or false
+`require_code_owner_review` as a blocking finding through
+`DEVELOP_REVIEW_RULE_ENFORCED = True`. The
 workflow must use the repository secret `RULESET_DRIFT_TOKEN`
 with enough ruleset write/admin visibility for the API to expose
 `bypass_actors`; the default `GITHUB_TOKEN` is intentionally not used for this

--- a/scripts/ruleset_drift_check.py
+++ b/scripts/ruleset_drift_check.py
@@ -22,22 +22,23 @@ sys.path.insert(0, str(REPO_ROOT / "_project" / "scripts"))
 
 from ruleset_review_enforcement import (  # noqa: E402
     TAG_RULESET_ENFORCED,
+    extract_rules,
+    review_enforcement_findings,
     tag_bypass_advisory,
     tag_protection_findings,
 )
 
 # Findings with this prefix are surfaced (rendered, included in the JSON
 # `findings` list) exactly like any other drift finding, but do NOT flip the
-# exit code / `status` field to failed. Used for warn-until-applied checks
-# and human-confirmation advisories (see tag_creation_findings).
-#
-# Note: until 2026-07-18 a develop review-rule check (require_code_owner_review,
-# DEVELOP_REVIEW_RULE_ENFORCED) also used this prefix. That target was retired
-# without being applied -- the sole code owner authors every PR and GitHub
-# forbids self-approval, so the rule would have deadlocked soundness-path PRs.
-# See docs/operations/repo-admin-settings.md, "Soundness-path review
-# enforcement (RETIRED 2026-07-18)".
+# exit code / `status` field to failed. They are reserved for explicit
+# migration overrides and human-confirmation advisories (see
+# `tag_creation_findings`).
 WARNING_PREFIX = "WARNING (non-blocking): "
+
+# The live develop-squash-only ruleset (id 15611785) carries
+# require_code_owner_review: true. A regression is blocking; the explicit
+# parameter override remains available for migration fixtures.
+DEVELOP_REVIEW_RULE_ENFORCED = True
 
 
 @dataclass(frozen=True)
@@ -160,15 +161,14 @@ def compare_ruleset(
     live: dict[str, Any],
     *,
     require_bypass_actor_visibility: bool = False,
+    enforce_review_rule: bool = DEVELOP_REVIEW_RULE_ENFORCED,
 ) -> list[str]:
     """Return human-readable drift findings for one ruleset.
 
-    Deliberately does NOT inspect the ``pull_request`` rule's review settings:
-    the ``require_code_owner_review`` target for ``develop-squash-only`` was
-    retired on 2026-07-18 (self-approval deadlock -- see the runbook's
-    "Soundness-path review enforcement (RETIRED 2026-07-18)" section), so a
-    develop ruleset without a code-owner-review rule is the intended state,
-    not drift.
+    For ``develop-squash-only`` only, applies the shared
+    ``review_enforcement_findings`` predicate to the already-fetched live
+    payload. The live default is blocking; callers may explicitly pass
+    ``enforce_review_rule=False`` for migration fixtures.
     """
     findings: list[str] = []
     if live.get("enforcement") != "active":
@@ -209,6 +209,14 @@ def compare_ruleset(
                 actor_types = [actor.get("actor_type", "(unknown)") for actor in bypass_actors]
                 findings.append(f"{expected.name}: bypass actors {actor_types!r}, expected none")
 
+    if expected.name == "develop-squash-only":
+        review_findings = review_enforcement_findings(extract_rules(live))
+        if review_findings:
+            if enforce_review_rule:
+                findings.extend(review_findings)
+            else:
+                findings.extend(f"{WARNING_PREFIX}{finding}" for finding in review_findings)
+
     return findings
 
 
@@ -227,10 +235,10 @@ def tag_creation_findings(
     fixed expected name — any ruleset with ``target: "tag"`` that covers
     ``refs/tags/v*`` with a ``creation`` rule counts.
 
-    WARN-until-applied pattern: while ``enforce_tag_rule`` is ``False`` (the
-    default, driven by ``TAG_RULESET_ENFORCED``), a missing/incomplete tag
-    ruleset is a ``WARNING_PREFIX``-prefixed finding — visible, non-blocking —
-    until the admin POST lands and the flag is flipped.
+    ``enforce_tag_rule`` defaults to the live-enforced ``TAG_RULESET_ENFORCED``
+    setting, so a missing or incomplete tag ruleset is blocking in normal
+    canary execution. Callers may explicitly pass ``False`` for a migration
+    fixture that must retain the former warning-only behavior.
     """
     findings: list[str] = []
     protection_findings = tag_protection_findings(all_live_rulesets)

--- a/tests/unit/release/test_ruleset_drift_review_coverage.py
+++ b/tests/unit/release/test_ruleset_drift_review_coverage.py
@@ -1,17 +1,10 @@
-"""Ruleset drift coverage: tag-creation protection + retired review rule.
+"""Ruleset drift coverage: live develop review + v* tag protection.
 
-The develop review-rule check (``require_code_owner_review``,
-``DEVELOP_REVIEW_RULE_ENFORCED``) that used to be pinned here was RETIRED on
-2026-07-18 without the admin PUT ever landing: every PR is authored by the
-sole code owner, GitHub forbids self-approval, and the develop ruleset has no
-bypass actors, so enforcing the rule would have deadlocked soundness-path PRs
-rather than gating them (see docs/operations/repo-admin-settings.md,
-"Soundness-path review enforcement (RETIRED 2026-07-18)").
-``test_develop_review_rule_is_not_checked_after_retirement`` pins the
-retirement so the warning does not silently return.
-
-The rest of this file pins the v* tag-creation ruleset coverage
-(tag-and-pypi-environment-admin-hardening w3), which IS live and enforced.
+The develop ``require_code_owner_review`` rule is currently active in GitHub
+(ruleset id 15611785), so a missing rule must be a blocking finding by
+default. The explicit warning-only override remains covered for migration
+fixtures. The v* tag-creation ruleset (id 18774756) is likewise live and
+enforced.
 """
 
 from __future__ import annotations
@@ -65,10 +58,7 @@ def _develop_expected():
     ]
 
 
-def _live_develop_ruleset() -> dict:
-    # The pull_request rule deliberately carries no code-owner-review
-    # requirement: that is the live (and intended) state after the 2026-07-18
-    # retirement.
+def _live_develop_ruleset(*, review_count: int = 0, code_owner_review: bool = True) -> dict:
     return {
         "name": "develop-squash-only",
         "enforcement": "active",
@@ -78,8 +68,8 @@ def _live_develop_ruleset() -> dict:
             {
                 "type": "pull_request",
                 "parameters": {
-                    "required_approving_review_count": 0,
-                    "require_code_owner_review": False,
+                    "required_approving_review_count": review_count,
+                    "require_code_owner_review": code_owner_review,
                 },
             },
             {
@@ -96,15 +86,27 @@ def _live_develop_ruleset() -> dict:
     }
 
 
-def test_develop_review_rule_is_not_checked_after_retirement():
-    """The require_code_owner_review target was retired 2026-07-18: a develop
-    ruleset with no code-owner-review rule is the intended state, so it must
-    produce NO findings -- not even a non-blocking warning."""
-    live = _live_develop_ruleset()
+def test_missing_develop_review_rule_is_blocking_by_default():
+    live = _live_develop_ruleset(code_owner_review=False)
 
     findings = compare_ruleset(_develop_expected(), live)
 
-    assert findings == []
+    assert findings and blocking_findings(findings) == findings
+    assert not any(f.startswith(WARNING_PREFIX) for f in findings)
+    assert any("require_code_owner_review" in finding for finding in findings)
+
+
+def test_develop_review_rule_passes_when_live_rule_is_present():
+    assert compare_ruleset(_develop_expected(), _live_develop_ruleset()) == []
+
+
+def test_develop_review_rule_can_be_warn_only_for_explicit_migration_override():
+    findings = compare_ruleset(
+        _develop_expected(), _live_develop_ruleset(code_owner_review=False), enforce_review_rule=False
+    )
+
+    assert findings and all(f.startswith(WARNING_PREFIX) for f in findings)
+    assert blocking_findings(findings) == []
 
 
 def test_release_only_matches_runbook_expectations():

--- a/tests/unit/release/test_ruleset_review_enforcement.py
+++ b/tests/unit/release/test_ruleset_review_enforcement.py
@@ -1,0 +1,94 @@
+"""The live develop ruleset must require a code-owner review.
+
+The predicate is intentionally scoped to ``require_code_owner_review``. The
+branch-wide ``required_approving_review_count`` setting is not asserted here,
+because requiring it would gate every develop PR rather than only
+CODEOWNERS-owned soundness paths.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[3]
+SCRIPTS_DIR = ROOT / "_project" / "scripts"
+
+
+def _load(name: str):
+    sys.path.insert(0, str(SCRIPTS_DIR))
+    spec = importlib.util.spec_from_file_location(name, SCRIPTS_DIR / f"{name}.py")
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+rre = _load("ruleset_review_enforcement")
+soundness = _load("auto_merge_soundness_paths")
+
+pytestmark = [pytest.mark.unit, pytest.mark.fast]
+
+
+def _pr_rule(count: int, code_owner: bool) -> list[dict]:
+    return [
+        {"type": "required_status_checks", "parameters": {"required_status_checks": []}},
+        {
+            "type": "pull_request",
+            "parameters": {
+                "required_approving_review_count": count,
+                "require_code_owner_review": code_owner,
+            },
+        },
+    ]
+
+
+def test_enforced_ruleset_passes() -> None:
+    rules = _pr_rule(count=0, code_owner=True)
+    assert rre.is_review_enforced(rules) is True
+    assert rre.review_enforcement_findings(rules) == []
+
+
+def test_unenforced_ruleset_fails() -> None:
+    findings = rre.review_enforcement_findings(_pr_rule(count=0, code_owner=False))
+    assert findings
+    assert "require_code_owner_review=False" in " ".join(findings)
+
+
+def test_required_approving_review_count_is_not_checked() -> None:
+    for count in (0, 1, 5):
+        assert rre.review_enforcement_findings(_pr_rule(count=count, code_owner=True)) == []
+
+
+def test_missing_pull_request_rule_fails() -> None:
+    rules = [{"type": "required_status_checks", "parameters": {"required_status_checks": []}}]
+    findings = rre.review_enforcement_findings(rules)
+    assert findings and "no pull_request rule" in findings[0]
+
+
+def test_narrated_soundness_paths_come_from_shared_predicate() -> None:
+    for prefix in soundness.SOUNDNESS_PREFIXES:
+        assert any(prefix in glob for glob in rre.SOUNDNESS_PATH_GLOBS)
+    assert "benchbox/core/**/validation.py" in rre.SOUNDNESS_PATH_GLOBS
+
+
+def test_extract_rules_accepts_both_payload_shapes() -> None:
+    flat = _pr_rule(count=0, code_owner=True)
+    assert rre.extract_rules(flat) == flat
+    assert rre.extract_rules({"rules": flat}) == flat
+    assert rre.extract_rules({"name": "develop-squash-only", "rules": flat}) == flat
+
+
+def test_cli_exit_codes(tmp_path: Path) -> None:
+    import json
+
+    enforced = tmp_path / "enforced.json"
+    enforced.write_text(json.dumps(_pr_rule(count=0, code_owner=True)), encoding="utf-8")
+    unenforced = tmp_path / "unenforced.json"
+    unenforced.write_text(json.dumps(_pr_rule(count=0, code_owner=False)), encoding="utf-8")
+
+    assert rre.main(["--rules-file", str(enforced)]) == 0
+    assert rre.main(["--rules-file", str(unenforced)]) == 1


### PR DESCRIPTION
## Summary

- Restore the shared develop code-owner-review drift predicate and make it blocking by default.
- Preserve the existing blocking v* tag-creation drift flag.
- Reconcile tests and repository-admin documentation with the live GitHub rulesets.

## Why

The related PR history was audited before implementation: #1129 already landed the v* tag enforcement, while #1215 retired the develop predicate based on a stale/unverifiable state. Live verification on 2026-07-21 shows ruleset 15611785 (`develop-squash-only`) is active with `require_code_owner_review: true` and ruleset 18774756 (`v-tag-restricted`) is active for `refs/tags/v*`. This change makes those controls load-bearing in drift checks.

The current single-owner setup can still make soundness-path PRs unmergeable because self-approval is forbidden; the documentation records that operational caution.

## Verification

- Targeted release/drift suite: 109 passed, 2 deselected.
- Fast suite: 25,302 passed, 26 skipped, 2,647 deselected.
- `make docs-validate`: 57/57 examples valid.
- `make pr-preflight`: 25,286 passed, 27 skipped, 48 warnings, 4 subtests passed.
- Live develop-review and v* tag predicates both pass against current GitHub API responses.