### PR TITLE
fix(snowflake): reconcile the output-location guidance with the run path

### DIFF
--- a/benchbox/cli/config.py
+++ b/benchbox/cli/config.py
@@ -143,7 +143,10 @@ def _apply_environment_overrides(config_dict: dict[str, Any]) -> dict[str, Any]:
         "BENCHBOX_VERBOSE": ("execution", "verbose", lambda v: v.lower() in ["true", "1", "yes", "on"]),
         "BENCHBOX_MAX_WORKERS": ("execution", "max_workers", int),
         "BENCHBOX_TUNING_CONFIG": ("tuning", "default_config_file", str),
-        "BENCHBOX_OUTPUT_DIR": ("output", "directory", str),
+        # NOTE: BENCHBOX_OUTPUT_DIR is deliberately absent. It is resolved on the
+        # run path by benchbox.utils.path_utils.resolve_benchmark_runs_dir(), not
+        # through this config object. Mapping it to a config key nothing reads
+        # made the setting look authoritative while having no effect.
         "BENCHBOX_MEMORY_LIMIT_GB": ("execution", "memory_limit_gb", int),
     }
 
@@ -251,7 +254,9 @@ class ConfigManager:
             },
             output={
                 "formats": ["json", "console"],
-                "directory": "./benchmark_runs/results",
+                # No "directory" key: the results root is resolved at run time
+                # from BENCHBOX_OUTPUT_DIR / the work-tree-anchored default, so a
+                # config default here would be dead and misleading.
                 "timestamp_format": "%Y%m%d_%H%M%S",
                 "submit_to_service": False,
                 "service_url": "https://api.benchbox.dev/v1",

--- a/benchbox/core/platform_registry.py
+++ b/benchbox/core/platform_registry.py
@@ -99,6 +99,14 @@ _PLATFORM_SUPPORT_STATUS: dict[str, SupportStatus] = {
     "clickhouse": "deprecated",
 }
 
+# The output location the Snowflake credential prompt advertises as its
+# default. It lives next to get_cloud_path_examples() — and is the first entry
+# of the snowflake example list — so the prompt and the documented examples
+# cannot drift apart again. Any value here must stay acceptable to
+# benchbox.utils.cloud_storage.is_cloud_path, which is the classifier the run
+# path uses; a test pins that agreement.
+SNOWFLAKE_DEFAULT_OUTPUT_LOCATION = "@~/benchbox"
+
 _NATIVE_IMPORT_ERROR_MARKERS = (
     "dlopen",
     "dylib",
@@ -763,6 +771,9 @@ class PlatformRegistry:
                 "gs://my-bucket/benchbox/data",
             ],
             "snowflake": [
+                # User stage first: it is what the credential prompt defaults to
+                # and needs no cloud-storage setup.
+                SNOWFLAKE_DEFAULT_OUTPUT_LOCATION,
                 "s3://my-bucket/benchbox/data",
                 "azure://my-container/benchbox/data",
                 "gcs://my-bucket/benchbox/data",

--- a/benchbox/platforms/credentials/snowflake.py
+++ b/benchbox/platforms/credentials/snowflake.py
@@ -177,6 +177,7 @@ def _prompt_default_output_location(
         console: Rich console for output
         credentials: Current credentials dictionary
     """
+    from benchbox.core.platform_registry import SNOWFLAKE_DEFAULT_OUTPUT_LOCATION, PlatformRegistry
     from benchbox.utils.cloud_storage import is_cloud_path
 
     console.print("\n[bold]Default Output Location (Optional):[/bold]")
@@ -189,32 +190,35 @@ def _prompt_default_output_location(
         console.print("[dim]You can add --output <cloud-path> when running benchmarks[/dim]\n")
         return
 
-    # Show examples - user stage first (simpler, no setup required)
-    console.print("\n[bold cyan]Recommended: User Stage (easiest)[/bold cyan]")
-    console.print("  • [dim]@~/benchbox[/dim] (your private user stage)")
-    console.print("  • [dim]@~/data[/dim]")
-    console.print("  • [dim]@~/staged[/dim]")
-    console.print("\n[dim]User stages (@~) are private to your account and require no setup[/dim]")
+    # Examples come from the registry so this prompt and the documented
+    # examples cannot drift apart; stage forms sort first (no setup required).
+    examples = PlatformRegistry.get_cloud_path_examples("snowflake")
+    stage_examples = [e for e in examples if e.startswith("@")]
+    external_examples = [e for e in examples if not e.startswith("@")]
 
-    console.print("\n[bold cyan]Alternative: External Stage Locations[/bold cyan]")
-    console.print("  • [dim]s3://my-bucket/benchbox-data[/dim]")
-    console.print("  • [dim]azure://container/benchbox-data[/dim]")
-    console.print("  • [dim]gcs://my-bucket/benchbox-data[/dim]")
-    console.print("\n[dim]Note: External stages require cloud storage setup[/dim]\n")
+    if stage_examples:
+        console.print("\n[bold cyan]Recommended: User Stage (easiest)[/bold cyan]")
+        for example in stage_examples:
+            console.print(f"  • [dim]{example}[/dim]")
+        console.print("\n[dim]User stages (@~) are private to your account and require no setup[/dim]")
+
+    if external_examples:
+        console.print("\n[bold cyan]Alternative: External Stage Locations[/bold cyan]")
+        for example in external_examples:
+            console.print(f"  • [dim]{example}[/dim]")
+        console.print("\n[dim]Note: External stages require cloud storage setup[/dim]\n")
 
     # Prompt for path with validation - suggest user stage as default
     while True:
-        cloud_path = Prompt.ask("[bold]Enter default storage path[/bold]", default="@~/benchbox")
+        cloud_path = Prompt.ask("[bold]Enter default storage path[/bold]", default=SNOWFLAKE_DEFAULT_OUTPUT_LOCATION)
 
         if not cloud_path:
             console.print("[yellow]Skipping default output location[/yellow]\n")
             return
 
-        # Validate path format - accept Snowflake user stages (@~) or cloud paths
-        is_user_stage = cloud_path.startswith("@~")
-        is_valid_cloud = is_cloud_path(cloud_path)
-
-        if not is_user_stage and not is_valid_cloud:
+        # Validate with the SAME classifier the run path uses, so anything this
+        # prompt accepts is guaranteed to resolve as a remote location later.
+        if not is_cloud_path(cloud_path):
             console.print(f"[yellow]⚠️  Warning: '{cloud_path}' doesn't look like a valid path[/yellow]")
             console.print(
                 "[dim]Expected formats: @~/path (user stage) or s3://, azure://, gcs:// (external stage)[/dim]"

--- a/tests/unit/platforms/credentials/test_snowflake_defaults.py
+++ b/tests/unit/platforms/credentials/test_snowflake_defaults.py
@@ -604,7 +604,9 @@ class TestPromptDefaultOutputLocation:
         # wants default=True; 1st path invalid, user declines → retry; 2nd path valid, user confirms
         mock_confirm.side_effect = [True, False, True]
         mock_prompt.side_effect = ["bad-path", "@~/good"]
-        mock_is_cloud.side_effect = [False, False]  # called for bad-path only (second is @~)
+        # The prompt now validates with is_cloud_path alone; that classifier
+        # accepts stage paths directly, so '@~/good' is valid on the retry.
+        mock_is_cloud.side_effect = [False, True]
 
         creds = {"account": "acct"}
         _prompt_default_output_location(mgr, console, creds)

--- a/tests/unit/platforms/test_snowflake_output_location_agreement.py
+++ b/tests/unit/platforms/test_snowflake_output_location_agreement.py
@@ -1,0 +1,156 @@
+"""The Snowflake output-location sources must agree with the run-path classifier.
+
+The credential prompt advertised ``@~/benchbox`` as its default while
+``get_cloud_path_examples("snowflake")`` listed only ``s3://``/``azure://``/
+``gcs://``. A user who accepted the advertised default therefore stored a value
+the documented examples never mentioned — and, before the stage-classification
+fix, one the run path treated as a *local relative directory*.
+
+These tests pin the agreement between the three sources so they cannot drift
+apart again: the prompt's default, the registry's examples, and
+``is_cloud_path`` (the classifier the run path actually gates on).
+
+Copyright 2026 Joe Harris / BenchBox Project
+
+Licensed under the MIT License. See LICENSE file in the project root for details.
+"""
+
+import inspect
+from pathlib import Path
+
+import pytest
+
+from benchbox.core.platform_registry import SNOWFLAKE_DEFAULT_OUTPUT_LOCATION, PlatformRegistry
+from benchbox.utils.cloud_storage import create_path_handler, is_cloud_path
+
+pytestmark = [
+    pytest.mark.unit,
+    pytest.mark.fast,
+]
+
+
+SNOWFLAKE_EXAMPLES = PlatformRegistry.get_cloud_path_examples("snowflake")
+
+
+class TestPromptDefaultIsAcceptedByTheRunPath:
+    """Whatever the prompt suggests must survive the run path's classifier."""
+
+    def test_prompt_default_classifies_as_cloud(self):
+        """The advertised default must not resolve to a local directory."""
+        assert is_cloud_path(SNOWFLAKE_DEFAULT_OUTPUT_LOCATION)
+
+    def test_prompt_default_never_becomes_a_relative_local_path(self):
+        """The spill mode: a relative handler would write under cwd."""
+        handler = create_path_handler(SNOWFLAKE_DEFAULT_OUTPUT_LOCATION)
+        assert not (isinstance(handler, Path) and not handler.is_absolute()), handler
+
+    def test_prompt_default_is_offered_as_a_registry_example(self):
+        """The two sources name the same value, not merely compatible ones."""
+        assert SNOWFLAKE_DEFAULT_OUTPUT_LOCATION in SNOWFLAKE_EXAMPLES
+
+    def test_prompt_default_is_listed_first(self):
+        """User stage leads, matching the prompt's 'Recommended' framing."""
+        assert SNOWFLAKE_EXAMPLES[0] == SNOWFLAKE_DEFAULT_OUTPUT_LOCATION
+
+
+class TestRegistryExamplesAreAllUsable:
+    """Every documented example must be accepted by the same classifier."""
+
+    @pytest.mark.parametrize("example", SNOWFLAKE_EXAMPLES)
+    def test_every_snowflake_example_classifies_as_cloud(self, example):
+        """An example the run path would treat as local is a documentation bug."""
+        assert is_cloud_path(example), example
+
+    @pytest.mark.parametrize("example", SNOWFLAKE_EXAMPLES)
+    def test_no_example_resolves_to_a_relative_local_path(self, example):
+        """No advertised value may put generated data under the cwd.
+
+        ``azure://`` and ``gcs://`` are accepted by ``is_cloud_path`` but raise
+        in ``create_path_handler`` because cloudpathlib only knows ``az://`` /
+        ``gs://`` / ``s3://``. That alias gap is a pre-existing defect tracked
+        separately (it predates this batch and spans abfss:// too); it is still
+        a *remote* classification, which is what this test is about, so the
+        raise is tolerated here rather than silently asserted away.
+        """
+        try:
+            handler = create_path_handler(example)
+        except ValueError as exc:
+            assert "Invalid cloud path format" in str(exc), exc
+            return
+        assert not (isinstance(handler, Path) and not handler.is_absolute()), (example, handler)
+
+    def test_examples_still_cover_external_stages(self):
+        """Must-preserve: external stage URIs remain valid output locations."""
+        schemes = {e.split("://")[0] for e in SNOWFLAKE_EXAMPLES if "://" in e}
+        assert {"s3", "azure", "gcs"} <= schemes, schemes
+
+
+class TestPromptUsesTheSharedSources:
+    """The prompt must derive from the registry rather than duplicating it."""
+
+    def _prompt_source(self) -> str:
+        from benchbox.platforms.credentials import snowflake as snowflake_credentials
+
+        return inspect.getsource(snowflake_credentials._prompt_default_output_location)
+
+    def test_prompt_defaults_to_the_shared_constant(self):
+        """A duplicated literal is what let the two sides drift apart."""
+        source = self._prompt_source()
+        assert "SNOWFLAKE_DEFAULT_OUTPUT_LOCATION" in source
+        assert 'default="@~/benchbox"' not in source
+
+    def test_prompt_renders_examples_from_the_registry(self):
+        """Example bullets come from get_cloud_path_examples, not hardcoded text."""
+        source = self._prompt_source()
+        assert 'get_cloud_path_examples("snowflake")' in source
+
+    def test_prompt_validates_with_the_run_path_classifier(self):
+        """The old startswith('@~') check was narrower than is_cloud_path.
+
+        It rejected named, table and qualified stage forms that the run path
+        accepts, so the prompt could refuse a value the run path would honour.
+        """
+        source = self._prompt_source()
+        assert "is_cloud_path(" in source
+        assert 'startswith("@~")' not in source
+
+
+class TestOutputDirectoryConfigKeyIsGone:
+    """The dead ``output.directory`` key must not come back."""
+
+    def test_default_config_has_no_output_directory_key(self):
+        """A key nothing reads makes users believe runs go somewhere they do not."""
+        from benchbox.cli.config import ConfigManager
+
+        default_config = ConfigManager._get_default_config(ConfigManager.__new__(ConfigManager))
+        assert "directory" not in default_config.output
+
+    def test_output_dir_env_var_is_not_mapped_into_config(self):
+        """BENCHBOX_OUTPUT_DIR is resolved on the run path, not via config."""
+        from benchbox.cli import config as config_module
+
+        source = inspect.getsource(config_module)
+        assert '"BENCHBOX_OUTPUT_DIR": ("output", "directory", str)' not in source
+
+    def test_legacy_config_containing_the_key_still_loads(self, tmp_path):
+        """Must-preserve: an older config file must not raise after removal."""
+        import yaml
+
+        from benchbox.cli.config import ConfigManager
+
+        config_path = tmp_path / "config.yaml"
+        config_path.write_text(
+            yaml.safe_dump(
+                {
+                    "output": {"formats": ["json"], "directory": "./benchmark_runs/results"},
+                    "database": {"preferred": "duckdb"},
+                }
+            )
+        )
+
+        manager = ConfigManager(config_path=config_path)
+
+        # Loaded without raising, and the unknown key is carried through rather
+        # than dropped, so nothing a user wrote is silently discarded.
+        assert manager.config.output["directory"] == "./benchmark_runs/results"
+        assert manager.config.database["preferred"] == "duckdb"


### PR DESCRIPTION
The credential prompt advertised @~/benchbox as its default and called it
the recommended option, while get_cloud_path_examples("snowflake")
listed only s3://, azure:// and gcs:// — never mentioning a stage at all.
A user who accepted the advertised default stored a value the documented
examples denied, and (before the stage-classification fix) one the run
path treated as a local relative directory.

Give the two sides one source. SNOWFLAKE_DEFAULT_OUTPUT_LOCATION lives
next to get_cloud_path_examples() and is the first entry of the snowflake
example list; the prompt now defaults to that constant and renders its
example bullets from the registry instead of hardcoding a second list.

The prompt also validated with an ad-hoc startswith("@~") check alongside
is_cloud_path. That was *narrower* than the run path's classifier — it
rejected named, table and qualified stages the run path accepts — so
validation is now is_cloud_path alone, the same call the run path gates
on. Whatever this prompt accepts is therefore guaranteed to resolve as a
remote location later.

Separately, resolve the dead output.directory config key by removing it
end-to-end: both writers (the BENCHBOX_OUTPUT_DIR env mapping and the
"./benchmark_runs/results" default) are gone, since nothing ever read it.
Wiring it into the precedence chain was not an option here — path_utils
and runtime_paths are outside this change's scope — and its repo-relative
default also contradicted the work-tree-anchored root. An older
config.yaml that still carries the key loads unchanged and keeps it.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01FweRvfL9Mq25NrCcLRNjRH


## Code review record

| Severity | Finding | Resolution |
|---|---|---|
| Required | `test_invalid_path_declined_retries_then_valid` mocked `is_cloud_path` to return **False** for `@~/good`. That only passed because of the separate `startswith("@~")` branch; with validation unified on the classifier the mock contradicted reality and the test hit `StopIteration`. | **Fixed** — the mock now returns `True` for the stage path, matching what the real classifier does since #1299, with a comment explaining why. |
| Consider | New `platforms → core` import, while `core/platform_registry.py` already imports `benchbox.platforms.base` — a cycle risk. | **Verified safe.** The import is function-level (matching the existing deferred `is_cloud_path` import), so no cycle exists at module load. Checked by importing the modules standalone and in both orders. |
| Consider | The prompt previously listed three stage examples (`@~/benchbox`, `@~/data`, `@~/staged`); the registry has one. | **Accepted.** They were variants of one form, and the item asks for *a single set* of accepted forms. The "Expected formats: `@~/path`" hint still conveys the general shape, and a test pins that the default is present and listed first, so the section can never silently disappear. |

No nits were skipped.

## Deferred finding (pre-existing, promoted)

While testing that every advertised example survives the run path, two of them **crash**:

```
is_cloud_path("azure://c/x")        -> True
create_path_handler("azure://c/x")  -> ValueError: Invalid cloud path format
```

`is_cloud_path` accepts `[s3, gs, gcs, az, abfss, azure, dbfs]`, but cloudpathlib only registers `az://`, `gs://`, `s3://` — so `azure://`, `gcs://` **and** `abfss://` classify as cloud and then raise at handler construction.

This is **pre-existing** (the scheme list predates this batch; #1299 only appended the stage predicate) and **out of scope** here: `cloud_storage.py` is do-not-modify for this item, and the must-preserve list requires `azure://`/`gcs://` to remain valid Snowflake output locations, so they cannot simply be dropped from the examples. Promoted to `cloud-path-scheme-aliases-raise-in-create-path-handler` (medium). The parametrised test tolerates the raise explicitly and documents why, rather than asserting it away.

## Verification

1. `pytest tests/unit/platforms/ -k snowflake` — 299 passed
2. `pytest -k 'snowflake and (output_location or stage)'` — 87 passed
3. `pytest tests/unit/cli/` — 1601 passed (no orphaned `output.directory` reference)
4. Fast lane — 25,712 passed, 15 skipped

Also green: `make lint`, `lint-markers`, `lint-imports`, `make typecheck`. Fast-lane collect 25,727 vs the 26,050 cap.

Must-preserves checked empirically: a legacy `~/.benchbox/config.yaml` containing `output.directory` loads without raising and keeps the key verbatim; fresh defaults no longer emit it; `BENCHBOX_OUTPUT_DIR` still drives the run path (`resolve_benchmark_runs_dir()` → `/tmp/probe-root`); external `s3://`/`azure://`/`gcs://` stage URIs remain valid; and the setup flow gained no required prompt.
