### PR TITLE
fix(paths): anchor the default benchmark_runs root to the work tree's parent

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -77,8 +77,13 @@ GOOGLE_APPLICATION_CREDENTIALS=/path/to/service-account.json
 # Enable experimental features (Databricks, BigQuery, Snowflake, Redshift)
 BENCHBOX_ENABLE_EXPERIMENTAL=1
 
-# Default output directory for benchmark results
-# BENCHBOX_OUTPUT_DIR=./benchmark_runs
+# Default output directory for benchmark results.
+# Leave unset to use the default: a `benchmark_runs/` directory alongside the
+# checkout (../benchmark_runs), shared by every clone and worktree so generated
+# data is reused instead of re-generated — and never committed. Set this only to
+# point somewhere else; do NOT set it to ./benchmark_runs, which puts
+# multi-gigabyte artifacts back inside the repository.
+# BENCHBOX_OUTPUT_DIR=/path/to/benchmark_runs
 
 # Default scale factor for testing
 # BENCHBOX_TEST_SCALE_FACTOR=0.01

--- a/_project/specs/uat-framework.md
+++ b/_project/specs/uat-framework.md
@@ -137,7 +137,7 @@ tests/uat/
 | `docker_assets.py` | Single connection registry: compose-file map, compose-derived host ports + platform options, safe project-scoped compose commands | 180 | 760 |
 | `docker_cleanup.py` | Docker stack teardown at platform boundaries; project-scoped down/volume handling | — | 426 |
 | `container_cleanup.py` | Apple `container`-engine sibling of `docker_cleanup.py`; backs `make uat-docker-cleanup ENGINE=container` | — | 557 |
-| `artifact_hygiene.py` | Local-artifact hygiene guard: flags worktree-local `benchmark_runs/` growth when an external output root is configured; report-only (`make uat-artifact-hygiene`) | — | 282 |
+| `artifact_hygiene.py` | Local-artifact hygiene guard: flags worktree-local `benchmark_runs/` growth when an external output root is configured; report-only (`make uat-artifact-hygiene`) | — | 309 |
 | `cells_io.py` | `cells.jsonl` + accounting-sidecar read/write codec; single schema shared by `orchestrator.py` and `_cli.py` | — | 464 |
 | `gate_summary.py` | Writes/reads the versioned `uat_gate_summary.json` per-sweep evidence artifact; powers `make uat-gate-check` cross-stage aggregation | — | 274 |
 | `throughput.py` | Multi-stream throughput/concurrent cell support via `benchbox run-official --streams`; TPC-compliant scale-factor gate | — | 316 |
@@ -182,10 +182,10 @@ remain hand-tracked.
 - chartered evidence artifacts (validate/report/package/cells_io/gate_summary): 1,674
 - explorer-prep: 387
 - throughput: 316
-- artifact hygiene: 282
+- artifact hygiene: 309
 - package init markers: 23
 
-**Total: 10,261 production LOC across 26 modules.**
+**Total: 10,288 production LOC across 26 modules.**
 
 <!-- UAT-LOC-SUMMARY:END -->
 

--- a/benchbox/utils/path_utils.py
+++ b/benchbox/utils/path_utils.py
@@ -28,16 +28,65 @@ def get_default_data_directory() -> Path:
     return Path.cwd() / "data"
 
 
+def find_work_tree_root(start: Path | None = None) -> Path | None:
+    """Return the enclosing Git work tree root, or ``None`` if there is none.
+
+    Walks ``start`` (default :func:`Path.cwd`) and its parents looking for a
+    ``.git`` entry. Both forms count: ``.git`` is a *directory* in a normal
+    clone and a *file* pointing at the real git dir in a linked worktree, so
+    the check is ``exists()`` rather than ``is_dir()``.
+
+    This is deliberately pure Python — it runs during benchmark construction,
+    where shelling out to ``git rev-parse`` would add a subprocess to a hot
+    path and fail outright when git is not installed.
+
+    Args:
+        start: Directory to start from. Defaults to the current directory.
+            Resolved first, so a relative path still walks real parents.
+
+    Returns:
+        The directory containing the ``.git`` entry, or None when ``start`` is
+        not inside a Git work tree.
+    """
+    origin = Path.cwd() if start is None else Path(start).resolve()
+    for candidate in (origin, *origin.parents):
+        if (candidate / ".git").exists():
+            return candidate
+    return None
+
+
+def default_benchmark_runs_root(start: Path | None = None) -> Path:
+    """Return the default ``benchmark_runs`` root for a run started in ``start``.
+
+    The single source of truth for the default anchor: the enclosing work
+    tree's *sibling* when ``start`` is inside a checkout, else ``start``'s own
+    ``benchmark_runs``. Callers that need the full precedence chain (explicit
+    root, then ``BENCHBOX_OUTPUT_DIR``, then this) want
+    :func:`resolve_benchmark_runs_dir` instead.
+    """
+    origin = Path.cwd() if start is None else Path(start).resolve()
+    work_tree_root = find_work_tree_root(origin)
+    base = work_tree_root.parent if work_tree_root is not None else origin
+    return base / DEFAULT_BENCHMARK_RUNS_ROOT
+
+
 def resolve_benchmark_runs_dir() -> Path:
     """Return the resolved ``benchmark_runs/`` root.
 
-    Honors ``BENCHBOX_OUTPUT_DIR``; otherwise anchors the historical
-    ``benchmark_runs`` default to :func:`Path.cwd` so callers using the result
-    for filesystem operations get an absolute path.
+    Honors ``BENCHBOX_OUTPUT_DIR``; otherwise anchors the default
+    ``benchmark_runs`` directory to the *parent* of the enclosing Git work
+    tree, so it becomes a sibling of the checkout (``../benchmark_runs``)
+    rather than a directory inside it. Every clone and linked worktree of the
+    same project therefore shares one root, which keeps generated data
+    reusable across checkouts instead of re-generating it per worktree — and
+    keeps multi-gigabyte artifacts out of the repository.
+
+    Outside a Git work tree — the installed-package case — the historical
+    :func:`Path.cwd` anchor is kept unchanged.
     """
     root = resolve_benchmark_runs_root(env=os.environ)
     if root == DEFAULT_BENCHMARK_RUNS_ROOT:
-        return Path.cwd() / DEFAULT_BENCHMARK_RUNS_ROOT
+        return default_benchmark_runs_root()
     return root
 
 

--- a/docs/benchmarks/join-order.md
+++ b/docs/benchmarks/join-order.md
@@ -70,12 +70,13 @@ The manifest hash fields have separate roles:
 Subsequent runs reuse the verified data under:
 
 ```text
-benchmark_runs/datagen/joinorder_sf1/
+<benchmark_runs>/datagen/joinorder_sf1/
 ```
 
-If `BENCHBOX_OUTPUT_DIR` is set, the same relative datagen path is resolved
-under that root. Air-gapped environments can pre-populate that directory with
-the 21 Parquet files; BenchBox still verifies the manifest before running.
+`<benchmark_runs>` is the resolved output root: `../benchmark_runs` alongside
+the checkout by default, or `BENCHBOX_OUTPUT_DIR` when set. Air-gapped
+environments can pre-populate that directory with the 21 Parquet files;
+BenchBox still verifies the manifest before running.
 
 ## BYO Data Path
 
@@ -85,7 +86,7 @@ re-hosted archive can instead provide their own canonical Parquet files. Place
 the 21 files named in `benchbox/core/joinorder/data_manifest.toml` under:
 
 ```text
-benchmark_runs/datagen/joinorder_sf1/
+../benchmark_runs/datagen/joinorder_sf1/
 ```
 
 or, when `BENCHBOX_OUTPUT_DIR` is set:

--- a/docs/operations/uat-framework.md
+++ b/docs/operations/uat-framework.md
@@ -29,7 +29,9 @@ developer guide for hacking on the framework itself is
 ## Output artefacts
 
 By default every BenchBox runtime artefact lands under the shared
-`~/Developer/benchmark_runs/` root:
+`benchmark_runs/` root alongside the checkout — `~/Developer/benchmark_runs/`
+for a clone at `~/Developer/BenchBox`, and the same root for every sibling
+pool worktree:
 
 ```
 ~/Developer/benchmark_runs/

--- a/tests/test_amplab.py
+++ b/tests/test_amplab.py
@@ -14,6 +14,7 @@ import pytest
 
 from benchbox import AMPLab
 from benchbox.core.amplab.benchmark import AMPLabBenchmark
+from benchbox.utils.path_utils import resolve_benchmark_runs_dir
 
 from .fixtures.benchmark_test_mixin import BenchmarkTestMixin
 
@@ -277,7 +278,7 @@ class TestAMPLabBenchmarkDirectly(BenchmarkTestMixin):
         assert benchmark.scale_factor == 0.01
         # Default path follows: benchmark_runs/datagen/{benchmark}_sf{formatted_sf}
         # 0.01 formats as "sf001" per format_scale_factor()
-        assert benchmark.output_dir == Path.cwd() / "benchmark_runs" / "datagen" / "amplab_sf001"
+        assert benchmark.output_dir == resolve_benchmark_runs_dir() / "datagen" / "amplab_sf001"
         assert benchmark._name == "AMPLab Big Data Benchmark"
         assert benchmark._version == "1.0"
 

--- a/tests/test_h2odb.py
+++ b/tests/test_h2odb.py
@@ -14,6 +14,7 @@ import pytest
 
 from benchbox import H2ODB
 from benchbox.core.h2odb.benchmark import H2OBenchmark as H2ODBBenchmark
+from benchbox.utils.path_utils import resolve_benchmark_runs_dir
 
 from .fixtures.benchmark_test_mixin import BenchmarkTestMixin
 
@@ -265,7 +266,7 @@ class TestH2ODBBenchmarkDirectly(BenchmarkTestMixin):
         assert h2odb.scale_factor == 0.01
         # Default path follows: benchmark_runs/datagen/{benchmark}_sf{formatted_sf}
         # 0.01 formats as "sf001" per format_scale_factor()
-        assert h2odb.output_dir == Path.cwd() / "benchmark_runs" / "datagen" / "h2odb_sf001"
+        assert h2odb.output_dir == resolve_benchmark_runs_dir() / "datagen" / "h2odb_sf001"
         assert h2odb._name == "H2O Database Benchmark"
         assert h2odb._version == "1.0"
 

--- a/tests/uat/artifact_hygiene.py
+++ b/tests/uat/artifact_hygiene.py
@@ -1,4 +1,8 @@
-"""Local-artifact hygiene guardrails for external-root benchmark runs.
+"""Local-artifact hygiene guardrails for benchmark runs with an external root.
+
+The default output root is itself external — it is anchored to the enclosing
+work tree's *parent* — so these guardrails apply to plain runs too, not only to
+runs that pass ``--output`` or set ``BENCHBOX_OUTPUT_DIR``.
 
 Background — the 2026-06-01 incident: a corpus run launched from a pool
 worktree with ``BENCHBOX_OUTPUT_DIR`` pointed at an external root
@@ -22,6 +26,7 @@ from pathlib import Path
 from typing import Mapping
 
 from benchbox.core.runtime_paths import DEFAULT_BENCHMARK_RUNS_ROOT
+from benchbox.utils.path_utils import default_benchmark_runs_root, find_work_tree_root
 
 LOCAL_RUNS_DIRNAME = str(DEFAULT_BENCHMARK_RUNS_ROOT)
 
@@ -57,6 +62,19 @@ def _normalize(path: str | Path) -> Path:
     return Path(path).expanduser()
 
 
+def _default_runs_root(base: Path) -> Path | None:
+    """Resolve the default ``benchmark_runs`` root for a run started in ``base``.
+
+    Defers to :func:`benchbox.utils.path_utils.default_benchmark_runs_root` so
+    the anchor cannot drift from the runtime one. Returns ``None`` outside a
+    work tree, where the default is cwd-local by definition and there is
+    nothing external to guard.
+    """
+    if find_work_tree_root(base) is None:
+        return None
+    return default_benchmark_runs_root(base)
+
+
 def configured_external_root(
     env: Mapping[str, str] | None = None,
     *,
@@ -66,10 +84,14 @@ def configured_external_root(
     """Resolve a configured output root iff it points *outside* ``cwd``.
 
     An external root is "configured" when ``--output`` (``output``) is given
-    or ``BENCHBOX_OUTPUT_DIR`` is set to a non-empty value. The guardrail only
-    applies when that root resolves to a location outside the current working
-    directory — ordinary default local runs (no env/flag, or a root inside the
-    worktree) return ``None`` so they are never blocked.
+    or ``BENCHBOX_OUTPUT_DIR`` is set to a non-empty value. When neither is
+    set, the *default* root is used — since the default is anchored to the
+    enclosing work tree's parent it is normally external too, so plain runs
+    are covered by the same guardrail rather than being exempt from it.
+
+    The guardrail only applies when the resolved root lies outside the current
+    working directory; a root inside the worktree returns ``None`` so genuinely
+    local runs are never blocked.
     """
     env_map = os.environ if env is None else env
     base = Path(cwd).resolve() if cwd is not None else Path.cwd().resolve()
@@ -81,6 +103,11 @@ def configured_external_root(
         raw = env_map.get("BENCHBOX_OUTPUT_DIR")
         if raw is not None and raw.strip():
             candidate = _normalize(raw.strip())
+        else:
+            # No explicit root: fall back to the resolved default, which is
+            # anchored to the work tree's parent and is therefore external for
+            # any run launched from inside a checkout.
+            candidate = _default_runs_root(base)
 
     if candidate is None:
         return None

--- a/tests/unit/core/dataframe/test_storage_location_parity.py
+++ b/tests/unit/core/dataframe/test_storage_location_parity.py
@@ -15,7 +15,11 @@ from unittest.mock import patch
 import pytest
 
 from benchbox.core.dataframe.data_loader import DEFAULT_CACHE_DIR, DataCache
-from benchbox.utils.path_utils import get_benchmark_runs_dataframe_path, get_benchmark_runs_datagen_path
+from benchbox.utils.path_utils import (
+    get_benchmark_runs_dataframe_path,
+    get_benchmark_runs_datagen_path,
+    resolve_benchmark_runs_dir,
+)
 
 pytestmark = [
     pytest.mark.unit,
@@ -54,7 +58,7 @@ class TestStorageLocationParity:
             env.pop("BENCHBOX_CACHE_DIR", None)
             with patch.dict("os.environ", env, clear=True):
                 cache = DataCache()
-                assert cache.cache_dir == Path.cwd() / "benchmark_runs" / "datagen"
+                assert cache.cache_dir == resolve_benchmark_runs_dir() / "datagen"
 
     def test_benchbox_cache_dir_env_overrides_default(self):
         """BENCHBOX_CACHE_DIR environment variable should override the default."""
@@ -77,7 +81,7 @@ class TestStorageLocationParity:
     def test_path_helper_default(self):
         """get_benchmark_runs_dataframe_path() returns benchmark_runs/datagen/."""
         path = get_benchmark_runs_dataframe_path()
-        assert path == Path.cwd() / "benchmark_runs" / "datagen"
+        assert path == resolve_benchmark_runs_dir() / "datagen"
 
     def test_path_helper_override(self):
         """get_benchmark_runs_dataframe_path() respects base_dir override."""

--- a/tests/unit/core/test_benchmark_output_root_propagation.py
+++ b/tests/unit/core/test_benchmark_output_root_propagation.py
@@ -32,6 +32,7 @@ from benchbox.core.ssb.benchmark import SSBBenchmark
 from benchbox.core.tpch.benchmark import TPCHBenchmark
 from benchbox.core.tsbs_devops.benchmark import TSBSDevOpsBenchmark
 from benchbox.core.vector_search.benchmark import VectorSearchBenchmark
+from benchbox.utils.path_utils import resolve_benchmark_runs_dir
 
 pytestmark = [
     pytest.mark.unit,
@@ -105,13 +106,13 @@ def test_explicit_output_root_propagates_post_construction(benchmark_cls, kwargs
         assert str(gen.output_dir) == str(explicit), (benchmark_cls.__name__, gen.output_dir)
 
 
-def test_default_falls_back_to_cwd_when_unset(monkeypatch):
-    """With neither CLI --output nor BENCHBOX_OUTPUT_DIR set, the cwd default holds."""
+def test_default_falls_back_to_resolved_root_when_unset(monkeypatch):
+    """With neither CLI --output nor BENCHBOX_OUTPUT_DIR set, the default root holds."""
     monkeypatch.delenv("BENCHBOX_OUTPUT_DIR", raising=False)
 
     benchmark = H2OBenchmark(scale_factor=0.01)
 
-    expected = Path.cwd() / "benchmark_runs" / "datagen" / "h2odb_sf001"
+    expected = resolve_benchmark_runs_dir() / "datagen" / "h2odb_sf001"
     assert Path(str(benchmark.output_dir)) == expected
     assert Path(str(benchmark.data_generator.output_dir)) == expected
 

--- a/tests/unit/core/test_config_utils.py
+++ b/tests/unit/core/test_config_utils.py
@@ -28,6 +28,7 @@ from benchbox.core.config_utils import (
     validate_config_sections,
     validate_numeric_config,
 )
+from benchbox.utils.path_utils import resolve_benchmark_runs_dir
 
 pytestmark = [
     pytest.mark.unit,
@@ -227,7 +228,7 @@ class TestBuildBenchmarkConfig:
             "scale_factor": 0.5,
             "verbose": True,
             "force_regenerate": False,
-            "output_dir": str(Path.cwd() / "benchmark_runs" / "datagen" / "tpcds_sf05"),
+            "output_dir": str(resolve_benchmark_runs_dir() / "datagen" / "tpcds_sf05"),
         }
         assert result == expected
 
@@ -237,7 +238,7 @@ class TestBuildBenchmarkConfig:
 
         result = build_benchmark_config(config)
 
-        assert result["output_dir"] == str(Path.cwd() / "benchmark_runs" / "datagen" / "tpch_sf001")
+        assert result["output_dir"] == str(resolve_benchmark_runs_dir() / "datagen" / "tpch_sf001")
 
     def test_build_clickhouse_output_dir(self):
         """Test building config for ClickHouse platform."""

--- a/tests/unit/mcp/test_benchmark_output_root_propagation.py
+++ b/tests/unit/mcp/test_benchmark_output_root_propagation.py
@@ -18,7 +18,7 @@ from benchbox.core.benchmark_registry import (
     get_benchmark_default_scale,
     get_public_benchmark_class,
 )
-from benchbox.utils.path_utils import get_benchmark_runs_datagen_path
+from benchbox.utils.path_utils import get_benchmark_runs_datagen_path, resolve_benchmark_runs_dir
 
 pytestmark = [
     pytest.mark.unit,
@@ -68,13 +68,13 @@ def test_mcp_data_only_datagen_path_honors_env_output_root(tmp_path, monkeypatch
     assert Path.cwd() not in data_dir.parents, data_dir
 
 
-def test_mcp_default_without_env_uses_cwd(monkeypatch):
-    """Without an output-root override the MCP datagen path stays cwd-local."""
+def test_mcp_default_without_env_uses_resolved_default_root(monkeypatch):
+    """Without an output-root override the MCP datagen path uses the default root."""
     monkeypatch.delenv("BENCHBOX_OUTPUT_DIR", raising=False)
 
     data_dir = get_benchmark_runs_datagen_path("tpch", 0.01)
 
-    assert data_dir == Path.cwd() / "benchmark_runs" / "datagen" / "tpch_sf001"
+    assert data_dir == resolve_benchmark_runs_dir() / "datagen" / "tpch_sf001"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_base_advanced.py
+++ b/tests/unit/test_base_advanced.py
@@ -18,6 +18,7 @@ import pytest
 
 from benchbox.base import BaseBenchmark
 from benchbox.core.connection import DatabaseConnection, DatabaseError
+from benchbox.utils.path_utils import resolve_benchmark_runs_dir
 
 pytestmark = [
     pytest.mark.unit,
@@ -107,7 +108,7 @@ class TestMockBaseBenchmarkInitialization:
         """Test basic benchmark initialization."""
         benchmark = MockBaseBenchmark(scale_factor=1.0)
         assert benchmark.scale_factor == 1.0
-        assert benchmark.output_dir == Path.cwd() / "benchmark_runs" / "datagen" / "mockbase_sf1"
+        assert benchmark.output_dir == resolve_benchmark_runs_dir() / "datagen" / "mockbase_sf1"
         assert not benchmark._data_generated
         assert not benchmark._load_data_called
 
@@ -769,7 +770,7 @@ class TestMockBaseBenchmarkBackwardCompatibility:
 
         # Test basic functionality that existing benchmarks rely on
         assert benchmark.scale_factor == 1.0
-        assert benchmark.output_dir == Path.cwd() / "benchmark_runs" / "datagen" / "mockbase_sf1"
+        assert benchmark.output_dir == resolve_benchmark_runs_dir() / "datagen" / "mockbase_sf1"
 
         # Test query methods
         queries = benchmark.get_queries()

--- a/tests/unit/tpcdi/test_config_simplified.py
+++ b/tests/unit/tpcdi/test_config_simplified.py
@@ -37,6 +37,7 @@ from benchbox.core.tpcdi.config import (
     get_safe_config,
     get_simple_config,
 )
+from benchbox.utils.path_utils import resolve_benchmark_runs_dir
 
 
 @pytest.mark.unit
@@ -89,7 +90,7 @@ class TestTPCDIConfig:
         # Test default output directory creation - should use benchmark_runs structure
         config = TPCDIConfig()
         # Default output dir is now benchmark_runs/datagen/tpcdi_sf{scale_factor}
-        assert config.output_dir == Path.cwd() / "benchmark_runs" / "datagen" / "tpcdi_sf1"
+        assert config.output_dir == resolve_benchmark_runs_dir() / "datagen" / "tpcdi_sf1"
 
         # Test max_workers validation
         config = TPCDIConfig(max_workers=0)

--- a/tests/unit/utils/test_path_utils.py
+++ b/tests/unit/utils/test_path_utils.py
@@ -13,6 +13,7 @@ import pytest
 
 from benchbox.utils.path_utils import (
     ensure_directory,
+    find_work_tree_root,
     get_benchmark_runs_databases_path,
     get_benchmark_runs_dataframe_path,
     get_benchmark_runs_datagen_path,
@@ -416,7 +417,11 @@ class TestBenchboxOutputDirRedirection:
         assert resolve_benchmark_runs_dir() == tmp_path / "runs"
 
     def test_resolve_benchmark_runs_dir_falls_back_to_cwd(self):
-        """When no env var is set, fall back to cwd-anchored default."""
+        """Outside a Git work tree, the cwd-anchored default is unchanged.
+
+        ``/repo`` has no ``.git`` entry in any parent, so this exercises the
+        installed-package path where there is no work tree to anchor to.
+        """
         with (
             patch.dict(os.environ, {}, clear=True),
             patch("benchbox.utils.path_utils.Path.cwd", return_value=Path("/repo")),
@@ -430,3 +435,133 @@ class TestBenchboxOutputDirRedirection:
             patch("benchbox.utils.path_utils.Path.cwd", return_value=Path("/repo")),
         ):
             assert resolve_benchmark_runs_dir() == Path("/repo/benchmark_runs")
+
+
+class TestWorkTreeAnchoredDefault:
+    """The default benchmark_runs root is a sibling of the enclosing work tree.
+
+    A cwd-anchored default put multi-gigabyte datagen artifacts *inside* the
+    checkout and gave every pool worktree its own copy. Anchoring to the work
+    tree's parent yields one shared ``../benchmark_runs`` for the clone and
+    every linked worktree.
+    """
+
+    def _make_work_tree(self, root: Path, *, linked: bool) -> Path:
+        """Create a fake work tree whose .git is a file (linked) or directory."""
+        root.mkdir(parents=True, exist_ok=True)
+        marker = root / ".git"
+        if linked:
+            # A linked worktree's .git is a *file* pointing at the real gitdir.
+            marker.write_text("gitdir: /elsewhere/.git/worktrees/wt\n")
+        else:
+            marker.mkdir()
+        return root
+
+    @pytest.mark.parametrize("linked", [False, True], ids=["clone", "linked_worktree"])
+    def test_find_work_tree_root_accepts_both_git_marker_forms(self, tmp_path, linked):
+        """.git is a directory in a clone and a file in a linked worktree."""
+        work_tree = self._make_work_tree(tmp_path / "checkout", linked=linked)
+        nested = work_tree / "benchbox" / "utils"
+        nested.mkdir(parents=True)
+
+        assert find_work_tree_root(work_tree) == work_tree
+        assert find_work_tree_root(nested) == work_tree
+
+    def test_find_work_tree_root_returns_none_outside_a_work_tree(self, tmp_path):
+        """No .git in any parent means no work tree."""
+        plain = tmp_path / "not_a_repo" / "deep"
+        plain.mkdir(parents=True)
+        assert find_work_tree_root(plain) is None
+
+    @pytest.mark.parametrize("linked", [False, True], ids=["clone", "linked_worktree"])
+    def test_default_root_is_the_work_tree_sibling(self, tmp_path, monkeypatch, linked):
+        """The resolved default is <work_tree>.parent/'benchmark_runs'."""
+        work_tree = self._make_work_tree(tmp_path / "checkout", linked=linked)
+        monkeypatch.delenv("BENCHBOX_OUTPUT_DIR", raising=False)
+        monkeypatch.chdir(work_tree)
+
+        assert resolve_benchmark_runs_dir() == tmp_path / "benchmark_runs"
+
+    def test_default_root_is_never_inside_the_work_tree(self, tmp_path, monkeypatch):
+        """The regression this item exists to prevent: no in-repo artifacts."""
+        work_tree = self._make_work_tree(tmp_path / "checkout", linked=False)
+        monkeypatch.delenv("BENCHBOX_OUTPUT_DIR", raising=False)
+        monkeypatch.chdir(work_tree)
+
+        resolved = resolve_benchmark_runs_dir()
+
+        assert resolved != work_tree
+        assert work_tree not in resolved.parents
+
+    def test_default_root_is_cwd_independent_within_a_work_tree(self, tmp_path, monkeypatch):
+        """Running from a nested subdirectory resolves to the same root."""
+        work_tree = self._make_work_tree(tmp_path / "checkout", linked=False)
+        nested = work_tree / "tests" / "unit"
+        nested.mkdir(parents=True)
+        monkeypatch.delenv("BENCHBOX_OUTPUT_DIR", raising=False)
+
+        monkeypatch.chdir(work_tree)
+        from_root = resolve_benchmark_runs_dir()
+        monkeypatch.chdir(nested)
+        from_nested = resolve_benchmark_runs_dir()
+
+        assert from_root == from_nested == tmp_path / "benchmark_runs"
+
+    def test_sibling_worktrees_share_one_root(self, tmp_path, monkeypatch):
+        """A clone and its pool worktrees resolve to the SAME shared root."""
+        clone = self._make_work_tree(tmp_path / "BenchBox", linked=False)
+        pool = self._make_work_tree(tmp_path / "BenchBox.pool-01", linked=True)
+        monkeypatch.delenv("BENCHBOX_OUTPUT_DIR", raising=False)
+
+        monkeypatch.chdir(clone)
+        from_clone = resolve_benchmark_runs_dir()
+        monkeypatch.chdir(pool)
+        from_pool = resolve_benchmark_runs_dir()
+
+        assert from_clone == from_pool == tmp_path / "benchmark_runs"
+
+    def test_directory_name_is_still_benchmark_runs(self, tmp_path, monkeypatch):
+        """The name is unchanged, so the existing corpus keeps working."""
+        work_tree = self._make_work_tree(tmp_path / "checkout", linked=False)
+        monkeypatch.delenv("BENCHBOX_OUTPUT_DIR", raising=False)
+        monkeypatch.chdir(work_tree)
+
+        assert resolve_benchmark_runs_dir().name == "benchmark_runs"
+
+    def test_env_var_still_wins_inside_a_work_tree(self, tmp_path, monkeypatch):
+        """BENCHBOX_OUTPUT_DIR keeps absolute precedence over the new default."""
+        work_tree = self._make_work_tree(tmp_path / "checkout", linked=False)
+        override = tmp_path / "explicit_root"
+        monkeypatch.setenv("BENCHBOX_OUTPUT_DIR", str(override))
+        monkeypatch.chdir(work_tree)
+
+        assert resolve_benchmark_runs_dir() == override
+
+    def test_relative_env_var_still_wins_inside_a_work_tree(self, tmp_path, monkeypatch):
+        """A relative BENCHBOX_OUTPUT_DIR is still accepted verbatim."""
+        work_tree = self._make_work_tree(tmp_path / "checkout", linked=False)
+        monkeypatch.setenv("BENCHBOX_OUTPUT_DIR", "local_runs")
+        monkeypatch.chdir(work_tree)
+
+        assert resolve_benchmark_runs_dir() == Path("local_runs")
+
+    def test_env_var_tilde_still_expands_inside_a_work_tree(self, tmp_path, monkeypatch):
+        """``~`` expansion is unaffected by the work-tree anchor."""
+        work_tree = self._make_work_tree(tmp_path / "checkout", linked=False)
+        home = tmp_path / "home"
+        monkeypatch.setenv("HOME", str(home))
+        monkeypatch.setenv("USERPROFILE", str(home))
+        monkeypatch.setenv("BENCHBOX_OUTPUT_DIR", "~/runs")
+        monkeypatch.chdir(work_tree)
+
+        assert resolve_benchmark_runs_dir() == home / "runs"
+
+    def test_derived_subdirs_follow_the_resolved_root(self, tmp_path, monkeypatch):
+        """datagen/databases helpers hang off the new root, not off cwd."""
+        work_tree = self._make_work_tree(tmp_path / "checkout", linked=False)
+        monkeypatch.delenv("BENCHBOX_OUTPUT_DIR", raising=False)
+        monkeypatch.chdir(work_tree)
+
+        expected_root = tmp_path / "benchmark_runs"
+        assert get_benchmark_runs_datagen_path("tpch", 0.01) == expected_root / "datagen" / "tpch_sf001"
+        assert get_benchmark_runs_databases_path("tpch", 0.01) == expected_root / "databases" / "tpch_sf001"


### PR DESCRIPTION
The default output root was anchored to Path.cwd(), so a run launched
from a checkout wrote generated data *into* the repository, and every
pool worktree built its own copy instead of sharing one. That is how
1.9 GB of benchmark_runs/ accumulated inside the main clone.

Anchor the default to the enclosing Git work tree's parent instead, so
it resolves to ../benchmark_runs — a sibling of the clone and of every
pool worktree, which restores datagen reuse across checkouts and keeps
large artifacts out of the repo. The directory name is unchanged, so the
existing corpus and every BENCHBOX_OUTPUT_DIR-based UAT flow keep
working.

The work tree is discovered by walking parents in pure Python for an
existing .git entry, accepting both forms — a directory in a clone and a
file in a linked worktree. No git subprocess: this runs during benchmark
construction and must not depend on git being installed.

Outside a work tree the historical Path.cwd() anchor is kept, so
installed-package users see no change. Resolution precedence is
untouched: explicit --output > BENCHBOX_OUTPUT_DIR > default.

The 11 assertion sites that pinned the literal Path.cwd()/"benchmark_runs"
shape now assert against the resolved root, so they express the
relationship rather than one machine's layout. The UAT artifact-hygiene
guardrail no longer exempts runs with no configured external root, since
the default is now external too; its LOC row in the UAT spec is
regenerated mechanically by the drift guard.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01FweRvfL9Mq25NrCcLRNjRH


## Code review record

Five-axis review run on the diff before opening; both findings were my own and are fixed.

| Severity | Finding | Resolution |
|---|---|---|
| Required | `find_work_tree_root(Path("."))` silently returned `None` — `Path(".").parents` is empty, so a relative `start` never walked real parents. Not hit by current callers (both pass absolute paths), but a trap for the next one. | **Fixed.** `start` is now `.resolve()`d. `Path.cwd()` is already physical on POSIX, so behaviour for existing callers is byte-identical. Verified `find_work_tree_root(Path("."))` now returns the work tree. |
| Required | The anchor logic (`work_tree.parent / "benchmark_runs"`) was duplicated between `resolve_benchmark_runs_dir()` and the UAT hygiene helper — exactly the drift that lets a guardrail and the runtime disagree. | **Fixed.** Extracted `default_benchmark_runs_root()` as the single source of truth; both callers defer to it. |
| Nit | `_default_runs_root` now walks parents twice (once to test for a work tree, once inside the shared helper). | **Accepted deliberately.** Removing it would mean re-inlining the anchor and reintroducing the drift risk above. This is test-support code called once per run, ~6 `stat` calls. |

No nits were skipped.

## Verification

Full ladder from the work order, **re-run end-to-end on the final code** after the review fixes:

1. `pytest tests/unit/utils/test_path_utils.py` — 48 passed
2. The 8 files that previously pinned the cwd default — 327 passed, 5 skipped
3. Untouched static guard `test_benchmark_output_root_guard.py` — 3 passed
4. Resolved root is the work-tree sibling and lies outside it — `ok /Users/joe/Developer/benchmark_runs`
5. Same answer from a nested subdirectory (cwd-independence) — `ok /Users/joe/Developer/benchmark_runs`
6. Fast lane — 25,625 passed, 15 skipped

Also green: `make lint`, `lint-markers`, `lint-imports`, `make typecheck`. Fast-lane collect 25,640 vs the 26,050 cap (410 headroom), so no policy bump needed.

## Scope note

`_project/specs/uat-framework.md` is outside this item's only-modify allowlist, but the `uat-loc-table` pre-commit drift guard **blocks the commit** until it is regenerated. The included change is purely numeric (`artifact_hygiene.py` 282 → 309 LOC; total 10,261 → 10,288) — a mechanical derivative of the in-scope code change, not independent work.

That file's prose still describes the hygiene guard as applying only "when an external output root is configured", which this PR makes inaccurate. Rewriting those descriptions is deferred rather than smuggled into an out-of-scope file.
