### PR TITLE
feat(explorer): add the ADR-2 physical_rendering_id secondary facet to the query workbench

### DIFF
--- a/results-explorer/src/lib/__tests__/queryFilters.test.ts
+++ b/results-explorer/src/lib/__tests__/queryFilters.test.ts
@@ -22,6 +22,7 @@ const EMPTY_FILTERS: QueryFilterState = {
   instanceTypes: [],
   warehouseSizes: [],
   storageFormats: [],
+  physicalRenderingIds: [],
   hasCost: "all",
   dateWindow: "all",
 };
@@ -185,6 +186,34 @@ describe("buildWhereClause - normalized cost/deployment facets", () => {
     expect(sql).toContain("cost_status IN (?)");
     expect(sql).not.toContain("cloud_provider IN (?)");
     expect(params).toEqual(["normalized"]);
+  });
+
+  it("filters on the physical_rendering_id secondary facet", () => {
+    const filters: QueryFilterState = {
+      ...EMPTY_FILTERS,
+      physicalRenderingIds: ["databricks_liquid_auto"],
+    };
+
+    const { sql, params } = buildSelectQuery(filters, ["result_id"], DEFAULT_SORT, 10);
+
+    expect(sql).toContain("physical_rendering_id IN (?)");
+    expect(params).toEqual(["databricks_liquid_auto"]);
+  });
+
+  it("excludes the physical_rendering_id facet from its own count while preserving others", () => {
+    const filters: QueryFilterState = {
+      ...EMPTY_FILTERS,
+      storageFormats: ["parquet"],
+      physicalRenderingIds: ["databricks_liquid_auto"],
+    };
+
+    const { sql, params } = buildFacetCountQuery("physical_rendering_id", filters, {
+      exclude: "physicalRenderingIds",
+    });
+
+    expect(sql).toContain("storage_format IN (?)");
+    expect(sql).not.toContain("physical_rendering_id IN (?)");
+    expect(params).toEqual(["parquet"]);
   });
 });
 

--- a/results-explorer/src/lib/queryFilters.ts
+++ b/results-explorer/src/lib/queryFilters.ts
@@ -21,6 +21,7 @@ export interface QueryFilterState {
   instanceTypes: string[];
   warehouseSizes: string[];
   storageFormats: string[];
+  physicalRenderingIds: string[];
   hasCost: "all" | "yes" | "no";
   dateWindow: DateWindowFacet;
 }
@@ -82,6 +83,7 @@ const ALLOWED_COLUMNS = new Set([
   "node_count",
   "cluster_size",
   "storage_format",
+  "physical_rendering_id",
   "storage_tier",
   "compliance_class",
   "is_ranking_eligible",
@@ -131,6 +133,7 @@ export function buildWhereClause(filters: QueryFilterState): BuiltQuery {
     params,
   );
   expandListFilter("storage_format", filters.storageFormats, clauses, params);
+  expandListFilter("physical_rendering_id", filters.physicalRenderingIds, clauses, params);
 
   if (filters.hasCost === "yes") clauses.push("cost_usd IS NOT NULL");
   if (filters.hasCost === "no") clauses.push("cost_usd IS NULL");
@@ -194,6 +197,8 @@ export function buildFacetCountQuery(
     instanceTypes: options.exclude === "instanceTypes" ? [] : filters.instanceTypes,
     warehouseSizes: options.exclude === "warehouseSizes" ? [] : filters.warehouseSizes,
     storageFormats: options.exclude === "storageFormats" ? [] : filters.storageFormats,
+    physicalRenderingIds:
+      options.exclude === "physicalRenderingIds" ? [] : filters.physicalRenderingIds,
     hasCost: options.exclude === "hasCost" ? "all" : filters.hasCost,
     dateWindow: options.exclude === "dateWindow" ? "all" : filters.dateWindow,
   };

--- a/results-explorer/src/pages/Query.tsx
+++ b/results-explorer/src/pages/Query.tsx
@@ -102,6 +102,16 @@ export function Query(_: RoutableProps) {
   const [cloudRegions, setCloudRegions] = useFacetField("cloud_region");
   const [instanceOrWarehouses, setInstanceOrWarehouses] = useFacetField("instance_or_warehouse");
   const [storageFormats, setStorageFormats] = useFacetField("storage_format");
+  // ADR-2 §3: `physical_rendering_id` is a *secondary*, on-demand narrowing
+  // facet — deliberately page-local (like `cost_model`) rather than part of
+  // the shared FACET_KEYS coarse-comparability set, which the comparison
+  // matcher iterates. Registering it there would silently fold it into the
+  // coarse facet match; ADR-2 rejects that. See `physicalRenderingIdsMatch`.
+  const [physicalRenderingIds, setPhysicalRenderingIds] = useUrlState<string[]>(
+    "physical_rendering_id",
+    EMPTY_STRING_ARRAY,
+    arraySerde,
+  );
   const [rowLimitRaw, setRowLimitRaw] = useUrlState<string>("limit", "default", stringSerde);
   const [hasCost, setHasCost] = useUrlState<string>("has_cost", "all", stringSerde);
   const [dateWindow, setDateWindowFacet] = useFacetField("date_window");
@@ -157,6 +167,7 @@ export function Query(_: RoutableProps) {
       instanceTypes: EMPTY_STRING_ARRAY,
       warehouseSizes: EMPTY_STRING_ARRAY,
       storageFormats,
+      physicalRenderingIds,
       hasCost: hasCost === "yes" || hasCost === "no" ? hasCost : "all",
       dateWindow,
     }),
@@ -170,6 +181,7 @@ export function Query(_: RoutableProps) {
       deploymentClasses,
       hasCost,
       instanceOrWarehouses,
+      physicalRenderingIds,
       platforms,
       scaleFactors,
       storageFormats,
@@ -376,6 +388,13 @@ export function Query(_: RoutableProps) {
       defaultCollapsed: true,
     }),
     makeFacetGroup(
+      "physical_rendering_id",
+      "Physical rendering",
+      facetCounts.physical_rendering_id ?? [],
+      physicalRenderingIds,
+      { defaultCollapsed: true },
+    ),
+    makeFacetGroup(
       "has_cost",
       "Has cost",
       [{ value: "all", count: rows.length }, ...(facetCounts.has_cost ?? [])],
@@ -410,6 +429,12 @@ export function Query(_: RoutableProps) {
     ...makeActiveChips("cloud_region", "Cloud region", cloudRegions, setCloudRegions),
     ...makeActiveChips("instance_or_warehouse", "Instance / warehouse", instanceOrWarehouses, setInstanceOrWarehouses),
     ...makeActiveChips("storage_format", "Storage", storageFormats, setStorageFormats),
+    ...makeActiveChips(
+      "physical_rendering_id",
+      "Physical rendering",
+      physicalRenderingIds,
+      setPhysicalRenderingIds,
+    ),
     ...(hasCost === "all"
       ? []
       : [{
@@ -507,6 +532,9 @@ export function Query(_: RoutableProps) {
       case "storage_format":
         toggleMulti(value, storageFormats, setStorageFormats);
         break;
+      case "physical_rendering_id":
+        toggleMulti(value, physicalRenderingIds, setPhysicalRenderingIds);
+        break;
       case "has_cost":
         setHasCost(value);
         break;
@@ -530,6 +558,7 @@ export function Query(_: RoutableProps) {
     setCloudRegions([]);
     setInstanceOrWarehouses([]);
     setStorageFormats([]);
+    setPhysicalRenderingIds([]);
     setHasCost("all");
     setDateWindow("all");
   }
@@ -1211,6 +1240,11 @@ function buildQueryFacetCountQueries(
       exclude: "storageFormats",
     });
   }
+  if (schemaColumns.has("physical_rendering_id")) {
+    facetQueries.physical_rendering_id = buildFacetCountQuery("physical_rendering_id", activeFilters, {
+      exclude: "physicalRenderingIds",
+    });
+  }
   return facetQueries;
 }
 
@@ -1227,6 +1261,7 @@ function applySchemaFilterSupport(filters: QueryFilterState, schema: SchemaColum
     instanceTypes: [],
     warehouseSizes: [],
     storageFormats: columns.has("storage_format") ? filters.storageFormats : [],
+    physicalRenderingIds: columns.has("physical_rendering_id") ? filters.physicalRenderingIds : [],
   };
 }
 

--- a/results-explorer/src/pages/__tests__/Query.test.tsx
+++ b/results-explorer/src/pages/__tests__/Query.test.tsx
@@ -35,6 +35,7 @@ const BASE_SCHEMA_COLUMNS = [
   { name: "cloud_region", type: "VARCHAR" },
   { name: "instance_or_warehouse", type: "VARCHAR" },
   { name: "storage_format", type: "VARCHAR" },
+  { name: "physical_rendering_id", type: "VARCHAR" },
 ];
 let schemaColumns = BASE_SCHEMA_COLUMNS;
 
@@ -201,6 +202,9 @@ beforeEach(() => {
     }
     if (isFacetCountSql(normalized, "storage_format")) {
       return [{ value: "parquet", count: 1 }];
+    }
+    if (isFacetCountSql(normalized, "physical_rendering_id")) {
+      return [{ value: "databricks_liquid_auto", count: 1 }];
     }
     if (normalized.includes("SELECT CASE WHEN cost_usd IS NULL THEN 'no' ELSE 'yes' END AS value")) {
       return [
@@ -700,6 +704,29 @@ describe("Query", () => {
     expect(params.get("deployment")).toBe("cloud");
     expect(params.get("cloud_provider")).toBe("aws");
     expect(params.get("shape")).toBe("MEDIUM");
+  });
+
+  it("applies the physical_rendering_id secondary facet to the generated query", async () => {
+    render(<Query />);
+    await waitFor(() => expect(screen.getAllByText("DuckDB").length).toBeGreaterThan(0));
+    await waitFor(() => expect(screen.getAllByText("Physical rendering").length).toBeGreaterThan(0));
+
+    const desktopFilters = screen.getByTestId("query-desktop-filters");
+    const physical = within(desktopFilters)
+      .getByRole("heading", { name: "Physical rendering" })
+      .closest("section")!;
+    fireEvent.click(within(physical).getByRole("button", { name: /^Physical rendering/ }));
+    fireEvent.click(within(physical).getByLabelText(/^Physical rendering: databricks liquid auto/i));
+
+    await waitFor(() => {
+      const selectCalls = vi.mocked(queryRows).mock.calls.filter(([sql]) => isDefaultResultSelect(sql));
+      expect(String(selectCalls.at(-1)?.[0])).toContain("physical_rendering_id IN (?)");
+    });
+    // ADR-2 §3: it is a page-local URL facet, not a coarse FACET_KEYS chip, so
+    // it persists under its own literal query key.
+    expect(new URL(window.location.href).searchParams.get("physical_rendering_id")).toBe(
+      "databricks_liquid_auto",
+    );
   });
 
   it("does not build facet SQL for URL params absent from the introspected schema", async () => {


### PR DESCRIPTION
## Description

Surfaces `physical_rendering_id` as an on-demand narrowing facet in the Results
Query Workbench, letting users filter runs down to those that rendered the same
physical tuning strategy (e.g. `databricks_liquid_auto`). The column already
flows through the explorer pipeline into the browser DuckDB `results` table
(added under ADR-2); this PR wires it into the query-page **filter surface**
only.

Why page-local, not a shared facet: `physical_rendering_id` is deliberately a
page-local URL-persisted facet (mirroring `cost_model`) rather than a member of
the shared `FACET_KEYS` coarse-comparability set that the comparison matcher
iterates. ADR-2 §3 frames it as a *secondary, independently-matchable* facet —
an on-demand narrowing tool, not a change to the coarse `tuning_mode` facet
semantics. Folding it into `FACET_KEYS` would silently make it a coarse
comparability criterion, which ADR-2 rejects. The dormant
`physicalRenderingIdsMatch` helper and the comparability matcher
(`matchesFacetKey`/`FACET_KEYS`) are untouched.

## Type of Change

- [x] New feature

## Testing

- `npx vitest run` — 810 passed (incl. 2 new `queryFilters` unit tests and 1 new
  `Query` page interaction test asserting the facet applies to the generated
  SQL and persists under its own `physical_rendering_id` URL key).
- `npx tsc --noEmit` — clean.
- `npm run build` — clean.
- No Python touched; verified the existing DuckDB browser contract test still
  green on the base (`physical_rendering_id` was already in the DDL and the
  test's expected column set).

## Public Contract Check

- [x] No public/beta/deprecated/generated/experimental/repo-only contract
      surface changes — this is an explorer UI filter addition over an existing
      read-model column. No result-schema field, MCP parameter, or platform
      support status changes.

## Documentation

- [x] No user-facing doc change required; ADR-2 §3 already specifies this facet.
      (Noted separately: `docs/development/browser-duckdb-schema.sql` predates
      the `physical_mechanisms`/`physical_rendering_id` DDL columns and is out of
      sync — pre-existing drift, out of scope for this UI PR.)

## Code Quality

- [x] tsc + vitest green (repo has no biome/eslint config for the explorer).
- [x] Additive, schema-gated facet — renders only when the snapshot carries the
      column; no backwards-compatibility impact.
- [x] Added/updated tests for the new filter behavior.

## Artifact Hygiene

- [x] No screenshots, reports, logs, benchmark outputs, or binaries committed.

## Notes

- Reviewer focus: the intentional boundary with the comparability matcher — this
  facet must not become a coarse `FACET_KEYS` member. The inline comment in
  `Query.tsx` and this PR body record that rationale.
- Follow-up (out of scope): sync `docs/development/browser-duckdb-schema.sql`
  with the ADR-2 `physical_mechanisms` / `physical_rendering_id` columns already
  present in the pipeline DDL.

---
_Generated by [Claude Code](https://claude.ai/code/session_01ReAoE6uW4XdAiB7ERvhNgR)_