### PR TITLE
feat(tracker): findings-domain phase 4 — surface untriaged findings in ready/stats

### DIFF
--- a/.claude/skills/todo-db/SKILL.md
+++ b/.claude/skills/todo-db/SKILL.md
@@ -34,7 +34,13 @@ Global `--db` / `--actor` flags go before the subcommand.
 | `ready` / `claim` / `start` / `done` / `defer` / `check-scope` / `verify` / `complete` / `promote` / `dismiss` | `references/implement.md` |
 | `create` / `update` / `list` / `show` / `stats` / `deps` / `export` / `block` / `unblock` / `release` / `sweep-stale` / `drop` | `references/queries.md` |
 | `lint` | `references/review.md` |
+| `finding candidates` / `finding triage` / `finding sync` / `finding promote` | `references/implement.md` |
 | `batch` | `references/batch.md` |
+
+`ready` and `stats` print a one-line stderr banner when untriaged findings exist
+(open findings or unsynced drafts); run `todo finding candidates` to triage them.
+The banner is stderr-only and suppressed at zero, so it never perturbs the
+machine-readable stdout those commands emit.
 
 Standalone-only actions — declared machine-readably in the skill sidecar as
 `standalone_only_commands`, currently `update` — exist only in todo-db >= 0.3;

--- a/.claude/skills/todo-db/references/batch.md
+++ b/.claude/skills/todo-db/references/batch.md
@@ -77,6 +77,9 @@ or `/loop` may wrap the action, but the ledger + DB remain the source of truth.
 Loop until every item is `done` or `blocked`:
 
 1. Re-read the ledger; refresh readiness with `todo ready` and `todo deps`.
+   `ready`/`stats` also surface untriaged findings on stderr; run
+   `todo finding candidates` to triage them (they are review blind spots, not
+   batch items, and never enter the ready queue).
 2. Classify each non-terminal item (`ready` is derived, not stored):
    - `ready`: batch-local `pending`, every in-batch dep `done` (its PR merged
      into the integration branch — unless a stacked-branch exception is

--- a/.claude/skills/todo-db/references/implement.md
+++ b/.claude/skills/todo-db/references/implement.md
@@ -2,7 +2,10 @@
 
 1. `todo ready` picks the top ready item; `todo claim <id>` prints the work
    order: scope, must-preserves, anti-patterns, verification ladder, ready
-   units, and deferrals. Treat it as the whole briefing.
+   units, and deferrals. Treat it as the whole briefing. If `ready` prints an
+   untriaged-findings banner on stderr, run `todo finding candidates` and
+   `todo finding triage <id> ...` to dispose of them (a review blind spot, not
+   a claimable item) before picking up new work.
 2. Per unit, optionally `todo start <id> <wid>`, implement, then
    `todo done <id> <wid> --evidence "<command run / commit / PR>"`.
 3. Defer skipped work immediately with `todo defer <id> --summary "..."

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -111,7 +111,11 @@ The shared database is the only TODO record. `_project/scripts/todo` is the
 only write path; global `--db`/`--actor` flags precede the subcommand. Tracker
 writes follow the same worktree policy. `todo claim <id>` prints the binding
 work order; follow its scope, preserve rules, anti-patterns, dependencies, and
-verification. Exit 2 means fix the cause, never bypass it.
+verification. Exit 2 means fix the cause, never bypass it. `todo ready` and
+`todo stats` print an untriaged-findings banner on stderr when open findings or
+unsynced drafts exist; triage via `todo finding candidates` (`finding
+list`/`show`/`candidates` are read-only; findings are review blind spots, never
+claimable items).
 
 ## BenchBox invariants
 

--- a/_project/scripts/todo_db.py
+++ b/_project/scripts/todo_db.py
@@ -2893,14 +2893,24 @@ def _cmd_list(conn, actor, args):
 
 def _emit_findings_banner(conn) -> None:
     """Print the untriaged-findings hint to stderr, never stdout. Best-effort: a
-    hint must never break ``ready``/``stats`` core output, so any failure here
-    (e.g. a transient read error) is swallowed after the stdout contract is met."""
+    hint must never break ``ready``/``stats`` core output, so any failure here is
+    swallowed after the stdout contract is met.
+
+    The *print* is inside the guard too, not just the query: the banner carries
+    non-ASCII (``→``/``—``), so a byte-oriented stderr (C locale, or a POSIX pipe
+    under LC_ALL=C) raises UnicodeEncodeError on write. Degrade to an ASCII
+    transliteration before giving up, so the hint survives such a stream instead
+    of vanishing."""
     try:
         banner = todo_findings.surfacing_banner(conn)
+        if not banner:
+            return
+        try:
+            print(banner, file=sys.stderr)
+        except UnicodeEncodeError:
+            print(banner.encode("ascii", "replace").decode("ascii"), file=sys.stderr)
     except Exception:
         return
-    if banner:
-        print(banner, file=sys.stderr)
 
 
 def _cmd_ready(conn, actor, args):

--- a/_project/scripts/todo_db.py
+++ b/_project/scripts/todo_db.py
@@ -1761,6 +1761,9 @@ def stats(conn: sqlite3.Connection) -> dict[str, Any]:
         ),
         "deferrals_by_resolution": counts("SELECT resolution, count(*) FROM deferrals GROUP BY resolution"),
         "claimed": counts("SELECT claimed_by, count(*) FROM items WHERE claimed_by IS NOT NULL GROUP BY claimed_by"),
+        # Additive findings-domain key (phase 4). Present but empty when there are
+        # no findings; existing items-domain keys above are untouched.
+        "findings_by_disposition": todo_findings.findings_by_disposition(conn),
     }
 
 
@@ -2888,15 +2891,29 @@ def _cmd_list(conn, actor, args):
     return 0
 
 
+def _emit_findings_banner(conn) -> None:
+    """Print the untriaged-findings hint to stderr, never stdout. Best-effort: a
+    hint must never break ``ready``/``stats`` core output, so any failure here
+    (e.g. a transient read error) is swallowed after the stdout contract is met."""
+    try:
+        banner = todo_findings.surfacing_banner(conn)
+    except Exception:
+        return
+    if banner:
+        print(banner, file=sys.stderr)
+
+
 def _cmd_ready(conn, actor, args):
     for item in ready_items(conn, actor):
         claim_note = " (claimed by you)" if item["claimed_by"] == actor else ""
         print(f"{item['id']:55s} {item['priority']:12s} {item['worktree']}{claim_note}")
+    _emit_findings_banner(conn)
     return 0
 
 
 def _cmd_stats(conn, actor, args):
     print(json.dumps(stats(conn), indent=2, sort_keys=True))
+    _emit_findings_banner(conn)
     return 0
 
 

--- a/_project/scripts/todo_db.py
+++ b/_project/scripts/todo_db.py
@@ -2891,24 +2891,38 @@ def _cmd_list(conn, actor, args):
     return 0
 
 
-def _emit_findings_banner(conn) -> None:
+_BANNER_ASCII = {ord("→"): "->", ord("—"): "--"}
+
+
+def _emit_findings_banner(conn, open_count: int | None = None) -> None:
     """Print the untriaged-findings hint to stderr, never stdout. Best-effort: a
     hint must never break ``ready``/``stats`` core output, so any failure here is
     swallowed after the stdout contract is met.
 
-    The *print* is inside the guard too, not just the query: the banner carries
-    non-ASCII (``→``/``—``), so a byte-oriented stderr (C locale, or a POSIX pipe
-    under LC_ALL=C) raises UnicodeEncodeError on write. Degrade to an ASCII
-    transliteration before giving up, so the hint survives such a stream instead
-    of vanishing."""
+    ``open_count`` lets a caller that already counted findings (``stats``) pass
+    the number through instead of paying a second aggregate.
+
+    Two stderr hazards are handled explicitly, because the guard alone cannot:
+
+    * ``sys.stderr is None`` -- when fd 2 is closed (``2>&-``) CPython sets it to
+      None and ``print(..., file=None)`` falls back to *stdout*, which would put
+      the hint in the machine-readable stream. Bail out instead.
+    * a strict non-UTF-8 stream -- the banner carries ``->``/``--`` as ``→``/``—``.
+      CPython's default stderr uses ``errors='backslashreplace'`` and C locales
+      get coerced to UTF-8 (PEP 538), so this needs an explicitly strict stream
+      (``PYTHONIOENCODING=ascii:strict``, or a ``reconfigure``d stderr) to bite --
+      uncommon, but cheap to survive: fall back to an ASCII transliteration
+      rather than losing the hint."""
+    if sys.stderr is None:
+        return
     try:
-        banner = todo_findings.surfacing_banner(conn)
+        banner = todo_findings.surfacing_banner(conn, open_count=open_count)
         if not banner:
             return
         try:
             print(banner, file=sys.stderr)
         except UnicodeEncodeError:
-            print(banner.encode("ascii", "replace").decode("ascii"), file=sys.stderr)
+            print(banner.translate(_BANNER_ASCII), file=sys.stderr)
     except Exception:
         return
 
@@ -2922,8 +2936,11 @@ def _cmd_ready(conn, actor, args):
 
 
 def _cmd_stats(conn, actor, args):
-    print(json.dumps(stats(conn), indent=2, sort_keys=True))
-    _emit_findings_banner(conn)
+    computed = stats(conn)
+    print(json.dumps(computed, indent=2, sort_keys=True))
+    # Reuse the disposition breakdown already computed above rather than issuing
+    # a second `count(*) WHERE disposition='open'` for the banner.
+    _emit_findings_banner(conn, open_count=computed["findings_by_disposition"].get("open", 0))
     return 0
 
 

--- a/_project/scripts/todo_findings.py
+++ b/_project/scripts/todo_findings.py
@@ -520,6 +520,47 @@ def count_unsynced_drafts(drafts_dir: str | Path = DEFAULT_DRAFTS_DIR) -> int:
     return sum(1 for p in directory.glob("*.md") if p.name != "README.md")
 
 
+def open_findings_count(conn) -> int:
+    """Count findings still awaiting triage (``disposition='open'``).
+
+    A single cheap ``count(*)`` on the connection ``ready``/``stats`` already
+    holds -- on the hosted backend it is served from the local embedded replica,
+    so it adds no primary (network) round-trip to those commands.
+    """
+    row = conn.execute("SELECT count(*) FROM findings WHERE disposition = 'open'").fetchone()
+    return int(row[0])
+
+
+def findings_by_disposition(conn) -> dict[str, int]:
+    """Findings grouped by disposition, for the additive ``todo stats`` key."""
+    return {row[0]: row[1] for row in conn.execute("SELECT disposition, count(*) FROM findings GROUP BY disposition")}
+
+
+def surfacing_banner(conn, drafts_dir: str | Path | None = None) -> str | None:
+    """A one-line hint for ``ready``/``stats`` pointing at untriaged findings.
+
+    Returns ``None`` when there is nothing to surface (no open findings and no
+    unsynced drafts), so callers emit nothing at zero-state and never perturb the
+    machine-readable *stdout* of those commands. Callers must print the returned
+    string to *stderr* (the stdout contract is items-domain only).
+
+    ``drafts_dir`` defaults to ``DEFAULT_DRAFTS_DIR`` resolved at call time (not
+    bound at definition), so the default remains overridable for tests.
+    """
+    if drafts_dir is None:
+        drafts_dir = DEFAULT_DRAFTS_DIR
+    open_count = open_findings_count(conn)
+    draft_count = count_unsynced_drafts(drafts_dir)
+    if not open_count and not draft_count:
+        return None
+    parts = []
+    if open_count:
+        parts.append(f"{open_count} open finding(s)")
+    if draft_count:
+        parts.append(f"{draft_count} unsynced draft(s)")
+    return f"→ {', '.join(parts)} awaiting triage — see: todo finding candidates"
+
+
 # ---------------------------------------------------------------------------
 # Capture (zero-credential draft write)
 

--- a/_project/scripts/todo_findings.py
+++ b/_project/scripts/todo_findings.py
@@ -536,7 +536,7 @@ def findings_by_disposition(conn) -> dict[str, int]:
     return {row[0]: row[1] for row in conn.execute("SELECT disposition, count(*) FROM findings GROUP BY disposition")}
 
 
-def surfacing_banner(conn, drafts_dir: str | Path | None = None) -> str | None:
+def surfacing_banner(conn, drafts_dir: str | Path | None = None, open_count: int | None = None) -> str | None:
     """A one-line hint for ``ready``/``stats`` pointing at untriaged findings.
 
     Returns ``None`` when there is nothing to surface (no open findings and no
@@ -546,10 +546,13 @@ def surfacing_banner(conn, drafts_dir: str | Path | None = None) -> str | None:
 
     ``drafts_dir`` defaults to ``DEFAULT_DRAFTS_DIR`` resolved at call time (not
     bound at definition), so the default remains overridable for tests.
+    ``open_count`` lets a caller that already has the number (``stats``) skip the
+    aggregate entirely.
     """
     if drafts_dir is None:
         drafts_dir = DEFAULT_DRAFTS_DIR
-    open_count = open_findings_count(conn)
+    if open_count is None:
+        open_count = open_findings_count(conn)
     draft_count = count_unsynced_drafts(drafts_dir)
     if not open_count and not draft_count:
         return None

--- a/skill-sync.lock
+++ b/skill-sync.lock
@@ -533,16 +533,16 @@
       "installMode": "mirror",
       "files": {
         "references/batch.md": {
-          "sha256": "dc29f1de1ee519229b0fc7a6c572d072b23d6c9af61f67af997451f69b50e8f0",
-          "size": 7148
+          "sha256": "4776c543bc4d561b474c1756f0eeb070be5ae1abc2289036324685e6d581cc19",
+          "size": 7342
         },
         "references/bootstrap.md": {
           "sha256": "32e63add6eeb9a867e21c35edf6860fd11723815efd79df10b082ee5b0197ac9",
           "size": 3691
         },
         "references/implement.md": {
-          "sha256": "bb2d86fc5851b133972e436905af70930c856d807aa279c9937ca850359b6874",
-          "size": 724
+          "sha256": "419ded392de794af2585e6e62ead71c0f2d2fbd82c3af5ce566fe9ae1e1bcb7b",
+          "size": 947
         },
         "references/queries.md": {
           "sha256": "01c5148027786407db44217d055d1551479eed925b53750bb97ed29f00277eeb",
@@ -553,8 +553,8 @@
           "size": 318
         },
         "SKILL.md": {
-          "sha256": "27968ecb235dc38a08c0e3c57bae0aecc59db9bae18f340766fee369805b6195",
-          "size": 2731
+          "sha256": "88b37f7ebeacb92b38b12defaf3d2a52dfd82bc9b91423e459aeef9b84465b72",
+          "size": 3124
         },
         "skill.yaml": {
           "sha256": "fa88ff2e982370807916731064d93e278e7ad93f320fe8bcacf1c078ab2b093f",

--- a/skill-sync.lock
+++ b/skill-sync.lock
@@ -1,16 +1,16 @@
 {
   "version": 1,
-  "lockedAt": "2026-07-28T18:14:03.945Z",
+  "lockedAt": "2026-07-29T11:48:57.836Z",
   "skills": {
     "blog": {
       "source": {
         "type": "git",
         "name": "canonical",
         "url": "https://github.com/joeharris76/skill-sync-skills.git",
-        "ref": "b98bf27413ee122f47c515d4d685965ce5df7df7",
+        "ref": "a48d0c02884f032b075f5968ab23e1261cf23dbc",
         "subdir": "skills",
-        "revision": "b98bf27413ee122f47c515d4d685965ce5df7df7",
-        "fetchedAt": "2026-07-28T18:13:51.941Z"
+        "revision": "a48d0c02884f032b075f5968ab23e1261cf23dbc",
+        "fetchedAt": "2026-07-29T11:48:46.755Z"
       },
       "installMode": "mirror",
       "files": {
@@ -61,10 +61,10 @@
         "type": "git",
         "name": "canonical",
         "url": "https://github.com/joeharris76/skill-sync-skills.git",
-        "ref": "b98bf27413ee122f47c515d4d685965ce5df7df7",
+        "ref": "a48d0c02884f032b075f5968ab23e1261cf23dbc",
         "subdir": "skills",
-        "revision": "b98bf27413ee122f47c515d4d685965ce5df7df7",
-        "fetchedAt": "2026-07-28T18:13:52.571Z"
+        "revision": "a48d0c02884f032b075f5968ab23e1261cf23dbc",
+        "fetchedAt": "2026-07-29T11:48:47.365Z"
       },
       "installMode": "mirror",
       "files": {
@@ -111,10 +111,10 @@
         "type": "git",
         "name": "canonical",
         "url": "https://github.com/joeharris76/skill-sync-skills.git",
-        "ref": "b98bf27413ee122f47c515d4d685965ce5df7df7",
+        "ref": "a48d0c02884f032b075f5968ab23e1261cf23dbc",
         "subdir": "skills",
-        "revision": "b98bf27413ee122f47c515d4d685965ce5df7df7",
-        "fetchedAt": "2026-07-28T18:13:53.239Z"
+        "revision": "a48d0c02884f032b075f5968ab23e1261cf23dbc",
+        "fetchedAt": "2026-07-29T11:48:48.044Z"
       },
       "installMode": "mirror",
       "files": {
@@ -157,10 +157,10 @@
         "type": "git",
         "name": "canonical",
         "url": "https://github.com/joeharris76/skill-sync-skills.git",
-        "ref": "b98bf27413ee122f47c515d4d685965ce5df7df7",
+        "ref": "a48d0c02884f032b075f5968ab23e1261cf23dbc",
         "subdir": "skills",
-        "revision": "b98bf27413ee122f47c515d4d685965ce5df7df7",
-        "fetchedAt": "2026-07-28T18:13:54.536Z"
+        "revision": "a48d0c02884f032b075f5968ab23e1261cf23dbc",
+        "fetchedAt": "2026-07-29T11:48:49.301Z"
       },
       "installMode": "mirror",
       "files": {
@@ -187,10 +187,10 @@
         "type": "git",
         "name": "canonical",
         "url": "https://github.com/joeharris76/skill-sync-skills.git",
-        "ref": "b98bf27413ee122f47c515d4d685965ce5df7df7",
+        "ref": "a48d0c02884f032b075f5968ab23e1261cf23dbc",
         "subdir": "skills",
-        "revision": "b98bf27413ee122f47c515d4d685965ce5df7df7",
-        "fetchedAt": "2026-07-28T18:13:55.812Z"
+        "revision": "a48d0c02884f032b075f5968ab23e1261cf23dbc",
+        "fetchedAt": "2026-07-29T11:48:50.607Z"
       },
       "installMode": "mirror",
       "files": {
@@ -245,10 +245,10 @@
         "type": "git",
         "name": "canonical",
         "url": "https://github.com/joeharris76/skill-sync-skills.git",
-        "ref": "b98bf27413ee122f47c515d4d685965ce5df7df7",
+        "ref": "a48d0c02884f032b075f5968ab23e1261cf23dbc",
         "subdir": "skills",
-        "revision": "b98bf27413ee122f47c515d4d685965ce5df7df7",
-        "fetchedAt": "2026-07-28T18:13:56.680Z"
+        "revision": "a48d0c02884f032b075f5968ab23e1261cf23dbc",
+        "fetchedAt": "2026-07-29T11:48:51.234Z"
       },
       "installMode": "mirror",
       "files": {
@@ -267,10 +267,10 @@
         "type": "git",
         "name": "canonical",
         "url": "https://github.com/joeharris76/skill-sync-skills.git",
-        "ref": "b98bf27413ee122f47c515d4d685965ce5df7df7",
+        "ref": "a48d0c02884f032b075f5968ab23e1261cf23dbc",
         "subdir": "skills",
-        "revision": "b98bf27413ee122f47c515d4d685965ce5df7df7",
-        "fetchedAt": "2026-07-28T18:13:57.338Z"
+        "revision": "a48d0c02884f032b075f5968ab23e1261cf23dbc",
+        "fetchedAt": "2026-07-29T11:48:51.835Z"
       },
       "installMode": "mirror",
       "files": {
@@ -289,10 +289,10 @@
         "type": "git",
         "name": "canonical",
         "url": "https://github.com/joeharris76/skill-sync-skills.git",
-        "ref": "b98bf27413ee122f47c515d4d685965ce5df7df7",
+        "ref": "a48d0c02884f032b075f5968ab23e1261cf23dbc",
         "subdir": "skills",
-        "revision": "b98bf27413ee122f47c515d4d685965ce5df7df7",
-        "fetchedAt": "2026-07-28T18:13:57.990Z"
+        "revision": "a48d0c02884f032b075f5968ab23e1261cf23dbc",
+        "fetchedAt": "2026-07-29T11:48:52.442Z"
       },
       "installMode": "mirror",
       "files": {
@@ -311,10 +311,10 @@
         "type": "git",
         "name": "canonical",
         "url": "https://github.com/joeharris76/skill-sync-skills.git",
-        "ref": "b98bf27413ee122f47c515d4d685965ce5df7df7",
+        "ref": "a48d0c02884f032b075f5968ab23e1261cf23dbc",
         "subdir": "skills",
-        "revision": "b98bf27413ee122f47c515d4d685965ce5df7df7",
-        "fetchedAt": "2026-07-28T18:13:58.651Z"
+        "revision": "a48d0c02884f032b075f5968ab23e1261cf23dbc",
+        "fetchedAt": "2026-07-29T11:48:53.032Z"
       },
       "installMode": "mirror",
       "files": {
@@ -333,10 +333,10 @@
         "type": "git",
         "name": "canonical",
         "url": "https://github.com/joeharris76/skill-sync-skills.git",
-        "ref": "b98bf27413ee122f47c515d4d685965ce5df7df7",
+        "ref": "a48d0c02884f032b075f5968ab23e1261cf23dbc",
         "subdir": "skills",
-        "revision": "b98bf27413ee122f47c515d4d685965ce5df7df7",
-        "fetchedAt": "2026-07-28T18:13:59.328Z"
+        "revision": "a48d0c02884f032b075f5968ab23e1261cf23dbc",
+        "fetchedAt": "2026-07-29T11:48:53.616Z"
       },
       "installMode": "mirror",
       "files": {
@@ -355,10 +355,10 @@
         "type": "git",
         "name": "canonical",
         "url": "https://github.com/joeharris76/skill-sync-skills.git",
-        "ref": "b98bf27413ee122f47c515d4d685965ce5df7df7",
+        "ref": "a48d0c02884f032b075f5968ab23e1261cf23dbc",
         "subdir": "skills",
-        "revision": "b98bf27413ee122f47c515d4d685965ce5df7df7",
-        "fetchedAt": "2026-07-28T18:14:03.208Z"
+        "revision": "a48d0c02884f032b075f5968ab23e1261cf23dbc",
+        "fetchedAt": "2026-07-29T11:48:57.115Z"
       },
       "installMode": "mirror",
       "files": {
@@ -389,10 +389,10 @@
         "type": "git",
         "name": "canonical",
         "url": "https://github.com/joeharris76/skill-sync-skills.git",
-        "ref": "b98bf27413ee122f47c515d4d685965ce5df7df7",
+        "ref": "a48d0c02884f032b075f5968ab23e1261cf23dbc",
         "subdir": "skills",
-        "revision": "b98bf27413ee122f47c515d4d685965ce5df7df7",
-        "fetchedAt": "2026-07-28T18:13:59.955Z"
+        "revision": "a48d0c02884f032b075f5968ab23e1261cf23dbc",
+        "fetchedAt": "2026-07-29T11:48:54.194Z"
       },
       "installMode": "mirror",
       "files": {
@@ -411,10 +411,10 @@
         "type": "git",
         "name": "canonical",
         "url": "https://github.com/joeharris76/skill-sync-skills.git",
-        "ref": "b98bf27413ee122f47c515d4d685965ce5df7df7",
+        "ref": "a48d0c02884f032b075f5968ab23e1261cf23dbc",
         "subdir": "skills",
-        "revision": "b98bf27413ee122f47c515d4d685965ce5df7df7",
-        "fetchedAt": "2026-07-28T18:14:00.598Z"
+        "revision": "a48d0c02884f032b075f5968ab23e1261cf23dbc",
+        "fetchedAt": "2026-07-29T11:48:54.765Z"
       },
       "installMode": "mirror",
       "files": {
@@ -433,10 +433,10 @@
         "type": "git",
         "name": "canonical",
         "url": "https://github.com/joeharris76/skill-sync-skills.git",
-        "ref": "b98bf27413ee122f47c515d4d685965ce5df7df7",
+        "ref": "a48d0c02884f032b075f5968ab23e1261cf23dbc",
         "subdir": "skills",
-        "revision": "b98bf27413ee122f47c515d4d685965ce5df7df7",
-        "fetchedAt": "2026-07-28T18:14:01.248Z"
+        "revision": "a48d0c02884f032b075f5968ab23e1261cf23dbc",
+        "fetchedAt": "2026-07-29T11:48:55.360Z"
       },
       "installMode": "mirror",
       "files": {
@@ -455,10 +455,10 @@
         "type": "git",
         "name": "canonical",
         "url": "https://github.com/joeharris76/skill-sync-skills.git",
-        "ref": "b98bf27413ee122f47c515d4d685965ce5df7df7",
+        "ref": "a48d0c02884f032b075f5968ab23e1261cf23dbc",
         "subdir": "skills",
-        "revision": "b98bf27413ee122f47c515d4d685965ce5df7df7",
-        "fetchedAt": "2026-07-28T18:14:02.542Z"
+        "revision": "a48d0c02884f032b075f5968ab23e1261cf23dbc",
+        "fetchedAt": "2026-07-29T11:48:56.549Z"
       },
       "installMode": "mirror",
       "files": {
@@ -481,10 +481,10 @@
         "type": "git",
         "name": "canonical",
         "url": "https://github.com/joeharris76/skill-sync-skills.git",
-        "ref": "b98bf27413ee122f47c515d4d685965ce5df7df7",
+        "ref": "a48d0c02884f032b075f5968ab23e1261cf23dbc",
         "subdir": "skills",
-        "revision": "b98bf27413ee122f47c515d4d685965ce5df7df7",
-        "fetchedAt": "2026-07-28T18:14:03.870Z"
+        "revision": "a48d0c02884f032b075f5968ab23e1261cf23dbc",
+        "fetchedAt": "2026-07-29T11:48:57.698Z"
       },
       "installMode": "mirror",
       "files": {
@@ -503,10 +503,10 @@
         "type": "git",
         "name": "canonical",
         "url": "https://github.com/joeharris76/skill-sync-skills.git",
-        "ref": "b98bf27413ee122f47c515d4d685965ce5df7df7",
+        "ref": "a48d0c02884f032b075f5968ab23e1261cf23dbc",
         "subdir": "skills",
-        "revision": "b98bf27413ee122f47c515d4d685965ce5df7df7",
-        "fetchedAt": "2026-07-28T18:14:01.893Z"
+        "revision": "a48d0c02884f032b075f5968ab23e1261cf23dbc",
+        "fetchedAt": "2026-07-29T11:48:55.952Z"
       },
       "installMode": "mirror",
       "files": {
@@ -525,10 +525,10 @@
         "type": "git",
         "name": "canonical",
         "url": "https://github.com/joeharris76/skill-sync-skills.git",
-        "ref": "b98bf27413ee122f47c515d4d685965ce5df7df7",
+        "ref": "a48d0c02884f032b075f5968ab23e1261cf23dbc",
         "subdir": "skills",
-        "revision": "b98bf27413ee122f47c515d4d685965ce5df7df7",
-        "fetchedAt": "2026-07-28T18:13:55.164Z"
+        "revision": "a48d0c02884f032b075f5968ab23e1261cf23dbc",
+        "fetchedAt": "2026-07-29T11:48:50.011Z"
       },
       "installMode": "mirror",
       "files": {
@@ -567,10 +567,10 @@
         "type": "git",
         "name": "canonical",
         "url": "https://github.com/joeharris76/skill-sync-skills.git",
-        "ref": "b98bf27413ee122f47c515d4d685965ce5df7df7",
+        "ref": "a48d0c02884f032b075f5968ab23e1261cf23dbc",
         "subdir": "skills",
-        "revision": "b98bf27413ee122f47c515d4d685965ce5df7df7",
-        "fetchedAt": "2026-07-28T18:13:53.902Z"
+        "revision": "a48d0c02884f032b075f5968ab23e1261cf23dbc",
+        "fetchedAt": "2026-07-29T11:48:48.712Z"
       },
       "installMode": "mirror",
       "files": {

--- a/skill-sync.yaml
+++ b/skill-sync.yaml
@@ -3,7 +3,7 @@ sources:
   - name: canonical
     type: git
     url: https://github.com/joeharris76/skill-sync-skills.git
-    ref: b98bf27413ee122f47c515d4d685965ce5df7df7
+    ref: a48d0c02884f032b075f5968ab23e1261cf23dbc
     subdir: skills
 skills:
   - blog

--- a/tests/unit/scripts/test_todo_findings.py
+++ b/tests/unit/scripts/test_todo_findings.py
@@ -509,6 +509,25 @@ class TestSurfacingBanner:
         assert "SENTINEL-banner" not in captured.out
         assert "SENTINEL-banner" in captured.err
 
+    def test_banner_survives_ascii_only_stderr(self, conn, monkeypatch, capfd):
+        # The banner carries non-ASCII (→ / —). On a byte-oriented stderr (C
+        # locale, or a POSIX pipe under LC_ALL=C) the *write* raises
+        # UnicodeEncodeError -- which must not escape and break `ready`.
+        import io
+
+        _mk_item(conn, item_id="ready-item")
+        _mk_finding(conn)
+        monkeypatch.setattr(todo_findings, "DEFAULT_DRAFTS_DIR", "/nonexistent-drafts")
+        buffer = io.BytesIO()
+        ascii_stderr = io.TextIOWrapper(buffer, encoding="ascii", errors="strict")
+        monkeypatch.setattr(todo_db.sys, "stderr", ascii_stderr)
+        assert todo_db._cmd_ready(conn, "tester", SimpleNamespace()) == 0
+        ascii_stderr.flush()
+        # The hint degrades to ASCII rather than vanishing or crashing.
+        emitted = buffer.getvalue().decode("ascii")
+        assert "open finding(s)" in emitted
+        assert "todo finding candidates" in emitted
+
     def test_banner_never_breaks_ready_when_hint_fails(self, conn, capsys, monkeypatch):
         # A hint must never break the core command: a failing banner is swallowed
         # AFTER the stdout contract is met, ready still returns 0.

--- a/tests/unit/scripts/test_todo_findings.py
+++ b/tests/unit/scripts/test_todo_findings.py
@@ -15,6 +15,7 @@ sibling ``test_todo_db*`` suites, so it stays out of the fast-lane budget.
 from __future__ import annotations
 
 import importlib
+import json
 import sys
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
@@ -170,8 +171,11 @@ class TestFindingsNonClaimable:
         _mk_finding(conn)
         _mk_finding(conn, finding_id="2026-01-02-030406-another-class")
         after = todo_db.stats(conn)
-        # Adding findings must not move any items-domain count.
-        assert after == before
+        # Adding findings must not move any ITEMS-DOMAIN count; phase 4 adds an
+        # additive findings_by_disposition key that DOES reflect them.
+        items_domain = ("items_by_state", "open_by_priority", "open_by_worktree", "deferrals_by_resolution", "claimed")
+        assert {k: after[k] for k in items_domain} == {k: before[k] for k in items_domain}
+        assert after["findings_by_disposition"] == {"open": 2}
 
     def test_findings_do_not_appear_in_items_table(self, conn):
         _mk_finding(conn)
@@ -414,3 +418,137 @@ class TestFindingListOrdering:
         ids = [f["id"] for f in todo_findings.list_findings(conn)]
         # both open -> ordered by created_at/id, so the earlier id sorts first
         assert ids == ["2026-01-02-030405-first-class", "2026-01-02-030406-second-class"]
+
+
+# ---------------------------------------------------------------------------
+# Phase 4: surfacing -- the ready/stats banner + additive stats key.
+#
+# The banner must never perturb the machine-readable STDOUT of ready/stats
+# (automation parses it): it renders to stderr, is suppressed at zero-state, and
+# piggybacks a single cheap aggregate on the existing connection (no extra hosted
+# round-trip). ``findings_by_disposition`` is an additive stats key.
+
+
+class _CountingConn:
+    """Proxy that records every SQL string executed, delegating to a real conn.
+
+    sqlite3.Connection is a C type whose ``execute`` cannot be monkeypatched, so
+    the banner's statement count is asserted through this thin proxy instead."""
+
+    def __init__(self, real):
+        self._real = real
+        self.executed: list[str] = []
+
+    def execute(self, sql, *args, **kwargs):
+        self.executed.append(sql)
+        return self._real.execute(sql, *args, **kwargs)
+
+
+class TestSurfacingBanner:
+    def test_banner_none_at_zero_state(self, conn, tmp_path):
+        # No findings and an empty drafts dir -> nothing to surface.
+        assert todo_findings.surfacing_banner(conn, drafts_dir=tmp_path / "nope") is None
+
+    def test_banner_counts_open_findings_and_unsynced_drafts(self, conn, tmp_path):
+        _mk_finding(conn)  # open
+        _mk_finding(conn, finding_id="2026-01-02-030406-b-class", disposition="dismissed", disposition_reason="no")
+        drafts = tmp_path / "drafts"
+        drafts.mkdir()
+        (drafts / "2026-01-02-030407-draft-class.md").write_text("draft", encoding="utf-8")
+        (drafts / "README.md").write_text("skip me", encoding="utf-8")  # README excluded
+        banner = todo_findings.surfacing_banner(conn, drafts_dir=drafts)
+        assert banner is not None
+        assert "1 open finding(s)" in banner  # 'dismissed' is not 'open'
+        assert "1 unsynced draft(s)" in banner  # README.md not counted
+        assert "todo finding candidates" in banner
+
+    def test_banner_open_findings_only(self, conn, tmp_path):
+        _mk_finding(conn)
+        banner = todo_findings.surfacing_banner(conn, drafts_dir=tmp_path / "empty")
+        assert "1 open finding(s)" in banner
+        assert "draft" not in banner
+
+    def test_banner_unsynced_drafts_only(self, conn, tmp_path):
+        drafts = tmp_path / "drafts"
+        drafts.mkdir()
+        (drafts / "2026-01-02-030407-draft-class.md").write_text("draft", encoding="utf-8")
+        banner = todo_findings.surfacing_banner(conn, drafts_dir=drafts)
+        assert "1 unsynced draft(s)" in banner
+        assert "open finding" not in banner
+
+    def test_banner_uses_single_findings_query(self, conn):
+        # "No extra hosted round-trip": the open-findings count is ONE aggregate,
+        # not a per-row scan, so it stays O(1) statements as findings accumulate.
+        _mk_finding(conn)
+        _mk_finding(conn, finding_id="2026-01-02-030406-b-class")
+        spy = _CountingConn(conn)
+        assert todo_findings.open_findings_count(spy) == 2
+        assert len([s for s in spy.executed if "FROM findings" in s]) == 1
+
+    def test_banner_opens_no_new_connection(self, conn, monkeypatch):
+        # "No extra hosted round-trip": the banner reuses the caller's connection
+        # (a new hosted connect would be an extra round-trip).
+        _mk_finding(conn)
+        monkeypatch.setattr(todo_db, "connect", lambda *a, **k: pytest.fail("banner must not open a new connection"))
+        assert todo_findings.surfacing_banner(conn, drafts_dir=Path("/nonexistent-drafts")) is not None
+
+    def test_banner_ready_on_stderr_not_stdout(self, conn, capsys, monkeypatch):
+        _mk_item(conn, item_id="ready-item")  # a ready planning item -> stdout content
+        monkeypatch.setattr(todo_findings, "surfacing_banner", lambda c: "→ SENTINEL-banner")
+        todo_db._cmd_ready(conn, "tester", SimpleNamespace())
+        captured = capsys.readouterr()
+        assert "ready-item" in captured.out  # items on stdout
+        assert "SENTINEL-banner" not in captured.out  # banner NEVER on stdout
+        assert "SENTINEL-banner" in captured.err  # banner on stderr
+
+    def test_banner_stats_on_stderr_not_stdout(self, conn, capsys, monkeypatch):
+        monkeypatch.setattr(todo_findings, "surfacing_banner", lambda c: "→ SENTINEL-banner")
+        todo_db._cmd_stats(conn, "tester", SimpleNamespace())
+        captured = capsys.readouterr()
+        json.loads(captured.out)  # stdout stays valid JSON, banner absent
+        assert "SENTINEL-banner" not in captured.out
+        assert "SENTINEL-banner" in captured.err
+
+    def test_banner_never_breaks_ready_when_hint_fails(self, conn, capsys, monkeypatch):
+        # A hint must never break the core command: a failing banner is swallowed
+        # AFTER the stdout contract is met, ready still returns 0.
+        _mk_item(conn, item_id="ready-item")
+        monkeypatch.setattr(todo_findings, "surfacing_banner", lambda c: (_ for _ in ()).throw(RuntimeError("boom")))
+        assert todo_db._cmd_ready(conn, "tester", SimpleNamespace()) == 0
+        assert "ready-item" in capsys.readouterr().out
+
+
+class TestFindingsStats:
+    def test_findings_stats_shape(self, conn):
+        _mk_finding(conn)  # open
+        _mk_finding(conn, finding_id="2026-01-02-030406-b-class", disposition="dismissed", disposition_reason="x")
+        s = todo_db.stats(conn)
+        assert s["findings_by_disposition"] == {"open": 1, "dismissed": 1}
+        # Existing items-domain keys are untouched (additive-only change).
+        for key in ("items_by_state", "open_by_priority", "open_by_worktree", "deferrals_by_resolution", "claimed"):
+            assert key in s
+
+    def test_findings_stats_empty_when_no_findings(self, conn):
+        assert todo_db.stats(conn)["findings_by_disposition"] == {}
+
+
+class TestSurfacingFlow:
+    def test_surfacing_flow_ready_shows_findings_when_present(self, conn, capsys, tmp_path, monkeypatch):
+        # Documented-flow encounter: an agent following the planning flow runs
+        # `ready`; when an untriaged finding exists it is surfaced (on stderr).
+        monkeypatch.setattr(todo_findings, "DEFAULT_DRAFTS_DIR", str(tmp_path / "no-drafts"))
+        _mk_item(conn, item_id="ready-item")
+        _mk_finding(conn)  # one open finding
+        todo_db._cmd_ready(conn, "tester", SimpleNamespace())
+        captured = capsys.readouterr()
+        assert "ready-item" in captured.out
+        assert "1 open finding(s)" in captured.err
+        assert "todo finding candidates" in captured.err
+
+    def test_surfacing_flow_silent_when_nothing_untriaged(self, conn, capsys, tmp_path, monkeypatch):
+        monkeypatch.setattr(todo_findings, "DEFAULT_DRAFTS_DIR", str(tmp_path / "no-drafts"))
+        _mk_item(conn, item_id="ready-item")
+        todo_db._cmd_ready(conn, "tester", SimpleNamespace())
+        captured = capsys.readouterr()
+        assert "ready-item" in captured.out
+        assert "finding" not in captured.err  # zero-state: no banner

--- a/tests/unit/scripts/test_todo_findings.py
+++ b/tests/unit/scripts/test_todo_findings.py
@@ -171,10 +171,14 @@ class TestFindingsNonClaimable:
         _mk_finding(conn)
         _mk_finding(conn, finding_id="2026-01-02-030406-another-class")
         after = todo_db.stats(conn)
-        # Adding findings must not move any ITEMS-DOMAIN count; phase 4 adds an
-        # additive findings_by_disposition key that DOES reflect them.
-        items_domain = ("items_by_state", "open_by_priority", "open_by_worktree", "deferrals_by_resolution", "claimed")
-        assert {k: after[k] for k in items_domain} == {k: before[k] for k in items_domain}
+        # Adding findings must not move ANY items-domain count. Compare every key
+        # except the additive findings one (rather than a hardcoded allowlist), so
+        # a future stats key that wrongly reflects findings is still caught.
+
+        def items_domain(snapshot):
+            return {k: v for k, v in snapshot.items() if k != "findings_by_disposition"}
+
+        assert items_domain(after) == items_domain(before)
         assert after["findings_by_disposition"] == {"open": 2}
 
     def test_findings_do_not_appear_in_items_table(self, conn):
@@ -476,25 +480,35 @@ class TestSurfacingBanner:
         assert "1 unsynced draft(s)" in banner
         assert "open finding" not in banner
 
-    def test_banner_uses_single_findings_query(self, conn):
-        # "No extra hosted round-trip": the open-findings count is ONE aggregate,
-        # not a per-row scan, so it stays O(1) statements as findings accumulate.
+    @pytest.mark.parametrize("command", ["ready", "stats"])
+    def test_command_issues_at_most_one_findings_query(self, conn, capsys, monkeypatch, command):
+        # "No extra hosted round-trip", pinned at the COMMAND level -- spying on
+        # the helper alone is true by construction (one function, one statement)
+        # and so can never regress. `stats` must reuse the disposition breakdown
+        # it already computed instead of a second open-count aggregate.
         _mk_finding(conn)
         _mk_finding(conn, finding_id="2026-01-02-030406-b-class")
+        monkeypatch.setattr(todo_findings, "DEFAULT_DRAFTS_DIR", "/nonexistent-drafts")
         spy = _CountingConn(conn)
-        assert todo_findings.open_findings_count(spy) == 2
-        assert len([s for s in spy.executed if "FROM findings" in s]) == 1
+        handler = {"ready": todo_db._cmd_ready, "stats": todo_db._cmd_stats}[command]
+        assert handler(spy, "tester", SimpleNamespace()) == 0
+        findings_queries = [s for s in spy.executed if "FROM findings" in s]
+        assert len(findings_queries) == 1, f"{command} issued {len(findings_queries)}: {findings_queries}"
+        assert "2 open finding(s)" in capsys.readouterr().err
 
     def test_banner_opens_no_new_connection(self, conn, monkeypatch):
-        # "No extra hosted round-trip": the banner reuses the caller's connection
-        # (a new hosted connect would be an extra round-trip).
+        # "No extra hosted round-trip": the banner reuses the caller's connection.
+        # Block EVERY connect entry point -- a regression would realistically open
+        # a hosted connection, not the local one.
         _mk_finding(conn)
-        monkeypatch.setattr(todo_db, "connect", lambda *a, **k: pytest.fail("banner must not open a new connection"))
+        for entry in ("connect", "connect_backend", "connect_hosted", "_hosted_read_connect", "_hosted_raw_connect"):
+            if hasattr(todo_db, entry):
+                monkeypatch.setattr(todo_db, entry, lambda *a, _e=entry, **k: pytest.fail(f"banner must not call {_e}"))
         assert todo_findings.surfacing_banner(conn, drafts_dir=Path("/nonexistent-drafts")) is not None
 
     def test_banner_ready_on_stderr_not_stdout(self, conn, capsys, monkeypatch):
         _mk_item(conn, item_id="ready-item")  # a ready planning item -> stdout content
-        monkeypatch.setattr(todo_findings, "surfacing_banner", lambda c: "→ SENTINEL-banner")
+        monkeypatch.setattr(todo_findings, "surfacing_banner", lambda c, **kw: "→ SENTINEL-banner")
         todo_db._cmd_ready(conn, "tester", SimpleNamespace())
         captured = capsys.readouterr()
         assert "ready-item" in captured.out  # items on stdout
@@ -502,7 +516,7 @@ class TestSurfacingBanner:
         assert "SENTINEL-banner" in captured.err  # banner on stderr
 
     def test_banner_stats_on_stderr_not_stdout(self, conn, capsys, monkeypatch):
-        monkeypatch.setattr(todo_findings, "surfacing_banner", lambda c: "→ SENTINEL-banner")
+        monkeypatch.setattr(todo_findings, "surfacing_banner", lambda c, **kw: "→ SENTINEL-banner")
         todo_db._cmd_stats(conn, "tester", SimpleNamespace())
         captured = capsys.readouterr()
         json.loads(captured.out)  # stdout stays valid JSON, banner absent
@@ -523,16 +537,33 @@ class TestSurfacingBanner:
         monkeypatch.setattr(todo_db.sys, "stderr", ascii_stderr)
         assert todo_db._cmd_ready(conn, "tester", SimpleNamespace()) == 0
         ascii_stderr.flush()
-        # The hint degrades to ASCII rather than vanishing or crashing.
+        # The hint degrades to readable ASCII rather than vanishing or crashing.
         emitted = buffer.getvalue().decode("ascii")
         assert "open finding(s)" in emitted
         assert "todo finding candidates" in emitted
+        assert "-> " in emitted  # transliterated, not "?"-replaced
+        # ...and the degraded path still never touches stdout.
+        assert "finding" not in capfd.readouterr().out
+
+    def test_banner_bails_out_when_stderr_is_closed(self, conn, capsys, monkeypatch):
+        # With fd 2 closed CPython sets sys.stderr to None, and print(file=None)
+        # falls back to STDOUT -- which would put the hint in the machine-readable
+        # stream (and break `stats` JSON). Bail out instead.
+        _mk_item(conn, item_id="ready-item")
+        _mk_finding(conn)
+        monkeypatch.setattr(todo_db.sys, "stderr", None)
+        assert todo_db._cmd_ready(conn, "tester", SimpleNamespace()) == 0
+        out = capsys.readouterr().out
+        assert "ready-item" in out
+        assert "finding" not in out
 
     def test_banner_never_breaks_ready_when_hint_fails(self, conn, capsys, monkeypatch):
         # A hint must never break the core command: a failing banner is swallowed
         # AFTER the stdout contract is met, ready still returns 0.
         _mk_item(conn, item_id="ready-item")
-        monkeypatch.setattr(todo_findings, "surfacing_banner", lambda c: (_ for _ in ()).throw(RuntimeError("boom")))
+        monkeypatch.setattr(
+            todo_findings, "surfacing_banner", lambda c, **kw: (_ for _ in ()).throw(RuntimeError("boom"))
+        )
         assert todo_db._cmd_ready(conn, "tester", SimpleNamespace()) == 0
         assert "ready-item" in capsys.readouterr().out
 

--- a/tests/unit/scripts/test_todo_wrapper.py
+++ b/tests/unit/scripts/test_todo_wrapper.py
@@ -52,7 +52,11 @@ def _declared_standalone_only() -> set[str]:
 def _unknown_commands(text: str, declared: set[str]) -> set[str]:
     """Referenced `todo <cmd>` forms that are neither wrapper handlers nor declared."""
     referenced = set(re.findall(r"`todo ([a-z][a-z-]*)", text))
-    return referenced - set(todo_db._HANDLERS) - declared
+    # `finding` is a real top-level command dispatched via _dispatch's special
+    # branch (not _HANDLERS) to keep the todo_db<->todo_findings import cycle
+    # load-order-independent -- see _dispatch's comment.
+    real = set(todo_db._HANDLERS) | {"finding"}
+    return referenced - real - declared
 
 
 def _load_script():


### PR DESCRIPTION
## Summary

Phase 4 of the findings domain (`_project/specs/findings-domain.md`): surface
captured blind-spot findings in the tracker surfaces agents already use, so a
finding is encountered and triaged instead of forgotten. Depends on phase 3
(schema v3), merged in #1273 and applied to prod.

Independently reviewed (five-axis, adversarial). Every Required finding is
fixed; see **Review** below.

## What changed

- **`todo ready` / `todo stats` banner (w1)** — a one-line hint printed to
  **stderr** when there are open findings or unsynced drafts:
  `→ N open finding(s), M unsynced draft(s) awaiting triage — see: todo finding candidates`.
  - **Stderr-only and suppressed at zero-state**, so the machine-readable
    *stdout* of both commands is byte-identical to before. Automation and batch
    scheduling that parse `ready`/`stats` stdout are unaffected.
  - **Best-effort**: `_emit_findings_banner` swallows any failure *after* the
    stdout contract is met — a findings read error can never break `ready`/`stats`
    (they still return 0). Pinned by `test_banner_never_breaks_ready_when_hint_fails`.
  - **No extra hosted round-trip**: the open-findings count is a single
    `count(*)` on the connection the command already holds (served from the local
    embedded replica on hosted); the unsynced-draft count is a local glob (no
    credentials). Pinned by `test_banner_uses_single_findings_query` +
    `test_banner_opens_no_new_connection`.
- **`stats()` additive key (w1)** — gains `findings_by_disposition` (empty dict
  when no findings). Every items-domain key is untouched; the phase-3 exclusion
  test now checks the items-domain keys explicitly and asserts the new key
  reflects findings.
- **Tests (w2)** — `TestSurfacingBanner`, `TestFindingsStats`, `TestSurfacingFlow`.
- **Skill + doc routing (w3, w4)** — the todo-db skill (`SKILL.md`,
  `references/implement.md`, `references/batch.md`) and `AGENTS.md` route the
  planning flow to `todo finding candidates`/`triage`. `skill-sync.lock`
  sha256/size recomputed (skill-sync verify green).

`finding` is a real top-level command dispatched via `_dispatch`'s special branch
(kept out of `_HANDLERS` so the todo_db↔todo_findings import cycle stays
load-order-independent); the skill-thinness guard now recognises it.

## Review

Five-axis adversarial review; all Required findings fixed and pinned.

**R1 (Required) — skill routing was hand-edited in the mirror, not authored
upstream.** Both integrity gates compare the mirror against the *lock*, not the
*source*, so CI stayed green while the canonical `skill-sync-skills` repo never
received the change — the next `make skill-sync` would have silently reverted
phase 4's routing while `AGENTS.md` kept pointing at it (the split-brain #1318
established this workflow to prevent). Fixed properly: landed upstream first
(skill-sync-skills#12 → `a48d0c0`, exactly those 3 files/13 insertions), then
re-materialized here via `make skill-sync` with the pinned ref bumped
`b98bf274` → `a48d0c0`. The mirror files are now byte-identical to the merged
source. No unrelated drift — `git diff b98bf274 a48d0c0 -- skills/` is exactly
those three files.

**Required (found in an earlier pass) — the banner could break `ready`.** The
`print` sat outside the guard while the banner carries non-ASCII, so a strict
non-UTF-8 stderr raised `UnicodeEncodeError` that escaped `_cmd_ready`.
Reproduced, fixed (print inside the guard + real transliteration), pinned.

**Nits fixed:** closed-stderr leak (`sys.stderr is None` → `print` falls back to
*stdout*, which would corrupt `stats` JSON — now bails out, pinned); `stats`
issued a redundant second findings aggregate (now reuses the breakdown it already
computed); the "no extra round-trip" pin moved from the helper (true by
construction) to the command level, parametrized over ready/stats — it would have
caught that duplicate; the no-new-connection pin now blocks every connect entry
point; `test_stats_open_counts_exclude_findings` regained exhaustiveness instead
of a hardcoded 5-key allowlist.

**Consciously not changed:** `stats()`'s findings call sits outside the defensive
wrapper — the reviewer confirmed this is safe (every connection path version-gates
to v3 first, and `migrate_db` commits DDL before the version bump, so the failure
ordering is the safe one). Also flagged for phases 5/6, not defects: `actionable`
findings don't surface on `ready` (matches the spec's "open-findings count"), and
the thin-skill budget is now 39/40 lines.

## Scope note

**w3 skill files vs `only_modify`.** The item's scope listed `skill-sync.lock`
but omitted `.claude/skills/todo-db/**`, while w3 names those three skill files
as its deliverable — a clerical gap (the lock is only ever touched when skills
change). `todo check-scope` flags the three files accordingly. The edits are
w3's explicit requirement; the lock and pinned ref are updated to match.
**w4 "CLAUDE.md auto-allowed reads" is obsolete.** develop restructured
   `CLAUDE.md` into a 7-line pointer with no command allowlist (none in
   `settings.json` either), so there is nothing to amend there. The AGENTS.md
   half is done (documents the banner + `finding list/show/candidates` as
   read-only triage).

## Verification

- Ladder: seq1 `-k 'banner or findings_stats'` **12 pass**, seq2
  `-k 'surfacing_flow'` **2 pass**, seq3 `make test-fast` **25887 pass**.
- Full `tests/unit/scripts` **1085 pass**; ruff clean; skill-sync lock audit
  6 pass; fast-lane timing policy 0 violations (new tests are `medium`, not
  `fast`, so the cap is untouched).
- Real CLI exercised on a scratch v3 DB: banner appears on stderr only, absent at
  zero-state, stdout unchanged.

## Not in scope

phase 5 (migration — prod data import + freeze) and phase 6 (demolition) remain
gated; phase 5 needs the dry-run → parity → review sequence with maintainer
sign-off.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
