### PR TITLE
refactor(dataframe): consolidate empty-string/null CSV coercion into one shared step

### DIFF
--- a/benchbox/platforms/dataframe/cudf_df.py
+++ b/benchbox/platforms/dataframe/cudf_df.py
@@ -59,6 +59,7 @@ from benchbox.platforms.dataframe.pandas_df import _pandas_string_columns
 from benchbox.platforms.dataframe.pandas_family import (
     PandasFamilyAdapter,
 )
+from benchbox.platforms.dataframe.shared_loading import coerce_empty_string_columns
 from benchbox.utils.file_format import TRAILING_DUMMY_COLUMN, has_trailing_delimiter
 
 logger = logging.getLogger(__name__)
@@ -253,13 +254,9 @@ class CuDFDataFrameAdapter(PandasFamilyAdapter[CuDFDF]):
         df = cudf.read_csv(path, **read_kwargs)
 
         # Match the SQL dialect's empty-field semantics (null_marker None -> keep '';
-        # '' -> NULL), as the pandas adapter does.
-        if null_marker is None and string_columns:
-            for column in string_columns:
-                if column in df.columns:
-                    # Per-column (not df[list]=...) so it works across dask/modin/cudf,
-                    # whose multi-column assignment support differs from pandas.
-                    df[column] = df[column].fillna("")
+        # '' -> NULL), as the pandas adapter does. Shared step: see
+        # coerce_empty_string_columns.
+        df = coerce_empty_string_columns(df, string_columns, null_marker)
 
         # Drop trailing column if present
         if TRAILING_DUMMY_COLUMN in df.columns:

--- a/benchbox/platforms/dataframe/dask_df.py
+++ b/benchbox/platforms/dataframe/dask_df.py
@@ -61,6 +61,7 @@ from benchbox.platforms.dataframe.pandas_df import _pandas_string_columns
 from benchbox.platforms.dataframe.pandas_family import (
     PandasFamilyAdapter,
 )
+from benchbox.platforms.dataframe.shared_loading import coerce_empty_string_columns
 from benchbox.utils.file_format import TRAILING_DUMMY_COLUMN, has_trailing_delimiter
 
 logger = logging.getLogger(__name__)
@@ -449,13 +450,9 @@ class DaskDataFrameAdapter(PandasFamilyAdapter[DaskDF]):
 
         # Match the SQL dialect's empty-field semantics (null_marker None -> keep '';
         # '' -> NULL), as the pandas adapter does, so an empty text field does not
-        # surface as None where the SQL reference emits ''.
-        if null_marker is None and string_columns:
-            for column in string_columns:
-                if column in df.columns:
-                    # Per-column (not df[list]=...) so it works across dask/modin/cudf,
-                    # whose multi-column assignment support differs from pandas.
-                    df[column] = df[column].fillna("")
+        # surface as None where the SQL reference emits ''. Shared step: see
+        # coerce_empty_string_columns.
+        df = coerce_empty_string_columns(df, string_columns, null_marker)
 
         # Drop trailing column if present (lazy operation)
         if TRAILING_DUMMY_COLUMN in df.columns:

--- a/benchbox/platforms/dataframe/datafusion_df.py
+++ b/benchbox/platforms/dataframe/datafusion_df.py
@@ -64,6 +64,7 @@ from benchbox.platforms.base.adapter import DriverIsolationCapability
 from benchbox.platforms.dataframe.expression_family import (
     ExpressionFamilyAdapter,
 )
+from benchbox.platforms.dataframe.shared_loading import resolve_empty_string_restore_columns
 from benchbox.utils.file_format import (
     TRAILING_DUMMY_COLUMN,
     detect_data_format,
@@ -571,17 +572,22 @@ class DataFusionDataFrameAdapter(ExpressionFamilyAdapter[DataFusionDF, DataFusio
             # and the empty text fields stay NULL instead of "".
             df = self._apply_tbl_column_names(df, column_names)
 
-        if null_marker is None and string_columns:
+        if null_marker is None:
             # ``null_marker is None`` means empty fields in declared string
             # columns must stay ``""`` (ClickBench filters ``SearchPhrase <> ''``
             # etc.). DataFusion reads an empty CSV field as NULL, so coalesce it
-            # back to "". The membership guard tolerates a declared column that
-            # genuinely isn't present (e.g. column_names was not supplied so the
-            # rename above could not align the schema names).
-            present_columns = {field.name for field in df.schema()}
-            for name in string_columns:
-                if name in present_columns:
-                    df = df.with_column(name, f.coalesce(col(name), lit("")))
+            # back to "". The shared guard (see resolve_empty_string_restore_columns)
+            # tolerates a declared column that genuinely isn't present (e.g.
+            # column_names was not supplied so the rename above could not align
+            # the schema names). Gating on ``null_marker is None`` here (rather
+            # than passing an unconditional genexpr into the shared helper)
+            # keeps ``df.schema()`` from being called when the restore isn't
+            # needed -- a genexpr's outermost iterable is evaluated eagerly at
+            # creation, so building it unconditionally would call df.schema()
+            # even when null_marker is not None.
+            present_columns = (field.name for field in df.schema())
+            for name in resolve_empty_string_restore_columns(string_columns, null_marker, present_columns):
+                df = df.with_column(name, f.coalesce(col(name), lit("")))
 
         return df
 

--- a/benchbox/platforms/dataframe/modin_df.py
+++ b/benchbox/platforms/dataframe/modin_df.py
@@ -127,6 +127,7 @@ from benchbox.platforms.dataframe.pandas_df import _pandas_string_columns  # noq
 from benchbox.platforms.dataframe.pandas_family import (  # noqa: E402
     PandasFamilyAdapter,
 )
+from benchbox.platforms.dataframe.shared_loading import coerce_empty_string_columns  # noqa: E402
 from benchbox.utils.file_format import TRAILING_DUMMY_COLUMN, has_trailing_delimiter  # noqa: E402
 
 logger = logging.getLogger(__name__)
@@ -311,13 +312,9 @@ class ModinDataFrameAdapter(PandasFamilyAdapter[ModinDF]):
         df = mpd.read_csv(path, **read_kwargs)
 
         # Match the SQL dialect's empty-field semantics (null_marker None -> keep '';
-        # '' -> NULL), as the pandas adapter does.
-        if null_marker is None and string_columns:
-            for column in string_columns:
-                if column in df.columns:
-                    # Per-column (not df[list]=...) so it works across dask/modin/cudf,
-                    # whose multi-column assignment support differs from pandas.
-                    df[column] = df[column].fillna("")
+        # '' -> NULL), as the pandas adapter does. Shared step: see
+        # coerce_empty_string_columns.
+        df = coerce_empty_string_columns(df, string_columns, null_marker)
 
         # Drop trailing column if present
         if TRAILING_DUMMY_COLUMN in df.columns:

--- a/benchbox/platforms/dataframe/pandas_df.py
+++ b/benchbox/platforms/dataframe/pandas_df.py
@@ -45,6 +45,7 @@ from benchbox.core.dataframe.tuning import DataFrameTuningConfiguration
 from benchbox.platforms.dataframe.pandas_family import (
     PandasFamilyAdapter,
 )
+from benchbox.platforms.dataframe.shared_loading import coerce_empty_string_columns
 from benchbox.utils.file_format import TRAILING_DUMMY_COLUMN, has_trailing_delimiter
 
 logger = logging.getLogger(__name__)
@@ -375,15 +376,13 @@ class PandasDataFrameAdapter(PandasFamilyAdapter[PandasDF]):
         df = pd.read_csv(path, **read_kwargs)
         df = _coerce_date_columns(df, date_columns)
 
-        # When the SQL loader's dialect keeps empty fields as empty strings
-        # (null_marker is None, e.g. ClickBench), restore "" on declared text
-        # columns: pandas reads an empty field as NaN, which would surface as None
-        # where the DuckDB SQL reference emits "". Skipped when null_marker == ""
-        # (empty -> NULL, e.g. JoinOrder), preserving that surface's NULLs.
-        if null_marker is None and string_columns:
-            present = [column for column in string_columns if column in df.columns]
-            if present:
-                df[present] = df[present].fillna("")
+        # Restore "" on declared text columns when the SQL loader's dialect keeps
+        # empty fields as empty strings (null_marker is None, e.g. ClickBench):
+        # pandas reads an empty field as NaN, which would surface as None where
+        # the DuckDB SQL reference emits "". Skipped when null_marker == "" (empty
+        # -> NULL, e.g. JoinOrder), preserving that surface's NULLs. Shared step:
+        # see coerce_empty_string_columns.
+        df = coerce_empty_string_columns(df, string_columns, null_marker)
 
         # Drop trailing column if present
         if TRAILING_DUMMY_COLUMN in df.columns:

--- a/benchbox/platforms/dataframe/polars_df.py
+++ b/benchbox/platforms/dataframe/polars_df.py
@@ -292,6 +292,11 @@ class PolarsDataFrameAdapter(ExpressionFamilyAdapter[PolarsDF, PolarsLazyDF, Pol
             # empty->null. Without this, a prefer_parquet=False load reintroduces the
             # empty-string->null divergence (the cross-surface Q6/Q17/Q18 bug) on the
             # Polars surface. Numeric columns always treat an empty field as null.
+            # This is the same null_marker-is-None decision that
+            # shared_loading.resolve_empty_string_restore_columns makes for every
+            # other adapter; Polars applies it natively as a single scan_csv flag
+            # (over all UTF-8 columns) instead of a per-column post-read restore, so
+            # there is no post-hoc coercion step here to consolidate.
             "missing_utf8_is_empty_string": null_marker is None,
         }
 

--- a/benchbox/platforms/dataframe/pyspark_df.py
+++ b/benchbox/platforms/dataframe/pyspark_df.py
@@ -67,6 +67,7 @@ from benchbox.core.dataframe.tuning import DataFrameTuningConfiguration
 from benchbox.platforms.dataframe.expression_family import (
     ExpressionFamilyAdapter,
 )
+from benchbox.platforms.dataframe.shared_loading import resolve_empty_string_restore_columns
 from benchbox.utils.file_format import TRAILING_DUMMY_COLUMN, has_trailing_delimiter
 
 if TYPE_CHECKING:
@@ -476,10 +477,10 @@ class PySparkDataFrameAdapter(ExpressionFamilyAdapter[PySparkDF, PySparkLazyDF, 
             # Let Spark infer schema
             df = reader.option("inferSchema", "true").csv(path_str)
 
-        if null_marker is None and string_columns:
-            present = [name for name in string_columns if name in df.columns]
-            if present:
-                df = df.fillna("", subset=present)
+        # Shared guard: see resolve_empty_string_restore_columns.
+        present = resolve_empty_string_restore_columns(string_columns, null_marker, df.columns)
+        if present:
+            df = df.fillna("", subset=present)
 
         return df
 

--- a/benchbox/platforms/dataframe/shared_loading.py
+++ b/benchbox/platforms/dataframe/shared_loading.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Any, Protocol, runtime_checkable
+from typing import Any, Iterable, Protocol, runtime_checkable
 
 from benchbox.core.dataframe.schema_utils import (
     column_name,
@@ -107,6 +107,76 @@ def declared_string_columns(
         if sql_type and SchemaMapper.sql_type_to_pyarrow(sql_type) == "string":
             string_columns.append(name)
     return string_columns
+
+
+def resolve_empty_string_restore_columns(
+    string_columns: list[str] | None,
+    null_marker: str | None,
+    available_columns: Iterable[str],
+) -> list[str]:
+    """Return declared string columns whose empty CSV fields must be restored to ``""``.
+
+    This is the single shared decision step behind every DataFrame adapter's
+    empty-string/null CSV coercion: ``null_marker is None`` means the resolved
+    CSV dialect keeps empty fields as empty strings (e.g. ClickBench), but many
+    reader libraries still surface an empty text field as null/NaN regardless
+    of dialect. Declared string columns need ``""`` restored post-read so the
+    DataFrame surface matches the SQL reference (e.g. DuckDB, which keeps
+    ``""``).
+
+    Returns an empty list -- meaning "no coercion needed" -- when ``null_marker``
+    is not ``None`` (the dialect already treats empty as SQL NULL, e.g. the
+    TPC-style ``""`` marker / JoinOrder, so existing NULLs must be preserved) or
+    when there are no declared string columns for this table.
+
+    Args:
+        string_columns: Declared string/text columns for this table (from
+            :func:`declared_string_columns` or an equivalent per-family lookup).
+        null_marker: The resolved CSV dialect's null marker.
+        available_columns: The columns actually present in the loaded frame
+            (membership is re-checked here because a declared column can be
+            absent, e.g. when column_names was not supplied).
+
+    Returns:
+        The subset of ``string_columns`` that are present in
+        ``available_columns`` and need empty-field restoration, or ``[]``.
+    """
+    if null_marker is not None or not string_columns:
+        return []
+    available = set(available_columns)
+    return [column for column in string_columns if column in available]
+
+
+def coerce_empty_string_columns(
+    df: Any,
+    string_columns: list[str] | None,
+    null_marker: str | None,
+) -> Any:
+    """Restore ``""`` for empty CSV fields in declared string columns.
+
+    Shared coercion step for DataFrame libraries whose column objects share
+    Pandas' ``.fillna()`` and per-column assignment semantics (Pandas, cuDF,
+    Dask, Modin). Delegates the empty-vs-null decision to
+    :func:`resolve_empty_string_restore_columns` so all four adapters apply
+    the identical guard and the identical restore action instead of each
+    carrying its own copy.
+
+    Column-by-column assignment (not a single ``df[cols] = ...`` batch
+    assignment) is used because multi-column assignment support differs
+    across dask/modin/cudf/pandas; looping is the common denominator that
+    behaves identically -- and produces the same final values -- on all four.
+
+    Args:
+        df: The loaded DataFrame (Pandas/cuDF/Dask/Modin).
+        string_columns: Declared string/text columns for this table.
+        null_marker: The resolved CSV dialect's null marker.
+
+    Returns:
+        ``df``, mutated in place for the restored columns.
+    """
+    for column in resolve_empty_string_restore_columns(string_columns, null_marker, df.columns):
+        df[column] = df[column].fillna("")
+    return df
 
 
 def load_tables_from_data_source_impl(


### PR DESCRIPTION
# Pull Request

## Description

Consolidates the empty-string/null CSV coercion that was duplicated across DataFrame adapters into one shared step in the common load path (`shared_loading.py`), so the empty-string-vs-null contract has a single source of truth. Follow-up to #904 (which landed the coercion per-adapter) and #936 (the cross-adapter parity net). **Behavior-preserving structural move only** — no adapter's observable CSV-loading semantics change.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [x] Refactor / chore

## Testing

- `uv run -- python -m pytest tests/integration/test_dataframe_csv_empty_string_null_semantics.py -q` → **14 passed, 4 skipped** (modin/cudf not installed), **2 pre-existing pyspark failures** (Java-version env issue, reproduced byte-identically on unmodified `develop` via an A/B worktree — unrelated to this change).
- `ruff check` / `ruff format --check` clean on all touched files.
- Independent adversarial review re-ran the parity net + a hunk-by-hunk equivalence check across all six consolidated adapters (incl. a counterexample search on the pandas vectorized→per-column-loop change): **APPROVE, no Critical/Required findings**.

## Public Contract Check

- [x] This PR does not change public, beta-public, deprecated, generated, experimental, or repo-only contract surfaces (internal adapter load path only).
- [x] No result-schema / MCP tool parameter / platform-status / wrapper-facade / subclassing-hook / generated-docs impact.
- [x] No platform/benchmark count claims touched.

## Documentation

- [x] No user-facing docs affected (internal refactor).
- [x] No behavior change → no regression notes needed.
- [x] API contract wording unaffected.

## Code Quality

- [x] Ran `ruff format` + lint.
- [x] Reviewed adapters for backwards compat: pandas/cudf/dask/modin route through the shared `coerce_empty_string_columns`; datafusion/pyspark route through the shared `resolve_empty_string_restore_columns` guard while keeping their backend-specific restore actions; polars keeps its native `missing_utf8_is_empty_string` flag (nothing to consolidate).
- [x] Tests: the #936 parity suite is the behavior-preservation net; it stays byte-identical green — no new tests needed.
- [x] Public contracts / release checklists unaffected.

## Artifact Hygiene

- [x] No raw screenshots, reports, logs, benchmark outputs, or temporary binaries committed.
- [x] No binary/raw evidence files added.

## Notes

- **Behavior-preservation evidence**: pandas moves from a vectorized `df[cols] = df[cols].fillna("")` to the shared per-column loop; verified byte-identical across object+NaN, all-null `float64`, `string` dtype, mixed-NaN, categorical (both paths raise the same `TypeError`), and duplicate-label frames — `fillna` with a scalar is per-column-independent.
- **Review nits**: (1) datafusion `df.schema()` was briefly evaluated unconditionally by the refactor — **fixed** (guard reinstated so it evaluates only on the `null_marker is None` path). (2) polars left on its native flag — **considered and kept**: the flag encodes the same `null_marker is None` decision natively over all UTF-8 columns, so there is no post-read coercion to extract; routing it through the shared step would risk a behavior change for no gain.
- Pre-existing pyspark/Java test failures are environmental and out of scope for this refactor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E5RRSgj1WZy8rgHyBNnUk7

---
_Generated by [Claude Code](https://claude.ai/code/session_01E5RRSgj1WZy8rgHyBNnUk7)_