### PR TITLE
chore(ci): promote load-bearing regression reproducers into the required develop gate

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -424,6 +424,54 @@ jobs:
             tests/integration/test_plan_capture_phase.py \
             -m "medium" -n 0 --tb=short -q
 
+      - name: Run promoted TPC-DS power-test drain-before-commit reproducer
+        run: |
+          # This file is 100% slow-marked and otherwise never runs in ANY CI
+          # workflow (make test-slow/test-stress are invoked by no workflow).
+          # The TPC-H side of this exact fix (#1137/#1144: draining a raw
+          # DB-API cursor must happen BEFORE commit(), some drivers reject/
+          # invalidate commit() on unread SELECT results) is already required
+          # via the fast-marked test_tpc_power_tests.py, but TPC-DS has a
+          # separate, parallel implementation (benchbox/core/tpcds/power_test.py
+          # _execute_one_query - the only call site TPCDSPowerTest.run() uses)
+          # with no coverage anywhere. Bounded: the single reproducer node.
+          uv run -- python -m pytest \
+            tests/integration/test_tpcds_power_test.py \
+            -m "slow" -n 0 -k "test_execute_one_query_drains_raw_cursor_before_commit" --tb=short -q
+
+      - name: Run promoted DuckDB FK tuning load-ordering reproducers
+        run: |
+          # tuning-fk-load-ordering-fix-20260716: TPCHBenchmark.get_table_loading_order
+          # derives a FK-topological load order so a tuned run with
+          # foreign_keys.enabled really loads under real FK enforcement; without
+          # it, DataLoader falls back to alphabetical order, which zeros out
+          # every FK-dependent table under DuckDB constraint enforcement. This
+          # file is 100% slow-marked and otherwise never runs in ANY CI
+          # workflow. Bounded: one small (SF=0.01) file, 3 tests, ~5s.
+          uv run -- python -m pytest \
+            tests/integration/tuning/test_duckdb_fk_load_ordering.py \
+            -m "slow" -n 0 --tb=short -q
+
+      - name: Run promoted TPC-H power/throughput boundary-query (w0 defect) reproducers
+        run: |
+          # The w0 defect: with a custom (non-reference) seed at SF=1.0, TPC-H's
+          # answer-set-boundary queries (Q11/16/18/20) came back falsely FAILED.
+          # The shared validator exclusion is already unit-tested in the
+          # required fast lane (test_validation_engine.py), but the
+          # set_reference_seed_context() WIRING at each call site
+          # (benchbox/core/tpch/power_test.py and .../throughput_test.py - two
+          # separate production code paths) is not: breaking either site's
+          # wiring is invisible to the unit test and only caught here. Both
+          # files are 100% slow-marked and otherwise never run in ANY CI
+          # workflow. Bounded: the single boundary_query reproducer node(s) in
+          # each file, not the surrounding slow suites.
+          uv run -- python -m pytest \
+            tests/integration/test_tpch_power_test.py \
+            -m "slow" -n 0 -k "boundary_query" --tb=short -q
+          uv run -- python -m pytest \
+            tests/integration/test_tpch_throughput_test.py \
+            -m "slow" -n 0 -k "boundary_query" --tb=short -q
+
       - name: Run fast tests
         run: |
           # -p pytest_cov re-enables coverage plugin (disabled by default in pytest.ini)


### PR DESCRIPTION
# Pull Request

## Description

Systemic follow-up to #932 (`required-ci-coverage-deepest-reproducers`), which promoted three specific reproducers and deferred the suite-wide sweep. Several regression reproducers were parked **outside** the required develop gate `ci-required-result` (module-level `@pytest.mark.slow`, excluded from every required lane), so the PR that introduced each fix could self-merge without ever running its own deepest guard. This audits the suite and promotes **4 load-bearing cells** into the required `code-test` job via bounded explicit-node steps (the #932 mechanism), so each fix's reproducer runs in the required gate.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [x] Refactor / chore

## Testing

All four promoted steps proven **load-bearing** (revert the underlying fix → the required cell goes RED → restore → GREEN). These proofs were **independently reproduced by adversarial review** (all four, not just a sample):

| Cell | Underlying fix reverted | Reverted result |
|---|---|---|
| `test_tpcds_power_test.py -k test_execute_one_query_drains_raw_cursor_before_commit` | `benchbox/core/tpcds/power_test.py` (commit before `_query_result_count`) | RED — `assert False is True` |
| `test_duckdb_fk_load_ordering.py` (3 tests) | `benchbox/core/tpch/benchmark.py::get_table_loading_order` → `sorted(...)` | RED — 2/3 fail, `customer loaded 0 rows (FK violation)` |
| `test_tpch_power_test.py -k boundary_query` | `benchbox/core/tpch/power_test.py:327` `set_reference_seed_context(...)` → `True` | RED — boundary Q exact-fail (999 vs 186 rows); negative control stayed green |
| `test_tpch_throughput_test.py -k boundary_query` | `benchbox/core/tpch/throughput_test.py:507` `set_reference_seed_context(...)` → `True` | RED — `stream 0: boundary queries wrongly failed: {11,16,18,20}` |

- All added steps live in the `code-test` job (which **is** in `ci-required-result.needs`), have **no** `continue-on-error`, and use narrow `-k` selectors. Combined added wall-clock ≈ **8.6s**.
- `uv run -- python -c "import yaml; yaml.safe_load(open('.github/workflows/pr.yml'))"` → parses OK.
- Non-redundancy verified: all four files are `slow`-marked and excluded from the required fast/medium blanket lanes; the promoted cells are not covered elsewhere in required CI.

## Public Contract Check

- [x] Does not change public/beta/deprecated/generated/experimental/repo-only contract surfaces (CI configuration only).
- [x] No result-schema / MCP / platform-status / facade / subclassing-hook / generated-docs impact.
- [x] No platform/benchmark count claims touched.

## Documentation

- [x] No user-facing docs affected (CI gate wiring).
- [x] No source behavior change → no regression notes needed.
- [x] API contract wording unaffected.

## Code Quality

- [x] `pr.yml` validated (parses; steps in a required non-`continue-on-error` job).
- [x] Reviewed for CI-time impact: bounded `-k -n 0` selectors, ~8.6s added.
- [x] Each promoted cell is an existing test; no new tests added — this promotes existing reproducers into the required gate.
- [x] Public contracts / release checklists unaffected.

## Artifact Hygiene

- [x] No raw screenshots, reports, logs, benchmark outputs, or temporary binaries committed.
- [x] No binary/raw evidence files added.

## Notes

- **Deferred (follow-up candidate)**: `test_duckdb_table_mode_external.py::test_external_mode_works_on_reused_database` looked promising but its fix could not be conclusively isolated to a single revert within budget (~12s, 2 full lifecycle parity tests). It was **not** promoted unproven — a clean revert→red proof is the gate. Worth a follow-up TODO.
- **Review nit (considered, kept)**: cell-2 runs its whole `test_duckdb_fk_load_ordering.py` file without a `-k` selector, unlike the other three. Kept as-is: it is a dedicated 3-test reproducer file (all load-bearing), so running it in full is correct and auto-includes any future reproducer added there; a `-k` would be redundant or risk excluding a later case.
- Scope: `.github/workflows/pr.yml` only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E5RRSgj1WZy8rgHyBNnUk7

---
_Generated by [Claude Code](https://claude.ai/code/session_01E5RRSgj1WZy8rgHyBNnUk7)_