### PR TITLE
fix(todo): check-scope must not report OK on a diff it never checked

### DIFF
--- a/_project/scripts/todo_db.py
+++ b/_project/scripts/todo_db.py
@@ -2518,6 +2518,11 @@ def main(argv: list[str] | None = None) -> int:
     p = sub.add_parser("check-scope", help="git diff --name-only vs scope rules")
     p.add_argument("id")
     p.add_argument("--base", help="diff BASE...HEAD instead of the working tree")
+    p.add_argument(
+        "--strict",
+        action="store_true",
+        help="exit non-zero when the item has no scope rules (nothing was checked)",
+    )
 
     p = sub.add_parser("verify", help="list or run verification steps")
     p.add_argument("id")
@@ -2903,6 +2908,16 @@ def _cmd_stats(conn, actor, args):
 def _cmd_check_scope(conn, actor, args):
     item = get_item(conn, args.id)
     files = changed_files(args.base)
+
+    # An item with no scope rules has nothing to violate, so check_paths()
+    # returns clean and the command used to print "scope OK" -- announcing a
+    # passed check while performing none. Every item promoted before the
+    # guardrail flags existed has empty scope, so this reported OK on diffs it
+    # had never looked at. Say what actually happened instead.
+    if not item["scope"]:
+        print(f"SCOPE_UNCHECKED: no scope rules on {args.id!r}; {len(files)} changed file(s) were not checked")
+        return 1 if getattr(args, "strict", False) else 0
+
     violations = check_paths(files, item["scope"])
     for violation in violations:
         print(violation)

--- a/tests/unit/scripts/test_todo_db.py
+++ b/tests/unit/scripts/test_todo_db.py
@@ -844,3 +844,62 @@ class TestPromoteCarriesGuardrails:
         item = todo_db.get_item(conn, "promoted-bare")
         assert item["scope"] == []
         assert item["verifications"] == []
+
+
+class TestCheckScopeReportsWhatItActuallyChecked:
+    """`check-scope` must not claim a pass it never performed.
+
+    An item with no scope rules has nothing to violate, so `check_paths()`
+    returned clean and the command printed "scope OK" over a diff it had never
+    looked at. Every item promoted before the guardrail flags existed has
+    empty scope, so this was the common case, not an edge case.
+    """
+
+    def _run(self, conn, monkeypatch, item_id, files, strict=False):
+        monkeypatch.setattr(todo_db, "changed_files", lambda base: files)
+        return todo_db._cmd_check_scope(conn, "tester", SimpleNamespace(id=item_id, base=None, strict=strict))
+
+    def test_no_rules_reports_unchecked_not_ok(self, conn, monkeypatch, capsys):
+        """The headline: no rules must never render as OK."""
+        _mk(conn)
+        rc = self._run(conn, monkeypatch, "sample-item", ["benchbox/anything.py", "docs/x.md"])
+        out = capsys.readouterr().out
+        assert "SCOPE_UNCHECKED" in out
+        assert "scope OK" not in out
+        assert "2 changed file(s) were not checked" in out
+        assert rc == 0  # default stays non-blocking for existing callers
+
+    def test_no_rules_under_strict_exits_non_zero(self, conn, monkeypatch, capsys):
+        """Opt-in gate for callers that want an unchecked item to fail."""
+        _mk(conn)
+        assert self._run(conn, monkeypatch, "sample-item", ["benchbox/x.py"], strict=True) == 1
+        assert "SCOPE_UNCHECKED" in capsys.readouterr().out
+
+    def test_strict_is_optional_for_programmatic_callers(self, conn, monkeypatch, capsys):
+        """A namespace without --strict must not raise (getattr, not attribute)."""
+        _mk(conn)
+        monkeypatch.setattr(todo_db, "changed_files", lambda base: ["a.py"])
+        assert todo_db._cmd_check_scope(conn, "tester", SimpleNamespace(id="sample-item", base=None)) == 0
+
+    def test_scoped_item_compliant_still_reports_ok(self, conn, monkeypatch, capsys):
+        """Must-preserve: an item WITH rules keeps its pass behaviour."""
+        _mk(conn, scope=[("only_modify", "benchbox/core/*")])
+        rc = self._run(conn, monkeypatch, "sample-item", ["benchbox/core/thing.py"])
+        out = capsys.readouterr().out
+        assert rc == 0
+        assert "scope OK (1 changed file(s))" in out
+        assert "SCOPE_UNCHECKED" not in out
+
+    def test_scoped_item_violation_still_fails(self, conn, monkeypatch, capsys):
+        """Must-preserve: violations keep exit 1 and their message."""
+        _mk(conn, scope=[("only_modify", "benchbox/core/*")])
+        rc = self._run(conn, monkeypatch, "sample-item", ["benchbox/cli/other.py"])
+        out = capsys.readouterr().out
+        assert rc == 1
+        assert "benchbox/cli/other.py" in out
+        assert "SCOPE_UNCHECKED" not in out
+
+    def test_scoped_item_violation_under_strict_is_unchanged(self, conn, monkeypatch):
+        """--strict only affects the no-rules case."""
+        _mk(conn, scope=[("only_modify", "benchbox/core/*")])
+        assert self._run(conn, monkeypatch, "sample-item", ["benchbox/cli/x.py"], strict=True) == 1


### PR DESCRIPTION
An item with no scope rules has nothing to violate, so check_paths()
returned clean and the command printed "scope OK (N changed file(s))" —
announcing a passed check while performing none. That is not an edge
case: every item created by `promote` before it could carry guardrails
has empty scope, so across the last three batches at least six PRs
recorded "check-scope passes trivially rather than meaningfully" and
self-policed scope by hand instead.

Report what actually happened:

    SCOPE_UNCHECKED: no scope rules on 'x'; 2 changed file(s) were not checked

The default exit code stays 0, because no Makefile target, pre-commit
hook or CI job calls check-scope today and agents treat non-zero as "you
touched the wrong file" — turning an unscoped item into that would be a
different lie. `--strict` opts into exiting non-zero for callers that
want an unchecked item to fail.

An item WITH rules is untouched: compliant still prints "scope OK" and
exits 0, a violation still names the file and exits 1, and --strict
changes neither.

Same defect class as two others fixed this cycle: timing_policy_check
reporting an environment failure as policy violations (#1306), and
delta-check blaming a missing baseline for a failed collect (#1320). A
check that cannot fail must not report success.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01FweRvfL9Mq25NrCcLRNjRH


## Live before/after

`workflow-lint-guard-for-invalid-context-references` was promoted before
`promote` could carry guardrails, so it has **0 scope rules**. With a 2-file
working diff:

```
before:  scope OK (2 changed file(s))
after :  SCOPE_UNCHECKED: no scope rules on '...'; 2 changed file(s) were not checked
--strict exit: 1
```

The old output is the problem in one line: a green "OK" over two files it never
looked at.

## Why the default exit code stays 0

I checked every caller before touching this. **No** Makefile target, pre-commit
hook or CI workflow invokes `check-scope` — only agents and tests. (The tracker
spec says hooks *may* call it; none do yet.)

Agents read a non-zero exit as "you touched a file outside scope". Making an
*unscoped* item exit non-zero would swap one wrong signal for another. So the
default stays 0 with honest output, and `--strict` is the opt-in gate for
callers that want an unchecked item to fail.

## Must-preserve, tested

| Case | Before | After |
|---|---|---|
| rules + compliant | `scope OK (N)`, exit 0 | unchanged |
| rules + violation | names the file, exit 1 | unchanged |
| rules + violation + `--strict` | — | still exit 1 (`--strict` only affects the no-rules case) |
| **no rules** | **`scope OK (N)`, exit 0** | **`SCOPE_UNCHECKED`, exit 0 (1 under `--strict`)** |

`--strict` is read with `getattr`, so a programmatic caller building a minimal
namespace does not break — a real test in this repo does exactly that.

## Provenance

This is the finding I kept *writing down and not filing*. The phrase
"check-scope passes trivially rather than meaningfully" appears in six PR bodies
across the last three batches; it only became a tracked item when I audited my
own follow-ups. Same defect class as two already fixed this cycle —
`timing_policy_check` reporting an environment failure as policy violations
(#1306) and `delta-check` blaming a missing baseline for a failed collect
(#1320). A check that cannot fail must not report success.

## Verification

- `pytest tests/unit/scripts/test_todo_db.py -k CheckScope` — 6 passed (new)
- Tracker rungs 1 and 2 — pass
- Fast lane — 25,908 passed, 18 skipped
- `make lint` — green
