### PR TITLE
fix(cloud-storage): complete DatabricksPath's Path proxy surface

### DIFF
--- a/benchbox/utils/cloud_storage.py
+++ b/benchbox/utils/cloud_storage.py
@@ -141,6 +141,24 @@ class DatabricksPath:
         """Return the path as a POSIX string."""
         return self._path.as_posix()
 
+    @property
+    def suffix(self) -> str:
+        """Get the final component's suffix."""
+        return self._path.suffix
+
+    def joinpath(self, *other: Union[str, Path]) -> Path:
+        """Join path components - returns a regular Path, like ``__truediv__``.
+
+        Required for parity with a plain ``Path``: the runner reaches the
+        datagen manifest through ``output_dir.joinpath(...)`` and treats an
+        object without it as an *unconfigured* output directory.
+        """
+        return self._path.joinpath(*other)
+
+    def stat(self, *, follow_symlinks: bool = True):
+        """Stat the local path."""
+        return self._path.stat(follow_symlinks=follow_symlinks)
+
     def resolve(self, strict: bool = False) -> Path:
         """Resolve to absolute path."""
         return self._path.resolve(strict=strict)

--- a/tests/unit/utils/test_databricks_path_proxy_parity.py
+++ b/tests/unit/utils/test_databricks_path_proxy_parity.py
@@ -1,0 +1,166 @@
+"""DatabricksPath must proxy a Path as completely as CloudStagingPath does.
+
+``create_path_handler`` passes a ``DatabricksPath`` straight through, so a
+Databricks run's ``benchmark.output_dir`` *is* one. It had no ``joinpath``, and
+the runner reaches the datagen manifest through ``output_dir.joinpath(...)``
+behind a ``hasattr(output_dir, "joinpath")`` guard. The result was not a crash
+but two silent wrong answers for every Databricks run:
+
+* ``_run_manifest_validation`` reported "Benchmark output directory not
+  configured; cannot validate manifest" — false, it was configured;
+* ``_read_datagen_stats_from_manifest`` returned ``{}``, so the result record
+  carried no table/row/byte counts.
+
+Copyright 2026 Joe Harris / BenchBox Project
+
+Licensed under the MIT License. See LICENSE file in the project root for details.
+"""
+
+import json
+import tempfile
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from benchbox.utils.cloud_storage import CloudStagingPath, DatabricksPath, create_path_handler
+
+pytestmark = [
+    pytest.mark.unit,
+    pytest.mark.fast,
+]
+
+
+# Every attribute the codebase reads off `output_dir`.
+OUTPUT_DIR_ATTRS = ["exists", "glob", "is_dir", "joinpath", "mkdir", "parent", "resolve", "stat", "suffix"]
+
+
+# The full TPC-H table set: manifest validation checks completeness, so a
+# partial manifest fails for a real reason unrelated to the proxy surface.
+TPCH_TABLES = ["customer", "lineitem", "nation", "orders", "part", "partsupp", "region", "supplier"]
+ROWS_PER_TABLE = 150
+BYTES_PER_TABLE = 120
+
+
+def _write_manifest(directory: Path) -> None:
+    """Write a complete v1 datagen manifest for TPC-H."""
+    tables = {}
+    for name in TPCH_TABLES:
+        data_file = directory / f"{name}.tbl"
+        data_file.write_text("x" * BYTES_PER_TABLE)
+        tables[name] = [{"path": str(data_file), "size_bytes": BYTES_PER_TABLE, "row_count": ROWS_PER_TABLE}]
+    manifest = {
+        "version": 1,
+        "benchmark": "tpch",
+        "scale_factor": 0.01,
+        "tables": tables,
+    }
+    (directory / "_datagen_manifest.json").write_text(json.dumps(manifest))
+
+
+class TestDatabricksPathProxySurface:
+    """The wrapper must not be missing attributes its consumers rely on."""
+
+    @pytest.mark.parametrize("attr", OUTPUT_DIR_ATTRS)
+    def test_required_attribute_is_present(self, attr):
+        """A missing attribute silently changes what the runner does."""
+        assert hasattr(DatabricksPath("/tmp/cache", "dbfs:/Volumes/c/s/v"), attr), attr
+
+    def test_surface_matches_cloud_staging_path(self):
+        """The two staging wrappers must not drift apart again."""
+        databricks = {m for m in dir(DatabricksPath) if not m.startswith("_")} - {"dbfs_target"}
+        staging = {m for m in dir(CloudStagingPath) if not m.startswith("_")} - {"cloud_target"}
+        assert databricks == staging
+
+    def test_joinpath_matches_the_local_path(self):
+        """The runner joins the manifest filename onto output_dir."""
+        wrapper = DatabricksPath("/tmp/cache", "dbfs:/Volumes/c/s/v")
+        assert wrapper.joinpath("_datagen_manifest.json") == Path("/tmp/cache/_datagen_manifest.json")
+
+    def test_joinpath_agrees_with_truediv(self):
+        """Two spellings of the same operation must not diverge."""
+        wrapper = DatabricksPath("/tmp/cache", "dbfs:/Volumes/c/s/v")
+        assert wrapper.joinpath("x") == wrapper / "x"
+
+    def test_joinpath_accepts_multiple_components(self):
+        """Parity with Path.joinpath's varargs signature."""
+        wrapper = DatabricksPath("/tmp/cache", "dbfs:/Volumes/c/s/v")
+        assert wrapper.joinpath("a", "b") == Path("/tmp/cache/a/b")
+
+    def test_stat_reads_the_local_directory(self):
+        """Disk-space probing calls stat() on the output dir."""
+        with tempfile.TemporaryDirectory() as tmp:
+            assert DatabricksPath(tmp, "dbfs:/x").stat().st_mode == Path(tmp).stat().st_mode
+
+    def test_suffix_matches_the_local_path(self):
+        """suffix is read off output_dir in the compare command."""
+        assert DatabricksPath("/tmp/a/b.parquet", "dbfs:/x").suffix == ".parquet"
+
+
+class TestDatabricksUploadContractUnchanged:
+    """Must-preserve: this is the local proxy surface only."""
+
+    def test_dbfs_target_is_untouched(self):
+        """The upload destination still round-trips."""
+        wrapper = DatabricksPath("/tmp/cache", "dbfs:/Volumes/c/s/v")
+        assert wrapper.dbfs_target == "dbfs:/Volumes/c/s/v"
+        assert create_path_handler(wrapper) is wrapper
+
+    def test_dbfs_scheme_still_builds_a_databricks_path(self):
+        """create_path_handler routing is unchanged."""
+        handler = create_path_handler("dbfs:/Volumes/c/s/v")
+        assert isinstance(handler, DatabricksPath)
+        assert handler.dbfs_target == "dbfs:/Volumes/c/s/v"
+
+
+class TestRunnerNoLongerMisreadsDatabricksOutput:
+    """The two behaviours the missing attribute silently changed."""
+
+    def test_datagen_stats_match_a_plain_path(self):
+        """Previously {} for Databricks; now identical to every other handler."""
+        from benchbox.core.runner.runner import _read_datagen_stats_from_manifest
+
+        with tempfile.TemporaryDirectory() as tmp:
+            directory = Path(tmp)
+            _write_manifest(directory)
+            expected = {
+                "tables_generated": len(TPCH_TABLES),
+                "total_rows": len(TPCH_TABLES) * ROWS_PER_TABLE,
+                "total_size_bytes": len(TPCH_TABLES) * BYTES_PER_TABLE,
+            }
+
+            for output_dir in (
+                directory,
+                DatabricksPath(directory, "dbfs:/Volumes/c/s/v"),
+                CloudStagingPath(directory, "s3://bucket/p"),
+            ):
+                benchmark = SimpleNamespace(output_dir=output_dir)
+                assert _read_datagen_stats_from_manifest(benchmark) == expected, type(output_dir).__name__
+
+    def test_manifest_validation_no_longer_claims_the_dir_is_unconfigured(self):
+        """The old error blamed configuration for a missing attribute."""
+        from benchbox.core.config import BenchmarkConfig
+        from benchbox.core.runner.runner import _run_manifest_validation
+
+        with tempfile.TemporaryDirectory() as tmp:
+            benchmark = SimpleNamespace(output_dir=DatabricksPath(tmp, "dbfs:/Volumes/c/s/v"))
+            result = _run_manifest_validation(benchmark, BenchmarkConfig(name="tpch", display_name="TPC-H"))
+
+            joined = " ".join(result.errors)
+            assert "output directory not configured" not in joined
+            # It now reports the real problem, naming the path it looked at.
+            assert "_datagen_manifest.json" in joined
+
+    def test_manifest_validation_passes_when_the_manifest_is_present(self):
+        """Databricks runs actually validate now, rather than short-circuiting."""
+        from benchbox.core.config import BenchmarkConfig
+        from benchbox.core.runner.runner import _run_manifest_validation
+
+        with tempfile.TemporaryDirectory() as tmp:
+            directory = Path(tmp)
+            _write_manifest(directory)
+            benchmark = SimpleNamespace(output_dir=DatabricksPath(directory, "dbfs:/Volumes/c/s/v"))
+
+            result = _run_manifest_validation(benchmark, BenchmarkConfig(name="tpch", display_name="TPC-H"))
+
+            assert result.is_valid, result.errors


### PR DESCRIPTION
create_path_handler passes a DatabricksPath straight through, so a
Databricks run's benchmark.output_dir *is* one. It had no joinpath, and
the runner reaches the datagen manifest through output_dir.joinpath(...)
behind a hasattr(output_dir, "joinpath") guard.

That produced no crash and no warning — just two wrong answers on every
Databricks run. _run_manifest_validation reported "Benchmark output
directory not configured; cannot validate manifest", blaming
configuration for a missing attribute on a directory that was configured
perfectly well. And _read_datagen_stats_from_manifest returned {}, so the
result record carried no table, row or byte counts.

Add joinpath, stat and suffix, mirroring what CloudStagingPath received
for the same reason, which also restores full surface parity between the
two staging wrappers — a test now pins that they cannot drift apart
again.

The behaviour change is that Databricks runs now really validate their
manifest instead of short-circuiting, so a run with an incomplete
manifest will start failing validation where it previously passed by
never looking. That is the point: the check was silently absent.

dbfs:// routing and upload behaviour are untouched; this is the local
staging proxy surface only.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01FweRvfL9Mq25NrCcLRNjRH


## Correction to the ticket

The TODO (written by me while fixing #1304) claimed `runner.py:181` was an
**unguarded** `output_dir.joinpath(...)` and therefore "a latent AttributeError".
That is **wrong** — it has the same `hasattr(output_dir, "joinpath")` guard at
line 173. Nothing ever crashed.

The real behaviour was worse than a crash, because it was silent. On every
Databricks run:

| Call site | Before | After |
|---|---|---|
| `_run_manifest_validation` | `is_valid=False`, error **"Benchmark output directory not configured; cannot validate manifest"** — blaming configuration for a missing attribute | Really validates; on a missing manifest reports `Manifest file not found: <actual path>` |
| `_read_datagen_stats_from_manifest` | `{}` — result record carried no table/row/byte counts | Identical stats to every other handler type |

Demonstrated with a complete TPC-H manifest — all three handler types now agree:

```
DatabricksPath    -> {'tables_generated': 8, 'total_rows': 1200, 'total_size_bytes': 960}
CloudStagingPath  -> {'tables_generated': 8, 'total_rows': 1200, 'total_size_bytes': 960}
plain Path        -> {'tables_generated': 8, 'total_rows': 1200, 'total_size_bytes': 960}
```

## Behaviour change worth knowing

Databricks runs now genuinely validate their datagen manifest instead of
short-circuiting. **A Databricks run with an incomplete manifest will start
failing validation where it previously "passed" by never looking.** That is the
intended outcome — the check was silently absent — but it can surface
pre-existing manifest gaps on the next Databricks run. `dbfs://` routing and
upload behaviour are untouched.

## Code review record

| Severity | Finding | Resolution |
|---|---|---|
| Required | My first version of `test_manifest_validation_passes_when_the_manifest_is_present` asserted `result.is_valid` against a **one-table** manifest. It failed — correctly — with `Expected 8 tables, found 1`. The fixture was wrong, not the code, and a weaker assertion would have hidden that real validation now runs. | **Fixed** — the fixture writes a complete 8-table TPC-H manifest, so the test proves validation genuinely succeeds end to end rather than just "doesn't error". |
| Consider | The two staging wrappers could drift apart again. | Added `test_surface_matches_cloud_staging_path`, comparing the full public surface of both classes modulo their target property. |

No nits were skipped.

## Verification

- `pytest tests/unit/utils/test_databricks_path_proxy_parity.py` — 20 passed (new)
- Tracker rung 1 (attribute parity probe) — pass
- Fast lane — 25,795 passed, 15 skipped
- `make lint`, `lint-markers`, `make typecheck` — green
- `todo check-scope` — OK (2 files, both inside the item's allowlist)
