### PR TITLE
chore(ci): daily drain signal for parked soundness-gated PRs

### DIFF
--- a/.github/workflows/soundness-drain.yml
+++ b/.github/workflows/soundness-drain.yml
@@ -1,0 +1,55 @@
+name: Soundness-PR Drain Digest
+
+# Soundness-path PRs correctly WITHHOLD auto-merge (auto-merge-on-open.yml +
+# _project/scripts/auto_merge_soundness_paths.py): the owner must review and
+# merge them by hand. That gate is intentional and this workflow does not
+# touch it -- no auto-merge, no auto-approve. What was missing is an
+# observability signal: those PRs can park silently and grow conflicts
+# (#1116, #1142 sat for days before anyone noticed). This job runs
+# _project/scripts/soundness_drain_report.py, which:
+#   - classifies open develop PRs that are green on required checks,
+#     awaiting the owner (auto-merge off + soundness-path touch, or
+#     review-requested-from-owner), and idle > 24h;
+#   - syncs the `awaiting-owner` label to match that set;
+#   - upserts ONE pinned issue ("Soundness-PR drain queue") with the digest,
+#     but ONLY when the queue is non-empty -- silent otherwise, so this is
+#     one digest a day, never a per-PR/per-event ping.
+#
+# See docs/operations/soundness-drain.md for the full design and the label
+# semantics.
+
+on:
+  schedule:
+    # Daily, 05:00 UTC -- off-peak, distinct from the other daily/weekly
+    # scheduled jobs (release-canary 08:00, nightly 06:00, cross-platform
+    # 03:00, extension-smoke 06:00).
+    - cron: "0 5 * * *"
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+
+jobs:
+  drain-digest:
+    name: Report parked soundness-path PRs
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Run drain report (observe + apply label/digest only)
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+        run: uv run -- python _project/scripts/soundness_drain_report.py --apply

--- a/Makefile
+++ b/Makefile
@@ -1297,7 +1297,7 @@ release-finalize:
 # branches stay live in parallel via worktrees.
 # =============================================================================
 
-.PHONY: pr-preflight pr-preflight-fast-tests pr-content-guard pr-open pr-fanout pr-refresh pr-conflict-scan pr-status pr-review-followups pr-review-followups-list dev-loop-metrics shrink-rollup audit-sha-check agent-write-preflight worktree-pool-init worktree-pool-status worktree-pool-check worktree-claim worktree-claim-locked worktree-claim-attempt worktree-release worktree-release-locked worktree-pool-reset worktree-pool-reset-locked worktree-pool-sweep-stale worktree-pool-sweep-stale-locked worktree-pool-disk-clean worktree-list worktree-prune blind-spots-list blind-spots-report blind-spots-sweep
+.PHONY: pr-preflight pr-preflight-fast-tests pr-content-guard pr-open pr-fanout pr-refresh pr-conflict-scan pr-status pr-review-followups pr-review-followups-list dev-loop-metrics shrink-rollup audit-sha-check agent-write-preflight worktree-pool-init worktree-pool-status worktree-pool-check worktree-claim worktree-claim-locked worktree-claim-attempt worktree-release worktree-release-locked worktree-pool-reset worktree-pool-reset-locked worktree-pool-sweep-stale worktree-pool-sweep-stale-locked worktree-pool-disk-clean worktree-list worktree-prune blind-spots-list blind-spots-report blind-spots-sweep soundness-drain-report soundness-drain-self-test
 
 agent-write-preflight:
 	@sh scripts/agent_write_preflight.sh
@@ -2094,6 +2094,14 @@ blind-spots-report:
 # Alias: 'sweep' as the verb users will reach for; report is the v1 sweep view.
 blind-spots-sweep: blind-spots-report
 
+# Soundness-PR drain digest (read-only local run; the scheduled workflow
+# runs the same script with --apply). See docs/operations/soundness-drain.md.
+soundness-drain-report:
+	@uv run -- python _project/scripts/soundness_drain_report.py
+
+soundness-drain-self-test:
+	@uv run -- python _project/scripts/soundness_drain_report.py --self-test
+
 # ----------------------------------------------------------------------
 # UAT framework (tests/uat/) — see _project/specs/uat-framework.md.
 # Operator-only; not exposed as `benchbox` CLI subcommands. UAT is a
@@ -2408,6 +2416,10 @@ help:
 	@echo "  make blind-spots-list   List open findings (one row each)"
 	@echo "  make blind-spots-report Counts by status + kind, oldest active first"
 	@echo "  make blind-spots-sweep  Alias for blind-spots-report"
+	@echo ""
+	@echo "Soundness-PR Drain Digest (see docs/operations/soundness-drain.md):"
+	@echo "  make soundness-drain-report     Read-only local digest of parked soundness-path PRs"
+	@echo "  make soundness-drain-self-test  Run the fixture-based classifier self-test (no network)"
 	@echo ""
 	@echo "Release Workflow (2-command flow; see docs/operations/release-guide.md):"
 	@echo "  make release-cut VERSION=X.Y.Z      Cut v\$$VERSION off develop, bump + changelog + curate, push, open PR vs release (re-run to resume)"

--- a/_project/scripts/fixtures/soundness_drain_fixture.json
+++ b/_project/scripts/fixtures/soundness_drain_fixture.json
@@ -1,0 +1,182 @@
+{
+  "as_of": "2026-07-23T12:00:00Z",
+  "owner_login": "joeharris76",
+  "expected_qualifying": [
+    9101,
+    9105,
+    9107
+  ],
+  "expected_excluded_reasons": {
+    "9102": "auto_merge_on",
+    "9103": "too_young",
+    "9104": "not_green",
+    "9106": "draft"
+  },
+  "prs": [
+    {
+      "number": 9101,
+      "title": "fix(equivalence): tighten epsilon comparator",
+      "html_url": "https://github.com/joeharris76/BenchBox/pull/9101",
+      "draft": false,
+      "created_at": "2026-07-15T09:00:00Z",
+      "updated_at": "2026-07-16T09:00:00Z",
+      "auto_merge": null,
+      "requested_reviewers": [
+        "joeharris76"
+      ],
+      "changed_files": [
+        "benchbox/core/equivalence/comparator.py"
+      ],
+      "check_runs": [
+        {
+          "name": "ci-required-result",
+          "status": "completed",
+          "conclusion": "success",
+          "completed_at": "2026-07-16T08:00:00Z"
+        }
+      ]
+    },
+    {
+      "number": 9102,
+      "title": "docs(operations): refresh UAT provisioning notes",
+      "html_url": "https://github.com/joeharris76/BenchBox/pull/9102",
+      "draft": false,
+      "created_at": "2026-07-14T09:00:00Z",
+      "updated_at": "2026-07-15T09:00:00Z",
+      "auto_merge": {
+        "enabled_by": {
+          "login": "joeharris76"
+        },
+        "merge_method": "squash"
+      },
+      "requested_reviewers": [],
+      "changed_files": [
+        "docs/operations/uat-local-provisioning.md"
+      ],
+      "check_runs": [
+        {
+          "name": "ci-required-result",
+          "status": "completed",
+          "conclusion": "success",
+          "completed_at": "2026-07-15T08:30:00Z"
+        }
+      ]
+    },
+    {
+      "number": 9103,
+      "title": "fix(query_plans): parser edge case for window functions",
+      "html_url": "https://github.com/joeharris76/BenchBox/pull/9103",
+      "draft": false,
+      "created_at": "2026-07-23T09:00:00Z",
+      "updated_at": "2026-07-23T10:00:00Z",
+      "auto_merge": null,
+      "requested_reviewers": [
+        "joeharris76"
+      ],
+      "changed_files": [
+        "benchbox/core/query_plans/parsers/window.py"
+      ],
+      "check_runs": [
+        {
+          "name": "ci-required-result",
+          "status": "completed",
+          "conclusion": "success",
+          "completed_at": "2026-07-23T09:45:00Z"
+        }
+      ]
+    },
+    {
+      "number": 9104,
+      "title": "feat(expected_results): add SF10 digest fixtures",
+      "html_url": "https://github.com/joeharris76/BenchBox/pull/9104",
+      "draft": false,
+      "created_at": "2026-07-10T09:00:00Z",
+      "updated_at": "2026-07-18T09:00:00Z",
+      "auto_merge": null,
+      "requested_reviewers": [
+        "joeharris76"
+      ],
+      "changed_files": [
+        "benchbox/core/expected_results/reference_digests/tpch_value_digests_sf10.json"
+      ],
+      "check_runs": [
+        {
+          "name": "ci-required-result",
+          "status": "completed",
+          "conclusion": "failure",
+          "completed_at": "2026-07-18T08:30:00Z"
+        }
+      ]
+    },
+    {
+      "number": 9105,
+      "title": "fix(cli): correct exit code on partial config load",
+      "html_url": "https://github.com/joeharris76/BenchBox/pull/9105",
+      "draft": false,
+      "created_at": "2026-07-16T09:00:00Z",
+      "updated_at": "2026-07-17T09:00:00Z",
+      "auto_merge": null,
+      "requested_reviewers": [
+        "joeharris76"
+      ],
+      "changed_files": [
+        "benchbox/cli/main.py"
+      ],
+      "check_runs": [
+        {
+          "name": "ci-required-result",
+          "status": "completed",
+          "conclusion": "success",
+          "completed_at": "2026-07-17T08:15:00Z"
+        }
+      ]
+    },
+    {
+      "number": 9106,
+      "title": "wip: draft comparator rewrite",
+      "html_url": "https://github.com/joeharris76/BenchBox/pull/9106",
+      "draft": true,
+      "created_at": "2026-07-12T09:00:00Z",
+      "updated_at": "2026-07-13T09:00:00Z",
+      "auto_merge": null,
+      "requested_reviewers": [
+        "joeharris76"
+      ],
+      "changed_files": [
+        "benchbox/core/equivalence/comparator.py"
+      ],
+      "check_runs": [
+        {
+          "name": "ci-required-result",
+          "status": "completed",
+          "conclusion": "success",
+          "completed_at": "2026-07-13T08:30:00Z"
+        }
+      ]
+    },
+    {
+      "number": 9107,
+      "title": "Anti-flap: parked 5 days, but updated_at bumped 30min ago by a label write",
+      "html_url": "https://github.com/joeharris76/BenchBox/pull/9107",
+      "draft": false,
+      "created_at": "2026-07-15T09:00:00Z",
+      "updated_at": "2026-07-23T11:30:00Z",
+      "auto_merge": null,
+      "requested_reviewers": [
+        "joeharris76"
+      ],
+      "changed_files": [
+        "benchbox/core/equivalence/comparator.py"
+      ],
+      "check_runs": [
+        {
+          "name": "ci-required-result",
+          "status": "completed",
+          "conclusion": "success",
+          "started_at": "2026-07-18T08:00:00Z",
+          "completed_at": "2026-07-18T08:10:00Z"
+        }
+      ]
+    }
+  ]
+}

--- a/_project/scripts/soundness_drain_report.py
+++ b/_project/scripts/soundness_drain_report.py
@@ -1,0 +1,635 @@
+#!/usr/bin/env python3
+"""Daily observability signal for parked soundness-path PRs.
+
+Soundness-path PRs correctly never auto-merge (see
+``_project/scripts/auto_merge_soundness_paths.py`` and
+``.github/workflows/auto-merge-on-open.yml``: the owner must review and
+merge those PRs by hand). That withholding gate is intentional and this
+script does NOT touch it -- no auto-merge, no auto-approve, nothing that
+changes whether or how a PR can merge. What the gate does not do on its own
+is tell anyone a PR has been sitting there: #1116 and #1142 both sat parked
+for days with accumulating conflicts before anyone noticed. This script is
+the missing "someone should look at this" signal:
+
+- It classifies every OPEN PR targeting ``develop`` as qualifying for the
+  drain queue when ALL of the following hold:
+    (a) required-lane green  -- the ``ci-required-result`` check run on the
+        PR's head SHA completed with conclusion ``success``.
+    (b) awaiting the owner   -- auto-merge is OFF *and* (the PR touches a
+        soundness-critical path per ``SOUNDNESS_PREFIXES``, OR the owner is
+        a requested reviewer).
+    (c) parked > 24h          -- more than 24 hours of park time (anchored
+        on the required lane going green, NOT ``updated_at``: the label
+        writes below and ordinary human comments bump ``updated_at``, and a
+        gate based on it would flap a genuinely parked PR out of the queue).
+- The only mutations it ever performs (and only under ``--apply``) are:
+    1. adding/removing the ``awaiting-owner`` label to match the current
+       qualifying set, and
+    2. creating/updating ONE tracking issue (title "Soundness-PR drain
+       queue") with the current digest -- created/refreshed only while the
+       queue is non-empty; when the queue drains, an existing digest is
+       patched to the empty state exactly once, then left alone (silent).
+  It never merges, approves, or otherwise changes a PR's mergeability.
+
+Auth: GITHUB_TOKEN or GH_TOKEN from the environment (used directly over the
+REST API). If neither is set but the ``gh`` CLI is on PATH, its token
+(``gh auth token``) is used instead -- this lets the script run locally
+against an interactively-authenticated ``gh`` without exporting a token by
+hand. No long-lived PAT is required or read from anywhere else.
+
+Usage:
+    uv run -- python _project/scripts/soundness_drain_report.py
+    uv run -- python _project/scripts/soundness_drain_report.py --json
+    uv run -- python _project/scripts/soundness_drain_report.py --apply
+    uv run -- python _project/scripts/soundness_drain_report.py --self-test
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import json
+import os
+import shutil
+import subprocess
+import sys
+import urllib.error
+import urllib.parse
+import urllib.request
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+sys.path.insert(0, str(SCRIPT_DIR))
+
+from auto_merge_soundness_paths import any_soundness_path  # noqa: E402
+
+FIXTURE_PATH = SCRIPT_DIR / "fixtures" / "soundness_drain_fixture.json"
+
+# The sole code owner today (mirrors .github/CODEOWNERS). Used to detect
+# "review requested from the owner" for non-soundness-path PRs that still
+# need the owner's eyes (e.g. a manual review request on a normal PR).
+OWNER_LOGIN = "joeharris76"
+
+DEFAULT_REPO = "joeharris76/BenchBox"
+REQUIRED_CHECK_NAME = "ci-required-result"
+DRAIN_LABEL = "awaiting-owner"
+DRAIN_LABEL_COLOR = "b60205"
+DRAIN_LABEL_DESCRIPTION = "Green, gated on owner review, parked >24h (see docs/operations/soundness-drain.md)"
+PINNED_ISSUE_TITLE = "Soundness-PR drain queue"
+# Body marker: proves the digest issue was written by this script, so
+# find_pinned_issue never adopts (and later clobbers) a human issue that
+# happens to reuse the title.
+DIGEST_BODY_MARKER = "<!-- soundness-drain-digest -->"
+IDLE_THRESHOLD_HOURS = 24.0
+API_ROOT = "https://api.github.com"
+
+
+# ---------------------------------------------------------------------------
+# Pure classification logic (unit-/self-tested; no git/network)
+# ---------------------------------------------------------------------------
+@dataclass(frozen=True)
+class ClassifiedPR:
+    number: int
+    title: str
+    html_url: str
+    draft: bool
+    required_green: bool
+    soundness_gated: bool
+    auto_merge_enabled: bool
+    review_requested_owner: bool
+    awaiting_owner: bool
+    idle_hours: float
+    park_time_hours: float | None
+    qualifies: bool
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+def _parse_iso(value: str) -> dt.datetime:
+    # GitHub timestamps are RFC3339 with a trailing "Z".
+    return dt.datetime.fromisoformat(value.replace("Z", "+00:00"))
+
+
+def required_lane_check_run(check_runs: list[dict[str, Any]]) -> dict[str, Any] | None:
+    """Return the latest ``ci-required-result`` check run, if present.
+
+    A re-run can leave multiple same-named runs on one SHA; pick the most
+    recently started so a stale conclusion never wins.
+    """
+    matches = [run for run in check_runs if run.get("name") == REQUIRED_CHECK_NAME]
+    if not matches:
+        return None
+    return max(matches, key=lambda run: run.get("started_at") or "")
+
+
+def is_required_lane_green(check_runs: list[dict[str, Any]]) -> bool:
+    run = required_lane_check_run(check_runs)
+    if run is None:
+        return False
+    return run.get("status") == "completed" and run.get("conclusion") == "success"
+
+
+def is_soundness_gated(changed_files: list[str]) -> bool:
+    return any_soundness_path(changed_files)
+
+
+def is_awaiting_owner(
+    *,
+    auto_merge_enabled: bool,
+    soundness_gated: bool,
+    review_requested_owner: bool,
+) -> bool:
+    """True when the PR is parked on the owner: auto-merge off AND gated."""
+    return (not auto_merge_enabled) and (soundness_gated or review_requested_owner)
+
+
+def idle_hours(updated_at: str, now: dt.datetime) -> float:
+    return (now - _parse_iso(updated_at)).total_seconds() / 3600.0
+
+
+def park_time_hours(pr: dict[str, Any], now: dt.datetime, *, required_green: bool) -> float | None:
+    """Hours since the PR became ready-and-green.
+
+    Anchored on the ``ci-required-result`` check run's ``completed_at`` --
+    the point the PR became green (the soundness-path/auto-merge-off state
+    is static from the diff and typically already true by then, so "went
+    green" is the later, load-bearing event in practice). Falls back to
+    ``updated_at`` if the check run lacks a completion timestamp. Returns
+    None when the required lane is not green (park time is undefined until
+    it is).
+    """
+    if not required_green:
+        return None
+    run = required_lane_check_run(pr.get("check_runs") or [])
+    anchor = (run or {}).get("completed_at") or pr.get("updated_at")
+    if not anchor:
+        return None
+    return (now - _parse_iso(anchor)).total_seconds() / 3600.0
+
+
+def classify_pr(
+    pr: dict[str, Any],
+    now: dt.datetime,
+    *,
+    owner_login: str = OWNER_LOGIN,
+    idle_threshold_hours: float = IDLE_THRESHOLD_HOURS,
+) -> ClassifiedPR:
+    """Classify one normalized PR record. Pure -- no I/O."""
+    check_runs = pr.get("check_runs") or []
+    changed_files = pr.get("changed_files") or []
+    requested_reviewers = pr.get("requested_reviewers") or []
+
+    required_green = is_required_lane_green(check_runs)
+    soundness_gated = is_soundness_gated(changed_files)
+    auto_merge_enabled = bool(pr.get("auto_merge"))
+    review_requested_owner = owner_login in requested_reviewers
+    awaiting_owner = is_awaiting_owner(
+        auto_merge_enabled=auto_merge_enabled,
+        soundness_gated=soundness_gated,
+        review_requested_owner=review_requested_owner,
+    )
+    idle_h = idle_hours(pr["updated_at"], now)
+    draft = bool(pr.get("draft"))
+    park_h = park_time_hours(pr, now, required_green=required_green)
+    # Gate on park time (anchored to the required lane going green), NOT
+    # idle_hours: `updated_at` is bumped by this script's own label writes and
+    # by any human comment, so an updated_at-based gate flaps a genuinely
+    # parked PR out of the queue every time the signal fires.
+    qualifies = (not draft) and required_green and awaiting_owner and (park_h or 0.0) > idle_threshold_hours
+
+    return ClassifiedPR(
+        number=pr["number"],
+        title=pr.get("title", ""),
+        html_url=pr.get("html_url", ""),
+        draft=draft,
+        required_green=required_green,
+        soundness_gated=soundness_gated,
+        auto_merge_enabled=auto_merge_enabled,
+        review_requested_owner=review_requested_owner,
+        awaiting_owner=awaiting_owner,
+        idle_hours=idle_h,
+        park_time_hours=park_h,
+        qualifies=qualifies,
+    )
+
+
+def classify_all(
+    prs: list[dict[str, Any]],
+    now: dt.datetime,
+    *,
+    owner_login: str = OWNER_LOGIN,
+    idle_threshold_hours: float = IDLE_THRESHOLD_HOURS,
+) -> list[ClassifiedPR]:
+    return [classify_pr(pr, now, owner_login=owner_login, idle_threshold_hours=idle_threshold_hours) for pr in prs]
+
+
+def qualifying(classified: list[ClassifiedPR]) -> list[ClassifiedPR]:
+    """Qualifying PRs, longest-parked first (most in need of attention)."""
+    ready = [c for c in classified if c.qualifies]
+    return sorted(ready, key=lambda c: c.park_time_hours or 0.0, reverse=True)
+
+
+def _fmt_hours(hours: float) -> str:
+    days, rem = divmod(hours, 24.0)
+    if days >= 1:
+        return f"{days:.0f}d{rem:.0f}h"
+    return f"{hours:.1f}h"
+
+
+def build_digest(classified: list[ClassifiedPR], *, now: dt.datetime, repo: str) -> str:
+    """Human-readable digest body.
+
+    Empty-queue body is used by local/manual runs and by the one-time
+    "mark existing digest empty" patch; --apply never CREATES an issue for
+    an empty queue.
+    """
+    ready = qualifying(classified)
+    stamp = now.strftime("%Y-%m-%d %H:%M UTC")
+    lines = [
+        DIGEST_BODY_MARKER,
+        f"Soundness-PR drain queue -- daily digest (last updated {stamp})",
+        "",
+    ]
+    if not ready:
+        lines.append("Queue is empty: no PRs currently parked awaiting owner review.")
+        return "\n".join(lines)
+
+    lines.append(f"{len(ready)} PR(s) green on required checks, awaiting owner review, parked > 24h since green:")
+    lines.append("")
+    for c in ready:
+        reason = "soundness-gated" if c.soundness_gated else "review-requested"
+        park = _fmt_hours(c.park_time_hours) if c.park_time_hours is not None else "?"
+        idle = _fmt_hours(c.idle_hours)
+        lines.append(f"- #{c.number} {c.title} -- {reason}, idle {idle}, parked {park} -- {c.html_url}")
+    lines.append("")
+    lines.append(
+        f"The `{DRAIN_LABEL}` label above reflects this list exactly (added/removed to match). "
+        "The soundness auto-merge gate itself is untouched by this report -- see "
+        "docs/operations/soundness-drain.md."
+    )
+    lines.append(f"(repo: {repo})")
+    return "\n".join(lines)
+
+
+# ---------------------------------------------------------------------------
+# I/O: GitHub REST (token-source chain: GITHUB_TOKEN/GH_TOKEN env, else the
+# `gh` CLI's own token if it is on PATH -- never a separately-stored PAT).
+# ---------------------------------------------------------------------------
+def resolve_token() -> str | None:
+    token = os.environ.get("GITHUB_TOKEN") or os.environ.get("GH_TOKEN")
+    if token:
+        return token
+    if shutil.which("gh"):
+        try:
+            result = subprocess.run(
+                ["gh", "auth", "token"],
+                capture_output=True,
+                text=True,
+                timeout=10,
+                check=False,
+            )
+        except OSError:
+            return None
+        if result.returncode == 0:
+            candidate = result.stdout.strip()
+            if candidate:
+                return candidate
+    return None
+
+
+class GitHubClient:
+    """Thin REST client. GET pagination via Link headers; single-page
+    mutations otherwise. Mirrors detect_orphaned_commits.py's retry/urllib
+    conventions.
+    """
+
+    def __init__(self, token: str) -> None:
+        self.token = token
+
+    def _request(self, method: str, url: str, body: dict[str, Any] | None = None) -> Any:
+        data = json.dumps(body).encode("utf-8") if body is not None else None
+        req = urllib.request.Request(
+            url,
+            data=data,
+            method=method,
+            headers={
+                "Authorization": f"Bearer {self.token}",
+                "Accept": "application/vnd.github+json",
+                "User-Agent": "benchbox-soundness-drain-report",
+                **({"Content-Type": "application/json"} if data is not None else {}),
+            },
+        )
+        for attempt in range(3):
+            try:
+                with urllib.request.urlopen(req, timeout=30) as resp:
+                    payload = resp.read()
+                    return json.loads(payload) if payload else None
+            except urllib.error.HTTPError as err:
+                if err.code == 404:
+                    return None
+                if attempt == 2:
+                    raise
+            except urllib.error.URLError:
+                if attempt == 2:
+                    raise
+        return None
+
+    def get_all(self, path: str, params: dict[str, str] | None = None) -> list[dict[str, Any]]:
+        """GET a list endpoint, following `page` params up to a sane cap."""
+        query = dict(params or {})
+        query.setdefault("per_page", "100")
+        out: list[dict[str, Any]] = []
+        page = 1
+        while page <= 10:  # 1000 items is far beyond this repo's open-PR volume
+            query["page"] = str(page)
+            url = f"{API_ROOT}/{path}?{urllib.parse.urlencode(query)}"
+            result = self._request("GET", url) or []
+            if isinstance(result, dict) and "check_runs" in result:
+                result = result["check_runs"]
+            if not result:
+                break
+            out.extend(result)
+            if len(result) < int(query["per_page"]):
+                break
+            page += 1
+        return out
+
+    def get_one(self, path: str) -> Any:
+        return self._request("GET", f"{API_ROOT}/{path}")
+
+    def post(self, path: str, body: dict[str, Any]) -> Any:
+        return self._request("POST", f"{API_ROOT}/{path}", body)
+
+    def patch(self, path: str, body: dict[str, Any]) -> Any:
+        return self._request("PATCH", f"{API_ROOT}/{path}", body)
+
+    def delete(self, path: str) -> Any:
+        return self._request("DELETE", f"{API_ROOT}/{path}")
+
+
+def fetch_open_prs(client: GitHubClient, owner: str, repo: str) -> list[dict[str, Any]]:
+    """Fetch + normalize every OPEN PR targeting develop into the internal
+    shape consumed by classify_pr (same shape as the self-test fixture).
+    """
+    raw_prs = client.get_all(f"repos/{owner}/{repo}/pulls", {"state": "open", "base": "develop"})
+    normalized: list[dict[str, Any]] = []
+    for raw in raw_prs:
+        number = raw["number"]
+        head_sha = raw["head"]["sha"]
+        files = client.get_all(f"repos/{owner}/{repo}/pulls/{number}/files")
+        check_runs = client.get_all(f"repos/{owner}/{repo}/commits/{head_sha}/check-runs")
+        normalized.append(
+            {
+                "number": number,
+                "title": raw.get("title", ""),
+                "html_url": raw.get("html_url", ""),
+                "draft": bool(raw.get("draft")),
+                "created_at": raw.get("created_at"),
+                "updated_at": raw.get("updated_at"),
+                "auto_merge": raw.get("auto_merge"),
+                "requested_reviewers": [r.get("login") for r in (raw.get("requested_reviewers") or [])],
+                "changed_files": [f.get("filename", "") for f in files],
+                "check_runs": [
+                    {
+                        "name": run.get("name"),
+                        "status": run.get("status"),
+                        "conclusion": run.get("conclusion"),
+                        "completed_at": run.get("completed_at"),
+                    }
+                    for run in check_runs
+                ],
+            }
+        )
+    return normalized
+
+
+# ---------------------------------------------------------------------------
+# Mutations (only reached under --apply): label sync + pinned issue upsert.
+# ---------------------------------------------------------------------------
+def ensure_label_exists(client: GitHubClient, owner: str, repo: str) -> None:
+    existing = client.get_one(f"repos/{owner}/{repo}/labels/{DRAIN_LABEL}")
+    if existing is not None:
+        return
+    client.post(
+        f"repos/{owner}/{repo}/labels",
+        {"name": DRAIN_LABEL, "color": DRAIN_LABEL_COLOR, "description": DRAIN_LABEL_DESCRIPTION},
+    )
+
+
+def sync_labels(client: GitHubClient, owner: str, repo: str, ready: list[ClassifiedPR]) -> tuple[list[int], list[int]]:
+    """Add DRAIN_LABEL to qualifying PRs, remove it from evaluated PRs that
+    no longer qualify but currently carry it. Returns (added, removed).
+    """
+    ensure_label_exists(client, owner, repo)
+    qualifying_numbers = {c.number for c in ready}
+
+    labeled_prs = client.get_all(
+        f"repos/{owner}/{repo}/issues",
+        {"labels": DRAIN_LABEL, "state": "open"},
+    )
+    labeled_numbers = {item["number"] for item in labeled_prs if "pull_request" in item}
+
+    added: list[int] = []
+    for number in sorted(qualifying_numbers - labeled_numbers):
+        client.post(f"repos/{owner}/{repo}/issues/{number}/labels", {"labels": [DRAIN_LABEL]})
+        added.append(number)
+
+    removed: list[int] = []
+    for number in sorted(labeled_numbers - qualifying_numbers):
+        client.delete(f"repos/{owner}/{repo}/issues/{number}/labels/{DRAIN_LABEL}")
+        removed.append(number)
+
+    return added, removed
+
+
+def find_pinned_issue(client: GitHubClient, owner: str, repo: str) -> dict[str, Any] | None:
+    """Locate the digest issue: exact title AND the body marker.
+
+    The marker requirement means a manually-created issue that happens to
+    reuse the title is never clobbered; the script only adopts issues it
+    wrote. Title matches without the marker are skipped.
+    """
+    issues = client.get_all(f"repos/{owner}/{repo}/issues", {"state": "all"})
+    for item in issues:
+        if "pull_request" in item:
+            continue
+        if item.get("title") == PINNED_ISSUE_TITLE and DIGEST_BODY_MARKER in (item.get("body") or ""):
+            return item
+    return None
+
+
+def upsert_pinned_issue(client: GitHubClient, owner: str, repo: str, body: str) -> str:
+    """Create/update the single digest issue (non-empty queue path)."""
+    existing = find_pinned_issue(client, owner, repo)
+    if existing is None:
+        created = client.post(
+            f"repos/{owner}/{repo}/issues",
+            {"title": PINNED_ISSUE_TITLE, "body": body},
+        )
+        return f"created issue #{created['number']}"
+    payload: dict[str, Any] = {"body": body}
+    if existing.get("state") == "closed":
+        payload["state"] = "open"
+    client.patch(f"repos/{owner}/{repo}/issues/{existing['number']}", payload)
+    return f"updated issue #{existing['number']}"
+
+
+# ---------------------------------------------------------------------------
+# Self-test (fixture-driven, no network)
+# ---------------------------------------------------------------------------
+def run_self_test() -> int:
+    fixture = json.loads(FIXTURE_PATH.read_text(encoding="utf-8"))
+    now = _parse_iso(fixture["as_of"])
+    owner_login = fixture.get("owner_login", OWNER_LOGIN)
+    classified = classify_all(fixture["prs"], now, owner_login=owner_login)
+    by_number = {c.number: c for c in classified}
+
+    failures: list[str] = []
+
+    def expect(condition: bool, message: str) -> None:
+        if not condition:
+            failures.append(message)
+
+    expected_qualifying = set(fixture["expected_qualifying"])
+    actual_qualifying = {c.number for c in qualifying(classified)}
+    expect(
+        actual_qualifying == expected_qualifying,
+        f"qualifying set mismatch: expected {sorted(expected_qualifying)}, got {sorted(actual_qualifying)}",
+    )
+
+    for number in expected_qualifying:
+        expect(number in by_number, f"expected PR #{number} in fixture")
+
+    for number, reason in fixture.get("expected_excluded_reasons", {}).items():
+        c = by_number.get(int(number))
+        expect(c is not None, f"missing fixture PR #{number}")
+        if c is None:
+            continue
+        expect(not c.qualifies, f"PR #{number} unexpectedly qualifies (expected excluded: {reason})")
+        if reason == "not_green":
+            expect(not c.required_green, f"PR #{number} expected required_green=False")
+        elif reason == "auto_merge_on":
+            expect(c.auto_merge_enabled, f"PR #{number} expected auto_merge_enabled=True")
+        elif reason == "too_young":
+            expect(
+                (c.park_time_hours or 0.0) <= IDLE_THRESHOLD_HOURS,
+                f"PR #{number} expected park_time_hours <= 24",
+            )
+        elif reason == "draft":
+            expect(c.draft, f"PR #{number} expected draft=True")
+
+    # park_time_hours is only defined once the required lane is green.
+    for c in classified:
+        if c.required_green:
+            expect(c.park_time_hours is not None, f"PR #{c.number}: required_green but park_time_hours is None")
+        else:
+            expect(c.park_time_hours is None, f"PR #{c.number}: not required_green but park_time_hours is set")
+
+    if failures:
+        print("SELF-TEST FAILED:", file=sys.stderr)
+        for f in failures:
+            print(f"  - {f}", file=sys.stderr)
+        return 1
+
+    print(f"SELF-TEST PASSED ({len(classified)} fixture PRs, {len(actual_qualifying)} qualifying).")
+    return 0
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+def _parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument(
+        "--repo",
+        default=os.environ.get("GITHUB_REPOSITORY", DEFAULT_REPO),
+        help=f"owner/name (default: $GITHUB_REPOSITORY or {DEFAULT_REPO})",
+    )
+    parser.add_argument("--json", action="store_true", help="Emit machine-readable JSON instead of the digest text.")
+    parser.add_argument(
+        "--apply",
+        action="store_true",
+        help="Mutate: sync the awaiting-owner label and (if non-empty) upsert the pinned digest issue.",
+    )
+    parser.add_argument(
+        "--idle-hours",
+        type=float,
+        default=IDLE_THRESHOLD_HOURS,
+        help=f"Idle threshold in hours (default: {IDLE_THRESHOLD_HOURS}).",
+    )
+    parser.add_argument("--self-test", action="store_true", help="Run the bundled fixture-based classifier test.")
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parse_args(argv or sys.argv[1:])
+
+    if args.self_test:
+        return run_self_test()
+
+    try:
+        owner, repo = args.repo.split("/", 1)
+    except ValueError:
+        print(f"::error::--repo must be owner/name, got {args.repo!r}", file=sys.stderr)
+        return 2
+
+    token = resolve_token()
+    if not token:
+        print(
+            "::error::No GITHUB_TOKEN/GH_TOKEN in the environment and no authenticated `gh` on PATH.",
+            file=sys.stderr,
+        )
+        return 2
+
+    client = GitHubClient(token)
+    prs = fetch_open_prs(client, owner, repo)
+    now = dt.datetime.now(dt.timezone.utc)
+    classified = classify_all(prs, now, idle_threshold_hours=args.idle_hours)
+    ready = qualifying(classified)
+
+    if args.json:
+        print(
+            json.dumps(
+                {
+                    "generated_at": now.isoformat(),
+                    "repo": args.repo,
+                    "evaluated_count": len(classified),
+                    "qualifying": [c.to_dict() for c in ready],
+                },
+                indent=2,
+            )
+        )
+    else:
+        print(build_digest(classified, now=now, repo=args.repo))
+
+    if args.apply:
+        added, removed = sync_labels(client, owner, repo, ready)
+        if added:
+            print(f"label: added {DRAIN_LABEL} to {added}", file=sys.stderr)
+        if removed:
+            print(f"label: removed {DRAIN_LABEL} from {removed}", file=sys.stderr)
+        if ready:
+            outcome = upsert_pinned_issue(client, owner, repo, build_digest(classified, now=now, repo=args.repo))
+            print(f"digest issue: {outcome}", file=sys.stderr)
+        else:
+            # Silent-when-empty means no new issue and no repeated updates --
+            # but an existing digest must not keep showing yesterday's parked
+            # PRs forever. Patch it to the empty state exactly once.
+            existing = find_pinned_issue(client, owner, repo)
+            if existing is not None and "Queue is empty" not in (existing.get("body") or ""):
+                client.patch(
+                    f"repos/{owner}/{repo}/issues/{existing['number']}",
+                    {"body": build_digest(classified, now=now, repo=args.repo)},
+                )
+                print(f"digest issue: #{existing['number']} marked empty (one-time)", file=sys.stderr)
+            else:
+                print("digest issue: queue empty, no update (silent by design)", file=sys.stderr)
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/docs/operations/soundness-drain.md
+++ b/docs/operations/soundness-drain.md
@@ -1,0 +1,99 @@
+<!-- Copyright 2026 Joe Harris / BenchBox Project. Licensed under the MIT License. -->
+
+# Soundness-PR drain digest
+
+```{tags} contributor, operations, ci
+```
+
+## The signal, and what it is not
+
+Soundness-path PRs (see `_project/scripts/auto_merge_soundness_paths.py`'s
+`SOUNDNESS_PREFIXES`, mirrored in `.github/CODEOWNERS`) correctly **never
+auto-merge**. `.github/workflows/auto-merge-on-open.yml` withholds or revokes
+squash auto-merge the moment a PR's diff touches the comparator/parser
+surface, the oracle-adjacent reference data, the `sql_compat` rule-dispatch
+core, or the gate machinery itself. That withholding is intentional — CI
+cannot catch a change that redefines the oracle it validates against, so
+those PRs must be reviewed and merged by hand.
+
+What the gate does not do on its own is tell anyone a PR is *waiting*. Two
+PRs (#1116, #1142) sat parked for days, accumulating merge conflicts,
+before anyone noticed. **This digest is purely observational** — it adds a
+daily "someone should look at this" signal on top of the unchanged gate. It
+never merges, approves, or otherwise changes a PR's mergeability. The only
+mutations it performs are:
+
+1. adding/removing the `awaiting-owner` label to match the current queue, and
+2. creating/updating a single pinned tracking issue with the digest text —
+   and only when the queue is non-empty.
+
+## How a PR qualifies for the queue
+
+`_project/scripts/soundness_drain_report.py` lists every OPEN PR targeting
+`develop` and includes a PR in the digest when **all** of the following
+hold:
+
+- **(a) required-lane green** — the `ci-required-result` check run (the
+  aggregate required-check job defined in `.github/workflows/pr.yml`) on the
+  PR's head SHA completed with `conclusion: success`.
+- **(b) awaiting the owner** — auto-merge is currently OFF, **and** either
+  the diff touches a soundness-critical path (reused via
+  `any_soundness_path` imported from `auto_merge_soundness_paths.py` —
+  never re-derived or edited), or the owner (`joeharris76`, per
+  `.github/CODEOWNERS`) is a requested reviewer.
+- **(c) parked > 24h** — more than 24 hours of park time (see below).
+  The gate deliberately does NOT use `updated_at`: the script's own label
+  writes and ordinary human comments bump `updated_at`, so an idle-based
+  gate would flap a genuinely parked PR out of the queue every time the
+  signal fires.
+
+Draft PRs are always excluded regardless of the above.
+
+### Park time
+
+Each qualifying PR also reports **park time**: hours since the PR became
+ready-and-green, anchored on the `ci-required-result` check run's
+`completed_at` (falling back to `updated_at` if that timestamp is
+unavailable). This is emitted per PR in both the text digest and `--json`
+output, and is the intended input for park-time re-measurement work (the
+WS9 re-measure references this field rather than recomputing it).
+
+## Running locally
+
+```bash
+uv run -- python _project/scripts/soundness_drain_report.py            # human digest, read-only
+uv run -- python _project/scripts/soundness_drain_report.py --json      # machine-readable, read-only
+uv run -- python _project/scripts/soundness_drain_report.py --apply     # also syncs the label + pinned issue
+uv run -- python _project/scripts/soundness_drain_report.py --self-test # fixture-only, no network
+```
+
+Auth is a short token-source chain, never a long-lived PAT: `GITHUB_TOKEN`
+or `GH_TOKEN` from the environment first; if neither is set and the `gh`
+CLI is on `PATH`, its own token (`gh auth token`) is used. Without `--apply`
+the script only reads — no labels or issues are touched.
+
+## The `awaiting-owner` label
+
+The label is fully owned by this script under `--apply`: it is added to
+every currently-qualifying PR and removed from any evaluated PR that no
+longer qualifies (check went red, auto-merge got re-enabled, idle dropped
+back under 24h on a fresh push, etc.). Do not hand-manage it — the next
+scheduled run will reconcile it back to the computed set.
+
+## The daily digest issue
+
+`.github/workflows/soundness-drain.yml` runs the report on a daily schedule
+(`workflow_dispatch` is also available for an on-demand run) and calls
+`--apply`. The digest is posted to a single pinned issue titled
+**"Soundness-PR drain queue"** — found by exact title plus a body marker
+(`<!-- soundness-drain-digest -->`, so a human issue reusing the title is
+never adopted or clobbered) and updated in place (or created if it doesn't
+exist yet), never as per-PR or per-event comments. When the queue drains,
+an existing digest is patched to the empty state exactly once; after that
+an empty queue produces no create, no update, no notification. This keeps
+the signal to at most one digest a day, silent on a clean queue, and never
+leaves a stale "parked" list showing after the queue empties.
+
+The workflow uses the default `GITHUB_TOKEN` with a minimal permissions
+block (`contents: read`, `pull-requests: write`, `issues: write`) and never
+`pull_request_target`.


### PR DESCRIPTION
## Description

WS7 of `_project/planning/ci-failure-reduction-plan.md`: soundness-path PRs correctly never auto-merge (the owner reviews and merges by hand), but they park silently and grow conflicts while waiting — #1116/#1142 sat for days. This adds an observe-and-report-only daily signal; the withholding gate itself is untouched.

- `_project/scripts/soundness_drain_report.py` (stdlib-only): classifies open develop PRs — required-lane green (latest `ci-required-result` run on head), awaiting-owner (auto-merge off AND (soundness-path touch via `any_soundness_path` imported from `auto_merge_soundness_paths.py`, never re-derived, OR owner review-requested)), parked > 24h. The gate anchors on **park time since green**, not `updated_at` — the script's own label writes and human comments bump `updated_at`, and an idle-based gate would flap a parked PR out of the queue (Opus-review Required finding; pinned by an anti-flap fixture case: idle 30 min, parked 5 days → qualifies).
- Mutations only under `--apply`, and only: `awaiting-owner` label sync + ONE digest issue found by exact title **plus body marker** (a human issue reusing the title is never adopted); patched to empty-state exactly once when the queue drains, silent thereafter. No merge/approve/comment paths exist.
- `--self-test` runs offline against a bundled 7-PR fixture (3 qualifying incl. both awaiting-owner branches; exclusions cover auto-merge-on / too-young / not-green / draft). Park-time per PR emitted in digest + `--json` for the WS9 re-measure.
- `.github/workflows/soundness-drain.yml`: daily 05:00 UTC + `workflow_dispatch`; permissions exactly `contents: read`, `pull-requests: write`, `issues: write`; default `GITHUB_TOKEN`; no `pull_request_target`. Make targets `soundness-drain-report`/`soundness-drain-self-test`; runbook at `docs/operations/soundness-drain.md`.

Tracker: `soundness-pr-drain-signal-2`. Opus review: Required flap-gate finding fixed (+ latest-check-run selection, marker-hardened issue lookup, one-time empty-state patch — all three nits).

## Type of Change

- [x] New feature (dev-loop tooling; no product surface)

## Testing

- `--self-test` → PASSED (7 fixture PRs, 3 qualifying), fully offline.
- `ruff check` / `ruff format --check` clean; workflow YAML parses.

## Public Contract Check

- [x] No public contract surfaces — CI/dev tooling only.

## Documentation

- [x] `docs/operations/soundness-drain.md` (signal semantics, label ownership, digest behavior, local runs).

## Code Quality

- [x] Read-only without `--apply`; the five write calls are all `--apply`-gated and enumerated in review.
- [x] `SOUNDNESS_PREFIXES` consumed via import only; `auto_merge_soundness_paths.py`, `auto-merge-on-open.yml`, `release.yml` untouched.

## Artifact Hygiene

- [x] Fixture is a small hand-written JSON with durable test value.

## Notes

- The `awaiting-owner` label is fully script-owned (reconciled each run) — documented in the runbook.

---
_Generated by [Claude Code](https://claude.ai/code/session_016NqSKtt68mqUpFA6C2qUkB)_