### PR TITLE
fix(cloud-storage): classify Snowflake stage paths as non-local

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,6 +66,10 @@ docs/site/
 data/
 generated/
 benchmark_runs/
+# Defence in depth: a Snowflake stage path (@~/...) must never resolve to a
+# local directory, but if one ever does it must not become a commit. Left
+# unanchored so a run started from any subdirectory is covered too.
+@~/
 spark-warehouse/
 *.db
 *.csv

--- a/benchbox/utils/cloud_storage.py
+++ b/benchbox/utils/cloud_storage.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 
 import logging
 import os
+import re
 from pathlib import Path
 from typing import Any, List, Protocol, Union, runtime_checkable
 from urllib.parse import urlparse
@@ -341,24 +342,81 @@ class DatabricksVolumeAdapter:
             return []
 
 
-def is_cloud_path(path: Union[str, Path]) -> bool:
-    """Check if a path is a cloud storage path.
+# Snowflake stage references are schemeless, so urlparse never yields a scheme
+# for them and the scheme list in is_cloud_path() cannot express this shape.
+# Grammar (always anchored at a leading '@'):
+#   @~/sub/path                  user stage
+#   @%table/sub/path             table stage
+#   @stage/sub/path              named stage
+#   @db.schema.stage/sub/path    qualified named stage
+# Identifiers are unquoted (letter/underscore lead) or double-quoted.
+# The stage and sub-path groups make this regex the single source of truth for
+# both matching and splitting, so a quoted stage name containing '/' can never
+# be mis-split by a separate parser.
+_STAGE_IDENTIFIER = r'(?:"[^"]+"|[A-Za-z_][A-Za-z0-9_$]*)'
+_SNOWFLAKE_STAGE_RE = re.compile(
+    rf"^@(?P<stage>~|%{_STAGE_IDENTIFIER}|{_STAGE_IDENTIFIER}(?:\.{_STAGE_IDENTIFIER}){{0,2}})"
+    rf"(?:/(?P<sub_path>.*))?$"
+)
 
-    Includes dbfs:// paths (Databricks File System / Unity Catalog Volumes)
-    which require special handling via Databricks Files API.
+
+def _match_snowflake_stage(path: Union[str, Path]) -> Union[re.Match, None]:
+    """Match a Snowflake stage reference, returning the match or None.
+
+    Shared by the predicate and by :func:`get_cloud_path_info` so the grammar
+    and the stage/sub-path split can never drift apart.
+    """
+    if isinstance(path, Path):
+        path = str(path)
+
+    if not isinstance(path, str):
+        return None
+
+    return _SNOWFLAKE_STAGE_RE.match(path)
+
+
+def is_snowflake_stage_path(path: Union[str, Path]) -> bool:
+    """Check if a path is a Snowflake stage reference (``@~/...``, ``@stage/...``).
+
+    Stage paths have no URI scheme, so they must be matched structurally rather
+    than through :func:`urlparse`. The match is anchored at a leading ``@`` so
+    that cloud URIs which merely contain ``@`` — notably
+    ``abfss://container@account.dfs.core.windows.net/path`` — are never
+    misrouted here.
 
     Args:
         path: Path to check
 
     Returns:
-        True if path is a cloud storage path (s3://, gs://, abfss://, dbfs://, etc.)
+        True if path is a Snowflake user, table, named or qualified-named stage
+    """
+    return _match_snowflake_stage(path) is not None
+
+
+def is_cloud_path(path: Union[str, Path]) -> bool:
+    """Check if a path is a cloud storage path.
+
+    Includes dbfs:// paths (Databricks File System / Unity Catalog Volumes)
+    which require special handling via Databricks Files API, and Snowflake
+    stage references (``@~/...``), which are remote namespaces even though they
+    carry no URI scheme.
+
+    Args:
+        path: Path to check
+
+    Returns:
+        True if path is a cloud storage path (s3://, gs://, abfss://, dbfs://,
+        @stage/..., etc.)
     """
     # Convert Path objects (including CloudPath from cloudpathlib) to strings
     if not isinstance(path, str):
         path = str(path)
 
     parsed = urlparse(path)
-    return parsed.scheme in ["s3", "gs", "gcs", "az", "abfss", "azure", "dbfs"]
+    if parsed.scheme in ["s3", "gs", "gcs", "az", "abfss", "azure", "dbfs"]:
+        return True
+
+    return is_snowflake_stage_path(path)
 
 
 def is_databricks_path(path: Union[str, Path]) -> bool:
@@ -393,20 +451,22 @@ def validate_cloud_path_support() -> bool:
     return cloud_path is not None
 
 
-def create_path_handler(path: Union[str, Path]) -> Union[Path, CloudPath, DatabricksPath]:
+def create_path_handler(path: Union[str, Path]) -> Union[Path, CloudPath, DatabricksPath, CloudStagingPath]:
     """Create appropriate path handler for local or cloud paths.
 
-    Note: dbfs:// paths (Databricks UC Volumes) cannot be handled directly by
-    cloudpathlib. For these paths, we create a local temporary directory for
-    data generation and store the target dbfs:// path as an attribute. The actual
-    upload is handled by DatabricksAdapter during the load phase.
+    Note: dbfs:// paths (Databricks UC Volumes) and Snowflake stage paths
+    (``@~/...``) cannot be handled directly by cloudpathlib. For these paths, we
+    create a local temporary directory for data generation and store the remote
+    target as an attribute. The actual upload is handled by the platform adapter
+    during the load phase.
 
     Args:
         path: Local or cloud storage path (or already-created DatabricksPath/CloudPath)
 
     Returns:
         Path object for local paths, CloudPath for cloud paths,
-        DatabricksPath for dbfs:// paths (either created or passed through)
+        DatabricksPath for dbfs:// paths (either created or passed through),
+        CloudStagingPath for Snowflake stage paths
 
     Raises:
         ImportError: If cloud path is provided but cloudpathlib not installed
@@ -445,6 +505,22 @@ def create_path_handler(path: Union[str, Path]) -> Union[Path, CloudPath, Databr
         logger.debug(f"Target UC Volume: {path_str}")
 
         return databricks_path
+
+    # Handle Snowflake stage paths specially - like dbfs://, they are a remote
+    # namespace cloudpathlib cannot open, so data is generated locally and the
+    # stage target is carried alongside for the adapter to upload.
+    if is_snowflake_stage_path(path):
+        path_str = str(path)
+
+        import tempfile
+
+        temp_dir_str = tempfile.mkdtemp(prefix="benchbox_stage_")
+        staging_path = CloudStagingPath(temp_dir_str, path_str)
+
+        logger.info(f"Created temporary directory for Snowflake stage path: {staging_path}")
+        logger.debug(f"Target stage: {path_str}")
+
+        return staging_path
 
     if not is_cloud_path(path):
         return Path(path)
@@ -670,6 +746,21 @@ def get_cloud_path_info(path: Union[str, Path]) -> dict[str, Any]:
             "path": parsed.path,
             "credentials_valid": True,  # Checked by Databricks adapter
             "volume_info": volume_info,
+        }
+
+    # Handle Snowflake stage paths specially - the stage name is the container
+    # and there is no scheme/netloc for urlparse to split.
+    stage_match = _match_snowflake_stage(path)
+    if stage_match is not None:
+        stage_name = stage_match.group("stage")
+        sub_path = stage_match.group("sub_path") or ""
+        return {
+            "is_cloud": True,
+            "provider": "snowflake_stage",
+            "bucket": stage_name,
+            "path": sub_path,
+            "credentials_valid": True,  # Checked by the Snowflake adapter
+            "stage_info": {"stage": stage_name, "sub_path": sub_path},
         }
 
     if not is_cloud_path(path):

--- a/tests/unit/cli/test_orchestrator_stage_output_root.py
+++ b/tests/unit/cli/test_orchestrator_stage_output_root.py
@@ -1,0 +1,134 @@
+"""Orchestrator output-root routing for Snowflake stage paths.
+
+A stored ``default_output_location`` of ``@~/benchbox`` (the Snowflake
+credential prompt's advertised default) used to classify as local, so the
+orchestrator returned it verbatim as the datagen root and every generated file
+landed in a relative ``@~/`` directory under the current working directory.
+These tests pin the routing that makes that structurally impossible.
+
+Copyright 2026 Joe Harris / BenchBox Project
+
+Licensed under the MIT License. See LICENSE file in the project root for details.
+"""
+
+import shutil
+import tempfile
+from pathlib import Path
+from unittest.mock import Mock
+
+import pytest
+
+from benchbox.cli.orchestrator import BenchmarkOrchestrator
+from benchbox.core.schemas import BenchmarkConfig
+from benchbox.utils.cloud_storage import CloudStagingPath
+
+pytestmark = [
+    pytest.mark.unit,
+    pytest.mark.fast,
+]
+
+
+# Shapes a user can end up with in ~/.benchbox/credentials via the Snowflake
+# credential prompt, which offers '@~/benchbox' as its default.
+CREDENTIAL_SHAPED_DEFAULTS = [
+    "@~/benchbox",
+    "@~/data",
+    "@~/staged",
+    "@my_stage/benchbox",
+    "@my_db.my_schema.my_stage/benchbox",
+    "s3://my-bucket/benchbox-data",
+    "azure://container/benchbox-data",
+    "gcs://my-bucket/benchbox-data",
+]
+
+
+class TestStageOutputRootRouting:
+    """_resolve_custom_output_root and _resolve_construction_output_dir."""
+
+    def setup_method(self):
+        """Set up test fixtures."""
+        self.temp_dir = tempfile.mkdtemp()
+        self.orchestrator = BenchmarkOrchestrator(base_dir=self.temp_dir)
+        self.config = BenchmarkConfig(name="tpch", display_name="TPC-H", scale_factor=0.01)
+        self.benchmark = Mock()
+        self.benchmark.get_data_source_benchmark = Mock(return_value=None)
+
+    def teardown_method(self):
+        """Clean up test fixtures."""
+        shutil.rmtree(self.temp_dir, ignore_errors=True)
+
+    def test_stage_path_routes_through_cloud_staging_path(self):
+        """A stage path stages locally and keeps the stage as the cloud target."""
+        self.orchestrator.custom_output_dir = "@~/benchbox"
+        platform_cfg = {}
+
+        output_root = self.orchestrator._resolve_custom_output_root(self.config, self.benchmark, platform_cfg)
+
+        assert isinstance(output_root, CloudStagingPath)
+        assert output_root.cloud_target == "@~/benchbox"
+        assert Path(str(output_root)).is_absolute()
+
+    def test_stage_path_populates_staging_root(self):
+        """platform_cfg carries the stage target through to the adapter."""
+        self.orchestrator.custom_output_dir = "@~/benchbox"
+        platform_cfg = {}
+
+        self.orchestrator._resolve_custom_output_root(self.config, self.benchmark, platform_cfg)
+
+        assert platform_cfg["staging_root"] == "@~/benchbox"
+
+    def test_stage_path_staging_matches_s3_routing(self):
+        """Stage paths take exactly the same route as s3://, per the work order."""
+        platform_cfg_stage = {}
+        self.orchestrator.custom_output_dir = "@~/benchbox"
+        stage_root = self.orchestrator._resolve_custom_output_root(self.config, self.benchmark, platform_cfg_stage)
+
+        platform_cfg_s3 = {}
+        self.orchestrator.custom_output_dir = "s3://bucket/benchbox"
+        s3_root = self.orchestrator._resolve_custom_output_root(self.config, self.benchmark, platform_cfg_s3)
+
+        assert type(stage_root) is type(s3_root)
+        # Both stage into the same managed local cache for this benchmark/scale.
+        assert Path(str(stage_root)) == Path(str(s3_root))
+        assert platform_cfg_stage["staging_root"] == "@~/benchbox"
+        assert platform_cfg_s3["staging_root"] == "s3://bucket/benchbox"
+
+    @pytest.mark.parametrize("default_output", CREDENTIAL_SHAPED_DEFAULTS)
+    def test_no_credential_default_resolves_to_a_relative_local_path(self, default_output):
+        """The core regression: no stored default may become a relative dir."""
+        self.orchestrator.custom_output_dir = default_output
+        platform_cfg = {}
+
+        output_root = self.orchestrator._resolve_custom_output_root(self.config, self.benchmark, platform_cfg)
+
+        assert not isinstance(output_root, str), f"{default_output!r} returned a raw local string"
+        assert Path(str(output_root)).is_absolute(), f"{default_output!r} resolved to a relative path"
+
+    @pytest.mark.parametrize("default_output", CREDENTIAL_SHAPED_DEFAULTS)
+    def test_construction_output_dir_defers_for_remote_defaults(self, default_output):
+        """The construction-time gate mirrors the post-construction one."""
+        self.orchestrator.custom_output_dir = default_output
+
+        resolved = self.orchestrator._resolve_construction_output_dir(self.config, Mock(DATA_SOURCE_BENCHMARK=None))
+
+        assert resolved is None, f"{default_output!r} was resolved locally at construction time"
+
+    def test_local_custom_output_dir_is_still_returned_verbatim(self):
+        """Genuine local --output paths keep their existing behaviour."""
+        local_dir = str(Path(self.temp_dir) / "explicit-output")
+        self.orchestrator.custom_output_dir = local_dir
+        platform_cfg = {}
+
+        output_root = self.orchestrator._resolve_custom_output_root(self.config, self.benchmark, platform_cfg)
+
+        assert output_root == local_dir
+        assert "staging_root" not in platform_cfg
+
+    def test_local_custom_output_dir_resolves_at_construction_time(self):
+        """A local --output is knowable before construction and is returned."""
+        local_dir = str(Path(self.temp_dir) / "explicit-output")
+        self.orchestrator.custom_output_dir = local_dir
+
+        resolved = self.orchestrator._resolve_construction_output_dir(self.config, Mock(DATA_SOURCE_BENCHMARK=None))
+
+        assert resolved == local_dir

--- a/tests/unit/utils/test_cloud_storage_snowflake_stage.py
+++ b/tests/unit/utils/test_cloud_storage_snowflake_stage.py
@@ -1,0 +1,192 @@
+"""Tests for Snowflake stage path classification.
+
+Snowflake stage references (``@~/...``) carry no URI scheme, so before this
+classification existed they fell through to the local branch and resolved to a
+*relative* directory under the current working directory — silently spilling
+generated benchmark data into whatever checkout the run started from.
+
+Copyright 2026 Joe Harris / BenchBox Project
+
+Licensed under the MIT License. See LICENSE file in the project root for details.
+"""
+
+import os
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from benchbox.utils.cloud_storage import (
+    CloudStagingPath,
+    create_path_handler,
+    get_cloud_path_info,
+    is_cloud_path,
+    is_snowflake_stage_path,
+)
+
+pytestmark = [
+    pytest.mark.unit,
+    pytest.mark.fast,
+]
+
+
+STAGE_PATHS = [
+    "@~",  # user stage root
+    "@~/benchbox",  # user stage, the credential prompt's advertised default
+    "@~/a/b/c",  # user stage, nested
+    "@%orders",  # table stage
+    "@%orders/part-0",  # table stage with sub-path
+    '@%"My Table"',  # quoted table stage
+    "@my_stage",  # named stage
+    "@my_stage/data",  # named stage with sub-path
+    "@my_db.my_schema.my_stage/data",  # qualified named stage
+    '@"My Stage"/data',  # quoted named stage
+    "@stage$name/data",  # '$' is legal in Snowflake identifiers
+]
+
+NON_STAGE_PATHS = [
+    "abfss://container@account.dfs.core.windows.net/path",  # '@' inside a cloud URI
+    "azure://container@account/path",
+    "s3://bucket/prefix",
+    "gs://bucket/prefix",
+    "dbfs:/Volumes/catalog/schema/volume",
+    "user@host:/remote/path",  # scp-style, '@' not leading
+    "team@example.com",
+    "/tmp/@~/already-spilled",  # '@~' present but not leading
+    "@",  # bare sigil, no stage name
+    "@/foo",  # missing stage name
+    "@.",
+    "@%",  # table sigil with no table
+    "/local/path",
+    "./relative/path",
+    "~/home/path",
+    "",
+]
+
+
+class TestIsSnowflakeStagePath:
+    """The dedicated stage predicate, including the shapes it must reject."""
+
+    @pytest.mark.parametrize("path", STAGE_PATHS)
+    def test_recognises_stage_paths(self, path):
+        """User, table, named and qualified-named stages all match."""
+        assert is_snowflake_stage_path(path), f"{path!r} should classify as a stage"
+
+    @pytest.mark.parametrize("path", NON_STAGE_PATHS)
+    def test_rejects_non_stage_paths(self, path):
+        """Cloud URIs containing '@' and ordinary local paths never match."""
+        assert not is_snowflake_stage_path(path), f"{path!r} should not classify as a stage"
+
+    def test_azure_uri_with_at_sign_is_not_a_stage(self):
+        """Regression: the match is anchored, so abfss:// is never misrouted."""
+        azure = "abfss://container@account.dfs.core.windows.net/path"
+        assert not is_snowflake_stage_path(azure)
+        # ...but it is still a cloud path, via the scheme branch.
+        assert is_cloud_path(azure)
+
+    def test_accepts_path_objects_and_rejects_non_string_input(self):
+        """Path inputs are stringified; None/int are not stage paths."""
+        assert is_snowflake_stage_path(Path("@~/benchbox"))
+        assert not is_snowflake_stage_path(None)
+        assert not is_snowflake_stage_path(123)
+
+
+class TestStageClassification:
+    """is_cloud_path / get_cloud_path_info treat stages as non-local."""
+
+    @pytest.mark.parametrize("path", STAGE_PATHS)
+    def test_stage_paths_are_not_local(self, path):
+        """The core defect: a stage path must never classify as local."""
+        assert is_cloud_path(path), f"{path!r} still classifies as local"
+
+    def test_existing_schemes_are_unchanged(self):
+        """Every previously-supported scheme keeps classifying as today."""
+        for path in [
+            "s3://bucket/p",
+            "gs://bucket/p",
+            "gcs://bucket/p",
+            "az://container/p",
+            "abfss://container@account.dfs.core.windows.net/p",
+            "azure://container/p",
+            "dbfs:/Volumes/c/s/v",
+        ]:
+            assert is_cloud_path(path), path
+        for path in ["/local/path", "./rel", "~/home", "", "C:\\Windows\\path"]:
+            assert not is_cloud_path(path), path
+
+    def test_get_cloud_path_info_reports_stage_provider(self):
+        """The info dict names the stage provider and splits stage from sub-path."""
+        info = get_cloud_path_info("@my_stage/data/part-0")
+        assert info["is_cloud"] is True
+        assert info["provider"] == "snowflake_stage"
+        assert info["bucket"] == "my_stage"
+        assert info["path"] == "data/part-0"
+        assert info["stage_info"] == {"stage": "my_stage", "sub_path": "data/part-0"}
+
+    def test_get_cloud_path_info_user_stage_without_sub_path(self):
+        """A bare user stage reports an empty sub-path rather than failing."""
+        info = get_cloud_path_info("@~")
+        assert info["provider"] == "snowflake_stage"
+        assert info["bucket"] == "~"
+        assert info["path"] == ""
+
+    @pytest.mark.parametrize(
+        ("path", "stage", "sub_path"),
+        [
+            ("@~/benchbox", "~", "benchbox"),
+            ("@%orders/part-0", "%orders", "part-0"),
+            ("@my_db.my_schema.my_stage/data", "my_db.my_schema.my_stage", "data"),
+            # A '/' inside a quoted identifier belongs to the stage name, not
+            # the sub-path; a naive split on the first '/' gets this wrong.
+            ('@"My/Stage"/data', '"My/Stage"', "data"),
+            ('@"My Stage"', '"My Stage"', ""),
+        ],
+    )
+    def test_stage_and_sub_path_split_matches_the_grammar(self, path, stage, sub_path):
+        """The regex is the single source of truth for matching and splitting."""
+        info = get_cloud_path_info(path)
+        assert info["stage_info"] == {"stage": stage, "sub_path": sub_path}
+        assert info["bucket"] == stage
+        assert info["path"] == sub_path
+
+
+class TestStagePathHandler:
+    """create_path_handler must never hand back a relative local directory."""
+
+    @pytest.mark.parametrize("path", STAGE_PATHS)
+    def test_handler_is_never_a_relative_path(self, path):
+        """This is the property that makes the cwd spill structurally impossible."""
+        handler = create_path_handler(path)
+        assert not (isinstance(handler, Path) and not handler.is_absolute()), handler
+
+    def test_handler_is_a_staging_path_carrying_the_stage_target(self):
+        """Stages stage locally and keep the remote target for the adapter."""
+        handler = create_path_handler("@~/benchbox")
+        assert isinstance(handler, CloudStagingPath)
+        assert handler.cloud_target == "@~/benchbox"
+        assert Path(str(handler)).is_absolute()
+
+    def test_resolving_a_stage_creates_no_directory_in_cwd(self, tmp_path, monkeypatch):
+        """Regression for the 319 MB '@~/' spill: nothing lands under cwd."""
+        monkeypatch.chdir(tmp_path)
+        create_path_handler("@~/benchbox")
+        assert not (tmp_path / "@~").exists()
+        assert list(tmp_path.iterdir()) == []
+
+    def test_stage_handler_does_not_require_cloudpathlib(self, monkeypatch):
+        """cloudpathlib stays lazy: a stage path must not trigger the import."""
+        import benchbox.utils.cloud_storage as cs
+
+        def _fail():  # pragma: no cover - invoked only on regression
+            raise AssertionError("cloudpathlib must not be loaded for stage paths")
+
+        monkeypatch.setattr(cs, "_load_cloudpathlib", _fail)
+        handler = cs.create_path_handler("@~/benchbox")
+        assert isinstance(handler, CloudStagingPath)
+
+    def test_local_paths_still_return_plain_paths(self):
+        """Genuine local paths are untouched by the stage branch."""
+        with tempfile.TemporaryDirectory() as tmp:
+            assert create_path_handler(tmp) == Path(tmp)
+        assert create_path_handler("./rel") == Path("./rel")
+        assert create_path_handler(os.path.expanduser("~")) == Path(os.path.expanduser("~"))


### PR DESCRIPTION
Snowflake stage references (@~/..., @%tbl/..., @stage/...) carry no URI
scheme, so urlparse yields nothing for them and is_cloud_path() returned
False. A stored default_output_location of "@~/benchbox" -- the exact
default the Snowflake credential prompt advertises -- therefore resolved
to a *relative* directory and every generated file landed in an "@~/"
tree under whatever directory the run started from.

Add a dedicated is_snowflake_stage_path() predicate rather than widening
the urlparse scheme list, which cannot express a schemeless shape. The
match is anchored at a leading '@' so cloud URIs that merely contain '@'
-- notably abfss://container@account.dfs.core.windows.net/... -- are
never misrouted. A single regex with named groups is the source of truth
for both matching and the stage/sub-path split, so a quoted stage name
containing '/' cannot be mis-split.

is_cloud_path() now consults the predicate alongside the scheme check,
create_path_handler() stages stage paths locally via CloudStagingPath
before the cloudpathlib fallthrough (keeping cloudpathlib lazy), and
get_cloud_path_info() reports a snowflake_stage provider.

Both orchestrator gates already branch on is_cloud_path, so stage paths
now take exactly the s3:// route and populate platform_cfg
["staging_root"] with no orchestrator change; tests pin that agreement.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01FweRvfL9Mq25NrCcLRNjRH


## Code review record

Five-axis review run on the diff before opening.

| Severity | Finding | Resolution |
|---|---|---|
| Required | `get_cloud_path_info` split the stage from the sub-path with a naive `partition("/")`, but the grammar accepts `/` inside a double-quoted identifier — `@"My/Stage"/data` yielded a malformed stage name `"My`. | **Fixed.** The regex now carries named `stage`/`sub_path` groups and is the single source of truth for matching *and* splitting; `_match_snowflake_stage()` is shared by the predicate and the info builder so they cannot drift. Pinned by `test_stage_and_sub_path_split_matches_the_grammar`. |
| Consider | `create_path_handler` has no `CloudStagingPath` pass-through, unlike the explicit `DatabricksPath` "avoids double-wrapping" guard, so re-wrapping one drops `cloud_target`. | **Deferred and promoted** to `cloud-staging-path-rewrap-drops-cloud-target`. Verified pre-existing and *identical* for `s3://` and stage inputs (both return `PosixPath('/tmp/cache')`), so it is not a regression here. Fixing it would change the handler type returned for `s3://` flows, which this item's must-preserve list forbids. |

No nits were skipped.

## Verification

Full ladder from the tracker work order, all re-run after the review fix:

1. `pytest tests/unit/utils/ -k 'cloud or path or stage'` — 233 passed
2. Stage path no longer resolves to a relative local dir — pass
3. `pytest tests/unit/cli/ -k 'output_root or staging'` — 21 passed
4. Resolving a stage from a clean temp cwd creates no stray directory — pass
5. Fast lane — 25,612 passed, 15 skipped

Also green: `make lint`, `lint-markers`, `lint-imports`, `make typecheck`. Fast-lane collect is 25,622 against the 26,050 cap (428 headroom), so no policy bump was needed.

## Scope note

`benchbox/cli/orchestrator.py` was in scope but needed **no change** — both gates
(`_resolve_construction_output_dir`, `_resolve_custom_output_root`) already
branch on `is_cloud_path`, so fixing classification routes stage paths through
the existing `CloudStagingPath` branch automatically. Tests pin that agreement
rather than adding redundant code.
