### PR TITLE
chore(guards): make guards-fix regen target + self-explaining drift-guard failures

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -768,6 +768,55 @@ mutation-test:
 	@echo "--- Mutation test results ---"
 	uv run -- mutmut results
 
+##@ Guards / drift-guard remediation
+#
+# guards-fix-regen-target: a "drift-guard" class of CI checks -- dependency
+# inventory, oracle coverage map, parity fixtures, compat docs, UAT LOC
+# table, skill-sync -- each fails on drift against a checked-in artifact and
+# each has ONE known mechanical regen command. This target runs every regen
+# that exists, in one place, so agents stop rediscovering the right command
+# per guard from a hand-carried prompt.
+#
+# guards-fix ONLY regenerates artifacts -- it never edits allowlists,
+# ceilings, or curation lists. Each guard's CHECK target still fails CI on
+# drift; regen is remediation, not suppression. Never wire this into CI to
+# self-heal -- it is an operator command, run locally, with the diff reviewed
+# and committed by a human.
+#
+# Some CHECK guards in this class have NO regen mode (the fix is always a
+# reviewed hand edit, not a mechanical rewrite) -- guards-fix does not touch
+# them; it only echoes where to look:
+#   - module-size guard (tests/system/test_module_size_thresholds.py) --
+#     the failure message prints a ready-to-paste ALLOWLIST entry.
+#   - DDL governance drift (benchbox/sql_compat/inventory.py --check-ddl-drift)
+#     -- register the transform, add a _DDL_GOVERNANCE_TRANSFORMER_ALIASES
+#     alias, or add a _DDL_DRIFT_EXEMPTIONS entry.
+#   - release curation list (scripts/check_release_curation.py) -- classify
+#     the path as main-only (docs) or release-cut curated (Makefile), by hand.
+.PHONY: guards-fix
+guards-fix:
+	@echo "== guards-fix: regenerating every mechanically-regenerable drift-guard artifact =="
+	@echo "-- dependency inventory (audit-raw) --"
+	@$(MAKE) -s audit-raw
+	@echo "-- benchmark correctness-oracle coverage map --"
+	@$(MAKE) -s oracle-coverage-map
+	@echo "-- visualization parity fixtures --"
+	@$(MAKE) -s parity-fixtures
+	@echo "-- sql_compat capability matrix / skip-reference docs --"
+	@$(MAKE) -s compat-docs
+	@echo "-- UAT spec module-LOC table --"
+	@uv run --project _project/scripts -- python _project/scripts/uat_loc_table.py
+	@echo "-- skill-sync (no-ops with a notice if the skill-sync CLI is not installed) --"
+	@$(MAKE) -s skill-sync
+	@echo ""
+	@echo "No regen mode -- these are reviewed hand edits, guards-fix does not touch them:"
+	@echo "  - module-size guard: tests/system/test_module_size_thresholds.py (see its failure output for the ALLOWLIST entry to paste)"
+	@echo "  - DDL governance drift: benchbox/sql_compat/inventory.py --check-ddl-drift (register the transform, alias it, or exempt it)"
+	@echo "  - release curation list: scripts/check_release_curation.py (classify the path as main-only or release-cut curated)"
+	@echo ""
+	@echo "== guards-fix done. Review the diff below, then commit what you intend to keep. =="
+	@git status --porcelain
+
 ##@ CI Local Equivalents
 # These targets mirror GitHub Actions workflows for local validation
 
@@ -1039,7 +1088,7 @@ parity-check:
 	diff -r --exclude='.gitkeep' tests/parity/fixtures $$tmpdir && \
 	echo "parity-check: fixtures match Python source" && \
 	rm -rf $$tmpdir || \
-	(echo "parity-check FAILED: fixtures are out of date - run 'make parity-fixtures' to regenerate" && rm -rf $$tmpdir && exit 1)
+	(echo "parity-check FAILED: fixtures are out of date - run 'make parity-fixtures' to regenerate (or 'make guards-fix' to regenerate every mechanical drift-guard artifact)" && rm -rf $$tmpdir && exit 1)
 
 # Create distribution packages
 dist: clean
@@ -1731,6 +1780,10 @@ worktree-claim-attempt:
 			|| [ -n "$$(find "$$wt/uv.lock" "$$wt/pyproject.toml" -newer "$$wt/.venv/pyvenv.cfg" 2>/dev/null | head -n 1)" ]; then \
 			( cd "$$wt" && uv sync --group dev >/dev/null ); \
 		fi; \
+		if [ -f "$$wt/.pre-commit-config.yaml" ]; then \
+			( cd "$$wt" && uv run -- pre-commit install >/dev/null 2>&1 ) \
+				|| echo "note: pre-commit install failed/unavailable in $$wt; codespell etc. won't run at commit time (run \`uv run -- pre-commit install\` manually)" >&2; \
+		fi; \
 		rm -f "$$marker"; \
 		marker=""; \
 		claim_ok=1; \
@@ -2362,6 +2415,7 @@ help:
 	@echo "  make validate-imports Validate import structure and detect circular dependencies"
 	@echo "  make dependency-check Validate lock file against pyproject specs (ARGS='--matrix' to show summary)"
 	@echo "  make duplicate-check Detect duplicate code via AST structural hashing"
+	@echo "  make guards-fix      Regenerate every mechanical drift-guard artifact (inventory/oracle-map/parity/compat-docs/UAT-LOC/skill-sync), then print git status"
 	@echo "  make mutation-test   Run mutation testing on critical modules (mutmut)"
 	@echo "  make format          Format code with ruff"
 	@echo "  make clean           Remove build artifacts"

--- a/_project/scripts/dependency_audit/parse_deps.py
+++ b/_project/scripts/dependency_audit/parse_deps.py
@@ -164,7 +164,8 @@ def main() -> int:
         if current != content:
             print(
                 f"DRIFT: {out.relative_to(_ROOT)} is out of date with pyproject.toml.\n"
-                f"Regenerate it with: uv run -- python {_GENERATOR_REL}",
+                f"Regenerate it with: uv run -- python {_GENERATOR_REL}\n"
+                "(or `make guards-fix` to regenerate every mechanical drift-guard artifact)",
                 file=sys.stderr,
             )
             return 1

--- a/_project/scripts/generate_oracle_coverage_map.py
+++ b/_project/scripts/generate_oracle_coverage_map.py
@@ -247,7 +247,10 @@ def oracle_independence_and_rationale(primary: str, strength: str, benchmark_id:
         return _cross_surface_independence(benchmark_id)
     independence = oracle_reference_independence(primary, strength, benchmark_id)
     if independence == INDEPENDENCE_SELF:
-        return independence, "Reference is a shared/generated surface or frozen benchbox snapshot, not an external authority."
+        return (
+            independence,
+            "Reference is a shared/generated surface or frozen benchbox snapshot, not an external authority.",
+        )
     if independence == INDEPENDENCE_SEMI:
         return independence, "External TPC answer sets provide row-count authority only; result values are not checked."
     if independence == INDEPENDENCE_INDEPENDENT:
@@ -557,15 +560,16 @@ def check_artifacts(rows: list[dict[str, Any]]) -> list[str]:
         (JSON_ARTIFACT, render_json(rows), False),
         (MARKDOWN_ARTIFACT, render_markdown(rows), True),
     )
+    fix_hint = "run `make oracle-coverage-map` (or `make guards-fix`) and commit"
     for path, expected, strip in checks:
         if not path.exists():
-            problems.append(f"missing artifact: {path.relative_to(_REPO_ROOT)} (run the generator)")
+            problems.append(f"missing artifact: {path.relative_to(_REPO_ROOT)} ({fix_hint})")
             continue
         actual = path.read_text(encoding="utf-8")
         if strip:
             actual = _strip_provenance(actual)
         if actual != expected:
-            problems.append(f"stale artifact: {path.relative_to(_REPO_ROOT)} (run the generator and commit)")
+            problems.append(f"stale artifact: {path.relative_to(_REPO_ROOT)} ({fix_hint})")
     return problems
 
 

--- a/_project/scripts/uat_loc_table.py
+++ b/_project/scripts/uat_loc_table.py
@@ -170,6 +170,7 @@ def main() -> int:
             sys.stderr.write(
                 "\nUAT LOC table/summary is stale. Run:\n"
                 "  uv run --project _project/scripts -- python _project/scripts/uat_loc_table.py\n"
+                "(or `make guards-fix` to regenerate every mechanical drift-guard artifact)\n"
             )
             return 1
         print("UAT LOC table + summary match the tree.")

--- a/benchbox/sql_compat/inventory.py
+++ b/benchbox/sql_compat/inventory.py
@@ -1068,9 +1068,15 @@ def main(argv: list[str] | None = None) -> int:
                 if d.detail:
                     emit(f"    {d.detail}", stderr=True)
             emit(
-                "Register each unregistered transform in "
-                "benchbox/sql_compat/rules/ddl_optimize/{platform}_ddl_rewrites.py "
-                "or add an explicit drift exemption with rationale.",
+                "Fix by one of:\n"
+                "  1) register the transform's rule in "
+                "benchbox/sql_compat/rules/ddl_optimize/{platform}_ddl_rewrites.py, or\n"
+                "  2) if it IS registered but under a different function name, add a "
+                "(platform_key, func_name) -> (registered_name, ...) entry to "
+                "_DDL_GOVERNANCE_TRANSFORMER_ALIASES in benchbox/sql_compat/inventory.py, or\n"
+                "  3) add an explicit drift exemption (_DDL_DRIFT_EXEMPTIONS) with rationale.\n"
+                "No regen mode exists for this guard -- it is always a reviewed hand edit, "
+                "not covered by `make guards-fix`.",
                 stderr=True,
             )
             exit_code = 1

--- a/docs/operations/dev-loop-worktree-pool.md
+++ b/docs/operations/dev-loop-worktree-pool.md
@@ -37,7 +37,7 @@ The minimum surface for routine work — start here.
 
 | When | Command | Effect |
 |---|---|---|
-| Start a new task | `make worktree-claim BRANCH=fix/foo` | Pick a free slot, fetch + reset to current `origin/develop`, create branch, refresh `.venv/` only if `uv.lock`/`pyproject.toml` changed. Prints `WORKTREE_PATH=…`. |
+| Start a new task | `make worktree-claim BRANCH=fix/foo` | Pick a free slot, fetch + reset to current `origin/develop`, create branch, refresh `.venv/` only if `uv.lock`/`pyproject.toml` changed, and (re)install the pre-commit hooks (idempotent; `\|\| true` with a notice if `pre-commit` is unavailable). Prints `WORKTREE_PATH=…`. |
 | Inside the slot, ship the work | `make pr-preflight && make pr-open` | Run the local lint + fast-test gate, push, open PR vs `develop`, enable squash auto-merge. Walk away — auto-merge lands it once CI is green. |
 | After the PR merges | `make worktree-release` | Detach the slot back to `origin/develop`, delete the local feature branch. Refuses unless the PR state is `MERGED` (use `FORCE=1` to escape — only when intentional). |
 | See pool state any time | `make worktree-pool-status` | Tabular: pool, path, branch, state, claim age, venv health, disk size. Read-only; safe to run during other operations. |
@@ -140,6 +140,13 @@ Creates `BenchBox.pool-01..10` as detached siblings, runs `uv sync
 leaves existing slots alone, only fills missing ones. Override defaults
 via env: `POOL_SIZE=N` and `WORKTREE_POOL_PARENT=…` (used by the test
 suite for disposable pools).
+
+`worktree-claim` also (re)installs the pre-commit hooks every time it
+hands you a slot — not just at pool-init — so slots created before this
+step existed, or a `.git/hooks` that got clobbered, still get codespell
+et al. running at commit time. It's a no-op if the hook is already
+current, and it never fails the claim: if `pre-commit` isn't available
+it prints a notice and moves on.
 
 ### Publish across many open branches
 

--- a/docs/operations/guards-fix.md
+++ b/docs/operations/guards-fix.md
@@ -1,0 +1,78 @@
+# `make guards-fix`: drift-guard remediation, one command
+
+A small class of CI checks are "drift guards": they compare a checked-in
+artifact (a doc, a fixture, a generated table) against a fresh regeneration
+from the live source of truth, and fail when the two disagree. Each one is
+fixed by a known, mechanical regen command — but the command differed per
+guard and lived only in hand-carried agent prompts, so the same fix kept
+getting rediscovered every time one of these failed in CI (a "steady
+trickle" of otherwise-routine failures). `make guards-fix` runs every regen
+that exists, in one place, then prints `git status --porcelain` so you can
+review the diff before committing.
+
+```bash
+make guards-fix
+```
+
+## What it regenerates
+
+| Guard | CHECK target | Regen it runs |
+|---|---|---|
+| Dependency inventory | `make audit-raw-check` | `make audit-raw` (`_project/scripts/dependency_audit/parse_deps.py`) |
+| Benchmark correctness-oracle coverage map | `make oracle-coverage-map-check` | `make oracle-coverage-map` (`_project/scripts/generate_oracle_coverage_map.py`) |
+| Visualization parity fixtures | `make parity-check` | `make parity-fixtures` (`tests/parity/generate_visualization_fixtures.py`) |
+| sql_compat capability matrix / skip-reference docs | `make compat-docs-check` | `make compat-docs` (`scripts/generate_compat_docs.py`) |
+| UAT spec module-LOC table | `uv run --project _project/scripts -- python _project/scripts/uat_loc_table.py --check` | `uv run --project _project/scripts -- python _project/scripts/uat_loc_table.py` |
+| skill-sync tracked snapshot | `make skill-sync-check` | `make skill-sync` (no-op with a notice if the skill-sync CLI isn't installed locally — see its section in `dev-loop-worktree-pool.md`/the Makefile comments) |
+
+Each regen is idempotent: run it against an already-current artifact and
+nothing changes. `make guards-fix` on a clean `develop` checkout should be a
+complete no-op — an empty `git status --porcelain` at the end. If it isn't,
+that's real drift that predates your change; investigate before assuming
+it's something you introduced.
+
+Two of the regenerated artifacts carry a provenance timestamp that is
+intentionally excluded from the CHECK comparison (e.g. the oracle coverage
+map's `generated:` header) — `guards-fix` refreshing that date alone, with
+the `content-revision` hash unchanged, is not drift and won't fail CI.
+
+## What it deliberately does not touch
+
+`guards-fix` only regenerates artifacts. It never edits an allowlist,
+ceiling, or curation list — those stay a human-reviewed decision, and each
+guard still fails CI on drift afterward (regen is remediation, not
+suppression). Three guards in this class have no regen mode at all; their
+failure output names the exact hand edit instead:
+
+- **Module-size guard** (`tests/system/test_module_size_thresholds.py`) —
+  when a tracked module exceeds its budget, the failure prints a
+  ready-to-paste `ALLOWLIST` entry carrying the module's *current* line
+  count. Paste it in with a real justification; `ALLOWLIST_HEADROOM` is
+  added on top automatically.
+- **DDL governance drift** (`benchbox/sql_compat/inventory.py
+  --check-ddl-drift`, run as part of `make compat-docs-check`) — an
+  unregistered or uninspectable DDL-optimize transform is fixed by
+  registering it under `benchbox/sql_compat/rules/ddl_optimize/`, adding a
+  `_DDL_GOVERNANCE_TRANSFORMER_ALIASES` entry (if it's registered under a
+  different function name), or an explicit `_DDL_DRIFT_EXEMPTIONS` entry
+  with rationale.
+- **Release curation list** (`scripts/check_release_curation.py`) — an
+  unaccounted-for top-level path is classified by hand as either
+  `main`-only (`_project/decisions/single-repo-migration.md`) or
+  release-cut curated (the `release-cut:` target in `Makefile`).
+
+## When to run it
+
+Run it locally whenever one of the CHECK targets above fails, or
+proactively before opening a PR that touched a file one of these guards
+watches (dependencies, benchmark registry/oracles, visualization math,
+`sql_compat` rules, `tests/uat/*`). Review the resulting diff like any other
+change before committing — `guards-fix` is an operator command, not
+something CI runs on your behalf. It is intentionally **not** wired into any
+CI workflow to self-heal: a guard failing in CI should fail, and be fixed by
+a human running this command and reviewing the diff, not silently patched by
+the pipeline itself.
+
+See also: `make -n guards-fix` to preview what it will run without
+executing anything, and the `guards-fix-regen-target-2` TODO for the
+class-level rationale.

--- a/tests/system/test_module_size_thresholds.py
+++ b/tests/system/test_module_size_thresholds.py
@@ -63,6 +63,16 @@ def _count_lines(path: Path) -> int:
         return sum(1 for _ in handle)
 
 
+def _allowlist_snippet(path: Path, line_count: int) -> str:
+    """Ready-to-paste ALLOWLIST entry for a module that just tripped the guard.
+
+    No regen mode exists for this guard (guards-fix never edits allowlists,
+    per policy) -- the fix is always a human-reviewed hand edit, so the
+    failure prints the exact entry to paste.
+    """
+    return f'    Path(\n        "{path.as_posix()}"\n    ): {line_count},  # <justification -- why this module must exceed the default>'
+
+
 def test_runtime_modules_respect_size_limits() -> None:
     repo_root = Path(__file__).resolve().parents[2]
     violations = []
@@ -83,10 +93,14 @@ def test_runtime_modules_respect_size_limits() -> None:
 
     if violations:
         details = "\n".join(f"{path} has {lines} lines (limit {limit})" for path, lines, limit in violations)
+        snippets = "\n".join(_allowlist_snippet(path, lines) for path, lines, _limit in violations)
         raise AssertionError(
             "Runtime module size guardrails tripped:\n"
             + details
-            + "\nReduce the module size or update the allowlist with justification."
+            + "\nReduce the module size, or -- if the size is justified -- paste this into "
+            "ALLOWLIST in tests/system/test_module_size_thresholds.py with a real "
+            "justification (ALLOWLIST_HEADROOM is added automatically on top; no `make "
+            "guards-fix` regen exists for this guard, it is always a reviewed hand edit):\n" + snippets
         )
 
 

--- a/tests/unit/scripts/test_guard_messages.py
+++ b/tests/unit/scripts/test_guard_messages.py
@@ -1,0 +1,153 @@
+"""Pin the remediation text of the drift-guard class covered by `make guards-fix`.
+
+guards-fix-regen-target-2: each of these CHECK guards fails a "steady trickle"
+of CI runs; the fix is a known mechanical regen command (or, for the two
+guards with no regen mode, a specific hand edit). These tests pin that the
+failure output actually names the exact fix -- not just "something drifted" --
+so a future edit to any of these scripts can't silently regress the message
+into something an agent has to rediscover from a hand-carried prompt again.
+
+Covers:
+  * dependency inventory (_project/scripts/dependency_audit/parse_deps.py)
+  * UAT LOC table (_project/scripts/uat_loc_table.py)
+  * module-size guard (tests/system/test_module_size_thresholds.py) -- no
+    regen mode; pins the ready-to-paste ALLOWLIST entry instead.
+  * DDL governance drift (benchbox/sql_compat/inventory.py --check-ddl-drift)
+    -- no regen mode; pins the _DDL_GOVERNANCE_TRANSFORMER_ALIASES mention.
+
+The oracle-coverage-map guard's message is pinned alongside its other guards
+in tests/unit/test_oracle_coverage_map.py rather than duplicated here.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import io
+import sys
+from contextlib import redirect_stderr
+from pathlib import Path
+
+import pytest
+
+pytestmark = [pytest.mark.unit, pytest.mark.fast]
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+
+
+def _load_module(name: str, path: Path):
+    spec = importlib.util.spec_from_file_location(name, path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+parse_deps = _load_module(
+    "guard_messages_parse_deps",
+    REPO_ROOT / "_project" / "scripts" / "dependency_audit" / "parse_deps.py",
+)
+uat_loc_table = _load_module(
+    "guard_messages_uat_loc_table",
+    REPO_ROOT / "_project" / "scripts" / "uat_loc_table.py",
+)
+module_size_guard = _load_module(
+    "guard_messages_module_size_thresholds",
+    REPO_ROOT / "tests" / "system" / "test_module_size_thresholds.py",
+)
+
+
+def test_parse_deps_check_message_names_exact_regen_command(tmp_path, monkeypatch):
+    """audit-raw-check's drift message must name the exact regen invocation
+    and point at `make guards-fix` as the one-command alternative."""
+    pyproject = tmp_path / "pyproject.toml"
+    pyproject.write_text(
+        '[project]\nname = "x"\nversion = "0"\ndependencies = ["foo>=1"]\n',
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(parse_deps, "_ROOT", tmp_path)
+    monkeypatch.setattr(sys, "argv", ["parse_deps.py", "--check"])
+
+    buf = io.StringIO()
+    with redirect_stderr(buf):
+        exit_code = parse_deps.main()
+
+    assert exit_code == 1
+    message = buf.getvalue()
+    assert "uv run -- python _project/scripts/dependency_audit/parse_deps.py" in message
+    assert "make guards-fix" in message
+
+
+def test_uat_loc_table_check_message_names_exact_regen_command(tmp_path, monkeypatch):
+    """uat_loc_table.py --check's drift message must name the exact regen
+    invocation and point at `make guards-fix`."""
+    real_spec = uat_loc_table.SPEC_PATH.read_text(encoding="utf-8")
+    begin = real_spec.find(uat_loc_table.SUMMARY_BEGIN)
+    end = real_spec.find(uat_loc_table.SUMMARY_END) + len(uat_loc_table.SUMMARY_END)
+    assert begin != -1 and end != -1, "fixture assumption: real spec has the summary markers"
+
+    stale_spec = (
+        real_spec[:begin]
+        + uat_loc_table.SUMMARY_BEGIN
+        + "\n\n(deliberately stale for test_guard_messages)\n\n"
+        + uat_loc_table.SUMMARY_END
+        + real_spec[end:]
+    )
+    stale_path = tmp_path / "uat-framework.md"
+    stale_path.write_text(stale_spec, encoding="utf-8")
+
+    monkeypatch.setattr(uat_loc_table, "SPEC_PATH", stale_path)
+    monkeypatch.setattr(sys, "argv", ["uat_loc_table.py", "--check"])
+
+    buf = io.StringIO()
+    with redirect_stderr(buf):
+        exit_code = uat_loc_table.main()
+
+    assert exit_code == 1
+    message = buf.getvalue()
+    assert "uv run --project _project/scripts -- python _project/scripts/uat_loc_table.py" in message
+    assert "make guards-fix" in message
+
+
+def test_module_size_allowlist_snippet_is_pasteable():
+    """The module-size guard has no regen mode; its failure must print a
+    ready-to-paste ALLOWLIST entry carrying the *current* line count."""
+    snippet = module_size_guard._allowlist_snippet(Path("benchbox/example/module.py"), 1_337)
+    assert "Path(" in snippet
+    assert '"benchbox/example/module.py"' in snippet
+    assert "1337" in snippet
+    assert "<justification" in snippet
+
+
+def test_module_size_violation_message_includes_snippet_and_no_regen_note(monkeypatch):
+    """Simulate a tripped guard and confirm the raised message carries the
+    pasteable ALLOWLIST entry plus a pointer that this guard has no
+    `make guards-fix` regen mode."""
+    fixture_relpath = Path("tests/unit/scripts/test_guard_messages.py")  # exists, real file, no allowlist entry
+    monkeypatch.setattr(module_size_guard, "MODULE_PATHS", [fixture_relpath])
+    monkeypatch.setattr(module_size_guard, "ALLOWLIST", {})
+    monkeypatch.setattr(module_size_guard, "MAX_LINES_DEFAULT", 1)
+
+    with pytest.raises(AssertionError) as excinfo:
+        module_size_guard.test_runtime_modules_respect_size_limits()
+
+    message = str(excinfo.value)
+    assert "ALLOWLIST" in message
+    assert "test_module_size_thresholds.py" in message
+    assert "no `make guards-fix` regen exists for this guard" in message
+    assert f'Path(\n        "{fixture_relpath.as_posix()}"\n    ):' in message
+
+
+def test_ddl_drift_message_mentions_alias_dict_and_no_regen():
+    """benchbox/sql_compat/inventory.py --check-ddl-drift has no regen mode;
+    pin that its remediation names the exact fix mechanisms: registering the
+    rule, adding a _DDL_GOVERNANCE_TRANSFORMER_ALIASES entry, or an explicit
+    _DDL_DRIFT_EXEMPTIONS entry."""
+    source = (REPO_ROOT / "benchbox" / "sql_compat" / "inventory.py").read_text(encoding="utf-8")
+    # Locate the emitted remediation block for --check-ddl-drift drift findings.
+    marker = 'emit(\n                "Fix by one of:'
+    assert marker in source, "expected the DDL-drift remediation emit() block to be present verbatim"
+    idx = source.index(marker)
+    block = source[idx : idx + 900]
+    assert "_DDL_GOVERNANCE_TRANSFORMER_ALIASES" in block
+    assert "_DDL_DRIFT_EXEMPTIONS" in block
+    assert "make guards-fix" in block

--- a/tests/unit/test_oracle_coverage_map.py
+++ b/tests/unit/test_oracle_coverage_map.py
@@ -65,6 +65,23 @@ def test_checked_in_artifacts_are_current(rows):
     assert not problems, "oracle coverage map is stale:\n" + "\n".join(problems)
 
 
+def test_check_artifacts_fix_hint_names_exact_regen_command(rows, monkeypatch):
+    """guards-fix-regen-target-2: a stale/missing artifact must name the exact
+    regen command (`make oracle-coverage-map`) and point at `make guards-fix`
+    as the one-command alternative -- not just say "stale, go figure it out"."""
+    from _project.scripts import generate_oracle_coverage_map as gocm
+
+    # Must resolve under _REPO_ROOT: check_artifacts() calls path.relative_to(_REPO_ROOT).
+    missing_path = gocm.ARTIFACT_DIR / "does-not-exist-guard-messages-test.md"
+    monkeypatch.setattr(gocm, "MARKDOWN_ARTIFACT", missing_path)
+
+    problems = check_artifacts(rows)
+    assert problems, "expected a missing-artifact problem to be reported"
+    hint_problems = [p for p in problems if "does-not-exist-guard-messages-test.md" in p]
+    assert hint_problems, problems
+    assert any("make oracle-coverage-map" in p and "make guards-fix" in p for p in hint_problems)
+
+
 def test_every_shipped_benchmark_is_classified(rows):
     """Every registry benchmark appears exactly once with a primary oracle."""
     from benchbox.core.benchmark_registry import list_benchmark_ids


### PR DESCRIPTION
## Description

WS5 of `_project/planning/ci-failure-reduction-plan.md`: the drift-guard class fails CI in a steady trickle, each failure fixed by a known mechanical regen that agents rediscover from a hand-carried prompt. This gives the repo one command and self-explaining failures:

- **`make guards-fix`** runs every regen that exists (`audit-raw`, `oracle-coverage-map`, `parity-fixtures`, `compat-docs`, `uat_loc_table.py`, `skill-sync` — which no-ops with a notice when not installed) and echoes the three guards with no regen mode (module-size, DDL governance, release curation), ending with `git status`. Crash aborts nonzero; drift regenerates and exits 0. Never edits allowlists/ceilings; not wired into any CI workflow (verified: zero workflow hits).
- **Remediation messages**: the module-size guard now prints a ready-to-paste `ALLOWLIST` entry with the module's current line count (matching its documented re-baseline + `ALLOWLIST_HEADROOM` convention, off-by-one-checked in review); the DDL-drift report names `_DDL_GOVERNANCE_TRANSFORMER_ALIASES` / `_DDL_DRIFT_EXEMPTIONS` (message-only hunk in `benchbox/sql_compat/inventory.py` — review-verified no logic change); `parse_deps` / oracle-map / `uat_loc_table` cross-reference `make guards-fix`. All pinned by tests (5 new in `tests/unit/scripts/test_guard_messages.py`, 1 extended; 22 pass).
- **`worktree-claim` installs pre-commit hooks** in the claimed worktree (after `uv sync`, guarded by config existence, non-fatal) so codespell fires at commit time instead of in CI.
- Docs: `docs/operations/guards-fix.md` (+ worktree-pool doc update).

Tracker: `guards-fix-regen-target-2`. Opus review: **APPROVE** (soundness-adjacent `inventory.py` hunk verified message-only; both pre-existing develop drift artifacts confirmed reverted out of the diff).

## Type of Change

- [x] Refactor / chore

## Testing

- 22/22 targeted tests pass; new tests carry `unit, fast` markers.
- Fast-lane check at review time: 25541 collected vs 25545 ceiling (+4 headroom — this PR adds 6 fast tests and fits; if a concurrent fast-test-adding PR lands first, the merge ref may need a small ceiling bump, which reviewers should treat as expected).
- `make -n guards-fix` renders; no-op verified on clean develop (two *pre-existing* drift artifacts found during that verification were reverted, not shipped: the UAT LOC table — fixed separately in #1284 — and a sandbox-local parity-fixture float diff, recorded as a tracker follow-up).

## Public Contract Check

- [x] No public contract surfaces — dev tooling, guard messages, tests, docs.

## Documentation

- [x] `docs/operations/guards-fix.md` documents what regenerates, what deliberately doesn't, and when to run it.

## Code Quality

- [x] `ruff check` / `format --check` clean on all touched Python files.
- [x] Message-pinning tests prevent remediation-text rot.

## Artifact Hygiene

- [x] No raw artifacts; no regenerated files shipped (regens verified no-op on clean tree).

## Notes

- Consciously skipped review nit: `uat_loc_table.py` is invoked directly via `uv run` rather than through a make indirection target — no such target existed before, and adding one purely for stylistic symmetry adds Makefile surface without behavior; noted here per protocol.

---
_Generated by [Claude Code](https://claude.ai/code/session_016NqSKtt68mqUpFA6C2qUkB)_