### PR TITLE
docs: fix review-protocol section citations in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -72,14 +72,14 @@ Behavior is governed by `~/.claude/skills/SHARED/review-protocol/SKILL.md`.
 BenchBox bindings:
 
 - Path: `~/.benchbox/finding-drafts/YYYY-MM-DD-HHMMSS-<slug>.md` (out of the Git
-  tree; the sole in-review write per §4 — never a tracked `_project/blind-spots/`
+  tree; the sole in-review write per §1 — never a tracked `_project/blind-spots/`
   file, which is legacy read-only until the findings migration lands)
 - Schema: `_project/blind-spots/README.md`
 - Validate: `uv run --project _project/scripts -- python _project/scripts/validate_blind_spot.py <file>`
 - Sweep: `make blind-spots-{list,report,sweep}` (reads the legacy tracked corpus)
 - Chat marker: prefix the body quote with `Recorded: ~/.benchbox/finding-drafts/<file>.md`
 
-Per SHARED §4: capture is local-only — do not commit beyond the
+Per SHARED §1: capture is local-only — do not commit beyond the
 capture file, do not push, do not run `make pr-open`. Apply the
 SHARED §2 defect gate before recording — defects belong in the
 severity table and TODOs, not in blind-spots. The `/blind-spot` slash


### PR DESCRIPTION
The blind-spot capture section cited review-protocol §4 (Project Bindings) for the capture-is-local-only rule, which actually lives in §1 (Scope). The SHARED review-protocol skill headings are being numbered explicitly in the same maintenance pass, so these citations now resolve correctly.

Part of the todo-db extraction/portability maintenance sequence (worktree cleanup, skills portability, findings-domain parity port).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UCPfeNLMH2gHBHVu4NwjXn