### PR TITLE
fix(cloud-storage): keep cloud_target when re-wrapping a CloudStagingPath

### DIFF
--- a/benchbox/utils/cloud_storage.py
+++ b/benchbox/utils/cloud_storage.py
@@ -245,6 +245,25 @@ class CloudStagingPath:
         """Get path components."""
         return self._path.parts
 
+    @property
+    def suffix(self) -> str:
+        """Get the final component's suffix."""
+        return self._path.suffix
+
+    def joinpath(self, *other: Union[str, Path]) -> Path:
+        """Join path components - returns a regular Path, like ``__truediv__``.
+
+        Required for parity with the plain ``Path`` that callers used to
+        receive: the runner joins ``_datagen_manifest.json`` onto the output
+        dir, and one call site skips manifest validation entirely when the
+        object has no ``joinpath``.
+        """
+        return self._path.joinpath(*other)
+
+    def stat(self, *, follow_symlinks: bool = True):
+        """Stat the local path."""
+        return self._path.stat(follow_symlinks=follow_symlinks)
+
     def as_posix(self) -> str:
         """Return the path as a POSIX string."""
         return self._path.as_posix()
@@ -516,6 +535,13 @@ def create_path_handler(path: Union[str, Path]) -> Union[Path, CloudPath, Databr
     """
     # If already a DatabricksPath instance, return as-is (avoids double-wrapping)
     if isinstance(path, DatabricksPath):
+        return path
+
+    # Same for CloudStagingPath. Without this it fell through to the local
+    # branch and was rebuilt as a plain Path of the staging directory, silently
+    # discarding cloud_target — so a handler that had been carrying its upload
+    # destination stopped doing so the moment it was re-wrapped.
+    if isinstance(path, CloudStagingPath):
         return path
 
     # If already a CloudPath instance, return as-is (avoids double-wrapping)

--- a/tests/unit/utils/test_cloud_staging_path_rewrap.py
+++ b/tests/unit/utils/test_cloud_staging_path_rewrap.py
@@ -1,0 +1,130 @@
+"""A CloudStagingPath must survive being handed back to create_path_handler.
+
+``create_path_handler`` passes ``DatabricksPath`` through explicitly to avoid
+double-wrapping, but had no equivalent guard for ``CloudStagingPath``. One fell
+through to the local branch and was rebuilt as a plain ``Path`` of the staging
+directory, silently discarding ``cloud_target`` — so a handler that had been
+carrying its upload destination stopped doing so the moment anything re-wrapped
+it (the benchmark ``output_dir`` setter does exactly that).
+
+Copyright 2026 Joe Harris / BenchBox Project
+
+Licensed under the MIT License. See LICENSE file in the project root for details.
+"""
+
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from benchbox.utils.cloud_storage import (
+    CloudStagingPath,
+    DatabricksPath,
+    create_path_handler,
+)
+
+pytestmark = [
+    pytest.mark.unit,
+    pytest.mark.fast,
+]
+
+
+# Remote targets that reach CloudStagingPath through the orchestrator.
+REMOTE_TARGETS = [
+    "s3://bucket/benchbox",
+    "gs://bucket/benchbox",
+    "az://container/benchbox",
+    "abfss://container@account.dfs.core.windows.net/benchbox",
+    "@~/benchbox",
+]
+
+
+class TestRewrapPreservesCloudTarget:
+    """The defect: re-wrapping dropped the upload destination."""
+
+    @pytest.mark.parametrize("target", REMOTE_TARGETS)
+    def test_rewrap_returns_the_same_object(self, target):
+        """Pass-through, matching the DatabricksPath guard."""
+        staging = CloudStagingPath("/tmp/cache", target)
+        assert create_path_handler(staging) is staging
+
+    @pytest.mark.parametrize("target", REMOTE_TARGETS)
+    def test_rewrap_keeps_cloud_target(self, target):
+        """The upload destination must survive the round trip."""
+        staging = CloudStagingPath("/tmp/cache", target)
+        assert create_path_handler(staging).cloud_target == target
+
+    def test_rewrap_is_idempotent(self):
+        """Repeated wrapping must not degrade or re-allocate."""
+        staging = CloudStagingPath("/tmp/cache", "s3://bucket/p")
+        assert create_path_handler(create_path_handler(staging)) is staging
+
+    def test_rewrap_does_not_downgrade_to_a_plain_path(self):
+        """The old behaviour returned PosixPath('/tmp/cache')."""
+        staging = CloudStagingPath("/tmp/cache", "s3://bucket/p")
+        result = create_path_handler(staging)
+        assert not isinstance(result, Path)
+        assert isinstance(result, CloudStagingPath)
+
+    def test_databricks_passthrough_is_unchanged(self):
+        """The behaviour this fix mirrors must keep working."""
+        databricks = DatabricksPath("/tmp/cache", "dbfs:/Volumes/c/s/v")
+        assert create_path_handler(databricks) is databricks
+
+
+class TestStagingPathIsAFaithfulPathProxy:
+    """Consumers that used to get a plain Path must keep working.
+
+    The full set of attributes the codebase reads off ``output_dir`` is
+    exists / glob / is_dir / joinpath / mkdir / parent / resolve / stat /
+    suffix. Everything there must exist on CloudStagingPath now that one can
+    reach those consumers directly.
+    """
+
+    REQUIRED_ATTRS = ["exists", "glob", "is_dir", "joinpath", "mkdir", "parent", "resolve", "stat", "suffix"]
+
+    @pytest.mark.parametrize("attr", REQUIRED_ATTRS)
+    def test_required_attribute_is_present(self, attr):
+        """A missing attribute is an AttributeError in the runner."""
+        assert hasattr(CloudStagingPath("/tmp/cache", "s3://b/p"), attr), attr
+
+    def test_joinpath_matches_the_local_path(self):
+        """The runner joins the datagen manifest onto output_dir."""
+        staging = CloudStagingPath("/tmp/cache", "s3://b/p")
+        assert staging.joinpath("_datagen_manifest.json") == Path("/tmp/cache/_datagen_manifest.json")
+
+    def test_joinpath_accepts_multiple_components(self):
+        """Parity with Path.joinpath's varargs signature."""
+        staging = CloudStagingPath("/tmp/cache", "s3://b/p")
+        assert staging.joinpath("a", "b") == Path("/tmp/cache/a/b")
+
+    def test_joinpath_agrees_with_truediv(self):
+        """Two spellings of the same operation must not diverge."""
+        staging = CloudStagingPath("/tmp/cache", "s3://b/p")
+        assert staging.joinpath("x") == staging / "x"
+
+    def test_manifest_validation_is_not_silently_skipped(self):
+        """runner.py guards on hasattr(output_dir, 'joinpath').
+
+        Without joinpath the guard short-circuits and manifest validation is
+        skipped without a word — a silent loss of checking, not a crash.
+        """
+        assert hasattr(CloudStagingPath("/tmp/cache", "s3://b/p"), "joinpath")
+
+    def test_stat_reads_the_local_directory(self):
+        """Disk-space probing calls stat() on the output dir."""
+        with tempfile.TemporaryDirectory() as tmp:
+            staging = CloudStagingPath(tmp, "s3://b/p")
+            assert staging.stat().st_mode == Path(tmp).stat().st_mode
+
+    def test_suffix_matches_the_local_path(self):
+        """suffix is read off output_dir in the compare command."""
+        assert CloudStagingPath("/tmp/a/b.parquet", "s3://b/p").suffix == ".parquet"
+
+    def test_local_delegation_still_works_after_rewrap(self):
+        """A re-wrapped handler is still usable for filesystem work."""
+        with tempfile.TemporaryDirectory() as tmp:
+            staging = create_path_handler(CloudStagingPath(Path(tmp) / "out", "s3://b/p"))
+            staging.mkdir()
+            assert staging.exists()
+            assert staging.is_dir()


### PR DESCRIPTION
create_path_handler passes a DatabricksPath through explicitly to avoid
double-wrapping, but had no equivalent guard for CloudStagingPath. One
fell through to the local branch and was rebuilt as a plain Path of the
staging directory, silently discarding cloud_target — so a handler that
had been carrying its upload destination stopped doing so the moment
anything re-wrapped it, which the benchmark output_dir setter does on
every assignment.

Adding the pass-through alone would have been a regression: the object
callers now receive is a CloudStagingPath rather than a Path, and the
runner joins the datagen manifest onto output_dir. CloudStagingPath had
no joinpath, so runner.py would have raised AttributeError in one place
and, worse, silently skipped manifest validation in another that guards
with hasattr(output_dir, "joinpath").

So the delegation surface is completed first. The attributes the codebase
actually reads off output_dir are exists, glob, is_dir, joinpath, mkdir,
parent, resolve, stat and suffix; joinpath, stat and suffix were missing
and are added, delegating to the local path and returning a plain Path
from joinpath exactly as __truediv__ already does.

DatabricksPath is left alone: it has the same gap, but it passes through
today, so closing it there would flip that hasattr guard from skip to run
for Databricks and change what those runs validate. That needs its own
verification, tracked separately.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01FweRvfL9Mq25NrCcLRNjRH


## Scope note

Created by `promote`, so this item has **no scope globs, verification ladder or
work units** (those fields are create-time-only). Scope self-policed to
`benchbox/utils/cloud_storage.py` plus its tests.

## Code review record

| Severity | Finding | Resolution |
|---|---|---|
| Critical | The pass-through alone is a **regression**. Callers would start receiving a `CloudStagingPath` where they got a `Path`, and `runner.py` joins the datagen manifest onto `output_dir`. `CloudStagingPath` had no `joinpath`, so `runner.py:181` would raise `AttributeError` — and `runner.py:1323` guards with `hasattr(output_dir, "joinpath")` and returns `{}`, so manifest validation would be **silently skipped** rather than failing loudly. | **Fixed** — completed the delegation surface first. Audited every attribute the codebase reads off `output_dir` (`exists glob is_dir joinpath mkdir parent resolve stat suffix`); `joinpath`, `stat`, `suffix` were missing and are added. |
| Consider | `DatabricksPath` has the identical gap and *already* passes through, so `runner.py:1323` silently skips manifest validation for Databricks runs today, and `runner.py:181` looks like a latent `AttributeError`. | **Deliberately not fixed here.** Closing it flips that guard from skip→run for Databricks, changing what those runs validate — a behavioural change needing its own verification. Tracked separately (see below). |

No nits were skipped.

## Evidence the pass-through is safe

`CloudStagingPath` and `DatabricksPath` have **identical** public API surfaces apart from their target property:

```
shared: as_posix exists glob is_dir is_file iterdir mkdir name parent parts resolve
only:   cloud_target / dbfs_target
```

`DatabricksPath` already flows through these call sites, so the parity argument holds — but parity alone was not enough, because `CloudStagingPath` is far more reachable (every s3/gs/az/abfss/stage run, not just Databricks). Hence the attribute audit above rather than relying on parity.

## A pre-existing crash found while verifying (not from this change)

Running `pytest tests/unit/utils/ tests/unit/core/runner/ tests/unit/cli/` together aborts a worker with `Fatal Python error: gilstate_tss_set: failed to set current tstate (TSS)` and cascades into spurious failures. Confirmed **pre-existing and unrelated**: with all changes stashed it reproduces on a clean tree and takes down a *different, random* set of tests each run, while every affected file passes in isolation. The fast lane is unaffected. Logged separately.

## Verification

- `pytest tests/unit/utils/test_cloud_staging_path_rewrap.py` — 29 passed (new)
- Fast lane — 25,775 passed, 15 skipped
- `make lint`, `lint-markers`, `make typecheck` — green
