### PR TITLE
fix(review): close review follow-ups across merged PRs #1261-#1289

### DIFF
--- a/.github/workflows/cross-surface-baseline-autodetect.yml
+++ b/.github/workflows/cross-surface-baseline-autodetect.yml
@@ -106,7 +106,7 @@ jobs:
             echo "detect step produced no summary - see the failing step above"
             exit 0
           fi
-          python3 - <<'PY'
+          uv run -- python - <<'PY'
           import json
           import os
 

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -742,6 +742,14 @@ jobs:
       contents: read
       pull-requests: read
       issues: write
+      # green_unmerged_sweep.py lists check runs (commits/{sha}/check-runs) for
+      # every candidate PR, and with --check-post-merge also lists workflow runs
+      # (actions/workflows/develop-post-merge.yml/runs). A job-level permissions
+      # map sets every unlisted scope to "no access", so without these two the
+      # scheduled sweep 403s before it can classify PRs or update its tracking
+      # issue.
+      checks: read
+      actions: read
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/Makefile
+++ b/Makefile
@@ -718,7 +718,14 @@ artifact-hygiene:
 SKILL_SYNC ?= /Users/joe/Developer/skill-sync/dist/cli/index.js
 
 skill-sync:
-	@if [ -f "$(SKILL_SYNC)" ]; then \
+	@# This recipe contains $$(MAKE), so make runs it even under `-n` (recursive
+	@# dry-run passthrough). Without the guard below, `make -n skill-sync` and
+	@# `make -n guards-fix` really execute `node ... sync` and mutate the skill
+	@# mirrors, so a documented "preview" was not read-only.
+	@case "$(firstword -$(MAKEFLAGS))" in \
+		*n*) echo "dry-run (-n): skipping skill-sync"; exit 0 ;; \
+	esac; \
+	if [ -f "$(SKILL_SYNC)" ]; then \
 		$(MAKE) -s agent-write-preflight; \
 		node "$(SKILL_SYNC)" sync; \
 	else \
@@ -796,6 +803,11 @@ mutation-test:
 .PHONY: guards-fix
 guards-fix:
 	@echo "== guards-fix: regenerating every mechanically-regenerable drift-guard artifact =="
+	@# Enforce the pool-worktree write rule BEFORE the first regen rewrites a
+	@# checked-in artifact. skill-sync runs this guard too, but only after
+	@# several earlier write steps -- and not at all when the skill-sync CLI is
+	@# absent, which would leave this whole write target unguarded.
+	@$(MAKE) -s agent-write-preflight
 	@echo "-- dependency inventory (audit-raw) --"
 	@$(MAKE) -s audit-raw
 	@echo "-- benchmark correctness-oracle coverage map --"

--- a/_project/scripts/dev_loop_pr_metrics.py
+++ b/_project/scripts/dev_loop_pr_metrics.py
@@ -142,6 +142,14 @@ def _urllib_api(path: str, token: str) -> object | None:
     return None
 
 
+class ApiFailure(RuntimeError):
+    """A GitHub API page fetch failed, so any list built from it is incomplete.
+
+    Raised instead of returning a short list, so a partial API outage surfaces
+    as a skipped/partial report rather than as understated exact metrics.
+    """
+
+
 class GitHubClient:
     """Thin GET-only GitHub API client: gh CLI first, urllib+token fallback."""
 
@@ -174,7 +182,14 @@ class GitHubClient:
         while True:
             data = self.get(f"{path}{sep}per_page=100&page={page}")
             if data is None:
-                break
+                # A failed page (rate limit, timeout, transient `gh api` error)
+                # must not read as "no more items". Callers derive exact metrics
+                # from this list, so silently returning the partial (usually
+                # empty) accumulation would record real-looking values such as
+                # pushes_after_open=0 or touched_fast_test_lane_policy=False for
+                # a run that simply could not read GitHub -- understating the
+                # very CI-failure metrics this baseline exists to track.
+                raise ApiFailure(f"GitHub API page fetch failed: {path} (page {page})")
             batch = data.get(item_key, []) if item_key else data
             if not isinstance(batch, list) or not batch:
                 break
@@ -231,9 +246,32 @@ def fetch_merged_prs(client: GitHubClient, since: datetime) -> list[dict]:
     return merged
 
 
-def pushes_after_open(client: GitHubClient, number: int) -> int:
+def pushes_after_open(client: GitHubClient, number: int, created_at: str) -> int:
+    """Count commits that landed on the PR *after* it was opened (fix-forward proxy).
+
+    `len(commits) - 1` counted every pre-open local commit beyond the first as a
+    fix-forward push even when nothing was pushed after the PR existed. The
+    repo's review-followup flow deliberately opens a PR over several
+    pre-existing per-comment commits (`_project/scripts/pr_review_followups.py`),
+    so those PRs alone would inflate the fix-forward rate. Compare each commit's
+    timestamp against the PR's `created_at` instead.
+    """
     commits = client.get_paginated(f"/repos/{client.repo}/pulls/{number}/commits")
-    return max(0, len(commits) - 1)
+    opened = _iso_to_dt(created_at)
+    after = 0
+    for entry in commits:
+        commit = entry.get("commit") or {}
+        # Prefer committer date: a rebase/amend rewrites it, which is what
+        # "landed on the PR" means here; author date can predate the push.
+        stamp = (commit.get("committer") or {}).get("date") or (commit.get("author") or {}).get("date")
+        if not stamp:
+            continue
+        try:
+            if _iso_to_dt(stamp) > opened:
+                after += 1
+        except (TypeError, ValueError):
+            continue
+    return after
 
 
 def touched_fast_test_lane_policy(client: GitHubClient, number: int) -> bool:
@@ -278,7 +316,7 @@ def collect_pr_metrics(client: GitHubClient, pr: dict) -> PrMetrics:
         created_at=created_at,
         merged_at=merged_at,
         open_to_merge_seconds=open_to_merge,
-        pushes_after_open=pushes_after_open(client, number),
+        pushes_after_open=pushes_after_open(client, number, created_at),
         touched_fast_test_lane_policy=touched_fast_test_lane_policy(client, number),
         first_pass_green=first_pass_green,
         fast_test_job_seconds=fast_test_seconds,
@@ -385,8 +423,15 @@ def main(argv: list[str] | None = None) -> int:
         return 0
 
     since = datetime.now(timezone.utc) - timedelta(days=args.days)
-    prs = fetch_merged_prs(client, since)
-    metrics = [collect_pr_metrics(client, pr) for pr in prs]
+    # A mid-run API failure makes every derived metric understate reality (see
+    # ApiFailure), so report the run as skipped instead of publishing a
+    # partial-but-valid-looking baseline. Mirrors the no-API-access branch above.
+    try:
+        prs = fetch_merged_prs(client, since)
+        metrics = [collect_pr_metrics(client, pr) for pr in prs]
+    except ApiFailure as exc:
+        print(f"SKIPPED: GitHub API access failed mid-collection, metrics would be understated ({exc}).")
+        return 0
     summary = summarize(metrics)
 
     if args.json:

--- a/_project/scripts/soundness_drain_report.py
+++ b/_project/scripts/soundness_drain_report.py
@@ -391,7 +391,16 @@ def fetch_open_prs(client: GitHubClient, owner: str, repo: str) -> list[dict[str
                 "updated_at": raw.get("updated_at"),
                 "auto_merge": raw.get("auto_merge"),
                 "requested_reviewers": [r.get("login") for r in (raw.get("requested_reviewers") or [])],
-                "changed_files": [f.get("filename", "") for f in files],
+                # GitHub reports a rename as the *new* `filename` plus a
+                # `previous_filename`. The live auto-merge gate deliberately uses
+                # `git diff --name-only --no-renames` (both sides of a rename) and
+                # tests/unit/test_auto_merge_soundness_paths.py pins that, so a PR
+                # that moves a protected soundness file OUT to an unprotected path
+                # still disables auto-merge. Keep both names here or this report
+                # would miss exactly those parked soundness-gated PRs.
+                "changed_files": [
+                    name for f in files for name in (f.get("filename", ""), f.get("previous_filename", "")) if name
+                ],
                 "check_runs": [
                     {
                         "name": run.get("name"),

--- a/benchbox/cli/commands/compare.py
+++ b/benchbox/cli/commands/compare.py
@@ -35,6 +35,7 @@ from benchbox.core.results.loader import (
     iter_query_results,
     load_result_file,
 )
+from benchbox.validation.bundle import COMPANION_SUFFIXES
 
 
 class ResultFileMetadata:
@@ -112,11 +113,7 @@ def _discover_result_files_with_metadata(
         # Find JSON files, sorted by modification time (newest first)
         # Skip companion files
         json_files = sorted(
-            (
-                f
-                for f in search_dir.glob("**/*.json")
-                if not f.name.endswith(".plans.json") and not f.name.endswith(".tuning.json")
-            ),
+            (f for f in search_dir.glob("**/*.json") if not f.name.endswith(COMPANION_SUFFIXES)),
             key=lambda p: p.stat().st_mtime,
             reverse=True,
         )

--- a/benchbox/core/publishing/bundle_publisher.py
+++ b/benchbox/core/publishing/bundle_publisher.py
@@ -123,12 +123,12 @@ class BundlePublisher:
                 errors=[f"Source bundle not found: {source_bundle}"],
             )
 
-        if bundle_path.suffix != ".json" or bundle_path.name.endswith((".plans.json", ".tuning.json")):
+        if bundle_path.suffix != ".json" or bundle_path.name.endswith(COMPANION_SUFFIXES):
             return BundlePublishResult(
                 success=False,
                 errors=[
                     f"Expected a primary .json result bundle, got: {bundle_path.name}. "
-                    "Companion files (.plans.json, .tuning.json) are published automatically."
+                    f"Companion files ({', '.join(COMPANION_SUFFIXES)}) are published automatically."
                 ],
             )
 

--- a/benchbox/core/results/exporter.py
+++ b/benchbox/core/results/exporter.py
@@ -51,6 +51,7 @@ from benchbox.core.results.schema import (
 from benchbox.core.results.schema_policy import is_loader_supported_result_schema
 from benchbox.core.runtime_paths import resolve_results_dir
 from benchbox.utils.cloud_storage import create_path_handler, is_cloud_path
+from benchbox.validation.bundle import COMPANION_SUFFIXES
 
 logger = logging.getLogger(__name__)
 
@@ -731,11 +732,7 @@ class ResultExporter:
 
         for json_file in self.output_dir.glob("*.json"):
             # Skip companion files
-            if (
-                json_file.name.endswith(".plans.json")
-                or json_file.name.endswith(".tuning.json")
-                or json_file.name.endswith(".submission.json")
-            ):
+            if json_file.name.endswith(COMPANION_SUFFIXES) or json_file.name.endswith(".submission.json"):
                 continue
 
             try:

--- a/benchbox/core/results/loader.py
+++ b/benchbox/core/results/loader.py
@@ -27,6 +27,7 @@ from benchbox.core.results.models import (
 from benchbox.core.results.query_normalizer import normalize_query_id
 from benchbox.core.results.query_plan_models import QueryPlanDAG
 from benchbox.core.results.schema_policy import LOADER_SCHEMA_POLICY, is_loader_supported_result_schema
+from benchbox.validation.bundle import COMPANION_SUFFIXES
 
 logger = logging.getLogger(__name__)
 
@@ -64,11 +65,7 @@ def find_latest_result(
         return None
 
     # Find all JSON files, excluding companion files
-    result_files = [
-        f
-        for f in directory_path.glob("*.json")
-        if not f.name.endswith(".plans.json") and not f.name.endswith(".tuning.json")
-    ]
+    result_files = [f for f in directory_path.glob("*.json") if not f.name.endswith(COMPANION_SUFFIXES)]
 
     if not result_files:
         return None

--- a/benchbox/core/runner/dataframe_runner.py
+++ b/benchbox/core/runner/dataframe_runner.py
@@ -123,6 +123,31 @@ def _benchmark_provides_dataframe_queries(benchmark_instance: Any | None) -> boo
     return _benchmark_defines_hook(benchmark_instance, "get_dataframe_queries")
 
 
+def _serialize_tuning_config(tuning_config: Any) -> dict[str, Any] | None:
+    """Render a DataFrame tuning config as a JSON-safe dict for run-config metadata.
+
+    ``BenchmarkConfig.options["df_tuning_config"]`` holds a live
+    ``DataFrameTuningConfiguration`` because adapters need the object itself.
+    ``RunConfigInput.tuning_config`` is typed ``dict`` and is emitted verbatim
+    into ``execution_metadata.run_config``, which the JSON exporter writes with
+    plain ``json.dumps`` -- so the live object must never reach it or export
+    raises and the run silently produces no result JSON and no ``.applied.json``
+    companion. Falls back to dropping the value (``None``) rather than failing
+    the run when the object exposes no usable ``to_dict()``.
+    """
+    if tuning_config is None:
+        return None
+    if isinstance(tuning_config, dict):
+        return tuning_config
+    to_dict = getattr(tuning_config, "to_dict", None)
+    if callable(to_dict):
+        rendered = to_dict()
+        if isinstance(rendered, dict):
+            return rendered
+    logger.debug("Dropping non-serializable df_tuning_config (%s) from run-config metadata", type(tuning_config))
+    return None
+
+
 @dataclass
 class DataFramePhases:
     """Phases for DataFrame benchmark execution."""
@@ -222,7 +247,13 @@ def run_dataframe_benchmark(
             phases=options_map.get("phases"),
             query_subset=getattr(benchmark_config, "queries", None),
             tuning_mode=options_map.get("tuning_mode"),
-            tuning_config=options_map.get("df_tuning_config"),
+            # `df_tuning_config` is the *live* DataFrameTuningConfiguration kept in
+            # options for adapter construction. RunConfigInput.tuning_config is
+            # emitted verbatim into execution_metadata.run_config and the JSON
+            # exporter uses plain json.dumps, so passing the object through makes
+            # export raise -- the run then yields no result JSON and no
+            # .applied.json companion. Serialize it before it reaches metadata.
+            tuning_config=_serialize_tuning_config(options_map.get("df_tuning_config")),
         )
     )
 

--- a/benchbox/core/tuning/capability_registry.py
+++ b/benchbox/core/tuning/capability_registry.py
@@ -324,11 +324,17 @@ PLATFORM_TUNING_CAPABILITIES: dict[str, dict[TuningType, TuningCapability]] = {
             "without recreating, then runs ANALYZE/VACUUM maintenance only (redshift.py:2616-2624). "
             "Corrects the prior false _ddl(adapter_mixin:RedshiftAdapter.generate_tuning_clause) claim.",
         ),
-        _T.SORTING: _none(
-            "redshift_ddl_generator:preview_only",
-            "Same execution gap as DISTRIBUTION: SORTKEY is built only by the uncalled generate_tuning_clause "
-            "mixin (redshift.py:2500-2510) and the preview generator; apply_table_tunings logs the sort-key "
-            "mismatch (redshift.py:2599-2605) but cannot apply it without table recreation.",
+        _T.SORTING: _post_load(
+            "redshift_ctas_sort",
+            "Conditional post-load mechanism, gated on sorted ingestion being enabled "
+            "(resolve_sorted_ingestion_strategy). After COPY/INSERT the loader calls apply_ctas_sort "
+            "(redshift.py:1524, 1602), which resolves TuningType.SORTING columns and executes the SQL built "
+            "by _build_ctas_sort_sql (redshift.py:207-224) -- either 'VACUUM SORT ONLY' or a CTAS "
+            "'... ORDER BY <sort cols>' + DROP + RENAME. Inline SORTKEY remains preview-only: it is built by "
+            "the uncalled generate_tuning_clause mixin (redshift.py:2500-2510) and the preview generator, and "
+            "apply_table_tunings only logs the sort-key mismatch (redshift.py:2599-2605) because it cannot "
+            "rewrite the key without table recreation. With sorted ingestion off, _build_ctas_sort_sql "
+            "returns None and nothing is rendered.",
         ),
         _T.PARTITIONING: _none(
             "redshift_no_partition_rendering",

--- a/benchbox/core/tuning/introspection.py
+++ b/benchbox/core/tuning/introspection.py
@@ -402,6 +402,14 @@ def corroborate(ledger: AppliedTuningLedger, introspected_state: IntrospectedSta
         state_error = "introspection unavailable (no state)"
     elif introspected_state.error:
         state_error = introspected_state.error
+    elif introspected_state.truncated:
+        # A bound hit means the catalog snapshot is incomplete: a match would
+        # only prove the object appeared among the rows we happened to fetch,
+        # and an ABSENT verdict cannot be trusted at all. Per this module's
+        # contract (see IntrospectedState) a truncated snapshot is treated
+        # exactly like a degraded one -- refuse the upgrade rather than certify
+        # partial evidence as applied_verified.
+        state_error = "introspection truncated (catalog row bound hit)"
 
     entries: list[ReceiptEntry] = []
     for stmt in ledger.executed_statements:

--- a/benchbox/mcp/resources/registry.py
+++ b/benchbox/mcp/resources/registry.py
@@ -25,6 +25,7 @@ from benchbox.core.benchmark_registry import (
     get_public_benchmark_class,
     list_public_benchmark_ids,
 )
+from benchbox.validation.bundle import COMPANION_SUFFIXES
 
 logger = logging.getLogger(__name__)
 
@@ -195,11 +196,7 @@ def _build_recent_results(results_dir: Path) -> str:
             }
         )
 
-    result_files = [
-        path
-        for path in results_dir.glob("*.json")
-        if not path.name.endswith(".plans.json") and not path.name.endswith(".tuning.json")
-    ]
+    result_files = [path for path in results_dir.glob("*.json") if not path.name.endswith(COMPANION_SUFFIXES)]
     runs = []
 
     for file_path in sorted(result_files, key=lambda p: p.stat().st_mtime, reverse=True)[:20]:

--- a/benchbox/mcp/tools/analytics.py
+++ b/benchbox/mcp/tools/analytics.py
@@ -24,6 +24,7 @@ from benchbox.core.results.query_normalizer import normalize_query_id
 from benchbox.mcp.errors import ErrorCode, make_error, make_not_found_error
 from benchbox.mcp.tools.path_utils import resolve_result_file_path
 from benchbox.utils.printing import get_quiet_console
+from benchbox.validation.bundle import COMPANION_SUFFIXES
 
 logger = logging.getLogger(__name__)
 
@@ -228,11 +229,7 @@ def register_analytics_tools(mcp: FastMCP, *, results_dir: Path) -> None:
 
 def _list_result_files(results_dir: Path) -> list[Path]:
     """List and sort result JSON files, excluding plans and tuning files."""
-    result_files = [
-        path
-        for path in results_dir.glob("*.json")
-        if not path.name.endswith(".plans.json") and not path.name.endswith(".tuning.json")
-    ]
+    result_files = [path for path in results_dir.glob("*.json") if not path.name.endswith(COMPANION_SUFFIXES)]
     return sorted(result_files, key=lambda p: p.stat().st_mtime, reverse=True)
 
 

--- a/benchbox/mcp/tools/results.py
+++ b/benchbox/mcp/tools/results.py
@@ -23,6 +23,7 @@ from mcp.types import ToolAnnotations
 from benchbox.core.results.loader import ResultLoadError, UnsupportedSchemaError, load_result_file
 from benchbox.mcp.errors import ErrorCode, make_error
 from benchbox.mcp.tools.path_utils import resolve_result_file_path
+from benchbox.validation.bundle import COMPANION_SUFFIXES
 
 logger = logging.getLogger(__name__)
 
@@ -108,11 +109,7 @@ def _list_recent_runs_impl(
     if not results_dir.exists():
         return {"runs": [], "count": 0, "message": f"No results directory found at {results_dir}"}
 
-    result_files = [
-        path
-        for path in results_dir.glob("*.json")
-        if not path.name.endswith(".plans.json") and not path.name.endswith(".tuning.json")
-    ]
+    result_files = [path for path in results_dir.glob("*.json") if not path.name.endswith(COMPANION_SUFFIXES)]
 
     runs = []
     for file_path in sorted(result_files, key=lambda p: p.stat().st_mtime, reverse=True):

--- a/benchbox/validation/bundle.py
+++ b/benchbox/validation/bundle.py
@@ -50,8 +50,12 @@ REQUIRED_QUERY_KEYS = {"id", "ms"}
 ACCEPTED_VERSION_PREFIX = "2."
 NUMERIC_SCHEMA_VERSION_RE = re.compile(r"^\d+\.\d+(?:\.\d+)?$")
 
-# Companion file suffixes - skipped during bundle discovery.
-COMPANION_SUFFIXES = (".plans.json", ".tuning.json")
+# Companion file suffixes - skipped during bundle discovery, and copied
+# alongside their result bundle by publish/submit. `.applied.json` carries the
+# applied tuning ledger + `applied_ledger_hash`; leaving it out of this tuple
+# dropped that evidence from public bundles and surfaced it as a standalone run
+# in discovery paths.
+COMPANION_SUFFIXES = (".plans.json", ".tuning.json", ".applied.json")
 SUBMISSION_MANIFEST_FILENAME = "submission-manifest.json"
 SUBMISSION_MANIFEST_SUFFIX = ".manifest.json"
 PUBLIC_CLEAN_VALIDATION_STATUS = "passed"


### PR DESCRIPTION
## PR review follow-up sweep — merged PRs #1261–#1289

Scanned the last 30 merged `develop` PRs for unresolved
`chatgpt-codex-connector[bot]` inline review threads. **25 found**; each is
dispositioned below and its GitHub thread replied-to + resolved.

### Fixed here (11)

| PR | Sev | File | Fix |
|----|-----|------|-----|
| #1288 | P1 | `.github/workflows/nightly.yml` | Grant `checks: read` + `actions: read`; a job-level `permissions` map zeroes unlisted scopes, so the sweep 403'd listing check-runs/workflow-runs before it could classify PRs. |
| #1274 | P1 | `core/runner/dataframe_runner.py` | Serialize the live `DataFrameTuningConfiguration` before it reaches `RunConfigInput`/export metadata — the JSON exporter uses plain `json.dumps`, so the object made export raise and the run emitted no result JSON and no `.applied.json`. |
| #1261 | P1 | `validation/bundle.py` + 7 discovery sites | Add `.applied.json` to `COMPANION_SUFFIXES` and route every discovery filter through it, so publish/submit copy the applied-ledger sidecar and discovery stops surfacing it as a standalone run. |
| #1286 | P2 | `Makefile` (`guards-fix`) | Run `agent-write-preflight` before the first regen, so the pool-worktree rule is enforced ahead of any artifact rewrite — including when the skill-sync CLI is absent. |
| #1286 | P2 | `Makefile` (`skill-sync`) | Short-circuit under `make -n`. The recipe contains `$(MAKE)`, so make executes it during a dry run and really ran `node ... sync` — the documented preview mutated skill mirrors. Verified with a fake CLI: it no longer executes. |
| #1285 | P2 | `_project/scripts/soundness_drain_report.py` | Keep `previous_filename` for renames so a PR moving a protected soundness path *out* still classifies as soundness-gated, matching the gate's `git diff --no-renames`. |
| #1282 | P2 | `_project/scripts/dev_loop_pr_metrics.py` | Raise `ApiFailure` instead of silently returning a short list on a failed page, and report the run SKIPPED rather than publishing understated metrics. |
| #1282 | P2 | `_project/scripts/dev_loop_pr_metrics.py` | Count only commits landed after `created_at`; `len(commits) - 1` counted pre-open commits as fix-forward pushes (which the review-followup flow produces by design). |
| #1268 | P2 | `core/tuning/introspection.py` | Treat a truncated catalog snapshot as degraded, so a row-bound hit can no longer upgrade a run to `applied_verified` on partial evidence — matching the module's documented contract. |
| #1267 | P2 | `.github/workflows/cross-surface-baseline-autodetect.yml` | Run the inline summary parser through `uv run` per the repo's Python-tooling convention. |
| #1263 | P2 | `core/tuning/capability_registry.py` | Redshift `SORTING` is a conditional **post-load** mechanism (`apply_ctas_sort` → `_build_ctas_sort_sql`) when sorted ingestion is on — not `rendered_via="none"`, which baked a false "execution never renders" claim into drift tests. |

### Already fixed upstream — no change (3)

`#1287`, `#1270`, `#1264` all asked for the explorer read-model version bump.
Current `develop` already has the Python contract, the Node validator
(`explorer-build-contract.mjs`) and the browser `db.ts` aligned at **v5**.
Verified against the tree; threads resolved.

### Deferred — tracked follow-up (11)

These need design decisions or live-platform verification beyond a code-fix
sweep, so they are intentionally **not** bundled here:

- **Tuning-ledger semantics (5):** `#1275`×2 (ClickHouse partition-key
  corroboration + sort-DDL execution chronology), `#1269`×2 (DataFrame
  write-layout marking, per-adapter ledger instrumentation for
  `datafusion-df`/`dask-df`), `#1261` (`platforms/base/adapter.py`
  schema-phase DDL capture). Each changes what counts as *verified* tuning and
  needs a real platform run to confirm.
- **Generator contract (1):** `#1262` StarRocks `distribute_by`. Six+ tests
  pin the bare column as an intentional *summary* value, so fixing the stray
  preview line means deciding whether `distribute_by` is SQL or summary —
  which also affects Doris and Firebolt.
- **Tracker schema (2):** `#1273`×2 (full-payload evidence comparison; a
  FK `ON DELETE` change implying a hosted-DB migration).
- **Docs/spec (2):** `#1271`×2 (`/blind-spot` command vs. the new
  protocol invariant; legacy frontmatter mapping in the findings schema).
- **Explorer UI (1):** `#1289` (`unknown` facet token must map to
  `IS NULL`).

### Notes

- The named `mcp__github__*` tools are unavailable in this environment, so
  GitHub reads/replies/resolves and this PR use the `gh` CLI + `make pr-open`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
