### PR TITLE
feat(explorer): consume requested_config_hash + applied_ledger_hash from bundles

### DIFF
--- a/_project/scripts/explorer_pipeline/duckdb_builder.py
+++ b/_project/scripts/explorer_pipeline/duckdb_builder.py
@@ -397,6 +397,11 @@ class DuckDBSnapshotBuilder:
                 execution_mode       VARCHAR,
                 tuning_mode          VARCHAR,
                 tuning_hash          VARCHAR,
+                -- ADR-1 bundle-emitted tuning identities (display-only, never
+                -- a join/dedup key): canonical requested-config hash and the
+                -- physical applied-ledger hash. NULL for legacy bundles.
+                requested_config_hash VARCHAR,
+                applied_ledger_hash   VARCHAR,
                 test_type            VARCHAR,
                 validation_status    VARCHAR,
                 cost_usd             DOUBLE,
@@ -461,6 +466,8 @@ class DuckDBSnapshotBuilder:
                 r.execution_mode,
                 r.tuning_mode,
                 r.tuning_hash,
+                r.requested_config_hash,
+                r.applied_ledger_hash,
                 r.test_type,
                 r.validation_status,
                 r.cost_usd,
@@ -785,6 +792,8 @@ class DuckDBSnapshotBuilder:
                     entry.execution_mode,
                     entry.tuning_mode,
                     entry.tuning_hash,
+                    entry.requested_config_hash,
+                    entry.applied_ledger_hash,
                     entry.test_type,
                     entry.validation_status,
                     entry.cost_usd,

--- a/_project/scripts/explorer_pipeline/models.py
+++ b/_project/scripts/explorer_pipeline/models.py
@@ -152,7 +152,15 @@ class ManifestEntry(BaseModel):
     platform_version: str | None = None
     execution_mode: str | None = None
     tuning_mode: str | None = None
+    # Self-derived, display-only tuning fingerprint (see transformer._tuning_hash).
+    # Kept for legacy bundles; NEVER a join/dedup/grouping key.
     tuning_hash: str | None = None
+    # ADR-1 bundle-emitted tuning identities, ingested verbatim from the
+    # bundle's platform.tuning summary (never recomputed here): the canonical
+    # requested-config hash and the physical applied-ledger hash. Null for
+    # legacy bundles predating these fields. Display-only, like tuning_hash.
+    requested_config_hash: str | None = None
+    applied_ledger_hash: str | None = None
     test_type: str | None = None
     validation_status: str | None = None
     failed_query_count: int = 0
@@ -355,7 +363,15 @@ class DetailResult(BaseModel):
     platform_version: str | None = None
     execution_mode: str | None = None
     tuning_mode: str | None = None
+    # Self-derived, display-only tuning fingerprint (see transformer._tuning_hash).
+    # Kept for legacy bundles; NEVER a join/dedup/grouping key.
     tuning_hash: str | None = None
+    # ADR-1 bundle-emitted tuning identities, ingested verbatim from the
+    # bundle's platform.tuning summary (never recomputed here): the canonical
+    # requested-config hash and the physical applied-ledger hash. Null for
+    # legacy bundles predating these fields. Display-only, like tuning_hash.
+    requested_config_hash: str | None = None
+    applied_ledger_hash: str | None = None
     test_type: str | None = None
     validation_status: str | None = None
     failed_query_count: int = 0

--- a/_project/scripts/explorer_pipeline/transformer.py
+++ b/_project/scripts/explorer_pipeline/transformer.py
@@ -237,6 +237,51 @@ def _tuning_hash(data: dict[str, Any]) -> str | None:
     return hashlib.sha256(payload.encode()).hexdigest()[:8]
 
 
+def _tuning_summary(data: dict[str, Any]) -> dict[str, Any] | None:
+    """Return the ``platform.tuning`` summary block, or None when absent.
+
+    This is the per-platform tuning summary emitted by
+    ``benchbox/core/results/schema.py::_build_tuning_summary`` -- the same
+    block that carries ``logical_profile`` (see ``_logical_profile``). None
+    for legacy bundles that never recorded a tuning summary.
+    """
+    platform = data.get("platform", {})
+    if not isinstance(platform, dict):
+        return None
+    tuning = platform.get("tuning", {})
+    return tuning if isinstance(tuning, dict) else None
+
+
+def _requested_config_hash(data: dict[str, Any]) -> str | None:
+    """Ingest the ADR-1 canonical requested-config hash from the bundle.
+
+    Read verbatim from ``platform.tuning.requested_config_hash`` (emitted by
+    ``_build_tuning_summary``); never recomputed here. None for legacy bundles
+    that predate the field. Display-only, like ``tuning_hash`` -- never a
+    join/dedup/grouping key.
+    """
+    summary = _tuning_summary(data)
+    if summary is None:
+        return None
+    val = summary.get("requested_config_hash")
+    return str(val) if val else None
+
+
+def _applied_ledger_hash(data: dict[str, Any]) -> str | None:
+    """Ingest the ADR-1 physical applied-ledger hash from the bundle.
+
+    Read verbatim from ``platform.tuning.applied_ledger_hash`` (emitted by
+    ``_build_tuning_summary`` from the execution-path applied ledger); never
+    recomputed here. None for legacy bundles, or new-generation bundles whose
+    applied ledger recorded no executed statements. Display-only.
+    """
+    summary = _tuning_summary(data)
+    if summary is None:
+        return None
+    val = summary.get("applied_ledger_hash")
+    return str(val) if val else None
+
+
 def _logical_profile(data: dict[str, Any]) -> dict[str, Any] | None:
     """Extract the `platform.tuning.logical_profile` block (ADR-2 §3).
 
@@ -925,6 +970,8 @@ class BundleTransformer:
             execution_mode=_execution_mode(bundle_data),
             tuning_mode=_tuning_mode(bundle_data),
             tuning_hash=_tuning_hash(bundle_data),
+            requested_config_hash=_requested_config_hash(bundle_data),
+            applied_ledger_hash=_applied_ledger_hash(bundle_data),
             test_type=_test_type(bundle_data),
             validation_status=_validation_status(bundle_data),
             failed_query_count=failed_query_count,
@@ -1007,6 +1054,8 @@ class BundleTransformer:
             execution_mode=_execution_mode(bundle_data),
             tuning_mode=_tuning_mode(bundle_data),
             tuning_hash=_tuning_hash(bundle_data),
+            requested_config_hash=_requested_config_hash(bundle_data),
+            applied_ledger_hash=_applied_ledger_hash(bundle_data),
             test_type=_test_type(bundle_data),
             validation_status=_validation_status(bundle_data),
             failed_query_count=bundle_failed_query_count(bundle_data),

--- a/results-explorer/src/components/ComparabilityReceipt.tsx
+++ b/results-explorer/src/components/ComparabilityReceipt.tsx
@@ -1,5 +1,5 @@
 import type { DetailResult, Environment } from "@/types";
-import { humanizeBenchmark } from "@/utils";
+import { humanizeBenchmark, shortHash } from "@/utils";
 import { costModelSummary, costScopeSummary, normalizedCostLabel } from "@/lib/costDisplay";
 import { formatCount, formatWarningCount } from "@/lib/copyFormatters";
 import { StatusBadge, type StatusTone } from "@/components/StatusBadge";
@@ -227,10 +227,21 @@ function queryCount(result: DetailResult) {
 }
 
 function formatTuning(result: DetailResult) {
-  if (!result.tuning_mode && !result.tuning_hash && !result.has_tuning) return "Not recorded";
+  // The fingerprint is built from the ADR-1 bundle-emitted identities only:
+  // the canonical requested-config hash and the physical applied-ledger hash.
+  // The self-derived `tuning_hash` is NOT used here -- it must stay
+  // display-only and never act as a comparability key. When neither identity
+  // hash exists (legacy / mode-only bundles) the coarse `tuning_mode` is shown
+  // as a plain label, not dressed up as a hash-level fingerprint it isn't.
+  const requestedHash = result.requested_config_hash;
+  const appliedHash = result.applied_ledger_hash;
+  if (!result.tuning_mode && !requestedHash && !appliedHash && !result.has_tuning) {
+    return "Not recorded";
+  }
   const parts = [
     result.tuning_mode ? result.tuning_mode : "Recorded",
-    result.tuning_hash ? `hash ${result.tuning_hash}` : null,
+    requestedHash ? `requested ${shortHash(requestedHash)}` : null,
+    appliedHash ? `applied ${shortHash(appliedHash)}` : null,
   ].filter((part): part is string => part !== null);
   return parts.join(", ");
 }

--- a/results-explorer/src/components/RunReceipt.tsx
+++ b/results-explorer/src/components/RunReceipt.tsx
@@ -1,7 +1,7 @@
 import { useState } from "preact/hooks";
 import type { ComponentChildren } from "preact";
 import type { DetailResult } from "@/types";
-import { humanizeBenchmark } from "@/utils";
+import { humanizeBenchmark, shortHash } from "@/utils";
 import { costModelSummary, costScopeSummary, normalizedCostLabel } from "@/lib/costDisplay";
 import {
   formatFunding,
@@ -51,6 +51,22 @@ function rowFromSummary(label: string, value: string): ReceiptRow {
   return recordedRow(label, value);
 }
 
+/**
+ * Row for a full-length identity hash (ADR-1 requested-config / applied-ledger
+ * SHA-256). Renders a monospace prefix for readability while the full value
+ * stays available in the `title` tooltip, keeping the receipt compact without
+ * hiding identity. Missing for legacy bundles that never recorded the hash.
+ */
+function hashRow(label: string, raw: string | null | undefined): ReceiptRow {
+  if (raw === null || raw === undefined || raw === "") return missingRow(label);
+  return recordedRow(
+    label,
+    <code class="font-mono text-xs" title={raw}>
+      {shortHash(raw)}
+    </code>,
+  );
+}
+
 export function RunReceipt({
   detail,
   shortId = null,
@@ -82,6 +98,12 @@ export function RunReceipt({
         rowFromString("Execution mode", detail.execution_mode),
         rowFromString("Tuning mode", detail.tuning_mode),
         rowFromString("Tuning hash", detail.tuning_hash),
+        // ADR-1 bundle-emitted tuning identities, shown as distinct labeled
+        // kinds: the canonical requested-config hash and the physical
+        // applied-ledger hash. Distinct from the self-derived "Tuning hash"
+        // above; null for legacy bundles.
+        hashRow("Requested config hash", detail.requested_config_hash),
+        hashRow("Applied ledger hash", detail.applied_ledger_hash),
       ],
     },
     {

--- a/results-explorer/src/lib/duckdbQueries.ts
+++ b/results-explorer/src/lib/duckdbQueries.ts
@@ -58,6 +58,12 @@ export interface ResultRow extends CostDeploymentFields {
   execution_mode: string | null;
   tuning_mode: string | null;
   tuning_hash: string | null;
+  // ADR-1 bundle-emitted tuning identities (see DetailResult in types.ts):
+  // canonical requested-config hash and physical applied-ledger hash. Optional
+  // (like physical_rendering_id below) so fixtures/SQL paths predating these
+  // columns default to undefined. Display-only; never a join/dedup key.
+  requested_config_hash?: string | null;
+  applied_ledger_hash?: string | null;
   test_type: string | null;
   validation_status: string | null;
   cost_usd: number | null;
@@ -292,6 +298,8 @@ const RESULT_COLUMNS = [
   "execution_mode",
   "tuning_mode",
   "tuning_hash",
+  "requested_config_hash",
+  "applied_ledger_hash",
   "test_type",
   "validation_status",
   "cost_usd",
@@ -349,6 +357,8 @@ const RESULT_DETAIL_METRICS_COLUMNS = [
   "execution_mode",
   "tuning_mode",
   "tuning_hash",
+  "requested_config_hash",
+  "applied_ledger_hash",
   "test_type",
   "validation_status",
   "cost_usd",
@@ -633,6 +643,8 @@ export async function getDetailResult(resultId: string): Promise<DetailResult | 
     execution_mode: wide.execution_mode,
     tuning_mode: wide.tuning_mode,
     tuning_hash: wide.tuning_hash,
+    requested_config_hash: wide.requested_config_hash ?? null,
+    applied_ledger_hash: wide.applied_ledger_hash ?? null,
     test_type: wide.test_type,
     validation_status: wide.validation_status,
     cost_usd: wide.cost_usd,

--- a/results-explorer/src/types.ts
+++ b/results-explorer/src/types.ts
@@ -92,7 +92,17 @@ export interface DetailResult extends CostDeploymentFields {
   platform_version: string | null;
   execution_mode: string | null;
   tuning_mode: string | null;
+  // Self-derived, display-only tuning fingerprint. Kept for legacy bundles;
+  // never a join/dedup/grouping key.
   tuning_hash: string | null;
+  // ADR-1 bundle-emitted tuning identities, ingested verbatim from the
+  // bundle's platform.tuning summary (see explorer_pipeline/transformer.py):
+  // the canonical requested-config hash and the physical applied-ledger hash.
+  // Null/undefined for legacy bundles predating these fields (optional so
+  // fixtures/factories and SQL paths predating them default to undefined).
+  // Display-only, like tuning_hash.
+  requested_config_hash?: string | null;
+  applied_ledger_hash?: string | null;
   test_type: string | null;
   validation_status: string | null;
   cost_usd: number | null;

--- a/results-explorer/src/utils.ts
+++ b/results-explorer/src/utils.ts
@@ -68,6 +68,17 @@ export function errMsg(err: unknown): string {
 }
 
 /**
+ * Shorten a full-length identity hash (e.g. the ADR-1 requested-config /
+ * applied-ledger SHA-256s, 64 hex chars) to a readable prefix for display.
+ * Returns short hashes unchanged. Display-only helper: the full value is kept
+ * elsewhere (e.g. a `title` tooltip) so nothing depends on the prefix for
+ * identity.
+ */
+export function shortHash(hash: string, length = 12): string {
+  return hash.length > length ? hash.slice(0, length) : hash;
+}
+
+/**
  * Render the parenthetical compliance tag used next to benchmark titles.
  * Mirrors the `compliance_class` values written by the Python pipeline.
  */

--- a/tests/unit/scripts/explorer_pipeline/test_transformer.py
+++ b/tests/unit/scripts/explorer_pipeline/test_transformer.py
@@ -558,6 +558,42 @@ class TestExtendedManifestFields:
         assert entry.tuning_hash is not None
         assert len(entry.tuning_hash) == 8
 
+    def test_config_hashes_ingested_verbatim_from_tuning_summary(self, tmp_path: Path) -> None:
+        """New-generation bundles carry requested_config_hash + applied_ledger_hash,
+        read verbatim from platform.tuning (never recomputed)."""
+        import copy
+
+        data = copy.deepcopy(MINIMAL_BUNDLE)
+        data["platform"]["tuning"] = {
+            "requested_config_hash": "a" * 64,
+            "applied_ledger_hash": "b" * 64,
+        }
+        bundle = tmp_path / "hashes.json"
+        bundle.write_text(json.dumps(data), encoding="utf-8")
+
+        entry = BundleTransformer().to_manifest_entry(bundle)
+        assert entry.requested_config_hash == "a" * 64
+        assert entry.applied_ledger_hash == "b" * 64
+
+    def test_config_hashes_none_for_legacy_bundle(self, bundle_file: Path) -> None:
+        """Legacy bundles (no platform.tuning hashes) keep current behavior: None."""
+        entry = BundleTransformer().to_manifest_entry(bundle_file)
+        assert entry.requested_config_hash is None
+        assert entry.applied_ledger_hash is None
+
+    def test_applied_ledger_hash_none_when_only_requested_present(self, tmp_path: Path) -> None:
+        """A tuned run whose applied ledger recorded nothing emits requested only."""
+        import copy
+
+        data = copy.deepcopy(MINIMAL_BUNDLE)
+        data["platform"]["tuning"] = {"requested_config_hash": "c" * 64}
+        bundle = tmp_path / "req_only.json"
+        bundle.write_text(json.dumps(data), encoding="utf-8")
+
+        entry = BundleTransformer().to_manifest_entry(bundle)
+        assert entry.requested_config_hash == "c" * 64
+        assert entry.applied_ledger_hash is None
+
     def test_tuning_hash_dict_detail_is_hashed_canonically(self, tmp_path: Path) -> None:
         """A dict tuning_config is machine-readable, so key order must not affect the hash."""
         import copy


### PR DESCRIPTION
## Explorer consumes bundle hashes

Implements `tuning-explorer-consume-bundle-hashes-20260716` (w1-w3). The explorer ingests the ADR-1 `requested_config_hash` + `applied_ledger_hash` **verbatim** from `platform.tuning` (emitted by #1261's tuning summary) instead of only self-deriving a fingerprint.

- **Python** (`explorer_pipeline`): new display-only model fields + DuckDB columns (never join/dedup keys); legacy bundles keep current behavior (null). Verbatim ingest, never recomputed.
- **TS** (`results-explorer`): receipts show distinct labeled hash kinds (Requested config hash / Applied ledger hash); mode-only fallback no longer displays as a fingerprint. Fields optional → no build break.
- **Tests**: Python w3 tests added (transformer ingest + legacy fallback); **287 pipeline tests pass**, ruff/ty clean.

### Deferred to follow-ups (tracked)
- TS unit tests for the non-null hash path (node_modules absent locally → npm can't run this session; CI verifies build + suite, and existing receipt tests exercise the null path).
- w4: `physical_rendering_id` secondary facet in the UI (from #1182).

🤖 Generated with [Claude Code](https://claude.com/claude-code)