### PR TITLE
chore(ci): lint lane reports ALL guard failures in one run (no fail-fast)

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -253,24 +253,46 @@ jobs:
         run: |
           uv sync --group dev
 
+      # --- Lint guards ------------------------------------------------
+      # Every guard below is independent: `id: guard-*` (the naming
+      # convention the `lint-guard-summary` step and
+      # tests/system/test_ci_lint_parity.py both key off of) plus
+      # `continue-on-error: true` so one guard's failure doesn't hide the
+      # others' results behind a stopped job. The job as a whole still
+      # fails iff any guard failed -- see the `lint-guard-summary` step,
+      # which is what `ci-required-result` actually gates on. Setup steps
+      # above (checkout/setup-python/setup-uv/install deps) are not
+      # guards and carry neither `id: guard-*` nor `continue-on-error`.
       - name: Lint and format check with ruff
+        id: guard-ruff
+        continue-on-error: true
         run: |
           uv run ruff check .
           uv run ruff format --check .
 
       - name: Type check with ty
+        id: guard-ty
+        continue-on-error: true
         run: uv run ty check
 
       - name: Validate test marker annotations
+        id: guard-lint-markers
+        continue-on-error: true
         run: make lint-markers
 
       - name: Validate import layering
+        id: guard-lint-imports
+        continue-on-error: true
         run: make lint-imports
 
       - name: Validate artifact hygiene
+        id: guard-artifact-hygiene
+        continue-on-error: true
         run: make artifact-hygiene
 
       - name: Timing policy (wall-clock allowlist)
+        id: guard-timing-policy
+        continue-on-error: true
         run: uv run -- python _project/scripts/timing_policy_check.py --strict
 
       - name: UAT spec LOC table drift check
@@ -279,30 +301,46 @@ jobs:
         # LOC/table doc that drifts from source could merge through a normal
         # develop PR, leaving the drift guard dependent on the local pre-commit
         # hook alone.
+        id: guard-uat-loc-table
+        continue-on-error: true
         run: uv run --project _project/scripts -- python _project/scripts/uat_loc_table.py --check
 
       - name: Compatibility governance drift check
+        id: guard-compat-docs
+        continue-on-error: true
         run: make compat-docs-check
 
       - name: Oracle coverage map drift check
+        id: guard-oracle-coverage-map
+        continue-on-error: true
         run: make oracle-coverage-map-check
 
       - name: Public contract drift check
+        id: guard-public-contract-drift
+        continue-on-error: true
         run: uv run -- python scripts/check_public_contract_drift.py
 
       - name: Dependency audit (no unused declarations)
+        id: guard-audit-deps
+        continue-on-error: true
         run: make audit-deps
 
       - name: Dependency inventory drift check
+        id: guard-audit-raw
+        continue-on-error: true
         run: make audit-raw-check
 
       - name: Release curation list drift check
+        id: guard-release-curation
+        continue-on-error: true
         run: uv run -- python scripts/check_release_curation.py
 
       - name: skill-sync tracked snapshot verify (cloud/CI integrity gate)
         # Public tool, pinned by sha (no token). Proves .claude/skills matches
         # skill-sync.lock + the regenerated config — fails on any hand-edit or
         # stale snapshot. Switch to `npx -y skill-sync@<ver>` once published.
+        id: guard-skill-sync-verify
+        continue-on-error: true
         run: npx -y github:joeharris76/skill-sync#d3c9c45 verify --project .
 
       - name: Untracked skill-mirror drift guard (cloud parity)
@@ -312,7 +350,62 @@ jobs:
         # (it skips untracked targets and `ignore`d paths), so it cannot catch these
         # being force-added. Fail the build if any become git-tracked.
         # Rationale: _project/decisions/claude-settings-cloud-ownership-2026-06-29.md
+        id: guard-skill-mirror-drift
+        continue-on-error: true
         run: sh scripts/check_untracked_skill_mirrors.sh
+
+      # --- Aggregator ---------------------------------------------------
+      # Reports every guard's pass/fail in one CI cycle instead of stopping
+      # at the first failure. Derives the guard set programmatically from
+      # the `guard-*` id prefix (never hand-list ids here -- a guard added
+      # above without the prefix silently escapes aggregation, which is
+      # exactly what tests/system/test_ci_lint_parity.py now checks for).
+      - name: lint-guard-summary
+        id: lint-guard-summary
+        if: always()
+        env:
+          STEPS_CONTEXT: ${{ toJSON(steps) }}
+        run: |
+          set -euo pipefail
+          printf '%s\n' "$STEPS_CONTEXT" > "$RUNNER_TEMP/steps_context.json"
+
+          # FAIL CLOSED: the whole gate rests on this step's exit code, so a
+          # jq parse failure or an empty guard set must fail the job -- never
+          # fall through to "all passed" with zero guards inspected.
+          ids=$(jq -r 'keys[] | select(startswith("guard-"))' "$RUNNER_TEMP/steps_context.json" | sort) || {
+            echo "aggregator: jq failed to parse the steps context" >&2
+            exit 1
+          }
+          if [ -z "$ids" ]; then
+            echo "aggregator: no guard-* steps found in the steps context" >&2
+            exit 1
+          fi
+
+          {
+            echo "## Lint guard summary"
+            echo
+            echo "| Guard | Outcome |"
+            echo "| --- | --- |"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+          failed=0
+          for id in $ids; do
+            outcome=$(jq -r --arg id "$id" '.[$id].outcome' "$RUNNER_TEMP/steps_context.json")
+            if [ "$outcome" = "failure" ]; then
+              echo "| $id | ❌ failure |" >> "$GITHUB_STEP_SUMMARY"
+              echo "FAILED: $id"
+              failed=1
+            else
+              echo "| $id | ✅ $outcome |" >> "$GITHUB_STEP_SUMMARY"
+            fi
+          done
+
+          if [ "$failed" -eq 1 ]; then
+            echo "One or more lint guards failed -- see the table above and the" \
+              "per-step logs for details." >&2
+            exit 1
+          fi
+          echo "All lint guards passed."
 
   code-test:
     name: test (ubuntu-latest, 3.12)

--- a/Makefile
+++ b/Makefile
@@ -843,28 +843,62 @@ guards-fix:
 # network access this sandbox/local dev flow cannot rely on (verified: it
 # hangs with no route even when npx is installed) — see that doc and the
 # parity test's exclusion dict for the full rationale.
+#
+# Report-all: mirrors pr.yml's `lint-guard-summary` design. Every guard runs
+# to completion in one pass (no stopping at the first failure) with its
+# output streamed live as it runs; failures are collected into `failed` and
+# a single consolidated FAILED-guards list prints at the end, with a
+# nonzero exit iff at least one guard failed. `set +e` plus a `[ $$? -eq 0 ]`
+# check after each guard is what keeps this one shell session (the whole
+# recipe is one logical line via `\` continuations) going past a failing
+# guard instead of `make` aborting at the first nonzero exit.
 ci-lint:
 	@echo "Running CI lint checks..."
-	uv run ruff check .
-	uv run ruff format --check .
-	uv run ty check
-	$(MAKE) lint-markers
-	$(MAKE) lint-imports
-	$(MAKE) lint-explorer-tokens
-	$(MAKE) lint-site-theme-tokens
-	$(MAKE) artifact-hygiene
-	$(MAKE) skill-sync-check
-	uv run -- python _project/scripts/timing_policy_check.py --strict
-	uv run --project _project/scripts -- python _project/scripts/uat_loc_table.py --check
-	$(MAKE) compat-docs-check
-	$(MAKE) oracle-coverage-map-check
-	uv run -- python scripts/check_public_contract_drift.py
-	$(MAKE) audit-deps
-	$(MAKE) audit-raw-check
-	uv run -- python scripts/check_release_curation.py
-	sh scripts/check_untracked_skill_mirrors.sh
-	$(MAKE) spellcheck
-	@echo "✅ CI lint checks passed"
+	@set +e; failed=""; \
+	uv run ruff check .; \
+	[ $$? -eq 0 ] || failed="$$failed ruff-check"; \
+	uv run ruff format --check .; \
+	[ $$? -eq 0 ] || failed="$$failed ruff-format"; \
+	uv run ty check; \
+	[ $$? -eq 0 ] || failed="$$failed ty-check"; \
+	$(MAKE) lint-markers; \
+	[ $$? -eq 0 ] || failed="$$failed lint-markers"; \
+	$(MAKE) lint-imports; \
+	[ $$? -eq 0 ] || failed="$$failed lint-imports"; \
+	$(MAKE) lint-explorer-tokens; \
+	[ $$? -eq 0 ] || failed="$$failed lint-explorer-tokens"; \
+	$(MAKE) lint-site-theme-tokens; \
+	[ $$? -eq 0 ] || failed="$$failed lint-site-theme-tokens"; \
+	$(MAKE) artifact-hygiene; \
+	[ $$? -eq 0 ] || failed="$$failed artifact-hygiene"; \
+	$(MAKE) skill-sync-check; \
+	[ $$? -eq 0 ] || failed="$$failed skill-sync-check"; \
+	uv run -- python _project/scripts/timing_policy_check.py --strict; \
+	[ $$? -eq 0 ] || failed="$$failed timing-policy"; \
+	uv run --project _project/scripts -- python _project/scripts/uat_loc_table.py --check; \
+	[ $$? -eq 0 ] || failed="$$failed uat-loc-table"; \
+	$(MAKE) compat-docs-check; \
+	[ $$? -eq 0 ] || failed="$$failed compat-docs-check"; \
+	$(MAKE) oracle-coverage-map-check; \
+	[ $$? -eq 0 ] || failed="$$failed oracle-coverage-map-check"; \
+	uv run -- python scripts/check_public_contract_drift.py; \
+	[ $$? -eq 0 ] || failed="$$failed public-contract-drift"; \
+	$(MAKE) audit-deps; \
+	[ $$? -eq 0 ] || failed="$$failed audit-deps"; \
+	$(MAKE) audit-raw-check; \
+	[ $$? -eq 0 ] || failed="$$failed audit-raw-check"; \
+	uv run -- python scripts/check_release_curation.py; \
+	[ $$? -eq 0 ] || failed="$$failed release-curation"; \
+	sh scripts/check_untracked_skill_mirrors.sh; \
+	[ $$? -eq 0 ] || failed="$$failed skill-mirror-drift"; \
+	$(MAKE) spellcheck; \
+	[ $$? -eq 0 ] || failed="$$failed spellcheck"; \
+	if [ -n "$$failed" ]; then \
+		echo ""; \
+		echo "❌ FAILED guards:$$failed"; \
+		exit 1; \
+	fi; \
+	echo "✅ CI lint checks passed"
 
 # CI test check - exact match for test.yml workflow (fast tests with coverage)
 # Note: -p pytest_cov re-enables pytest-cov which is disabled by default in pytest.ini

--- a/docs/operations/ci-local-parity.md
+++ b/docs/operations/ci-local-parity.md
@@ -28,17 +28,83 @@ what CI checks.
 
 When you add a new guard step to the `lint` job in `pr.yml`:
 
-1. Add the equivalent command to the `ci-lint:` recipe in the `Makefile`
+1. Give the step an `id: guard-<slug>` (see "Report-all: one CI cycle,
+   every guard's result" below for why) and `continue-on-error: true`.
+2. Add the equivalent command to the `ci-lint:` recipe in the `Makefile`
    (a `$(MAKE) <target>` line if the guard already has a `make` target, or
-   the same `uv run ...` / script invocation the CI step uses).
-2. If the guard has meaningful inline logic (more than a couple of lines)
+   the same `uv run ...` / script invocation the CI step uses), followed
+   by its own `[ $$? -eq 0 ] || failed="$$failed <slug>"` bookkeeping line
+   -- copy the pattern of an existing guard pair in the recipe.
+3. If the guard has meaningful inline logic (more than a couple of lines)
    and would otherwise live only inside the workflow YAML, extract it to a
    script under `scripts/` first and have both `pr.yml` and `ci-lint` call
    that script. Duplicating logic into the Makefile as a second
    implementation is exactly the drift this invariant exists to prevent.
-3. Run `uv run -- python -m pytest tests/system/test_ci_lint_parity.py -q`.
-   If it fails, either step 1 was missed or the command text doesn't match
-   verbatim.
+4. Run `uv run -- python -m pytest tests/system/test_ci_lint_parity.py -q`.
+   If it fails: either step 2 was missed, the command text doesn't match
+   verbatim, or step 1's `id`/`continue-on-error` are missing or malformed
+   (`test_guard_steps_follow_naming_convention` enforces the convention;
+   `test_lint_job_guards_run_in_ci_lint` enforces command parity).
+
+## Report-all: one CI cycle, every guard's result
+
+The `lint` job runs around fifteen independent guards. Historically the
+job stopped at the first failing step, so a PR that tripped two unrelated
+guards paid one full CI round trip per guard, discovered one at a time.
+Every guard step now sets `continue-on-error: true` so a failure doesn't
+stop the job -- every guard still runs, and each one's own pass/fail is
+still visible as its own step in the Actions UI with its own log and
+timing. What changes is that the *job's* overall result no longer
+silently skips the guards after the first failure.
+
+**Naming convention (this is what the aggregation is keyed on, not a
+hand-maintained list):** every independent guard step's `id:` starts with
+the prefix `guard-` (e.g. `guard-ruff`, `guard-audit-deps`). Setup steps
+(checkout, `setup-python`, `setup-uv`, install dependencies) are not
+guards -- they get no `id: guard-*` and no `continue-on-error`, because a
+setup failure should stop the job immediately (there's nothing meaningful
+to report about guards that never ran because `uv sync` failed).
+
+The job's last step, `lint-guard-summary`, aggregates: it reads the
+Actions `steps` context (`${{ toJSON(steps) }}`, passed in via an env var
+rather than interpolated directly into the script), finds every step id
+that starts with `guard-`, and checks that step's `outcome` (the raw
+per-step result *before* `continue-on-error` is applied -- `conclusion`
+would show `success` for every failed-but-continued guard and defeat the
+whole point). It writes a pass/fail table to `$GITHUB_STEP_SUMMARY` and
+exits nonzero if any guard's `outcome` was `failure`. Because
+`lint-guard-summary` itself has no `continue-on-error`, that nonzero exit
+makes the `code-lint` job's own result `failure` -- so `ci-required-result`
+(which gates on `needs.code-lint.result`) still blocks the merge exactly
+as before. Nothing here softens the gate; it only changes *when* you find
+out a second guard also failed.
+
+Deriving the guard set from the `guard-` id prefix (rather than hand-listing
+step ids in the aggregator) is deliberate: a new guard added without the
+prefix would otherwise run, fail, and be silently invisible to the
+summary and its own `continue-on-error: true` would swallow the job-level
+failure entirely. `tests/system/test_ci_lint_parity.py::test_guard_steps_follow_naming_convention`
+pins the convention (every guard has the prefix + `continue-on-error`,
+every non-guard step has neither), and
+`test_lint_guard_summary_step_exists` pins that the aggregator step exists,
+is named exactly `lint-guard-summary`, runs with `if: always()` (so it
+still executes -- and reports -- after an earlier guard fails), and is the
+job's last step.
+
+`make ci-lint` mirrors the same report-all shape locally: the whole
+recipe runs as one shell invocation (via `\` line continuations) with
+`set +e`, running every guard command in turn and collecting failures
+into a `$$failed` list instead of `make` aborting at the first nonzero
+exit, then printing a consolidated `❌ FAILED guards:` list and exiting
+nonzero if the list is non-empty. Guard output still streams live as each
+guard runs -- nothing is buffered or captured, only the exit code is
+checked after each command -- so `make ci-lint`'s console output looks the
+same as before, just with the run continuing past a failure instead of
+stopping. Because the `ci-lint` recipe body is now one logical shell line,
+the parity test's line-matching normalizes away each guard command's
+trailing `; \` continuation marker before comparing it against the `pr.yml`
+command text -- see `_normalize_recipe_lines` in
+`tests/system/test_ci_lint_parity.py`.
 
 If a guard genuinely cannot run locally (see the network exception below
 for the only current example), add it to the `EXCLUDED_STEPS` dict in the

--- a/tests/system/test_ci_lint_parity.py
+++ b/tests/system/test_ci_lint_parity.py
@@ -15,6 +15,14 @@ in ``EXCLUDED_STEPS`` below with a reason -- never silently dropped and
 never faked by weakening the CI guard to pass locally. See
 docs/operations/ci-local-parity.md for the parity invariant and how to add
 a new lint guard without breaking this test.
+
+This module also pins the `code-lint` job's report-all structure: every
+guard step runs to completion in one CI cycle (via `continue-on-error`)
+instead of the job stopping at the first failure, and a final
+`lint-guard-summary` step derives the guard set from the `guard-*` id
+naming convention -- never a hand-maintained id list, which would let a
+newly added guard silently escape aggregation. See
+docs/operations/ci-local-parity.md for the naming-convention contract.
 """
 
 from __future__ import annotations
@@ -35,6 +43,14 @@ REPO_ROOT = Path(__file__).resolve().parent.parent.parent
 PR_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "pr.yml"
 MAKEFILE = REPO_ROOT / "Makefile"
 LINT_JOB_ID = "code-lint"
+
+# Naming convention the `code-lint` job's report-all aggregation relies on:
+# every independent guard step gets `id: guard-<slug>` + `continue-on-error:
+# true`, and the aggregator (below) discovers the guard set by filtering the
+# `steps` context on this prefix -- never a hand-maintained id list, which
+# would let a newly added guard silently escape aggregation.
+GUARD_ID_PREFIX = "guard-"
+AGGREGATOR_STEP_NAME = "lint-guard-summary"
 
 # Steps whose `run:` command is a setup/install action, not a guard -- they
 # have no failure-condition semantics of their own and ci-lint doesn't need
@@ -73,9 +89,12 @@ def _load_lint_job_steps() -> list[dict]:
 def _guard_commands() -> dict[str, list[str]]:
     """Map step name -> list of individual shell command lines.
 
-    Steps with no `run:` key (pure `uses:` actions like checkout/setup-python)
-    and the dependency-install step are excluded here; everything else is a
-    candidate guard.
+    Steps with no `run:` key (pure `uses:` actions like checkout/setup-python),
+    the dependency-install step, and the `lint-guard-summary` aggregator itself
+    are excluded here; everything else is a candidate guard. The aggregator
+    has no local equivalent to mirror -- it's the report-all mechanism, not a
+    policy guard -- so ci-lint's own report-all block (see the `ci-lint`
+    target's comment) covers the same job without needing a matching line.
     """
     commands: dict[str, list[str]] = {}
     for step in _load_lint_job_steps():
@@ -83,7 +102,7 @@ def _guard_commands() -> dict[str, list[str]]:
         run = step.get("run")
         if not name or not run:
             continue
-        if name in SETUP_STEP_NAMES:
+        if name in SETUP_STEP_NAMES or name == AGGREGATOR_STEP_NAME:
             continue
         lines = [line.strip() for line in run.splitlines() if line.strip()]
         commands[name] = lines
@@ -118,6 +137,17 @@ def _normalize_recipe_lines(recipe_text: str) -> list[str]:
         stripped = stripped.lstrip("@")
         if not stripped or stripped.startswith("#"):
             continue
+        # ci-lint runs every guard inside one shell invocation (the whole
+        # recipe is a single logical line joined with `\` continuations) so
+        # it can collect every guard's exit code instead of `make` aborting
+        # at the first failure -- see the report-all comment on the
+        # `ci-lint` target. Each guard-command line therefore ends with a
+        # `; \` continuation marker that isn't part of the guard command
+        # itself, so strip it before comparing.
+        if stripped.endswith("\\"):
+            stripped = stripped[:-1].rstrip()
+        if stripped.endswith(";"):
+            stripped = stripped[:-1].rstrip()
         normalized.append(stripped)
     return normalized
 
@@ -174,3 +204,60 @@ def test_excluded_steps_still_exist() -> None:
         "EXCLUDED_STEPS references pr.yml `lint`-job step name(s) that no "
         f"longer exist (renamed or removed) -- update the exclusion: {stale}"
     )
+
+
+def test_guard_steps_follow_naming_convention() -> None:
+    """Every independent guard step in `code-lint` must carry both
+    `id: guard-*` and `continue-on-error: true` -- that's what lets the
+    `lint-guard-summary` aggregator discover the guard set programmatically
+    (see GUARD_ID_PREFIX) instead of a hand-maintained id list that a new
+    guard could silently escape. Non-guard steps (checkout/setup-python/
+    setup-uv/install-deps, and the aggregator itself) must carry neither."""
+    violations: list[str] = []
+    for step in _load_lint_job_steps():
+        name = step.get("name")
+        step_id = step.get("id", "")
+        has_run = "run" in step
+        is_setup = name in SETUP_STEP_NAMES or "run" not in step
+        is_aggregator = name == AGGREGATOR_STEP_NAME
+        is_guard = has_run and not is_setup and not is_aggregator
+
+        has_guard_id = step_id.startswith(GUARD_ID_PREFIX)
+        has_continue_on_error = step.get("continue-on-error") is True
+
+        if is_guard:
+            if not has_guard_id:
+                violations.append(f"{name!r}: guard step missing id prefix {GUARD_ID_PREFIX!r}")
+            if not has_continue_on_error:
+                violations.append(f"{name!r}: guard step missing `continue-on-error: true`")
+        else:
+            if has_guard_id:
+                violations.append(f"{name!r}: non-guard step must not carry a {GUARD_ID_PREFIX!r} id")
+            if has_continue_on_error:
+                violations.append(f"{name!r}: non-guard step must not carry `continue-on-error: true`")
+
+    assert not violations, (
+        "code-lint step(s) violate the guard naming convention (id prefix "
+        f"{GUARD_ID_PREFIX!r} + continue-on-error: true for guards, neither "
+        "for setup/aggregator steps):\n  " + "\n  ".join(violations)
+    )
+
+
+def test_lint_guard_summary_step_exists() -> None:
+    """The report-all aggregator step must exist, be named exactly
+    `lint-guard-summary`, and run with `if: always()` so it still executes
+    (and reports) after an earlier guard fails with continue-on-error."""
+    steps = _load_lint_job_steps()
+    matches = [step for step in steps if step.get("name") == AGGREGATOR_STEP_NAME]
+    assert matches, f"code-lint job has no {AGGREGATOR_STEP_NAME!r} step"
+    assert len(matches) == 1, f"code-lint job has multiple {AGGREGATOR_STEP_NAME!r} steps"
+
+    aggregator = matches[0]
+    assert aggregator.get("id") == AGGREGATOR_STEP_NAME, (
+        f"{AGGREGATOR_STEP_NAME!r} step must use a matching `id:` (found {aggregator.get('id')!r})"
+    )
+    assert aggregator.get("if") == "always()", (
+        f"{AGGREGATOR_STEP_NAME!r} step must run with `if: always()` so it still reports after an earlier guard fails"
+    )
+    # Must be the last step -- it aggregates every guard that ran before it.
+    assert steps[-1] is aggregator, f"{AGGREGATOR_STEP_NAME!r} must be the last step in the code-lint job"


### PR DESCRIPTION
## Description

WS4 of `_project/planning/ci-failure-reduction-plan.md`: the `code-lint` job ran ~15 independent guards fail-fast, so multi-guard misses cost one full CI cycle (plus a triage wake) per discovery. Now one run reports everything:

- Every guard step carries `id: guard-<slug>` + `continue-on-error: true` (the 4 setup steps carry neither); a final `lint-guard-summary` step (`if: always()`, last step) derives the guard set **programmatically** from the id prefix via jq over `toJSON(steps)` — no hand-maintained list — writes a pass/fail table to the step summary, and exits nonzero if any guard's `outcome` (not `conclusion`, which lies under continue-on-error) failed.
- **Fail-closed aggregator** (Opus-review Required finding, fixed and empirically exercised): a jq parse failure or an empty guard set fails the job rather than passing vacuously. Gate hardness unchanged — `ci-required-result` still keys off the `code-lint` job result; review confirmed no guard was previously conditional so no semantics drifted.
- `make ci-lint` mirrors the semantics: single `set +e` shell, per-guard exit-code accumulation (crash-safe — signals/127s recorded same as failures, per review), consolidated `FAILED guards:` list, nonzero iff any failed, streaming output preserved; guard commands byte-identical.
- Parity test grows to 4 tests (medium tier): naming-convention enforcement means a new guard step **cannot silently escape aggregation**, and the aggregator's presence/shape is pinned.

**Proof**: two deliberate throwaway breaks (a ruff F401 + a codespell hit) reported together in a single `make ci-lint` run (`❌ FAILED guards: ruff-check spellcheck`, exit 2), then a clean run after full revert.

Tracker: `lint-lane-report-all-guards-2`. Opus review: REQUEST_CHANGES on the fail-open aggregator edge — fixed as above; `printf` nit applied; all other axes (outcome-vs-conclusion, job-conclusion coupling, injection surface, normalizer false-positive attack, crash-safety) verified clean.

## Type of Change

- [x] Refactor / chore

## Testing

- 4 parity tests pass (`-m medium`); pr.yml YAML parses; diff confined to the `code-lint` job + `ci-lint` target.
- Fail-closed paths exercised locally: invalid JSON → exit 1; empty guard set → exit 1; valid set → proceeds.
- Two-failure consolidated report proven locally (log retained in session scratchpad).

## Public Contract Check

- [x] No contract surfaces — CI control flow and dev tooling only.

## Documentation

- [x] `docs/operations/ci-local-parity.md`: report-all semantics + the guard naming-convention contract.

## Code Quality

- [x] Guard commands and step names byte-identical — pure control-flow restructure.
- [x] The aggregator is the only non-continue-on-error guard-bearing step and it fails closed.

## Artifact Hygiene

- [x] No artifacts; throwaway proof files fully reverted (git-status verified).

## Notes

- Local `ci-lint` remains a deliberate superset of CI (explorer-token scans, skill-sync doctor, spellcheck) — unchanged by this PR.

---
_Generated by [Claude Code](https://claude.ai/code/session_016NqSKtt68mqUpFA6C2qUkB)_