### PR TITLE
fix(review): correct two deferrals from the #1261-#1289 sweep

### DIFF
--- a/benchbox/core/dataframe/data_loader.py
+++ b/benchbox/core/dataframe/data_loader.py
@@ -985,7 +985,18 @@ class DataFrameDataLoader:
         # Reset the applied-layout signal; set it only on paths where the returned
         # data actually carries a non-default physical layout (see below).
         self.applied_write_layout = None
-        layout_applied = bool(effective_write_config and not effective_write_config.is_default())
+        layout_applied = bool(
+            effective_write_config
+            and not effective_write_config.is_default()
+            # Only the Parquet path physically writes the requested layout:
+            # `_convert_data` logs a warning and returns the source files
+            # unchanged for any other target format. That is reachable for
+            # pandas-df (whose optimal format is CSV) once a `sort_by` config
+            # pushes past the already-in-target-format early return. Claiming the
+            # layout there folds POST_LOAD statements and an applied hash into
+            # the ledger for a layout that was never written.
+            and target_format == DataFormat.PARQUET
+        )
 
         # Check if source is already in target format.
         # Skip conversion unless write_config requests physical layout changes (e.g. sort_by),

--- a/results-explorer/src/lib/__tests__/queryFilters.test.ts
+++ b/results-explorer/src/lib/__tests__/queryFilters.test.ts
@@ -134,6 +134,53 @@ describe("buildWhereClause - tuning_mode not-recorded/untuned sentinels", () => 
   });
 });
 
+describe("buildWhereClause - physical_rendering_id unknown sentinel", () => {
+  it("matches NULL physical_rendering_id rows for the unknown bucket", () => {
+    // Regression (PR #1289 review follow-up): the `unknown` option is produced
+    // by buildFacetCountQuery's `CASE WHEN <col> IS NULL THEN 'unknown'`, but the
+    // filter sent it through a plain IN (...) predicate, so selecting the
+    // advertised bucket returned zero rows instead of the NULL rows.
+    const filters: QueryFilterState = { ...EMPTY_FILTERS, physicalRenderingIds: ["unknown"] };
+
+    const { sql, params } = buildSelectQuery(filters, ["result_id"], DEFAULT_SORT, 10);
+
+    expect(sql).toContain("(physical_rendering_id IS NULL)");
+    expect(sql).not.toContain("physical_rendering_id IN (?)");
+    expect(params).toEqual([]);
+  });
+
+  it("combines a real rendering id with the unknown sentinel via OR", () => {
+    const filters: QueryFilterState = {
+      ...EMPTY_FILTERS,
+      physicalRenderingIds: ["databricks_liquid_auto", "unknown"],
+    };
+
+    const { sql, params } = buildSelectQuery(filters, ["result_id"], DEFAULT_SORT, 10);
+
+    expect(sql).toContain("(physical_rendering_id IN (?) OR physical_rendering_id IS NULL)");
+    expect(params).toEqual(["databricks_liquid_auto"]);
+  });
+
+  it("still emits a plain IN predicate when no unknown bucket is selected", () => {
+    const filters: QueryFilterState = {
+      ...EMPTY_FILTERS,
+      physicalRenderingIds: ["databricks_liquid_auto"],
+    };
+
+    const { sql, params } = buildSelectQuery(filters, ["result_id"], DEFAULT_SORT, 10);
+
+    expect(sql).toContain("(physical_rendering_id IN (?))");
+    expect(sql).not.toContain("physical_rendering_id IS NULL");
+    expect(params).toEqual(["databricks_liquid_auto"]);
+  });
+
+  it("keeps the facet-count producer and the filter consumer on one token", () => {
+    const { sql } = buildFacetCountQuery("physical_rendering_id", EMPTY_FILTERS);
+
+    expect(sql).toContain("THEN 'unknown'");
+  });
+});
+
 describe("buildWhereClause - normalized cost/deployment facets", () => {
   it("filters by normalized cost status and deployment metadata", () => {
     const filters: QueryFilterState = {

--- a/results-explorer/src/lib/facetModel.ts
+++ b/results-explorer/src/lib/facetModel.ts
@@ -42,6 +42,18 @@ export const NULL_TUNING_MODE_SENTINELS = [
   LEGACY_UNLABELLED_TUNING_MODE,
 ] as const;
 
+/**
+ * The token `buildFacetCountQuery` emits for a NULL value in any facet column
+ * (`CASE WHEN <col> IS NULL THEN 'unknown'`). Exported so the count query that
+ * *produces* the bucket and the WHERE builder that *consumes* it share one
+ * literal: a filter that sends this token through a plain `IN (...)` predicate
+ * matches no rows, silently returning nothing for a bucket the UI advertised.
+ */
+export const UNKNOWN_FACET_VALUE = "unknown";
+
+/** Facet tokens that must match a NULL physical_rendering_id row (ADR-2 secondary facet). */
+export const NULL_PHYSICAL_RENDERING_SENTINELS = [UNKNOWN_FACET_VALUE] as const;
+
 export interface FacetState {
   benchmark: string[];
   scale_factor: string[];

--- a/results-explorer/src/lib/queryFilters.ts
+++ b/results-explorer/src/lib/queryFilters.ts
@@ -1,5 +1,7 @@
 import {
+  NULL_PHYSICAL_RENDERING_SENTINELS,
   NULL_TUNING_MODE_SENTINELS,
+  UNKNOWN_FACET_VALUE,
   addNullableSentinelClause,
   dateWindowCutoffIso,
   type DateWindowFacet,
@@ -133,7 +135,17 @@ export function buildWhereClause(filters: QueryFilterState): BuiltQuery {
     params,
   );
   expandListFilter("storage_format", filters.storageFormats, clauses, params);
-  expandListFilter("physical_rendering_id", filters.physicalRenderingIds, clauses, params);
+  // `buildFacetCountQuery` surfaces rows with a NULL physical_rendering_id as an
+  // `unknown` option, so that token must become `IS NULL` rather than being sent
+  // through `IN (...)` -- which matched nothing and returned zero rows for a
+  // bucket the UI advertised. Mirrors the tuning_mode handling above.
+  addNullableSentinelClause(
+    "physical_rendering_id",
+    filters.physicalRenderingIds,
+    NULL_PHYSICAL_RENDERING_SENTINELS,
+    clauses,
+    params,
+  );
 
   if (filters.hasCost === "yes") clauses.push("cost_usd IS NOT NULL");
   if (filters.hasCost === "no") clauses.push("cost_usd IS NULL");
@@ -245,7 +257,7 @@ export function buildFacetCountQuery(
 
   return {
     sql: `
-      SELECT CASE WHEN ${column} IS NULL THEN 'unknown' ELSE CAST(${column} AS VARCHAR) END AS value, COUNT(*) AS count
+      SELECT CASE WHEN ${column} IS NULL THEN '${UNKNOWN_FACET_VALUE}' ELSE CAST(${column} AS VARCHAR) END AS value, COUNT(*) AS count
       FROM bench.results
       ${where.sql}
       GROUP BY 1

--- a/tests/unit/core/dataframe/test_data_loader.py
+++ b/tests/unit/core/dataframe/test_data_loader.py
@@ -1552,6 +1552,30 @@ class TestDataFrameDataLoaderWithWriteConfig:
             assert source in returned
             assert loader.applied_write_layout is None
 
+    def test_applied_write_layout_none_when_target_format_is_not_parquet(self):
+        """Regression (PR #1269 review follow-up): `_convert_data` returns the source
+        files unchanged for a non-Parquet target, so no physical layout is written --
+        the signal must stay None even though a sort_by config forced us past the
+        already-in-target-format early return. Otherwise the adapter folds POST_LOAD
+        statements and an applied hash into the ledger for a layout never applied."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmpdir = Path(tmpdir)
+            source = tmpdir / "customer.csv"
+            source.write_text("1|Alice|100.00\n")
+
+            # prefer_parquet=False -> optimal target format is CSV, not Parquet.
+            loader = DataFrameDataLoader(prefer_parquet=False)
+            benchmark = MagicMock()
+            benchmark.name = "tpch"
+            benchmark.tables = {"customer": source}
+
+            # sort_by forces the conversion path (past the verbatim early return),
+            # but _convert_data cannot apply a layout to a non-Parquet target.
+            write_config = DataFrameWriteConfiguration(sort_by=[SortColumn(name="c_custkey", order="asc")])
+            loader.prepare_benchmark_data(benchmark, scale_factor=1.0, write_config=write_config)
+
+            assert loader.applied_write_layout is None
+
     def test_applied_write_layout_none_for_default_config_on_cache_hit(self):
         """A default write_config applies no physical layout -> signal stays None."""
         with tempfile.TemporaryDirectory() as tmpdir:


### PR DESCRIPTION
## Correct two deferrals from the #1261–#1289 review sweep

[#1292](https://github.com/joeharris76/BenchBox/pull/1292) swept 25 unresolved
review threads and deferred 11 to
[#1293](https://github.com/joeharris76/BenchBox/issues/1293). On re-examination
**two of those deferrals did not hold up** — neither needed a maintainer
decision nor live-platform verification, so both are fixed here with regression
coverage. Issue #1293 is updated to drop them (9 remain).

### #1289 — Explorer `unknown` facet returned zero rows

`buildFacetCountQuery` advertises NULL values as an `unknown` bucket
(`CASE WHEN <col> IS NULL THEN 'unknown'`), but the `physical_rendering_id`
filter sent that token through a plain `IN (...)` predicate, so selecting the
bucket produced `physical_rendering_id IN ('unknown')` and matched nothing.

The codebase already had the right idiom for this — `addNullableSentinelClause`,
used for `tuning_mode`. The filter now uses it. The `unknown` literal is now a
shared `UNKNOWN_FACET_VALUE` constant consumed by **both** the count query that
produces the token and the WHERE builder that consumes it, so they cannot drift
apart again.

*Why the original deferral was wrong:* I claimed it "needs its own e2e
coverage". The producer and the broken consumer are in the same file ~100 lines
apart, and a query-builder unit test covers it. "Needs a test" is a reason to
write one, not to defer.

### #1269 — `applied_write_layout` claimed a layout that was never written

`layout_applied` was computed purely from the requested config, but
`_convert_data` logs a warning and returns the source files **unchanged** for
any non-Parquet target. That path is reachable for `pandas-df` (optimal format
CSV) once a `sort_by` config pushes past the already-in-target-format early
return, so the adapter folded POST_LOAD statements and an applied hash into the
tuning ledger for a layout that never hit disk. The signal is now gated on
`target_format == DataFormat.PARQUET`.

*Why the original deferral was wrong:* I grouped it with the "changes what
counts as verified tuning, needs a live run" cluster. It does change that — but
strictly in the **conservative** direction (records less, never over-certifies),
which is exactly the direction that is safe to land without a platform run.

### Verification

- Explorer lib suite: 23 files / 213 tests green, incl. 4 new sentinel tests
  (`IS NULL` alone, OR-combined with a real id, plain `IN` when unselected, and
  a producer/consumer token-parity check).
- `tests/unit/core/dataframe/` + `tests/unit/platforms/dataframe/`: 1963 passed,
  incl. 1 new applied-layout test.
- ruff check + format clean.

### Still deferred (9, tracked in #1293)

The remaining deferrals stand on their evidence: the StarRocks
`get_inline_clauses()` contract is owned by the shared `TuningClauses` dataclass
(no per-platform override seam, and 6+ tests pin the current value); the
`finding_links` FK change implies a hosted-DB migration; the ClickHouse ledger
items reorder already-published `applied_ledger_hash` inputs; and the remaining
docs/spec items are governance decisions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
