### PR TITLE
fix(ci): seed-corpus workflow failed to start on every push

### DIFF
--- a/.github/workflows/seed-corpus.yml
+++ b/.github/workflows/seed-corpus.yml
@@ -109,27 +109,36 @@ jobs:
             scale_factor: "0.1"
             extras: polars
 
-    # Skip matrix entries that don't match the requested benchmark (when provided).
-    if: >
-      github.event.inputs.benchmark == '' ||
-      github.event.inputs.benchmark == matrix.benchmark
+    # Skip matrix entries that don't match the requested benchmark (when
+    # provided). This CANNOT be a job-level `if`: the matrix context is not
+    # available there (the job `if` is evaluated before the matrix expands), and
+    # referencing it made the whole workflow fail to start — GitHub recorded a
+    # failed run with zero jobs on every push. `env` at job level *can* read
+    # matrix, so the condition is computed once here and each step guards on it.
+    env:
+      SELECTED: ${{ github.event.inputs.benchmark == '' || github.event.inputs.benchmark == matrix.benchmark }}
 
     steps:
       - name: Checkout code
+        if: env.SELECTED == 'true'
         uses: actions/checkout@v4
 
       - name: Set up Python
+        if: env.SELECTED == 'true'
         uses: actions/setup-python@v5
         with:
           python-version: "3.12"
 
       - name: Install uv
+        if: env.SELECTED == 'true'
         uses: astral-sh/setup-uv@v4
 
       - name: Install BenchBox
+        if: env.SELECTED == 'true'
         run: uv sync --extra ${{ matrix.extras }}
 
       - name: Run benchmark
+        if: env.SELECTED == 'true'
         env:
           CLICKHOUSE_CLOUD_HOST: ${{ secrets.CLICKHOUSE_CLOUD_HOST }}
           CLICKHOUSE_CLOUD_PASSWORD: ${{ secrets.CLICKHOUSE_CLOUD_PASSWORD }}
@@ -142,6 +151,7 @@ jobs:
             --compression zstd:9
 
       - name: Locate result bundle
+        if: env.SELECTED == 'true'
         id: locate
         shell: bash
         run: |
@@ -159,6 +169,7 @@ jobs:
           echo "Found result bundle: $RESULT"
 
       - name: Stage bundle under results-data/
+        if: env.SELECTED == 'true'
         shell: bash
         env:
           RESULT_FILE: ${{ steps.locate.outputs.result_file }}
@@ -177,6 +188,7 @@ jobs:
         id: stage
 
       - name: Upload bundle artifact
+        if: env.SELECTED == 'true'
         uses: actions/upload-artifact@v4
         with:
           # Artifact name must be unique per matrix entry.


### PR DESCRIPTION
Every push to any branch produced a red "Seed Corpus" run: conclusion
failure, zero jobs, no logs. Eight of eight sampled runs failed this way,
spanning 2026-07-25 to 2026-07-26. Zero jobs and no logs is the signature
of a startup failure — GitHub rejecting the workflow file itself — which
is why nothing showed up in job output and why it looked unattributable.

The job declared:

    if: >
      github.event.inputs.benchmark == '' ||
      github.event.inputs.benchmark == matrix.benchmark

The matrix context is not available in jobs.<id>.if — that condition is
evaluated before the matrix expands. The expression is therefore invalid,
and an invalid workflow file fails at startup for every event GitHub
evaluates it against, including pushes the workflow does not even
subscribe to (it is workflow_dispatch-only).

Job-level `env` *can* read matrix, so the condition is computed once there
and each of the eight steps guards on it. The manual benchmark filter
behaves as before; the workflow remains dispatch-only.

Scanned every workflow for the same shape: seed-corpus.yml was the only
job-level offender. nightly.yml:67 also references matrix in an `if`, but
at step level, where it is legal.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01FweRvfL9Mq25NrCcLRNjRH


## Root cause

A **job-level** `if` referencing the matrix context:

```yaml
    if: >
      github.event.inputs.benchmark == '' ||
      github.event.inputs.benchmark == matrix.benchmark
```

`matrix` is not available in `jobs.<job_id>.if` — that condition is evaluated
*before* the matrix expands. The expression is therefore invalid, and GitHub
records a **startup failure**: a run with `conclusion=failure` and **zero jobs**.

Sampled the last 8 runs before the fix: **8 of 8 failed**, every one
`event=push`, `jobs total_count=0`. Not just develop — the run I diagnosed was
triggered by a push to a feature branch. So every push in the repo produced a red
"Seed Corpus" check, unrelated to any change, which is exactly the noise that
trains reviewers to ignore red.

It went unnoticed because nothing catches it: the YAML is valid (`yaml.safe_load`
parses it happily), the failure has no job logs to read, and there is no
actionlint in any lane.

## Fix

`env` at job level **can** read `matrix`, unlike `if`. So the condition is
computed once there and each of the 8 steps guards on it:

```yaml
    env:
      SELECTED: ${{ github.event.inputs.benchmark == '' || github.event.inputs.benchmark == matrix.benchmark }}
    steps:
      - name: Checkout code
        if: env.SELECTED == 'true'
```

The `benchmark` dispatch input keeps working exactly as documented — the
must-preserve — and the workflow stays dispatch-only.

## Scope of the defect class

I scanned every `.github/workflows/*.yml` for the same shape:

```
job-level ifs referencing matrix: none   (after this fix)
```

`seed-corpus.yml` was the **only** job-level offender. `nightly.yml:67` also
references `matrix` in an `if`, but that is a *step*-level `if`, which is legal.
So no other workflow needs changing today.

## Deferred

No automated guard stops this recurring — promoted to
`workflow-lint-guard-for-invalid-context-references` (medium). A unit guard under
`tests/unit/workflows/` or actionlint in the lint lane would catch it; both are
outside this item's `only_modify` allowlist of the single workflow file.

## Verification rung 1 is post-merge by construction

Rung 1 counts failures among the **last 5 historical runs**, so it necessarily
reports `fail` until this has merged and five further pushes have occurred. It
currently reads 5/5 failures — the pre-fix state it was written to describe.
Unlike the unsatisfiable rungs found earlier in this batch, this one becomes true
on its own; it just cannot be green before merge.

Checked instead, pre-merge:

- `yaml.safe_load` parses the file; jobs are `generate-seed-corpus`, `create-pr`
- no job-level `if` in the file references `matrix` (programmatic check)
- all 8 steps carry the guard; the dispatch input is unchanged
- `make lint` green; `pytest tests/unit/workflows/` — 59 passed
