### PR TITLE
fix(uat): durable prune counts + registry/compatibility split in reports

### DIFF
--- a/tests/uat/_cli.py
+++ b/tests/uat/_cli.py
@@ -178,12 +178,22 @@ def _handle_report(args: argparse.Namespace) -> int:
     accounting, sidecar_present = read_accounting_sidecar(Path(args.cells_jsonl))
     skipped_unreachable_count = coerce_accounting_count(accounting.get("skipped_unreachable_count", 0))
     startup_failed_count = coerce_accounting_count(accounting.get("startup_failed_count", 0))
+    # Prune counts are not cells.jsonl rows either; read them back from the
+    # sidecar so a regenerated report reconstructs the same total_defined the
+    # live report had, and registry drops stay in their own bucket instead of
+    # collapsing to compatibility_pruned=0 (uat-report-regen-prune-accounting w1/w2).
+    compatibility_pruned_count = coerce_accounting_count(accounting.get("compatibility_pruned_count", 0))
+    early_stop_pruned_count = coerce_accounting_count(accounting.get("early_stop_pruned_count", 0))
+    registry_pruned_count = coerce_accounting_count(accounting.get("registry_pruned_count", 0))
     rungs = _split_csv(args.rungs)
     summary = write_report(
         cells,
         output_path=Path(args.output_tsv),
         rungs=rungs,
         cross_scale_floor=args.cross_scale_floor,
+        compatibility_pruned_count=compatibility_pruned_count,
+        early_stop_pruned_count=early_stop_pruned_count,
+        registry_pruned_count=registry_pruned_count,
         skipped_unreachable_count=skipped_unreachable_count,
         startup_failed_count=startup_failed_count,
         unreachable_count_is_estimated=not sidecar_present,

--- a/tests/uat/cells_io.py
+++ b/tests/uat/cells_io.py
@@ -229,6 +229,9 @@ def write_cells_jsonl(
     source_info: SourceInfo,
     skipped_unreachable_count: int = 0,
     startup_failed_count: int = 0,
+    compatibility_pruned_count: int = 0,
+    early_stop_pruned_count: int = 0,
+    registry_pruned_count: int = 0,
     disk_gate_disabled: bool = False,
     container_engine: str | None = None,
     finalize: bool = True,
@@ -258,6 +261,16 @@ def write_cells_jsonl(
                 # probe that found nothing listening. Additive field -- see
                 # uat-fail-advance-consistency w3.
                 "startup_failed_count": int(startup_failed_count),
+                # Prune counts persisted so `make uat-report` regeneration
+                # reconstructs the same total_defined the live report had,
+                # instead of defaulting these to 0 (which made a regenerated
+                # report under-count) -- uat-report-regen-prune-accounting w1.
+                # registry_pruned_count is disjoint from compatibility_pruned_count:
+                # a registry/ladder drop (pruned-registry) vs a platform/benchmark
+                # compatibility-RULE drop (w2).
+                "compatibility_pruned_count": int(compatibility_pruned_count),
+                "early_stop_pruned_count": int(early_stop_pruned_count),
+                "registry_pruned_count": int(registry_pruned_count),
                 "disk_gate_disabled": bool(disk_gate_disabled),
                 # Resolved engine binary (docker/mocker/...) at sweep start --
                 # additive field, None on older artifacts and on sweeps whose

--- a/tests/uat/orchestrator.py
+++ b/tests/uat/orchestrator.py
@@ -24,6 +24,7 @@ from typing import Any
 from tests.uat import cells_io, docker_assets, gate_summary, preflight_budget
 from tests.uat.config import UATConfig, disk_gate_disabled_warning, load_config
 from tests.uat.phases import (
+    enumerate as enumerate_phase,
     execute as exec_phase,
     preflight as preflight_phase,
     report as report_phase,
@@ -396,12 +397,18 @@ def _run_sweep_phases(  # noqa: C901
                     container_engine=container_engine,
                 )
                 break
+            compat_rule_pruned_count, registry_pruned_count = enumerate_phase.count_pruned_by_kind(
+                getattr(execute_outcome, "compatibility_pruned", ())
+            )
             cells_io.write_cells_jsonl(
                 cells_jsonl,
                 execute_outcome.results,
                 source_info=source_info,
                 skipped_unreachable_count=len(getattr(execute_outcome, "skipped_unreachable", ())),
                 startup_failed_count=len(getattr(execute_outcome, "startup_failed", ())),
+                compatibility_pruned_count=compat_rule_pruned_count,
+                early_stop_pruned_count=len(getattr(execute_outcome, "pruned", ())),
+                registry_pruned_count=registry_pruned_count,
                 disk_gate_disabled=not config.disk_gate_enabled,
                 container_engine=container_engine,
             )
@@ -603,14 +610,22 @@ def _run_sweep_phases(  # noqa: C901
             # cross_scale_clean_pair_count silently degrades to a
             # passed-only check.
             validator_status_by_path = _validator_status_by_path(validator_rollup_tsv)
+            # Split registry drops out of the compatibility-rule bucket so the
+            # live report labels them under registry_pruned_count (matching the
+            # regenerated report, which reads the same split from the sidecar)
+            # -- uat-report-regen-prune-accounting w2.
+            report_compat_pruned_count, report_registry_pruned_count = enumerate_phase.count_pruned_by_kind(
+                getattr(execute_outcome, "compatibility_pruned", ())
+            )
             summary = report_phase.write_report(
                 cells,
                 output_path=tsv_path,
                 rungs=list(config.scales.requested_rungs),
                 cross_scale_floor=config.report.cross_scale_coverage_min_pairs,
                 validator_status_by_path=validator_status_by_path,
-                compatibility_pruned_count=len(getattr(execute_outcome, "compatibility_pruned", ())),
+                compatibility_pruned_count=report_compat_pruned_count,
                 early_stop_pruned_count=len(getattr(execute_outcome, "pruned", ())),
+                registry_pruned_count=report_registry_pruned_count,
                 skipped_unreachable_count=len(getattr(execute_outcome, "skipped_unreachable", ())),
                 startup_failed_count=len(getattr(execute_outcome, "startup_failed", ())),
                 source_info=source_info,
@@ -694,12 +709,18 @@ def _emit_abort_artifacts(
         )
     if startup_failed_count is None:
         startup_failed_count = len(getattr(execute_outcome, "startup_failed", ())) if execute_outcome is not None else 0
+    # Same registry/compatibility split as the happy path so an abort report
+    # and its regenerated counterpart agree on the buckets (w1/w2).
+    compat_rule_pruned_count, registry_pruned_count = enumerate_phase.count_pruned_by_kind(compatibility_pruned)
     cells_io.write_cells_jsonl(
         log_dir / "cells.jsonl",
         cells,
         source_info=source_info,
         skipped_unreachable_count=skipped_unreachable_count,
         startup_failed_count=startup_failed_count,
+        compatibility_pruned_count=compat_rule_pruned_count,
+        early_stop_pruned_count=early_stop_pruned_count,
+        registry_pruned_count=registry_pruned_count,
         disk_gate_disabled=not config.disk_gate_enabled,
         container_engine=container_engine,
     )
@@ -711,8 +732,9 @@ def _emit_abort_artifacts(
         output_path=_partial_report_path(log_dir / config.report.matrix_summary_tsv),
         rungs=list(config.scales.requested_rungs),
         cross_scale_floor=config.report.cross_scale_coverage_min_pairs,
-        compatibility_pruned_count=len(compatibility_pruned),
+        compatibility_pruned_count=compat_rule_pruned_count,
         early_stop_pruned_count=early_stop_pruned_count,
+        registry_pruned_count=registry_pruned_count,
         skipped_unreachable_count=skipped_unreachable_count,
         startup_failed_count=startup_failed_count,
         source_info=source_info,

--- a/tests/uat/phases/enumerate.py
+++ b/tests/uat/phases/enumerate.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from collections.abc import Iterable
 from dataclasses import dataclass
 
 from tests.uat.compatibility import CompatibilityRule, compatibility_rule_for
@@ -53,6 +54,26 @@ class EnumerationResult:
     @property
     def candidate_count(self) -> int:
         return len(self.cells) + len(self.compatibility_pruned)
+
+
+def is_registry_prune(cell: CompatibilityPrunedCell) -> bool:
+    """True when a pruned row is a registry/ladder-derived drop (``pruned-registry``).
+
+    Registry drops (a benchmark/platform id absent from the registry, or a
+    scale outside a benchmark's declared ``scale_options``) share the
+    ``CompatibilityPrunedCell`` shape with platform/benchmark compatibility-RULE
+    prunes, but must be accounted separately: `write_report` carries a distinct
+    ``registry_pruned_count`` bucket, and lumping registry rows into
+    ``compatibility_pruned_count`` mislabels them (uat-report-regen-prune-accounting w2).
+    """
+    return cell.status == REGISTRY_PRUNE_STATUS
+
+
+def count_pruned_by_kind(pruned: Iterable[CompatibilityPrunedCell]) -> tuple[int, int]:
+    """Split a mixed pruned-row stream into (compatibility_rule_count, registry_count)."""
+    rows = tuple(pruned)
+    registry = sum(1 for cell in rows if is_registry_prune(cell))
+    return len(rows) - registry, registry
 
 
 def enumerate_cells(

--- a/tests/uat/test_orchestrator.py
+++ b/tests/uat/test_orchestrator.py
@@ -1186,6 +1186,9 @@ def test_update_accounting_sidecar_preserves_existing_counts(tmp_path: Path):
     assert payload == {
         "skipped_unreachable_count": 3,
         "startup_failed_count": 2,
+        "compatibility_pruned_count": 0,
+        "early_stop_pruned_count": 0,
+        "registry_pruned_count": 0,
         "disk_gate_disabled": False,
         "container_engine": None,
         "explorer_smoke_status": "skipped_no_node",

--- a/tests/uat/test_report_regen_prune.py
+++ b/tests/uat/test_report_regen_prune.py
@@ -1,0 +1,118 @@
+"""make uat-report regeneration: durable prune counts + registry/compatibility split.
+
+uat-report-regen-prune-accounting:
+  w1 -- prune counts (compatibility/early_stop/registry) are persisted in the
+        accounting sidecar so a regenerated report reconstructs the same
+        total_defined the live report had, instead of defaulting them to 0.
+  w2 -- registry/ladder drops (status == pruned-registry) are accounted under
+        registry_pruned_count, not lumped into compatibility_pruned_count.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from tests.uat import _cli as uat_cli, cells_io, orchestrator
+from tests.uat.phases.enumerate import (
+    REGISTRY_PRUNE_STATUS,
+    CompatibilityPrunedCell,
+    count_pruned_by_kind,
+    is_registry_prune,
+)
+from tests.uat.runner import CellResult
+
+pytestmark = pytest.mark.fast
+
+
+def _source_info() -> orchestrator.RunSourceInfo:
+    return orchestrator.RunSourceInfo(commit_sha="deadbeef", commit_short_sha="deadbee", dirty=False)
+
+
+def _passed_cell(benchmark: str) -> CellResult:
+    return CellResult(
+        platform="duckdb",
+        benchmark=benchmark,
+        scale=0.01,
+        status="passed",
+        exit_code=0,
+        elapsed_s=1.0,
+        log_path=Path(f"/tmp/{benchmark}.log"),
+        result_path=Path(f"/tmp/{benchmark}.json"),
+    )
+
+
+def _registry_prune(benchmark: str, rule_id: str) -> CompatibilityPrunedCell:
+    return CompatibilityPrunedCell("duckdb", benchmark, 0.01, rule_id, REGISTRY_PRUNE_STATUS, "not in registry", "")
+
+
+def _compat_rule_prune(benchmark: str) -> CompatibilityPrunedCell:
+    return CompatibilityPrunedCell("clickhouse-server", benchmark, 1.0, "some-rule", "blocked", "unsupported", "")
+
+
+# ----------------------------------------------------------------------- w2
+
+
+def test_is_registry_prune_distinguishes_registry_from_compatibility():
+    assert is_registry_prune(_registry_prune("nope", "benchmark-not-in-registry")) is True
+    assert is_registry_prune(_compat_rule_prune("tpch")) is False
+
+
+def test_count_pruned_by_kind_splits_registry_from_compatibility():
+    rows = [
+        _registry_prune("nope", "benchmark-not-in-registry"),
+        _registry_prune("nope-platform", "platform-not-in-registry"),
+        _compat_rule_prune("tpch"),
+    ]
+    assert count_pruned_by_kind(rows) == (1, 2)  # (compatibility_rule, registry)
+    assert count_pruned_by_kind(()) == (0, 0)
+    assert count_pruned_by_kind(iter(rows)) == (1, 2)  # accepts any iterable
+
+
+# ----------------------------------------------------------------------- w1
+
+
+def test_regen_report_reconstructs_prune_counts_from_sidecar(tmp_path: Path, capsys: pytest.CaptureFixture[str]):
+    """A regenerated report reads the prune counts back from the sidecar, so its
+    total_defined matches the live report instead of collapsing the prunes to 0."""
+    cells_jsonl = tmp_path / "cells.jsonl"
+    cells_io.write_cells_jsonl(
+        cells_jsonl,
+        [_passed_cell("tpch"), _passed_cell("tpcds")],  # 2 attempted
+        source_info=_source_info(),
+        compatibility_pruned_count=2,
+        early_stop_pruned_count=1,
+        registry_pruned_count=3,
+    )
+    output_tsv = tmp_path / "matrix_summary.tsv"
+
+    exit_code = uat_cli.main(["report", "--cells-jsonl", str(cells_jsonl), "--output-tsv", str(output_tsv)])
+
+    assert exit_code == 0
+    payload = json.loads(capsys.readouterr().out)
+    # 2 attempted + (2 compat + 1 early_stop + 3 registry) skipped = 8. Without
+    # the durable sidecar counts this would collapse to 2.
+    assert payload["total_defined"] == 8
+    assert payload["registry_pruned"] == 3
+    text = output_tsv.read_text(encoding="utf-8")
+    # Registry rows stay in their own bucket, not folded into compatibility.
+    assert "compatibility_pruned=2" in text
+    assert "registry_pruned=3" in text
+    assert "early_stop_pruned=1" in text
+
+
+def test_regen_without_prune_counts_is_unchanged(tmp_path: Path, capsys: pytest.CaptureFixture[str]):
+    """A sidecar with no prune counts (older artifact / no prunes) still reads 0,
+    so the pinned no-prune regeneration behavior is preserved."""
+    cells_jsonl = tmp_path / "cells.jsonl"
+    cells_io.write_cells_jsonl(cells_jsonl, [_passed_cell("tpch")], source_info=_source_info())
+    output_tsv = tmp_path / "matrix_summary.tsv"
+
+    exit_code = uat_cli.main(["report", "--cells-jsonl", str(cells_jsonl), "--output-tsv", str(output_tsv)])
+
+    assert exit_code == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["total_defined"] == 1
+    assert payload["registry_pruned"] == 0


### PR DESCRIPTION
`make uat-report` regeneration lost the prune counts and mislabeled
registry drops:

w1: the accounting sidecar only persisted skipped_unreachable and
startup_failed, so a regenerated report defaulted compatibility/
early_stop/registry prune counts to 0 and its total_defined
under-counted vs the live report. Persist all three prune counts in
the sidecar (cells_io.write_cells_jsonl) and read them back in
_handle_report.

w2: the live report and the regen both passed every compatibility_pruned
row (including status==pruned-registry registry/ladder drops) as
compatibility_pruned_count with registry_pruned_count=0. Add
enumerate.is_registry_prune / count_pruned_by_kind and split the two
buckets in the live report, the sidecar, and the abort path. total_defined
is unchanged (both buckets feed skipped); only the labeling is corrected.

Backward-compatible: a sidecar without the new fields reads 0, so
no-prune regeneration is unchanged. Adds tests/uat/test_report_regen_prune.py;
full tests/uat lane (573) green.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
