### PR TITLE
docs(uat): the artifact-hygiene guard is no longer external-root-only

### DIFF
--- a/_project/specs/uat-framework.md
+++ b/_project/specs/uat-framework.md
@@ -137,7 +137,7 @@ tests/uat/
 | `docker_assets.py` | Single connection registry: compose-file map, compose-derived host ports + platform options, safe project-scoped compose commands | 180 | 760 |
 | `docker_cleanup.py` | Docker stack teardown at platform boundaries; project-scoped down/volume handling | — | 426 |
 | `container_cleanup.py` | Apple `container`-engine sibling of `docker_cleanup.py`; backs `make uat-docker-cleanup ENGINE=container` | — | 557 |
-| `artifact_hygiene.py` | Local-artifact hygiene guard: flags worktree-local `benchmark_runs/` growth when an external output root is configured; report-only (`make uat-artifact-hygiene`) | — | 309 |
+| `artifact_hygiene.py` | Local-artifact hygiene guard: flags worktree-local `benchmark_runs/` growth whenever the resolved output root is outside the worktree — including the default `../benchmark_runs`, not only a configured one; report-only (`make uat-artifact-hygiene`) | — | 309 |
 | `cells_io.py` | `cells.jsonl` + accounting-sidecar read/write codec; single schema shared by `orchestrator.py` and `_cli.py` | — | 464 |
 | `gate_summary.py` | Writes/reads the versioned `uat_gate_summary.json` per-sweep evidence artifact; powers `make uat-gate-check` cross-stage aggregation | — | 274 |
 | `throughput.py` | Multi-stream throughput/concurrent cell support via `benchbox run-official --streams`; TPC-compliant scale-factor gate | — | 316 |
@@ -514,7 +514,7 @@ Args below are the real Makefile signatures (`Makefile` targets `uat-*`);
 | `make uat-sweep` | `CONFIG=` `[DRY_RUN=1]` | Full sweep: walks `phases:` list. (W9) |
 | `python -m tests.uat._cli preflight` | `--config <path>` | Advisory disk-budget estimate plus current preflight status. |
 | `make uat-stress` | `[PLATFORM=] [BENCHMARK=] [SCALE=] [CONFIG=]` | Canned preset for framework-owned stress-test use. (W9) |
-| `make uat-artifact-hygiene` | `[OUTPUT=<root>] [THRESHOLD_BYTES=N]` | Local-artifact hygiene guard: no-op unless an external output root is configured; report-only. Wired into `make pr-preflight`. |
+| `make uat-artifact-hygiene` | `[OUTPUT=<root>] [THRESHOLD_BYTES=N]` | Local-artifact hygiene guard: applies whenever the resolved output root is outside the worktree (the default `../benchmark_runs` included), no-op only when it is inside; report-only. Wired into `make pr-preflight`. |
 | `make uat-bring-up` | `PLATFORM=` `[TIMEOUT_S=300] [DRY_RUN=1] [BENCHMARK_RUNS_DIR=]` | Bring up one Docker-managed platform in isolation and probe health (measure-then-set `docker_start_timeout_s`). |
 | `make uat-prepull` | `PLATFORM=` `[PREPULL_TIMEOUT_S=900] [DRY_RUN=1]` | Pull/build a platform's compose images ahead of a sweep (no health probe); shares `uat-bring-up`'s platform validation. |
 | `make uat-docker-cleanup` | `[ENGINE=docker\|container] [MODE=owned\|images\|max] [APPLY=1] [PREFIX=benchbox-uat]` | Interrupted-run recovery: inventories (default) or removes (`APPLY=1`) UAT-owned compose resources. |

--- a/docs/operations/uat-framework.md
+++ b/docs/operations/uat-framework.md
@@ -59,13 +59,19 @@ path — no silent root switching for a configured sweep.
 
 ## Local-artifact hygiene (external-root invariant)
 
-**Invariant:** when an external output root is configured — `BENCHBOX_OUTPUT_DIR`
-set (or `--output` pointing outside the worktree) — the worktree-local
-`benchmark_runs/` must **not** grow. Datagen, databases, and result JSONs all
-belong under the external root. This guards the 2026-06-01 incident, where a
-corpus sweep launched from a pool worktree with
+**Invariant:** whenever the resolved output root lies outside the worktree, the
+worktree-local `benchmark_runs/` must **not** grow. Datagen, databases, and
+result JSONs all belong under that root. This guards the 2026-06-01 incident,
+where a corpus sweep launched from a pool worktree with
 `BENCHBOX_OUTPUT_DIR=~/Developer/benchmark_runs` still accumulated ~4.2 GB
 under the worktree-local `benchmark_runs/datagen/`.
+
+Since the default root became the work tree's sibling (`../benchmark_runs`),
+"outside the worktree" is the **ordinary** case, not only the configured one:
+a plain `benchbox run` with no `--output` and no `BENCHBOX_OUTPUT_DIR` is
+covered too. The guard steps aside only when the resolved root is *inside* the
+worktree, or when the run starts outside a Git work tree (where the historical
+cwd-anchored default applies and any growth is local by definition).
 
 The guardrails are **report-only** — they detect and name the offending paths
 but never delete or move artifacts.
@@ -73,9 +79,9 @@ but never delete or move artifacts.
 * The UAT runner (`tests/uat/runner.py`) snapshots `cwd/benchmark_runs` before
   each external-root cell and fails loudly if it grows, naming both the
   unexpected local path and the configured external root.
-* `make uat-artifact-hygiene` audits the live worktree (no-op unless an
-  external root is configured) and is wired into `make pr-preflight`. Ordinary
-  default local runs (no `BENCHBOX_OUTPUT_DIR`) are never blocked.
+* `make uat-artifact-hygiene` audits the live worktree (no-op only when the
+  resolved root is inside it) and is wired into `make pr-preflight`. A run
+  whose root really is worktree-local is never blocked.
 
   ```bash
   # Audit the current worktree (skips silently with no external root):


### PR DESCRIPTION
Three places described the guard as applying only when an external output
root is configured, and one went further: "Ordinary default local runs (no
BENCHBOX_OUTPUT_DIR) are never blocked." That stopped being true when the
default root became the work tree's sibling — a plain run with no --output
and no env var now resolves to ../benchmark_runs, which is outside the
worktree, so the guard covers it.

Restate the invariant in terms of what the code actually tests: whether the
*resolved* root lies outside the worktree. That makes the default case the
ordinary one and names the two genuine no-ops — a root pointed inside the
worktree, and a run started outside a Git work tree, where the historical
cwd-anchored default applies and any growth is local by definition.

Each claim was checked against tests/uat/artifact_hygiene.py rather than
against the neighbouring prose:

  default run inside a checkout -> /Users/joe/Developer/benchmark_runs
  root inside the worktree      -> None
  outside a Git work tree       -> None
  explicit external root        -> /ext/root

The spec's Responsibility column is hand-maintained — uat_loc_table.py
rewrites only the Actual column — so editing it does not fight the drift
guard, which still reports the table matching the tree.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01FweRvfL9Mq25NrCcLRNjRH


## Scope note

Created by `promote`, so no scope globs, ladder, or work units (create-time-only
fields). Scope self-policed to the two docs; `todo check-scope` reports OK
trivially rather than meaningfully.

## What was wrong

The ticket named two sites. There were **three**, and the third was the worst:

| Site | Text | Status |
|---|---|---|
| `docs/operations/uat-framework.md:62` | "when an external output root is configured …" | narrowed the invariant |
| `docs/operations/uat-framework.md:~77` | **"Ordinary default local runs (no `BENCHBOX_OUTPUT_DIR`) are never blocked."** | **outright false** — not in the ticket |
| `_project/specs/uat-framework.md:140` | module-table Responsibility | narrowed |
| `_project/specs/uat-framework.md:517` | make-target table | "no-op unless an external root is configured" |

Since the default root became the work tree's sibling, a plain `benchbox run`
with no `--output` and no env var resolves to `../benchmark_runs` — outside the
worktree — so the guard *does* cover it.

## Claims verified against code, not against neighbouring prose

Each rewritten statement was checked by executing `configured_external_root`:

```
default run inside a checkout -> /Users/joe/Developer/benchmark_runs   (guarded)
root inside the worktree      -> None                                  (no-op)
outside a Git work tree       -> None                                  (no-op)
explicit external root        -> /ext/root                             (guarded)
```

So the doc now names the two *genuine* no-ops instead of implying default runs
are exempt.

## Drift-guard interaction

`_project/specs/uat-framework.md:140` is inside the table `uat_loc_table.py`
regenerates. Checked before editing: it rewrites **only the Actual column** —
"the Responsibility and … are preserved" — so hand-editing the description does
not fight the guard. Confirmed after the edit: `uat_loc_table.py --check` reports
*"UAT LOC table + summary match the tree."*

## Verification

- `uat_loc_table.py --check` — clean (exit 0)
- `make docs-validate` — no new broken links
- `pytest tests/unit/test_artifact_hygiene_guardrails.py tests/uat/test_output_root_hygiene.py tests/uat/test_runner.py` — 37 passed
- `make lint` — green
