### PR TITLE
fix(tuning): capture native Spark session config in the applied ledger

### DIFF
--- a/benchbox/platforms/_spark_helpers.py
+++ b/benchbox/platforms/_spark_helpers.py
@@ -378,12 +378,23 @@ class SparkLikeAdapterMixin:
         apply_standard_unified_tuning(self, unified_config, connection)
 
     def apply_platform_optimizations(self, platform_config: Any, connection: Any) -> None:
-        """Forward ``platform_config.spark`` settings to ``spark.conf.set``."""
+        """Forward ``platform_config.spark`` settings to ``spark.conf.set``.
+
+        ``spark.conf.set(...)`` is a native Spark call, not an ``execute()`` /
+        ``cursor().execute()``, so it bypasses the applied-ledger
+        ``RecordingConnection`` that wraps this connection -- without the explicit
+        record below, a tuned native-Spark run would apply real session config
+        yet report ``noop`` (never a false ``applied``). Mirror the cloud-Spark
+        capture (``CloudSparkConfigMixin.configure_for_benchmark``): record each
+        setting that actually took effect as an executed ``PHASE_SESSION``
+        statement in the shared ledger.
+        """
         if not platform_config:
             return
 
         spark = connection
         platform = self.platform_name  # type: ignore[attr-defined]
+        ledger = getattr(self, "_applied_tuning_ledger", None)
         if hasattr(platform_config, "spark") and platform_config.spark:
             for key, value in platform_config.spark.items():
                 try:
@@ -393,8 +404,36 @@ class SparkLikeAdapterMixin:
                     self.logger.warning(  # type: ignore[attr-defined]
                         f"Failed to apply {platform} config spark.{key}: {exc}"
                     )
+                    self._record_spark_conf_ledger(ledger, key, value, applied=False, error=exc)
+                    continue
+                # Record only after the set actually took effect (honest ledger).
+                self._record_spark_conf_ledger(ledger, key, value, applied=True)
 
         self.logger.info(f"{platform} platform optimizations applied")  # type: ignore[attr-defined]
+
+    @staticmethod
+    def _record_spark_conf_ledger(ledger: Any, key: str, value: Any, *, applied: bool, error: Any = None) -> None:
+        """Record a ``spark.conf.set`` into the applied-tuning ledger. Never raises.
+
+        Reuses the shared ``benchbox.core.tuning.applied_ledger`` vocabulary (a
+        ``PHASE_SESSION`` ``SET spark.<key>=<value>`` statement, executed/failed)
+        so native Spark session config appears in the same ledger + hash as every
+        other platform's tuning statements.
+        """
+        if ledger is None:
+            return
+        try:
+            from benchbox.core.tuning.applied_ledger import EXECUTED, PHASE_SESSION, STATEMENT_FAILED
+
+            ledger.record(
+                f"SET spark.{key}={value}",
+                PHASE_SESSION,
+                status=EXECUTED if applied else STATEMENT_FAILED,
+                mechanism="spark_session_config",
+                error=error,
+            )
+        except Exception:  # pragma: no cover - capture must never break a run
+            pass
 
 
 def run_spark_schema_creation_loop(

--- a/tests/unit/platforms/test_spark_helpers.py
+++ b/tests/unit/platforms/test_spark_helpers.py
@@ -745,6 +745,54 @@ class TestSparkLikeAdapterMixin:
         warnings = [r.message for r in caplog.records if r.levelno == logging.WARNING]
         assert any("Failed to apply Spark config spark.foo.bar" in m for m in warnings)
 
+    def test_platform_optimizations_recorded_in_applied_ledger(self) -> None:
+        # spark.conf.set bypasses RecordingConnection; the applied config must be
+        # recorded so a tuned native-Spark run reports applied_unverified, not noop.
+        from benchbox.core.tuning.applied_ledger import AppliedTuningLedger
+
+        adapter = _StubAdapter("Spark")
+        adapter._applied_tuning_ledger = AppliedTuningLedger()
+        spark = MagicMock()
+        adapter.apply_platform_optimizations(
+            _DummyPlatformConfig({"sql.shuffle.partitions": "200", "sql.cbo.enabled": "true"}),
+            connection=spark,
+        )
+        statements = adapter._applied_tuning_ledger.statements
+        assert {s.statement for s in statements} == {
+            "SET spark.sql.shuffle.partitions=200",
+            "SET spark.sql.cbo.enabled=true",
+        }
+        assert all(s.phase == "session" and s.mechanism == "spark_session_config" for s in statements)
+        assert (
+            adapter._applied_tuning_ledger.overall_status(tuning_enabled=True, has_config=True) == "applied_unverified"
+        )
+
+    def test_failed_conf_set_recorded_as_failed_statement(self) -> None:
+        from benchbox.core.tuning.applied_ledger import EXECUTED, STATEMENT_FAILED, AppliedTuningLedger
+
+        adapter = _StubAdapter("Spark")
+        adapter._applied_tuning_ledger = AppliedTuningLedger()
+        spark = MagicMock()
+
+        def _set(key, _value):
+            if key == "spark.sql.shuffle.partitions":
+                raise RuntimeError("rejected")
+
+        spark.conf.set.side_effect = _set
+        adapter.apply_platform_optimizations(
+            _DummyPlatformConfig({"sql.shuffle.partitions": "200", "sql.cbo.enabled": "true"}),
+            connection=spark,
+        )
+        by_stmt = {s.statement: s.status for s in adapter._applied_tuning_ledger.statements}
+        assert by_stmt["SET spark.sql.shuffle.partitions=200"] == STATEMENT_FAILED
+        assert by_stmt["SET spark.sql.cbo.enabled=true"] == EXECUTED
+
+    def test_platform_optimizations_without_ledger_does_not_raise(self) -> None:
+        adapter = _StubAdapter("Spark")  # no _applied_tuning_ledger attribute
+        spark = MagicMock()
+        adapter.apply_platform_optimizations(_DummyPlatformConfig({"sql.cbo.enabled": "true"}), connection=spark)
+        spark.conf.set.assert_called_with("spark.sql.cbo.enabled", "true")
+
     def test_apply_unified_tuning_dispatches_in_fixed_order(self) -> None:
         adapter = _StubAdapter("LakeSail")
         spark = MagicMock()


### PR DESCRIPTION
## Description

`SparkLikeAdapterMixin.apply_platform_optimizations` (shared by `SparkAdapter` and
`LakeSailAdapter`) forwards `platform_config.spark` settings via `spark.conf.set(...)`,
a native Spark call that bypasses the applied-ledger `RecordingConnection` (which only
wraps `execute()` / `cursor().execute()`). A tuned native-Spark run therefore applied
real session config yet reported `noop` — under-reporting, though never a false `applied`.

Record each setting that actually took effect as an executed `PHASE_SESSION` statement
(`SET spark.<key>=<value>`, `mechanism=spark_session_config`), and each failed set as a
failed statement, reusing the shared `benchbox/core/tuning/applied_ledger` vocabulary
(**not** forking it) and mirroring the existing
`CloudSparkConfigMixin.configure_for_benchmark` capture. Guarded: a no-op when no ledger
is present and never raises. A tuned run now reports `applied_unverified`.

Partially resolves TODO `tuning-native-spark-snowpark-ledger-capture-20260722` (follow-up
from the #1261 applied-ledger keystone).

### Snowpark deferred (with rationale)

The Snowpark half is split to follow-up `tuning-snowpark-session-ledger-capture-20260723`.
The current `snowpark_connect.py` applies **no** tuning-derived `self._session.sql(...)`
statement: its `apply_platform_optimizations` (from `base/cloud_spark/mixins.py`
`SparkTuningMixin`) returns `[]`, and `configure_for_benchmark` issues only
`ALTER SESSION SET USE_CACHED_RESULT = FALSE` — benchmarking hygiene applied to **all**
runs, not tuning-derived. Recording that would falsely report baseline runs as
`applied_unverified`, so honest capture there needs maintainer input on the intended
Snowpark tuning-session surface rather than a guess on the soundness path.

## Type of Change

- [x] Bug fix

## Testing

- New tests (`tests/unit/platforms/test_spark_helpers.py`): applied settings recorded as
  `PHASE_SESSION` `spark_session_config` statements → `overall_status` `applied_unverified`;
  a failed `conf.set` recorded as `failed` while others stay `executed`; no-ledger path
  does not raise.
- `pytest test_spark_helpers.py test_lakesail_adapter.py` → 114 passed.
- `ruff check` / `ruff format --check` / `ty check` clean on changed files.
- `timing_policy_check.py --strict` → violations 0 (fast lane collects 25508 < 25520 cap; no bump needed).

## Public Contract Check

- [x] No public/beta/deprecated/generated/experimental/repo-only contract surfaces
      change — internal soundness fix. Recording is honest (only settings that actually
      took effect; failures recorded as `failed`); `applied_verified` is unaffected (Spark
      session config is transient/non-corroboratable, so the run stays `applied_unverified`).

## Documentation

- [x] Behavior fix; no user-facing doc change. Regression captured by tests.

## Code Quality

- [x] Ran `ruff`, `ruff format --check`, `ty check`.
- [x] Reuses the shared applied-ledger vocabulary (`EXECUTED`/`STATEMENT_FAILED`/`PHASE_SESSION`) rather than forking it.
- [x] Added positive, failure, and no-ledger tests.

## Artifact Hygiene

- [x] No raw artifacts committed.

## Notes

- One shared fix covers both `spark.py` and `lakesail.py` (they share `SparkLikeAdapterMixin`).
- Snowpark deferred to `tuning-snowpark-session-ledger-capture-20260723` (see rationale above).
- No skipped review nits.

---
_Generated by [Claude Code](https://claude.ai/code/session_01ReAoE6uW4XdAiB7ERvhNgR)_