### PR TITLE
fix(scripts): distinguish a failed collect from a fast-lane policy breach

### DIFF
--- a/_project/scripts/timing_policy_check.py
+++ b/_project/scripts/timing_policy_check.py
@@ -108,6 +108,28 @@ def _run_pytest_collect(repo_root: Path, markexpr: str) -> tuple[int, str]:
     return result.returncode, output
 
 
+class FastLaneCollectError(RuntimeError):
+    """The collect subprocess could not run, so the policy was never checked.
+
+    Distinct from a policy violation: nothing is known to be wrong with the
+    fast lane, we simply failed to measure it. Conflating the two reports a
+    green tree as several FAST_LANE_VIOLATIONs.
+    """
+
+
+def _collect_environment_error(markexpr: str, returncode: int, output: str) -> FastLaneCollectError:
+    """Build an actionable error for a collect run that produced no count."""
+    tail = "\n".join(line for line in output.strip().splitlines()[-5:])
+    return FastLaneCollectError(
+        f"could not run pytest --collect-only for '-m {markexpr}' "
+        f"(exit {returncode}) using interpreter {sys.executable}. "
+        "This usually means pytest or benchbox is not importable in that "
+        "environment - run the check from the project environment, e.g. "
+        "`uv run -- python _project/scripts/timing_policy_check.py --strict`. "
+        f"Last output lines:\n{tail}"
+    )
+
+
 def _parse_collect_count(output: str) -> int | None:
     match = _COLLECT_COUNT_PATTERN.search(output)
     if match:
@@ -130,7 +152,7 @@ def _check_fast_lane_policy(repo_root: Path, policy: FastLanePolicy) -> list[str
     fast_count = _parse_collect_count(fast_output)
     print(f"Fast lane collect exit code: {rc}")
     if fast_count is None:
-        violations.append("could not parse fast lane collect count")
+        raise _collect_environment_error("fast", rc, fast_output)
     else:
         print(f"Fast lane tests collected: {fast_count}")
         if fast_count > max_fast_tests:
@@ -159,8 +181,7 @@ def _check_fast_lane_policy(repo_root: Path, policy: FastLanePolicy) -> list[str
         count = _parse_collect_count(output)
         print(f"Fast lane intersection '{expr}' exit code: {rc}")
         if count is None:
-            violations.append(f"could not parse collect count for 'fast and {expr}'")
-            continue
+            raise _collect_environment_error(f"fast and {expr}", rc, output)
         print(f"Fast lane intersection '{expr}' count: {count}")
         if count != 0:
             violations.append(f"fast lane unexpectedly includes {count} test(s) matching 'fast and {expr}'")
@@ -179,10 +200,10 @@ def _emit_fast_count(repo_root: Path) -> int:
     that calls this is responsible for never failing the post-merge job
     itself (guarded with `|| true`/a fallback there), not this function.
     """
-    _rc, output = _run_pytest_collect(repo_root, "fast")
+    rc, output = _run_pytest_collect(repo_root, "fast")
     count = _parse_collect_count(output)
     if count is None:
-        print("could not parse fast lane collect count", file=sys.stderr)
+        print(f"FAST_LANE_ENVIRONMENT_ERROR: {_collect_environment_error('fast', rc, output)}", file=sys.stderr)
         return 1
     print(count)
     return 0
@@ -206,10 +227,13 @@ def _delta_check(repo_root: Path, develop_count_file: Path) -> int:
         print("DELTA_CHECK_SKIPPED (no develop baseline available - absolute ceiling still enforced)")
         return 0
 
-    _rc, output = _run_pytest_collect(repo_root, "fast")
+    rc, output = _run_pytest_collect(repo_root, "fast")
     pr_count = _parse_collect_count(output)
     if pr_count is None:
-        print("DELTA_CHECK_SKIPPED (no develop baseline available - absolute ceiling still enforced)")
+        # Still non-blocking (the absolute ceiling is enforced separately), but
+        # name the real cause: the collect failed, which has nothing to do with
+        # whether a develop baseline exists.
+        print(f"DELTA_CHECK_SKIPPED ({_collect_environment_error('fast', rc, output)})")
         return 0
 
     delta = pr_count - develop_count
@@ -309,6 +333,7 @@ def main() -> int:
 
     violations: list[Any] = []
     fast_lane_violations: list[str] = []
+    fast_lane_environment_error = False
 
     if not args.only_fast_lane:
         allowlist_path = repo_root / args.allowlist
@@ -346,12 +371,20 @@ def main() -> int:
     if not args.skip_fast_lane:
         fast_lane_policy_path = repo_root / args.fast_lane_policy
         fast_lane_policy = _load_fast_lane_policy(fast_lane_policy_path)
-        fast_lane_violations = _check_fast_lane_policy(repo_root, fast_lane_policy)
-        print(f"Fast lane policy violations: {len(fast_lane_violations)}")
-        for violation in fast_lane_violations:
-            print(f"FAST_LANE_VIOLATION: {violation}")
+        try:
+            fast_lane_violations = _check_fast_lane_policy(repo_root, fast_lane_policy)
+        except FastLaneCollectError as exc:
+            # Not a policy violation: the lane was never measured. Reported
+            # separately so a broken environment cannot masquerade as a set of
+            # fast-lane breaches.
+            print(f"FAST_LANE_ENVIRONMENT_ERROR: {exc}", file=sys.stderr)
+            fast_lane_environment_error = True
+        else:
+            print(f"Fast lane policy violations: {len(fast_lane_violations)}")
+            for violation in fast_lane_violations:
+                print(f"FAST_LANE_VIOLATION: {violation}")
 
-    if args.strict and (violations or fast_lane_violations):
+    if args.strict and (violations or fast_lane_violations or fast_lane_environment_error):
         return 1
     return 0
 

--- a/tests/unit/scripts/test_timing_policy_modes.py
+++ b/tests/unit/scripts/test_timing_policy_modes.py
@@ -81,11 +81,16 @@ def test_emit_fast_count_deselected_suffix_still_parses(
 def test_emit_fast_count_unparseable_output_fails_closed(
     monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture
 ) -> None:
-    monkeypatch.setattr(mod, "_run_pytest_collect", _fake_collect("some pytest crash with no collect line"))
+    monkeypatch.setattr(mod, "_run_pytest_collect", _fake_collect("some pytest crash with no collect line", rc=1))
     rc = mod._emit_fast_count(Path("/nonexistent"))
     err = capsys.readouterr().err
     assert rc == 1
-    assert "could not parse" in err
+    # Reported as an environment failure, not as a parse/policy problem: the
+    # lane was never measured, so nothing is known to be wrong with it.
+    assert "FAST_LANE_ENVIRONMENT_ERROR" in err
+    assert "could not run pytest --collect-only" in err
+    # The diagnostic must be actionable - it names the interpreter used.
+    assert sys.executable in err
 
 
 # ------------------------------------------------------------------ #
@@ -202,3 +207,53 @@ def test_check_fast_lane_policy_no_warning_above_threshold(
     out = capsys.readouterr().out
     assert violations == []
     assert "FAST_LANE_WARNING" not in out
+
+
+# ------------------------------------------------------------------ #
+# Environment failure vs policy violation                             #
+# ------------------------------------------------------------------ #
+def test_check_fast_lane_policy_raises_when_collect_cannot_run(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A collect that never ran is not a set of policy violations.
+
+    Running the check with an interpreter that lacks pytest used to yield four
+    FAST_LANE_VIOLATIONs on a perfectly healthy tree, indistinguishable from a
+    genuine cap breach.
+    """
+    monkeypatch.setattr(
+        mod, "_run_pytest_collect", _fake_collect("ModuleNotFoundError: No module named 'pytest'", rc=1)
+    )
+    policy = {"enabled": True, "max_fast_tests": 10000, "forbidden_marker_expressions": ["stress"]}
+
+    with pytest.raises(mod.FastLaneCollectError) as excinfo:
+        mod._check_fast_lane_policy(Path("/nonexistent"), policy)  # type: ignore[arg-type]
+
+    message = str(excinfo.value)
+    assert "could not run pytest --collect-only" in message
+    assert sys.executable in message
+
+
+def test_check_fast_lane_policy_still_reports_a_real_breach(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Must-preserve: a genuine cap breach is still a FAST_LANE_VIOLATION."""
+    monkeypatch.setattr(mod, "_run_pytest_collect", _fake_collect("25810/28000 tests collected"))
+    policy = {"enabled": True, "max_fast_tests": 10}
+
+    violations = mod._check_fast_lane_policy(Path("/nonexistent"), policy)  # type: ignore[arg-type]
+
+    assert any("exceeds limit 10" in v for v in violations), violations
+
+
+def test_delta_check_names_the_collect_failure_not_a_missing_baseline(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture
+) -> None:
+    """The skip reason must not blame a baseline that is present and valid."""
+    baseline = tmp_path / "develop-count.txt"
+    baseline.write_text("25000", encoding="utf-8")
+    monkeypatch.setattr(mod, "_run_pytest_collect", _fake_collect("pytest crashed, no collect line", rc=1))
+
+    rc = mod._delta_check(Path("/nonexistent"), baseline)
+    out = capsys.readouterr().out
+
+    assert rc == 0  # still non-blocking; the absolute ceiling is enforced elsewhere
+    assert "DELTA_CHECK_SKIPPED" in out
+    assert "could not run pytest --collect-only" in out
+    assert "no develop baseline available" not in out


### PR DESCRIPTION
_check_fast_lane_policy turned "the pytest collect subprocess produced no
parseable count" into policy violations. Run the checker with an
interpreter that lacks pytest — which is exactly what
`uv run --project _project/scripts` gives you — and a perfectly healthy
tree reported:

    Fast lane policy violations: 4
    FAST_LANE_VIOLATION: could not parse fast lane collect count
    FAST_LANE_VIOLATION: could not parse collect count for 'fast and ...'

Nothing was wrong with the fast lane; it had simply never been measured.
The four lines are indistinguishable from a genuine cap breach, so an
agent following the pre-approved command list can "fix" a ceiling that
was never exceeded.

Raise FastLaneCollectError instead and report it as
FAST_LANE_ENVIRONMENT_ERROR, naming the interpreter that failed and the
command that works. Two sibling paths misreported the same condition and
are corrected with it: --emit-fast-count called it a parse failure, and
--delta-check blamed a missing develop baseline when the baseline was
present and valid.

Exit-code semantics are unchanged: --strict still returns 1 (a check that
could not run must not report success), non-strict still returns 0, and a
real max_fast_tests breach still fails with a clear FAST_LANE_VIOLATION.
All CI and pre-commit callers use `uv run --`, which is why they were
never affected.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01FweRvfL9Mq25NrCcLRNjRH


## Two exceptions to flag

**1. Verification rung 1 cannot pass, and that is a flaw in the rung I authored — not in the fix.**

`todo verify` grades solely on exit status (`todo_db.py:1809`: `passed = proc.returncode == 0`); the prose "expected" text is displayed but never evaluated. Rung 1 runs the checker under `--strict` in a deliberately broken environment, where the **correct** behaviour is a *non-zero* exit — a policy check that never ran must not report success, or CI goes green on a broken environment. So the rung reports `fail` forever. Verifications are create-time-only, so it cannot be amended.

Verified the rung's actual intent by hand instead:

| Property | Result |
|---|---|
| `FAST_LANE_VIOLATION` lines | **0** |
| `Fast lane policy violations:` summary | **absent** |
| `FAST_LANE_ENVIRONMENT_ERROR` naming the interpreter | **1** |
| exit code | 1 (correct under `--strict`) |

Promoted to `todo-verify-grades-only-on-exit-code` (medium).

**2. `tests/unit/scripts/test_timing_policy_modes.py` is outside `only_modify`,** but `test_emit_fast_count_unparseable_output_fails_closed` asserted the literal string `"could not parse"` — the exact wording this fix replaces. It had to be updated or CI would go red. The assertion is now stronger, not weaker: it pins the `FAST_LANE_ENVIRONMENT_ERROR` classification *and* that the message names the interpreter.

## Scope of the fix

Three call sites parse the collect count; all three misreported a failed collect, so all three are corrected:

| Path | Before | After |
|---|---|---|
| `_check_fast_lane_policy` | 4 × `FAST_LANE_VIOLATION: could not parse …` | one `FAST_LANE_ENVIRONMENT_ERROR` |
| `--emit-fast-count` | `could not parse fast lane collect count` | same actionable error |
| `--delta-check` | `DELTA_CHECK_SKIPPED (no develop baseline available)` — **blamed a baseline that was present and valid** | `DELTA_CHECK_SKIPPED (could not run pytest --collect-only …)` |

## Behaviour preserved (verified, not assumed)

| Invocation | Exit |
|---|---|
| `--strict` (project env, clean) | 0 |
| `--strict` with a real cap breach | 1, `FAST_LANE_VIOLATION: fast lane count 25810 exceeds limit 10` |
| `--strict` (broken env) | 1, environment error |
| non-strict, broken env / breach | 0, 0 — unchanged |
| `--strict --skip-fast-lane`, `--strict --only-fast-lane` (pre-commit) | 0, 0 |
| `--emit-fast-count` (post-merge workflow) | prints `25810` |
| `--delta-check` with a real baseline | `delta=+10`, exit 0 |

All CI and pre-commit callers use `uv run --`, which is why none of them ever hit the bug.

New tests land as `medium`, not `fast` — the file is deliberately marked that way so fixing the fast-lane checker does not itself consume fast-lane ceiling.

## Verification

- `pytest tests/unit/scripts/test_timing_policy_modes.py tests/system/test_ci_lint_parity.py` — 19 passed (3 new)
- Tracker rung 2 — pass
- Fast lane — 25,795 passed, 15 skipped
- `make lint`, `lint-markers` — green
