### PR TITLE
feat(tracker): findings-domain phase 3 — schema v3 + `todo finding` CLI + sync

### DIFF
--- a/_project/scripts/todo_db.py
+++ b/_project/scripts/todo_db.py
@@ -47,15 +47,44 @@ from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Any
 
-SCHEMA_VERSION = 2
+# Make this script's own directory importable so the findings sibling resolves
+# whether todo_db runs via `uv run ... todo_db.py` (dir already on sys.path[0])
+# or is loaded by file path in tests (spec_from_file_location adds nothing).
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+# Alias THIS module as "todo_db" so the findings sibling's `import todo_db`
+# binds this exact instance instead of re-executing the file under the canonical
+# name. Without it, running as __main__ (`python todo_db.py`) or loading under a
+# synthetic name in tests would create a SECOND todo_db instance, and a
+# TodoError raised inside todo_findings would then be a different class than the
+# one main() catches -- a traceback instead of a clean exit 2. setdefault never
+# clobbers a genuine prior import of todo_db. Guarded with .get(): a few tests
+# exec this file via a loader that does not pre-register the module, so
+# sys.modules[__name__] may be absent -- skip the alias there (those paths do
+# not cross the findings boundary).
+_self_module = sys.modules.get(__name__)
+if _self_module is not None:
+    sys.modules.setdefault("todo_db", _self_module)
+
+# Sibling module: findings-domain schema + `todo finding` CLI (phase 3). Imported
+# here (not lazily) because SCHEMA_SQL and MIGRATIONS below compose its DDL. The
+# import cycle (todo_findings imports todo_db) is safe: the alias above keeps it a
+# single instance, and todo_findings defines its schema constants before it first
+# touches todo_db. See todo_findings.py's header.
+import todo_findings  # noqa: E402
+
+SCHEMA_VERSION = 3
 
 # Applied in order by `todo migrate`; each version's statements are additive.
+# v3 lands the findings domain; its DDL comes from todo_findings so the fresh
+# schema (SCHEMA_SQL) and the migration delta are ONE source and cannot drift.
 MIGRATIONS: dict[int, list[str]] = {
     2: [
         "ALTER TABLE work_units ADD COLUMN started_at TEXT",
         "ALTER TABLE work_units ADD COLUMN started_worktree TEXT",
         "ALTER TABLE work_units ADD COLUMN started_branch TEXT",
     ],
+    3: todo_findings.finding_schema_statements(),
 }
 
 PRIORITIES = ("critical", "high", "medium-high", "medium", "low")
@@ -72,7 +101,7 @@ SLUG_RE = re.compile(r"^[a-z0-9][a-z0-9-]*[a-z0-9]$")
 WID_RE = re.compile(r"^w[0-9]{1,3}$")
 DEFAULT_LEASE_TTL_HOURS = 24
 
-SCHEMA_SQL = """
+_CORE_SCHEMA_SQL = """
 CREATE TABLE items (
   id             TEXT PRIMARY KEY,
   title          TEXT NOT NULL CHECK (length(title) BETWEEN 5 AND 200),
@@ -192,6 +221,11 @@ CREATE TABLE meta (
 CREATE INDEX idx_items_state ON items(state);
 CREATE INDEX idx_deferrals_open ON deferrals(from_item, resolution);
 """
+
+# The full current schema = core (items domain) + findings domain (phase 3). A
+# fresh bootstrap runs this; an existing v2 DB reaches the same schema through
+# MIGRATIONS[3], which applies todo_findings.FINDINGS_SCHEMA_SQL verbatim.
+SCHEMA_SQL = _CORE_SCHEMA_SQL + todo_findings.FINDINGS_SCHEMA_SQL
 
 
 class TodoError(Exception):
@@ -902,6 +936,13 @@ def _command_mutates_tracker(args: argparse.Namespace) -> bool:
         return args.run is not None
     if args.command == "config":
         return args.value is not None
+    if args.command == "finding":
+        # The nested `finding` subcommands share one top-level command name, so
+        # classify by the subcommand (create/candidates/list/show are draft-only
+        # or read-only; sync/dismiss/triage/link/promote mutate). Interactive
+        # finding reads use the normal embedded-replica path, exactly like item
+        # `list`/`show`, so they are absent from READ_ONLY_COMMANDS by design.
+        return todo_findings.finding_command_mutates(args)
     return args.command not in _IMPLICIT_LOCAL_READ_COMMANDS
 
 
@@ -2416,8 +2457,22 @@ def main(argv: list[str] | None = None) -> int:
     p = sub.add_parser("export", help="deterministic JSONL + markdown index")
     p.add_argument("--out", default=None)
 
+    pf = sub.add_parser("finding", help="findings domain: capture, sync, triage, promote")
+    todo_findings.add_finding_subparsers(pf)
+
     args = parser.parse_args(argv)
     actor = args.actor or default_actor()
+
+    # Zero-credential capture: `finding create` writes (and `finding candidates`
+    # reads) only the local drafts directory -- no backend, no network, no token.
+    # Handled before any backend resolution so capture works with no creds (R5).
+    if args.command == "finding" and args.finding_command in todo_findings.FINDING_OFFLINE_SUBCOMMANDS:
+        try:
+            return todo_findings.run_offline(actor, args)
+        except TodoError as exc:
+            print(f"error: {exc}", file=sys.stderr)
+            return 2
+
     backend, implicit_default_local = _resolve_backend(args.db)
     _report_backend(backend, implicit_default_local=implicit_default_local)
     if implicit_default_local and _command_mutates_tracker(args):
@@ -2861,6 +2916,11 @@ _HANDLERS = {
 
 
 def _dispatch(conn: sqlite3.Connection, actor: str, args: argparse.Namespace) -> int:
+    # `finding` is dispatched by name (not via _HANDLERS) so this module never
+    # references a todo_findings symbol at load time -- keeping the todo_db <->
+    # todo_findings import cycle resolvable regardless of load order.
+    if args.command == "finding":
+        return todo_findings.dispatch_finding(conn, actor, args)
     return _HANDLERS[args.command](conn, actor, args)
 
 

--- a/_project/scripts/todo_findings.py
+++ b/_project/scripts/todo_findings.py
@@ -1,0 +1,910 @@
+#!/usr/bin/env python3
+"""todo_findings.py - findings-domain sibling module for the DB-backed tracker.
+
+Phase 3 of ``_project/specs/findings-domain.md``. This module owns everything
+the findings domain adds so the 2,800-line ``todo_db.py`` monolith does not
+absorb the blast radius (its hosted write paths are only manually
+acceptance-tested). ``todo_db.py`` wires the ``finding`` subparser and dispatch;
+all findings logic lives here.
+
+Responsibilities:
+- the v3 findings schema (``FINDINGS_SCHEMA_SQL``), composed into
+  ``todo_db.SCHEMA_SQL`` (fresh DBs) and ``todo_db.MIGRATIONS[3]`` (existing v2
+  DBs) from ONE source so the two can never drift;
+- row helpers, disposition transitions, and append-only ``finding_events``
+  logging (a separate table, never the item ``events`` table, so finding review
+  prose can never reach the version-controlled export snapshot);
+- the ``todo finding {create,list,show,candidates,dismiss,triage,link,promote,
+  sync}`` subcommands.
+
+Capture stays credential-free: ``create`` and ``candidates`` touch only the
+local drafts directory (``~/.benchbox/finding-drafts/``); ``sync`` is the sole
+credentialed landing step (review-protocol §4).
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any
+
+import validate_blind_spot as vbs  # sibling; no todo_db dependency, so cycle-free
+
+# ---------------------------------------------------------------------------
+# Schema (composed into todo_db.SCHEMA_SQL and MIGRATIONS[3])
+#
+# Defined BEFORE ``import todo_db`` so the todo_db <-> todo_findings import
+# cycle resolves in EITHER entry order. todo_db imports this module at load
+# time for FINDINGS_SCHEMA_SQL, so that constant must exist before this module
+# first touches todo_db -- which it does only at call time, below. All four
+# findings tables are deliberately ABSENT from todo_db's EXPORT_TABLE_ALLOWLIST
+# / TRANSFER_TABLES: their review prose is not version-controlled (findings
+# domain "Export boundary"), and the phase-2 pinning test fails closed on any
+# ``finding%`` table by construction.
+
+FINDINGS_SCHEMA_SQL = """
+CREATE TABLE findings (
+  id                 TEXT PRIMARY KEY CHECK (length(id) BETWEEN 3 AND 200),
+  date               TEXT NOT NULL,
+  finding_kind       TEXT NOT NULL,
+  review_context     TEXT NOT NULL,
+  observed_sha       TEXT,
+  title              TEXT NOT NULL,
+  finding_text       TEXT NOT NULL,
+  why_matters        TEXT NOT NULL,
+  next_steps         TEXT NOT NULL,
+  disposition        TEXT NOT NULL DEFAULT 'open' CHECK (disposition IN
+                       ('open','actionable','actioned','dismissed','promoted')),
+  disposition_reason TEXT,
+  urgency            TEXT,
+  breadth            TEXT,
+  confidence         TEXT,
+  reconsider_after   TEXT,
+  created_at         TEXT NOT NULL,
+  imported_from      TEXT,
+  CHECK (disposition NOT IN ('actionable','dismissed')
+         OR (disposition_reason IS NOT NULL AND length(disposition_reason) > 0))
+);
+
+CREATE TABLE finding_evidence (
+  id         INTEGER PRIMARY KEY,
+  finding_id TEXT NOT NULL REFERENCES findings(id) ON DELETE CASCADE,
+  path       TEXT NOT NULL,
+  pattern    TEXT,
+  line_start INTEGER,
+  line_end   INTEGER,
+  note       TEXT
+);
+
+CREATE TABLE finding_links (
+  id             INTEGER PRIMARY KEY,
+  finding_id     TEXT NOT NULL REFERENCES findings(id) ON DELETE CASCADE,
+  kind           TEXT NOT NULL CHECK (kind IN
+                   ('promoted-to','informs','resolved-by','related-finding','duplicate-of')),
+  target_item    TEXT REFERENCES items(id),
+  target_finding TEXT REFERENCES findings(id),
+  note           TEXT
+);
+
+CREATE TABLE finding_events (
+  seq        INTEGER PRIMARY KEY,
+  at         TEXT NOT NULL,
+  actor      TEXT NOT NULL,
+  finding_id TEXT REFERENCES findings(id),
+  action     TEXT NOT NULL,
+  detail     TEXT
+);
+
+CREATE INDEX idx_findings_disposition ON findings(disposition);
+CREATE INDEX idx_finding_events_finding ON finding_events(finding_id, seq);
+"""
+
+
+def finding_schema_statements() -> list[str]:
+    """The v3 migration delta: each CREATE statement, semicolon-split.
+
+    Shared verbatim by ``todo_db.SCHEMA_SQL`` (fresh DBs) and
+    ``todo_db.MIGRATIONS[3]`` (existing v2 DBs) so the two representations of the
+    findings schema can never drift. FINDINGS_SCHEMA_SQL is our own controlled
+    DDL: no string literal contains a ``;``.
+    """
+    return [statement.strip() for statement in FINDINGS_SCHEMA_SQL.split(";") if statement.strip()]
+
+
+import todo_db  # noqa: E402  (cycle-break: import must follow FINDINGS_SCHEMA_SQL; see note above)
+
+# ---------------------------------------------------------------------------
+# Constants
+
+DISPOSITIONS = ("open", "actionable", "actioned", "dismissed", "promoted")
+# Disposition values that the CHECK (and this module) require a reason for.
+DISPOSITION_REASON_REQUIRED = frozenset({"actionable", "dismissed"})
+# Terminal dispositions: no transition leaves them.
+TERMINAL_DISPOSITIONS = frozenset({"actioned", "dismissed", "promoted"})
+# Legal disposition transitions (everything else is rejected). `promoted` is
+# reached only through `finding promote`, never a plain triage flip.
+DISPOSITION_TRANSITIONS = frozenset(
+    {
+        ("open", "actionable"),
+        ("open", "actioned"),
+        ("open", "dismissed"),
+        ("open", "promoted"),
+        ("actionable", "actioned"),
+        ("actionable", "dismissed"),
+        ("actionable", "promoted"),
+    }
+)
+LINK_KINDS = ("promoted-to", "informs", "resolved-by", "related-finding", "duplicate-of")
+
+# Draft `status` frontmatter -> DB `disposition` (findings-domain phase-5 status
+# map; sync applies it too). `merged-to-todo` is the legacy YAML-era label.
+STATUS_TO_DISPOSITION = {
+    "open": "open",
+    "actionable": "actionable",
+    "actioned": "actioned",
+    "dismissed": "dismissed",
+    "merged-to-todo": "promoted",
+}
+
+DEFAULT_DRAFTS_DIR = vbs.DEFAULT_DRAFTS_DIR
+SYNCED_SUFFIX = ".synced"
+SYNCED_PRUNE_DAYS = 30
+
+# YYYY-MM-DD-HHMMSS-<kebab-slug> (matches the phase-1 validator's FILENAME_RE).
+FINDING_ID_RE = vbs.FILENAME_RE
+
+# `finding` subcommands that NEVER touch the DB (zero-credential capture path).
+FINDING_OFFLINE_SUBCOMMANDS = frozenset({"create", "candidates"})
+# `finding` subcommands that only READ the tracker (no mutation). Like item
+# `list`/`show`, these use the normal connection -- they are NOT bulk readers,
+# so they stay out of todo_db.READ_ONLY_COMMANDS (the remote-only RO-token path).
+FINDING_READ_SUBCOMMANDS = frozenset({"list", "show"})
+# Everything else (sync, dismiss, triage, link, promote) mutates the tracker.
+
+
+# ---------------------------------------------------------------------------
+# Classifier hook (called from todo_db._command_mutates_tracker)
+
+
+def finding_command_mutates(args: argparse.Namespace) -> bool:
+    """Whether a parsed ``finding`` subcommand can modify tracker state.
+
+    Fail closed: an unrecognized subcommand is treated as mutating.
+    """
+    sub = getattr(args, "finding_command", None)
+    if sub in FINDING_OFFLINE_SUBCOMMANDS or sub in FINDING_READ_SUBCOMMANDS:
+        return False
+    return True
+
+
+# ---------------------------------------------------------------------------
+# Draft parsing (reuses the phase-1 validator)
+
+
+def _slugify(raw: str) -> str:
+    slug = re.sub(r"[^a-z0-9]+", "-", raw.lower()).strip("-")
+    return re.sub(r"-{2,}", "-", slug)
+
+
+def _str_or_none(value: Any) -> str | None:
+    if value is None:
+        return None
+    return str(value)
+
+
+def _split_body(body: str) -> tuple[str, dict[str, str]]:
+    """Split a draft body into (title, {section_heading: text}).
+
+    Title is the first top-level ``# `` heading; sections are keyed by the
+    ``## `` heading text (e.g. ``Finding``, ``Why this matters``).
+    """
+    title = ""
+    sections: dict[str, str] = {}
+    current: str | None = None
+    buf: list[str] = []
+
+    def _flush() -> None:
+        if current is not None:
+            sections[current] = "\n".join(buf).strip()
+
+    for line in vbs.normalize_newlines(body).splitlines():
+        stripped = line.strip()
+        if stripped.startswith("## "):
+            _flush()
+            current = stripped[3:].strip()
+            buf = []
+        elif stripped.startswith("# ") and not title:
+            title = stripped[2:].strip()
+        else:
+            buf.append(line)
+    _flush()
+    return title, sections
+
+
+def parse_draft(path: Path) -> dict[str, Any]:
+    """Parse a draft markdown file into finding-row fields.
+
+    Validates via the phase-1 validator first; a malformed draft is a loud
+    ``TodoError`` (never a partial insert).
+    """
+    errors = vbs.validate_file(path)
+    if errors:
+        raise todo_db.TodoError(f"draft {path.name} failed validation: " + "; ".join(errors))
+    text = vbs.normalize_newlines(path.read_text(encoding="utf-8"))
+    data, body, _ = vbs.parse_frontmatter(text)
+    if data is None:  # pragma: no cover - validate_file already rejected this
+        raise todo_db.TodoError(f"draft {path.name}: unparseable frontmatter")
+    title, sections = _split_body(body)
+    status = str(data.get("status", "open"))
+    disposition = STATUS_TO_DISPOSITION.get(status, "open")
+    triage_log = sections.get("Triage log", "").strip()
+    reason: str | None = None
+    if disposition in DISPOSITION_REASON_REQUIRED:
+        # A fresh draft is `open`; a non-open draft carries its rationale in the
+        # triage log. Never fabricate a judgement -- carry the prose verbatim,
+        # or name the source when the log is absent.
+        reason = triage_log or f"synced from draft {path.stem} (status {status})"
+    return {
+        "id": path.stem,
+        "date": str(data["date"]),
+        "finding_kind": str(data["finding_kind"]),
+        "review_context": str(data["review_context"]),
+        "observed_sha": _str_or_none(data.get("observed_sha")),
+        "title": title,
+        "finding_text": sections.get("Finding", "").strip(),
+        "why_matters": sections.get("Why this matters", "").strip(),
+        "next_steps": sections.get("Suggested next steps", "").strip(),
+        "disposition": disposition,
+        "disposition_reason": reason,
+        "urgency": _str_or_none(data.get("urgency")),
+        "breadth": _str_or_none(data.get("breadth")),
+        "confidence": _str_or_none(data.get("confidence")),
+        "evidence": list(data.get("evidence") or []),
+        "triage_log": triage_log,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Row helpers
+
+_FINDING_COLUMNS = (
+    "id",
+    "date",
+    "finding_kind",
+    "review_context",
+    "observed_sha",
+    "title",
+    "finding_text",
+    "why_matters",
+    "next_steps",
+    "disposition",
+    "disposition_reason",
+    "urgency",
+    "breadth",
+    "confidence",
+    "reconsider_after",
+    "created_at",
+    "imported_from",
+)
+
+# Fields compared to decide same-id-different-content on sync. Excludes
+# created_at (assigned at first insert) and imported_from (provenance).
+_CONTENT_FIELDS = (
+    "date",
+    "finding_kind",
+    "review_context",
+    "observed_sha",
+    "title",
+    "finding_text",
+    "why_matters",
+    "next_steps",
+    "disposition",
+)
+
+
+def log_finding_event(
+    conn: Any,
+    actor: str,
+    finding_id: str | None,
+    action: str,
+    detail: dict[str, Any] | None = None,
+) -> None:
+    """Append a provenance row to ``finding_events`` (never the item ``events``
+    table -- finding prose must not reach the committed export snapshot)."""
+    conn.execute(
+        "INSERT INTO finding_events (at, actor, finding_id, action, detail) VALUES (?, ?, ?, ?, ?)",
+        (todo_db.utc_now(), actor, finding_id, action, json.dumps(detail or {}, sort_keys=True)),
+    )
+
+
+def get_finding(conn: Any, finding_id: str) -> dict[str, Any] | None:
+    row = conn.execute("SELECT * FROM findings WHERE id = ?", (finding_id,)).fetchone()
+    if row is None:
+        return None
+    finding = dict(row)
+    finding["evidence"] = [
+        dict(r)
+        for r in conn.execute(
+            "SELECT path, pattern, line_start, line_end, note FROM finding_evidence WHERE finding_id = ? ORDER BY id",
+            (finding_id,),
+        )
+    ]
+    finding["links"] = [
+        dict(r)
+        for r in conn.execute(
+            "SELECT kind, target_item, target_finding, note FROM finding_links WHERE finding_id = ? ORDER BY id",
+            (finding_id,),
+        )
+    ]
+    finding["events"] = [
+        dict(r)
+        for r in conn.execute(
+            "SELECT seq, at, actor, action, detail FROM finding_events WHERE finding_id = ? ORDER BY seq",
+            (finding_id,),
+        )
+    ]
+    return finding
+
+
+def _require_finding(conn: Any, finding_id: str) -> dict[str, Any]:
+    finding = get_finding(conn, finding_id)
+    if finding is None:
+        raise todo_db.TodoError(f"no finding {finding_id!r}")
+    return finding
+
+
+def insert_finding(conn: Any, actor: str, fields: dict[str, Any], *, imported_from: str | None = None) -> None:
+    """Insert one finding row plus its evidence, INSIDE a caller-held write
+    transaction. Raises ``TodoError`` on an invalid id or a reason-less
+    terminal disposition (the CHECK enforces the latter too; this phrases it)."""
+    finding_id = str(fields["id"])
+    if not FINDING_ID_RE.match(finding_id):
+        raise todo_db.TodoError(f"invalid finding id {finding_id!r} (expect YYYY-MM-DD-HHMMSS-<kebab-slug>)")
+    disposition = fields.get("disposition", "open")
+    if disposition not in DISPOSITIONS:
+        raise todo_db.TodoError(f"invalid disposition {disposition!r}; one of {', '.join(DISPOSITIONS)}")
+    reason = fields.get("disposition_reason")
+    if disposition in DISPOSITION_REASON_REQUIRED and not (reason and str(reason).strip()):
+        raise todo_db.TodoError(f"disposition {disposition!r} requires a reason (finding {finding_id!r})")
+    for section in ("title", "finding_text", "why_matters", "next_steps"):
+        if not str(fields.get(section) or "").strip():
+            raise todo_db.TodoError(f"finding {finding_id!r} is missing body section {section!r}")
+    row = {name: fields.get(name) for name in _FINDING_COLUMNS}
+    row["id"] = finding_id
+    row["disposition"] = disposition
+    row["created_at"] = fields.get("created_at") or todo_db.utc_now()
+    row["imported_from"] = fields.get("imported_from") or imported_from
+    placeholders = ", ".join("?" for _ in _FINDING_COLUMNS)
+    try:
+        conn.execute(
+            f"INSERT INTO findings ({', '.join(_FINDING_COLUMNS)}) VALUES ({placeholders})",
+            tuple(row[name] for name in _FINDING_COLUMNS),
+        )
+    except todo_db.sqlite3.IntegrityError as exc:
+        raise todo_db.TodoError(f"cannot insert finding {finding_id!r}: {exc}") from exc
+    for entry in fields.get("evidence") or []:
+        if not isinstance(entry, dict):
+            raise todo_db.TodoError(f"finding {finding_id!r} evidence entry must be a mapping, got {entry!r}")
+        path = entry.get("path")
+        if not (isinstance(path, str) and path.strip()):
+            raise todo_db.TodoError(f"finding {finding_id!r} evidence entry needs a non-empty path")
+        conn.execute(
+            "INSERT INTO finding_evidence (finding_id, path, pattern, line_start, line_end, note)"
+            " VALUES (?, ?, ?, ?, ?, ?)",
+            (
+                finding_id,
+                path,
+                entry.get("pattern"),
+                entry.get("line_start"),
+                entry.get("line_end"),
+                entry.get("note"),
+            ),
+        )
+    log_finding_event(
+        conn, actor, finding_id, "sync" if imported_from is None else "import", {"disposition": disposition}
+    )
+
+
+def _finding_matches(existing: dict[str, Any], fields: dict[str, Any]) -> bool:
+    """True when a stored finding equals a re-parsed draft on content fields
+    (sync idempotency). Different content is a conflict, never a merge."""
+    for name in _CONTENT_FIELDS:
+        if (existing.get(name) or None) != (fields.get(name) or None):
+            return False
+    return True
+
+
+def _set_disposition(conn: Any, actor: str, finding_id: str, new: str, reason: str | None) -> None:
+    """Apply a legal disposition transition with a conditional UPDATE (the same
+    defense-in-depth as claim_item), INSIDE a caller-held write transaction."""
+    finding = _require_finding(conn, finding_id)
+    current = finding["disposition"]
+    if current == new:
+        raise todo_db.TodoError(f"finding {finding_id!r} is already {new}")
+    if current in TERMINAL_DISPOSITIONS:
+        raise todo_db.TodoError(f"finding {finding_id!r} is {current} (terminal); no further transition")
+    if (current, new) not in DISPOSITION_TRANSITIONS:
+        raise todo_db.TodoError(f"illegal disposition transition {current} -> {new} for {finding_id!r}")
+    if new in DISPOSITION_REASON_REQUIRED and not (reason and reason.strip()):
+        raise todo_db.TodoError(f"disposition {new!r} requires a --reason")
+    updated = conn.execute(
+        "UPDATE findings SET disposition = ?, disposition_reason = ? WHERE id = ? AND disposition = ?",
+        (new, reason, finding_id, current),
+    )
+    if updated.rowcount != 1:
+        raise todo_db.TodoError(f"finding {finding_id!r} disposition changed concurrently")
+    log_finding_event(conn, actor, finding_id, "disposition", {"from": current, "to": new, "reason": reason})
+
+
+# ---------------------------------------------------------------------------
+# Sync (the authorized landing step)
+
+
+def _mark_synced(path: Path) -> None:
+    """Rename ``foo.md`` -> ``foo.md.synced`` so it drops out of the unsynced
+    glob. Best-effort: idempotency is guaranteed by the id-absence check, not
+    this rename, so a failure here just re-syncs (and no-ops) next time."""
+    try:
+        path.replace(path.with_name(path.name + SYNCED_SUFFIX))
+    except OSError:  # pragma: no cover - best-effort; next sync is idempotent
+        pass
+
+
+def _prune_synced(drafts_dir: Path) -> int:
+    """Delete ``*.md.synced`` files older than SYNCED_PRUNE_DAYS. Returns count."""
+    cutoff = datetime.now(timezone.utc) - timedelta(days=SYNCED_PRUNE_DAYS)
+    pruned = 0
+    for path in sorted(drafts_dir.glob("*" + SYNCED_SUFFIX)):
+        try:
+            mtime = datetime.fromtimestamp(path.stat().st_mtime, tz=timezone.utc)
+        except OSError:  # pragma: no cover
+            continue
+        if mtime < cutoff:
+            try:
+                path.unlink()
+                pruned += 1
+            except OSError:  # pragma: no cover
+                pass
+    return pruned
+
+
+def sync_drafts(conn: Any, actor: str, drafts_dir: str | Path) -> dict[str, Any]:
+    """Insert-if-absent every draft under ``drafts_dir`` by filename-stem id.
+
+    Idempotent: an identical already-landed finding is skipped (and its draft
+    marked synced). Same-id/different-content is a loud error naming the id --
+    never a merge (silent data loss in an audit-trail domain).
+    """
+    drafts_dir = Path(drafts_dir).expanduser()
+    result: dict[str, Any] = {"synced": [], "skipped": [], "conflicts": [], "pruned": 0}
+    if not drafts_dir.is_dir():
+        return result
+    for path in sorted(drafts_dir.glob("*.md")):
+        if path.name == "README.md":
+            continue
+        fields = parse_draft(path)
+        existing = get_finding(conn, fields["id"])
+        if existing is not None:
+            if _finding_matches(existing, fields):
+                result["skipped"].append(fields["id"])
+                _mark_synced(path)
+            else:
+                result["conflicts"].append(fields["id"])
+            continue
+        with todo_db._write_txn(conn):
+            insert_finding(conn, actor, fields)
+        _mark_synced(path)
+        result["synced"].append(fields["id"])
+    result["pruned"] = _prune_synced(drafts_dir)
+    if result["conflicts"]:
+        raise todo_db.TodoError(
+            "sync conflict -- same filename-stem id, different content: "
+            + ", ".join(result["conflicts"])
+            + ". The DB copy and the draft disagree; resolve by hand (findings are an audit trail, never merged)."
+        )
+    return result
+
+
+def count_unsynced_drafts(drafts_dir: str | Path = DEFAULT_DRAFTS_DIR) -> int:
+    """Local directory glob of unsynced drafts -- no credentials, no network.
+
+    A draft is 'unsynced' until ``sync`` renames it to ``*.md.synced``; this is
+    the count the phase-4 ``todo ready`` / ``todo stats`` banner shows.
+    """
+    directory = Path(drafts_dir).expanduser()
+    if not directory.is_dir():
+        return 0
+    return sum(1 for p in directory.glob("*.md") if p.name != "README.md")
+
+
+# ---------------------------------------------------------------------------
+# Capture (zero-credential draft write)
+
+_GATE_TEXT = (
+    "review-protocol §2 defect gate: a finding is a *class* blind spot (a gap in "
+    "what the review looks for), never a single defect. A concrete bug goes to the "
+    "severity table / a TODO, not here. Attest with --gate class-not-instance."
+)
+
+
+def create_draft(args: argparse.Namespace) -> Path:
+    """Write a draft finding file (never the DB). Prints the §2 gate; requires
+    the ``--gate class-not-instance`` attestation; a ``bug-class`` finding
+    requires ``--fixed-by`` (a bug-class blind spot needs an already-landed
+    fix)."""
+    print(_GATE_TEXT, file=todo_db.sys.stderr)
+    if args.gate != "class-not-instance":
+        raise todo_db.TodoError("create requires --gate class-not-instance (the review-protocol §2 attestation)")
+    kind = args.finding_kind
+    if kind not in vbs.ALLOWED_KIND:
+        raise todo_db.TodoError(f"finding_kind {kind!r} not in {sorted(vbs.ALLOWED_KIND)}")
+    if kind == "bug-class" and not (args.fixed_by and args.fixed_by.strip()):
+        raise todo_db.TodoError(
+            "finding_kind 'bug-class' requires --fixed-by <ref> (a bug-class finding needs a landed fix)"
+        )
+    slug = _slugify(args.slug or args.title)
+    if not slug:
+        raise todo_db.TodoError("could not derive a slug; pass --slug <kebab-slug>")
+    drafts_dir = Path(args.drafts_dir).expanduser()
+    drafts_dir.mkdir(parents=True, exist_ok=True)
+    timestamp = datetime.now(timezone.utc).strftime("%Y-%m-%d-%H%M%S")
+    stem = f"{timestamp}-{slug}"
+    path = drafts_dir / f"{stem}.md"
+    suffix = 2
+    while path.exists():
+        path = drafts_dir / f"{stem}-{suffix}.md"
+        suffix += 1
+    stem = path.stem
+    front = {
+        "id": stem,
+        "date": timestamp[:10],
+        "status": "open",
+        "finding_kind": kind,
+        "review_context": args.review_context,
+    }
+    if args.observed_sha:
+        front["observed_sha"] = args.observed_sha
+    lines = ["---"]
+    for key, value in front.items():
+        lines.append(f"{key}: {json.dumps(value) if key == 'review_context' else value}")
+    lines.append("---")
+    lines.append("")
+    lines.append(f"# {args.title}")
+    lines.append("")
+    lines.append("## Finding")
+    lines.append(args.finding or "<verbatim audit text>")
+    if kind == "bug-class":
+        lines.append("")
+        lines.append(f"Fixed by: {args.fixed_by}")
+    lines.append("")
+    lines.append("## Why this matters")
+    lines.append(args.why or "<one short paragraph on the lesson, not the instance>")
+    lines.append("")
+    lines.append("## Suggested next steps")
+    lines.append(args.next_steps or "- [ ] <concrete action>")
+    lines.append("")
+    path.write_text("\n".join(lines), encoding="utf-8")
+    errors = vbs.validate_file(path)
+    if errors:
+        path.unlink()
+        raise todo_db.TodoError("generated draft failed validation (not written): " + "; ".join(errors))
+    return path
+
+
+# ---------------------------------------------------------------------------
+# Promote (finding -> tracker item, atomic)
+
+
+def promote_finding(
+    conn: Any,
+    actor: str,
+    finding_id: str,
+    *,
+    new_item_id: str,
+    title: str | None = None,
+    priority: str = "medium",
+    worktree: str | None = None,
+    description: str | None = None,
+) -> None:
+    """Create a planning item from a finding, link it, and flip the finding to
+    ``promoted`` -- all in ONE write transaction, so a payload failure (e.g. a
+    duplicate item id) rolls back with NO orphan link and NO disposition flip.
+    Mirrors ``todo_db.promote_deferral``."""
+    with todo_db._write_txn(conn):
+        finding = _require_finding(conn, finding_id)
+        if finding["disposition"] in TERMINAL_DISPOSITIONS:
+            raise todo_db.TodoError(f"finding {finding_id!r} is {finding['disposition']} (terminal); cannot promote")
+        # Defaults must NOT inline the finding's verbatim review prose (title,
+        # finding_text, why_matters): the new item lands in the version-
+        # controlled export snapshot (items.jsonl) and its create event lands in
+        # events.jsonl -- both exported. Copying prose here would smuggle exactly
+        # the review text the export boundary keeps out of Git. Default to a
+        # reference instead; a caller who wants prose in the item passes explicit
+        # --title/--description and owns that choice. The finding id (a
+        # kebab-slug) is a tolerable identifier.
+        todo_db.create_item(
+            conn,
+            actor,
+            item_id=new_item_id,
+            title=title or f"Promoted finding {finding_id}"[:200],
+            worktree=worktree or "main",
+            priority=priority,
+            description=description
+            or (
+                f"Promoted from finding {finding_id}. "
+                f"Run `todo finding show {finding_id}` for the review prose "
+                f"(deliberately kept out of version control)."
+            ),
+            _in_txn=True,
+        )
+        conn.execute(
+            "INSERT INTO finding_links (finding_id, kind, target_item, note) VALUES (?, 'promoted-to', ?, ?)",
+            (finding_id, new_item_id, f"promoted by {actor}"),
+        )
+        updated = conn.execute(
+            "UPDATE findings SET disposition = 'promoted' WHERE id = ? AND disposition IN ('open','actionable')",
+            (finding_id,),
+        )
+        if updated.rowcount != 1:
+            raise todo_db.TodoError(f"finding {finding_id!r} disposition changed concurrently")
+        log_finding_event(conn, actor, finding_id, "promote", {"new_item": new_item_id})
+
+
+def add_link(
+    conn: Any,
+    actor: str,
+    finding_id: str,
+    *,
+    kind: str,
+    target_item: str | None,
+    target_finding: str | None,
+    note: str | None,
+) -> None:
+    if kind not in LINK_KINDS:
+        raise todo_db.TodoError(f"invalid link kind {kind!r}; one of {', '.join(LINK_KINDS)}")
+    if kind == "promoted-to":
+        # A 'promoted-to' link is created only by `todo finding promote`, which
+        # atomically flips the disposition alongside the link. Allowing it via
+        # `link` would leave a promoted-to edge with no disposition change.
+        raise todo_db.TodoError("'promoted-to' links are created by `todo finding promote`, not `link`")
+    if bool(target_item) == bool(target_finding):
+        raise todo_db.TodoError("link needs exactly one of --to-item / --to-finding")
+    with todo_db._write_txn(conn):
+        _require_finding(conn, finding_id)
+        if target_item and conn.execute("SELECT 1 FROM items WHERE id = ?", (target_item,)).fetchone() is None:
+            raise todo_db.TodoError(f"link target item {target_item!r} does not exist")
+        if target_finding:
+            _require_finding(conn, target_finding)
+        try:
+            conn.execute(
+                "INSERT INTO finding_links (finding_id, kind, target_item, target_finding, note)"
+                " VALUES (?, ?, ?, ?, ?)",
+                (finding_id, kind, target_item, target_finding, note),
+            )
+        except todo_db.sqlite3.IntegrityError as exc:
+            raise todo_db.TodoError(f"cannot link finding {finding_id!r}: {exc}") from exc
+        log_finding_event(
+            conn,
+            actor,
+            finding_id,
+            "link",
+            {"kind": kind, "target_item": target_item, "target_finding": target_finding},
+        )
+
+
+# ---------------------------------------------------------------------------
+# Query helpers
+
+
+def list_findings(conn: Any, *, disposition: str | None = None, rank: str | None = None) -> list[dict[str, Any]]:
+    """List findings. Default order is disposition then age (created_at); the
+    capture-time judgement fields (urgency/breadth/confidence) are often absent,
+    so ranking by them is opt-in (``--rank``) and never the default, or missing
+    values would launder guesses into a deterministic-looking order."""
+    query = "SELECT id, disposition, finding_kind, urgency, breadth, confidence, created_at, title FROM findings"
+    params: list[Any] = []
+    if disposition:
+        query += " WHERE disposition = ?"
+        params.append(disposition)
+    if rank in ("urgency", "breadth", "confidence"):
+        # NULLs last, then the rank field descending, then age; still deterministic.
+        query += f" ORDER BY ({rank} IS NULL), {rank} DESC, created_at, id"
+    else:
+        query += " ORDER BY disposition, created_at, id"
+    return [dict(row) for row in conn.execute(query, params)]
+
+
+# ---------------------------------------------------------------------------
+# Parser + dispatch
+
+
+def add_finding_subparsers(parser: argparse.ArgumentParser) -> None:
+    """Attach the ``finding`` sub-subcommands to todo_db's top-level parser."""
+    sub = parser.add_subparsers(dest="finding_command", required=True)
+
+    p = sub.add_parser("create", help="write a draft finding (draft file only, never the DB)")
+    p.add_argument("--title", required=True)
+    p.add_argument("--finding-kind", required=True, choices=sorted(vbs.ALLOWED_KIND))
+    p.add_argument("--review-context", required=True)
+    p.add_argument("--gate", help="review-protocol §2 attestation; must be 'class-not-instance'")
+    p.add_argument("--fixed-by", help="landed fix ref (required when --finding-kind bug-class)")
+    p.add_argument("--slug", help="kebab-slug override (default: derived from --title)")
+    p.add_argument("--finding", help="## Finding body text")
+    p.add_argument("--why", help="## Why this matters body text")
+    p.add_argument("--next-steps", dest="next_steps", help="## Suggested next steps body text")
+    p.add_argument("--observed-sha", help="provenance SHA (not a lookup key)")
+    p.add_argument("--drafts-dir", default=DEFAULT_DRAFTS_DIR)
+
+    p = sub.add_parser("candidates", help="list unsynced drafts (local glob, zero-credential)")
+    p.add_argument("--drafts-dir", default=DEFAULT_DRAFTS_DIR)
+
+    p = sub.add_parser("list", help="list findings")
+    p.add_argument("--disposition", choices=DISPOSITIONS)
+    p.add_argument("--rank", choices=("urgency", "breadth", "confidence"), help="opt-in post-triage ranking")
+
+    p = sub.add_parser("show", help="show one finding")
+    p.add_argument("id")
+    p.add_argument("--json", action="store_true")
+
+    p = sub.add_parser("sync", help="land drafts into the tracker (authorized landing step)")
+    p.add_argument("--drafts-dir", default=DEFAULT_DRAFTS_DIR)
+
+    p = sub.add_parser("dismiss", help="dismiss a finding with a reason")
+    p.add_argument("id")
+    p.add_argument("--reason", required=True)
+
+    p = sub.add_parser("triage", help="set judgement fields and/or move disposition")
+    p.add_argument("id")
+    p.add_argument("--urgency")
+    p.add_argument("--breadth")
+    p.add_argument("--confidence")
+    p.add_argument("--reconsider-after", dest="reconsider_after")
+    p.add_argument("--disposition", choices=("actionable", "actioned"))
+    p.add_argument("--reason")
+
+    p = sub.add_parser("link", help="link a finding to an item or another finding")
+    p.add_argument("id")
+    # 'promoted-to' is reserved for `todo finding promote` (it flips disposition
+    # atomically), so it is not offered here.
+    p.add_argument("--kind", required=True, choices=[k for k in LINK_KINDS if k != "promoted-to"])
+    p.add_argument("--to-item", dest="to_item")
+    p.add_argument("--to-finding", dest="to_finding")
+    p.add_argument("--note")
+
+    p = sub.add_parser("promote", help="promote a finding to a planning item (atomic)")
+    p.add_argument("id")
+    p.add_argument("--to-item", dest="to_item", required=True)
+    p.add_argument("--title")
+    p.add_argument("--priority", default="medium", choices=todo_db.PRIORITIES)
+    p.add_argument("--worktree")
+    p.add_argument("--description")
+
+
+def run_offline(actor: str, args: argparse.Namespace) -> int:
+    """Handle the zero-credential subcommands (``create``, ``candidates``) with
+    NO database connection -- capture must work with no creds and no network."""
+    if args.finding_command == "create":
+        path = create_draft(args)
+        print(f"Recorded: {path}")
+        print("Draft only -- run `todo finding sync` (a separate, authorized step) to land it.")
+        return 0
+    if args.finding_command == "candidates":
+        directory = Path(args.drafts_dir).expanduser()
+        drafts = sorted(p for p in directory.glob("*.md") if p.name != "README.md") if directory.is_dir() else []
+        for path in drafts:
+            print(path.name)
+        print(f"{len(drafts)} unsynced draft(s) in {directory}")
+        return 0
+    raise todo_db.TodoError(f"unknown offline finding subcommand {args.finding_command!r}")  # pragma: no cover
+
+
+def dispatch_finding(conn: Any, actor: str, args: argparse.Namespace) -> int:
+    """Handle the DB-backed ``finding`` subcommands (list/show/sync/dismiss/
+    triage/link/promote). ``create``/``candidates`` are handled offline in
+    ``todo_db.main`` before any connection is opened."""
+    command = args.finding_command
+    if command == "list":
+        for finding in list_findings(conn, disposition=args.disposition, rank=args.rank):
+            print(f"{finding['id']:45s} {finding['disposition']:11s} {finding['finding_kind']:14s} {finding['title']}")
+        return 0
+    if command == "show":
+        finding = _require_finding(conn, args.id)
+        if args.json:
+            print(json.dumps(finding, indent=2, sort_keys=True))
+        else:
+            _print_finding(finding)
+        return 0
+    if command == "sync":
+        result = sync_drafts(conn, actor, args.drafts_dir)
+        print(
+            f"synced {len(result['synced'])}, skipped {len(result['skipped'])} (already landed),"
+            f" pruned {result['pruned']} old .synced draft(s)"
+        )
+        return 0
+    if command == "dismiss":
+        with todo_db._write_txn(conn):
+            _set_disposition(conn, actor, args.id, "dismissed", args.reason)
+        print(f"{args.id} dismissed")
+        return 0
+    if command == "triage":
+        return _cmd_triage(conn, actor, args)
+    if command == "link":
+        add_link(
+            conn,
+            actor,
+            args.id,
+            kind=args.kind,
+            target_item=args.to_item,
+            target_finding=args.to_finding,
+            note=args.note,
+        )
+        print(f"linked {args.id} [{args.kind}]")
+        return 0
+    if command == "promote":
+        promote_finding(
+            conn,
+            actor,
+            args.id,
+            new_item_id=args.to_item,
+            title=args.title,
+            priority=args.priority,
+            worktree=args.worktree,
+            description=args.description,
+        )
+        print(f"finding {args.id} promoted to {args.to_item}")
+        return 0
+    raise todo_db.TodoError(f"unknown finding subcommand {command!r}")  # pragma: no cover
+
+
+def _cmd_triage(conn: Any, actor: str, args: argparse.Namespace) -> int:
+    updates: list[tuple[str, Any]] = []
+    for field in ("urgency", "breadth", "confidence", "reconsider_after"):
+        value = getattr(args, field)
+        if value is not None:
+            updates.append((field, value))
+    if not updates and not args.disposition:
+        raise todo_db.TodoError(
+            "triage needs at least one of --urgency/--breadth/--confidence/--reconsider-after/--disposition"
+        )
+    with todo_db._write_txn(conn):
+        _require_finding(conn, args.id)
+        if updates:
+            assignments = ", ".join(f"{field} = ?" for field, _ in updates)
+            conn.execute(
+                f"UPDATE findings SET {assignments} WHERE id = ?",
+                (*[value for _, value in updates], args.id),
+            )
+            log_finding_event(conn, actor, args.id, "triage", dict(updates))
+        if args.disposition:
+            _set_disposition(conn, actor, args.id, args.disposition, args.reason)
+    print(f"{args.id} triaged")
+    return 0
+
+
+def _print_finding(finding: dict[str, Any]) -> None:
+    print(f"== {finding['id']} [{finding['disposition']}] {finding['title']}")
+    print(f"kind={finding['finding_kind']} date={finding['date']} review={finding['review_context']}")
+    if finding.get("disposition_reason"):
+        print(f"reason: {finding['disposition_reason']}")
+    for label in ("urgency", "breadth", "confidence", "reconsider_after", "observed_sha"):
+        if finding.get(label):
+            print(f"{label}: {finding[label]}")
+    print("-- Finding")
+    print(finding["finding_text"])
+    print("-- Why this matters")
+    print(finding["why_matters"])
+    print("-- Suggested next steps")
+    print(finding["next_steps"])
+    for evidence in finding.get("evidence", []):
+        loc = ""
+        if evidence.get("line_start"):
+            loc = f":{evidence['line_start']}"
+            if evidence.get("line_end"):
+                loc += f"-{evidence['line_end']}"
+        print(f"evidence: {evidence['path']}{loc} {evidence.get('pattern') or ''}".rstrip())
+    for link in finding.get("links", []):
+        target = link.get("target_item") or link.get("target_finding") or "(dangling)"
+        print(f"link: {link['kind']} -> {target}")

--- a/tests/unit/scripts/test_todo_db_export_allowlist.py
+++ b/tests/unit/scripts/test_todo_db_export_allowlist.py
@@ -88,23 +88,48 @@ class TestExportAllowlistShape:
 
 class TestExportFailsClosed:
     def test_unlisted_finding_table_never_reaches_the_snapshot(self, conn, tmp_path):
-        # A future findings table with real data must not leak into any
-        # committed export file. Because the exporter reads only allowlisted
-        # tables, the sentinel row is never read -> never written.
+        # The real findings-domain tables (v3 schema) carrying prose in every
+        # prose-heavy column must not leak into any committed export file.
+        # Because the exporter reads only allowlisted tables, this data is never
+        # read -> never written. Exercises all four tables so the guarantee is
+        # not tied to one name the exporter's SELECTs happen not to reference.
         _mk(conn, item_id="real-item")
         sentinel = "LEAK-SENTINEL-finding-prose-do-not-commit"
-        # Every findings-domain table (including the prose-heavy `findings` and
-        # `finding_events`), so the guarantee is not tied to one table name the
-        # exporter's SELECTs happen not to reference.
-        finding_tables = ("findings", "finding_evidence", "finding_links", "finding_events")
-        for table in finding_tables:
-            conn.execute(f"CREATE TABLE {table} (id TEXT PRIMARY KEY, body TEXT)")
-            conn.execute(f"INSERT INTO {table} (id, body) VALUES (?, ?)", ("x1", f"{sentinel}-{table}"))
+        fid = "2026-01-01-000000-leak-class"
+        conn.execute(
+            "INSERT INTO findings (id, date, finding_kind, review_context, title,"
+            " finding_text, why_matters, next_steps, created_at)"
+            " VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            (
+                fid,
+                "2026-01-01",
+                "framework-gap",
+                f"{sentinel}-review-context",
+                f"{sentinel}-title",
+                f"{sentinel}-finding",
+                f"{sentinel}-why",
+                f"{sentinel}-next",
+                "2026-01-01T00:00:00Z",
+            ),
+        )
+        conn.execute(
+            "INSERT INTO finding_evidence (finding_id, path, note) VALUES (?, ?, ?)",
+            (fid, "some/path.py", f"{sentinel}-evidence"),
+        )
+        conn.execute(
+            "INSERT INTO finding_links (finding_id, kind, note) VALUES (?, 'informs', ?)",
+            (fid, f"{sentinel}-link"),
+        )
+        conn.execute(
+            "INSERT INTO finding_events (at, actor, finding_id, action, detail) VALUES (?, ?, ?, ?, ?)",
+            ("2026-01-01T00:00:00Z", "tester", fid, "sync", f"{sentinel}-event"),
+        )
         conn.commit()
 
         out_dir = tmp_path / "export"
         todo_db.write_export(conn, out_dir)
 
+        finding_tables = ("findings", "finding_evidence", "finding_links", "finding_events")
         for produced in sorted(out_dir.iterdir()):
             text = produced.read_text(encoding="utf-8")
             assert sentinel not in text, f"findings data leaked into committed export file {produced.name}"

--- a/tests/unit/scripts/test_todo_db_hosted.py
+++ b/tests/unit/scripts/test_todo_db_hosted.py
@@ -533,6 +533,39 @@ class TestHostedAdapter:
         exported = todo_db.export_all(conn)
         assert exported[0]["anti_patterns"] == order["anti_patterns"]
 
+
+class TestHostedFindings:
+    """Findings writes travel the SAME hosted _write_txn + per-statement
+    delegation as items. CI exercises that path here so the phase-3 anti-pattern
+    (hosted write paths are only manually acceptance-tested) has fake-backend
+    coverage; w8 is the manual prod acceptance on top of this."""
+
+    def test_finding_insert_and_dismiss_through_hosted_delegation(self, fake_libsql):
+        todo_findings = todo_db.todo_findings
+        conn = _hosted_conn(fake_libsql)
+        fields = {
+            "id": "2026-01-02-030405-hosted-class",
+            "date": "2026-01-02",
+            "finding_kind": "framework-gap",
+            "review_context": "hosted path",
+            "title": "Hosted finding class",
+            "finding_text": "the review never checks the hosted delegation",
+            "why_matters": "hosted writes are only manually acceptance-tested",
+            "next_steps": "- [ ] exercise the hosted cursor",
+            "disposition": "open",
+        }
+        with todo_db._write_txn(conn):
+            todo_findings.insert_finding(conn, "tester", fields)
+        stored = todo_findings.get_finding(conn, fields["id"])
+        assert stored is not None and stored["disposition"] == "open"
+        assert [event["action"] for event in stored["events"]] == ["sync"]
+        # A disposition transition travels the same hosted write path.
+        with todo_db._write_txn(conn):
+            todo_findings._set_disposition(conn, "tester", fields["id"], "dismissed", "not load-bearing")
+        assert todo_findings.get_finding(conn, fields["id"])["disposition"] == "dismissed"
+        # Findings never leak into the items-domain export, even from a hosted conn.
+        assert todo_db.export_all(conn) == []
+
     def test_cursor_is_iterable(self, fake_libsql):
         conn = _hosted_conn(fake_libsql)
         _make_item(conn, item_id="iter-one")
@@ -975,7 +1008,10 @@ class TestHostedBulkImport:
 
 class TestHostedMigrate:
     def _v1_schema(self) -> str:
-        script = todo_db.SCHEMA_SQL
+        # CORE (pre-findings) schema minus the v2 columns: a real v1 DB had
+        # neither the started_* columns nor the v3 findings tables, so migrate
+        # can add both without a 'table findings already exists' collision.
+        script = todo_db._CORE_SCHEMA_SQL
         for column in ("started_at TEXT", "started_worktree TEXT", "started_branch TEXT"):
             script = script.replace(f"  {column},\n", "")
         assert "started_at" not in script
@@ -993,12 +1029,15 @@ class TestHostedMigrate:
         # current CLI must refuse it ...
         with pytest.raises(todo_db.TodoError, match="todo migrate"):
             todo_db.connect_backend(HOSTED_URL)
-        # ... and migrate must fix it in place
+        # ... and migrate must fix it in place, applying every pending version
         applied = todo_db.migrate_backend(HOSTED_URL)
-        assert applied == [2]
+        assert applied == [2, 3]
         conn = todo_db.connect_backend(HOSTED_URL)
         cols = [row[1] for row in conn.execute("PRAGMA table_info(work_units)").fetchall()]
         assert "started_at" in cols
+        # v3 findings tables landed too.
+        tables = [row[0] for row in conn.execute("SELECT name FROM sqlite_master WHERE type='table'").fetchall()]
+        assert "findings" in tables
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/scripts/test_todo_db_v2.py
+++ b/tests/unit/scripts/test_todo_db_v2.py
@@ -200,12 +200,16 @@ class TestResumeLocation:
 
 class TestSchemaMigration:
     def _make_v1_db(self, tmp_path):
-        """Reconstruct a v1 database: current schema minus the v2 columns."""
+        """Reconstruct a v1 database: the CORE (pre-findings) schema minus the
+        v2 columns. Uses _CORE_SCHEMA_SQL, not SCHEMA_SQL: a real v1/v2 DB never
+        had findings tables, and MIGRATIONS[3] recreates them on upgrade -- so
+        seeding from the full current schema would collide ('table findings
+        already exists')."""
         import sqlite3
 
         v1_sql = "\n".join(
             line
-            for line in todo_db.SCHEMA_SQL.splitlines()
+            for line in todo_db._CORE_SCHEMA_SQL.splitlines()
             if "started_at" not in line and "started_worktree" not in line and "started_branch" not in line
         )
         db_path = tmp_path / "v1.sqlite"
@@ -225,9 +229,13 @@ class TestSchemaMigration:
         db_path = self._make_v1_db(tmp_path)
         applied = todo_db.migrate_db(db_path)
         assert applied  # at least one migration ran
+        assert todo_db.SCHEMA_VERSION in applied  # ... reaching the current version
         conn = todo_db.connect(db_path)  # no longer refuses
         columns = {row["name"] for row in conn.execute("PRAGMA table_info(work_units)")}
         assert {"started_at", "started_worktree", "started_branch"} <= columns
+        # v3 (findings domain) tables exist after the upgrade.
+        tables = {row["name"] for row in conn.execute("SELECT name FROM sqlite_master WHERE type='table'")}
+        assert {"findings", "finding_evidence", "finding_links", "finding_events"} <= tables
         conn.close()
 
     def test_migrate_is_idempotent(self, tmp_path):

--- a/tests/unit/scripts/test_todo_findings.py
+++ b/tests/unit/scripts/test_todo_findings.py
@@ -1,0 +1,416 @@
+"""Tests for the findings domain (phase 3): schema v3, the ``todo finding`` CLI,
+sync, promote, and -- critically -- the non-claimability guarantee.
+
+Findings live in separate tables (``findings``, ``finding_evidence``,
+``finding_links``, ``finding_events``) and must be STRUCTURALLY invisible to the
+items-domain surfaces: ``ready``, ``claim``, ``lint --all``, ``stats`` open
+counts, and ``deps``. That invisibility is by construction (those queries read
+only ``items`` and its children), pinned here so a future refactor cannot
+silently make a finding claimable or inflate the open-item count.
+
+Marked ``medium`` (not ``fast``): materialises scratch databases and matches the
+sibling ``test_todo_db*`` suites, so it stays out of the fast-lane budget.
+"""
+
+from __future__ import annotations
+
+import importlib
+import sys
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+pytestmark = [
+    pytest.mark.unit,
+    pytest.mark.medium,
+]
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+SCRIPTS = REPO_ROOT / "_project" / "scripts"
+if str(SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS))
+
+todo_findings = importlib.import_module("todo_findings")
+# Bind the EXACT todo_db instance todo_findings raises TodoError from. Sibling
+# test files load todo_db under synthetic names (spec_from_file_location), so a
+# plain import_module("todo_db") can resolve to a different instance under broad
+# collection -- then `pytest.raises(todo_db.TodoError)` would miss the class the
+# findings code actually raises. At runtime there is only one instance.
+todo_db = todo_findings.todo_db
+
+
+@pytest.fixture()
+def conn(tmp_path):
+    connection = todo_db.connect(tmp_path / "todo.sqlite")
+    yield connection
+    connection.close()
+
+
+def _mk_finding(conn, finding_id="2026-01-02-030405-a-sample-class", **overrides):
+    fields = {
+        "id": finding_id,
+        "date": "2026-01-02",
+        "finding_kind": "framework-gap",
+        "review_context": "ultrareview X / feat/thing",
+        "observed_sha": None,
+        "title": "A sample blind-spot class",
+        "finding_text": "the review never checks axis Y",
+        "why_matters": "axis Y is a whole dimension of correctness",
+        "next_steps": "- [ ] add a gate for axis Y",
+        "disposition": "open",
+        "disposition_reason": None,
+        "evidence": [],
+    }
+    fields.update(overrides)
+    with todo_db._write_txn(conn):
+        todo_findings.insert_finding(conn, "tester", fields)
+    return finding_id
+
+
+def _mk_item(conn, item_id="a-real-item", **overrides):
+    kwargs = {
+        "item_id": item_id,
+        "title": "A real tracked item",
+        "worktree": "spike",
+        "priority": "medium",
+        "description": "A description longer than ten characters.",
+    }
+    kwargs.update(overrides)
+    todo_db.create_item(conn, "tester", **kwargs)
+    return item_id
+
+
+def _draft(path: Path, stem: str, *, status="open", finding="the review never checks axis Y", title="A sample class"):
+    path.parent.mkdir(parents=True, exist_ok=True)
+    (path.parent / f"{stem}.md").write_text(
+        "---\n"
+        f"id: {stem}\n"
+        "date: 2026-01-02\n"
+        f"status: {status}\n"
+        "finding_kind: framework-gap\n"
+        'review_context: "ultrareview X"\n'
+        "---\n\n"
+        f"# {title}\n\n"
+        f"## Finding\n{finding}\n\n"
+        "## Why this matters\naxis Y is a whole dimension\n\n"
+        "## Suggested next steps\n- [ ] add a gate for axis Y\n",
+        encoding="utf-8",
+    )
+    return path.parent / f"{stem}.md"
+
+
+# ---------------------------------------------------------------------------
+# Schema + CHECK constraints (w1)
+
+
+class TestFindingsSchema:
+    def test_v3_tables_and_version(self, conn):
+        tables = {row["name"] for row in conn.execute("SELECT name FROM sqlite_master WHERE type='table'")}
+        assert {"findings", "finding_evidence", "finding_links", "finding_events"} <= tables
+        assert conn.execute("SELECT value FROM meta WHERE key='schema_version'").fetchone()["value"] == "3"
+
+    def test_disposition_check_rejects_unknown(self, conn):
+        with pytest.raises(todo_db.sqlite3.IntegrityError):
+            conn.execute(
+                "INSERT INTO findings (id, date, finding_kind, review_context, title, finding_text,"
+                " why_matters, next_steps, disposition, created_at)"
+                " VALUES ('2026-01-01-000000-x', '2026-01-01', 'other', 'r', 't', 'f', 'w', 'n', 'bogus', 'now')"
+            )
+
+    def test_reason_required_check_for_dismissed(self, conn):
+        # dismissed/actionable without a reason violates the CHECK.
+        with pytest.raises(todo_db.sqlite3.IntegrityError):
+            conn.execute(
+                "INSERT INTO findings (id, date, finding_kind, review_context, title, finding_text,"
+                " why_matters, next_steps, disposition, created_at)"
+                " VALUES ('2026-01-01-000000-x', '2026-01-01', 'other', 'r', 't', 'f', 'w', 'n', 'dismissed', 'now')"
+            )
+
+
+# ---------------------------------------------------------------------------
+# Non-claimability pinning suite (w7): findings invisible to items surfaces
+
+
+class TestFindingsNonClaimable:
+    def test_findings_absent_from_ready(self, conn):
+        _mk_item(conn, item_id="ready-item")
+        _mk_finding(conn)
+        ready_ids = {item["id"] for item in todo_db.ready_items(conn, "tester")}
+        assert "ready-item" in ready_ids
+        assert not any("class" in rid for rid in ready_ids)
+        assert "2026-01-02-030405-a-sample-class" not in ready_ids
+
+    def test_finding_id_is_not_claimable_as_an_item(self, conn):
+        fid = _mk_finding(conn)
+        # A finding id is not an item id; claim must refuse it as a missing item.
+        with pytest.raises(todo_db.TodoError):
+            todo_db.claim_item(conn, "tester", fid)
+
+    def test_lint_all_ignores_findings(self, conn, capsys):
+        _mk_item(conn, item_id="lint-item")
+        fid = _mk_finding(conn)
+        # Drive the REAL `lint --all` code path: it iterates planning/active
+        # ITEMS only, so the finding is never a lint target (across 1 item, not 2).
+        todo_db._cmd_lint(conn, "tester", SimpleNamespace(all=True, id=None))
+        out = capsys.readouterr().out
+        assert fid not in out
+        assert "across 1 item(s)" in out
+
+    def test_findings_absent_from_deps(self, conn):
+        # `todo deps <finding-id>` must not resolve a finding as an item (N2).
+        fid = _mk_finding(conn)
+        with pytest.raises(todo_db.TodoError):
+            todo_db._cmd_deps(conn, "tester", SimpleNamespace(id=fid))
+
+    def test_stats_open_counts_exclude_findings(self, conn):
+        _mk_item(conn, item_id="stats-item")
+        before = todo_db.stats(conn)
+        _mk_finding(conn)
+        _mk_finding(conn, finding_id="2026-01-02-030406-another-class")
+        after = todo_db.stats(conn)
+        # Adding findings must not move any items-domain count.
+        assert after == before
+
+    def test_findings_do_not_appear_in_items_table(self, conn):
+        _mk_finding(conn)
+        item_ids = {row["id"] for row in conn.execute("SELECT id FROM items")}
+        assert item_ids == set()
+
+    def test_ready_and_claim_sql_reference_only_items(self):
+        # Guard the must-preserve "ready+claim SQL unchanged": neither routine's
+        # source may start reading a findings table.
+        import inspect
+
+        for func in (todo_db.ready_items, todo_db.claim_item):
+            src = inspect.getsource(func)
+            for table in ("findings", "finding_evidence", "finding_links", "finding_events"):
+                assert table not in src, f"{func.__name__} must not reference {table}"
+
+
+# ---------------------------------------------------------------------------
+# Sync: the authorized landing step (w5)
+
+
+class TestFindingSync:
+    def test_finding_sync_inserts_absent(self, conn, tmp_path):
+        drafts = tmp_path / "drafts"
+        _draft(drafts / "x.md", "2026-01-02-030405-sync-me-class")
+        result = todo_findings.sync_drafts(conn, "tester", drafts)
+        assert result["synced"] == ["2026-01-02-030405-sync-me-class"]
+        assert todo_findings.get_finding(conn, "2026-01-02-030405-sync-me-class") is not None
+        # renamed out of the unsynced glob
+        assert (drafts / "2026-01-02-030405-sync-me-class.md.synced").exists()
+        assert not (drafts / "2026-01-02-030405-sync-me-class.md").exists()
+
+    def test_finding_sync_is_idempotent(self, conn, tmp_path):
+        drafts = tmp_path / "drafts"
+        _draft(drafts / "x.md", "2026-01-02-030405-idem-class")
+        first = todo_findings.sync_drafts(conn, "tester", drafts)
+        assert len(first["synced"]) == 1
+        # Re-writing the SAME draft (unsynced again) and re-syncing is a no-op skip.
+        _draft(drafts / "x.md", "2026-01-02-030405-idem-class")
+        second = todo_findings.sync_drafts(conn, "tester", drafts)
+        assert second["synced"] == [] and second["skipped"] == ["2026-01-02-030405-idem-class"]
+
+    def test_finding_sync_conflict_is_loud_never_merged(self, conn, tmp_path):
+        drafts = tmp_path / "drafts"
+        _draft(drafts / "x.md", "2026-01-02-030405-conflict-class", finding="original text")
+        todo_findings.sync_drafts(conn, "tester", drafts)
+        # Same id, DIFFERENT content -> loud error, never a silent merge.
+        _draft(drafts / "x.md", "2026-01-02-030405-conflict-class", finding="TAMPERED text")
+        with pytest.raises(todo_db.TodoError, match="sync conflict"):
+            todo_findings.sync_drafts(conn, "tester", drafts)
+        # The stored copy is untouched (no merge).
+        stored = todo_findings.get_finding(conn, "2026-01-02-030405-conflict-class")
+        assert stored["finding_text"] == "original text"
+
+    def test_finding_sync_prunes_old_synced_drafts(self, conn, tmp_path):
+        drafts = tmp_path / "drafts"
+        drafts.mkdir()
+        old = drafts / "2020-01-01-000000-ancient-class.md.synced"
+        old.write_text("stale", encoding="utf-8")
+        stale_time = (datetime.now(timezone.utc) - timedelta(days=todo_findings.SYNCED_PRUNE_DAYS + 5)).timestamp()
+        import os
+
+        os.utime(old, (stale_time, stale_time))
+        result = todo_findings.sync_drafts(conn, "tester", drafts)
+        assert result["pruned"] == 1
+        assert not old.exists()
+
+    def test_finding_sync_zero_credential_candidate_count(self, tmp_path):
+        drafts = tmp_path / "drafts"
+        _draft(drafts / "x.md", "2026-01-02-030405-pending-class")
+        # A pure local glob -- no DB, no credentials.
+        assert todo_findings.count_unsynced_drafts(drafts) == 1
+
+
+# ---------------------------------------------------------------------------
+# Promote: finding -> item, atomic (w6)
+
+
+class TestFindingPromote:
+    def test_finding_promote_creates_item_links_and_flips(self, conn):
+        fid = _mk_finding(conn)
+        todo_findings.promote_finding(conn, "tester", fid, new_item_id="promoted-item")
+        assert conn.execute("SELECT 1 FROM items WHERE id='promoted-item'").fetchone() is not None
+        finding = todo_findings.get_finding(conn, fid)
+        assert finding["disposition"] == "promoted"
+        assert finding["links"] == [
+            {
+                "kind": "promoted-to",
+                "target_item": "promoted-item",
+                "target_finding": None,
+                "note": "promoted by tester",
+            }
+        ]
+
+    def test_finding_promote_does_not_leak_prose_into_item_or_events(self, conn):
+        # C1: the auto-generated item title/description (which land in the
+        # exported items.jsonl, and the create event lands in events.jsonl) must
+        # NOT inline the finding's verbatim review prose. Promote with no
+        # explicit --title/--description so only the defaults are in play.
+        prose = "SENTINEL-review-prose-not-versioned"
+        fid = _mk_finding(
+            conn,
+            finding_id="2026-01-02-030405-leaky-class",
+            title=f"{prose}-title",
+            finding_text=f"{prose}-finding",
+            why_matters=f"{prose}-why",
+        )
+        todo_findings.promote_finding(conn, "tester", fid, new_item_id="promoted-leaky")
+        item = todo_db.get_item(conn, "promoted-leaky")
+        assert prose not in item["title"]
+        assert prose not in (item["description"] or "")
+        events_text = " ".join(
+            str(row["detail"]) for row in conn.execute("SELECT detail FROM events WHERE item_id='promoted-leaky'")
+        )
+        assert prose not in events_text
+
+    def test_finding_promote_rolls_back_on_duplicate_item(self, conn):
+        _mk_item(conn, item_id="taken-id")
+        fid = _mk_finding(conn)
+        # Promoting to an existing item id must fail AND leave no partial state:
+        # disposition stays open, no link row, no finding_events promote row.
+        with pytest.raises(todo_db.TodoError):
+            todo_findings.promote_finding(conn, "tester", fid, new_item_id="taken-id")
+        finding = todo_findings.get_finding(conn, fid)
+        assert finding["disposition"] == "open"
+        assert finding["links"] == []
+        assert [e["action"] for e in finding["events"]] == ["sync"]  # only the original insert event
+
+    def test_finding_promote_rejects_terminal(self, conn):
+        fid = _mk_finding(conn, disposition="dismissed", disposition_reason="not load-bearing")
+        with pytest.raises(todo_db.TodoError, match="terminal"):
+            todo_findings.promote_finding(conn, "tester", fid, new_item_id="never-item")
+
+
+# ---------------------------------------------------------------------------
+# Capture: create gate + draft-only (w4)
+
+
+class TestFindingCreate:
+    def _args(self, drafts_dir, **overrides):
+        base = {
+            "finding_command": "create",
+            "title": "A sample class",
+            "finding_kind": "framework-gap",
+            "review_context": "ultrareview X",
+            "gate": "class-not-instance",
+            "fixed_by": None,
+            "slug": None,
+            "finding": "the review never checks axis Y",
+            "why": "axis Y matters",
+            "next_steps": "- [ ] add a gate",
+            "observed_sha": None,
+            "drafts_dir": str(drafts_dir),
+        }
+        base.update(overrides)
+        return SimpleNamespace(**base)
+
+    def test_finding_create_requires_gate_attestation(self, tmp_path):
+        with pytest.raises(todo_db.TodoError, match="class-not-instance"):
+            todo_findings.create_draft(self._args(tmp_path / "d", gate=None))
+
+    def test_finding_create_bug_class_requires_fixed_by(self, tmp_path):
+        with pytest.raises(todo_db.TodoError, match="fixed-by"):
+            todo_findings.create_draft(self._args(tmp_path / "d", finding_kind="bug-class"))
+
+    def test_finding_create_writes_valid_draft_only(self, tmp_path):
+        path = todo_findings.create_draft(self._args(tmp_path / "d"))
+        assert path.exists()
+        # The generated draft passes the phase-1 validator by construction.
+        import validate_blind_spot as vbs
+
+        assert vbs.validate_file(path) == []
+
+    def test_finding_create_collision_suffix(self, tmp_path):
+        a = todo_findings.create_draft(self._args(tmp_path / "d", slug="dup-class"))
+        b = todo_findings.create_draft(self._args(tmp_path / "d", slug="dup-class"))
+        assert a != b  # second write gets a -2 suffix, never overwrites
+
+
+# ---------------------------------------------------------------------------
+# Disposition transitions, triage, link (w3)
+
+
+class TestFindingDisposition:
+    def test_dismiss_requires_reason(self, conn):
+        fid = _mk_finding(conn)
+        with pytest.raises(SystemExit):
+            todo_db.main(["--db", "x", "finding", "dismiss", fid])  # argparse: --reason required
+
+    def test_dismiss_sets_disposition(self, conn):
+        fid = _mk_finding(conn)
+        with todo_db._write_txn(conn):
+            todo_findings._set_disposition(conn, "tester", fid, "dismissed", "not load-bearing")
+        assert todo_findings.get_finding(conn, fid)["disposition"] == "dismissed"
+
+    def test_illegal_transition_rejected(self, conn):
+        fid = _mk_finding(conn, disposition="actioned")
+        with pytest.raises(todo_db.TodoError, match="terminal"), todo_db._write_txn(conn):
+            todo_findings._set_disposition(conn, "tester", fid, "open", None)
+
+    def test_triage_sets_judgment_fields(self, conn):
+        fid = _mk_finding(conn)
+        args = SimpleNamespace(
+            finding_command="triage",
+            id=fid,
+            urgency="high",
+            breadth="wide",
+            confidence="med",
+            reconsider_after=None,
+            disposition=None,
+            reason=None,
+        )
+        todo_findings._cmd_triage(conn, "tester", args)
+        finding = todo_findings.get_finding(conn, fid)
+        assert (finding["urgency"], finding["breadth"], finding["confidence"]) == ("high", "wide", "med")
+
+    def test_link_requires_exactly_one_target(self, conn):
+        fid = _mk_finding(conn)
+        with pytest.raises(todo_db.TodoError, match="exactly one"):
+            todo_findings.add_link(
+                conn, "tester", fid, kind="informs", target_item=None, target_finding=None, note=None
+            )
+
+    def test_link_reserves_promoted_to_for_promote(self, conn):
+        # N6: 'promoted-to' edges come only from `finding promote` (atomic flip).
+        _mk_item(conn, item_id="an-item")
+        fid = _mk_finding(conn)
+        with pytest.raises(todo_db.TodoError, match="promote"):
+            todo_findings.add_link(
+                conn, "tester", fid, kind="promoted-to", target_item="an-item", target_finding=None, note=None
+            )
+
+
+class TestFindingListOrdering:
+    def test_list_default_order_is_not_by_urgency(self, conn):
+        # Capture-time urgency is often absent; the default order is disposition
+        # then age, never a fabricated urgency ranking (anti-pattern).
+        _mk_finding(conn, finding_id="2026-01-02-030405-first-class", urgency=None)
+        _mk_finding(conn, finding_id="2026-01-02-030406-second-class", urgency="high")
+        ids = [f["id"] for f in todo_findings.list_findings(conn)]
+        # both open -> ordered by created_at/id, so the earlier id sorts first
+        assert ids == ["2026-01-02-030405-first-class", "2026-01-02-030406-second-class"]


### PR DESCRIPTION
## ⚠️ Do NOT auto-merge — coordinated production migration required

Merging this bumps the tracker CLI to `SCHEMA_VERSION = 3`. The CLI **refuses to
run against a DB older than its `SCHEMA_VERSION`** (migrations never auto-apply),
so the moment this lands on `develop`, **every collaborator's `todo` CLI is inert
against the live v2 `benchbox-todo` DB until someone runs `todo migrate`.** Land
the code and run the hosted `todo migrate` **together**, with maintainer sign-off.
Work unit **w8 (manual hosted acceptance against `benchbox-todo`)** is the gate on
top of this PR and is intentionally **not** done yet (CI covers fakes only).
Auto-merge is deliberately left OFF.

## Summary

Phase 3 of the findings domain (`_project/specs/findings-domain.md`). Moves
blind-spot findings into the shared tracker DB as a sibling module and adds the
`todo finding` CLI. Additive migration, `SCHEMA_VERSION` 2 → 3.

- **Schema (w1)** — four tables (`findings`, `finding_evidence`, `finding_links`,
  `finding_events`) with CHECKs (disposition set, reason-required for
  actionable/dismissed). The DDL lives in `todo_findings.FINDINGS_SCHEMA_SQL` and
  is composed into **both** `SCHEMA_SQL` (fresh bootstrap) and `MIGRATIONS[3]`
  (v2→v3 upgrade) from one source, so fresh and migrated DBs converge. `migrate`
  covers hosted + local.
- **Module (w2)** — `todo_findings.py` holds all findings logic (row helpers,
  disposition transitions, append-only `finding_events` logging), keeping the
  2.8k-line `todo_db.py` monolith's blast radius contained. `todo_db.py` only
  wires the parser + dispatch.
- **CLI (w3–w6)** — `finding create | list | show | candidates | dismiss |
  triage | link | promote | sync`. Fail-closed classifier: create/candidates are
  zero-credential (draft/glob only, dispatched before backend resolution);
  list/show read; sync/dismiss/triage/link/promote mutate.
- **Capture gate (w4)** — `create` prints the review-protocol §2 defect gate,
  requires `--gate class-not-instance`, and refuses `bug-class` without
  `--fixed-by`. It writes the **draft file only, never the DB**.
- **Sync (w5)** — insert-if-absent by filename-stem id; same-id/different-content
  is a **loud error, never a merge**; `*.md.synced` rename + 30-day prune;
  cred-less unsynced-draft count.
- **Promote (w6)** — item + link + disposition flip in one `_write_txn` (mirrors
  `promote_deferral`), clean rollback on failure.
- **Non-claimability (w7)** — findings are structurally invisible to
  `ready`/`claim`/`lint --all`/`stats`/`deps` (separate tables; those routines
  read only the items domain). Pinned by tests.

## Export boundary

The four findings tables are absent from `EXPORT_TABLE_ALLOWLIST`,
`_ITEM_NESTED_EXPORT_TABLES`, and `TRANSFER_TABLES`, so review prose can never
reach the version-controlled `_project/todo-db-export/` snapshot. The phase-2
pinning test now inserts real v3 rows with prose sentinels and asserts absence.
Adversarial review caught one content-copy path (`promote` inlined the finding's
verbatim `finding_text`/`why_matters`/title into the exported item description +
create event); fixed to reference the finding (`todo finding show <id>`) instead,
pinned by `test_finding_promote_does_not_leak_prose_into_item_or_events`.

## Testing

- Verification ladder: seq1 `-k 'finding and (claim or ready or lint or stats)'`,
  seq2 `finding_sync`, seq3 `finding_promote`, seq4 `make test-fast` (25463
  passed) — all green.
- Full `tests/unit/scripts` = 955 passed. New `test_todo_findings.py` (30 tests) +
  a hosted-delegation finding write/dismiss test in `test_todo_db_hosted.py`.
- Import-cycle robustness verified live: `python todo_db.py finding create`
  without `--gate` exits 2 cleanly (no traceback) — proving `TodoError` identity
  under `__main__`.
- Findings tests are `medium` (consistent with sibling `test_todo_db*`), so the
  fast-lane cap (`fast_test_lane_policy.json`) is unchanged — correctly untouched.

## Review

Independent five-axis adversarial review: one Critical (the promote prose-leak
above) fixed and pinned; Nits N1 (tautological lint test → drives the real
`_cmd_lint`), N2 (added `deps` non-claimability test), N3 (cosmetic evidence
line-range), N6 (`link` reserves `promoted-to` for `promote`) all addressed.
Consciously **not** changed: N4 — `_set_disposition` overwrites
`disposition_reason` on transition (defensible: the column reflects the *current*
disposition; full history survives in `finding_events`). N5 — a latent test-only
module-identity nuance in `TestHostedFindings` (currently benign; `TodoError`
identity is safe there because no cross-instance `pytest.raises` is asserted).

## Scope

All changes within the item's `only_modify` globs: `_project/scripts/todo_db.py`,
`_project/scripts/todo_findings.py`, `tests/unit/scripts/**`. No `do_not_modify`
path touched. `validate_blind_spot.py` reused unchanged; the master spec is
unchanged (implementation matches the accepted design).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
