### PR TITLE
test(explorer): cover ADR-1 requested/applied hash rows on the receipts

### DIFF
--- a/results-explorer/src/components/__tests__/ComparabilityReceipt.test.tsx
+++ b/results-explorer/src/components/__tests__/ComparabilityReceipt.test.tsx
@@ -294,4 +294,36 @@ describe("ComparabilityReceipt", () => {
       expect(fields.find((f) => f.label === "Tuning policy generation")).toBeUndefined();
     });
   });
+
+  describe("tuning identity fingerprint (ADR-1)", () => {
+    it("includes the requested-config and applied-ledger hashes in the Tuning fingerprint", () => {
+      const fields = buildComparabilityFields([
+        makeDetail({
+          has_tuning: true,
+          tuning_mode: "tuned",
+          requested_config_hash: "a".repeat(64),
+          applied_ledger_hash: "b".repeat(64),
+        }),
+        makeDetail({ result_id: "r2", platform: "SQLite", platform_id: "sqlite", tuning_mode: "notuning" }),
+      ]);
+      const tuning = fields.find((f) => f.label === "Tuning");
+      expect(tuning?.detail).toContain("requested aaaaaaaaaaaa");
+      expect(tuning?.detail).toContain("applied bbbbbbbbbbbb");
+    });
+
+    it("shows a mode-only tuning value as a plain label, never a hash fingerprint", () => {
+      // The self-derived tuning_hash must never act as a comparability key, and a
+      // mode-only bundle (no ADR-1 identity hash) shows the coarse tuning_mode
+      // plainly rather than a fabricated `requested`/`applied` fingerprint.
+      const fields = buildComparabilityFields([
+        makeDetail({ has_tuning: true, tuning_mode: "tuned", tuning_hash: "tuning123" }),
+        makeDetail({ result_id: "r2", platform: "SQLite", platform_id: "sqlite", tuning_mode: "notuning" }),
+      ]);
+      const tuning = fields.find((f) => f.label === "Tuning");
+      expect(tuning?.detail).toContain("DuckDB: tuned");
+      expect(tuning?.detail).not.toContain("requested");
+      expect(tuning?.detail).not.toContain("applied");
+      expect(tuning?.detail).not.toContain("tuning123");
+    });
+  });
 });

--- a/results-explorer/src/components/__tests__/RunReceipt.test.tsx
+++ b/results-explorer/src/components/__tests__/RunReceipt.test.tsx
@@ -51,6 +51,8 @@ function makeDetail(overrides: Partial<DetailResult> = {}): DetailResult {
     execution_mode: "sql",
     tuning_mode: "tuned",
     tuning_hash: "tuning123",
+    requested_config_hash: "a".repeat(64),
+    applied_ledger_hash: "b".repeat(64),
     test_type: "power",
     validation_status: "exact",
     cost_usd: null,
@@ -307,5 +309,49 @@ describe("RunReceipt", () => {
   it("humanizes a disclosed funding source on the receipt", () => {
     render(<RunReceipt detail={makeDetail({ funding: "vendor-sponsored" })} />);
     expect(screen.getByText("vendor sponsored")).toBeTruthy();
+  });
+
+  it("renders the ADR-1 requested-config and applied-ledger hashes as monospace fingerprints", () => {
+    const requested = "a".repeat(64);
+    const applied = "b".repeat(64);
+    render(<RunReceipt detail={makeDetail({ requested_config_hash: requested, applied_ledger_hash: applied })} />);
+
+    const receipt = screen.getByRole("region", { name: "Run receipt" });
+    expect(within(receipt).getByText("Requested config hash")).toBeTruthy();
+    expect(within(receipt).getByText("Applied ledger hash")).toBeTruthy();
+    // Each renders a monospace <code> with the SHORT prefix visible and the
+    // FULL hash preserved in the title tooltip (identity kept, receipt compact).
+    const requestedCode = receipt.querySelector(`code[title="${requested}"]`);
+    const appliedCode = receipt.querySelector(`code[title="${applied}"]`);
+    expect(requestedCode).not.toBeNull();
+    expect(appliedCode).not.toBeNull();
+    expect(requestedCode?.textContent).toBe("aaaaaaaaaaaa");
+    expect(appliedCode?.textContent).toBe("bbbbbbbbbbbb");
+  });
+
+  it("does NOT dress the self-derived tuning_hash up as an identity fingerprint", () => {
+    // The mode-only `tuning_hash` is a coarse self-derived value, not an
+    // ADR-1 bundle identity, so it renders as a plain labeled string rather
+    // than a monospace hash fingerprint (no title-tooltip <code>).
+    render(<RunReceipt detail={makeDetail({ tuning_hash: "tuning123" })} />);
+
+    const receipt = screen.getByRole("region", { name: "Run receipt" });
+    expect(within(receipt).getByText("Tuning hash")).toBeTruthy();
+    expect(within(receipt).getByText("tuning123")).toBeTruthy();
+    // It must NOT be wrapped in the identity-hash <code title=...> fingerprint.
+    expect(receipt.querySelector('code[title="tuning123"]')).toBeNull();
+  });
+
+  it("marks missing ADR-1 hashes as not-recorded rather than fabricating a fingerprint", () => {
+    render(<RunReceipt detail={makeDetail({ requested_config_hash: null, applied_ledger_hash: null })} />);
+
+    const receipt = screen.getByRole("region", { name: "Run receipt" });
+    // Missing hash rows are hidden behind the disclosure, not rendered as a hash.
+    expect(within(receipt).queryByText("Requested config hash")).toBeNull();
+    expect(within(receipt).queryByText("Applied ledger hash")).toBeNull();
+    fireEvent.click(within(receipt).getByRole("button", { name: /Show missing metadata/ }));
+    expect(within(receipt).getByText("Requested config hash")).toBeTruthy();
+    expect(within(receipt).getByText("Applied ledger hash")).toBeTruthy();
+    expect(within(receipt).getAllByText("Not recorded").length).toBeGreaterThan(0);
   });
 });


### PR DESCRIPTION
## Description

#1264 added the requested-config / applied-ledger hash rows to `RunReceipt` and the
`ComparabilityReceipt` tuning fingerprint, but the TS unit tests were deferred because
`node_modules` was absent. That left the `RunReceipt` test fixture without the two hash
fields, so `hashRow` always rendered them as **missing** — breaking two count-based
disclosure tests (they've been red on `develop`).

This completes the deferred work:

- **RunReceipt** (`RunReceipt.test.tsx`): add `requested_config_hash` / `applied_ledger_hash`
  to the default `makeDetail` fixture — this fixes the two pre-existing failures
  ("does not render the missing-metadata disclosure when every field is recorded" and
  "counts placeholder cost summaries as missing") — and add coverage:
  - the two ADR-1 hashes render as monospace `shortHash` fingerprints with the full value in the `title` tooltip;
  - the self-derived `tuning_hash` is **not** dressed up as an identity fingerprint (plain labeled string, no `<code title>`);
  - missing hashes fall behind the not-recorded disclosure instead of fabricating a value.
- **ComparabilityReceipt** (`ComparabilityReceipt.test.tsx`): the Tuning comparability
  fingerprint includes `requested <short>` / `applied <short>` from the identity hashes,
  while a mode-only bundle shows the coarse `tuning_mode` plainly (never `requested`/`applied`, and never the self-derived `tuning_hash`).

Resolves TODO `tuning-explorer-hash-ts-unit-tests-20260722` (deferred from #1264).

## Type of Change

- [x] Bug fix (fixes two red tests) + test coverage

## Testing

- Installed `results-explorer/node_modules` locally and ran:
  - `npm test` (vitest) → **807 passed** (69 files); the two previously-failing RunReceipt tests are now green.
  - `npm run typecheck` (`tsc --noEmit`) → clean.
  - `npm run build` (`vite build`) → clean.
- Test-only change (two `__tests__` files); no component/runtime code touched.

## Public Contract Check

- [x] No contract surfaces change — test files only.

## Documentation

- [x] N/A (tests).

## Code Quality

- [x] Mirrors the existing receipt-test patterns (`makeDetail` fixture, `within(receipt)` queries, `buildComparabilityFields`).
- [x] Verified locally against real `node_modules` (vitest + tsc + build).

## Artifact Hygiene

- [x] `results-explorer/node_modules` is gitignored; only the two test files are committed.

## Notes

- These are vitest (TS) tests — they do not count toward the pytest fast-lane cap, so no `fast_test_lane_policy.json` bump is needed.
- First of the explorer receipt cluster; the follow-ups (verified-state display, physical_rendering_id facet) touch the same files and should sequence after this merges.
- No skipped review nits.

---
_Generated by [Claude Code](https://claude.ai/code/session_01ReAoE6uW4XdAiB7ERvhNgR)_