### PR TITLE
fix(todo): let lint audit finished items, so the rung sweep is possible

### DIFF
--- a/_project/scripts/todo_db.py
+++ b/_project/scripts/todo_db.py
@@ -2498,6 +2498,11 @@ def main(argv: list[str] | None = None) -> int:
     p.add_argument("--run", type=int, metavar="SEQ")
 
     p = sub.add_parser("lint", help="mechanical quality checks")
+    p.add_argument(
+        "--include-done",
+        action="store_true",
+        help="lint every item including done/dropped (audit mode; implies --all)",
+    )
     p.add_argument("id", nargs="?")
     p.add_argument("--all", action="store_true")
 
@@ -2892,11 +2897,19 @@ def _cmd_verify(conn, actor, args):
 
 
 def _cmd_lint(conn, actor, args):
-    targets = (
-        [row["id"] for row in conn.execute("SELECT id FROM items WHERE state IN ('planning','active') ORDER BY id")]
-        if args.all
-        else [args.id]
-    )
+    # --all lints the open backlog, which is what a triage pass wants. An audit
+    # of *authored quality* needs the finished ones too: a rung whose command
+    # can never express its expectation is invisible to --all once the item is
+    # done, and that is exactly where such rungs accumulate -- every offender
+    # found in the 2026-07-26 sweep sat on a done item.
+    # getattr: programmatic callers construct a minimal namespace, so a new
+    # optional flag must not become a required attribute.
+    include_done = getattr(args, "include_done", False)
+    if args.all or include_done:
+        states = "('planning','active','done','dropped')" if include_done else "('planning','active')"
+        targets = [row["id"] for row in conn.execute(f"SELECT id FROM items WHERE state IN {states} ORDER BY id")]
+    else:
+        targets = [args.id]
     if targets == [None]:
         raise TodoError("lint requires an item id or --all")
     total = 0


### PR DESCRIPTION
`lint --all` iterates `state IN ('planning','active')`. That is right for
triaging the open backlog, but it makes an audit of *authored quality*
impossible: a verification whose command can never express its expectation
is invisible once the item is done, and done is exactly where such rungs
accumulate. Running the corpus sweep this item asks for returned zero
findings for that reason, while linting a known-bad item directly reported
it — the sweep was silently scoped away from its own subject.

Add --include-done. The default is unchanged, so triage behaviour and
every existing caller keep working; the flag is read with getattr so a
programmatic caller building a minimal namespace does not break.

The sweep now covers 1626 items and finds 2 unsatisfiable rungs:
results-explorer-qa-pass2-fixes seq 8 (`open http://...`, which always
exits 0, expecting a page NOT to render something) and
timing-policy-check-misreports-pytest-failure-as-violation seq 1. Both sit
on done items, so neither can be repaired: verifications are create-time
only here, `update` is standalone-only, and amending a finished item is
refused by design. Repair depends on adopting todo-db >= 0.3, tracked
separately.

Correcting the record while here: PR #1311 reported this rule flagging
"8 of 2958 (0.27%)". That came from a draft regex in the calibration
script, not the one that merged — the shipped pattern binds "must not" to
an output verb and drops "rather than"/"instead of", so it flags 2. The
narrower rule is the right one ("must not fail with X" IS expressible by
exit code), but the published figure measured code that never shipped.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01FweRvfL9Mq25NrCcLRNjRH


## The sweep could not see its own subject

Running the corpus sweep this item asks for returned **zero** findings — while
linting a known-bad item directly reported it:

```
$ todo lint --all                              -> 0 unsatisfiable rungs
$ todo lint results-explorer-qa-pass2-fixes    -> verification seq [8] expects output that must be absent
```

`lint --all` iterates `state IN ('planning','active')`. Correct for triaging the
open backlog, wrong for auditing *authored quality*: a rung that can never pass
is invisible once the item is done, and done is exactly where they accumulate.
`--include-done` fixes that; the default is unchanged, and the flag is read with
`getattr` so a programmatic caller building a minimal namespace does not break
(a real test does exactly that).

## Sweep result

Across **1626 items**, exactly **2** unsatisfiable rungs remain:

| Item | Rung | Why it can never pass |
|---|---|---|
| `results-explorer-qa-pass2-fixes` | seq 8 | `open http://…` always exits 0, while the expectation is that a page does **not** render something |
| `timing-policy-check-misreports-…` | seq 1 | expects output, but the correct behaviour is a **non-zero** exit |

**Neither can be repaired.** Both are on `done` items: verifications are
create-time-only in this wrapper, `update` is standalone-only
(`adopt-todo-db-standalone-cli-for-amendable-items`), and amending a finished
item is refused by design — a done record is history. So the repair half is not
actionable here; the audit capability and the guidance from #1311 are.

## Correcting a number I published

PR #1311's body claims this rule flags **"8 of 2958 (0.27%)"**. That came from a
**draft regex in my calibration script, not the rule that merged**. The shipped
pattern is narrower:

```
must not\s+(?:print|contain|report|emit|include|output|show)
```

— `must not` is bound to an output verb, and there are no `rather than` /
`instead of` alternations. It flags **2**, not 8.

The narrower rule is the correct one: *"must not fail with X"* and *"instead of
failing setup"* **are** expressible by an exit code, so those 6 were false
positives. But the figure I published measured code that never shipped, and
anyone auditing that claim would not reproduce it.

## Scope note

`only_modify` on this item is `_project/scripts/todo_db.py` only — a limit I set
myself when filing it — so no test accompanies `--include-done`. The existing
`test_lint_all_ignores_findings` does exercise the changed function and passes;
findings live in their own `findings` table, so the widened state filter over
`items` cannot pull them in.

## Verification

- `pytest tests/unit/scripts/ -k todo` — 290 passed
- Fast lane — 25,900 passed, 18 skipped
- `make lint` — green
- `todo check-scope` — OK (1 file)
