### PR TITLE
chore(uat): regenerate stale LOC table after #1254 trimmed throughput.py

### DIFF
--- a/_project/specs/uat-framework.md
+++ b/_project/specs/uat-framework.md
@@ -140,7 +140,7 @@ tests/uat/
 | `artifact_hygiene.py` | Local-artifact hygiene guard: flags worktree-local `benchmark_runs/` growth when an external output root is configured; report-only (`make uat-artifact-hygiene`) | — | 282 |
 | `cells_io.py` | `cells.jsonl` + accounting-sidecar read/write codec; single schema shared by `orchestrator.py` and `_cli.py` | — | 464 |
 | `gate_summary.py` | Writes/reads the versioned `uat_gate_summary.json` per-sweep evidence artifact; powers `make uat-gate-check` cross-stage aggregation | — | 274 |
-| `throughput.py` | Multi-stream throughput/concurrent cell support via `benchbox run-official --streams`; TPC-compliant scale-factor gate | — | 318 |
+| `throughput.py` | Multi-stream throughput/concurrent cell support via `benchbox run-official --streams`; TPC-compliant scale-factor gate | — | 316 |
 | `ladder.py` | Per-(platform, benchmark) rung order; wall-clock and exit-code early-stop; pruning bookkeeping | 100 | 83 |
 | `preflight_budget.py` | Disk free-space floor budgeting and cell-key accounting | — | 236 |
 | `phases/__init__.py` | UAT phase package marker and phase contract documentation string | — | 17 |
@@ -181,11 +181,11 @@ remain hand-tracked.
 - Docker lifecycle (default-OFF, incl. `container_cleanup.py`): 1,743
 - chartered evidence artifacts (validate/report/package/cells_io/gate_summary): 1,674
 - explorer-prep: 387
-- throughput: 318
+- throughput: 316
 - artifact hygiene: 282
 - package init markers: 23
 
-**Total: 10,263 production LOC across 26 modules.**
+**Total: 10,261 production LOC across 26 modules.**
 
 <!-- UAT-LOC-SUMMARY:END -->
 


### PR DESCRIPTION
## Description

Develop's required lane is currently red for every PR: merged #1254 trimmed `tests/uat/throughput.py` by 2 lines (318 → 316) without regenerating the UAT-LOC table, so the lint job's `uat_loc_table.py --check` fails on the current tip (observed live on #1283's lint job; predicted independently during guards-fix work). Mechanical regen of `_project/specs/uat-framework.md` via `uv run --project _project/scripts -- python _project/scripts/uat_loc_table.py`; `--check` verified clean afterwards.

## Type of Change

- [x] Refactor / chore

## Testing

- `uv run --project _project/scripts -- python _project/scripts/uat_loc_table.py --check` → "UAT LOC table + summary match the tree."

## Public Contract Check

- [x] No contract surfaces — generated dev-spec table only.

## Documentation

- [x] The change *is* the documentation regen.

## Code Quality

- [x] Generated output only; no hand edits.

## Artifact Hygiene

- [x] No raw artifacts.

## Notes

- Unblocks the required lane for all open PRs (they need a branch update or re-run after this merges, since required checks are non-strict).

---
_Generated by [Claude Code](https://claude.ai/code/session_016NqSKtt68mqUpFA6C2qUkB)_