### PR TITLE
fix(cli): propagate DataFrame tuning config in non-interactive run

### DIFF
--- a/benchbox/cli/commands/run.py
+++ b/benchbox/cli/commands/run.py
@@ -773,6 +773,21 @@ def _tuning_override_entries(s: types.SimpleNamespace) -> dict[str, Any]:
     return entries
 
 
+def _df_tuning_config_option_entry(s: types.SimpleNamespace) -> dict[str, Any]:
+    """benchmark_config.options entry carrying the resolved DataFrame tuning config.
+
+    The interactive path sets ``options["df_tuning_config"]`` directly in
+    ``_interactive_tuning_step``; the non-interactive builders assemble
+    ``options`` inline and previously omitted it, so a plain
+    ``benchbox run --tuning <file>`` on a DataFrame platform reached the adapter
+    untuned (``orchestrator._build_platform_adapter`` reads the config from
+    ``benchmark_config.options``) and its bundle carried no applied ledger.
+    Mirror the interactive assignment here so the direct, data/load-only, and
+    dry-run builders propagate it identically.
+    """
+    return {"df_tuning_config": s.df_tuning_config} if s.df_tuning_config else {}
+
+
 def _validate_non_interactive(s: types.SimpleNamespace) -> None:
     """Set env flag and validate required args for non-interactive mode."""
     if not s.non_interactive:
@@ -1376,6 +1391,7 @@ def _run_dry_run(s: types.SimpleNamespace) -> None:
             "tuning_enabled": s.tuning_enabled,
             "table_mode": s.table_mode,
             "unified_tuning_configuration": s.loaded_unified_config,
+            **_df_tuning_config_option_entry(s),
             **({"data_organization": s.data_organization_payload} if s.data_organization_payload is not None else {}),
             "force_regenerate": s.force_regenerate,
             "enable_preflight_validation": s.enable_preflight_validation,
@@ -1564,6 +1580,7 @@ def _run_direct(s: types.SimpleNamespace) -> None:
             "tuning_enabled": s.tuning_enabled,
             "table_mode": s.table_mode,
             "unified_tuning_configuration": s.loaded_unified_config,
+            **_df_tuning_config_option_entry(s),
             **({"data_organization": s.data_organization_payload} if s.data_organization_payload is not None else {}),
             "force_regenerate": s.force_regenerate,
             "enable_preflight_validation": s.enable_preflight_validation,
@@ -1812,6 +1829,7 @@ def _run_data_or_load_only(s: types.SimpleNamespace) -> None:
             "estimated_time_range": benchmark_info["estimated_time_range"],
             "table_mode": s.table_mode,
             "unified_tuning_configuration": s.loaded_unified_config,
+            **_df_tuning_config_option_entry(s),
             **({"data_organization": s.data_organization_payload} if s.data_organization_payload is not None else {}),
             "force_regenerate": s.force_regenerate,
             "enable_preflight_validation": s.enable_preflight_validation,

--- a/tests/unit/cli/test_run_command_interactive_paths.py
+++ b/tests/unit/cli/test_run_command_interactive_paths.py
@@ -877,6 +877,98 @@ def test_fallback_wizard_baseline_reclassifies_runtime_state_for_dataframe_platf
     assert mock_save_last_run.call_args.kwargs["tuning_mode"] == "notuning"
 
 
+def test_direct_dataframe_tuning_config_propagates_to_benchmark_config(tmp_path: Path):
+    """Non-interactive `benchbox run` must forward the resolved DataFrame tuning
+    config into benchmark_config.options so the adapter is built tuned.
+
+    Regression for cli-dataframe-tuning-config-propagation: the direct builder
+    resolved df_tuning_config onto the run state but never placed it in
+    benchmark_config.options (the interactive path did), so a plain
+    ``benchbox run --tuning <file>`` on a DataFrame platform reached the adapter
+    untuned and its bundle carried no applied ledger.
+    """
+    runner = CliRunner()
+
+    profiler = Mock()
+    profiler.get_system_profile.return_value = SimpleNamespace(
+        cpu_cores_logical=8,
+        memory_total_gb=32,
+        architecture="x86_64",
+        os_type="darwin",
+    )
+    profiler.display_profile.return_value = None
+
+    database_config = SimpleNamespace(
+        type="polars-df",
+        options={},
+        execution_mode="dataframe",
+        driver_version_actual=None,
+        driver_version_resolved=None,
+    )
+    db_manager = Mock()
+    db_manager.create_config.return_value = database_config
+
+    bench_manager = Mock()
+    bench_manager.benchmarks = {
+        "tpch": {
+            "display_name": "TPC-H",
+            "estimated_time_range": (2, 10),
+            "complexity": "medium",
+            "num_queries": 22,
+        }
+    }
+    bench_manager.validate_scale_factor.return_value = None
+
+    orchestrator = Mock()
+    result_payload = SimpleNamespace(validation_status="PASSED", execution_id="exec-123", query_results=[])
+    df_tuning_config = SimpleNamespace(name="df-direct-tuned")
+
+    with ExitStack() as stack:
+        stack.enter_context(patch.object(_run_module, "SystemProfiler", return_value=profiler))
+        stack.enter_context(patch.object(_run_module, "DatabaseManager", return_value=db_manager))
+        stack.enter_context(patch.object(_run_module, "BenchmarkManager", return_value=bench_manager))
+        stack.enter_context(patch.object(_run_module, "BenchmarkOrchestrator", return_value=orchestrator))
+        stack.enter_context(patch.object(_run_module, "display_system_recommendations"))
+        stack.enter_context(
+            patch.object(
+                _run_module.PlatformRegistry,
+                "get_platform_capabilities",
+                return_value=SimpleNamespace(default_mode="dataframe", supports_sql=False, supports_dataframe=True),
+            )
+        )
+        stack.enter_context(patch.object(_run_module.PlatformRegistry, "requires_cloud_storage", return_value=False))
+        # Isolate the plumbing under test: pretend the resolver produced a
+        # DataFrame tuning config regardless of tuning-mode internals.
+        mock_resolve = stack.enter_context(
+            patch.object(_run_module, "resolve_dataframe_tuning_config", return_value=df_tuning_config)
+        )
+        mock_execute = stack.enter_context(
+            patch.object(_run_module, "_execute_orchestrated_run", return_value=result_payload)
+        )
+        stack.enter_context(
+            patch.object(
+                _run_module,
+                "_export_orchestrated_result",
+                return_value={"json": str(tmp_path / "results.json")},
+            )
+        )
+        stack.enter_context(patch.object(_run_module, "_render_post_run_charts"))
+        stack.enter_context(patch("benchbox.cli.onboarding.check_and_run_first_time_setup", return_value=False))
+        stack.enter_context(patch("benchbox.cli.preferences.load_last_run_config", return_value=None))
+        stack.enter_context(patch("benchbox.cli.preferences.save_last_run_config"))
+
+        result = runner.invoke(
+            run,
+            ["--platform", "polars-df", "--benchmark", "tpch", "--non-interactive"],
+            obj=_run_obj(),
+        )
+
+    assert result.exit_code == 0, result.output
+    assert mock_resolve.called
+    executed_benchmark_config = mock_execute.call_args.args[1]
+    assert executed_benchmark_config.options["df_tuning_config"] is df_tuning_config
+
+
 def test_interactive_tuning_declined_sets_notuning_state(tmp_path: Path):
     """Declining tuning must set tuning_enabled=False and suppress --tuning in the preview."""
     runner = CliRunner()


### PR DESCRIPTION
## Description

Non-interactive `benchbox run --tuning <file>` on a DataFrame platform built an
**untuned** adapter, and its bundle carried no applied ledger.

Root cause: the interactive path sets `benchmark_config.options["df_tuning_config"]`
in `_interactive_tuning_step`, but the three non-interactive builders
(`_run_direct`, `_run_data_or_load_only`, `_run_dry_run`) assemble `options`
inline and omitted it. Since `orchestrator._build_platform_adapter` reads the
DataFrame tuning config from `benchmark_config.options` (`opts.get("df_tuning_config")`),
the resolved `s.df_tuning_config` never reached the adapter on the non-interactive path.

Fix: add `_df_tuning_config_option_entry(s)` mirroring the interactive assignment
and apply it to all three non-interactive builders, so the resolved config reaches
the adapter identically (direct, data/load-only, and dry-run preview).

Resolves TODO `cli-dataframe-tuning-config-propagation-20260722` (follow-up from
`tuning-df-ledger-parity-20260716`).

## Type of Change

- [x] Bug fix

## Testing

- Added `test_direct_dataframe_tuning_config_propagates_to_benchmark_config` (fast,
  `tests/unit/cli/test_run_command_interactive_paths.py`): drives the direct
  non-interactive path with a patched `resolve_dataframe_tuning_config` sentinel and
  asserts it lands in the executed `benchmark_config.options`.
- `pytest tests/unit/cli/test_run_command_interactive_paths.py tests/unit/cli/test_run_command_branches.py` → 125 passed.
- Existing negative coverage (fallback baseline → `df_tuning_config` absent when tuning
  disabled) still passes.
- `ruff check` / `ruff format --check` clean on changed files.
- `timing_policy_check.py --strict` passes (no fast-lane cap bump needed; the +1 fast
  test fits existing headroom).

## Public Contract Check

- [x] No public/beta/deprecated/generated/experimental/repo-only contract surfaces
      change — this aligns the non-interactive CLI path with the already-documented
      interactive behavior.

## Documentation

- [x] Behavior fix bringing non-interactive in line with interactive; no user-facing
      doc change required. Regression captured by the new test.

## Code Quality

- [x] Ran `ruff check` and `ruff format --check` on changed files.
- [x] Reviewed the three non-interactive builders for identical propagation.
- [x] Added a regression test for the fixed path.

## Artifact Hygiene

- [x] No raw artifacts committed.

## Notes

- Scope limited to `benchbox/cli/**` plumbing (the TODO's stated scope). The helper is
  applied to `_run_dry_run` and `_run_data_or_load_only` as well as `_run_direct`, since
  all three shared the same omission (dry-run's tuning preview reads
  `config.options.get("df_tuning_config")`; load-only tuning affects write layout).
- No skipped review nits.

---
_Generated by [Claude Code](https://claude.ai/code/session_01ReAoE6uW4XdAiB7ERvhNgR)_