### PR TITLE
fix(cloud-storage): derive every scheme decision from one table

### DIFF
--- a/benchbox/platforms/azure_synapse.py
+++ b/benchbox/platforms/azure_synapse.py
@@ -87,10 +87,13 @@ class AzureSynapseAdapter(PlatformAdapter):
         # Azure storage configuration for data loading
         staging_root = config.get("staging_root")
         if staging_root:
-            from benchbox.utils.cloud_storage import get_cloud_path_info
+            from benchbox.utils.cloud_storage import cloud_provider_family, get_cloud_path_info
 
             path_info = get_cloud_path_info(staging_root)
-            if path_info["provider"] in ("az", "abfs", "abfss"):
+            # Gate on the provider *family*, not a literal list of spellings:
+            # the literal accepted "abfs" (which the classifier never produced)
+            # while rejecting the documented "azure://" form.
+            if cloud_provider_family(staging_root) == "azure":
                 self.storage_account = path_info.get("account") or self._extract_storage_account(staging_root)
                 self.container = path_info["bucket"]
                 self.storage_path = path_info["path"].strip("/") if path_info["path"] else "benchbox-data"
@@ -99,7 +102,8 @@ class AzureSynapseAdapter(PlatformAdapter):
                 )
             else:
                 raise ValueError(
-                    f"Azure Synapse requires Azure storage (az://, abfs://, abfss://), got: {path_info['provider']}://"
+                    "Azure Synapse requires Azure storage (az://, azure://, abfs://, abfss://), "
+                    f"got: {path_info['provider']}://"
                 )
         else:
             # Fall back to explicit storage configuration

--- a/benchbox/utils/cloud_storage.py
+++ b/benchbox/utils/cloud_storage.py
@@ -14,7 +14,7 @@ import logging
 import os
 import re
 from pathlib import Path
-from typing import Any, List, Protocol, Union, runtime_checkable
+from typing import Any, List, NamedTuple, Protocol, Union, runtime_checkable
 from urllib.parse import urlparse
 
 from benchbox.utils.dependencies import get_install_command, get_package_install_message
@@ -450,16 +450,79 @@ def is_cloud_path(path: Union[str, Path]) -> bool:
         path = str(path)
 
     parsed = urlparse(path)
-    if parsed.scheme in ["s3", "gs", "gcs", "az", "abfss", "azure", "dbfs"]:
+    if parsed.scheme.lower() in _SCHEME_BY_NAME:
         return True
 
     return is_snowflake_stage_path(path)
 
 
-# cloudpathlib registers only az://, gs://, s3:// (plus http/https). BenchBox
-# documents two aliases for those, so they are normalised at the hand-off to
-# cloudpathlib rather than by widening what is_cloud_path accepts.
-_CLOUD_SCHEME_ALIASES = {"gcs": "gs", "azure": "az"}
+class CloudScheme(NamedTuple):
+    """One cloud URI scheme family and everything that depends on it.
+
+    Single source of truth. Scheme identity used to be spelled out separately
+    in is_cloud_path's list, the cloudpathlib alias map, the ADLS predicate,
+    the credential env-var map and azure_synapse's provider gate -- so adding a
+    scheme to one left the others behind. That produced abfs:// classifying as
+    *local* (and so resolving to a relative directory that spills generated
+    data into the cwd), azure:// being rejected by Synapse despite being a
+    documented form, and az:// skipping its credential check entirely.
+    """
+
+    canonical: str
+    """Scheme cloudpathlib registers, or the canonical spelling for staged families."""
+
+    aliases: tuple[str, ...]
+    """Accepted alternative spellings, rewritten to ``canonical`` at the hand-off."""
+
+    family: str
+    """Provider family, for platform-level gating (e.g. Azure Synapse)."""
+
+    env_vars: tuple[str, ...]
+    """Credential environment variables checked by validate_cloud_credentials."""
+
+    stages_locally: bool = False
+    """True when cloudpathlib cannot open it, so data stages locally instead."""
+
+
+_CLOUD_SCHEMES: tuple[CloudScheme, ...] = (
+    CloudScheme("s3", (), "aws", ("AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY")),
+    CloudScheme("gs", ("gcs",), "gcp", ("GOOGLE_APPLICATION_CREDENTIALS",)),
+    CloudScheme("az", ("azure",), "azure", ("AZURE_STORAGE_ACCOUNT_NAME", "AZURE_STORAGE_ACCOUNT_KEY")),
+    # ADLS Gen2. Both spellings encode the storage account in the authority
+    # (abfss://container@account.dfs.core.windows.net/path), which cloudpathlib's
+    # az://container/path form cannot represent, so they stage locally rather
+    # than being rewritten -- rewriting would silently retarget whatever account
+    # the credentials happen to name.
+    CloudScheme(
+        "abfss",
+        ("abfs",),
+        "azure",
+        ("AZURE_STORAGE_ACCOUNT_NAME", "AZURE_STORAGE_ACCOUNT_KEY"),
+        stages_locally=True,
+    ),
+    # dbfs keeps its own DatabricksPath handling; listed so scheme recognition
+    # stays in one place.
+    CloudScheme("dbfs", (), "databricks", ()),
+)
+
+_SCHEME_BY_NAME: dict[str, CloudScheme] = {
+    name: scheme for scheme in _CLOUD_SCHEMES for name in (scheme.canonical, *scheme.aliases)
+}
+
+# Aliases that cloudpathlib cannot open under their own name and which are NOT
+# staged locally, so they must be rewritten to the canonical scheme.
+_CLOUD_SCHEME_ALIASES = {
+    alias: scheme.canonical for scheme in _CLOUD_SCHEMES if not scheme.stages_locally for alias in scheme.aliases
+}
+
+
+def _scheme_for(path: Union[str, Path]) -> Union[CloudScheme, None]:
+    """Return the CloudScheme for a path's URI scheme, or None if unrecognised."""
+    if isinstance(path, Path):
+        path = str(path)
+    if not isinstance(path, str):
+        return None
+    return _SCHEME_BY_NAME.get(urlparse(path).scheme.lower())
 
 
 def _normalize_cloud_scheme(path: str) -> str:
@@ -476,26 +539,32 @@ def _normalize_cloud_scheme(path: str) -> str:
 
 
 def is_adls_path(path: Union[str, Path]) -> bool:
-    """Check if a path is an Azure Data Lake Storage Gen2 URI (``abfss://``).
+    """Check if a path is an Azure Data Lake Storage Gen2 URI.
 
-    These encode the storage account in the authority
-    (``abfss://container@account.dfs.core.windows.net/path``), which
-    cloudpathlib's ``az://container/path`` form cannot represent, so they are
-    staged locally rather than rewritten.
+    Covers both ``abfss://`` and ``abfs://``. These encode the storage account
+    in the authority (``abfss://container@account.dfs.core.windows.net/path``),
+    which cloudpathlib's ``az://container/path`` form cannot represent, so they
+    are staged locally rather than rewritten.
 
     Args:
         path: Path to check
 
     Returns:
-        True if path uses the abfss:// scheme
+        True if path uses an ADLS Gen2 scheme
     """
-    if isinstance(path, Path):
-        path = str(path)
+    scheme = _scheme_for(path)
+    return scheme is not None and scheme.family == "azure" and scheme.stages_locally
 
-    if not isinstance(path, str):
-        return False
 
-    return urlparse(path).scheme == "abfss"
+def cloud_provider_family(path: Union[str, Path]) -> Union[str, None]:
+    """Return the provider family for a cloud path, or None if not one.
+
+    Platform adapters gate on the family rather than on a literal list of
+    scheme spellings, so a new alias cannot be accepted by the classifier and
+    rejected by the platform.
+    """
+    scheme = _scheme_for(path)
+    return scheme.family if scheme is not None else None
 
 
 def is_databricks_path(path: Union[str, Path]) -> bool:
@@ -706,15 +775,12 @@ def validate_cloud_credentials(path: Union[str, Path]) -> dict[str, Any]:
     parsed = urlparse(str(path))
     provider = parsed.scheme
 
-    # Define expected environment variables for each provider
-    env_checks = {
-        "s3": ["AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY"],
-        "gs": ["GOOGLE_APPLICATION_CREDENTIALS"],
-        "gcs": ["GOOGLE_APPLICATION_CREDENTIALS"],
-        "abfss": ["AZURE_STORAGE_ACCOUNT_NAME", "AZURE_STORAGE_ACCOUNT_KEY"],
-        "azure": ["AZURE_STORAGE_ACCOUNT_NAME", "AZURE_STORAGE_ACCOUNT_KEY"],
-    }
-    expected_vars = env_checks.get(provider, [])
+    # Expected environment variables, derived from the scheme table so an alias
+    # cannot be recognised by the classifier yet skip its credential check --
+    # which is exactly what happened to the canonical `az://` spelling while
+    # its `azure://` alias was checked.
+    scheme_entry = _SCHEME_BY_NAME.get(provider.lower())
+    expected_vars = list(scheme_entry.env_vars) if scheme_entry else []
 
     # For S3, check multiple credential sources (not just env vars)
     if provider == "s3":
@@ -895,6 +961,16 @@ def get_cloud_path_info(path: Union[str, Path]) -> dict[str, Any]:
     bucket = parsed.netloc
     cloud_path = parsed.path.lstrip("/")
 
+    # ADLS Gen2 encodes two things in the authority:
+    # abfss://<container>@<account>.dfs.core.windows.net/<path>. Reporting the
+    # whole netloc as the bucket hands consumers a container name of
+    # "container@account.dfs.core.windows.net", so split them apart and expose
+    # the account separately.
+    account = None
+    if is_adls_path(path) and "@" in bucket:
+        bucket, _, account_host = bucket.partition("@")
+        account = account_host.split(".", 1)[0] or None
+
     # Use scheme directly so provider identity matches the URI protocol.
     provider = scheme
 
@@ -904,6 +980,7 @@ def get_cloud_path_info(path: Union[str, Path]) -> dict[str, Any]:
         "is_cloud": True,
         "provider": provider,
         "bucket": bucket,
+        "account": account,
         "path": cloud_path,
         "credentials_valid": credential_check["valid"],
     }

--- a/tests/unit/platforms/test_azure_synapse_adapter.py
+++ b/tests/unit/platforms/test_azure_synapse_adapter.py
@@ -1180,3 +1180,40 @@ class TestAzureSynapseDataLoading:
             mock_conn.cursor.return_value = Mock()
             with pytest.raises(ValueError, match="No data files found"):
                 adapter.load_data(Mock(), mock_conn, tmp_path)
+
+
+class TestSynapseStagingRootAcceptsEveryAzureSpelling:
+    """The gate keys off the provider family, not a literal list of spellings.
+
+    The old literal accepted a provider string ("abfs") the classifier never
+    produced, while rejecting the documented `azure://` form outright.
+    """
+
+    @pytest.mark.parametrize(
+        "staging_root",
+        [
+            "az://container/benchbox",
+            "azure://container/benchbox",
+            "abfss://container@account.dfs.core.windows.net/benchbox",
+            "abfs://container@account.dfs.core.windows.net/benchbox",
+        ],
+    )
+    def test_azure_staging_roots_are_accepted(self, synapse_stubs, staging_root):
+        adapter = AzureSynapseAdapter(
+            server="myworkspace.sql.azuresynapse.net",
+            username="admin",
+            password="secret",
+            staging_root=staging_root,
+        )
+        assert adapter.container == "container"
+
+    @pytest.mark.parametrize("staging_root", ["s3://bucket/benchbox", "gs://bucket/benchbox"])
+    def test_non_azure_staging_roots_are_still_rejected(self, synapse_stubs, staging_root):
+        """Widening the accepted spellings must not accept another cloud."""
+        with pytest.raises(ValueError, match="requires Azure storage"):
+            AzureSynapseAdapter(
+                server="myworkspace.sql.azuresynapse.net",
+                username="admin",
+                password="secret",
+                staging_root=staging_root,
+            )

--- a/tests/unit/utils/test_cloud_scheme_table.py
+++ b/tests/unit/utils/test_cloud_scheme_table.py
@@ -1,0 +1,157 @@
+"""One scheme table drives classification, staging, credentials and gating.
+
+Scheme identity used to be spelled out in five places -- ``is_cloud_path``'s
+literal list, the cloudpathlib alias map, the ADLS predicate, the credential
+env-var map, and ``azure_synapse``'s provider gate. Adding a scheme to one left
+the others behind, which produced three live defects:
+
+* ``abfs://`` classified as **local**, so it resolved to a *relative* path and
+  spilled generated data into the cwd -- the same mechanism as the 319 MB
+  ``@~/`` incident;
+* ``azure://`` reported provider ``"azure"``, which Synapse rejected even
+  though it is a documented output-location form;
+* ``az://`` had no entry in the credential map, so the canonical spelling
+  skipped its Azure env-var check while its alias got one.
+
+Copyright 2026 Joe Harris / BenchBox Project
+
+Licensed under the MIT License. See LICENSE file in the project root for details.
+"""
+
+from pathlib import Path
+
+import pytest
+
+from benchbox.utils.cloud_storage import (
+    _CLOUD_SCHEMES,
+    _SCHEME_BY_NAME,
+    CloudStagingPath,
+    cloud_provider_family,
+    create_path_handler,
+    is_adls_path,
+    is_cloud_path,
+    validate_cloud_credentials,
+)
+
+pytestmark = [
+    pytest.mark.unit,
+    pytest.mark.fast,
+]
+
+
+ALL_SPELLINGS = [
+    ("s3://bucket/x", "aws"),
+    ("gs://bucket/x", "gcp"),
+    ("gcs://bucket/x", "gcp"),
+    ("az://container/x", "azure"),
+    ("azure://container/x", "azure"),
+    ("abfss://container@account.dfs.core.windows.net/x", "azure"),
+    ("abfs://container@account.dfs.core.windows.net/x", "azure"),
+    ("dbfs:/Volumes/catalog/schema/volume", "databricks"),
+]
+
+
+class TestEverySchemeIsWiredEverywhere:
+    """The invariant the table exists to enforce."""
+
+    @pytest.mark.parametrize(("path", "family"), ALL_SPELLINGS)
+    def test_recognised_scheme_classifies_as_cloud(self, path, family):
+        """A scheme in the table is never treated as a local path."""
+        assert is_cloud_path(path), path
+
+    @pytest.mark.parametrize(("path", "family"), ALL_SPELLINGS)
+    def test_recognised_scheme_never_yields_a_relative_path(self, path, family):
+        """The spill mode: a relative handler writes under the cwd."""
+        handler = create_path_handler(path)
+        assert not (isinstance(handler, Path) and not handler.is_absolute()), (path, handler)
+
+    @pytest.mark.parametrize(("path", "family"), ALL_SPELLINGS)
+    def test_recognised_scheme_reports_its_family(self, path, family):
+        """Platform gates key off the family, so every scheme must have one."""
+        assert cloud_provider_family(path) == family, path
+
+    @pytest.mark.parametrize(("path", "family"), ALL_SPELLINGS)
+    def test_scheme_with_credentials_declares_env_vars(self, path, family):
+        """A scheme that needs credentials must not silently skip its check."""
+        if family == "databricks":  # validated by the Databricks adapter
+            pytest.skip("dbfs credentials are checked by the adapter")
+        assert validate_cloud_credentials(path)["env_vars"], path
+
+
+class TestAbfsNoLongerSpillsToCwd:
+    """The headline defect: abfs:// was classified local."""
+
+    ABFS = "abfs://container@account.dfs.core.windows.net/data"
+
+    def test_abfs_is_cloud(self):
+        assert is_cloud_path(self.ABFS)
+
+    def test_abfs_stages_locally_like_abfss(self):
+        """Both ADLS spellings carry the account, so both stage rather than rewrite."""
+        assert is_adls_path(self.ABFS)
+        handler = create_path_handler(self.ABFS)
+        assert isinstance(handler, CloudStagingPath)
+        assert handler.cloud_target == self.ABFS
+
+    def test_abfs_is_not_remapped_to_azure_blob(self):
+        """Rewriting would drop the account in the authority."""
+        handler = create_path_handler(self.ABFS)
+        assert "account.dfs.core.windows.net" in handler.cloud_target
+        assert not str(handler).startswith("az://")
+
+    def test_abfs_creates_no_directory_in_cwd(self, tmp_path, monkeypatch):
+        """Regression for the spill itself."""
+        monkeypatch.chdir(tmp_path)
+        create_path_handler(self.ABFS)
+        assert list(tmp_path.iterdir()) == []
+
+
+class TestAliasesAreLossless:
+    """An alias must behave exactly like its canonical spelling."""
+
+    @pytest.mark.parametrize(
+        ("alias", "canonical"),
+        [("gcs://bucket/a/b", "gs://bucket/a/b"), ("azure://container/a/b", "az://container/a/b")],
+    )
+    def test_alias_matches_canonical_handler(self, alias, canonical):
+        assert type(create_path_handler(alias)) is type(create_path_handler(canonical))
+        assert str(create_path_handler(alias)) == str(create_path_handler(canonical))
+
+    @pytest.mark.parametrize(
+        ("alias", "canonical"),
+        [
+            ("gcs://b/x", "gs://b/x"),
+            ("azure://c/x", "az://c/x"),
+            ("abfs://c@a.dfs.core.windows.net/x", "abfss://c@a.dfs.core.windows.net/x"),
+        ],
+    )
+    def test_alias_matches_canonical_family_and_credentials(self, alias, canonical):
+        """Family and credential requirements must not depend on spelling."""
+        assert cloud_provider_family(alias) == cloud_provider_family(canonical)
+        assert validate_cloud_credentials(alias)["env_vars"] == validate_cloud_credentials(canonical)["env_vars"]
+
+
+class TestTableIsWellFormed:
+    """Guardrails on the table itself, so a future entry cannot be half-wired."""
+
+    def test_no_duplicate_spellings(self):
+        """A spelling must map to exactly one scheme."""
+        spellings = [n for s in _CLOUD_SCHEMES for n in (s.canonical, *s.aliases)]
+        assert len(spellings) == len(set(spellings)), spellings
+
+    def test_every_spelling_resolves_to_its_entry(self):
+        for scheme in _CLOUD_SCHEMES:
+            for name in (scheme.canonical, *scheme.aliases):
+                assert _SCHEME_BY_NAME[name] is scheme, name
+
+    def test_unknown_scheme_is_still_local(self):
+        """The table must not accidentally widen what counts as cloud."""
+        assert not is_cloud_path("ftp://host/path")
+        assert cloud_provider_family("ftp://host/path") is None
+        assert create_path_handler("ftp://host/path") == Path("ftp://host/path")
+
+    def test_snowflake_stage_still_routes_to_staging(self):
+        """Must-preserve: stage handling is independent of the scheme table."""
+        handler = create_path_handler("@~/benchbox")
+        assert isinstance(handler, CloudStagingPath)
+        assert handler.cloud_target == "@~/benchbox"

--- a/tests/unit/utils/test_cloud_storage_base.py
+++ b/tests/unit/utils/test_cloud_storage_base.py
@@ -235,11 +235,20 @@ class TestPathInfo:
         assert info["path"] == "path/to/data"
 
     def test_get_cloud_path_info_azure(self):
-        """Test path info for Azure paths."""
+        """Test path info for Azure paths.
+
+        ADLS Gen2 packs two values into the authority
+        (``abfss://<container>@<account>.dfs.core.windows.net/<path>``). This
+        used to assert the whole netloc as the bucket, which handed consumers a
+        container literally named "container@account.dfs.core.windows.net" —
+        the Azure Synapse adapter assigned exactly that to ``self.container``.
+        Container and account are now reported separately.
+        """
         info = get_cloud_path_info("abfss://container@account.dfs.core.windows.net/path/to/data")
         assert info["is_cloud"] is True
         assert info["provider"] == "abfss"
-        assert info["bucket"] == "container@account.dfs.core.windows.net"
+        assert info["bucket"] == "container"
+        assert info["account"] == "account"
         assert info["path"] == "path/to/data"
 
 


### PR DESCRIPTION
Scheme identity was spelled out in five independent places: is_cloud_path's
literal list, the cloudpathlib alias map, the ADLS predicate, the
credential env-var map, and azure_synapse's provider gate. Adding a scheme
to one left the others behind, which had produced three live defects.

abfs:// was absent from is_cloud_path's list, so it classified as *local*
and create_path_handler returned a RELATIVE path — generated data would
land in an "abfs:" tree under the current working directory. That is the
same mechanism as the 319 MB @~/ spill that started this line of work,
still open on a scheme nobody had re-checked.

azure:// reported provider "azure", but the Synapse gate accepted only
("az", "abfs", "abfss"), so a documented output-location form was rejected
outright — while "abfs" was accepted despite the classifier being unable
to produce it.

And the credential env-var map keyed on s3/gs/gcs/abfss/azure but not
"az", so the canonical Azure spelling skipped its credential check
entirely while its alias got one.

Replace all five with a single CloudScheme table (canonical spelling,
aliases, provider family, credential env vars, whether cloudpathlib can
open it). Classification, alias rewriting, ADLS detection, credential
checks and the Synapse gate now derive from it, so a new scheme cannot be
half-wired. Synapse gates on the provider *family* rather than a list of
spellings.

Fixing abfs:// exposed a second defect it would otherwise have inherited:
get_cloud_path_info reported the whole ADLS authority as the bucket, so
consumers got a container named "container@account.dfs.core.windows.net" —
azure_synapse assigned exactly that to self.container. Container and
account are now split. An existing test asserted the unsplit value, i.e.
it pinned the defect; it now pins the fix.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01FweRvfL9Mq25NrCcLRNjRH


## The headline: the original bug was still open on another scheme

`abfs://` classified as **local**, so it resolved to a *relative* path:

```
abfs://container@account.dfs.core.windows.net/data
  is_cloud_path : False
  handler       : PosixPath   relative: True
```

That is the same mechanism as the 319 MB `@~/` spill that started this whole
line of work. #1303 fixed `gcs`/`azure`/`abfss` and left `abfs` behind — I had
even noted the inconsistency in that PR's body as "not touched here" without
checking whether it was the same data-spill bug.

## Before → after

| Path | Before | After |
|---|---|---|
| `abfs://c@a…/x` | local, **relative PosixPath** | cloud, `CloudStagingPath`, family `azure` |
| `azure://c/x` | provider `azure` → **Synapse rejects** | family `azure` → accepted |
| `az://c/x` | **no credential env vars checked** | `AZURE_STORAGE_ACCOUNT_NAME/KEY` |
| `abfss://c@a…/x` bucket | `container@account.dfs.core.windows.net` | `container` + `account` |

Unchanged, as required: `s3://`→`S3Path`, `gs://`/`gcs://`→`GSPath`,
`az://`/`azure://`→`AzureBlobPath`, `abfss://`→`CloudStagingPath`,
`dbfs:/`→`DatabricksPath`, `@~/…`→`CloudStagingPath`, `ftp://`→local.

## Code review record

| Severity | Finding | Resolution |
|---|---|---|
| Critical | Enabling `abfs://` routed it into `azure_synapse`, where `self.container = path_info["bucket"]` yields `container@account.dfs.core.windows.net`. Shipping the classification fix alone would have introduced a newly-reachable broken path. | **Fixed** — `get_cloud_path_info` now splits the ADLS authority into `bucket` + `account`. Caught by my own new Synapse test, not by inspection. |
| Required | `tests/unit/utils/test_cloud_storage_base.py::test_get_cloud_path_info_azure` **asserted the defect**: `bucket == "container@account.dfs.core.windows.net"`. | **Updated** to pin the corrected split, with a docstring explaining what the old assertion cost. |

No nits were skipped.

## Design

One `CloudScheme` table (canonical, aliases, family, credential env vars,
`stages_locally`) now drives classification, alias rewriting, ADLS detection,
credential checks, and the Synapse gate. Synapse keys off the provider **family**
rather than a list of spellings, so an alias can no longer be accepted by the
classifier and rejected by the platform. Three tests guard the table itself
(no duplicate spellings, every spelling resolves to its entry, unknown schemes
stay local) so a future entry cannot be half-wired.

## Verification

- `pytest tests/unit/utils/test_cloud_scheme_table.py` — 44 passed, 1 skipped (new)
- `pytest tests/unit/utils/ tests/unit/platforms/` — 9,326 passed
- Tracker rungs 1 and 2 — pass
- Fast lane — 25,856 passed, 18 skipped
- `make lint`, `lint-imports`, `make typecheck` — green
