### PR TITLE
chore(release): sync develop version to 0.3.1 to match published release

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ BenchBox _loosely_ follows [Semantic Versioning](https://semver.org/) using the 
 - **MINOR** when we add backward-compatible changes _OR significantly expand functionality_.
 - **PATCH** when we make bug fixes or documentation updates, _bug-fixes may not be backward-compatible_.
 
-Current release: v0.2.1. This marker mirrors `pyproject.toml` on `develop` (bumped only during release-cut, so it trails the actual latest published release between cuts) and is checked for internal consistency by `benchbox --version`; it is **not** what `pip install benchbox` gets you today.
+Current release: v0.3.1. This marker mirrors `pyproject.toml` on `develop`, which is kept in sync with the latest published release (bumped to match after each release), and is checked for internal consistency by `benchbox --version`.
 
 **The current PyPI-latest release is `v0.3.1`** (published 2026-07-09; see [PyPI's release history](https://pypi.org/project/benchbox/#history) or `pip index versions benchbox` for the authoritative answer), and its clean install works — `pip install benchbox` followed by `import benchbox` succeeds. (The earlier `v0.3.0` shipped a broken clean install that failed with `ModuleNotFoundError: No module named 'pandas'`; `v0.3.1` is the recovery release that fixes it — see `CHANGELOG.md`.) Check your installation with `benchbox --version`, which also reports metadata consistency diagnostics pulled from `pyproject.toml` and documentation markers.
 

--- a/benchbox/__init__.py
+++ b/benchbox/__init__.py
@@ -11,7 +11,7 @@ from importlib import import_module
 from types import ModuleType
 from typing import TYPE_CHECKING, Any, Dict, Optional, Tuple, Type, Union
 
-__version__ = "0.2.1"
+__version__ = "0.3.1"
 
 from benchbox.base import BaseBenchmark
 from benchbox.flightdata import FlightData

--- a/benchbox/utils/VERSION_MANAGEMENT.md
+++ b/benchbox/utils/VERSION_MANAGEMENT.md
@@ -4,7 +4,7 @@
 
 This document outlines the version management strategy for BenchBox, ensuring consistency across all version references and providing clear guidelines for version updates.
 
-Current release: `v0.2.1`.
+Current release: `v0.3.1`.
 
 ## Version Sources
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -22,7 +22,7 @@ BenchBox adopts Semantic Versioning (`MAJOR.MINOR.PATCH`) to communicate compati
 - Increase **MINOR** for backward-compatible feature additions.
 - Increase **PATCH** for bug fixes or documentation-only updates.
 
-Current release: `v0.2.1`. Use `benchbox --version` for a human-readable summary or `benchbox --version-json` when you need structured diagnostics in automation. Both commands confirm that the package, `pyproject.toml`, and documentation markers stay aligned. Platform runs now capture the requested versus resolved driver package versions, so comparisons across DuckDB or connector releases remain reproducible.
+Current release: `v0.3.1`. Use `benchbox --version` for a human-readable summary or `benchbox --version-json` when you need structured diagnostics in automation. Both commands confirm that the package, `pyproject.toml`, and documentation markers stay aligned. Platform runs now capture the requested versus resolved driver package versions, so comparisons across DuckDB or connector releases remain reproducible.
 
 ## Usage Guides
 

--- a/docs/operations/release-guide.md
+++ b/docs/operations/release-guide.md
@@ -193,6 +193,17 @@ raw commit subjects, which step 3 requires you to curate anyway.
    design (per A3 in `_project/decisions/single-repo-migration.md`); the
    release squash on `release` does not need to be replayed onto develop.
 
+**Syncing `develop`'s version.** `release-cut`/`release-finalize` never modify
+`develop` (step 6), so its declared version does not track releases on its own —
+D5's original "rebase `develop` onto `main`" step became impossible once
+`release`/`develop` diverged as unrelated roots. After a release publishes, bump
+`develop` to match on a branch off `develop`:
+`scripts/update_version.py --version X.Y.Z --update-pyproject`, then `uv lock`,
+then PR back to `develop`. This realigns all six version sources
+(`benchbox/__init__.py`, `pyproject.toml`, the three `Current release:` doc
+markers, and the `landing/index.html` badge) with the latest published release,
+so `develop` no longer trails PyPI.
+
 Push-to-release jobs are post-merge signals. They may still start when `release`
 advances, but they are not pre-publish evidence: the tag push follows the
 successful release PR merge and `.github/workflows/release.yml` begins from

--- a/landing/index.html
+++ b/landing/index.html
@@ -120,7 +120,7 @@ from benchbox import TPCH</code></pre>
                                 href="https://github.com/joeharris76/benchbox/releases"
                                 target="_blank"
                                 class="badge badge-version"
-                                >v0.2.1</a
+                                >v0.3.1</a
                             >
                             <a href="https://benchbox.dev/docs/usage/installation.html" class="badge badge-info"
                                 >Python 3.10+</a

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "benchbox"
-version = "0.2.1"
+version = "0.3.1"
 description = "Embedded benchmark datasets and queries for database evaluation. Implements TPC-H, TPC-DS, TPC-DI and other industry-standard benchmarks."
 readme = "README.md"
 authors = [{ name = "Joe Harris", email = "joe@benchbox.dev" }]

--- a/uv.lock
+++ b/uv.lock
@@ -4753,11 +4753,11 @@ wheels = [
 
 [[package]]
 name = "pyasn1"
-version = "0.6.3"
+version = "0.6.4"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/5c/5f/6583902b6f79b399c9c40674ac384fd9cd77805f9e6205075f828ef11fb2/pyasn1-0.6.3.tar.gz", hash = "sha256:697a8ecd6d98891189184ca1fa05d1bb00e2f84b5977c481452050549c8a72cf", size = 148685, upload-time = "2026-03-17T01:06:53.382Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a4/9a/23310166d960def5897e91fe20e5b724601b02a22e84ba1f94232c0b7f67/pyasn1-0.6.4.tar.gz", hash = "sha256:9c447d8431c947fe4c8febc4ed9e760bc29011a5b01e5c74b67025bd9fb8ce81", size = 151262, upload-time = "2026-07-09T01:12:33.988Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/5d/a0/7d793dce3fa811fe047d6ae2431c672364b462850c6235ae306c0efd025f/pyasn1-0.6.3-py3-none-any.whl", hash = "sha256:a80184d120f0864a52a073acc6fc642847d0be408e7c7252f31390c0f4eadcde", size = 83997, upload-time = "2026-03-17T01:06:52.036Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/3b/6163796d69c3977d1e4287bea4a6979161cbbdd170ebb430511e8e1999ce/pyasn1-0.6.4-py3-none-any.whl", hash = "sha256:deda9277cfd454080ec40b207fb6df82206a3a2688735233cdcd8d3d565f088b", size = 84410, upload-time = "2026-07-09T01:12:32.92Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -323,7 +323,7 @@ wheels = [
 
 [[package]]
 name = "benchbox"
-version = "0.2.1"
+version = "0.3.1"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
develop's declared version had drifted to 0.2.1 while the release line
shipped 0.3.0 and 0.3.1. D5's original "rebase develop onto main" step
(which carried the release version back onto develop) became impossible
once release/develop diverged as unrelated roots, so develop silently
trailed PyPI and README rationalized the drift.

Bump all six version sources to 0.3.1 (benchbox/__init__.py, pyproject.toml,
the three Current-release doc markers, landing badge) + uv.lock, correct the
README narrative, and document the post-release develop version-sync step in
the release guide so the intent of D5 is preserved without the (now
impossible) rebase.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
