### PR TITLE
fix(tuning): make DuckDB sorting + ClickHouse keys verification-eligible

### DIFF
--- a/benchbox/platforms/base/adapter.py
+++ b/benchbox/platforms/base/adapter.py
@@ -804,6 +804,11 @@ class PlatformAdapter(
             # connection; read back once at result construction. Reset here so a
             # reused adapter instance never carries a prior run's statements.
             self._applied_tuning_ledger = AppliedTuningLedger()
+            # Fresh post-load layout-op accumulator for the same reason: adapters
+            # that record post-load layout statements here (DuckDB sort-index
+            # re-creation, ClickHouse tuned sort-key DDL, Databricks OPTIMIZE/
+            # ZORDER) must not fold a prior run's ops into this run's ledger.
+            self._applied_layout_operations = []
 
             self.log_verbose(f"Checking database_was_reused flag before schema creation: {self.database_was_reused}")
             if self.database_was_reused:

--- a/benchbox/platforms/clickhouse/introspection.py
+++ b/benchbox/platforms/clickhouse/introspection.py
@@ -11,14 +11,18 @@ tables) and non-fatal (any failure returns an :class:`IntrospectedState` with
 ``error`` set). Uses structured catalog columns, never ``SHOW CREATE TABLE``
 DDL text.
 
-Limitation (see the design note): ClickHouse applies ``ORDER BY`` /
-``PARTITION BY`` at ``CREATE TABLE`` time in the schema phase, which is not
-wrapped by the tuning recording connection, so those column-bearing DDLs
-never enter the applied ledger -- the ledger's ClickHouse tuning entries are
-``OPTIMIZE TABLE`` (maintenance, non-blocking) and session SETs. The observed
-keys are therefore reported as informational evidence but do NOT, on their
-own, mint ``applied_verified`` (a MergeTree table's ``sorting_key`` is always
-present, so that would be an unearned upgrade).
+ClickHouse applies ``ORDER BY`` / ``PARTITION BY`` at ``CREATE TABLE`` time in
+the schema phase, which is not wrapped by the tuning recording connection. A
+*tuned* sort key is therefore folded into the applied ledger explicitly by
+``create_schema`` (``_record_tuned_sort_key_op`` records the executed
+``CREATE TABLE ... ORDER BY (cols)`` as a ``PHASE_DDL`` statement), so this
+introspector's ``sorting_key`` read can corroborate that recorded intent and
+earn ``applied_verified``. The *engine-mandatory baseline* ``ORDER BY``
+(primary-key derived or ``tuple()``) is not tuning and is deliberately NOT
+recorded -- a MergeTree table's ``sorting_key`` is always present, so
+corroborating it against nothing would be an unearned upgrade. The ledger's
+other ClickHouse tuning entries remain ``OPTIMIZE TABLE`` (maintenance,
+non-blocking) and session SETs.
 
 Copyright 2026 Joe Harris / BenchBox Project
 

--- a/benchbox/platforms/clickhouse/workload.py
+++ b/benchbox/platforms/clickhouse/workload.py
@@ -59,13 +59,20 @@ class ClickHouseWorkloadMixin:
                 # Optimize table definitions for ClickHouse
                 table_name = self._extract_table_name(statement)
                 nullable_columns = nullable_columns_by_table.get(table_name.lower(), set()) if table_name else set()
-                statement = self._optimize_table_definition(
+                optimized = self._optimize_table_definition(
                     statement,
                     table_tunings,
                     nullable_columns=nullable_columns,
                 )
-                connection.execute(statement)
-                self.logger.debug(f"Executed schema statement: {statement[:100]}...")
+                connection.execute(optimized)
+                # Fold a tuned MergeTree ORDER BY into the applied ledger. The
+                # tuned sort key is rendered into the CREATE TABLE executed here
+                # on the raw connection (outside the tuning RecordingConnection),
+                # so without this it never enters the ledger and the run cannot
+                # reach applied_verified even though system.tables.sorting_key
+                # carries the key.
+                self._record_tuned_sort_key_op(statement, optimized, table_name, table_tunings)
+                self.logger.debug(f"Executed schema statement: {optimized[:100]}...")
 
             self.logger.info(f"Schema created (PKs: {enable_primary_keys}, FKs: {enable_foreign_keys})")
 
@@ -172,6 +179,54 @@ class ClickHouseWorkloadMixin:
                 statement = statement + order_by_clause
 
         return statement
+
+    def _record_tuned_sort_key_op(
+        self,
+        original_statement: str,
+        executed_statement: str,
+        table_name: str | None,
+        table_tunings: dict[str, Any] | None,
+    ) -> None:
+        """Record a tuned MergeTree ORDER BY as a post-load layout op.
+
+        ``_fold_layout_operations_into_ledger`` folds this into the applied
+        ledger as a ``PHASE_DDL`` statement, so the introspection receipt can
+        corroborate the recorded ``CREATE TABLE ... ORDER BY (cols)`` against the
+        catalog ``system.tables.sorting_key`` and upgrade the run to
+        ``applied_verified``.
+
+        Only the *tuned* sort key is recorded. The engine-mandatory baseline
+        ``ORDER BY`` (primary-key derived or ``tuple()``) is not tuning and stays
+        out of the ledger, matching the tuned-branch condition in
+        ``_optimize_table_definition`` (rendered only when the source statement
+        carried no ``ORDER BY`` and the tuned generator produced a ``sort_by``).
+        Never breaks a run: any failure degrades to a debug log.
+        """
+        try:
+            if not (getattr(self, "tuning_enabled", False) and table_tunings):
+                return
+            if "ORDER BY" in original_statement.upper():
+                return  # pre-existing ORDER BY was not overridden by tuning
+            tuning_clauses = self._resolve_tuned_ddl_clauses(original_statement, table_tunings)
+            if tuning_clauses is None or not tuning_clauses.sort_by:
+                return
+            from benchbox.core.tuning.applied_ledger import PHASE_DDL
+
+            ops = getattr(self, "_applied_layout_operations", None)
+            if ops is None:
+                ops = []
+                self._applied_layout_operations = ops
+            ops.append(
+                {
+                    "statement": executed_statement,
+                    "phase": PHASE_DDL,
+                    "status": "applied",
+                    "mechanism": "sort_key",
+                    "table": table_name,
+                }
+            )
+        except Exception as exc:  # capture must never break a run
+            self.logger.debug("clickhouse tuned sort-key ledger fold degraded: %s", exc)
 
     @staticmethod
     def _extract_table_name(statement: str) -> str | None:

--- a/benchbox/platforms/duckdb.py
+++ b/benchbox/platforms/duckdb.py
@@ -125,6 +125,18 @@ def _build_duckdb_ctas_sort_sql(table_name: str, sort_columns) -> str:
     )
 
 
+def _duckdb_sort_index_sql(table_name_upper: str, column_names: list[str]) -> str:
+    """CREATE INDEX DDL for a DuckDB sort index.
+
+    Shared by the pre-load tuning path (``apply_table_tunings``) and the
+    post-CTAS re-creation (``_recreate_sort_index_after_ctas``) so both land the
+    SAME ``idx_<table>_sort`` footprint -- the one ``duckdb_indexes()`` (and thus
+    the introspection receipt) corroborates.
+    """
+    index_name = f"idx_{table_name_upper.lower()}_sort"
+    return f"CREATE INDEX IF NOT EXISTS {index_name} ON {table_name_upper} ({', '.join(column_names)})"
+
+
 def _resolve_external_data_source(benchmark: Any, data_dir: Path, adapter: Any = None) -> Any:
     """Resolve the DataSource for external table/view registration."""
     from benchbox.platforms.base.data_loading import DataSourceResolver
@@ -946,6 +958,67 @@ class DuckDBAdapter(PlatformAdapter):
         """Build DuckDB CTAS SQL used by PlatformAdapter.apply_ctas_sort."""
         return _build_duckdb_ctas_sort_sql(table_name, sort_columns)
 
+    def apply_ctas_sort(self, table_name: str, tuning_config: Any, connection: Any) -> bool:
+        """CTAS-sort a table, then re-create its sort index so the footprint survives.
+
+        The shared CTAS sort issues ``CREATE OR REPLACE TABLE ... ORDER BY``,
+        which drops the ``idx_<table>_sort`` index ``apply_table_tunings`` built
+        pre-load. Left there, post-load introspection finds no catalog footprint
+        (``duckdb_indexes()`` is empty for the table) and the run stays
+        ``applied_unverified`` even though it physically sorted. Re-create the
+        index post-CTAS so introspection can corroborate it.
+        """
+        applied = super().apply_ctas_sort(table_name, tuning_config, connection)
+        if applied and not self.dry_run_mode:
+            self._recreate_sort_index_after_ctas(table_name, tuning_config, connection)
+        return applied
+
+    def _recreate_sort_index_after_ctas(self, table_name: str, tuning_config: Any, connection: Any) -> None:
+        """Re-create the sort index the CTAS re-materialization dropped.
+
+        Records the re-creation as a ``PHASE_POST_LOAD`` layout op (folded into
+        the applied ledger by ``_fold_layout_operations_into_ledger``) so the
+        introspection receipt can corroborate a real, surviving
+        ``duckdb_indexes()`` footprint and upgrade the run to
+        ``applied_verified``. Never breaks a run: a failed re-creation is logged
+        and recorded as a failed op, and the load continues.
+        """
+        sort_columns = self._resolve_ctas_sort_columns(table_name, tuning_config)
+        if not sort_columns:
+            return
+        sorted_cols = sorted(sort_columns, key=lambda col: col.order)
+        table_name_upper = table_name.upper()
+        index_sql = _duckdb_sort_index_sql(table_name_upper, [col.name for col in sorted_cols])
+        try:
+            connection.execute(index_sql)
+            self.log_verbose(f"Re-created sort index on {table_name_upper} after CTAS sort")
+        except Exception as exc:  # capture never breaks a run
+            self.logger.warning(f"Failed to re-create sort index on {table_name_upper} after CTAS: {exc}")
+            self._record_sort_index_layout_op(index_sql, table_name_upper, status="failed", error=exc)
+            return
+        self._record_sort_index_layout_op(index_sql, table_name_upper, status="applied")
+
+    def _record_sort_index_layout_op(
+        self, statement: str, table: str, *, status: str, error: Exception | None = None
+    ) -> None:
+        """Append a post-load sort-index op for ``_fold_layout_operations_into_ledger``."""
+        from benchbox.core.tuning.applied_ledger import PHASE_POST_LOAD
+
+        ops = getattr(self, "_applied_layout_operations", None)
+        if ops is None:
+            ops = []
+            self._applied_layout_operations = ops
+        ops.append(
+            {
+                "statement": statement,
+                "phase": PHASE_POST_LOAD,
+                "status": status,
+                "mechanism": "sort_index",
+                "table": table,
+                "error_message": str(error) if error is not None else None,
+            }
+        )
+
     def configure_for_benchmark(self, connection: Any, benchmark_type: str) -> None:
         """Apply DuckDB-specific optimizations based on benchmark type."""
         # Enable profiling only when displaying plans; skip when capture_plans is active.
@@ -1247,8 +1320,7 @@ class DuckDBAdapter(PlatformAdapter):
                 column_names = [col.name for col in sorted_cols]
 
                 # Create index for sort optimization
-                index_name = f"idx_{table_name_upper.lower()}_sort"
-                index_sql = f"CREATE INDEX IF NOT EXISTS {index_name} ON {table_name_upper} ({', '.join(column_names)})"
+                index_sql = _duckdb_sort_index_sql(table_name_upper, column_names)
 
                 try:
                     connection.execute(index_sql)

--- a/tests/unit/platforms/test_clickhouse_introspection.py
+++ b/tests/unit/platforms/test_clickhouse_introspection.py
@@ -15,11 +15,15 @@ from __future__ import annotations
 import pytest
 
 from benchbox.core.tuning.applied_ledger import (
+    APPLIED_UNVERIFIED,
+    APPLIED_VERIFIED,
     PHASE_DDL,
     PHASE_SESSION,
     AppliedTuningLedger,
 )
+from benchbox.core.tuning.interface import TableTuning, TuningColumn, UnifiedTuningConfiguration
 from benchbox.core.tuning.introspection import KIND_PARTITION_KEY, KIND_SORT_KEY, corroborate
+from benchbox.platforms.clickhouse.adapter import ClickHouseAdapter
 from benchbox.platforms.clickhouse.introspection import ClickHouseTuningIntrospector
 
 pytestmark = [pytest.mark.unit, pytest.mark.fast]
@@ -79,13 +83,82 @@ class TestClickHouseIntrospector:
         assert state.objects == []
 
     def test_optimize_ledger_reports_keys_but_stays_unverified(self):
-        # Documented limitation: ClickHouse's key DDL runs outside the ledger, so
-        # the ledger's OPTIMIZE (maintenance) + SET (transient) statements are
-        # non-blocking and there is nothing catalog-backed to earn verification.
-        # The observed keys still surface in the receipt as evidence.
+        # A ClickHouse ledger carrying only OPTIMIZE (maintenance) + SET
+        # (transient) statements is non-blocking and has nothing catalog-backed
+        # to earn verification. The observed keys still surface as evidence.
+        # (The tuned sort key IS folded into the ledger separately -- see
+        # TestTunedSortKeyFold below.)
         rows = [("lineitem", "l_orderkey, l_linenumber", "")]
         ledger = _optimize_ledger()
         receipt = corroborate(ledger, ClickHouseTuningIntrospector().introspect(_FakeCHConnection(rows), ledger))
         assert receipt.corroborated is False
         assert receipt.summary["verifiable_total"] == 0
         assert any(o.kind == KIND_SORT_KEY for o in receipt.observed)
+
+
+def _sorted_tuning_config() -> UnifiedTuningConfiguration:
+    config = UnifiedTuningConfiguration()
+    config.table_tunings["LINEITEM"] = TableTuning(
+        table_name="LINEITEM",
+        sorting=[
+            TuningColumn(name="l_orderkey", type="INTEGER", order=1),
+            TuningColumn(name="l_linenumber", type="INTEGER", order=2),
+        ],
+    )
+    return config
+
+
+class TestTunedSortKeyFold:
+    """The tuned MergeTree ORDER BY is folded into the applied ledger so it can
+    corroborate against ``system.tables.sorting_key`` and earn verification.
+    """
+
+    def _tuned_adapter(self) -> ClickHouseAdapter:
+        adapter = ClickHouseAdapter()
+        adapter.tuning_enabled = True
+        adapter._applied_tuning_ledger = AppliedTuningLedger()
+        adapter._applied_layout_operations = []
+        return adapter
+
+    def test_tuned_order_by_records_sort_key_op(self):
+        adapter = self._tuned_adapter()
+        tunings = _sorted_tuning_config().table_tunings
+        original = "CREATE TABLE lineitem (l_orderkey INTEGER, l_linenumber INTEGER, l_comment VARCHAR)"
+        optimized = adapter._optimize_table_definition(original, tunings, nullable_columns=set())
+        assert "ORDER BY (l_orderkey, l_linenumber)" in optimized
+
+        adapter._record_tuned_sort_key_op(original, optimized, "lineitem", tunings)
+        ops = [op for op in adapter._applied_layout_operations if op["mechanism"] == "sort_key"]
+        assert len(ops) == 1
+        assert ops[0]["phase"] == PHASE_DDL and ops[0]["table"] == "lineitem"
+
+    def test_full_flow_reaches_applied_verified(self):
+        adapter = self._tuned_adapter()
+        tunings = _sorted_tuning_config().table_tunings
+        original = "CREATE TABLE lineitem (l_orderkey INTEGER, l_linenumber INTEGER, l_comment VARCHAR)"
+        optimized = adapter._optimize_table_definition(original, tunings, nullable_columns=set())
+        adapter._record_tuned_sort_key_op(original, optimized, "lineitem", tunings)
+        adapter._fold_layout_operations_into_ledger()
+
+        conn = _FakeCHConnection([("lineitem", "l_orderkey, l_linenumber", "")])
+        status, receipt = adapter._corroborate_applied_ledger(conn, APPLIED_UNVERIFIED)
+        assert status == APPLIED_VERIFIED
+        assert receipt["corroborated"] is True
+
+    def test_baseline_order_by_not_recorded(self):
+        # An untuned table (not in the tuning config) gets only the
+        # engine-mandatory baseline ORDER BY, which is NOT tuning -> not recorded.
+        adapter = self._tuned_adapter()
+        tunings = _sorted_tuning_config().table_tunings
+        original = "CREATE TABLE nation (n_nationkey INTEGER PRIMARY KEY, n_name VARCHAR)"
+        optimized = adapter._optimize_table_definition(original, tunings, nullable_columns=set())
+        adapter._record_tuned_sort_key_op(original, optimized, "nation", tunings)
+        assert not [op for op in adapter._applied_layout_operations if op["mechanism"] == "sort_key"]
+
+    def test_no_record_when_tuning_disabled(self):
+        adapter = self._tuned_adapter()
+        adapter.tuning_enabled = False
+        tunings = _sorted_tuning_config().table_tunings
+        original = "CREATE TABLE lineitem (l_orderkey INTEGER, l_linenumber INTEGER)"
+        adapter._record_tuned_sort_key_op(original, original, "lineitem", tunings)
+        assert adapter._applied_layout_operations == []

--- a/tests/unit/platforms/test_duckdb_introspection.py
+++ b/tests/unit/platforms/test_duckdb_introspection.py
@@ -20,9 +20,11 @@ from benchbox.core.tuning.applied_ledger import (
     APPLIED_UNVERIFIED,
     APPLIED_VERIFIED,
     PHASE_DDL,
+    PHASE_POST_LOAD,
     AppliedTuningLedger,
     recording_connection,
 )
+from benchbox.core.tuning.interface import TableTuning, TuningColumn, UnifiedTuningConfiguration
 from benchbox.core.tuning.introspection import ABSENT, CORROBORATED, KIND_INDEX, corroborate
 from benchbox.platforms.duckdb import DuckDBAdapter
 from benchbox.platforms.duckdb_introspection import DuckDBTuningIntrospector
@@ -182,3 +184,67 @@ class TestAdapterUpgradeWiring:
 
     def test_duckdb_adapter_exposes_introspector(self):
         assert isinstance(DuckDBAdapter().get_tuning_introspector(), DuckDBTuningIntrospector)
+
+
+# ---------------------------------------------------------------------------
+# CTAS-sort index re-creation: the sort footprint survives to corroboration.
+# ---------------------------------------------------------------------------
+def _sorted_tuning_config() -> UnifiedTuningConfiguration:
+    config = UnifiedTuningConfiguration()
+    config.table_tunings["LINEITEM"] = TableTuning(
+        table_name="LINEITEM",
+        sorting=[
+            TuningColumn(name="L_ORDERKEY", type="INTEGER", order=1),
+            TuningColumn(name="L_LINENUMBER", type="INTEGER", order=2),
+        ],
+    )
+    return config
+
+
+class TestCtasSortIndexReCreation:
+    """The CTAS `CREATE OR REPLACE TABLE` drops the pre-load sort index; the
+    adapter re-creates it post-CTAS so the footprint survives and corroborates.
+    """
+
+    def _adapter_with_loaded_table(self) -> tuple[DuckDBAdapter, object]:
+        con = duckdb.connect(":memory:")
+        con.execute("CREATE TABLE LINEITEM(L_ORDERKEY INTEGER, L_LINENUMBER INTEGER, L_COMMENT VARCHAR)")
+        con.execute("INSERT INTO LINEITEM VALUES (3, 1, 'c'), (1, 2, 'a'), (2, 1, 'b')")
+        adapter = DuckDBAdapter()
+        adapter.tuning_enabled = True
+        adapter._applied_tuning_ledger = AppliedTuningLedger()
+        adapter._applied_layout_operations = []
+        return adapter, con
+
+    def test_ctas_sort_recreates_index_and_records_post_load_op(self):
+        adapter, con = self._adapter_with_loaded_table()
+        config = _sorted_tuning_config()
+        # Pre-load tuning creates the index (recorded via the wrapped connection).
+        adapter.apply_unified_tuning(config, recording_connection(con, adapter._applied_tuning_ledger, PHASE_DDL))
+        # CTAS sort drops-and-recreates the table; the override re-makes the index.
+        assert adapter.apply_ctas_sort("LINEITEM", config, con) is True
+
+        indexes = {row[0] for row in con.execute("SELECT index_name FROM duckdb_indexes()").fetchall()}
+        assert "idx_lineitem_sort" in indexes
+        post_load = [op for op in adapter._applied_layout_operations if op["mechanism"] == "sort_index"]
+        assert len(post_load) == 1
+        assert post_load[0]["phase"] == PHASE_POST_LOAD
+        assert post_load[0]["status"] == "applied"
+
+    def test_full_flow_reaches_applied_verified(self):
+        adapter, con = self._adapter_with_loaded_table()
+        config = _sorted_tuning_config()
+        adapter.apply_unified_tuning(config, recording_connection(con, adapter._applied_tuning_ledger, PHASE_DDL))
+        adapter.apply_ctas_sort("LINEITEM", config, con)
+        adapter._fold_layout_operations_into_ledger()
+        status, receipt = adapter._corroborate_applied_ledger(con, APPLIED_UNVERIFIED)
+        assert status == APPLIED_VERIFIED
+        assert receipt["corroborated"] is True
+
+    def test_dry_run_does_not_recreate_index(self):
+        adapter, con = self._adapter_with_loaded_table()
+        adapter.dry_run_mode = True
+        config = _sorted_tuning_config()
+        adapter.apply_ctas_sort("LINEITEM", config, con)
+        # Dry run captures SQL but must not execute the re-creation or record an op.
+        assert not [op for op in adapter._applied_layout_operations if op["mechanism"] == "sort_index"]


### PR DESCRIPTION
## Description

Two tuned-run gaps kept a physically-tuned run at `applied_unverified` because the
sort footprint never reached the introspection receipt (#1276 corroboration path):

- **DuckDB.** `apply_table_tunings` creates `idx_<t>_sort` pre-load (recorded in the
  ledger), but the sorted-ingestion CTAS (`CREATE OR REPLACE TABLE ... ORDER BY`)
  re-materializes the table and drops that index, so post-load `duckdb_indexes()` is
  empty → corroboration returns `ABSENT` → stays `applied_unverified`. Re-create the
  index post-CTAS (a real, surviving footprint) and fold it into the ledger as a
  `PHASE_POST_LOAD` op so introspection corroborates it.
- **ClickHouse.** The tuned MergeTree `ORDER BY` is rendered into `CREATE TABLE` and
  executed on the raw connection in `create_schema` (outside the tuning
  `RecordingConnection`), so it never enters the ledger and there is no verifiable
  statement to match the always-present `system.tables.sorting_key`. Fold the executed
  tuned `CREATE TABLE ... ORDER BY (cols)` into the ledger as a `PHASE_DDL` op (tuned
  sort keys only; the engine-mandatory baseline `ORDER BY` is deliberately not recorded).

Both fold through the existing `_applied_layout_operations` →
`_fold_layout_operations_into_ledger` seam, and record **only after** the real
statement executes, so `applied_verified` is still minted solely by live-catalog
corroboration in `_corroborate_applied_ledger`. `_applied_layout_operations` is now
reset per run in the base adapter so a reused adapter never folds a prior run's ops.

Resolves TODO `tuning-verification-footprint-duckdb-clickhouse-20260722` (follow-up
from `tuning-introspection-receipts-20260716`).

## Type of Change

- [x] Bug fix

## Testing

- New DuckDB tests (`tests/unit/platforms/test_duckdb_introspection.py`, real in-memory
  DuckDB): post-CTAS index re-creation + recorded `PHASE_POST_LOAD` op; full flow →
  `applied_verified`; dry-run skips re-creation.
- New ClickHouse tests (`tests/unit/platforms/test_clickhouse_introspection.py`, fake
  connection): tuned-sort-key fold; full flow → `applied_verified`; baseline `ORDER BY`
  not recorded; tuning-disabled not recorded.
- `pytest test_duckdb_introspection.py test_clickhouse_introspection.py test_introspection.py` → 47 passed.
- Broader regression: `pytest tests/unit/platforms -k "duckdb or clickhouse or sorted_ingestion or layout or applied_ledger"` → 693 passed, 2 skipped (env); databricks layout/ledger → 56 passed; applied-receipt/ledger export → 9 passed.
- `test_compat_lint_clean.py` → 10 passed (new methods do not trip the DDL-drift heuristic; no governance registration needed).
- `ruff check` / `ruff format --check` clean; `ty check` clean on changed files.
- `timing_policy_check.py --strict` → violations 0 (fast lane collects 25512 < 25520 cap; no bump needed).

## Public Contract Check

- [x] No public/beta/deprecated/generated/experimental/repo-only contract surfaces
      change — this is an internal soundness fix. `applied_verified` remains earned only
      via live-catalog corroboration (honesty invariant preserved).

## Documentation

- [x] Updated the ClickHouse introspector docstring to reflect that tuned sort keys are
      now folded into the ledger (the prior "keys never enter the ledger" limitation now
      applies only to the engine-mandatory baseline). Regression captured by tests.

## Code Quality

- [x] Ran `ruff`, `ruff format --check`, `ty check` on changed files.
- [x] Reviewed the `applied_verified` honesty path: both fixes execute the real
      statement first and record only on success; a failed DuckDB re-creation stays
      `applied_unverified` (ABSENT); the ClickHouse baseline `ORDER BY` is not recorded.
- [x] Added positive, negative, dry-run, and disabled-tuning tests.

## Artifact Hygiene

- [x] No raw artifacts committed.

## Notes

- DuckDB creates the sort index twice on a tuned run (pre-load on the empty table, then
  post-CTAS on the loaded/sorted table). The pre-load creation is cheap (empty table) and
  already existed; the post-CTAS re-creation is what restores the intended, corroboratable
  footprint the CTAS was silently dropping.
- MotherDuck (separate adapter) is out of scope and unchanged.
- No skipped review nits.

---
_Generated by [Claude Code](https://claude.ai/code/session_01ReAoE6uW4XdAiB7ERvhNgR)_