### PR TITLE
chore(ci): nightly green-but-unmerged sweep + PR-triage runbook

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -727,3 +727,34 @@ jobs:
       - name: Run PySpark tests
         run: |
           make test-pyspark
+
+  green-unmerged-sweep:
+    # External read-only observer for the harden-auto-merge-on-open-stranding
+    # failure class: auto-merge-on-open.yml's `enable` job can complete
+    # `conclusion: success` while the PR's own `auto_merge` field never ends
+    # up populated (see the script's "Known timing behavior" note). This job
+    # does NOT modify auto-merge-on-open.yml and does NOT enable auto-merge
+    # itself -- it only alerts via one marker-tagged tracking issue. See
+    # docs/operations/pr-triage.md.
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+      pull-requests: read
+      issues: write
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v4
+
+      - name: Run green-unmerged sweep
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: uv run -- python _project/scripts/green_unmerged_sweep.py --apply --check-post-merge

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -422,3 +422,4 @@ Markers: `fast`, `unit`, `integration`, `tpch`, `tpcds`, `ssb`,
 - SQL compatibility: `benchbox/sql_compat/README.md`
 - Dependency compatibility: `docs/development/dependency-compatibility.md`
 - Test taxonomy and lock: `tests/README.md`
+- PR triage judgment rules: `docs/operations/pr-triage.md`

--- a/_project/scripts/fixtures/green_unmerged_fixture.json
+++ b/_project/scripts/fixtures/green_unmerged_fixture.json
@@ -1,0 +1,113 @@
+{
+  "as_of": "2026-07-23T12:00:00Z",
+  "repo": "joeharris76/BenchBox",
+  "grace_hours": 2.0,
+  "prs": [
+    {
+      "number": 2001,
+      "title": "stranded hit: green, auto-merge off, aged past grace",
+      "html_url": "https://github.com/joeharris76/BenchBox/pull/2001",
+      "draft": false,
+      "updated_at": "2026-07-23T08:00:00Z",
+      "head_pushed_at": "2026-07-23T08:00:00Z",
+      "auto_merge": null,
+      "changed_files": ["benchbox/platforms/duckdb/adapter.py"],
+      "check_runs": [
+        {"name": "ci-required-result", "status": "completed", "conclusion": "success", "started_at": "2026-07-23T08:10:00Z"}
+      ]
+    },
+    {
+      "number": 2002,
+      "title": "soundness-gated exclusion: otherwise identical to the stranded hit",
+      "html_url": "https://github.com/joeharris76/BenchBox/pull/2002",
+      "draft": false,
+      "updated_at": "2026-07-23T08:00:00Z",
+      "head_pushed_at": "2026-07-23T08:00:00Z",
+      "auto_merge": null,
+      "changed_files": ["benchbox/core/equivalence/compare.py"],
+      "check_runs": [
+        {"name": "ci-required-result", "status": "completed", "conclusion": "success", "started_at": "2026-07-23T08:10:00Z"}
+      ]
+    },
+    {
+      "number": 2003,
+      "title": "auto-merge-on exclusion: green and aged, but auto-merge is already enabled",
+      "html_url": "https://github.com/joeharris76/BenchBox/pull/2003",
+      "draft": false,
+      "updated_at": "2026-07-23T08:00:00Z",
+      "head_pushed_at": "2026-07-23T08:00:00Z",
+      "auto_merge": {"enabled_by": {"login": "joeharris76"}, "merge_method": "squash"},
+      "changed_files": ["benchbox/platforms/snowflake/adapter.py"],
+      "check_runs": [
+        {"name": "ci-required-result", "status": "completed", "conclusion": "success", "started_at": "2026-07-23T08:10:00Z"}
+      ]
+    },
+    {
+      "number": 2004,
+      "title": "draft exclusion: draft is a deliberate not-ready signal",
+      "html_url": "https://github.com/joeharris76/BenchBox/pull/2004",
+      "draft": true,
+      "updated_at": "2026-07-23T08:00:00Z",
+      "head_pushed_at": "2026-07-23T08:00:00Z",
+      "auto_merge": null,
+      "changed_files": ["README.md"],
+      "check_runs": [
+        {"name": "ci-required-result", "status": "completed", "conclusion": "success", "started_at": "2026-07-23T08:10:00Z"}
+      ]
+    },
+    {
+      "number": 2005,
+      "title": "red-lane exclusion: required check failed",
+      "html_url": "https://github.com/joeharris76/BenchBox/pull/2005",
+      "draft": false,
+      "updated_at": "2026-07-23T08:00:00Z",
+      "head_pushed_at": "2026-07-23T08:00:00Z",
+      "auto_merge": null,
+      "changed_files": ["docs/development/adding-new-platforms.md"],
+      "check_runs": [
+        {"name": "ci-required-result", "status": "completed", "conclusion": "failure", "started_at": "2026-07-23T08:10:00Z"}
+      ]
+    },
+    {
+      "number": 2006,
+      "title": "within-grace exclusion: pushed 30 minutes ago",
+      "html_url": "https://github.com/joeharris76/BenchBox/pull/2006",
+      "draft": false,
+      "updated_at": "2026-07-23T11:30:00Z",
+      "head_pushed_at": "2026-07-23T11:30:00Z",
+      "auto_merge": null,
+      "changed_files": ["docs/development/adding-new-platforms.md"],
+      "check_runs": [
+        {"name": "ci-required-result", "status": "completed", "conclusion": "success", "started_at": "2026-07-23T11:35:00Z"}
+      ]
+    },
+    {
+      "number": 2007,
+      "title": "stale-conclusion guard: an older failed run must not shadow the latest success",
+      "html_url": "https://github.com/joeharris76/BenchBox/pull/2007",
+      "draft": false,
+      "updated_at": "2026-07-23T08:00:00Z",
+      "head_pushed_at": "2026-07-23T08:00:00Z",
+      "auto_merge": null,
+      "changed_files": ["benchbox/platforms/bigquery/adapter.py"],
+      "check_runs": [
+        {"name": "ci-required-result", "status": "completed", "conclusion": "failure", "started_at": "2026-07-23T07:00:00Z"},
+        {"name": "ci-required-result", "status": "completed", "conclusion": "success", "started_at": "2026-07-23T08:10:00Z"}
+      ]
+    }
+  ],
+  "expected_stranded": [2001, 2007],
+  "expected_excluded_reasons": {
+    "2002": "soundness_gated",
+    "2003": "auto_merge_on",
+    "2004": "draft",
+    "2005": "not_green",
+    "2006": "within_grace"
+  },
+  "post_merge_run": {
+    "status": "completed",
+    "conclusion": "failure",
+    "html_url": "https://github.com/joeharris76/BenchBox/actions/runs/999999"
+  },
+  "expected_post_merge_red": true
+}

--- a/_project/scripts/green_unmerged_sweep.py
+++ b/_project/scripts/green_unmerged_sweep.py
@@ -1,0 +1,703 @@
+#!/usr/bin/env python3
+"""Nightly sweep for open develop PRs that look stranded auto-merge-off.
+
+Prior art: `harden-auto-merge-on-open-stranding` diagnosed exactly this
+failure class -- three PRs had their auto-merge-on-open.yml `enable` job
+complete with `conclusion: success`, yet the PR's own `auto_merge` field
+later read back `null`, and the fixes sat un-merged until someone noticed
+by hand. This script does NOT modify `auto-merge-on-open.yml` or how it
+enables auto-merge; it is a read-only external observer that classifies
+every OPEN, non-draft develop PR and alerts when one looks stranded:
+
+    (a) required-lane green -- the LATEST `ci-required-result` check run
+        on the PR's head SHA completed with conclusion `success`.
+    (b) auto-merge is OFF    -- the PR's own `auto_merge` field is falsy
+        (null or an explicit off), regardless of what the enable job's
+        own run concluded (see "Known timing behavior" below -- a green
+        enable-job run is NOT proof the field ended up populated).
+    (c) not soundness-gated  -- `any_soundness_path` over the PR's changed
+        files is False. Soundness-gated PRs correctly never auto-merge
+        (see `auto_merge_soundness_paths.py` /
+        `.github/workflows/auto-merge-on-open.yml`); that withheld state
+        is by design and is covered by the separate daily
+        soundness-drain digest, not this sweep.
+    (d) past the grace period -- more than `GRACE_PERIOD_HOURS` (default
+        2h) since the head commit was pushed, so the enable workflow's
+        `synchronize`-triggered re-run has had every chance to fire
+        before this sweep calls a PR stranded.
+
+The only mutation this script ever performs (and only under `--apply`) is
+creating/updating ONE marker-tagged tracking issue (title "Green-but-unmerged
+PR sweep") with the current digest -- created/refreshed while the stranded
+set is non-empty (or develop post-merge is red, see `--check-post-merge`
+below), and patched to the empty state exactly once when it drains, then
+left alone. It never enables auto-merge, never merges, never labels, and
+never comments on a PR -- enabling auto-merge outside the sanctioned
+predicate path in `auto-merge-on-open.yml` would bypass the soundness gate.
+
+`--check-post-merge` additionally checks the most recent "Develop post-merge"
+workflow run; if its conclusion is `failure`, a prominent section is added to
+the top of the sweep issue calling out the fix-forward SLA (same day -- see
+docs/operations/pr-triage.md). This does not touch develop-post-merge.yml.
+
+Known timing behavior (observed live 2026-07-23 against PRs #1282-#1286,
+all opened and auto-merge-enabled the same day): the `auto-merge-on-open.yml`
+`enable` job (`gh pr merge --auto --squash`) completed `conclusion: success`
+on every one of those PRs' head SHAs, per the Actions API. However, reading
+those same PRs back through the GitHub MCP server's `pull_request_read` tool
+omitted the `auto_merge` field entirely rather than surfacing it as populated
+or explicit `null` -- i.e. a caller relying on that read path cannot tell
+"enabled but not yet visible" from "never enabled" from "the read path just
+doesn't carry this field". The raw REST `GET /pulls` endpoint (what this
+script calls directly) does carry `auto_merge` on every PR, so this script
+never infers state from a workflow run's conclusion -- it always re-fetches
+each PR's own current `auto_merge` object.
+
+Auth: GITHUB_TOKEN or GH_TOKEN from the environment (used directly over the
+REST API). If neither is set but the `gh` CLI is on PATH, its token
+(`gh auth token`) is used instead -- this lets the script run locally
+against an interactively-authenticated `gh` without exporting a token by
+hand. No long-lived PAT is required or read from anywhere else.
+
+Usage:
+    uv run -- python _project/scripts/green_unmerged_sweep.py
+    uv run -- python _project/scripts/green_unmerged_sweep.py --json
+    uv run -- python _project/scripts/green_unmerged_sweep.py --apply --check-post-merge
+    uv run -- python _project/scripts/green_unmerged_sweep.py --self-test
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import json
+import os
+import shutil
+import subprocess
+import sys
+import urllib.error
+import urllib.parse
+import urllib.request
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+sys.path.insert(0, str(SCRIPT_DIR))
+
+from auto_merge_soundness_paths import any_soundness_path  # noqa: E402
+
+FIXTURE_PATH = SCRIPT_DIR / "fixtures" / "green_unmerged_fixture.json"
+
+DEFAULT_REPO = "joeharris76/BenchBox"
+REQUIRED_CHECK_NAME = "ci-required-result"
+GRACE_PERIOD_HOURS = 2.0
+API_ROOT = "https://api.github.com"
+DEVELOP_POST_MERGE_WORKFLOW = "develop-post-merge.yml"
+
+PINNED_ISSUE_TITLE = "Green-but-unmerged PR sweep"
+# Body marker: proves the digest issue was written by this script, so
+# find_pinned_issue never adopts (and later clobbers) a human issue that
+# happens to reuse the title.
+DIGEST_BODY_MARKER = "<!-- green-unmerged-sweep -->"
+POST_MERGE_SLA = "fix-forward SLA: same day"
+
+
+# ---------------------------------------------------------------------------
+# Pure classification logic (unit-/self-tested; no git/network)
+# ---------------------------------------------------------------------------
+@dataclass(frozen=True)
+class ClassifiedPR:
+    number: int
+    title: str
+    html_url: str
+    draft: bool
+    required_green: bool
+    soundness_gated: bool
+    auto_merge_enabled: bool
+    head_age_hours: float
+    stranded: bool
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+def _parse_iso(value: str) -> dt.datetime:
+    # GitHub timestamps are RFC3339 with a trailing "Z".
+    return dt.datetime.fromisoformat(value.replace("Z", "+00:00"))
+
+
+def required_lane_check_run(check_runs: list[dict[str, Any]]) -> dict[str, Any] | None:
+    """Return the latest ``ci-required-result`` check run, if present.
+
+    A re-run can leave multiple same-named runs on one SHA; pick the most
+    recently started so a stale conclusion never wins.
+    """
+    matches = [run for run in check_runs if run.get("name") == REQUIRED_CHECK_NAME]
+    if not matches:
+        return None
+    return max(matches, key=lambda run: run.get("started_at") or "")
+
+
+def is_required_lane_green(check_runs: list[dict[str, Any]]) -> bool:
+    run = required_lane_check_run(check_runs)
+    if run is None:
+        return False
+    return run.get("status") == "completed" and run.get("conclusion") == "success"
+
+
+def is_soundness_gated(changed_files: list[str]) -> bool:
+    return any_soundness_path(changed_files)
+
+
+def head_age_hours(pr: dict[str, Any], now: dt.datetime) -> float:
+    """Hours since the PR's head commit was pushed.
+
+    Anchored on ``head_pushed_at`` when present (the commit's own
+    author/committer timestamp, fetched alongside the head SHA -- see
+    `fetch_head_pushed_at`). committer.date is a push-time APPROXIMATION:
+    rebases/cherry-picks reset it to ~push time, but an old commit held
+    locally then pushed, or a reopened PR, can look past-grace early. The
+    consequence is bounded to a premature advisory line (no PR mutation)
+    that self-corrects on the next nightly run. Falls back to
+    ``updated_at``. An unknown
+    anchor returns 0.0 (fail-closed: an unaged PR never qualifies as
+    stranded until its push time is actually known).
+    """
+    anchor = pr.get("head_pushed_at") or pr.get("updated_at")
+    if not anchor:
+        return 0.0
+    return (now - _parse_iso(anchor)).total_seconds() / 3600.0
+
+
+def is_stranded(
+    *,
+    draft: bool,
+    required_green: bool,
+    auto_merge_enabled: bool,
+    soundness_gated: bool,
+    age_hours: float,
+    grace_hours: float,
+) -> bool:
+    """True when a PR looks like a stranded (never-enabled-or-dropped) auto-merge."""
+    return (
+        (not draft)
+        and required_green
+        and (not auto_merge_enabled)
+        and (not soundness_gated)
+        and age_hours > grace_hours
+    )
+
+
+def classify_pr(
+    pr: dict[str, Any],
+    now: dt.datetime,
+    *,
+    grace_hours: float = GRACE_PERIOD_HOURS,
+) -> ClassifiedPR:
+    """Classify one normalized PR record. Pure -- no I/O."""
+    check_runs = pr.get("check_runs") or []
+    changed_files = pr.get("changed_files") or []
+
+    required_green = is_required_lane_green(check_runs)
+    soundness_gated = is_soundness_gated(changed_files)
+    auto_merge_enabled = bool(pr.get("auto_merge"))
+    draft = bool(pr.get("draft"))
+    age_h = head_age_hours(pr, now)
+    stranded = is_stranded(
+        draft=draft,
+        required_green=required_green,
+        auto_merge_enabled=auto_merge_enabled,
+        soundness_gated=soundness_gated,
+        age_hours=age_h,
+        grace_hours=grace_hours,
+    )
+
+    return ClassifiedPR(
+        number=pr["number"],
+        title=pr.get("title", ""),
+        html_url=pr.get("html_url", ""),
+        draft=draft,
+        required_green=required_green,
+        soundness_gated=soundness_gated,
+        auto_merge_enabled=auto_merge_enabled,
+        head_age_hours=age_h,
+        stranded=stranded,
+    )
+
+
+def classify_all(
+    prs: list[dict[str, Any]],
+    now: dt.datetime,
+    *,
+    grace_hours: float = GRACE_PERIOD_HOURS,
+) -> list[ClassifiedPR]:
+    return [classify_pr(pr, now, grace_hours=grace_hours) for pr in prs]
+
+
+def stranded_prs(classified: list[ClassifiedPR]) -> list[ClassifiedPR]:
+    """Stranded PRs, oldest-head-push first (longest stranded, most urgent)."""
+    hits = [c for c in classified if c.stranded]
+    return sorted(hits, key=lambda c: c.head_age_hours, reverse=True)
+
+
+def is_post_merge_red(run: dict[str, Any] | None) -> bool:
+    """True when the most recent Develop post-merge run completed red.
+
+    Anything other than a completed `failure` (queued/in-progress,
+    cancelled, success, or no run found at all) is treated as not-red --
+    this flag exists to raise a same-day SLA on a genuine failure, not to
+    editorialize about cancellations or in-flight runs.
+    """
+    if not run:
+        return False
+    return run.get("status") == "completed" and run.get("conclusion") == "failure"
+
+
+def _fmt_hours(hours: float) -> str:
+    days, rem = divmod(hours, 24.0)
+    if days >= 1:
+        return f"{days:.0f}d{rem:.0f}h"
+    return f"{hours:.1f}h"
+
+
+def build_digest(
+    classified: list[ClassifiedPR],
+    *,
+    now: dt.datetime,
+    repo: str,
+    post_merge_red: bool = False,
+    post_merge_run: dict[str, Any] | None = None,
+) -> str:
+    """Human-readable digest body.
+
+    Empty-queue body (no stranded PRs, develop post-merge not red) is used
+    by local/manual runs and by the one-time "mark existing digest empty"
+    patch; --apply never CREATES an issue for that state.
+    """
+    hits = stranded_prs(classified)
+    stamp = now.strftime("%Y-%m-%d %H:%M UTC")
+    lines = [
+        DIGEST_BODY_MARKER,
+        f"Green-but-unmerged PR sweep -- nightly digest (last updated {stamp})",
+        "",
+    ]
+
+    if post_merge_red:
+        run_url = (post_merge_run or {}).get("html_url", "")
+        lines.append(f"## develop post-merge is RED -- {POST_MERGE_SLA}")
+        lines.append("")
+        lines.append(
+            'The most recent "Develop post-merge" workflow run on develop\'s tip '
+            f"completed with conclusion `failure` -- {run_url}".rstrip()
+        )
+        lines.append('See docs/operations/pr-triage.md "Develop post-merge SLA" for the fix-forward expectation.')
+        lines.append("")
+
+    if not hits:
+        lines.append("No stranded PRs: every open, green, non-soundness develop PR has auto-merge on.")
+        return "\n".join(lines)
+
+    lines.append(
+        f"{len(hits)} PR(s) green on required checks, non-draft, non-soundness-gated, "
+        f"auto-merge OFF, head pushed > {GRACE_PERIOD_HOURS:.0f}h ago:"
+    )
+    lines.append("")
+    for c in hits:
+        lines.append(f"- #{c.number} {c.title} -- head pushed {_fmt_hours(c.head_age_hours)} ago -- {c.html_url}")
+    lines.append("")
+    lines.append(
+        "This sweep never enables auto-merge itself -- re-run `gh pr merge --auto --squash` "
+        "by hand (or re-push to retrigger auto-merge-on-open.yml's `synchronize` path) after "
+        "confirming the PR is genuinely ready. See docs/operations/pr-triage.md."
+    )
+    lines.append(f"(repo: {repo})")
+    return "\n".join(lines)
+
+
+# ---------------------------------------------------------------------------
+# I/O: GitHub REST (token-source chain: GITHUB_TOKEN/GH_TOKEN env, else the
+# `gh` CLI's own token if it is on PATH -- never a separately-stored PAT).
+# ---------------------------------------------------------------------------
+def resolve_token() -> str | None:
+    token = os.environ.get("GITHUB_TOKEN") or os.environ.get("GH_TOKEN")
+    if token:
+        return token
+    if shutil.which("gh"):
+        try:
+            result = subprocess.run(
+                ["gh", "auth", "token"],
+                capture_output=True,
+                text=True,
+                timeout=10,
+                check=False,
+            )
+        except OSError:
+            return None
+        if result.returncode == 0:
+            candidate = result.stdout.strip()
+            if candidate:
+                return candidate
+    return None
+
+
+class GitHubClient:
+    """Thin REST client. GET pagination via Link headers; single-page
+    mutations otherwise. Mirrors soundness_drain_report.py's retry/urllib
+    conventions.
+    """
+
+    def __init__(self, token: str) -> None:
+        self.token = token
+
+    def _request(self, method: str, url: str, body: dict[str, Any] | None = None) -> Any:
+        data = json.dumps(body).encode("utf-8") if body is not None else None
+        req = urllib.request.Request(
+            url,
+            data=data,
+            method=method,
+            headers={
+                "Authorization": f"Bearer {self.token}",
+                "Accept": "application/vnd.github+json",
+                "User-Agent": "benchbox-green-unmerged-sweep",
+                **({"Content-Type": "application/json"} if data is not None else {}),
+            },
+        )
+        for attempt in range(3):
+            try:
+                with urllib.request.urlopen(req, timeout=30) as resp:
+                    payload = resp.read()
+                    return json.loads(payload) if payload else None
+            except urllib.error.HTTPError as err:
+                if err.code == 404:
+                    return None
+                if attempt == 2:
+                    raise
+            except urllib.error.URLError:
+                if attempt == 2:
+                    raise
+        return None
+
+    def get_all(
+        self,
+        path: str,
+        params: dict[str, str] | None = None,
+        max_items: int | None = None,
+    ) -> list[dict[str, Any]]:
+        """GET a list endpoint, following `page` params up to a sane cap.
+
+        `max_items` stops fetching once that many items are collected --
+        without it, a small per_page (e.g. 1) would page all the way to the
+        cap just to return the first item.
+        """
+        query = dict(params or {})
+        query.setdefault("per_page", "100")
+        out: list[dict[str, Any]] = []
+        page = 1
+        while page <= 10:  # 1000 items is far beyond this repo's open-PR volume
+            query["page"] = str(page)
+            url = f"{API_ROOT}/{path}?{urllib.parse.urlencode(query)}"
+            result = self._request("GET", url) or []
+            if isinstance(result, dict) and "check_runs" in result:
+                result = result["check_runs"]
+            if isinstance(result, dict) and "workflow_runs" in result:
+                result = result["workflow_runs"]
+            if not result:
+                break
+            out.extend(result)
+            if max_items is not None and len(out) >= max_items:
+                return out[:max_items]
+            if len(result) < int(query["per_page"]):
+                break
+            page += 1
+        return out
+
+    def get_one(self, path: str) -> Any:
+        return self._request("GET", f"{API_ROOT}/{path}")
+
+    def post(self, path: str, body: dict[str, Any]) -> Any:
+        return self._request("POST", f"{API_ROOT}/{path}", body)
+
+    def patch(self, path: str, body: dict[str, Any]) -> Any:
+        return self._request("PATCH", f"{API_ROOT}/{path}", body)
+
+
+def fetch_open_prs(client: GitHubClient, owner: str, repo: str) -> list[dict[str, Any]]:
+    """Fetch + normalize every OPEN PR targeting develop into the internal
+    shape consumed by classify_pr (same shape as the self-test fixture).
+    """
+    raw_prs = client.get_all(f"repos/{owner}/{repo}/pulls", {"state": "open", "base": "develop"})
+    normalized: list[dict[str, Any]] = []
+    for raw in raw_prs:
+        number = raw["number"]
+        head_sha = raw["head"]["sha"]
+        files = client.get_all(f"repos/{owner}/{repo}/pulls/{number}/files")
+        check_runs = client.get_all(f"repos/{owner}/{repo}/commits/{head_sha}/check-runs")
+        commit = client.get_one(f"repos/{owner}/{repo}/commits/{head_sha}") or {}
+        commit_info = commit.get("commit") or {}
+        head_pushed_at = (commit_info.get("committer") or {}).get("date") or (commit_info.get("author") or {}).get(
+            "date"
+        )
+        normalized.append(
+            {
+                "number": number,
+                "title": raw.get("title", ""),
+                "html_url": raw.get("html_url", ""),
+                "draft": bool(raw.get("draft")),
+                "updated_at": raw.get("updated_at"),
+                "head_pushed_at": head_pushed_at,
+                # auto_merge is the PR's OWN current field -- re-fetched here,
+                # never inferred from a workflow run's conclusion. See "Known
+                # timing behavior" in the module docstring.
+                "auto_merge": raw.get("auto_merge"),
+                "changed_files": [f.get("filename", "") for f in files],
+                "check_runs": [
+                    {
+                        "name": run.get("name"),
+                        "status": run.get("status"),
+                        "conclusion": run.get("conclusion"),
+                        "started_at": run.get("started_at"),
+                    }
+                    for run in check_runs
+                ],
+            }
+        )
+    return normalized
+
+
+def fetch_latest_develop_post_merge_run(client: GitHubClient, owner: str, repo: str) -> dict[str, Any] | None:
+    """Latest "Develop post-merge" workflow run on develop, or None."""
+    runs = client.get_all(
+        f"repos/{owner}/{repo}/actions/workflows/{DEVELOP_POST_MERGE_WORKFLOW}/runs",
+        {"branch": "develop", "per_page": "1"},
+        max_items=1,
+    )
+    return runs[0] if runs else None
+
+
+# ---------------------------------------------------------------------------
+# Mutations (only reached under --apply): pinned-issue upsert only. No
+# label, no auto-merge call, no PR comments.
+# ---------------------------------------------------------------------------
+def find_pinned_issue(client: GitHubClient, owner: str, repo: str) -> dict[str, Any] | None:
+    """Locate the digest issue: exact title AND the body marker.
+
+    The marker requirement means a manually-created issue that happens to
+    reuse the title is never clobbered; the script only adopts issues it
+    wrote. Title matches without the marker are skipped.
+    """
+    issues = client.get_all(f"repos/{owner}/{repo}/issues", {"state": "all"})
+    for item in issues:
+        if "pull_request" in item:
+            continue
+        if item.get("title") == PINNED_ISSUE_TITLE and DIGEST_BODY_MARKER in (item.get("body") or ""):
+            return item
+    return None
+
+
+def upsert_pinned_issue(client: GitHubClient, owner: str, repo: str, body: str) -> str:
+    """Create/update the single digest issue (non-empty path)."""
+    existing = find_pinned_issue(client, owner, repo)
+    if existing is None:
+        created = client.post(
+            f"repos/{owner}/{repo}/issues",
+            {"title": PINNED_ISSUE_TITLE, "body": body},
+        )
+        return f"created issue #{created['number']}"
+    payload: dict[str, Any] = {"body": body}
+    if existing.get("state") == "closed":
+        payload["state"] = "open"
+    client.patch(f"repos/{owner}/{repo}/issues/{existing['number']}", payload)
+    return f"updated issue #{existing['number']}"
+
+
+# ---------------------------------------------------------------------------
+# Self-test (fixture-driven, no network)
+# ---------------------------------------------------------------------------
+def run_self_test() -> int:
+    fixture = json.loads(FIXTURE_PATH.read_text(encoding="utf-8"))
+    now = _parse_iso(fixture["as_of"])
+    grace_hours = fixture.get("grace_hours", GRACE_PERIOD_HOURS)
+    classified = classify_all(fixture["prs"], now, grace_hours=grace_hours)
+    by_number = {c.number: c for c in classified}
+
+    failures: list[str] = []
+
+    def expect(condition: bool, message: str) -> None:
+        if not condition:
+            failures.append(message)
+
+    expected_stranded = set(fixture["expected_stranded"])
+    actual_stranded = {c.number for c in stranded_prs(classified)}
+    expect(
+        actual_stranded == expected_stranded,
+        f"stranded set mismatch: expected {sorted(expected_stranded)}, got {sorted(actual_stranded)}",
+    )
+
+    for number, reason in fixture.get("expected_excluded_reasons", {}).items():
+        c = by_number.get(int(number))
+        expect(c is not None, f"missing fixture PR #{number}")
+        if c is None:
+            continue
+        expect(not c.stranded, f"PR #{number} unexpectedly stranded (expected excluded: {reason})")
+        if reason == "not_green":
+            expect(not c.required_green, f"PR #{number} expected required_green=False")
+        elif reason == "auto_merge_on":
+            expect(c.auto_merge_enabled, f"PR #{number} expected auto_merge_enabled=True")
+        elif reason == "draft":
+            expect(c.draft, f"PR #{number} expected draft=True")
+        elif reason == "soundness_gated":
+            expect(c.soundness_gated, f"PR #{number} expected soundness_gated=True")
+        elif reason == "within_grace":
+            expect(c.head_age_hours <= grace_hours, f"PR #{number} expected head_age_hours <= {grace_hours}")
+
+    # build_digest must always carry the marker, whatever the queue state.
+    expect(
+        DIGEST_BODY_MARKER in build_digest(classified, now=now, repo=fixture.get("repo", DEFAULT_REPO)),
+        "build_digest output missing DIGEST_BODY_MARKER",
+    )
+
+    post_merge_run = fixture.get("post_merge_run")
+    if "expected_post_merge_red" in fixture:
+        actual_red = is_post_merge_red(post_merge_run)
+        expect(
+            actual_red == fixture["expected_post_merge_red"],
+            f"is_post_merge_red mismatch: expected {fixture['expected_post_merge_red']}, got {actual_red}",
+        )
+        if actual_red:
+            digest_with_sla = build_digest(
+                classified,
+                now=now,
+                repo=fixture.get("repo", DEFAULT_REPO),
+                post_merge_red=True,
+                post_merge_run=post_merge_run,
+            )
+            expect(POST_MERGE_SLA in digest_with_sla, "post-merge-red digest missing the fix-forward SLA line")
+
+    if failures:
+        print("SELF-TEST FAILED:", file=sys.stderr)
+        for f in failures:
+            print(f"  - {f}", file=sys.stderr)
+        return 1
+
+    print(f"SELF-TEST PASSED ({len(classified)} fixture PRs, {len(actual_stranded)} stranded).")
+    return 0
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+def _parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument(
+        "--repo",
+        default=os.environ.get("GITHUB_REPOSITORY", DEFAULT_REPO),
+        help=f"owner/name (default: $GITHUB_REPOSITORY or {DEFAULT_REPO})",
+    )
+    parser.add_argument("--json", action="store_true", help="Emit machine-readable JSON instead of the digest text.")
+    parser.add_argument(
+        "--apply",
+        action="store_true",
+        help="Mutate: upsert the pinned digest issue (no label, no auto-merge call, no PR comments).",
+    )
+    parser.add_argument(
+        "--grace-hours",
+        type=float,
+        default=GRACE_PERIOD_HOURS,
+        help=f"Grace period in hours since head push (default: {GRACE_PERIOD_HOURS}).",
+    )
+    parser.add_argument(
+        "--check-post-merge",
+        action="store_true",
+        help="Also check the latest 'Develop post-merge' run and flag the issue if it's red.",
+    )
+    parser.add_argument("--self-test", action="store_true", help="Run the bundled fixture-based classifier test.")
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parse_args(argv or sys.argv[1:])
+
+    if args.self_test:
+        return run_self_test()
+
+    try:
+        owner, repo = args.repo.split("/", 1)
+    except ValueError:
+        print(f"::error::--repo must be owner/name, got {args.repo!r}", file=sys.stderr)
+        return 2
+
+    token = resolve_token()
+    if not token:
+        print(
+            "::error::No GITHUB_TOKEN/GH_TOKEN in the environment and no authenticated `gh` on PATH.",
+            file=sys.stderr,
+        )
+        return 2
+
+    client = GitHubClient(token)
+    prs = fetch_open_prs(client, owner, repo)
+    now = dt.datetime.now(dt.timezone.utc)
+    classified = classify_all(prs, now, grace_hours=args.grace_hours)
+    hits = stranded_prs(classified)
+
+    post_merge_run: dict[str, Any] | None = None
+    post_merge_red = False
+    if args.check_post_merge:
+        post_merge_run = fetch_latest_develop_post_merge_run(client, owner, repo)
+        post_merge_red = is_post_merge_red(post_merge_run)
+
+    if args.json:
+        print(
+            json.dumps(
+                {
+                    "generated_at": now.isoformat(),
+                    "repo": args.repo,
+                    "evaluated_count": len(classified),
+                    "stranded": [c.to_dict() for c in hits],
+                    "post_merge_checked": args.check_post_merge,
+                    "post_merge_red": post_merge_red,
+                },
+                indent=2,
+            )
+        )
+    else:
+        print(
+            build_digest(
+                classified, now=now, repo=args.repo, post_merge_red=post_merge_red, post_merge_run=post_merge_run
+            )
+        )
+
+    if args.apply:
+        should_have_issue = bool(hits) or post_merge_red
+        if should_have_issue:
+            body = build_digest(
+                classified, now=now, repo=args.repo, post_merge_red=post_merge_red, post_merge_run=post_merge_run
+            )
+            outcome = upsert_pinned_issue(client, owner, repo, body)
+            print(f"digest issue: {outcome}", file=sys.stderr)
+        else:
+            # Silent-when-clear means no new issue and no repeated updates --
+            # but an existing digest must not keep showing yesterday's
+            # stranded PRs forever. Patch it to the clear state exactly once.
+            existing = find_pinned_issue(client, owner, repo)
+            existing_body = (existing or {}).get("body") or ""
+            # Stale content = either yesterday's stranded list OR a RED
+            # post-merge banner from a recovered incident: a red+zero-stranded
+            # day writes a body that ALREADY contains the clear-state line, so
+            # guarding on that line alone would leave the RED banner up forever.
+            stale = "No stranded PRs" not in existing_body or "develop post-merge is RED" in existing_body
+            if existing is not None and stale:
+                client.patch(
+                    f"repos/{owner}/{repo}/issues/{existing['number']}",
+                    {"body": build_digest(classified, now=now, repo=args.repo)},
+                )
+                print(f"digest issue: #{existing['number']} marked clear (one-time)", file=sys.stderr)
+            else:
+                print("digest issue: nothing stranded, no update (silent by design)", file=sys.stderr)
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/docs/operations/pr-triage.md
+++ b/docs/operations/pr-triage.md
@@ -1,0 +1,105 @@
+# PR triage runbook
+
+Durable judgment rules for triaging open PRs against `develop` — the parts
+of PR triage that are stable enough to write down once, rather than
+rediscovered per-session. These are rules, not a walkthrough: they assume
+familiarity with the dev-loop (`AGENTS.md`) and the auto-merge machinery
+(`.github/workflows/auto-merge-on-open.yml`,
+`_project/scripts/auto_merge_soundness_paths.py`).
+
+## Always confirm against the current head SHA
+
+Webhook payloads and CI event data can reference a SHA that is no longer
+the PR's head — a later push superseded it before (or while) the event was
+being processed. Before acting on any webhook-delivered check-run or
+comment payload, re-fetch the PR and confirm its head SHA still matches
+what the event described. Acting on a stale SHA risks approving, merging,
+or "fixing" a state the PR has already moved past.
+
+## Platform outage vs. a real failure
+
+A whole-run failure where every job dies at the `setup-python` or
+`setup-uv` step, with GitHub's "Unicorn" HTML error page appearing in the
+job logs instead of normal output, is a GitHub Actions infrastructure
+outage — not a defect in the PR. Wait and re-run once the outage clears;
+do not start debugging the PR's own code for a failure signature like this.
+
+## Cross-branch comparison uses a worktree, never `checkout -- .`
+
+To compare the current branch against another ref (develop, a sibling
+branch, a tag), use `git worktree add <path> <ref>` and diff/read from
+there. Never run `git checkout <ref> -- .` against the current working
+tree to "borrow" another ref's files — that mutates the current branch's
+tracked files in place, can stage unrelated changes, and can silently
+discard uncommitted work with no undo path as clean as a worktree's.
+
+## TODO-tracker modify/delete merge conflicts
+
+When a merge conflict is a modify/delete on a TODO-tracker record (one
+side archived or completed the item; the other side still has edits
+against the live copy), check which side already archived/completed the
+item and keep that side's resolution. Do not resurrect an archived item by
+re-adding the modified-but-stale copy — that reintroduces work the other
+side had already closed out.
+
+## Browser-lane triage
+
+- Chromium's full e2e suite is "blocking" in name only — it is **not** in
+  the required-check set (tracker:
+  `chromium-blocking-suite-not-in-required-checks`). Before attributing a
+  red Chromium run to the PR under review, check whether it is already red
+  on develop's own tip; a pre-existing develop-side failure is not the
+  PR's fault.
+- Firefox `@smoke` has been green in recent history — a red Firefox run is
+  worth investigating as a real signal, not waved off as routine flake.
+- WebKit failures are **not** dismissible as flake. See
+  `docs/operations/browser-ci.md` for current lane status and the
+  triage rule in force there.
+
+## `mergeable_state` semantics
+
+- `dirty` — a real merge conflict against the base branch; the PR needs a
+  rebase/merge before anything else is worth checking.
+- `blocked` — a required check or gate hasn't passed (or hasn't run) yet.
+  Not a conflict; look at the check runs, not the tree.
+- `unknown` — GitHub hasn't finished computing the field yet. Refetch
+  after a short wait; never conclude anything (mergeable or not) from
+  `unknown` itself.
+
+## The two standing sweeps
+
+Two automated, read-only sweeps cover complementary parts of the "PR is
+green but stuck" problem; neither one enables auto-merge, merges, or edits
+a PR's mergeability — both only alert.
+
+- **Soundness-drain daily digest**
+  (`_project/scripts/soundness_drain_report.py`, scheduled via a daily
+  workflow) — for PRs that correctly never get auto-merge because they
+  touch a soundness-critical path (or have the owner as a requested
+  reviewer): flags ones parked more than 24h since their required lane
+  went green, so they don't sit forgotten accumulating conflicts while
+  waiting on the owner's manual review and merge.
+- **Green-unmerged nightly sweep**
+  (`_project/scripts/green_unmerged_sweep.py`,
+  `.github/workflows/nightly.yml`) — for PRs that *should* have auto-merge
+  on (non-draft, non-soundness-gated, required lane green) but don't:
+  flags ones stranded more than 2 hours after their head commit was
+  pushed, on the theory that `auto-merge-on-open.yml`'s `synchronize`
+  re-evaluation has had every chance to fire by then. A green
+  `enable`-job run is not proof the PR's own `auto_merge` field ended up
+  populated — the sweep always re-reads the PR's current field rather than
+  trusting the workflow run's conclusion.
+
+Both sweeps upsert a single marker-tagged tracking issue while their
+respective queue is non-empty, and patch it to the empty state exactly
+once when it drains — never a per-run flood of new issues.
+
+## Develop post-merge SLA
+
+The green-unmerged sweep also checks the most recent "Develop post-merge"
+workflow run (`.github/workflows/develop-post-merge.yml`) on develop's
+tip. If that run's conclusion is `failure`, treat it as **same-day
+fix-forward priority**: every PR opened after a red develop tip inherits
+that breakage, so the fix should land before the day ends rather than
+queuing behind routine work. This SLA is about triage priority only —
+it does not change how `develop-post-merge.yml` itself behaves.

--- a/tests/unit/scripts/test_green_unmerged_sweep.py
+++ b/tests/unit/scripts/test_green_unmerged_sweep.py
@@ -1,0 +1,205 @@
+"""Unit tests for _project/scripts/green_unmerged_sweep.py's pure classification logic.
+
+The GitHub-API I/O is exercised by the nightly workflow itself and by the
+script's own `--self-test` (fixture-driven, offline); here we pin the
+individual classification predicates and digest formatting with no network.
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+# medium, not fast: the fast-lane ceiling had ~4 tests of headroom when this
+# landed (see fast_test_lane_policy.json); the sweep still gets pre-merge CI
+# coverage via the medium-test job, without contending on the shared budget.
+pytestmark = [pytest.mark.unit, pytest.mark.medium]
+
+_ROOT = Path(__file__).resolve().parents[3]
+_SCRIPT = _ROOT / "_project" / "scripts" / "green_unmerged_sweep.py"
+_FIXTURE = _ROOT / "_project" / "scripts" / "fixtures" / "green_unmerged_fixture.json"
+
+
+def _load():
+    spec = importlib.util.spec_from_file_location("_green_unmerged_sweep", _SCRIPT)
+    assert spec is not None and spec.loader is not None
+    mod = importlib.util.module_from_spec(spec)
+    # Register in sys.modules before exec: the module uses @dataclass, whose
+    # field-type resolution looks the module up by name in sys.modules.
+    sys.modules[spec.name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+mod = _load()
+
+
+def _now() -> dt.datetime:
+    return dt.datetime(2026, 7, 23, 12, 0, tzinfo=dt.timezone.utc)
+
+
+# ------------------------------------------------------------------ #
+# required_lane_check_run / is_required_lane_green                    #
+# ------------------------------------------------------------------ #
+def test_required_lane_picks_latest_started_run() -> None:
+    runs = [
+        {
+            "name": "ci-required-result",
+            "status": "completed",
+            "conclusion": "failure",
+            "started_at": "2026-07-23T07:00:00Z",
+        },
+        {
+            "name": "ci-required-result",
+            "status": "completed",
+            "conclusion": "success",
+            "started_at": "2026-07-23T08:00:00Z",
+        },
+    ]
+    assert mod.is_required_lane_green(runs) is True
+
+
+def test_required_lane_missing_run_is_not_green() -> None:
+    assert mod.is_required_lane_green([]) is False
+
+
+def test_required_lane_ignores_unrelated_check_names() -> None:
+    runs = [
+        {
+            "name": "some-other-check",
+            "status": "completed",
+            "conclusion": "success",
+            "started_at": "2026-07-23T08:00:00Z",
+        }
+    ]
+    assert mod.is_required_lane_green(runs) is False
+
+
+# ------------------------------------------------------------------ #
+# is_soundness_gated                                                   #
+# ------------------------------------------------------------------ #
+def test_soundness_gated_true_for_equivalence_path() -> None:
+    assert mod.is_soundness_gated(["benchbox/core/equivalence/compare.py"]) is True
+
+
+def test_soundness_gated_false_for_ordinary_path() -> None:
+    assert mod.is_soundness_gated(["benchbox/platforms/duckdb/adapter.py"]) is False
+
+
+# ------------------------------------------------------------------ #
+# head_age_hours / is_stranded                                        #
+# ------------------------------------------------------------------ #
+def test_head_age_hours_uses_head_pushed_at_over_updated_at() -> None:
+    pr = {"head_pushed_at": "2026-07-23T10:00:00Z", "updated_at": "2026-07-23T11:59:00Z"}
+    assert mod.head_age_hours(pr, _now()) == pytest.approx(2.0)
+
+
+def test_head_age_hours_falls_back_to_updated_at() -> None:
+    pr = {"updated_at": "2026-07-23T09:00:00Z"}
+    assert mod.head_age_hours(pr, _now()) == pytest.approx(3.0)
+
+
+def test_head_age_hours_unknown_anchor_is_zero() -> None:
+    assert mod.head_age_hours({}, _now()) == 0.0
+
+
+@pytest.mark.parametrize(
+    ("draft", "required_green", "auto_merge_enabled", "soundness_gated", "age_hours", "expected"),
+    [
+        (False, True, False, False, 3.0, True),  # stranded
+        (True, True, False, False, 3.0, False),  # draft excluded
+        (False, False, False, False, 3.0, False),  # red lane excluded
+        (False, True, True, False, 3.0, False),  # auto-merge already on
+        (False, True, False, True, 3.0, False),  # soundness-gated excluded
+        (False, True, False, False, 1.0, False),  # within grace period
+    ],
+)
+def test_is_stranded_matrix(draft, required_green, auto_merge_enabled, soundness_gated, age_hours, expected) -> None:
+    assert (
+        mod.is_stranded(
+            draft=draft,
+            required_green=required_green,
+            auto_merge_enabled=auto_merge_enabled,
+            soundness_gated=soundness_gated,
+            age_hours=age_hours,
+            grace_hours=2.0,
+        )
+        is expected
+    )
+
+
+# ------------------------------------------------------------------ #
+# is_post_merge_red                                                    #
+# ------------------------------------------------------------------ #
+def test_post_merge_red_on_completed_failure() -> None:
+    assert mod.is_post_merge_red({"status": "completed", "conclusion": "failure"}) is True
+
+
+@pytest.mark.parametrize(
+    "run",
+    [
+        None,
+        {"status": "completed", "conclusion": "success"},
+        {"status": "in_progress", "conclusion": None},
+        {"status": "completed", "conclusion": "cancelled"},
+    ],
+)
+def test_post_merge_not_red(run) -> None:
+    assert mod.is_post_merge_red(run) is False
+
+
+# ------------------------------------------------------------------ #
+# build_digest                                                         #
+# ------------------------------------------------------------------ #
+def test_build_digest_always_carries_marker() -> None:
+    digest = mod.build_digest([], now=_now(), repo="joeharris76/BenchBox")
+    assert mod.DIGEST_BODY_MARKER in digest
+    assert "No stranded PRs" in digest
+
+
+def test_build_digest_post_merge_red_section() -> None:
+    digest = mod.build_digest(
+        [],
+        now=_now(),
+        repo="joeharris76/BenchBox",
+        post_merge_red=True,
+        post_merge_run={"html_url": "https://example.invalid/run/1"},
+    )
+    assert mod.POST_MERGE_SLA in digest
+    assert "develop post-merge is RED" in digest
+
+
+def test_build_digest_lists_stranded_prs() -> None:
+    c = mod.ClassifiedPR(
+        number=42,
+        title="Some PR",
+        html_url="https://github.com/joeharris76/BenchBox/pull/42",
+        draft=False,
+        required_green=True,
+        soundness_gated=False,
+        auto_merge_enabled=False,
+        head_age_hours=5.0,
+        stranded=True,
+    )
+    digest = mod.build_digest([c], now=_now(), repo="joeharris76/BenchBox")
+    assert "#42 Some PR" in digest
+    assert "never enables auto-merge itself" in digest
+
+
+# ------------------------------------------------------------------ #
+# Fixture / self-test consistency                                      #
+# ------------------------------------------------------------------ #
+def test_bundled_fixture_is_valid_json_with_required_keys() -> None:
+    fixture = json.loads(_FIXTURE.read_text(encoding="utf-8"))
+    assert "as_of" in fixture
+    assert "prs" in fixture and len(fixture["prs"]) >= 6
+    assert set(fixture["expected_stranded"]) == {2001, 2007}
+
+
+def test_run_self_test_passes() -> None:
+    assert mod.run_self_test() == 0


### PR DESCRIPTION
## Description

WS8 of `_project/planning/ci-failure-reduction-plan.md`, two pieces:

**1. Nightly stranded-PR sweep.** Prior art `harden-auto-merge-on-open-stranding`: PRs whose `enable` job succeeded can still end up `auto_merge: null` and sit green-but-unmerged. `_project/scripts/green_unmerged_sweep.py` flags open non-draft develop PRs that are green on the **latest** `ci-required-result` run, auto-merge OFF, **not** soundness-gated (those are correctly withheld — the soundness-drain digest in #1285 owns them; the two sweeps partition the space with no overlap), and past a 2h head-push grace window. Only mutation (`--apply`-gated): one marker-tagged tracking issue, patched to the clear state exactly once when the queue drains — including clearing a stale develop-post-merge RED banner after recovery (Opus-review Required finding, fixed). `--check-post-merge` adds a same-day fix-forward SLA callout when the latest develop-post-merge run failed. The script **never enables auto-merge** — that stays behind the sanctioned soundness predicate in `auto-merge-on-open.yml`, which is untouched.

Live investigation recorded in the module docstring: the MCP `pull_request_read` path omits the `auto_merge` field entirely (observed on #1282–#1286 today), so the script always re-fetches each PR's own REST field and never trusts the enable job's conclusion.

**2. `docs/operations/pr-triage.md`** codifies the durable triage judgment rules that previously lived in a hand-carried prompt: stale webhook SHAs, the GitHub-outage signature, worktree-based cross-branch comparison, tracker modify/delete conflict resolution, browser-lane status (Chromium blocking-in-name but not in the required set; WebKit failures not dismissible as flake), `mergeable_state` semantics, and the two standing sweeps + post-merge SLA. Linked from AGENTS.md.

Tracker: `auto-merge-verify-and-triage-runbook-2`. Opus review: both Required findings fixed (RED-banner clear-path; merge ordering vs #1285 — **enforced by keeping auto-merge on this PR disarmed until #1285 is merged**, see Notes) plus both nits (grace-anchor approximation documented; `max_items` early-return in pagination).

## Type of Change

- [x] New feature (dev-loop tooling; no product surface)

## Testing

- `--self-test` → PASSED (7 fixture PRs, 2 stranded; cases isolate each hit/exclusion class + a stale-conclusion guard).
- 24 pytest tests pass under `-m medium`; **zero collect under `-m fast`** — deliberately medium-tier, since the fast-lane ceiling had ~4 tests of headroom at authoring time (the fast-lane contention item in this same batch is the durable fix).
- `ruff check`/`format --check` clean; nightly.yml parses; `on:` block unchanged; no `pull_request_target`.

## Public Contract Check

- [x] No public contract surfaces — CI/dev tooling and operations docs only.

## Documentation

- [x] pr-triage.md (durable rules only, no session-specific facts); AGENTS.md Further Reading link.

## Code Quality

- [x] Write calls enumerated in review: issue create/patch only, all `--apply`-gated.
- [x] `auto-merge-on-open.yml`, `release.yml`, `auto_merge_soundness_paths.py` byte-identical to base.

## Artifact Hygiene

- [x] Hand-written JSON fixture only.

## Notes

- **Merge ordering**: pr-triage.md and the sweep's partition reference the soundness-drain sweep from #1285. Auto-merge on this PR is intentionally left OFF until #1285 merges; it will be armed immediately after.
- pr-triage.md references `docs/operations/browser-ci.md`, which lands with #1283.

---
_Generated by [Claude Code](https://claude.ai/code/session_016NqSKtt68mqUpFA6C2qUkB)_