### PR TITLE
fix(tuning): correct capability-registry entries resting on the dead generate_tuning_clause mixin

### DIFF
--- a/benchbox/core/tuning/capability_registry.py
+++ b/benchbox/core/tuning/capability_registry.py
@@ -160,10 +160,23 @@ PLATFORM_ALIASES: dict[str, str] = {
 # entry in `interface._PLATFORM_COMPATIBILITY_MAP` (the historical
 # compatibility map) or explicitly named in the renderer-consolidation TODO
 # (`starrocks`, `doris`) are covered; the DDL generator registry additionally
-# covers ~10 more SQL platforms (redshift, snowflake, etc. below) whose
-# adapter execution paths were not audited/migrated this round -- their
-# entries reflect the "per-adapter mixin" renderer ADR-3 calls the third
-# rendering universe, unchanged by this TODO.
+# covers ~10 more SQL platforms (redshift, snowflake, etc. below).
+#
+# Honesty correction (`tuning-registry-mixin-honesty`): the postgresql,
+# snowflake, redshift, bigquery and mysql entries below previously claimed
+# `_ddl("adapter_mixin:<X>Adapter.generate_tuning_clause", ...)`, but that
+# mixin has no production call site anywhere -- create_schema builds DDL from
+# `benchmark.get_create_tables_sql(tuning_config=...)`, which reads
+# tuning_config only for PK/FK constraint flags, never the partition/cluster/
+# distribution/sort columns (see e.g. core/tpch/benchmark.py:423-426). Those
+# entries now describe reality: snowflake renders CLUSTERING/PARTITIONING
+# post-load via a real ALTER TABLE ... CLUSTER BY in apply_table_tunings,
+# while postgresql/redshift/bigquery/mysql render nothing at execution
+# (rendered_via="none"; their generators/*.py DDL generators, where present,
+# feed dry-run preview only) -- the same preview-only reality PR #1198
+# recorded for the 9 coverage platforms below. The set of compatible tuning
+# types per platform is unchanged, so is_compatible_with_platform behavior is
+# preserved.
 PLATFORM_TUNING_CAPABILITIES: dict[str, dict[TuningType, TuningCapability]] = {
     "duckdb": {
         _T.SORTING: _post_load(
@@ -257,42 +270,109 @@ PLATFORM_TUNING_CAPABILITIES: dict[str, dict[TuningType, TuningCapability]] = {
         **_constraint_entries(),
     },
     "snowflake": {
-        _T.CLUSTERING: _ddl(
-            "adapter_mixin:SnowflakeAdapter.generate_tuning_clause",
-            "Execution still renders via the adapter's own generate_tuning_clause mixin, independent of "
-            "core.tuning.generators.snowflake.SnowflakeDDLGenerator (dry-run preview's renderer). Third "
-            "rendering universe per ADR-3; not in this TODO's migration order (duckdb, clickhouse, "
-            "starrocks).",
+        _T.CLUSTERING: _post_load(
+            "adapter_mixin:SnowflakeAdapter.apply_table_tunings",
+            "Real execution issues ALTER TABLE ... CLUSTER BY (...) from "
+            "SnowflakeAdapter.apply_table_tunings (snowflake.py:1710), reached via apply_unified_tuning -> "
+            "apply_standard_unified_tuning after create_schema (base/result_capture.py:1751-1753). This is "
+            "NOT part of the CREATE TABLE ddl and does NOT go through the adapter's generate_tuning_clause "
+            "mixin (snowflake.py:1605): that method builds a CLUSTER BY string but has no production call "
+            "site anywhere, and get_create_tables_sql consumes tuning_config only for PK/FK constraint "
+            "flags, never clustering columns. core.tuning.generators.snowflake.SnowflakeDDLGenerator emits "
+            "CLUSTER BY for dry-run preview only.",
         ),
-        _T.PARTITIONING: _ddl("adapter_mixin:SnowflakeAdapter.generate_tuning_clause", "See CLUSTERING entry."),
+        _T.PARTITIONING: _post_load(
+            "adapter_mixin:SnowflakeAdapter.apply_table_tunings",
+            "apply_table_tunings folds partitioning columns into the same ALTER TABLE ... CLUSTER BY when "
+            "no clustering columns are configured (snowflake.py:1690-1693); Snowflake has no separate "
+            "partition clause. See CLUSTERING entry for the full mechanism/evidence.",
+        ),
         _T.MATERIALIZED_VIEWS: _none("unimplemented", "Compatible per the legacy map; no adapter implementation."),
         **_constraint_entries(),
     },
     "bigquery": {
-        _T.PARTITIONING: _ddl("adapter_mixin:BigQueryAdapter.generate_tuning_clause", "See snowflake entry note."),
-        _T.CLUSTERING: _ddl("adapter_mixin:BigQueryAdapter.generate_tuning_clause", "See snowflake entry note."),
+        _T.PARTITIONING: _none(
+            "bigquery_ddl_generator:preview_only",
+            "core.tuning.generators.bigquery.BigQueryDDLGenerator computes a real PARTITION BY clause from "
+            "tuned columns for dry-run preview, but real execution never renders it. "
+            "BigQueryAdapter.generate_tuning_clause builds PARTITION BY/CLUSTER BY (bigquery.py:1893) but "
+            "has no production call site; get_create_tables_sql consumes tuning_config only for PK/FK "
+            "flags, never partition/cluster columns; and apply_table_tunings only inspects the table and "
+            "logs 'Consider recreating the table' (bigquery.py:2023-2027) -- it never re-creates it. "
+            "Corrects the prior false _ddl(adapter_mixin:BigQueryAdapter.generate_tuning_clause) claim.",
+        ),
+        _T.CLUSTERING: _none(
+            "bigquery_ddl_generator:preview_only",
+            "Same execution gap as PARTITIONING: generate_tuning_clause emits CLUSTER BY "
+            "(bigquery.py:1940-1949) and the generator previews it, but nothing renders it at execution "
+            "(apply_table_tunings only logs a recreation hint, bigquery.py:2013-2027).",
+        ),
         _T.MATERIALIZED_VIEWS: _none("unimplemented", "Compatible per the legacy map; no adapter implementation."),
         _T.PRIMARY_KEYS: _ddl(_INLINE_CONSTRAINT, _CONSTRAINT_NOTE),
         _T.FOREIGN_KEYS: _ddl(_INLINE_CONSTRAINT, _CONSTRAINT_NOTE),
         _T.CHECK_CONSTRAINTS: _ddl(_INLINE_CONSTRAINT, _CONSTRAINT_NOTE),
     },
     "redshift": {
-        _T.DISTRIBUTION: _ddl("adapter_mixin:RedshiftAdapter.generate_tuning_clause", "See snowflake entry note."),
-        _T.SORTING: _ddl("adapter_mixin:RedshiftAdapter.generate_tuning_clause", "See snowflake entry note."),
-        _T.PARTITIONING: _ddl("adapter_mixin:RedshiftAdapter.generate_tuning_clause", "See snowflake entry note."),
+        _T.DISTRIBUTION: _none(
+            "redshift_ddl_generator:preview_only",
+            "core.tuning.generators.redshift.RedshiftDDLGenerator computes real DISTSTYLE/DISTKEY clauses "
+            "from tuned columns for dry-run preview, but real execution never renders them. "
+            "RedshiftAdapter.generate_tuning_clause builds DISTSTYLE KEY/DISTKEY (redshift.py:2464) but has "
+            "no production call site; get_create_tables_sql consumes tuning_config only for PK/FK flags, "
+            "never distribution columns; and apply_table_tunings only reads pg_table_def and logs "
+            "'Redshift requires table recreation to change distribution/sort keys' (redshift.py:2607-2611) "
+            "without recreating, then runs ANALYZE/VACUUM maintenance only (redshift.py:2616-2624). "
+            "Corrects the prior false _ddl(adapter_mixin:RedshiftAdapter.generate_tuning_clause) claim.",
+        ),
+        _T.SORTING: _none(
+            "redshift_ddl_generator:preview_only",
+            "Same execution gap as DISTRIBUTION: SORTKEY is built only by the uncalled generate_tuning_clause "
+            "mixin (redshift.py:2500-2510) and the preview generator; apply_table_tunings logs the sort-key "
+            "mismatch (redshift.py:2599-2605) but cannot apply it without table recreation.",
+        ),
+        _T.PARTITIONING: _none(
+            "redshift_no_partition_rendering",
+            "Redshift has no CREATE TABLE partition clause; generate_tuning_clause explicitly emits nothing "
+            "for partitioning (redshift.py:2512-2517) and apply_table_tunings only logs the strategy "
+            "(redshift.py:2629-2636). Nothing is rendered at execution.",
+        ),
         _T.MATERIALIZED_VIEWS: _none("unimplemented", "Compatible per the legacy map; no adapter implementation."),
         **_constraint_entries(),
     },
     "sqlite": _constraint_entries(),
     "postgresql": {
-        _T.PARTITIONING: _ddl("adapter_mixin:PostgreSQLAdapter.generate_tuning_clause", "See snowflake entry note."),
-        _T.CLUSTERING: _ddl("adapter_mixin:PostgreSQLAdapter.generate_tuning_clause", "See snowflake entry note."),
+        _T.PARTITIONING: _none(
+            "postgresql_ddl_generator:preview_only",
+            "core.tuning.generators.postgresql.PostgreSQLDDLGenerator computes a real PARTITION BY RANGE/"
+            "LIST/HASH clause from tuned columns (generators/postgresql.py:139) for dry-run preview, but "
+            "real execution never renders it. PostgreSQLAdapter.generate_tuning_clause unconditionally "
+            "returns '' (postgresql.py:972-977) and has no production call site; apply_table_tunings and "
+            "apply_unified_tuning are both no-ops (postgresql.py:968-970, 979-981); and get_create_tables_sql "
+            "consumes tuning_config only for PK/FK constraint flags. Corrects the prior false "
+            "_ddl(adapter_mixin:PostgreSQLAdapter.generate_tuning_clause) claim (already flagged in the "
+            "pg-duckdb entry below).",
+        ),
+        _T.CLUSTERING: _none(
+            "postgresql_ddl_generator:preview_only",
+            "Same execution gap as PARTITIONING: the preview generator emits a CREATE INDEX + CLUSTER pair "
+            "(generators/postgresql.py:141-159) but the uncalled generate_tuning_clause mixin returns '' and "
+            "the no-op apply path renders nothing at execution.",
+        ),
         _T.BLOOM_FILTERS: _none("unimplemented", "Compatible per the legacy map; no adapter implementation."),
         _T.MATERIALIZED_VIEWS: _none("unimplemented", "Compatible per the legacy map; no adapter implementation."),
         **_constraint_entries(),
     },
     "mysql": {
-        _T.PARTITIONING: _ddl("adapter_mixin:MySQLAdapter.generate_tuning_clause", "See snowflake entry note."),
+        _T.PARTITIONING: _none(
+            "mysql_no_generator_dead_mixin",
+            "No MySQLAdapter class exists (the prior mechanism named a nonexistent class); MySQL-wire "
+            "adapters mix in base.mysql_wire.NoOpTableTuningMixin, whose generate_tuning_clause returns '' "
+            "(base/mysql_wire.py:475-476) and whose apply_table_tunings/apply_unified_tuning are no-ops "
+            "(base/mysql_wire.py:472-473, 478-479). get_ddl_generator('mysql') has no real generator and "
+            "falls through to NoOpDDLGenerator, so no MySQL PARTITION BY is rendered at preview or "
+            "execution. Corrects the prior false "
+            "_ddl(adapter_mixin:MySQLAdapter.generate_tuning_clause) claim.",
+        ),
         **_constraint_entries(),
     },
     # Explicitly named by the renderer-consolidation TODO even though absent

--- a/tests/unit/core/tuning/test_capability_source_drift.py
+++ b/tests/unit/core/tuning/test_capability_source_drift.py
@@ -616,3 +616,157 @@ class TestCapabilityMapperVsCompatibilityMapDrift:
         # additions (or removals) are caught even though they wouldn't
         # necessarily create a compat-map divergence.
         assert frozenset({"databricks", "duckdb", "bigquery", "redshift", "snowflake"}) == CAPABILITY_SUPPORTED_KEYS
+
+
+# ---------------------------------------------------------------------------
+# w2 (`tuning-registry-mixin-honesty`): honesty guards on the registry's
+# rendering-mechanism claims. Standalone functions (rather than edits to the
+# allowlists/classes above) so they merge cleanly with concurrent registry
+# work. Before this fix, postgresql/snowflake/redshift/bigquery/mysql claimed
+# `_ddl("adapter_mixin:<X>Adapter.generate_tuning_clause", ...)`, but that
+# mixin has no production call site: schema DDL comes from
+# `benchmark.get_create_tables_sql(tuning_config=...)`, which reads
+# tuning_config only for PK/FK constraint flags. These guards make any
+# dead-mechanism ddl/post_load/session claim fail.
+# ---------------------------------------------------------------------------
+
+_ADAPTER_MIXIN_MECHANISM = r"^adapter_mixin:(\w+)\.(\w+)$"
+_platform_source_cache: tuple[tuple[str, str], ...] | None = None
+
+
+def _platform_source_texts() -> tuple[tuple[str, str], ...]:
+    """(path, text) for every .py under benchbox/platforms/, read once and cached.
+
+    The platforms tree is where create_schema / apply_table_tunings /
+    apply_unified_tuning live, and it deliberately excludes
+    capability_registry.py's own note strings (which mention
+    ``.generate_tuning_clause(`` in prose, not as a call site).
+    """
+    global _platform_source_cache
+    if _platform_source_cache is None:
+        import pathlib
+
+        import benchbox.core.tuning.capability_registry as capreg
+
+        platforms_dir = pathlib.Path(capreg.__file__).resolve().parents[2] / "platforms"
+        sources: list[tuple[str, str]] = []
+        for path in sorted(platforms_dir.rglob("*.py")):
+            try:
+                sources.append((str(path), path.read_text(encoding="utf-8")))
+            except (OSError, UnicodeDecodeError):
+                continue
+        _platform_source_cache = tuple(sources)
+    return _platform_source_cache
+
+
+def _iter_registry_capabilities():
+    for platform, entries in PLATFORM_TUNING_CAPABILITIES.items():
+        for tuning_type, capability in entries.items():
+            yield platform, tuning_type, capability
+
+
+def _method_has_call_site(method_name: str) -> bool:
+    """True if ``.<method_name>(`` is invoked anywhere under benchbox/platforms/.
+
+    The leading dot means a definition (``def <method_name>(``) never matches;
+    only genuine ``self.foo(`` / ``adapter.foo(`` call expressions do.
+    """
+    needle = f".{method_name}("
+    return any(needle in text for _path, text in _platform_source_texts())
+
+
+def _find_adapter_method_source(class_name: str, method_name: str) -> str | None:
+    """Source of ``<class_name>.<method_name>`` if defined under benchbox/platforms/, else None."""
+    for _path, text in _platform_source_texts():
+        try:
+            tree = ast.parse(text)
+        except SyntaxError:
+            continue
+        for node in ast.walk(tree):
+            if isinstance(node, ast.ClassDef) and node.name == class_name:
+                for item in node.body:
+                    if isinstance(item, (ast.FunctionDef, ast.AsyncFunctionDef)) and item.name == method_name:
+                        return ast.get_source_segment(text, item)
+    return None
+
+
+def _method_only_returns_empty_string(method_source: str) -> bool:
+    """True if every ``return`` in the method yields ``""`` (an inert stub)."""
+    import textwrap
+
+    func = ast.parse(textwrap.dedent(method_source)).body[0]
+    returns = [node for node in ast.walk(func) if isinstance(node, ast.Return)]
+    if not returns:
+        return False
+    return all(isinstance(node.value, ast.Constant) and node.value.value == "" for node in returns)
+
+
+def test_generate_tuning_clause_has_no_production_call_site():
+    """The ``generate_tuning_clause`` adapter mixin is never invoked in production.
+
+    Every SQL adapter defines it, but a scan of benchbox/platforms/ for
+    ``.generate_tuning_clause(`` call sites (create_schema, apply_table_tunings,
+    apply_unified_tuning, ...) finds none. This is the empirical basis for the
+    ``tuning-registry-mixin-honesty`` correction: no registry entry may claim a
+    tuning type renders via that dead mixin. If a real call site is ever wired
+    in, this flips red on purpose -- update the registry to point at the new
+    call site and relax this guard.
+    """
+    assert not _method_has_call_site("generate_tuning_clause"), (
+        "generate_tuning_clause now has a production call site under benchbox/platforms/; the capability "
+        "registry's 'no ddl claim rests on this dead mixin' invariant needs revisiting."
+    )
+
+
+def test_no_registry_entry_rests_on_generate_tuning_clause_mixin():
+    """No capability entry may name the dead ``generate_tuning_clause`` mixin as its mechanism.
+
+    Reintroducing ``_ddl("adapter_mixin:<X>Adapter.generate_tuning_clause", ...)``
+    for postgresql/snowflake/redshift/bigquery/mysql (the pre-honesty claim)
+    turns this red immediately.
+    """
+    offenders = [
+        f"{platform}/{tuning_type.value} (rendered_via={cap.rendered_via}, mechanism={cap.mechanism_id})"
+        for platform, tuning_type, cap in _iter_registry_capabilities()
+        if "generate_tuning_clause" in cap.mechanism_id
+    ]
+    assert offenders == [], (
+        "Capability entries claim rendering via the dead generate_tuning_clause mixin (no production call "
+        "site -- see test_generate_tuning_clause_has_no_production_call_site):\n  " + "\n  ".join(offenders)
+    )
+
+
+def test_adapter_mixin_rendering_mechanisms_are_live_and_nonempty():
+    """Any ``adapter_mixin:<Class>.<method>`` rendering mechanism must be live and non-stub.
+
+    For every entry that claims rendering (rendered_via ddl/post_load/session)
+    via an ``adapter_mixin:<Class>.<method>`` mechanism, the named method must
+    (a) exist on that class under benchbox/platforms/, (b) have a production
+    call site, and (c) not be a stub that only ``return ""``. This generalises
+    the generate_tuning_clause fix: a dead-mechanism claim -- an uncalled
+    method, an empty-return stub, or a nonexistent class (e.g. the old
+    ``MySQLAdapter``) -- fails here. Today only snowflake's live
+    ``apply_table_tunings`` mechanism exercises this guard.
+    """
+    import re
+
+    offenders: list[str] = []
+    for platform, tuning_type, cap in _iter_registry_capabilities():
+        if cap.rendered_via not in ("ddl", "post_load", "session"):
+            continue
+        match = re.match(_ADAPTER_MIXIN_MECHANISM, cap.mechanism_id)
+        if match is None:
+            continue
+        class_name, method_name = match.group(1), match.group(2)
+        label = f"{platform}/{tuning_type.value} (mechanism={cap.mechanism_id})"
+        source = _find_adapter_method_source(class_name, method_name)
+        if source is None:
+            offenders.append(f"{label}: {class_name}.{method_name} is not defined under benchbox/platforms/")
+            continue
+        if _method_only_returns_empty_string(source):
+            offenders.append(f"{label}: {class_name}.{method_name} unconditionally returns '' (dead stub)")
+        if not _method_has_call_site(method_name):
+            offenders.append(f"{label}: {method_name} has no production call site under benchbox/platforms/")
+    assert offenders == [], "adapter_mixin rendering mechanisms that are dead, empty, or unresolved:\n  " + "\n  ".join(
+        offenders
+    )


### PR DESCRIPTION
## Capability-registry mixin honesty

Implements `tuning-registry-mixin-honesty-20260717`. Corrects capability-registry entries that falsely claimed tuning DDL renders via the `generate_tuning_clause` adapter mixin.

### Finding (w0)
`generate_tuning_clause` has **zero production call sites** — real `CREATE TABLE` DDL comes from `benchmark.get_create_tables_sql(tuning_config=...)`, which reads `tuning_config` only for PK/FK constraint flags (never partition/cluster/distribution/sort), and the `get_ddl_generator` generators feed **dry-run preview only**. Per-platform reality:

| platform | tuning types | reality |
|---|---|---|
| snowflake | clustering, partitioning | **post_load** — real `ALTER TABLE … CLUSTER BY` in `apply_table_tunings` (snowflake.py:1710), not the mixin |
| postgresql | partitioning, clustering | **none** — mixin returns `""`, apply is a no-op, generator preview-only |
| redshift | distribution, sorting, partitioning | **none** — mixin never called; apply only logs "requires recreation" + ANALYZE/VACUUM |
| bigquery | partitioning, clustering | **none** — apply only logs "Consider recreating" |
| mysql | partitioning | **none** — no `MySQLAdapter` class exists; mysql-wire uses `NoOpTableTuningMixin` |

### Changes
- **`capability_registry.py`**: the five entries rewritten to honest `rendered_via`/`mechanism`/notes (snowflake→`post_load`; the rest→`none` with `<gen>_ddl_generator:preview_only` + file:line evidence). **Tuning-type key sets are unchanged**, so `is_compatible_with_platform` behavior is identical (frozen-baseline test passes).
- **`test_capability_source_drift.py`**: 3 guards — `generate_tuning_clause` has no production call site; no registry entry rests on the dead mixin; any `adapter_mixin:<Class>.<method>` ddl/post_load claim must exist, have a call site, and not be an empty-return stub. Confirmed to go **red** on reintroducing a dead claim.

### Verify
`pytest tests/unit/core/tuning -k 'drift or registry'` → **62 passed**; full `tests/unit/core/tuning` → **574 passed**. ruff/ty clean. Rebased onto #1-merged develop (fast lane 25383 < cap — no bump needed).

### Preserved
PR #1198's nine `none`-entries, the emptied allowlist, the starrocks entry, and `EXPECTED_GENERATOR_ONLY_KEYS` are untouched (coordination surfaces). The dead `generate_tuning_clause` mixins are **not** deleted here (coordinated with the applied-ledger effort).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
