### PR TITLE
fix(e2e): widen DuckDB-WASM cold-start margins to stabilize the Chromium blocking gate

### DIFF
--- a/docs/operations/browser-ci.md
+++ b/docs/operations/browser-ci.md
@@ -11,7 +11,7 @@ and anyone triaging a red or advisory browser-lane check on a PR.
 
 | Browser  | Job name                          | Scope                | Gate       | Status as of 2026-07-23 |
 |----------|------------------------------------|-----------------------|------------|--------------------------|
-| Chromium | `Chromium (full suite, blocking)` | Full `e2e/` suite      | Blocking   | Green - unaffected by this note |
+| Chromium | `Chromium (full suite, blocking)` | Full `e2e/` suite      | Blocking   | Cold-start flake mitigated 2026-07-25 (see below) |
 | Firefox  | `Firefox (@smoke, non-blocking)`  | `@smoke`-tagged subset | Advisory   | Green in recent history |
 | WebKit   | `WebKit (@smoke, non-blocking)`   | `@smoke`-tagged subset | Advisory   | Fixed 2026-07-23 (see below) - was deterministically red on PRs #1264 and #1270 |
 
@@ -28,6 +28,32 @@ assertions in the same spec files that already called `waitForDataLoaded()`
 what pointed at timeout margin rather than a functional break. The fix adds
 `waitForDataLoaded()` calls ahead of the four assertions, matching the
 existing in-file pattern - no test was skipped, no assertion was weakened.
+
+## Chromium cold-start flake (2026-07-25)
+
+On PR #1298 the Chromium blocking gate went red on a *genuinely flaky*
+(varies run-to-run) data-load timeout: a different spec timed out each run
+(`result-detail-failures` one run, `compare` the next), always the same
+symptom - the first data-bound element never rendered within the wait window
+- while 103-107 of 111 tests passed. Two independent runs failed on different
+specs, which is the "varies across attempts" signal from the triage rule
+below, not a functional break in the PR under test. The cause is DuckDB-WASM
+cold-start under the gate's 2 parallel workers occasionally exceeding the 30s
+`waitForDataLoaded` budget - the same *concurrent-worker* contention class the
+earlier `stabilize-webkit-browser-smoke-flake-under-parallel-workers` fix
+addressed for WebKit by serializing to `--workers=1`.
+
+Mitigation (harness-only, no `results-explorer/src/**` change; Chromium keeps
+its 2 workers so the blocking gate stays fast rather than serializing):
+
+- `waitForDataLoaded` budget 30s -> 45s (matches the margin the suite's
+  careful inline data waits already use, and the exact value the failing
+  `result-detail-failures` inline wait used).
+- Per-test `timeout` 60s -> 90s so a ~45s data wait plus the rest of a flow
+  fits inside the cap.
+- CI `retries` 1 -> 2 so a spec slow on both its first attempts gets a third.
+  A real regression still fails all three attempts (deterministic), so this
+  does not mask functional breaks.
 
 ## Triage rule
 

--- a/results-explorer/e2e/support/fixtures.ts
+++ b/results-explorer/e2e/support/fixtures.ts
@@ -20,11 +20,21 @@ export async function waitForShell(page: Page) {
  * Wait for the DuckDB-WASM attach to complete and the page to render
  * real data. We assert on a user-visible element rather than internal
  * state so these waits also double as user-flow assertions.
+ *
+ * The 45s budget (up from 30s) absorbs the tail of DuckDB-WASM cold-start
+ * under the Chromium blocking gate's parallel workers: concurrent WASM
+ * compile + `results.duckdb` attach across workers on a small CI runner
+ * occasionally pushed a first data render past 30s, producing genuinely
+ * flaky (varies run-to-run) `waitForDataLoaded` timeouts. 45s matches the
+ * margin the more careful inline data waits in the suite already use and
+ * sits inside the 90s per-test timeout. See docs/operations/browser-ci.md.
  */
+const DATA_LOADED_TIMEOUT_MS = 45_000;
+
 export async function waitForDataLoaded(page: Page, locator: string | RegExp) {
   if (typeof locator === "string") {
-    await expect(page.locator(locator).first()).toBeVisible({ timeout: 30_000 });
+    await expect(page.locator(locator).first()).toBeVisible({ timeout: DATA_LOADED_TIMEOUT_MS });
   } else {
-    await expect(page.getByText(locator).first()).toBeVisible({ timeout: 30_000 });
+    await expect(page.getByText(locator).first()).toBeVisible({ timeout: DATA_LOADED_TIMEOUT_MS });
   }
 }

--- a/results-explorer/playwright.config.ts
+++ b/results-explorer/playwright.config.ts
@@ -30,12 +30,21 @@ export default defineConfig({
   outputDir: "./test-results",
   fullyParallel: true,
   forbidOnly: Boolean(process.env.CI),
-  retries: process.env.CI ? 1 : 0,
+  // 2 CI retries (up from 1): the Chromium full-suite blocking gate runs 2
+  // parallel workers, and concurrent DuckDB-WASM cold-start occasionally
+  // exceeds even the extended data-load wait on back-to-back attempts. The
+  // failing spec varies run-to-run (genuinely flaky, not a deterministic
+  // break), so a third attempt clears the timing tail. A real regression still
+  // fails all three attempts. See docs/operations/browser-ci.md.
+  retries: process.env.CI ? 2 : 0,
   workers: process.env.CI ? 2 : undefined,
   reporter: process.env.CI
     ? [["github"], ["html", { outputFolder: "playwright-report", open: "never" }]]
     : [["list"], ["html", { outputFolder: "playwright-report", open: "never" }]],
-  timeout: 60_000,
+  // 90s per-test cap (up from 60s) so a single ~45s data-load wait plus the
+  // rest of a flow does not collide with the global timeout under a slow
+  // DuckDB-WASM cold-start. Happy-path tests still finish in a few seconds.
+  timeout: 90_000,
   expect: { timeout: 10_000 },
 
   use: {


### PR DESCRIPTION
## Description

The `Chromium (full suite, blocking)` gate flaked on PR #1298: a **different** spec timed out each run (`result-detail-failures` one run, `compare` the next), always the same symptom — the first data-bound element never rendered within the wait window — while **103–107 of 111** tests passed. Because the failing spec *varies run-to-run*, this is genuinely flaky (per the `docs/operations/browser-ci.md` triage rubric), not a functional break.

Root cause: **DuckDB-WASM cold-start under the gate's 2 parallel workers** occasionally exceeds the 30s `waitForDataLoaded` budget on back-to-back attempts — the same concurrent-worker contention class the earlier WebKit `--workers=1` fix addressed. This is a repo-wide gate-reliability issue that will keep hitting future PRs, so it's fixed here as a separate change (surfaced while triaging #1298).

Harness-only mitigation — **no `results-explorer/src/**` change**, and Chromium keeps its 2 workers so the blocking gate stays fast rather than serializing:

- `waitForDataLoaded` budget **30s → 45s** (matches the margin the suite's careful inline data waits already use, including the exact 45s the failing `result-detail-failures` site uses).
- Per-test `timeout` **60s → 90s** so a ~45s data wait plus the rest of a flow fits inside the cap.
- CI `retries` **1 → 2** so a spec slow on both first attempts gets a third. A real regression still fails all three attempts (deterministic), so this does not mask breaks.

## Type of Change

- [x] Bug fix (CI harness flake / gate reliability)
- [x] Documentation

## Testing

- `cd results-explorer && npm run typecheck` (`tsc --noEmit`) — clean.
- Change is harness-only (Playwright config timeouts/retries + the shared `waitForDataLoaded` budget); no product code touched. A flake is not locally reproducible on demand, so validation is by construction: every observed failure was the `waitForDataLoaded`/inline data-wait timing out under cold-start, which the wider margin + extra retry directly target. CI on this branch exercises the new settings.

## Public Contract Check

- [x] This PR does not change public, beta-public, deprecated, generated, experimental, or repo-only contract surfaces (e2e test harness config + operations doc only).
- [x] No result-schema / MCP / platform-support / adapter-hook impact.
- [x] No platform/benchmark count claims changed.

## Documentation

- [x] Updated `docs/operations/browser-ci.md` (Chromium lane status + a "Chromium cold-start flake (2026-07-25)" section documenting cause and mitigation).
- [x] Added regression rationale in code comments (`fixtures.ts`, `playwright.config.ts`).

## Code Quality

- [x] Ran `tsc --noEmit`; edits match the files' existing style (no prettier/eslint config in `results-explorer`).
- [x] Backwards-compatible: local runs keep `retries: 0`; only CI margins change.
- [x] No new product behavior to test; the change is test-harness robustness.

## Artifact Hygiene

- [x] No screenshots, browser reports, generated logs, or binary artifacts committed.

## Notes

- **Risk / reviewer focus:** this raises the *blocking* gate's retry/timeout policy. The tradeoff is deliberate — retries only cost wall-time on failing specs, and a deterministic regression still fails all three attempts (so real breaks are not masked). I left **auto-merge off** so you can consciously approve the gate-policy change; happy to enable squash auto-merge if you'd prefer.
- **Alternative considered:** serialize Chromium to `--workers=1` (the proven WebKit remedy) — eliminates the contention entirely but roughly doubles the blocking gate's wall-time (~8 min → ~15 min) on every PR, so margin + retries is the more proportionate first lever.
- **Follow-up:** if margin + retries proves insufficient, the next step is `--workers=1` for Chromium or a shared DuckDB-WASM warm-up; both are larger and out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01KrNxNm6emSgaoo6LPwBUgB)_