### PR TITLE
chore(metrics): per-PR dev-loop CI-failure metrics + 2026-07-23 baseline snapshot

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1559,6 +1559,9 @@ dev-loop-metrics:
 			"Conflict rate: \(rate($$conflicts; $$total)) (\($$conflicts)/\($$total))", \
 			"runner minutes total: \($$runner)" \
 		] | .[]' $$FILES
+	@echo "---"; \
+	echo "Dev-loop PR metrics (CI-failure baseline, see dev-loop-metrics-ci-failure-baseline-2):"; \
+	test -f _project/scripts/dev_loop_pr_metrics.py && uv run -- python _project/scripts/dev_loop_pr_metrics.py --days "$(DEV_LOOP_METRICS_DAYS)" || true
 
 # Initialize retained pool worktrees. Existing pool-NN paths are left untouched.
 worktree-pool-init:

--- a/_project/analysis/ci-failure-baseline-2026-07-23.md
+++ b/_project/analysis/ci-failure-baseline-2026-07-23.md
@@ -1,0 +1,247 @@
+# CI-failure baseline (dev-loop-metrics-ci-failure-baseline-2)
+
+Source: `dev-loop-metrics-ci-failure-baseline-2`. First real-data baseline for
+the dev-loop CI-reduction workstreams (WS1-WS4), captured **before** any
+reduction work lands, so later re-measures have something to compare against.
+
+**Measured**: 2026-07-23, trailing 28 days (since 2026-06-25).
+**Re-measure cadence**: every 2 weeks while WS1-WS4 are active.
+**Re-measure command**:
+
+```
+uv run -- python _project/scripts/dev_loop_pr_metrics.py --days 28 --json \
+  > _project/analysis/ci-failure-$(date +%F).json
+```
+
+(also runs automatically, text-mode, as an additive step of `make
+dev-loop-metrics` — note that step uses the target's default
+DEV_LOOP_METRICS_DAYS=30 window, vs this baseline's 28; the JSON form above
+is for snapshotting a new dated baseline file like this one).
+
+**Decision hooks**:
+- WS1-WS4 effectiveness review — compare each re-measure's first-pass green
+  rate, pushes-after-open, and fast-test job wall time against this baseline;
+  a workstream that doesn't move these numbers didn't reduce real CI-failure
+  cost, regardless of its effect on head-SHA check-run color.
+- Input to `dev-loop-step-6-queue-decision-gate` — the merge-queue
+  build/no-build decision should weigh the measured composition-conflict
+  rate (`fast_test_lane_policy.json` touch rate) and fix-forward push rate
+  here, not a guess.
+
+## Why not head-SHA check runs (confirmed, not assumed)
+
+Dev PRs land via squash auto-merge once the required checks are green, so a
+merged PR's HEAD-SHA check runs are *definitionally* green — measuring them
+tells you about the auto-merge gate, not about CI-failure cost. This was
+re-confirmed live (w0) rather than assumed: 5 recent merged `develop` PRs
+(#1274, #1275, #1276, #1277, #1278) were sampled via
+`mcp__github__pull_request_read` (`method: get_check_runs`).
+
+| PR | ci-required-result | all check runs at head |
+|---|---|---|
+| #1274 | success | all success/skipped |
+| #1275 | success | all success/skipped |
+| #1276 | success | all success/skipped |
+| #1277 | success | all success/skipped |
+| #1278 | success | `ci-required-result` success, but **`Chromium (full suite, blocking)` = failure** and `WebKit (@smoke, non-blocking)` = failure at head |
+
+#1278 is the useful counter-example: it merged with a "blocking"-named
+Playwright job **red at the merged head SHA**, because that job is not in
+`ci-required-result`'s dependency set. Head-SHA check-run color conflates
+"required and green" with "every job green" and would have under-*and*-over-
+counted red here depending on which check you picked — exactly the
+anti-pattern this baseline avoids. All 5 PRs' `ci-required-result` (the
+actual gate) was green at head, confirming the squash-auto-merge policy is
+in force and head-SHA-based failure measurement is a dead end, full stop.
+
+## Method
+
+Two data sources, kept separate below because they cover different windows:
+
+1. **Full-population counts** — local `git log` against `origin/develop`
+   inside this worktree. The clone starts shallow; it was deepened
+   (`git fetch origin develop --deepen=1000`) until the oldest visible commit
+   (2026-05-01) predates the 28-day window start (2026-06-25), so the count
+   below is a complete population count, not a sample.
+   - `git log --since="2026-06-25T00:00:00" --oneline origin/develop | wc -l`
+   - `git log --since="2026-06-25T00:00:00" --oneline origin/develop -- _project/config/fast_test_lane_policy.json | wc -l`
+   - `git log --since="2026-06-25T00:00:00" --format="%s" origin/develop | grep -c '^Revert '`
+2. **Per-PR / per-run detail** (open-to-merge time, fix-forward pushes,
+   first-pass required-lane green rate, fast-test job wall time) — GitHub
+   MCP tools (`mcp__github__list_pull_requests`,
+   `mcp__github__pull_request_read`, `mcp__github__actions_list`), repo
+   `joeharris76/benchbox` only, paginated in batches of 10 PRs /
+   30-100 runs. **This is a sample, not the full population** — see
+   Limitations.
+
+## Full-population counts (28-day window, git log, N=355)
+
+| Metric | Value |
+|---|---|
+| Merged `develop` PRs (squash commits with a trailing `(#NNN)` subject) | **355** |
+| `_project/config/fast_test_lane_policy.json` touches | **16** (4.5%) |
+| Confirmed auto-revert-triggered revert commits (`^Revert `) merged to develop | **0** |
+| Merge cadence | ~12.7 PRs/day average, uneven (0-33 commits/day; gaps on 2026-07-01, 2026-07-13 to 2026-07-15) |
+
+Zero confirmed reverts landed in the window, but the window's **last day**
+carried a live, unresolved incident: PR #1279 (`auto-revert/035c92b3d341`),
+opened 2026-07-23T13:33Z reverting #1276 after develop went red
+post-merge (lint job), was still open/unmerged at measurement time — so it
+correctly does not count as a landed revert, but it is real evidence the
+mechanism fires. Re-measure in 2 weeks should confirm whether #1279 (or its
+fix-forward equivalent) landed and whether any further reverts occurred.
+
+## Sampled per-PR / per-run metrics
+
+Sample: the 19-21 most recently merged/active `develop` PRs and branches at
+measurement time (PRs #1259, #1261-#1278 minus #1260/#1279 which didn't
+merge), spanning **2026-07-22T01:01Z to 2026-07-23T14:11Z** (~37 hours) —
+the tail of the 28-day window, not a stratified sample across it (see
+Limitations for why).
+
+### Open-to-merge wall time (n=19, exact PR `created_at`/`merged_at`)
+
+| Stat | Value |
+|---|---|
+| Median | **1827s (30.5 min)** |
+| Mean | 15857s (264 min) — heavily skewed by 3 outliers |
+| P95 (of 19) | ~2151 min (~35.9h) |
+
+Outliers, all explainable, not noise:
+- **#1259** (35.9h): long-lived PR reused across a review-followup sweep,
+  multiple pushes, one run explicitly `cancelled` by the workflow's
+  `cancel-in-progress` concurrency group.
+- **#1273** (17.5h): `findings-phase3-schema-cli` — PR body explicitly says
+  "Do NOT auto-merge — coordinated production migration required"; long
+  merge time is by design, not CI friction.
+- **#1272** (13.9h): `chore/sync-develop-version-0.3.1` — first "Develop PR"
+  run **failed**, fixed forward, merged on the second run.
+- **#1262** (7.7h): `feat/tuning-starrocks-ddl-generator` — same pattern,
+  first run failed, fixed forward.
+
+### Fix-forward pushes after open (n=21 branches, proxy: count of
+`pull_request`-event "Develop PR" workflow runs on the branch, minus 1)
+
+| Stat | Value |
+|---|---|
+| Median | 0 |
+| Mean | 0.43 |
+| Branches with ≥1 extra run | 6 / 21 (28.6%) |
+
+This is a coarse proxy (a manual re-run or a concurrency-cancelled-then-
+retried push both count identically to a real fix-forward push); the script
+(`dev_loop_pr_metrics.py`) instead uses the PR's own commit list
+(`pulls/{n}/commits`) as the primary metric, which is more precise per-PR
+but costs one extra API call per PR — a tradeoff documented in the script
+itself.
+
+### First-pass required-lane green rate (n=21 branches; first `pull_request`-
+event "Develop PR" run per branch)
+
+| Outcome | Count | Share |
+|---|---|---|
+| success (green on first try) | 15 | 71.4% |
+| failure (fixed forward) | 3 | 14.3% |
+| cancelled (superseded by a fast follow-up push, concurrency group) | 3 | 14.3% |
+
+**First-pass green rate = 15/18 = 83.3%** (cancelled runs excluded — a
+concurrency-cancel is not a CI failure, it's evidence of *rapid* fix-forward
+push, which the pushes-after-open metric already captures) — or **15/21 =
+71.4%** if cancellations are conservatively counted as non-green. Both
+readings are reported because "cancelled" is genuinely ambiguous evidence
+and re-measures should track whether the ratio of cancelled:failed:green
+shifts, not just the single green-rate number.
+
+The 3 real failures (`feat/tuning-starrocks-ddl-generator` #1262,
+`chore/sync-develop-version-0.3.1` #1272,
+`feat/tuning-drift-validation-bundle-routing` #1277) each independently
+correspond to a PR whose own body/notes describe a fast-lane-cap or
+version-drift issue caught and fixed forward — the metric and the PR
+narratives agree, which is a good sanity check on the method.
+
+### Fast-test job wall time (`test (ubuntu-latest, 3.12)`, n=8 runs)
+
+| Stat | Value |
+|---|---|
+| Average | 631s (~10m31s) |
+| P95 | 651s (~10m51s) |
+| Range | 589s-651s |
+
+Sampled from job timings on 8 first-attempt "Develop PR" runs (5 via
+`pull_request_read get_check_runs` on PRs #1274-#1278, 3 via
+`actions_list list_workflow_jobs` on PRs #1261/#1269/#1273). Tight range
+(589-651s) suggests the job is CPU/IO-bound and consistent, not currently a
+source of CI-time variance worth optimizing first.
+
+## Per-PR appendix (sample, n=19)
+
+| PR | Title | Open->Merge | First-pass | Fix-fwd pushes (proxy) |
+|---|---|---|---|---|
+| #1278 | Explorer receipt hash test coverage | 18min | green | 0 |
+| #1277 | Route rerun drift-validation into applied.json | 1.3h | failure->fixed forward | 1 |
+| #1276 | Capture native Spark session config in applied ledger | 30min | green | 0 |
+| #1275 | Make DuckDB sorting + ClickHouse keys verification-eligible | 22min | green | 0 |
+| #1274 | Propagate DataFrame tuning config non-interactive | 20min | green | 0 |
+| #1273 | findings-domain phase 3 (schema v3 + CLI) - manual gate | 17.5h | green | 0 |
+| #1272 | Sync develop version to 0.3.1 | 13.9h | failure->fixed forward | 1 |
+| #1271 | findings-domain phases 0/1/2 | 1.3h | cancelled(concurrency)->green | 3 |
+| #1270 | Tuning-policy generation seam | 45min | cancelled(concurrency)->green | 1 |
+| #1269 | DataFrame tuning ledger parity | 35min | green | 0 |
+| #1268 | Tuning introspection receipts | 30min | green | 0 |
+| #1267 | Cross-surface baseline autodetect | 30min | green | 0 |
+| #1266 | Promote regression reproducers into required gate | 27min | green | 0 |
+| #1265 | Consolidate DataFrame CSV empty-string/null coercion | 22min | green | 0 |
+| #1264 | Explorer consumes bundle hashes | 30min | green | 0 |
+| #1263 | Correct capability-registry mixin honesty | 27min | green | 0 |
+| #1262 | StarRocks DDL generator | 7.7h | failure->fixed forward | 1 |
+| #1261 | Applied-tuning ledger + honest validation_status | 31min | green | 0 |
+| #1259 | PR review follow-up sweep #1244-#1258 | 35.9h | cancelled(concurrency)->green | 2 |
+
+("Fix-fwd pushes (proxy)" is the branch's extra `pull_request`-event run
+count, as described above; #1259/#1270/#1271's `cancelled` runs are counted
+here since they represent a real second push, even though the run itself
+carries `cancelled` rather than `failure`.)
+
+## What could not be computed, and why
+
+- **Stratified sample across the full 28 days.** `actions_list
+  list_workflow_runs` returns full run objects (~13KB each); a single page
+  of 30 rows is ~400K characters and hit the tool's output-size limit even
+  at `per_page=100` (the server appears to cap the effective page size
+  regardless of the requested value). Paginating back 28 days at that rate
+  would need dozens of multi-hundred-KB calls. The sample used here is
+  therefore the most recent ~37h of the window (the tail), which happens to
+  include an unusually dense "batch landing" burst (11+ PRs in a few hours
+  on 2026-07-22/23) — likely not representative of a typical day's pace.
+  **Re-measure should either sample multiple shorter windows spread across
+  the 28 days, or accept the recency bias and track it explicitly.**
+- **Full-population open-to-merge / first-pass-green / pushes-after-open.**
+  These require per-PR or per-branch API calls; computing them for all 355
+  window PRs was out of budget for this baseline. The 19-21 PR sample above
+  is the practical bound described in the TODO's "paginate 10 at a time,
+  keep MCP result sizes bounded" instruction.
+- **True historical PR count without deepening the clone.** The worktree
+  clone started shallow at exactly 57 commits (coincidentally close to a
+  plausible "in-window" count, which nearly produced a wrong population
+  figure — flagged here as a process note for future baselines: always
+  verify `git rev-parse --is-shallow-repository` and that the oldest visible
+  commit predates the window before trusting a local `git log --since`
+  count).
+- **pytest `--durations=20` top-20 local list.** `dev_loop_pr_metrics.py
+  --collect-durations` was implemented (per the TODO's w4 instruction) but
+  deliberately **not run** in this session — the fast lane is ~25k tests and
+  the run would be too slow for this baseline capture. It is documented as a
+  local-machine-only measure (not comparable across machines) in the
+  script's own help text and module docstring.
+
+## Reproduction
+
+```bash
+# Population counts (run from a worktree with enough depth; see Method §1)
+git fetch origin develop --deepen=1000   # only if the clone is shallow
+git log --since="$(date -d '28 days ago' +%F)T00:00:00" --oneline origin/develop | wc -l
+git log --since="$(date -d '28 days ago' +%F)T00:00:00" --oneline origin/develop -- _project/config/fast_test_lane_policy.json | wc -l
+
+# Per-PR sample + fast-test job timing (script; needs gh CLI or GITHUB_TOKEN)
+uv run -- python _project/scripts/dev_loop_pr_metrics.py --days 28 --json
+```

--- a/_project/scripts/dev_loop_pr_metrics.py
+++ b/_project/scripts/dev_loop_pr_metrics.py
@@ -1,0 +1,429 @@
+#!/usr/bin/env python3
+"""Per-PR dev-loop CI-failure baseline metrics for merged `develop` PRs.
+
+Dev PRs land via squash auto-merge once the required checks are green, so a
+merged PR's HEAD-SHA check runs are *always* green (see
+`_project/scripts/detect_orphaned_commits.py`'s module docstring for the
+related squash-merge mechanics). That makes head-SHA check-run status useless
+as a CI-failure signal. The real failure cost shows up upstream of the merge:
+fix-forward pushes after a PR is opened, PRs that touch the shared fast-test
+guard file (`_project/config/fast_test_lane_policy.json`, a frequent
+composition-conflict hotspot), and whether the PR's *first* "Develop PR"
+workflow run (the required-lane gate, `.github/workflows/pr.yml`) went green
+without a fix-forward push.
+
+This script computes, per merged `develop` PR in a trailing window:
+
+  - pushes_after_open: commits on the PR after its first commit (a proxy for
+    fix-forward pushes; the initial push that opened the PR is not a "push
+    after open").
+  - open_to_merge_seconds: PR created_at -> merged_at wall time.
+  - touched_fast_test_lane_policy: whether the PR's file list includes
+    _project/config/fast_test_lane_policy.json.
+  - first_pass_green: whether the PR's FIRST "Develop PR" (.github/workflows/
+    pr.yml) workflow run on its head branch concluded "success" -- i.e. the
+    required lane went green without a fix-forward push. Uses per-branch
+    Actions run history (event=pull_request), not the always-green head-SHA
+    check runs.
+  - fast_test_job_seconds: wall time of the "test (ubuntu-latest, 3.12)" job
+    within that first "Develop PR" run (used to compute the window's average
+    / p95 fast-test job wall time).
+
+Runtime data source, in order of preference: the `gh` CLI (`gh api ...`) when
+on PATH; otherwise a raw GitHub REST call via `urllib` authenticated with
+$GITHUB_TOKEN / $GH_TOKEN; otherwise this prints a "SKIPPED: no GitHub API
+access" notice and exits 0 (mirrors the `|| true` graceful-degradation
+pattern the existing `dev-loop-metrics` Make target uses for `gh run list`,
+Makefile ~line 1520). This script performs read-only GitHub API calls; it
+never mutates PRs, branches, or workflow state.
+
+Usage:
+    uv run -- python _project/scripts/dev_loop_pr_metrics.py
+    uv run -- python _project/scripts/dev_loop_pr_metrics.py --days 28 --json
+    uv run -- python _project/scripts/dev_loop_pr_metrics.py --collect-durations
+
+--collect-durations is a separate, local-machine-only mode: it runs the fast
+test lane under `pytest --durations=20` and prints the slowest tests. It does
+not touch the GitHub API and is not part of the default run (see the module
+TODO context: dev-loop-metrics-ci-failure-baseline-2).
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import shutil
+import statistics
+import subprocess
+import urllib.error
+import urllib.request
+from collections.abc import Callable
+from dataclasses import asdict, dataclass
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_REPO = "joeharris76/BenchBox"
+FAST_LANE_POLICY_PATH = "_project/config/fast_test_lane_policy.json"
+REQUIRED_LANE_WORKFLOW_NAME = "Develop PR"
+FAST_TEST_JOB_NAME = "test (ubuntu-latest, 3.12)"
+API_RETRY_ATTEMPTS = 3
+
+
+@dataclass
+class PrMetrics:
+    number: int
+    title: str
+    head_ref: str
+    created_at: str
+    merged_at: str
+    open_to_merge_seconds: float
+    pushes_after_open: int
+    touched_fast_test_lane_policy: bool
+    first_pass_green: bool | None
+    fast_test_job_seconds: float | None
+
+
+# ---------------------------------------------------------------------------
+# GitHub API access -- gh CLI, then urllib+token, else graceful skip.
+# ---------------------------------------------------------------------------
+def _gh_available() -> bool:
+    return shutil.which("gh") is not None
+
+
+def _gh_api(path: str) -> object | None:
+    """GET *path* via the `gh api` CLI. Returns None on any failure."""
+    try:
+        proc = subprocess.run(
+            ["gh", "api", path],
+            capture_output=True,
+            text=True,
+            timeout=30,
+            check=False,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return None
+    if proc.returncode != 0:
+        return None
+    try:
+        return json.loads(proc.stdout)
+    except json.JSONDecodeError:
+        return None
+
+
+def _urllib_api(path: str, token: str) -> object | None:
+    """GET https://api.github.com{path} via urllib. Returns None on failure."""
+    req = urllib.request.Request(
+        f"https://api.github.com{path}",
+        headers={
+            "Authorization": f"Bearer {token}",
+            "Accept": "application/vnd.github+json",
+            "User-Agent": "benchbox-dev-loop-pr-metrics",
+        },
+    )
+    for attempt in range(API_RETRY_ATTEMPTS):
+        try:
+            with urllib.request.urlopen(req, timeout=30) as resp:
+                try:
+                    return json.load(resp)
+                except ValueError:
+                    return None
+        except urllib.error.HTTPError as err:
+            if err.code == 404:
+                return None
+            if attempt == API_RETRY_ATTEMPTS - 1:
+                return None
+        # TimeoutError/OSError: read-path timeouts are NOT URLError subclasses;
+        # they must still resolve to the graceful-skip contract, never a crash.
+        except (urllib.error.URLError, TimeoutError, OSError):
+            if attempt == API_RETRY_ATTEMPTS - 1:
+                return None
+    return None
+
+
+class GitHubClient:
+    """Thin GET-only GitHub API client: gh CLI first, urllib+token fallback."""
+
+    def __init__(self, repo: str, use_gh: bool, token: str | None) -> None:
+        self.repo = repo
+        self.use_gh = use_gh
+        self.token = token
+
+    def get(self, path: str) -> object | None:
+        if self.use_gh:
+            return _gh_api(path)
+        if self.token:
+            return _urllib_api(path, self.token)
+        return None
+
+    def get_paginated(
+        self,
+        path: str,
+        item_key: str | None = None,
+        stop: Callable[[dict], bool] | None = None,
+    ) -> list[dict]:
+        """GET pages of a list endpoint (raw list or {item_key: [...]}).
+
+        `stop` halts pagination once any item on the current page satisfies
+        it, so windowed queries do not download the whole collection.
+        """
+        items: list[dict] = []
+        page = 1
+        sep = "&" if "?" in path else "?"
+        while True:
+            data = self.get(f"{path}{sep}per_page=100&page={page}")
+            if data is None:
+                break
+            batch = data.get(item_key, []) if item_key else data
+            if not isinstance(batch, list) or not batch:
+                break
+            items.extend(batch)
+            if stop is not None and any(stop(item) for item in batch):
+                break
+            if len(batch) < 100:
+                break
+            page += 1
+        return items
+
+
+def make_client(repo: str) -> GitHubClient | None:
+    """Return a usable GitHubClient, or None if no API access is available."""
+    if _gh_available():
+        probe = _gh_api(f"/repos/{repo}")
+        if probe is not None:
+            return GitHubClient(repo, use_gh=True, token=None)
+    token = os.environ.get("GITHUB_TOKEN") or os.environ.get("GH_TOKEN")
+    if token:
+        probe = _urllib_api(f"/repos/{repo}", token)
+        if probe is not None:
+            return GitHubClient(repo, use_gh=False, token=token)
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Metric collection
+# ---------------------------------------------------------------------------
+def _iso_to_dt(value: str) -> datetime:
+    return datetime.fromisoformat(value.replace("Z", "+00:00"))
+
+
+def fetch_merged_prs(client: GitHubClient, since: datetime) -> list[dict]:
+    """Merged develop PRs with merged_at >= since, newest first."""
+    prs = client.get_paginated(
+        f"/repos/{client.repo}/pulls?state=closed&base=develop&sort=updated&direction=desc",
+        stop=lambda pr: _iso_to_dt(pr["updated_at"]) < since,
+    )
+    merged: list[dict] = []
+    for pr in prs:
+        merged_at = pr.get("merged_at")
+        if not merged_at:
+            continue
+        if _iso_to_dt(merged_at) < since:
+            # Results are sorted by `updated`, not `merged_at`; a closed-but-
+            # never-merged PR can be more recently updated than an older
+            # merge. Filter rather than break, but stop once even `updated`
+            # itself has aged out (nothing later in the page can be newer).
+            if _iso_to_dt(pr["updated_at"]) < since:
+                break
+            continue
+        merged.append(pr)
+    return merged
+
+
+def pushes_after_open(client: GitHubClient, number: int) -> int:
+    commits = client.get_paginated(f"/repos/{client.repo}/pulls/{number}/commits")
+    return max(0, len(commits) - 1)
+
+
+def touched_fast_test_lane_policy(client: GitHubClient, number: int) -> bool:
+    files = client.get_paginated(f"/repos/{client.repo}/pulls/{number}/files")
+    return any(f.get("filename") == FAST_LANE_POLICY_PATH for f in files)
+
+
+def first_pass_green_and_job_seconds(client: GitHubClient, head_ref: str) -> tuple[bool | None, float | None]:
+    """First "Develop PR" pull_request-event run on head_ref: (green?, fast-test job seconds)."""
+    runs = client.get_paginated(
+        f"/repos/{client.repo}/actions/runs?branch={head_ref}&event=pull_request",
+        item_key="workflow_runs",
+    )
+    candidates = [r for r in runs if r.get("name") == REQUIRED_LANE_WORKFLOW_NAME]
+    if not candidates:
+        return None, None
+    first_run = min(candidates, key=lambda r: _iso_to_dt(r["created_at"]))
+    green = first_run.get("conclusion") == "success"
+
+    job_seconds: float | None = None
+    jobs = client.get_paginated(f"/repos/{client.repo}/actions/runs/{first_run['id']}/jobs", item_key="jobs")
+    for job in jobs:
+        if job.get("name") == FAST_TEST_JOB_NAME and job.get("started_at") and job.get("completed_at"):
+            started = _iso_to_dt(job["started_at"])
+            completed = _iso_to_dt(job["completed_at"])
+            job_seconds = (completed - started).total_seconds()
+            break
+    return green, job_seconds
+
+
+def collect_pr_metrics(client: GitHubClient, pr: dict) -> PrMetrics:
+    number = pr["number"]
+    head_ref = pr["head"]["ref"]
+    created_at = pr["created_at"]
+    merged_at = pr["merged_at"]
+    open_to_merge = (_iso_to_dt(merged_at) - _iso_to_dt(created_at)).total_seconds()
+    first_pass_green, fast_test_seconds = first_pass_green_and_job_seconds(client, head_ref)
+    return PrMetrics(
+        number=number,
+        title=pr.get("title", ""),
+        head_ref=head_ref,
+        created_at=created_at,
+        merged_at=merged_at,
+        open_to_merge_seconds=open_to_merge,
+        pushes_after_open=pushes_after_open(client, number),
+        touched_fast_test_lane_policy=touched_fast_test_lane_policy(client, number),
+        first_pass_green=first_pass_green,
+        fast_test_job_seconds=fast_test_seconds,
+    )
+
+
+def _pct(values: list[float], p: int) -> float | None:
+    if not values:
+        return None
+    s = sorted(values)
+    idx = min(len(s) - 1, max(0, -(-len(s) * p // 100) - 1))
+    return s[idx]
+
+
+def summarize(metrics: list[PrMetrics]) -> dict:
+    merge_times = [m.open_to_merge_seconds for m in metrics]
+    pushes = [m.pushes_after_open for m in metrics]
+    fast_job = [m.fast_test_job_seconds for m in metrics if m.fast_test_job_seconds is not None]
+    green_known = [m for m in metrics if m.first_pass_green is not None]
+    green_count = sum(1 for m in green_known if m.first_pass_green)
+    return {
+        "pr_count": len(metrics),
+        "open_to_merge_seconds_median": statistics.median(merge_times) if merge_times else None,
+        "pushes_after_open_median": statistics.median(pushes) if pushes else None,
+        "fast_test_lane_policy_touch_rate": (
+            sum(1 for m in metrics if m.touched_fast_test_lane_policy) / len(metrics) if metrics else None
+        ),
+        "first_pass_green_rate": (green_count / len(green_known)) if green_known else None,
+        "first_pass_green_sample_size": len(green_known),
+        "fast_test_job_seconds_avg": statistics.fmean(fast_job) if fast_job else None,
+        "fast_test_job_seconds_p95": _pct(fast_job, 95),
+    }
+
+
+# ---------------------------------------------------------------------------
+# --collect-durations: local-machine-only pytest --durations mode.
+# ---------------------------------------------------------------------------
+DURATIONS_PYTEST_CMD = [
+    "uv",
+    "run",
+    "--",
+    "python",
+    "-m",
+    "pytest",
+    "tests",
+    "-m",
+    "fast and not (slow or stress or resource_heavy or live_integration)",
+    "--durations=20",
+    "-q",
+    "--no-header",
+    "-p",
+    "no:cacheprovider",
+]
+
+
+def run_collect_durations() -> int:
+    print(
+        "Local-machine measure only (wall-clock durations vary by hardware; "
+        "not comparable across CI runners or between machines)."
+    )
+    print(f"Running: {' '.join(DURATIONS_PYTEST_CMD)}")
+    proc = subprocess.run(DURATIONS_PYTEST_CMD, cwd=REPO_ROOT, check=False)
+    return proc.returncode
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument(
+        "--repo",
+        default=os.environ.get("GITHUB_REPOSITORY", DEFAULT_REPO),
+        help=f"owner/name (default: $GITHUB_REPOSITORY or {DEFAULT_REPO})",
+    )
+    parser.add_argument(
+        "--days",
+        type=int,
+        default=28,
+        help="trailing window in days (default: 28)",
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="emit machine-readable JSON (summary + per-PR rows) instead of text",
+    )
+    parser.add_argument(
+        "--collect-durations",
+        action="store_true",
+        help=(
+            "local-machine-only mode: run the fast test lane with "
+            "pytest --durations=20 and print the slowest 20 tests. Does not "
+            "touch the GitHub API; mutually exclusive with the default mode."
+        ),
+    )
+    args = parser.parse_args(argv)
+
+    if args.collect_durations:
+        return run_collect_durations()
+
+    client = make_client(args.repo)
+    if client is None:
+        print("SKIPPED: no GitHub API access (no `gh` CLI and no usable GITHUB_TOKEN/GH_TOKEN).")
+        return 0
+
+    since = datetime.now(timezone.utc) - timedelta(days=args.days)
+    prs = fetch_merged_prs(client, since)
+    metrics = [collect_pr_metrics(client, pr) for pr in prs]
+    summary = summarize(metrics)
+
+    if args.json:
+        print(
+            json.dumps(
+                {
+                    "repo": args.repo,
+                    "since": since.isoformat(),
+                    "summary": summary,
+                    "prs": [asdict(m) for m in metrics],
+                },
+                indent=2,
+            )
+        )
+        return 0
+
+    print(f"Dev-loop PR metrics for {args.repo} since {since.date().isoformat()} ({len(metrics)} merged develop PRs)")
+    print(f"  open-to-merge P50: {summary['open_to_merge_seconds_median']!r} seconds")
+    print(f"  pushes-after-open P50: {summary['pushes_after_open_median']!r}")
+    print(f"  fast_test_lane_policy.json touch rate: {summary['fast_test_lane_policy_touch_rate']!r}")
+    print(
+        "  first-pass required-lane green rate: "
+        f"{summary['first_pass_green_rate']!r} (n={summary['first_pass_green_sample_size']})"
+    )
+    print(
+        f"  fast-test job seconds avg/p95: {summary['fast_test_job_seconds_avg']!r} / {summary['fast_test_job_seconds_p95']!r}"
+    )
+    for m in metrics:
+        print(
+            f"  PR #{m.number}: pushes_after_open={m.pushes_after_open} "
+            f"open_to_merge_s={m.open_to_merge_seconds:.0f} "
+            f"fast_lane_policy_touched={m.touched_fast_test_lane_policy} "
+            f"first_pass_green={m.first_pass_green} "
+            f"fast_test_job_s={m.fast_test_job_seconds}"
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Description

WS9 of `_project/planning/ci-failure-reduction-plan.md`: capture a measurable CI-failure baseline **before** the reduction workstreams land, so a 2-week re-measure can arbitrate their effect. Under squash auto-merge, head-SHA check runs are green by construction — the real failure cost hides in fix-forward pushes, guard-file conflicts, and post-merge breaks.

- New `_project/scripts/dev_loop_pr_metrics.py` (stdlib-only): per merged develop PR in a trailing window — pushes-after-open, open-to-merge wall time, `fast_test_lane_policy.json` touched, first-pass "Develop PR" workflow-run green rate **per head branch** (deliberately never head-SHA check color), and fast-test job wall time. Data-source chain: `gh` → `GITHUB_TOKEN` REST → graceful `SKIPPED` notice with exit 0. `--json` for snapshotting; `--collect-durations` local pytest mode.
- Additive final step in `make dev-loop-metrics` (original six output fields untouched; `test -f` guard for release curation).
- `_project/analysis/ci-failure-baseline-2026-07-23.md`: 355 merged PRs/28d (full population via git); 16 (4.5%) touched the fast-lane policy JSON; recency-biased API sample (n≈20, labeled): open-to-merge median 30.5 min, first-pass green 71–83%, fast-test job avg 631s / p95 651s. Includes the live counter-example: PR #1278 merged with the "Chromium (full suite, blocking)" check red at head. Method, limitations, re-measure cadence, and decision hooks documented in the file.

Tracker: `dev-loop-metrics-ci-failure-baseline-2`. Adversarial (Opus) review completed; Required finding fixed (graceful-skip now also covers read timeouts/JSON decode) plus all four nits (windowed pagination stop-predicate, datetime-keyed first-run sort, `test -f` Makefile guard, 30-vs-28-day window note).

## Type of Change

- [x] Refactor / chore

## Testing

- `make dev-loop-metrics` → exit 0; original fields unchanged; new step prints the graceful SKIP notice in this no-API sandbox.
- `uv run ruff check` / `ruff format --check` clean; `--help` and `--days 5` smoke-run pass.
- `make -n dev-loop-metrics` valid.

## Public Contract Check

- [x] No public/beta/deprecated/generated/experimental contract surfaces change — dev-tooling (`_project/`) + Makefile only.

## Documentation

- [x] Baseline snapshot documents method, limitations (recency-biased sample, shallow-clone hazard), re-measure command and cadence.

## Code Quality

- [x] Ran formatting and lint checks on the new script.
- [x] Additive-only change to the existing target; verified before/after output fields.
- [x] Script is read-only against GitHub; never mutates PRs/branches/workflow state.

## Artifact Hygiene

- [x] No raw artifacts committed — the snapshot is a curated analysis document with durable repo value.

## Notes

- Known measurement gap recorded as tracker deferral: a fully representative (non-recency-biased) 28-day per-PR API sample needs a cheaper query shape; attach to the first re-measure.

---
_Generated by [Claude Code](https://claude.ai/code/session_016NqSKtt68mqUpFA6C2qUkB)_