### PR TITLE
fix(todo): flag verification rungs that cannot express their expectation

### DIFF
--- a/_project/scripts/todo_db.py
+++ b/_project/scripts/todo_db.py
@@ -1820,6 +1820,32 @@ def run_verification(conn: sqlite3.Connection, actor: str, item_id: str, seq: in
 EVIDENCE_PIN_RE = re.compile(r"verified on|@ [0-9a-f]{7,}|\bPASS\b", re.IGNORECASE)
 
 
+# A rung is graded ONLY on its command's exit status (see run_verification);
+# `expected` is human acceptance text and is never evaluated. So an expectation
+# that names a string which must be ABSENT from the output describes something
+# the exit code cannot encode -- unless the command asserts on output itself.
+# Such a rung can never pass, however correct the implementation is.
+_EXPECTED_NEGATES_OUTPUT_RE = re.compile(
+    r"\bnot\s+['\"]|rather than|instead of|must not|does not (print|contain|report)|no longer (print|report)s?\b",
+    re.IGNORECASE,
+)
+# Constructs that turn output into an exit status, or compose an assertion.
+_COMMAND_ASSERTS_ON_OUTPUT_RE = re.compile(r"grep|rg\b|test\s|\[\s|&&|\|\||^\s*!|assert|--check|jq\b", re.IGNORECASE)
+
+
+def _unsatisfiable_verifications(item: dict) -> list[int]:
+    """Return seqs of rungs whose command cannot express their expectation."""
+    offenders = []
+    for ver in item["verifications"]:
+        command = ver.get("command") or ""
+        expected = ver.get("expected") or ""
+        if not command:
+            continue
+        if _EXPECTED_NEGATES_OUTPUT_RE.search(expected) and not _COMMAND_ASSERTS_ON_OUTPUT_RE.search(command):
+            offenders.append(ver["seq"])
+    return offenders
+
+
 def lint_item(conn: sqlite3.Connection, item_id: str) -> list[str]:
     item = get_item(conn, item_id)
     findings = []
@@ -1827,6 +1853,13 @@ def lint_item(conn: sqlite3.Connection, item_id: str) -> list[str]:
         findings.append("no verification steps recorded")
     elif not any(v["command"] for v in item["verifications"]):
         findings.append("verification steps exist but none has a runnable command")
+    unsatisfiable = _unsatisfiable_verifications(item)
+    if unsatisfiable:
+        findings.append(
+            f"verification seq {unsatisfiable} expects output that must be absent, but the command is graded "
+            "only on exit status - make the command self-asserting (exit 0 iff satisfied), e.g. pipe to `grep -q` "
+            "or negate with `!`"
+        )
     if get_config(conn, "lint.require_scope_rules") == "on" and item["work"] and not item["scope"]:
         findings.append("has work units but no scope rules (only_modify/do_not_modify)")
     if (
@@ -2379,7 +2412,19 @@ def main(argv: list[str] | None = None) -> int:
     p.add_argument("--only-modify", action="append", default=[], metavar="GLOB")
     p.add_argument("--do-not-modify", action="append", default=[], metavar="GLOB")
     p.add_argument("--preserve", action="append", default=[], metavar="BEHAVIOR")
-    p.add_argument("--verify", action="append", default=[], metavar="DESC[::COMMAND[::EXPECTED]]")
+    p.add_argument(
+        "--verify",
+        action="append",
+        default=[],
+        metavar="DESC[::COMMAND[::EXPECTED]]",
+        help=(
+            "A verification rung. COMMAND is graded ONLY on its exit status, so it must be "
+            "self-asserting: exit 0 if and only if the criterion holds. Assert on output by "
+            "composing (`cmd | grep -q PATTERN`), and on expected failure by negating (`! cmd`). "
+            "EXPECTED is human acceptance text and is never evaluated - it documents the rung, "
+            "it does not check it."
+        ),
+    )
 
     for name, help_text in (
         ("show", "show one item"),

--- a/tests/unit/scripts/test_todo_db.py
+++ b/tests/unit/scripts/test_todo_db.py
@@ -326,6 +326,14 @@ class TestVerifyRun:
         assert [(r["seq"], r["last_result"]) for r in rows] == [(1, "pass"), (2, "fail")]
 
     def test_verify_expected_is_human_acceptance_text(self, conn):
+        """`expected` documents a rung; it must never be graded.
+
+        Deliberate: 95% of the corpus's `expected` strings are prose like
+        "All tests pass" that would never match command output literally, so
+        evaluating them would fail almost every verification in the tracker.
+        Rungs assert via their command's exit status instead -- lint_item
+        flags the ones that cannot (see TestUnsatisfiableVerificationLint).
+        """
         _mk(
             conn,
             verifications=[
@@ -700,3 +708,76 @@ class TestCliSmoke:
         assert todo_db.main(base + ["complete", "cli-item", "--pr", "42"]) == 0
         assert todo_db.main(base + ["stats"]) == 0
         assert '"done": 1' in capsys.readouterr().out
+
+
+class TestUnsatisfiableVerificationLint:
+    """Rungs whose command cannot express their expectation.
+
+    A rung is graded only on exit status, so an expectation naming a string
+    that must be ABSENT describes something the exit code cannot encode. Such
+    a rung reports fail forever, however correct the implementation is --
+    confirmed twice in practice (a `--strict` checker whose correct behaviour
+    is a non-zero exit, and an `open http://...` command that always exits 0).
+    """
+
+    def _lint(self, conn, command, expected):
+        _mk(conn, verifications=[{"description": "d", "command": command, "expected": expected}])
+        return [f for f in todo_db.lint_item(conn, "sample-item") if "expects output that must be absent" in f]
+
+    def test_flags_absent_output_expectation_with_a_bare_command(self, conn):
+        """The real case: exit status cannot show a string was not printed."""
+        findings = self._lint(
+            conn,
+            "uv run -- python _project/scripts/timing_policy_check.py --strict",
+            "reports a tooling/environment error, not 'Fast lane policy violations: 4'",
+        )
+        assert findings, "expected the unsatisfiable-rung finding"
+        assert "self-asserting" in findings[0]
+
+    def test_flags_a_command_that_can_never_fail(self, conn):
+        """`open URL` exits 0 regardless of what the page renders."""
+        assert self._lint(
+            conn,
+            "open http://localhost:5173/results/does-not-exist/",
+            "Page renders the NotFound component, not 'DOES-NOT-EXIST Results'",
+        )
+
+    @pytest.mark.parametrize(
+        "command",
+        [
+            "cmd 2>&1 | grep -q FAST_LANE_ENVIRONMENT_ERROR",
+            "! cmd --strict",
+            "cmd && test -f out.json",
+            "uv run -- python script.py --check",
+        ],
+    )
+    def test_does_not_flag_a_self_asserting_command(self, conn, command):
+        """Composing the assertion into the command is the fix, not a finding."""
+        assert not self._lint(conn, command, "reports the error, not 'policy violations'")
+
+    @pytest.mark.parametrize(
+        "expected",
+        ["All tests pass", "Exit code 0", "No errors", "Adapter lifecycle tests pass."],
+    )
+    def test_does_not_flag_ordinary_prose_expectations(self, conn, expected):
+        """Regression guard: the corpus is 95% prose paired with plain commands.
+
+        Calibrated against the live tracker -- this rule flags 8 of 2958
+        verifications. A rule that fired on ordinary prose would be noise on
+        thousands of items and would be ignored.
+        """
+        assert not self._lint(conn, "uv run -- python -m pytest -m fast -q", expected)
+
+    def test_does_not_flag_a_rung_with_no_command(self, conn):
+        """A command-less rung is already reported by a different finding."""
+        assert not self._lint(conn, None, "must not print 'boom'")
+
+    def test_clean_item_still_lints_clean(self, conn):
+        """The new rule must not disturb an otherwise healthy item."""
+        _mk(
+            conn,
+            work=[{"id": "w0", "summary": "do it"}],
+            scope=[("only_modify", "benchbox/core/*")],
+            verifications=[{"description": "fast tests", "command": "true", "expected": "All tests pass"}],
+        )
+        assert todo_db.lint_item(conn, "sample-item") == []


### PR DESCRIPTION
A rung is graded only on its command's exit status; `expected` is human
acceptance text and is never evaluated. So an expectation naming a string
that must be ABSENT from the output describes something an exit code
cannot encode, and the rung reports fail forever however correct the
implementation is. Two instances turned up in one day: a --strict checker
whose correct behaviour in the failing case is a NON-zero exit, and an
`open http://...` command that exits 0 no matter what the page renders.

The tempting fix -- start matching `expected` against stdout -- is wrong,
and the tracker already says so: test_verify_expected_is_human_acceptance_
text pins exit-status grading deliberately. Measured against the live
corpus, 2787 of 2939 expectations are prose like "All tests pass" or "No
errors" that never appear literally in output, so evaluating them would
fail nearly every verification in the tracker.

The capability was never missing. Rung commands run under shell=True, so
`cmd | grep -q PATTERN` asserts on output and `! cmd` asserts on expected
failure, both today. What was missing is anything telling an author that
the command must be self-asserting, and anything catching them when it is
not.

So: document the contract on --verify's help text, and add a lint rule for
the shape that cannot work -- an absent-output expectation paired with a
command containing no assertion construct. Calibrated against the live
tracker before shipping: it flags 8 of 2958 commanded verifications
(0.27%), and a regression test pins that ordinary prose expectations
paired with plain commands stay silent, because a rule that fired on
thousands of items would simply be ignored.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01FweRvfL9Mq25NrCcLRNjRH


## This PR rejects the approach its own TODO proposes

`todo-verify-grades-only-on-exit-code` was filed by me and its description
suggests *"evaluate the expected string against stdout/stderr"*. Research
rejects that:

| Evidence | Source |
|---|---|
| Exit-status grading is **deliberate**, not an oversight | `test_todo_db.py` `test_verify_expected_is_human_acceptance_text` already pins identical `expected` text grading `true`→pass, `false`→fail |
| **2787 of 2939** expectations are prose (`"All tests pass"`, `"No errors"`) that never appear literally in output | live tracker export, 1587 items |
| The missing capability **already exists** | `run_verification` uses `shell=True`; `cmd \| grep -q P` and `! cmd` both work today |

So evaluating `expected` would fail nearly every verification in the tracker
while fixing nothing. **The tracker has no `update` verb** — its verbs are
create/claim/start/…/complete/drop — so the description cannot be corrected in
place; this PR body and the completion evidence are the correction.

## What actually ships

1. **The contract, on `--verify`'s help text**: the command is graded only on
   exit status and must be self-asserting — exit 0 iff the criterion holds;
   `expected` documents the rung, it does not check it.
2. **A lint rule** for the shape that cannot work: an expectation naming a
   string that must be *absent*, paired with a command containing no assertion
   construct.

## Calibrated before shipping, not after

A lint rule that fires on thousands of items is noise that gets ignored, so I
measured it against the live corpus:

```
live corpus: 8 flagged of 2958 commanded verifications (0.27%)
```

All 8 are true positives. Two examples:

- `results-explorer-qa-pass2-fixes` — expects *"renders the NotFound component,
  not 'DOES-NOT-EXIST Results'"*, command is `open http://localhost:5173/...`.
  `open` **always** exits 0; that rung can never fail.
- `timing-policy-check-misreports-pytest-failure-as-violation` — my own, from
  earlier in this batch.

A regression test pins that ordinary prose expectations paired with plain
commands stay silent.

## Known limits

The rule catches *this* shape, not every unsatisfiable rung. It does **not**
catch `medium-test-timeout-headroom`'s rung 1
(`grep -A1 'medium-test' … | grep timeout-minutes`, where the target sits 5+
lines below the match) because that command *does* contain `grep` — a static
heuristic cannot know the window is too narrow. That broader sweep is tracked
in `verification-rungs-authored-with-unsatisfiable-commands`.

## Verification

- `pytest tests/unit/scripts/test_todo_db.py` — 66 passed (13 new)
- `pytest tests/unit/scripts/ -k todo` — 282 passed
- Fast lane — 25,808 passed, 15 skipped
- `make lint` — green
- Rule re-run against the live corpus post-implementation: 8/2958, unchanged
