### PR TITLE
fix(tests): stop the isolated-runtime tests evicting the real duckdb module

### DIFF
--- a/tests/unit/utils/test_runtime_env.py
+++ b/tests/unit/utils/test_runtime_env.py
@@ -129,14 +129,30 @@ def test_ensure_driver_version_prefers_isolated_runtime(monkeypatch, tmp_path):
     )
 
 
+# Synthetic driver name for isolated-runtime tests. Deliberately NOT a real
+# driver: load_driver_module's isolated branch purges the module tree before
+# importing, and evicting an already-loaded C extension so it is re-dlopen'd
+# later corrupts the interpreter (see the SIGSEGV note in runtime_env.py).
+ISOLATED_DRIVER_NAME = "benchbox_fake_isolated_driver"
+
+
 def test_load_driver_module_from_isolated_runtime(tmp_path):
+    """The isolated strategy imports the driver from its own site-packages.
+
+    Uses a synthetic package name, never a real driver: the isolated branch
+    calls _purge_module_tree() unconditionally, so naming a real C extension
+    here would evict an already-loaded one from this process and re-dlopen it
+    later -- the SIGSEGV hazard load_driver_module's own comment warns about.
+    Under xdist that poisoned the worker and crashed it at interpreter
+    finalization (gilstate_tss_set), failing unrelated tests that shared it.
+    """
     site_packages = tmp_path / "env" / "lib" / "python3.11" / "site-packages"
-    package_dir = site_packages / "duckdb"
+    package_dir = site_packages / ISOLATED_DRIVER_NAME
     package_dir.mkdir(parents=True)
     (package_dir / "__init__.py").write_text("__version__ = '0.9.2'\n")
 
     resolution = DriverResolution(
-        package="duckdb",
+        package=ISOLATED_DRIVER_NAME,
         requested="0.9.2",
         resolved="0.9.2",
         actual="0.9.2",
@@ -147,21 +163,21 @@ def test_load_driver_module_from_isolated_runtime(tmp_path):
     )
 
     try:
-        module = load_driver_module(import_name="duckdb", resolution=resolution)
+        module = load_driver_module(import_name=ISOLATED_DRIVER_NAME, resolution=resolution)
         assert getattr(module, "__version__", None) == "0.9.2"
         assert str(Path(module.__file__).resolve()).startswith(str(site_packages.resolve()))
     finally:
-        sys.modules.pop("duckdb", None)
+        sys.modules.pop(ISOLATED_DRIVER_NAME, None)
 
 
 def test_load_driver_module_strict_version_mismatch_raises(tmp_path):
     site_packages = tmp_path / "env" / "lib" / "python3.11" / "site-packages"
-    package_dir = site_packages / "duckdb"
+    package_dir = site_packages / ISOLATED_DRIVER_NAME
     package_dir.mkdir(parents=True)
     (package_dir / "__init__.py").write_text("__version__ = '0.9.1'\n")
 
     resolution = DriverResolution(
-        package="duckdb",
+        package=ISOLATED_DRIVER_NAME,
         requested="0.9.2",
         resolved="0.9.2",
         actual="0.9.2",
@@ -173,9 +189,9 @@ def test_load_driver_module_strict_version_mismatch_raises(tmp_path):
 
     try:
         with pytest.raises(RuntimeError, match="requested version is 0.9.2"):
-            load_driver_module(import_name="duckdb", resolution=resolution)
+            load_driver_module(import_name=ISOLATED_DRIVER_NAME, resolution=resolution)
     finally:
-        sys.modules.pop("duckdb", None)
+        sys.modules.pop(ISOLATED_DRIVER_NAME, None)
 
 
 def test_autoinstall_invalidates_import_caches(monkeypatch):


### PR DESCRIPTION
Running tests/unit/utils/ + tests/unit/core/runner/ + tests/unit/cli/
together aborted a pytest-xdist worker with

    Fatal Python error: gilstate_tss_set: failed to set current tstate (TSS)
    Python runtime state: finalizing

and cascaded into 1-20 spurious failures whose membership changed every
run, all on one worker, all reporting "Platform 'duckdb' is not available
(missing dependencies)" for a duckdb that imports perfectly well.

Two tests exercised load_driver_module's ISOLATED_SITE_PACKAGES strategy
using the real module name. That branch calls _purge_module_tree()
unconditionally, so it evicted the already-loaded duckdb C extension from
sys.modules, imported a synthetic pure-Python stand-in from a temporary
site-packages, and the tests' cleanup then popped the stand-in without
restoring the original. Anything importing duckdb later in that worker
re-dlopen'd a C extension that had already been loaded once — exactly the
hazard load_driver_module's own comment warns about:

    C extension modules (e.g. DuckDB) cannot be safely unloaded and
    reloaded via dlopen within the same process - doing so causes SIGSEGV.

Hence both symptoms: a worker that suddenly cannot see duckdb, and a
worker that dies during interpreter finalization. It needed three
directories only because the poisoning test and the duckdb-dependent CLI
tests had to land on the same worker, which xdist's dynamic distribution
made intermittent — about 30% across the full set.

These tests are about the isolated-runtime mechanism, not about duckdb, so
they now use a synthetic driver name and never touch a real C extension.
No production code changes: the purge is legitimate for the isolated
strategy, which exists precisely to load a driver from somewhere else.

Reproducers, before -> after:
  the two tests + tests/unit/cli/                        3/3 -> 0/3
  test_runtime_env.py + tests/unit/cli/                  4/4 -> 0/4
  the original three-directory set                      ~30% -> 0/5

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01FweRvfL9Mq25NrCcLRNjRH


## Root cause

Two tests exercised `load_driver_module`'s `ISOLATED_SITE_PACKAGES` strategy
using the **real** module name `duckdb`. That branch purges unconditionally:

```python
# Ensure the requested module comes from the isolated runtime.
_purge_module_tree(import_name)
sys.path.insert(0, runtime_path)
module = importlib.import_module(import_name)
```

So each test evicted the already-loaded duckdb **C extension** from
`sys.modules`, imported a synthetic pure-Python stand-in from a `tmp_path`
site-packages, and then cleaned up with `sys.modules.pop("duckdb", None)` —
popping the stand-in **without restoring the original**. Anything importing
duckdb later in that worker re-`dlopen`'d a C extension that had already been
loaded once.

`load_driver_module`'s own comment, a few lines above, warns about exactly this:

> C extension modules (e.g. DuckDB) cannot be safely unloaded and reloaded via
> dlopen within the same process — doing so causes SIGSEGV.

The `auto_install_used` branch guards against it (`already_correct` → skip the
purge). The isolated branch does not, which is defensible — that strategy exists
to load a driver from somewhere else — but it means the *tests* must not aim it
at a real C extension living in the test process.

## Why both symptoms, and why it looked random

| Symptom | Cause |
|---|---|
| `Platform 'duckdb' is not available (missing dependencies)` on a duckdb that imports fine | the worker's `sys.modules['duckdb']` was left removed |
| `Fatal Python error: gilstate_tss_set … finalizing` | the same C extension re-`dlopen`'d, corrupting interpreter teardown |
| different tests failing each run, always on **one** worker | xdist's dynamic distribution decides whether the poisoning test and the duckdb-dependent CLI tests share a worker |

That last row is why it needed three directories and only fired ~30% of the
time: it is not a property of the directories, it is whether two particular
tests land together.

## Fix

The tests are about the isolated-runtime *mechanism*, not about duckdb, so they
now use a synthetic driver name and never touch a real C extension. **No
production change** — the purge is correct for that strategy.

## Before → after

| Reproducer | Before | After |
|---|---|---|
| the two tests + `tests/unit/cli/` | 3/3 crash | **0/3** |
| `test_runtime_env.py` + `tests/unit/cli/` | 4/4 crash | **0/4** |
| original three-directory set | ~30% | **0/5** |

## A correction from the investigation

Mid-investigation I reported "decisive: `-p no:randomly` makes it pass, so the
trigger is random ordering." That was wrong — **`pytest-randomly` is not
installed**, so the flag was a no-op and the clean run was luck. Test order here
is deterministic; the real variable is xdist work distribution. Recording it
because the wrong conclusion was reported before it was checked.

## Verification

- `pytest tests/unit/utils/test_runtime_env.py` — 27 passed
- Tracker rung 1 (three-directory subset, no fatal error) — pass
- Tracker rung 2 (fast lane) — pass
- `make lint` — green
