### PR TITLE
fix(cloud-storage): resolve every scheme is_cloud_path accepts

### DIFF
--- a/benchbox/utils/cloud_storage.py
+++ b/benchbox/utils/cloud_storage.py
@@ -419,6 +419,48 @@ def is_cloud_path(path: Union[str, Path]) -> bool:
     return is_snowflake_stage_path(path)
 
 
+# cloudpathlib registers only az://, gs://, s3:// (plus http/https). BenchBox
+# documents two aliases for those, so they are normalised at the hand-off to
+# cloudpathlib rather than by widening what is_cloud_path accepts.
+_CLOUD_SCHEME_ALIASES = {"gcs": "gs", "azure": "az"}
+
+
+def _normalize_cloud_scheme(path: str) -> str:
+    """Rewrite a documented scheme alias to the one cloudpathlib registers.
+
+    ``gcs://bucket/p`` and ``azure://container/p`` are spelling variants of
+    ``gs://`` and ``az://`` — same bucket/container, same credentials — so the
+    rewrite is lossless. Anything else is returned unchanged.
+    """
+    scheme, separator, rest = path.partition("://")
+    if separator and scheme.lower() in _CLOUD_SCHEME_ALIASES:
+        return f"{_CLOUD_SCHEME_ALIASES[scheme.lower()]}://{rest}"
+    return path
+
+
+def is_adls_path(path: Union[str, Path]) -> bool:
+    """Check if a path is an Azure Data Lake Storage Gen2 URI (``abfss://``).
+
+    These encode the storage account in the authority
+    (``abfss://container@account.dfs.core.windows.net/path``), which
+    cloudpathlib's ``az://container/path`` form cannot represent, so they are
+    staged locally rather than rewritten.
+
+    Args:
+        path: Path to check
+
+    Returns:
+        True if path uses the abfss:// scheme
+    """
+    if isinstance(path, Path):
+        path = str(path)
+
+    if not isinstance(path, str):
+        return False
+
+    return urlparse(path).scheme == "abfss"
+
+
 def is_databricks_path(path: Union[str, Path]) -> bool:
     """Check if a path is a Databricks DBFS or UC Volume path.
 
@@ -522,6 +564,24 @@ def create_path_handler(path: Union[str, Path]) -> Union[Path, CloudPath, Databr
 
         return staging_path
 
+    # Handle abfss:// specially - the URI encodes the storage account, which
+    # cloudpathlib's az:// form cannot carry, so rewriting one would silently
+    # point at whatever account the credentials happen to name. Stage locally
+    # and keep the URI for the adapter, exactly as dbfs:// and stages do. This
+    # also matches what the orchestrator already does with an abfss --output.
+    if is_adls_path(path):
+        path_str = str(path)
+
+        import tempfile
+
+        temp_dir_str = tempfile.mkdtemp(prefix="benchbox_abfss_")
+        staging_path = CloudStagingPath(temp_dir_str, path_str)
+
+        logger.info(f"Created temporary directory for ADLS path: {staging_path}")
+        logger.debug(f"Target ADLS URI: {path_str}")
+
+        return staging_path
+
     if not is_cloud_path(path):
         return Path(path)
 
@@ -529,8 +589,9 @@ def create_path_handler(path: Union[str, Path]) -> Union[Path, CloudPath, Databr
     if cloud_path_cls is None:
         raise ImportError(f"cloudpathlib is required for cloud storage paths. {get_install_command('cloudstorage')}")
 
+    normalized = _normalize_cloud_scheme(str(path))
     try:
-        return cloud_path_cls(str(path))
+        return cloud_path_cls(normalized)
     except Exception as e:
         raise ValueError(f"Invalid cloud path format '{path}': {e}") from e
 
@@ -651,9 +712,22 @@ def validate_cloud_credentials(path: Union[str, Path]) -> dict[str, Any]:
                 "env_vars": expected_vars,
             }
 
-    # Try to create a cloud path to test credentials
+    # abfss:// cannot be opened by cloudpathlib at all (the account lives in the
+    # authority), so probing it here would surface a prefix error dressed up as
+    # a credential failure. The env-var check above is the validation we can do;
+    # the Azure adapter validates the rest.
+    if is_adls_path(path):
+        return {
+            "valid": True,
+            "provider": provider,
+            "error": None,
+            "env_vars": expected_vars,
+        }
+
+    # Try to create a cloud path to test credentials. Scheme aliases are
+    # normalised first for the same reason as in create_path_handler.
     try:
-        cloud_path = cloud_path_cls(str(path))
+        cloud_path = cloud_path_cls(_normalize_cloud_scheme(str(path)))
         # Test basic operations
         _ = cloud_path.exists()
         return {

--- a/tests/unit/platforms/test_snowflake_output_location_agreement.py
+++ b/tests/unit/platforms/test_snowflake_output_location_agreement.py
@@ -65,18 +65,12 @@ class TestRegistryExamplesAreAllUsable:
     def test_no_example_resolves_to_a_relative_local_path(self, example):
         """No advertised value may put generated data under the cwd.
 
-        ``azure://`` and ``gcs://`` are accepted by ``is_cloud_path`` but raise
-        in ``create_path_handler`` because cloudpathlib only knows ``az://`` /
-        ``gs://`` / ``s3://``. That alias gap is a pre-existing defect tracked
-        separately (it predates this batch and spans abfss:// too); it is still
-        a *remote* classification, which is what this test is about, so the
-        raise is tolerated here rather than silently asserted away.
+        The ``azure://`` and ``gcs://`` examples used to raise here, because
+        cloudpathlib only registers ``az://`` / ``gs://`` / ``s3://``. The
+        scheme aliases are now normalised at the hand-off, so every advertised
+        example resolves and the raise no longer needs tolerating.
         """
-        try:
-            handler = create_path_handler(example)
-        except ValueError as exc:
-            assert "Invalid cloud path format" in str(exc), exc
-            return
+        handler = create_path_handler(example)
         assert not (isinstance(handler, Path) and not handler.is_absolute()), (example, handler)
 
     def test_examples_still_cover_external_stages(self):

--- a/tests/unit/utils/test_cloud_storage_scheme_aliases.py
+++ b/tests/unit/utils/test_cloud_storage_scheme_aliases.py
@@ -1,0 +1,213 @@
+"""Every scheme is_cloud_path accepts must produce a usable handler.
+
+``is_cloud_path`` accepted ``[s3, gs, gcs, az, abfss, azure, dbfs]``, but
+cloudpathlib only registers ``az://``, ``gs://`` and ``s3://``. So ``gcs://``,
+``azure://`` and ``abfss://`` classified as cloud and then raised
+``ValueError: Invalid cloud path format`` at handler construction — any caller
+that classifies first and constructs second accepted a path and then blew up.
+
+``gcs``/``azure`` are spelling aliases and are rewritten losslessly.
+``abfss`` is not: it encodes the storage account in the authority, which the
+``az://container/path`` form cannot carry, so it is staged locally like
+``dbfs://`` and Snowflake stages instead of being silently remapped.
+
+Copyright 2026 Joe Harris / BenchBox Project
+
+Licensed under the MIT License. See LICENSE file in the project root for details.
+"""
+
+from pathlib import Path
+
+import pytest
+
+from benchbox.utils.cloud_storage import (
+    CloudStagingPath,
+    create_path_handler,
+    get_cloud_path_info,
+    is_adls_path,
+    is_cloud_path,
+    validate_cloud_credentials,
+)
+
+pytestmark = [
+    pytest.mark.unit,
+    pytest.mark.fast,
+]
+
+
+# Every scheme is_cloud_path() accepts, with a representative path.
+ALL_ACCEPTED_SCHEMES = [
+    "s3://bucket/prefix",
+    "gs://bucket/prefix",
+    "gcs://bucket/prefix",
+    "az://container/prefix",
+    "azure://container/prefix",
+    "abfss://container@account.dfs.core.windows.net/prefix",
+    "dbfs:/Volumes/catalog/schema/volume",
+]
+
+ALIAS_EQUIVALENTS = [
+    ("gcs://bucket/a/b", "gs://bucket/a/b"),
+    ("azure://container/a/b", "az://container/a/b"),
+]
+
+
+class TestEveryAcceptedSchemeResolves:
+    """The core invariant: classify-then-construct must never raise."""
+
+    @pytest.mark.parametrize("path", ALL_ACCEPTED_SCHEMES)
+    def test_accepted_scheme_produces_a_handler(self, path):
+        """A scheme is_cloud_path accepts must not blow up in the handler."""
+        assert is_cloud_path(path), path
+        handler = create_path_handler(path)
+        assert handler is not None
+
+    @pytest.mark.parametrize("path", ALL_ACCEPTED_SCHEMES)
+    def test_accepted_scheme_never_yields_a_relative_local_path(self, path):
+        """A relative handler would write generated data under the cwd."""
+        handler = create_path_handler(path)
+        assert not (isinstance(handler, Path) and not handler.is_absolute()), handler
+
+
+class TestSchemeAliasesAreLossless:
+    """gcs:// and azure:// are spellings of gs:// and az://."""
+
+    @pytest.mark.parametrize(("alias", "canonical"), ALIAS_EQUIVALENTS)
+    def test_alias_resolves_to_the_same_handler_as_the_canonical_scheme(self, alias, canonical):
+        """Same class and same rendered path — nothing is dropped."""
+        alias_handler = create_path_handler(alias)
+        canonical_handler = create_path_handler(canonical)
+        assert type(alias_handler) is type(canonical_handler)
+        assert str(alias_handler) == str(canonical_handler)
+
+    @pytest.mark.parametrize(("alias", "canonical"), ALIAS_EQUIVALENTS)
+    def test_alias_preserves_container_and_key(self, alias, canonical):
+        """The bucket/container and key survive the rewrite."""
+        assert str(create_path_handler(alias)).endswith("/a/b")
+
+    def test_uppercase_alias_scheme_is_normalised(self):
+        """Scheme comparison is case-insensitive, as URI schemes are."""
+        assert str(create_path_handler("GCS://bucket/a")) == str(create_path_handler("gs://bucket/a"))
+
+    def test_alias_rewrite_does_not_touch_other_schemes(self):
+        """s3:// and friends pass through untouched."""
+        assert str(create_path_handler("s3://bucket/a")) == "s3://bucket/a"
+
+    def test_alias_inside_a_path_is_not_rewritten(self):
+        """Only a leading scheme is rewritten, not the word appearing later."""
+        handler = create_path_handler("s3://bucket/azure://nested")
+        assert "azure://nested" in str(handler)
+
+    def test_get_cloud_path_info_still_reports_the_original_provider(self):
+        """The rewrite is confined to the cloudpathlib hand-off.
+
+        Provider identity is consumed elsewhere (azure_synapse checks it), so
+        normalising it here would change behaviour well outside this fix.
+        """
+        assert get_cloud_path_info("gcs://bucket/p")["provider"] == "gcs"
+        assert get_cloud_path_info("azure://container/p")["provider"] == "azure"
+
+
+class TestAdlsPathsStageLocally:
+    """abfss:// encodes an account that az:// cannot represent."""
+
+    def test_is_adls_path_matches_only_abfss(self):
+        """The predicate is scheme-exact."""
+        assert is_adls_path("abfss://c@a.dfs.core.windows.net/p")
+        assert not is_adls_path("az://c/p")
+        assert not is_adls_path("s3://b/p")
+        assert not is_adls_path("/local/abfss")
+        assert not is_adls_path(None)
+
+    def test_abfss_stages_locally_and_keeps_the_full_uri(self):
+        """The account-bearing URI must survive verbatim for the adapter."""
+        uri = "abfss://container@account.dfs.core.windows.net/path/to/data"
+        handler = create_path_handler(uri)
+        assert isinstance(handler, CloudStagingPath)
+        assert handler.cloud_target == uri
+        assert Path(str(handler)).is_absolute()
+
+    def test_abfss_is_not_remapped_to_an_azure_blob_path(self):
+        """Remapping would silently retarget whatever account the creds name."""
+        handler = create_path_handler("abfss://container@account.dfs.core.windows.net/p")
+        assert "account.dfs.core.windows.net" in handler.cloud_target
+        assert not str(handler).startswith("az://")
+
+    def test_abfss_creates_no_directory_in_cwd(self, tmp_path, monkeypatch):
+        """Staging must not spill into the current working directory."""
+        monkeypatch.chdir(tmp_path)
+        create_path_handler("abfss://c@a.dfs.core.windows.net/p")
+        assert list(tmp_path.iterdir()) == []
+
+
+class TestCredentialValidationHandlesAliases:
+    """validate_cloud_credentials builds a CloudPath too — same alias trap.
+
+    Its construction is guarded by a broad ``except Exception`` that reports
+    every failure as a credential problem, so an unnormalised alias surfaced a
+    scheme error dressed up as "Cloud path validation failed". That path is only
+    reached once credentials are actually configured, which is exactly the
+    real-user case.
+    """
+
+    @pytest.mark.parametrize(("alias", "canonical"), ALIAS_EQUIVALENTS)
+    def test_alias_validates_identically_to_the_canonical_scheme(self, alias, canonical, monkeypatch):
+        """Same verdict and same error class, not a prefix complaint."""
+        for var in ("AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY", "GOOGLE_APPLICATION_CREDENTIALS"):
+            monkeypatch.setenv(var, "dummy")
+        monkeypatch.setenv("AZURE_STORAGE_ACCOUNT_NAME", "acct")
+        monkeypatch.setenv("AZURE_STORAGE_ACCOUNT_KEY", "key")
+
+        alias_result = validate_cloud_credentials(alias)
+        canonical_result = validate_cloud_credentials(canonical)
+
+        assert alias_result["valid"] == canonical_result["valid"]
+        assert "does not begin with a known prefix" not in str(alias_result["error"])
+
+    def test_adls_is_not_probed_with_cloudpathlib(self, monkeypatch):
+        """abfss:// cannot be opened, so probing it would fake a cred failure."""
+        monkeypatch.setenv("AZURE_STORAGE_ACCOUNT_NAME", "acct")
+        monkeypatch.setenv("AZURE_STORAGE_ACCOUNT_KEY", "key")
+
+        result = validate_cloud_credentials("abfss://c@a.dfs.core.windows.net/p")
+
+        assert result["valid"] is True
+        assert result["error"] is None
+
+    def test_adls_still_reports_missing_azure_env_vars(self, monkeypatch):
+        """Skipping the probe must not skip the env-var check."""
+        monkeypatch.delenv("AZURE_STORAGE_ACCOUNT_NAME", raising=False)
+        monkeypatch.delenv("AZURE_STORAGE_ACCOUNT_KEY", raising=False)
+
+        result = validate_cloud_credentials("abfss://c@a.dfs.core.windows.net/p")
+
+        assert result["valid"] is False
+        assert "AZURE_STORAGE_ACCOUNT_NAME" in result["error"]
+
+
+class TestExistingBehaviourUnchanged:
+    """The schemes that already worked must keep working identically."""
+
+    def test_dbfs_still_returns_a_databricks_path(self):
+        """dbfs:// keeps its DatabricksPath temp-dir behaviour."""
+        from benchbox.utils.cloud_storage import DatabricksPath
+
+        handler = create_path_handler("dbfs:/Volumes/c/s/v")
+        assert isinstance(handler, DatabricksPath)
+        assert handler.dbfs_target == "dbfs:/Volumes/c/s/v"
+
+    def test_snowflake_stage_still_returns_a_staging_path(self):
+        """Stage paths are unaffected by the alias work."""
+        handler = create_path_handler("@~/benchbox")
+        assert isinstance(handler, CloudStagingPath)
+        assert handler.cloud_target == "@~/benchbox"
+
+    def test_local_paths_are_untouched(self):
+        """Local paths still return plain Path objects."""
+        assert create_path_handler("/local/path") == Path("/local/path")
+        assert create_path_handler("./rel") == Path("./rel")
+
+    def test_unknown_scheme_still_classifies_as_local(self):
+        """The accepted-scheme list is not widened by this change."""
+        assert not is_cloud_path("ftp://host/path")
+        assert create_path_handler("ftp://host/path") == Path("ftp://host/path")


### PR DESCRIPTION
is_cloud_path accepted [s3, gs, gcs, az, abfss, azure, dbfs], but
cloudpathlib registers only az://, gs:// and s3://. So gcs://, azure://
and abfss:// classified as cloud and then raised "Invalid cloud path
format" at handler construction — any caller that classifies first and
constructs second accepted a path and then blew up on it.

gcs:// and azure:// are spelling variants of gs:// and az:// — same
bucket/container, same credentials — so they are rewritten losslessly at
the hand-off to cloudpathlib. The rewrite is confined to that hand-off:
get_cloud_path_info still reports the original scheme as the provider,
because provider identity is consumed elsewhere (azure_synapse gates on
it) and normalising it there would change behaviour outside this fix.

abfss:// is not an alias. It encodes the storage account in the
authority (abfss://container@account.dfs.core.windows.net/path), which
cloudpathlib's az://container/path form cannot carry, so rewriting one
would silently retarget whatever account the credentials happen to name.
It is staged locally instead, carrying the URI for the adapter — exactly
what dbfs:// and Snowflake stages already do, and what the orchestrator
already does with an abfss --output.

validate_cloud_credentials builds a CloudPath too, behind a broad
except Exception that reports every failure as a credential problem, so
the same aliases surfaced a scheme error dressed up as "Cloud path
validation failed". That path is only reached once credentials are
actually configured — the real-user case — so it is fixed here as well:
aliases are normalised, and abfss keeps its env-var check but is not
probed with a client that cannot open it.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01FweRvfL9Mq25NrCcLRNjRH


## Scope note

This TODO was created by `promote`, which carries only title/priority/worktree/
description — so it has **no scope globs, no verification ladder and no work
units**, and those fields are create-time-only. Scope was self-policed to
`benchbox/utils/cloud_storage.py` plus its tests; `todo check-scope` passes
trivially rather than meaningfully.

## Code review record

| Severity | Finding | Resolution |
|---|---|---|
| Required | The fix initially covered only `create_path_handler`. `validate_cloud_credentials` constructs a `CloudPath` too (`cloud_storage.py:717`), behind a broad `except Exception` that labels every failure a credential problem — so `gcs://`/`azure://` would report "Cloud path validation failed: … does not begin with a known prefix". Reached only once credentials are configured, i.e. the real-user case. | **Fixed** — aliases normalised there too, and `abfss://` returns after its env-var check instead of being probed with a client that cannot open it. Verified: with credentials set, `gcs://` now returns the *same* verdict and error class as `gs://`, and `azure://` the same as `az://`. |
| Required | `test_no_example_resolves_to_a_relative_local_path` (added in #1302) carried a `try/except ValueError` tolerating this exact raise, plus a docstring calling it a tracked pre-existing defect. Both became dead/stale the moment this fix landed. | **Fixed** — tolerance removed, docstring updated to record that the aliases are now normalised. |

No nits were skipped.

## Deliberate non-changes

- **`get_cloud_path_info` still reports the original scheme as `provider`.** `azure_synapse.py:93` gates on `provider in ("az", "abfs", "abfss")`, so normalising provider identity would change platform behaviour well outside this fix. The rewrite is confined to the cloudpathlib hand-off.
- **`abfss://` is not remapped to `az://`.** The account in the authority cannot be represented in `az://container/path`; remapping would silently retarget whatever account the credentials name. Pinned by `test_abfss_is_not_remapped_to_an_azure_blob_path`.
- **The accepted-scheme list is not widened.** `ftp://` still classifies as local. (Noted in passing: `azure_synapse` accepts a provider `"abfs"` that `is_cloud_path` never produces — a separate latent inconsistency, not touched here.)

## Verification

- `pytest tests/unit/utils/test_cloud_storage_scheme_aliases.py` — 34 passed (new)
- `pytest tests/unit/utils/ tests/unit/platforms/` — 9223 passed
- Fast lane — 25,746 passed, 15 skipped
- `make lint`, `lint-markers`, `lint-imports`, `make typecheck` — green
- Fast-lane collect 25,757 vs the 26,050 cap

Behaviour table after the fix — every accepted scheme resolves, nothing raises:

| Path | `is_cloud_path` | handler |
|---|---|---|
| `s3://b/x` | True | `S3Path` |
| `az://c/x` / `azure://c/x` | True | `AzureBlobPath` (identical) |
| `gs://b/x` / `gcs://b/x` | True | `GSPath` (identical) |
| `abfss://c@a.dfs.core.windows.net/x` | True | `CloudStagingPath` (URI preserved) |
| `dbfs:/Volumes/c/s/v` | True | `DatabricksPath` |
| `@~/benchbox` | True | `CloudStagingPath` |
| `/local/p`, `./rel` | False | `PosixPath` |
