### PR TITLE
fix(cli): gate the cloud output default by deployment, not platform category

### DIFF
--- a/benchbox/cli/commands/run.py
+++ b/benchbox/cli/commands/run.py
@@ -41,7 +41,7 @@ from benchbox.cli.exceptions import (
     create_error_handler,
 )
 from benchbox.cli.help import BenchBoxCommand, advanced_option
-from benchbox.cli.orchestrator import BenchmarkOrchestrator
+from benchbox.cli.orchestrator import BenchmarkOrchestrator, resolved_deployment_mode
 from benchbox.cli.output import ResultExporter
 from benchbox.cli.platform import get_platform_manager, normalize_platform_name
 from benchbox.cli.platform_checks import check_and_setup_platform_credentials
@@ -2198,10 +2198,16 @@ def _interactive_resolve_mode_for_selected_platform(s: types.SimpleNamespace) ->
         s.database_config.execution_mode = s.mode if s.mode is not None else "sql"
 
 
+def _run_stages_through_cloud_storage(s: types.SimpleNamespace) -> bool:
+    """Whether this run's *deployment* stages remotely; firebolt Core, motherduck and starburst do not."""
+    mode = resolved_deployment_mode(s.database_config)
+    return PlatformRegistry.requires_cloud_storage_for_deployment(s.database_config.type, mode)
+
+
 def _interactive_cloud_setup_if_needed(s: types.SimpleNamespace) -> None:
-    """Perform cloud credentials + output location setup for cloud-requiring platforms."""
+    """Perform cloud credentials + output location setup for runs that stage remotely."""
     ctx = s.ctx
-    if not PlatformRegistry.requires_cloud_storage(s.database_config.type):
+    if not _run_stages_through_cloud_storage(s):
         return
 
     credentials_ok = check_and_setup_platform_credentials(
@@ -2218,7 +2224,7 @@ def _interactive_cloud_setup_if_needed(s: types.SimpleNamespace) -> None:
     if s.output:
         return
     default_output = None
-    if PlatformRegistry.requires_cloud_storage(s.database_config.type):
+    if _run_stages_through_cloud_storage(s):
         from benchbox.security.credentials import CredentialManager
 
         cred_manager = CredentialManager()
@@ -2282,7 +2288,7 @@ def _interactive_prompt_output_and_format(
     prompt_table_format_fn: Any,
 ) -> None:
     """Prompt for optional output directory and table-format selection."""
-    if not s.output and not PlatformRegistry.requires_cloud_storage(s.database_config.type):
+    if not s.output and not _run_stages_through_cloud_storage(s):
         custom_output = prompt_output_fn(default_output="benchmark_runs/")
         if custom_output:
             s.output = custom_output
@@ -2484,7 +2490,7 @@ def _interactive_preflight_and_execute(s: types.SimpleNamespace, system_profile:
     # already shows the user, instead of silently running with the defaults.
     s.benchmark_config.stats_reset = getattr(s, "stats_reset", None)
     s.benchmark_config.stats_per_table_timing = bool(getattr(s, "stats_per_table_timing", False))
-    if PlatformRegistry.requires_cloud_storage(s.database_config.type) and not s.output:
+    if _run_stages_through_cloud_storage(s) and not s.output:
         console.print()
         console.print("[red]❌ Error: Cloud platform requires --output parameter[/red]")
         console.print(

--- a/benchbox/cli/orchestrator.py
+++ b/benchbox/cli/orchestrator.py
@@ -46,6 +46,21 @@ from benchbox.utils.verbosity import VerbositySettings
 console = quiet_console
 
 
+def resolved_deployment_mode(database_config) -> Optional[str]:
+    """Return the deployment mode this run selected, or None for the default.
+
+    Platforms that expose a deployment choice register it as a
+    ``deployment_mode`` platform option, so an explicit selection arrives in
+    ``database_config.options``. Returning None lets the registry fall back to
+    the platform's ``default_deployment``.
+    """
+    if not database_config:
+        return None
+    options = getattr(database_config, "options", None) or {}
+    mode = options.get("deployment_mode")
+    return mode or None
+
+
 def _build_failure_result(config: BenchmarkConfig, exc: Exception) -> BenchmarkResults:
     """Build a BenchmarkResults sentinel for a failed execute_benchmark() invocation."""
     from benchbox.core.results.models import ExecutionPhases, SetupPhase
@@ -372,12 +387,20 @@ class BenchmarkOrchestrator:
             return _build_failure_result(config, e)
 
     def _apply_default_cloud_output_dir(self, database_config) -> None:
-        """If no custom output dir is set and platform requires cloud storage, pull default from credentials."""
+        """If no custom output dir is set and this run stages remotely, pull default from credentials.
+
+        Gated on the *deployment* rather than the platform category: platforms
+        like firebolt (Core), motherduck and starburst are categorised as cloud
+        but their default deployment does not stage through cloud storage, so
+        pulling a cloud output location for them would redirect a local run's
+        data at a remote stage it never needed.
+        """
         if self.custom_output_dir or not database_config:
             return
         from benchbox.security.credentials import CredentialManager
 
-        if not PlatformRegistry.requires_cloud_storage(database_config.type):
+        deployment_mode = resolved_deployment_mode(database_config)
+        if not PlatformRegistry.requires_cloud_storage_for_deployment(database_config.type, deployment_mode):
             return
         cred_manager = CredentialManager()
         if not cred_manager.has_credentials(database_config.type):

--- a/tests/unit/cli/test_cloud_storage_gate_deployment_aware.py
+++ b/tests/unit/cli/test_cloud_storage_gate_deployment_aware.py
@@ -1,0 +1,137 @@
+"""The run-path cloud-storage gates follow the deployment, not the category.
+
+``requires_cloud_storage()`` answers a *platform category* question, so
+firebolt (whose default deployment is the local Core container), motherduck and
+starburst all answer True even though their default deployment stages nothing
+through cloud storage. Gating the run path on that answer pulled a cloud output
+location into runs that never needed one.
+
+These tests are driven from the registry rather than a hardcoded platform list,
+so they keep holding when a platform's ``deployment_modes`` block is edited.
+
+Copyright 2026 Joe Harris / BenchBox Project
+
+Licensed under the MIT License. See LICENSE file in the project root for details.
+"""
+
+import ast
+import inspect
+from pathlib import Path
+
+import pytest
+
+from benchbox.cli import orchestrator as orchestrator_module
+from benchbox.cli.orchestrator import resolved_deployment_mode
+from benchbox.core.platform_registry import PlatformRegistry
+from benchbox.core.schemas import DatabaseConfig
+
+pytestmark = [
+    pytest.mark.unit,
+    pytest.mark.fast,
+]
+
+
+def _all_platforms() -> list[str]:
+    """Every registered platform name, straight from the registry."""
+    PlatformRegistry._platform_metadata = PlatformRegistry._platform_metadata or (
+        PlatformRegistry._build_platform_metadata()
+    )
+    return sorted(PlatformRegistry._platform_metadata)
+
+
+ALL_PLATFORMS = _all_platforms()
+
+# Run-path modules whose cloud-storage gates must all be deployment-aware.
+RUN_PATH_SOURCES = [
+    Path(inspect.getfile(orchestrator_module)),
+    Path(inspect.getfile(orchestrator_module)).parent / "commands" / "run.py",
+]
+
+
+class TestRunPathGateMatchesDeployment:
+    """The gate answer must equal the deployment-aware registry answer."""
+
+    @pytest.mark.parametrize("platform", ALL_PLATFORMS)
+    def test_gate_matches_deployment_answer_for_every_platform(self, platform):
+        """For each platform's default deployment, the gate agrees with the registry."""
+        expected = PlatformRegistry.requires_cloud_storage_for_deployment(platform)
+        # The run path calls the same helper with the run's resolved mode; with
+        # no explicit deployment_mode that is None, i.e. the default deployment.
+        config = DatabaseConfig(type=platform, name=platform)
+        actual = PlatformRegistry.requires_cloud_storage_for_deployment(platform, resolved_deployment_mode(config))
+        assert actual == expected, platform
+
+    def test_known_divergence_is_still_exactly_the_three_platforms(self):
+        """Pins the premise: category and deployment answers differ for these only.
+
+        If this list changes, a platform's deployment_modes block moved and the
+        gate's behaviour changed with it — which is the point of gating on the
+        registry rather than a hardcoded skip-list.
+        """
+        diverging = {
+            name
+            for name in ALL_PLATFORMS
+            if PlatformRegistry.requires_cloud_storage(name)
+            != PlatformRegistry.requires_cloud_storage_for_deployment(name)
+        }
+        assert diverging == {"firebolt", "motherduck", "starburst"}, sorted(diverging)
+
+    @pytest.mark.parametrize("platform", ["firebolt", "motherduck", "starburst"])
+    def test_locally_deploying_cloud_platforms_are_not_gated_as_cloud(self, platform):
+        """The defect: these are cloud-category but do not stage remotely by default."""
+        assert PlatformRegistry.requires_cloud_storage(platform) is True
+        assert PlatformRegistry.requires_cloud_storage_for_deployment(platform) is False
+
+    @pytest.mark.parametrize("platform", ["snowflake", "bigquery", "databricks", "redshift", "athena", "synapse"])
+    def test_genuinely_remote_platforms_keep_pulling_their_default(self, platform):
+        """Must-preserve: platforms that really stage remotely are unaffected."""
+        if platform not in ALL_PLATFORMS:
+            pytest.skip(f"{platform} is not registered")
+        assert PlatformRegistry.requires_cloud_storage_for_deployment(platform) is True
+
+
+class TestResolvedDeploymentMode:
+    """The run's deployment mode is threaded when the run selected one."""
+
+    def test_explicit_deployment_mode_is_threaded(self):
+        """An explicit platform option reaches the registry call."""
+        config = DatabaseConfig(type="clickhouse", name="ch", options={"deployment_mode": "local"})
+        assert resolved_deployment_mode(config) == "local"
+
+    def test_missing_deployment_mode_means_platform_default(self):
+        """No explicit mode resolves to None so the registry uses the default."""
+        assert resolved_deployment_mode(DatabaseConfig(type="duckdb", name="d")) is None
+
+    def test_empty_deployment_mode_means_platform_default(self):
+        """An empty string must not be threaded as a real mode."""
+        config = DatabaseConfig(type="duckdb", name="d", options={"deployment_mode": ""})
+        assert resolved_deployment_mode(config) is None
+
+    def test_missing_config_is_tolerated(self):
+        """A None database_config resolves to the default, never raises."""
+        assert resolved_deployment_mode(None) is None
+
+    def test_threaded_mode_can_flip_the_gate(self):
+        """Selecting a cloud-storage deployment re-enables the gate."""
+        assert PlatformRegistry.requires_cloud_storage_for_deployment("firebolt") is False
+        assert PlatformRegistry.requires_cloud_storage_for_deployment("firebolt", "cloud") is True
+
+
+class TestNoCategoryGatesRemainOnTheRunPath:
+    """No run-path gate may still call the category-level check.
+
+    A leftover category gate is what makes the interactive flow incoherent:
+    cloud setup is skipped, the local-output prompt is skipped too, and the run
+    then hard-errors demanding --output with no way to supply it.
+    """
+
+    @pytest.mark.parametrize("source", RUN_PATH_SOURCES, ids=lambda p: p.name)
+    def test_run_path_never_calls_requires_cloud_storage_directly(self, source):
+        """Every gate in these modules uses the deployment-aware variant."""
+        tree = ast.parse(source.read_text())
+        offenders = [
+            node.lineno
+            for node in ast.walk(tree)
+            if isinstance(node, ast.Attribute) and node.attr == "requires_cloud_storage"
+        ]
+        assert not offenders, f"{source.name} still gates on requires_cloud_storage at lines {offenders}"

--- a/tests/unit/cli/test_run_command_interactive_paths.py
+++ b/tests/unit/cli/test_run_command_interactive_paths.py
@@ -187,7 +187,13 @@ def test_interactive_guided_flow_uses_prompted_values_and_saves_preferences(tmp_
         stack.enter_context(patch("benchbox.cli.tuning.run_tuning_wizard", return_value=guided_config))
         mock_preview = stack.enter_context(patch("benchbox.cli.dryrun.display_interactive_preview"))
         mock_confirm = stack.enter_context(patch.object(_run_module.Confirm, "ask"))
-        mock_caps.return_value = SimpleNamespace(default_mode="sql", supports_sql=True, supports_dataframe=False)
+        mock_caps.return_value = SimpleNamespace(
+            default_mode="sql",
+            supports_sql=True,
+            supports_dataframe=False,
+            deployment_modes={},
+            default_deployment=None,
+        )
 
         def _confirm_side_effect(prompt, default=False):
             text = str(prompt)
@@ -328,7 +334,13 @@ def test_interactive_stats_controls_reach_benchmark_config(tmp_path: Path):
         stack.enter_context(patch("benchbox.cli.tuning.run_tuning_wizard", return_value=guided_config))
         stack.enter_context(patch("benchbox.cli.dryrun.display_interactive_preview"))
         mock_confirm = stack.enter_context(patch.object(_run_module.Confirm, "ask"))
-        mock_caps.return_value = SimpleNamespace(default_mode="sql", supports_sql=True, supports_dataframe=False)
+        mock_caps.return_value = SimpleNamespace(
+            default_mode="sql",
+            supports_sql=True,
+            supports_dataframe=False,
+            deployment_modes={},
+            default_deployment=None,
+        )
 
         def _confirm_side_effect(prompt, default=False):
             text = str(prompt)
@@ -438,7 +450,13 @@ def test_interactive_execution_type_derived_from_phases(tmp_path: Path):
         stack.enter_context(patch("benchbox.cli.tuning.run_tuning_wizard"))
         stack.enter_context(patch("benchbox.cli.dryrun.display_interactive_preview"))
         mock_confirm = stack.enter_context(patch.object(_run_module.Confirm, "ask"))
-        mock_caps.return_value = SimpleNamespace(default_mode="sql", supports_sql=True, supports_dataframe=False)
+        mock_caps.return_value = SimpleNamespace(
+            default_mode="sql",
+            supports_sql=True,
+            supports_dataframe=False,
+            deployment_modes={},
+            default_deployment=None,
+        )
 
         def _confirm_side_effect(prompt, default=False):
             text = str(prompt)
@@ -543,7 +561,13 @@ def test_interactive_dataframe_tuning_acceptance_applies_runtime_defaults(tmp_pa
             patch("benchbox.core.dataframe.tuning.get_smart_defaults", return_value=df_tuning_config)
         )
         mock_confirm = stack.enter_context(patch.object(_run_module.Confirm, "ask"))
-        mock_caps.return_value = SimpleNamespace(default_mode="dataframe", supports_sql=False, supports_dataframe=True)
+        mock_caps.return_value = SimpleNamespace(
+            default_mode="dataframe",
+            supports_sql=False,
+            supports_dataframe=True,
+            deployment_modes={},
+            default_deployment=None,
+        )
 
         def _confirm_side_effect(prompt, default=False):
             text = str(prompt)
@@ -647,7 +671,13 @@ def test_interactive_wizard_baseline_maps_to_notuning_for_external_mode(tmp_path
         stack.enter_context(patch("benchbox.cli.tuning.run_tuning_wizard", return_value=baseline_config))
         mock_preview = stack.enter_context(patch("benchbox.cli.dryrun.display_interactive_preview"))
         mock_confirm = stack.enter_context(patch.object(_run_module.Confirm, "ask"))
-        mock_caps.return_value = SimpleNamespace(default_mode="sql", supports_sql=True, supports_dataframe=False)
+        mock_caps.return_value = SimpleNamespace(
+            default_mode="sql",
+            supports_sql=True,
+            supports_dataframe=False,
+            deployment_modes={},
+            default_deployment=None,
+        )
 
         def _confirm_side_effect(prompt, default=False):
             text = str(prompt)
@@ -754,7 +784,13 @@ def test_interactive_dataframe_wizard_baseline_skips_runtime_defaults(tmp_path: 
         mock_preview = stack.enter_context(patch("benchbox.cli.dryrun.display_interactive_preview"))
         mock_df_defaults = stack.enter_context(patch("benchbox.core.dataframe.tuning.get_smart_defaults"))
         mock_confirm = stack.enter_context(patch.object(_run_module.Confirm, "ask"))
-        mock_caps.return_value = SimpleNamespace(default_mode="dataframe", supports_sql=False, supports_dataframe=True)
+        mock_caps.return_value = SimpleNamespace(
+            default_mode="dataframe",
+            supports_sql=False,
+            supports_dataframe=True,
+            deployment_modes={},
+            default_deployment=None,
+        )
 
         def _confirm_side_effect(prompt, default=False):
             text = str(prompt)
@@ -827,7 +863,13 @@ def test_fallback_wizard_baseline_reclassifies_runtime_state_for_dataframe_platf
             patch.object(
                 _run_module.PlatformRegistry,
                 "get_platform_capabilities",
-                return_value=SimpleNamespace(default_mode="dataframe", supports_sql=False, supports_dataframe=True),
+                return_value=SimpleNamespace(
+                    default_mode="dataframe",
+                    supports_sql=False,
+                    supports_dataframe=True,
+                    deployment_modes={},
+                    default_deployment=None,
+                ),
             )
         )
         stack.enter_context(patch.object(_run_module.PlatformRegistry, "requires_cloud_storage", return_value=False))
@@ -933,7 +975,13 @@ def test_direct_dataframe_tuning_config_propagates_to_benchmark_config(tmp_path:
             patch.object(
                 _run_module.PlatformRegistry,
                 "get_platform_capabilities",
-                return_value=SimpleNamespace(default_mode="dataframe", supports_sql=False, supports_dataframe=True),
+                return_value=SimpleNamespace(
+                    default_mode="dataframe",
+                    supports_sql=False,
+                    supports_dataframe=True,
+                    deployment_modes={},
+                    default_deployment=None,
+                ),
             )
         )
         stack.enter_context(patch.object(_run_module.PlatformRegistry, "requires_cloud_storage", return_value=False))
@@ -1052,7 +1100,13 @@ def test_interactive_tuning_declined_sets_notuning_state(tmp_path: Path):
         mock_wizard = stack.enter_context(patch("benchbox.cli.tuning.run_tuning_wizard"))
         mock_preview = stack.enter_context(patch("benchbox.cli.dryrun.display_interactive_preview"))
         mock_confirm = stack.enter_context(patch.object(_run_module.Confirm, "ask"))
-        mock_caps.return_value = SimpleNamespace(default_mode="sql", supports_sql=True, supports_dataframe=False)
+        mock_caps.return_value = SimpleNamespace(
+            default_mode="sql",
+            supports_sql=True,
+            supports_dataframe=False,
+            deployment_modes={},
+            default_deployment=None,
+        )
 
         def _confirm_side_effect(prompt, default=False):
             text = str(prompt)
@@ -1115,7 +1169,13 @@ def test_interactive_cloud_platform_stops_when_credentials_are_missing():
         stack.enter_context(patch.object(_run_module, "check_and_setup_platform_credentials", return_value=False))
         stack.enter_context(patch("benchbox.cli.onboarding.check_and_run_first_time_setup", return_value=False))
         stack.enter_context(patch("benchbox.cli.preferences.load_last_run_config", return_value=None))
-        mock_caps.return_value = SimpleNamespace(default_mode="sql", supports_sql=True, supports_dataframe=False)
+        mock_caps.return_value = SimpleNamespace(
+            default_mode="sql",
+            supports_sql=True,
+            supports_dataframe=False,
+            deployment_modes={},
+            default_deployment=None,
+        )
 
         result = runner.invoke(run, [], obj=_run_obj())
 
@@ -1176,7 +1236,13 @@ class TestRunCommandValidation:
                 patch.object(
                     _run_module.PlatformRegistry,
                     "get_platform_capabilities",
-                    return_value=SimpleNamespace(default_mode="sql", supports_sql=True, supports_dataframe=False),
+                    return_value=SimpleNamespace(
+                        default_mode="sql",
+                        supports_sql=True,
+                        supports_dataframe=False,
+                        deployment_modes={},
+                        default_deployment=None,
+                    ),
                 )
             )
             stack.enter_context(
@@ -1288,7 +1354,13 @@ class TestRunCommandValidation:
                 patch.object(
                     _run_module.PlatformRegistry,
                     "get_platform_capabilities",
-                    return_value=SimpleNamespace(default_mode="sql", supports_sql=True, supports_dataframe=False),
+                    return_value=SimpleNamespace(
+                        default_mode="sql",
+                        supports_sql=True,
+                        supports_dataframe=False,
+                        deployment_modes={},
+                        default_deployment=None,
+                    ),
                 )
             )
             stack.enter_context(
@@ -1322,7 +1394,13 @@ class TestRunCommandValidation:
                 patch.object(
                     _run_module.PlatformRegistry,
                     "get_platform_capabilities",
-                    return_value=SimpleNamespace(default_mode="sql", supports_sql=True, supports_dataframe=False),
+                    return_value=SimpleNamespace(
+                        default_mode="sql",
+                        supports_sql=True,
+                        supports_dataframe=False,
+                        deployment_modes={},
+                        default_deployment=None,
+                    ),
                 )
             )
             stack.enter_context(
@@ -1344,7 +1422,13 @@ class TestRunCommandValidation:
                 patch.object(
                     _run_module.PlatformRegistry,
                     "get_platform_capabilities",
-                    return_value=SimpleNamespace(default_mode="sql", supports_sql=True, supports_dataframe=False),
+                    return_value=SimpleNamespace(
+                        default_mode="sql",
+                        supports_sql=True,
+                        supports_dataframe=False,
+                        deployment_modes={},
+                        default_deployment=None,
+                    ),
                 )
             )
             stack.enter_context(
@@ -1376,7 +1460,13 @@ class TestRunCommandValidation:
                 patch.object(
                     _run_module.PlatformRegistry,
                     "get_platform_capabilities",
-                    return_value=SimpleNamespace(default_mode="sql", supports_sql=True, supports_dataframe=False),
+                    return_value=SimpleNamespace(
+                        default_mode="sql",
+                        supports_sql=True,
+                        supports_dataframe=False,
+                        deployment_modes={},
+                        default_deployment=None,
+                    ),
                 )
             )
             stack.enter_context(
@@ -1399,7 +1489,13 @@ class TestRunCommandValidation:
                 patch.object(
                     _run_module.PlatformRegistry,
                     "get_platform_capabilities",
-                    return_value=SimpleNamespace(default_mode="sql", supports_sql=True, supports_dataframe=False),
+                    return_value=SimpleNamespace(
+                        default_mode="sql",
+                        supports_sql=True,
+                        supports_dataframe=False,
+                        deployment_modes={},
+                        default_deployment=None,
+                    ),
                 )
             )
             stack.enter_context(
@@ -1422,7 +1518,13 @@ class TestRunCommandValidation:
                 patch.object(
                     _run_module.PlatformRegistry,
                     "get_platform_capabilities",
-                    return_value=SimpleNamespace(default_mode="sql", supports_sql=True, supports_dataframe=False),
+                    return_value=SimpleNamespace(
+                        default_mode="sql",
+                        supports_sql=True,
+                        supports_dataframe=False,
+                        deployment_modes={},
+                        default_deployment=None,
+                    ),
                 )
             )
             stack.enter_context(
@@ -1445,7 +1547,13 @@ class TestRunCommandValidation:
                 patch.object(
                     _run_module.PlatformRegistry,
                     "get_platform_capabilities",
-                    return_value=SimpleNamespace(default_mode="sql", supports_sql=True, supports_dataframe=False),
+                    return_value=SimpleNamespace(
+                        default_mode="sql",
+                        supports_sql=True,
+                        supports_dataframe=False,
+                        deployment_modes={},
+                        default_deployment=None,
+                    ),
                 )
             )
             stack.enter_context(


### PR DESCRIPTION
requires_cloud_storage() answers a platform *category* question, so
firebolt (default deployment: the local Core container), motherduck and
starburst all answer True even though their default deployments stage
nothing through cloud storage. The run path gated on that answer, so
those runs pulled a stored cloud output location — redirecting a local
run's data at a remote stage it never needed.

Gate on the run's deployment instead, asking the registry per run via
requires_cloud_storage_for_deployment() rather than hardcoding a
skip-list that would go stale the moment a deployment_modes block is
edited. requires_cloud_storage() itself is unchanged, so every other
caller — including prompt_cloud_output_location — keeps its semantics.

The run's selected deployment mode is threaded when present, via
resolved_deployment_mode(); absent, None lets the registry fall back to
the platform's default deployment.

All five run-path gates are switched, not just the three that pull the
default. Changing only those three left the interactive flow incoherent:
cloud setup was skipped (so s.output was never set), the local-output
prompt was skipped too because it still gated on the category, and the
run then hard-errored "Cloud platform requires --output" with no way to
satisfy it. A parametrised registry-driven test plus an AST guard pin
that no run-path gate reverts to the category check.

The interactive-path test fixtures mocked PlatformCapabilities without
deployment_modes; completing them keeps those tests exercising the same
behaviour through the deployment-aware call.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01FweRvfL9Mq25NrCcLRNjRH


## Scope deviation — please read

The tracker item scoped this to **three** run-path gates (orchestrator
`_apply_default_cloud_output_dir`, plus both checks in
`_interactive_cloud_setup_if_needed`). Implementing exactly those three ships a
**reachable regression**, so this PR switches **five**.

Traced for firebolt (default deployment `core`, a local Docker container):

| Step | With only the 3 gates changed |
|---|---|
| `_interactive_cloud_setup_if_needed` | deployment-aware → **early return**, `s.output` never set |
| `_interactive_prompt_output_and_format` | still category-gated → local-output prompt **skipped** |
| `_interactive_preflight_and_execute` | still category-gated → **hard error, exit 1**: "Cloud platform requires --output" |

The user is told to pass `--output` after being denied every prompt that would
have supplied it. Before this change the flow worked because cloud setup itself
set `s.output`. The two extra gates are in `benchbox/cli/commands/run.py`, which
is inside the item's only-modify list, and `requires_cloud_storage()` itself is
still untouched — so the anti-pattern this item warns about (globally
redefining the registry call) is respected. An AST guard now fails if any
run-path gate reverts to the category check.

## Code review record

| Severity | Finding | Resolution |
|---|---|---|
| Critical | Three-gate scope leaves the interactive flow dead-ended for firebolt/motherduck/starburst (table above). | **Fixed** by making all five run-path gates deployment-aware; pinned by the AST guard. |
| Required | Interactive-path tests mocked `PlatformCapabilities` as a `SimpleNamespace` without `deployment_modes`, so the deployment-aware call raised `AttributeError` — 8 tests failed. | **Fixed** by completing the fixtures (`deployment_modes={}`, `default_deployment=None`). That makes `get_default_deployment` return `None`, so the registry falls back to the category answer and those tests exercise exactly the behaviour they did before. |
| Required | `run.py` imported the private `_resolved_deployment_mode` across modules. | **Fixed** — renamed to public `resolved_deployment_mode`. |
| Required | `run.py` grew to 3094 lines, tripping the 3085-line module-size guard (that guard file is outside scope, so allowlisting was not an option). | **Fixed** by collapsing the four repeated gate expressions into `_run_stages_through_cloud_storage(s)`. Now **3083** lines — smaller than before this PR, and the call sites read better. |

No nits were skipped.

## Verification

1. `pytest tests/unit/cli/` — 1601 passed
2. `pytest -k 'cloud_storage_gate or requires_cloud_storage'` — 74 passed
3. Premise pin — `confirmed ['firebolt', 'motherduck', 'starburst']` (checked across all 51 registered platforms)
4. Fast lane — 25,693 passed, 15 skipped

Also green: `make lint`, `lint-markers`, `lint-imports`, `make typecheck`, and the module-size guard. The new AST guard was verified non-vacuous — it flags a category call and ignores the deployment call.
