### PR TITLE
chore(ci): make ci-lint mirror the pr.yml lint job 1:1, pinned by a parity test

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -288,53 +288,7 @@ jobs:
         run: make oracle-coverage-map-check
 
       - name: Public contract drift check
-        run: |
-          uv run -- python - <<'PY'
-          from pathlib import Path
-          from benchbox.core.benchmark_registry import list_benchmark_ids, list_loader_benchmark_ids
-          from benchbox.core.platform_registry import PlatformRegistry
-          from benchbox.core.results.schema import SCHEMA_VERSION
-
-          contract = Path("docs/reference/public-contracts.md").read_text(encoding="utf-8")
-          readme = Path("README.md").read_text(encoding="utf-8")
-
-          forbidden_readme_count_claims = [
-              "Twenty-Two Benchmarks",
-              "SQL Platforms (",
-              "DataFrame Platforms (",
-          ]
-          offenders = [phrase for phrase in forbidden_readme_count_claims if phrase in readme]
-          if offenders:
-              raise SystemExit(
-                  "README.md has exact hand-maintained count claims; use registry-derived checks "
-                  f"or mark them non-authoritative: {offenders}"
-              )
-
-          platforms = PlatformRegistry.get_all_platform_metadata()
-          sql_capable = sum(1 for item in platforms.values() if item.get("capabilities", {}).get("supports_sql"))
-          dataframe_capable = sum(
-              1 for item in platforms.values() if item.get("capabilities", {}).get("supports_dataframe")
-          )
-          dual_mode = sum(
-              1
-              for item in platforms.values()
-              if item.get("capabilities", {}).get("supports_sql")
-              and item.get("capabilities", {}).get("supports_dataframe")
-          )
-
-          source_fragments = [
-              f"{len(list_benchmark_ids())} benchmark metadata entries",
-              f"{len(list_loader_benchmark_ids())} loader-resolved IDs",
-              f"{len(platforms)} platform metadata entries",
-              f"{sql_capable} SQL-capable",
-              f"{dataframe_capable} DataFrame-capable",
-              f"{dual_mode} dual-mode",
-              f"Current result schema version: `{SCHEMA_VERSION}`",
-          ]
-          missing_fragments = [fragment for fragment in source_fragments if fragment not in contract]
-          if missing_fragments:
-              raise SystemExit(f"public-contracts.md source-derived claims are stale: {missing_fragments}")
-          PY
+        run: uv run -- python scripts/check_public_contract_drift.py
 
       - name: Dependency audit (no unused declarations)
         run: make audit-deps
@@ -358,17 +312,7 @@ jobs:
         # (it skips untracked targets and `ignore`d paths), so it cannot catch these
         # being force-added. Fail the build if any become git-tracked.
         # Rationale: _project/decisions/claude-settings-cloud-ownership-2026-06-29.md
-        run: |
-          tracked=$(git ls-files -- \
-            '.codex/skills' '.codex/shared-skills' '.codex/shared-skills.lock.json' \
-            '.gemini/skills' '.antigravity/skills' \
-            '.claude/skills/blog')
-          if [ -n "$tracked" ]; then
-            echo "ERROR: deliberately-untracked skill mirrors are now git-tracked:" >&2
-            echo "$tracked" >&2
-            echo "Untrack them with 'git rm --cached -r <path>' (regenerate locally via 'make skill-sync')." >&2
-            exit 1
-          fi
+        run: sh scripts/check_untracked_skill_mirrors.sh
 
   code-test:
     name: test (ubuntu-latest, 3.12)

--- a/Makefile
+++ b/Makefile
@@ -820,21 +820,38 @@ guards-fix:
 ##@ CI Local Equivalents
 # These targets mirror GitHub Actions workflows for local validation
 
-# CI lint check - exact match for lint.yml workflow
+# CI lint check - superset covering both lint.yml (release-branch gate) and
+# the pr.yml `lint` job (job id `code-lint`, the routine dev-PR gate), plus a
+# few extra local-only conveniences (lint-explorer-tokens,
+# lint-site-theme-tokens, skill-sync-check, spellcheck). Every guard the
+# pr.yml `lint` job runs (after dependency install) must also run here at the
+# COMMAND level, or tests/system/test_ci_lint_parity.py fails — see
+# docs/operations/ci-local-parity.md. One guard is a documented, tested
+# exception: the pinned `npx github:...#sha verify` skill-sync step needs
+# network access this sandbox/local dev flow cannot rely on (verified: it
+# hangs with no route even when npx is installed) — see that doc and the
+# parity test's exclusion dict for the full rationale.
 ci-lint:
 	@echo "Running CI lint checks..."
 	uv run ruff check .
 	uv run ruff format --check .
 	uv run ty check
 	$(MAKE) lint-markers
+	$(MAKE) lint-imports
 	$(MAKE) lint-explorer-tokens
 	$(MAKE) lint-site-theme-tokens
 	$(MAKE) artifact-hygiene
 	$(MAKE) skill-sync-check
 	uv run -- python _project/scripts/timing_policy_check.py --strict
+	uv run --project _project/scripts -- python _project/scripts/uat_loc_table.py --check
 	$(MAKE) compat-docs-check
 	$(MAKE) oracle-coverage-map-check
+	uv run -- python scripts/check_public_contract_drift.py
 	$(MAKE) audit-deps
+	$(MAKE) audit-raw-check
+	uv run -- python scripts/check_release_curation.py
+	sh scripts/check_untracked_skill_mirrors.sh
+	$(MAKE) spellcheck
 	@echo "✅ CI lint checks passed"
 
 # CI test check - exact match for test.yml workflow (fast tests with coverage)
@@ -1359,17 +1376,22 @@ pr-preflight:
 	@$(MAKE) pr-preflight-fast-tests
 	@$(MAKE) -s uat-artifact-hygiene
 
+# Always runs pr-content-guard (YAML/markdown/docs hygiene + artifact
+# hygiene) regardless of whether code changes are present -- it used to run
+# only on the no-code-changes path, so a docs-plus-code PR could skip it
+# locally and hit those guards for the first time in CI's content-guard job.
+# The needs-code-ci decision still gates only the fast-test run below.
 pr-preflight-fast-tests:
 	@DECISION=$$(mktemp); \
 	LISTS=$$(mktemp -d); \
 	trap 'rm -f "$$DECISION"; rm -rf "$$LISTS"' EXIT; \
 	git fetch origin develop --quiet; \
 	uv run -- python scripts/path_filter_decision.py --base-ref origin/develop --json-out "$$DECISION" --lists-dir "$$LISTS" >/dev/null; \
+	$(MAKE) -s pr-content-guard PATH_LISTS="$$LISTS"; \
 	if uv run -- python scripts/path_filter_decision.py --json-in "$$DECISION" --check needs-code-ci >/dev/null; then \
 		echo "==> fast tests (CI marker selection; coverage remains CI-only)"; \
 		uv run -- python -m pytest -m "fast and not (slow or stress or resource_heavy or live_integration)" --tb=short -q; \
 	else \
-		$(MAKE) -s pr-content-guard PATH_LISTS="$$LISTS"; \
 		echo "No code changes detected; skipping fast tests."; \
 	fi
 

--- a/docs/operations/ci-local-parity.md
+++ b/docs/operations/ci-local-parity.md
@@ -1,0 +1,82 @@
+# CI / local lint parity
+
+`make ci-lint` (and `make pr-preflight`, which runs it) exists so that
+every lint guard CI enforces on a develop PR also runs locally, before you
+push. A guard that only exists in `.github/workflows/pr.yml` fires for the
+first time on a pushed PR -- that costs a full remote CI round trip for a
+failure you could have caught in seconds locally.
+
+## The invariant
+
+Every guard the `lint` job (job id `code-lint`) in `pr.yml` runs, after its
+dependency-install step, must also run in the Makefile's `ci-lint` recipe --
+at the **command** level, not just under a similarly-named local target.
+`tests/system/test_ci_lint_parity.py` parses `pr.yml` (the source of truth)
+and pins this: it fails if a `lint`-job guard command is missing from
+`ci-lint`, and it fails if an exclusion entry references a step that was
+renamed or removed (so the exclusion can't quietly rot into cover for a
+guard nobody runs anywhere).
+
+Command-level, not name-level, matters here: a local target can share a
+step's name while running different logic. `skill-sync-check` in `ci-lint`
+(`node skill-sync doctor`) is not the same command as CI's pinned
+`npx -y github:joeharris76/skill-sync#<sha> verify` step -- treating the
+name match as parity would hide that the local run isn't actually checking
+what CI checks.
+
+## Adding a new lint guard
+
+When you add a new guard step to the `lint` job in `pr.yml`:
+
+1. Add the equivalent command to the `ci-lint:` recipe in the `Makefile`
+   (a `$(MAKE) <target>` line if the guard already has a `make` target, or
+   the same `uv run ...` / script invocation the CI step uses).
+2. If the guard has meaningful inline logic (more than a couple of lines)
+   and would otherwise live only inside the workflow YAML, extract it to a
+   script under `scripts/` first and have both `pr.yml` and `ci-lint` call
+   that script. Duplicating logic into the Makefile as a second
+   implementation is exactly the drift this invariant exists to prevent.
+3. Run `uv run -- python -m pytest tests/system/test_ci_lint_parity.py -q`.
+   If it fails, either step 1 was missed or the command text doesn't match
+   verbatim.
+
+If a guard genuinely cannot run locally (see the network exception below
+for the only current example), add it to the `EXCLUDED_STEPS` dict in the
+parity test with a concrete reason -- do not silently omit it, and do not
+weaken the CI guard itself so a lossier local equivalent can "pass."
+
+## The one documented exception: skill-sync `npx` verify
+
+The `lint` job's "skill-sync tracked snapshot verify (cloud/CI integrity
+gate)" step runs a pinned `npx -y github:joeharris76/skill-sync#<sha>
+verify --project .`. This needs network access to fetch the pinned commit
+from GitHub over the npm/git-over-https path `npx` uses for a `github:`
+spec.
+
+This was tested directly in a local/sandboxed dev shell with `npx`
+installed: the command hangs with no route (no DNS/proxy path configured
+for the npm registry or a git-over-https fetch). Two options were
+considered:
+
+- **Guard it with `command -v npx && npx ... || echo notice`.** Rejected:
+  on a machine where `npx` *is* installed and network *is* reachable, this
+  swallows a real local verify failure and prints a "skipped" notice
+  instead -- silently weakening the guard, which is the exact anti-pattern
+  this parity invariant exists to prevent elsewhere.
+- **Exclude it explicitly, with a reason, in the parity test.** This is
+  what the repo does. CI's runner has network, so the gate stays fully
+  enforced there; it is simply not a viable *blocking* local gate.
+
+`make ci-lint` therefore does not run this step. `make skill-sync-check`
+(`node skill-sync doctor`) is a different, unrelated local convenience and
+does not substitute for it -- see the command-level-parity note above.
+
+## `pr-preflight` and the content guard
+
+`make pr-preflight-fast-tests` (called by `make pr-preflight`) always runs
+`pr-content-guard` (YAML/markdown/docs hygiene + artifact hygiene) now,
+regardless of whether the branch's `needs-code-ci` path-filter decision is
+true. Previously it only ran on the no-code-changes branch, so a PR that
+touched both code and docs/markdown could skip those hygiene checks
+locally and hit them for the first time in CI's `content-guard` job. The
+`needs-code-ci` decision still gates only the fast-test pytest run.

--- a/scripts/check_public_contract_drift.py
+++ b/scripts/check_public_contract_drift.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python3
+"""Public contract drift guard.
+
+Verifies that ``docs/reference/public-contracts.md`` has not drifted from the
+source-of-truth registries it claims to describe, and that README.md has not
+regressed to hand-maintained exact count claims that the contract doc is
+supposed to own instead.
+
+Extracted verbatim (logic byte-equivalent) from the "Public contract drift
+check" inline heredoc step in the `code-lint` (pr.yml `lint` job) job so the
+same guard can run both in CI and locally via `make ci-lint` /
+`make pr-preflight` without drifting out of sync. See
+docs/operations/ci-local-parity.md for the parity invariant this guard is
+part of.
+
+Note: this is intentionally narrower than the "Validate public contract
+drift guard" step in the `content-guard` job (which also checks required
+doc surfaces/support-status vocabulary and is gated on docs/markdown path
+changes) — that step is untouched by this extraction.
+
+Run locally:
+    uv run -- python scripts/check_public_contract_drift.py
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+
+def main() -> int:
+    from benchbox.core.benchmark_registry import list_benchmark_ids, list_loader_benchmark_ids
+    from benchbox.core.platform_registry import PlatformRegistry
+    from benchbox.core.results.schema import SCHEMA_VERSION
+
+    contract = (REPO_ROOT / "docs/reference/public-contracts.md").read_text(encoding="utf-8")
+    readme = (REPO_ROOT / "README.md").read_text(encoding="utf-8")
+
+    forbidden_readme_count_claims = [
+        "Twenty-Two Benchmarks",
+        "SQL Platforms (",
+        "DataFrame Platforms (",
+    ]
+    offenders = [phrase for phrase in forbidden_readme_count_claims if phrase in readme]
+    if offenders:
+        print(
+            "README.md has exact hand-maintained count claims; use registry-derived checks "
+            f"or mark them non-authoritative: {offenders}",
+            file=sys.stderr,
+        )
+        return 1
+
+    platforms = PlatformRegistry.get_all_platform_metadata()
+    sql_capable = sum(1 for item in platforms.values() if item.get("capabilities", {}).get("supports_sql"))
+    dataframe_capable = sum(1 for item in platforms.values() if item.get("capabilities", {}).get("supports_dataframe"))
+    dual_mode = sum(
+        1
+        for item in platforms.values()
+        if item.get("capabilities", {}).get("supports_sql") and item.get("capabilities", {}).get("supports_dataframe")
+    )
+
+    source_fragments = [
+        f"{len(list_benchmark_ids())} benchmark metadata entries",
+        f"{len(list_loader_benchmark_ids())} loader-resolved IDs",
+        f"{len(platforms)} platform metadata entries",
+        f"{sql_capable} SQL-capable",
+        f"{dataframe_capable} DataFrame-capable",
+        f"{dual_mode} dual-mode",
+        f"Current result schema version: `{SCHEMA_VERSION}`",
+    ]
+    missing_fragments = [fragment for fragment in source_fragments if fragment not in contract]
+    if missing_fragments:
+        print(f"public-contracts.md source-derived claims are stale: {missing_fragments}", file=sys.stderr)
+        return 1
+
+    print("OK: public-contracts.md matches source-derived registry claims.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/check_untracked_skill_mirrors.sh
+++ b/scripts/check_untracked_skill_mirrors.sh
@@ -1,0 +1,32 @@
+#!/bin/sh
+# Untracked skill-mirror drift guard (cloud parity).
+#
+# The codex/gemini/antigravity mirrors and the curated-out `blog` skill are
+# deliberately untracked: cloud is Claude-only and `blog` is published
+# separately. `skill-sync verify` only inspects the tracked `claude` target
+# (it skips untracked targets and `ignore`d paths), so it cannot catch these
+# being force-added. Fail the build if any become git-tracked.
+#
+# Rationale: _project/decisions/claude-settings-cloud-ownership-2026-06-29.md
+#
+# Extracted verbatim (logic byte-equivalent) from the "Untracked skill-mirror
+# drift guard (cloud parity)" step in the `code-lint` (pr.yml `lint` job) job
+# so the same guard runs both in CI and locally via `make ci-lint` /
+# `make pr-preflight` without drifting out of sync. See
+# docs/operations/ci-local-parity.md for the parity invariant this guard is
+# part of.
+#
+# Run locally:
+#   scripts/check_untracked_skill_mirrors.sh
+set -eu
+
+tracked=$(git ls-files -- \
+  '.codex/skills' '.codex/shared-skills' '.codex/shared-skills.lock.json' \
+  '.gemini/skills' '.antigravity/skills' \
+  '.claude/skills/blog')
+if [ -n "$tracked" ]; then
+  echo "ERROR: deliberately-untracked skill mirrors are now git-tracked:" >&2
+  echo "$tracked" >&2
+  echo "Untrack them with 'git rm --cached -r <path>' (regenerate locally via 'make skill-sync')." >&2
+  exit 1
+fi

--- a/tests/system/test_ci_lint_parity.py
+++ b/tests/system/test_ci_lint_parity.py
@@ -1,0 +1,176 @@
+"""Local/CI lint-guard parity pin.
+
+Guards that only run in CI (never locally) fire for the first time on a
+pushed PR, costing a full remote round trip per miss. This test parses
+``.github/workflows/pr.yml`` -- the source of truth -- and asserts that
+every guard command the `lint` job (job id ``code-lint``) runs after its
+dependency-install step also appears, verbatim, in the Makefile's
+``ci-lint`` recipe. Parity is asserted at the COMMAND level (not just
+target/step names): a local target that happens to share a name with a CI
+step but runs different logic (e.g. `skill-sync-check` vs. CI's pinned
+`npx ... verify`) must NOT be treated as satisfying parity.
+
+Steps that are genuinely CI-only stay out of ``ci-lint`` and must be listed
+in ``EXCLUDED_STEPS`` below with a reason -- never silently dropped and
+never faked by weakening the CI guard to pass locally. See
+docs/operations/ci-local-parity.md for the parity invariant and how to add
+a new lint guard without breaking this test.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+import yaml
+
+# medium, not fast: at authoring time the fast-lane merge ref sat at exactly
+# the max_fast_tests ceiling (25545); medium still runs in the required
+# pre-merge lane (medium-test), so parity stays enforced without contending
+# on the shared fast-lane budget this batch is in the middle of fixing.
+pytestmark = pytest.mark.medium
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+PR_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "pr.yml"
+MAKEFILE = REPO_ROOT / "Makefile"
+LINT_JOB_ID = "code-lint"
+
+# Steps whose `run:` command is a setup/install action, not a guard -- they
+# have no failure-condition semantics of their own and ci-lint doesn't need
+# a matching line (uv/make handle env sync implicitly). Identified by name
+# so reordering the job doesn't silently stop excluding them.
+SETUP_STEP_NAMES = {"Install dependencies"}
+
+# Steps that are genuinely CI-only. Every entry needs a reason, and the test
+# below fails if a listed step is renamed or removed -- so this dict can't
+# rot into cover for a guard that quietly stopped existing.
+EXCLUDED_STEPS: dict[str, str] = {
+    "skill-sync tracked snapshot verify (cloud/CI integrity gate)": (
+        "Pinned `npx -y github:joeharris76/skill-sync#<sha> verify` needs "
+        "network access to fetch the pinned skill-sync commit from GitHub. "
+        "Tested in a local/sandboxed dev shell with npx installed: the "
+        "command hangs with no route (no DNS/proxy support for the npm "
+        "registry or git-over-https fetch npx uses for a `github:` spec). "
+        "A `command -v npx && npx ... || echo notice` guard would either "
+        "hang the same way, or -- if given a short timeout -- silently "
+        "swallow a REAL local verify failure on machines that do have "
+        "working npx+network, which is exactly the anti-pattern this test "
+        "exists to prevent (weakening a CI guard to make it pass locally). "
+        "CI's runner has network, so the gate stays fully enforced there; "
+        "it is simply not runnable as a blocking local gate. See "
+        "docs/operations/ci-local-parity.md."
+    ),
+}
+
+
+def _load_lint_job_steps() -> list[dict]:
+    workflow = yaml.safe_load(PR_WORKFLOW.read_text(encoding="utf-8"))
+    job = workflow["jobs"][LINT_JOB_ID]
+    return job["steps"]
+
+
+def _guard_commands() -> dict[str, list[str]]:
+    """Map step name -> list of individual shell command lines.
+
+    Steps with no `run:` key (pure `uses:` actions like checkout/setup-python)
+    and the dependency-install step are excluded here; everything else is a
+    candidate guard.
+    """
+    commands: dict[str, list[str]] = {}
+    for step in _load_lint_job_steps():
+        name = step.get("name")
+        run = step.get("run")
+        if not name or not run:
+            continue
+        if name in SETUP_STEP_NAMES:
+            continue
+        lines = [line.strip() for line in run.splitlines() if line.strip()]
+        commands[name] = lines
+    return commands
+
+
+def _ci_lint_recipe_text() -> str:
+    """Extract the tab-indented recipe body of the `ci-lint:` Makefile target."""
+    lines = MAKEFILE.read_text(encoding="utf-8").splitlines()
+    start = None
+    for i, line in enumerate(lines):
+        if line == "ci-lint:":
+            start = i + 1
+            break
+    assert start is not None, "Makefile has no top-level 'ci-lint:' target"
+
+    recipe_lines = []
+    for line in lines[start:]:
+        if line.startswith("\t"):
+            recipe_lines.append(line[1:])
+        elif line.strip() == "":
+            continue
+        else:
+            break
+    return "\n".join(recipe_lines)
+
+
+def _normalize_recipe_lines(recipe_text: str) -> list[str]:
+    normalized = []
+    for line in recipe_text.splitlines():
+        stripped = line.strip()
+        stripped = stripped.lstrip("@")
+        if not stripped or stripped.startswith("#"):
+            continue
+        normalized.append(stripped)
+    return normalized
+
+
+def _command_satisfied(command: str, recipe_lines: list[str]) -> bool:
+    """Return True if `command` (a single guard shell command) is present in
+    the ci-lint recipe at the COMMAND level.
+
+    `make <target>` commands are matched against a `$(MAKE) <target>` or
+    `make <target>` recipe line (Makefile convention uses $(MAKE) so
+    sub-invocations respect -n/-j, but tolerate a literal `make` too).
+    Everything else (uv run ..., sh script.sh, npx ...) must appear
+    verbatim as its own recipe line -- this is what prevents a
+    same-named-but-different local command from faking parity.
+    """
+    make_target_match = re.match(r"^make\s+(\S+)$", command)
+    if make_target_match:
+        target = make_target_match.group(1)
+        pattern = re.compile(rf"^(\$\(MAKE\)|make)\s+{re.escape(target)}$")
+        return any(pattern.match(line) for line in recipe_lines)
+    return command in recipe_lines
+
+
+def test_lint_job_guards_run_in_ci_lint() -> None:
+    """Every non-excluded pr.yml `lint`-job guard command must appear,
+    command-for-command, in the `ci-lint` Makefile recipe."""
+    guard_commands = _guard_commands()
+    recipe_lines = _normalize_recipe_lines(_ci_lint_recipe_text())
+
+    missing: list[str] = []
+    for step_name, commands in guard_commands.items():
+        if step_name in EXCLUDED_STEPS:
+            continue
+        for command in commands:
+            if not _command_satisfied(command, recipe_lines):
+                missing.append(f"{step_name!r}: {command!r}")
+
+    assert not missing, (
+        "pr.yml `lint` job guard(s) not mirrored in `make ci-lint` -- these "
+        "will fire for the FIRST time in CI instead of locally. Add the "
+        "command to the ci-lint recipe in the Makefile (or, if genuinely "
+        "CI-only, add it to EXCLUDED_STEPS with a reason):\n  " + "\n  ".join(missing)
+    )
+
+
+def test_excluded_steps_still_exist() -> None:
+    """EXCLUDED_STEPS must only reference lint-job steps that still exist,
+    under their current name -- otherwise a rename/removal could silently
+    leave a stale, unenforced exclusion (or hide that the step's guard is no
+    longer excluded/covered at all)."""
+    current_step_names = {step.get("name") for step in _load_lint_job_steps()}
+    stale = sorted(name for name in EXCLUDED_STEPS if name not in current_step_names)
+    assert not stale, (
+        "EXCLUDED_STEPS references pr.yml `lint`-job step name(s) that no "
+        f"longer exist (renamed or removed) -- update the exclusion: {stale}"
+    )


### PR DESCRIPTION
## Description

WS3 of `_project/planning/ci-failure-reduction-plan.md`: every guard that runs in CI but not in `make ci-lint` is a guaranteed remote-only failure costing a full round trip. This closes the gap and pins it closed:

- **Extraction**: the two inline pr.yml guards become real scripts invoked by both CI and ci-lint — `scripts/check_public_contract_drift.py` (review-verified byte-equivalent logic to the deleted heredoc; SystemExit→stderr+exit-code is the only conversion) and `scripts/check_untracked_skill_mirrors.sh` (identical pathspecs and fail condition; POSIX-clean, `set -eu`). The pr.yml diff is exactly the two step bodies — no job/needs/trigger changes.
- **Sync**: ci-lint gains `lint-imports`, `uat_loc_table.py --check` (a gap discovered beyond the briefed five), the public-contract script, `audit-raw-check`, `check_release_curation.py`, the skill-mirror script, and `spellcheck`. Full `make ci-lint` passes end-to-end on a clean tree (twice).
- **Preflight**: `pr-preflight` now runs `pr-content-guard` unconditionally (previously skipped whenever code changes were present); no double-run.
- **Pin**: `tests/system/test_ci_lint_parity.py` parses the pr.yml `code-lint` job and asserts each guard's *command* appears in the ci-lint recipe (anchored matching — `make lint` cannot match `lint-imports`; the local `skill-sync-check` cannot satisfy the pinned npx verify). `EXCLUDED_STEPS` carries the one exception with a tested rationale — the pinned `npx skill-sync verify` hangs without npm network access, and wrapping it in a fallback guard would swallow genuine failures — plus a rot-check test that fails if an excluded step is renamed/removed.
- Runbook: `docs/operations/ci-local-parity.md` (the invariant + how to add a new guard).

Tracker: `ci-lint-parity-pin-2`. Opus review: extraction fidelity, diff shape, test robustness, and preflight plumbing all verified clean; the sole Required finding (composed fast-lane count landing at exactly the 25545 ceiling) is resolved by marking the two parity tests **medium-tier** — still enforced pre-merge via the required medium-test job — rather than perpetuating a minimal ceiling bump on the file the fast-lane workstream is about to rearchitect. Nits acknowledged (uvx codespell first-run fetch; deferred imports in the extracted script — both no-action per review).

## Type of Change

- [x] Refactor / chore

## Testing

- Parity tests: 2 passed (`-m medium`); zero collect under `-m fast`; `make lint-markers` green.
- `make ci-lint` → exit 0 end-to-end on clean tree; extracted scripts run green standalone.
- `ruff`/`format`/`ty` clean on new Python; `sh -n` clean on the shell guard; pr.yml YAML parses.

## Public Contract Check

- [x] No contract surfaces change — the public-contract *checker* moved files with identical logic.

## Documentation

- [x] `docs/operations/ci-local-parity.md`.

## Code Quality

- [x] Extraction verified line-by-line in adversarial review; same failure conditions and messages.
- [x] Parity test parses pr.yml as the single source of truth — no hand-maintained second list.

## Artifact Hygiene

- [x] No raw artifacts.

## Notes

- The stale `ci-lint` header comment ("exact match for lint.yml") was corrected in passing — it predated this change and misdescribed the recipe's coverage.

---
_Generated by [Claude Code](https://claude.ai/code/session_016NqSKtt68mqUpFA6C2qUkB)_