### PR TITLE
fix(tracker): keep the standalone export's lossless envelope out of Git

### DIFF
--- a/.github/workflows/todo-db-export.yml
+++ b/.github/workflows/todo-db-export.yml
@@ -76,6 +76,11 @@ jobs:
       GH_TOKEN: ${{ github.token }}
       PR_TOKEN_SET: ${{ secrets.TODO_EXPORT_PR_TOKEN != '' }}
       EXPORT_DIR: _project/todo-db-export
+      # The lossless envelope carries every table, including the findings domain
+      # whose review prose is deliberately not version-controlled. It is written
+      # OUTSIDE EXPORT_DIR (which `git add` stages) and travels via the 90-day CI
+      # artifact channel only -- see _project/specs/findings-domain.md.
+      LOSSLESS_DIR: ${{ github.workspace }}/todo-db-lossless
       SNAPSHOT_BRANCH: chore/todo-db-export-snapshot
       INCIDENT_LABEL: incident:todo-export-failed
       RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
@@ -164,9 +169,13 @@ jobs:
           BENCHBOX_TODO_DB_EXPECTED_VERSION: ${{ vars.TODO_DB_PACKAGE_VERSION }}
         run: |
           set -euo pipefail
+          # Rewrites EXPORT_DIR's items-domain views (items/events/index) from ONE
+          # envelope, so the committed pair can never straddle two read snapshots;
+          # the lossless envelope lands in LOSSLESS_DIR, never in EXPORT_DIR.
           BENCHBOX_TODO_DB_STANDALONE=1 uv run --isolated --project _project/scripts \
             --with "${TODO_DB_WHEEL}[hosted]" -- \
-            python _project/scripts/todo_db.py export --out "${EXPORT_DIR}"
+            python _project/scripts/todo_db.py export --out "${EXPORT_DIR}" \
+            --lossless-out "${LOSSLESS_DIR}"
 
       - name: Validate clean-database restore
         if: vars.TODO_DB_PACKAGE_VERSION != ''
@@ -180,7 +189,7 @@ jobs:
           uv run --isolated --with "${TODO_DB_WHEEL}[hosted]" -- \
             todo-db --db "${restore_dir}/restore.sqlite" \
             --project-id "${TODO_DB_PROJECT_ID}" --repository "${TODO_DB_REPOSITORY}" \
-            restore --input "${EXPORT_DIR}/todo-db.json" --replace
+            restore --input "${LOSSLESS_DIR}/todo-db.json" --replace
           uv run --isolated --with "${TODO_DB_WHEEL}[hosted]" -- \
             todo-db --db "${restore_dir}/restore.sqlite" \
             --project-id "${TODO_DB_PROJECT_ID}" --repository "${TODO_DB_REPOSITORY}" audit verify
@@ -189,7 +198,7 @@ jobs:
             --project-id "${TODO_DB_PROJECT_ID}" --repository "${TODO_DB_REPOSITORY}" \
             export --output "${restore_dir}/restored.json"
           uv run --isolated --with "${TODO_DB_WHEEL}[hosted]" -- \
-            python -c 'import json, pathlib; source=json.loads(pathlib.Path("'"${EXPORT_DIR}"'/todo-db.json").read_text()); restored=json.loads(pathlib.Path("'"${restore_dir}"'/restored.json").read_text()); assert source == restored'
+            python -c 'import json, pathlib; source=json.loads(pathlib.Path("'"${LOSSLESS_DIR}"'/todo-db.json").read_text()); restored=json.loads(pathlib.Path("'"${restore_dir}"'/restored.json").read_text()); assert source == restored'
 
       - name: Write directory README
         run: |
@@ -221,10 +230,13 @@ jobs:
             ordered by `seq`. A plain audit log (not hash-chained).
           - `index.md` — rendered `id / state / priority / worktree / title`.
 
-          When the optional standalone package export is enabled it additionally writes
-          a lossless `todo-db.json` envelope (project identity, metadata, migrations,
-          and a hash-chained audit trail) that restore validation replays into a clean
-          database before the snapshot PR is opened.
+          When the optional standalone package export is enabled it rewrites the three
+          files above from a single read snapshot and writes a lossless `todo-db.json`
+          envelope (project identity, metadata, migrations, every table, and a
+          hash-chained audit trail) **outside this directory**, to the workflow's
+          90-day CI artifact only. Restore validation replays that envelope into a
+          clean database before the snapshot PR is opened. It is never committed:
+          it carries the findings domain, whose review prose stays out of Git.
 
           This directory's git history is the tracker's provenance trail — the single
           sanctioned exception to the repo's DB-free-CI rule.
@@ -234,7 +246,12 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: todo-db-export-${{ github.run_id }}-${{ github.run_attempt }}
-          path: _project/todo-db-export/
+          # Both paths: the committed items-domain views AND the lossless
+          # envelope, which exists only here (never in the version-controlled
+          # tree) yet is what a real recovery replays.
+          path: |
+            _project/todo-db-export/
+            ${{ github.workspace }}/todo-db-lossless/
           if-no-files-found: error
           retention-days: 90
 

--- a/_project/scripts/todo_db_standalone_compat.py
+++ b/_project/scripts/todo_db_standalone_compat.py
@@ -237,24 +237,49 @@ def _atomic_write(path: Path, content: str) -> None:
     temporary.replace(path)
 
 
-def _write_legacy_export(output_dir: Path, envelope: dict[str, Any]) -> tuple[Path, Path, Path]:
+def _write_legacy_export(
+    output_dir: Path, envelope: dict[str, Any], lossless_dir: Path | None = None
+) -> tuple[Path, Path, Path, Path]:
+    """Write the committed items-domain views, plus the lossless envelope.
+
+    ``output_dir`` receives ONLY the items-domain views -- ``items.jsonl``,
+    ``events.jsonl``, ``index.md`` -- because it is the version-controlled export
+    snapshot. The lossless ``todo-db.json`` (every table, including the findings
+    domain whose review prose is deliberately not version-controlled) goes to
+    ``lossless_dir``, which defaults to a sibling *outside* ``output_dir`` so the
+    workflow's `git add` can never stage it. It remains the complete recovery
+    artifact the restore round-trip replays.
+
+    ``events.jsonl`` is derived from THIS envelope, not left over from a separate
+    main-path export: both committed views therefore come from one read snapshot,
+    so an item can never be missing the event that created it.
+    """
     output_dir.mkdir(parents=True, exist_ok=True)
-    lossless_path = output_dir / "todo-db.json"
+    lossless_dir = lossless_dir if lossless_dir is not None else output_dir.parent / f"{output_dir.name}-lossless"
+    lossless_dir.mkdir(parents=True, exist_ok=True)
+    lossless_path = lossless_dir / "todo-db.json"
     items_path = output_dir / "items.jsonl"
+    events_path = output_dir / "events.jsonl"
     index_path = output_dir / "index.md"
     items = _item_rows(envelope)
     _atomic_write(lossless_path, _canonical_json(envelope))
     _atomic_write(items_path, "".join(_canonical_json(item) for item in items))
+    events = sorted((dict(row) for row in envelope.get("events") or []), key=lambda row: row["seq"])
+    _atomic_write(events_path, "".join(_canonical_json(event) for event in events))
     lines = ["# TODO export", "", "| id | state | priority | worktree | title |", "|---|---|---|---|---|"]
     for item in items:
         lines.append(f"| {item['id']} | {item['state']} | {item['priority']} | {item['worktree']} | {item['title']} |")
     _atomic_write(index_path, "\n".join(lines) + "\n")
-    return lossless_path, items_path, index_path
+    return lossless_path, items_path, events_path, index_path
 
 
 def _export(argv: list[str], cwd: Path) -> int:
     out_dir, without_out = _option_value(argv, "--out")
+    # The lossless envelope is written outside --out (the committed snapshot);
+    # --lossless-out relocates it, e.g. to a CI artifact staging directory.
+    lossless_out, without_out = _option_value(without_out, "--lossless-out")
     output_dir = Path(out_dir).expanduser() if out_dir else cwd / ".todo-db" / "export"
+    lossless_dir = Path(lossless_out).expanduser() if lossless_out else None
     with tempfile.TemporaryDirectory(prefix="benchbox-todo-db-export-") as temporary:
         standalone_output = Path(temporary) / "todo-db.json"
         located = _command_index(without_out)
@@ -273,8 +298,8 @@ def _export(argv: list[str], cwd: Path) -> int:
         if result.returncode:
             return result.returncode
         envelope = json.loads(standalone_output.read_text(encoding="utf-8"))
-        lossless, items, index = _write_legacy_export(output_dir, envelope)
-        print(f"wrote {items} and {index} (lossless envelope: {lossless})")
+        lossless, items, events, index = _write_legacy_export(output_dir, envelope, lossless_dir)
+        print(f"wrote {items}, {events} and {index} (lossless envelope: {lossless})")
         return 0
 
 

--- a/tests/unit/scripts/test_todo_db_standalone_compat.py
+++ b/tests/unit/scripts/test_todo_db_standalone_compat.py
@@ -246,20 +246,114 @@ def test_export_writes_lossless_envelope_and_legacy_views(monkeypatch: pytest.Mo
     monkeypatch.setenv("BENCHBOX_REPO_ROOT", str(tmp_path))
     output_dir = tmp_path / "snapshot"
 
-    assert compat.main(["--db", str(tmp_path / "todo.sqlite"), "export", "--out", str(output_dir)]) == 0
+    lossless_dir = tmp_path / "lossless"
 
-    lossless = json.loads((output_dir / "todo-db.json").read_text(encoding="utf-8"))
-    assert lossless["metadata"] == envelope["metadata"]
-    assert lossless["events"] == envelope["events"]
+    assert (
+        compat.main(
+            [
+                "--db",
+                str(tmp_path / "todo.sqlite"),
+                "export",
+                "--out",
+                str(output_dir),
+                "--lossless-out",
+                str(lossless_dir),
+            ]
+        )
+        == 0
+    )
+
+    # The lossless envelope is the recovery artifact -- complete, and OUTSIDE the
+    # committed snapshot directory.
+    lossless = json.loads((lossless_dir / "todo-db.json").read_text(encoding="utf-8"))
+    assert lossless == envelope
+    assert not (output_dir / "todo-db.json").exists()
     item = json.loads((output_dir / "items.jsonl").read_text(encoding="utf-8").splitlines()[0])
     assert item["work"][0]["wid"] == "w0"
     assert "sample-item" in (output_dir / "index.md").read_text(encoding="utf-8")
+    # events.jsonl comes from THIS envelope (one read snapshot), not a stale
+    # leftover from a separate main-path export.
+    events = [json.loads(line) for line in (output_dir / "events.jsonl").read_text(encoding="utf-8").splitlines()]
+    assert events == envelope["events"]
+
+
+def test_export_lossless_envelope_defaults_outside_the_committed_snapshot(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    # Without --lossless-out the envelope must STILL not land in --out: the
+    # workflow's `git add "${EXPORT_DIR}"` would otherwise commit it.
+    envelope = _envelope()
+
+    def fake_delegate(argv: list[str], *, command: str, cwd: Path, capture: bool = True) -> CompletedProcess[str]:
+        Path(argv[argv.index("--output") + 1]).write_text(json.dumps(envelope), encoding="utf-8")
+        return CompletedProcess(argv, 0, stdout="", stderr="")
+
+    monkeypatch.setattr(compat, "_delegate", fake_delegate)
+    monkeypatch.setenv("BENCHBOX_REPO_ROOT", str(tmp_path))
+    output_dir = tmp_path / "snapshot"
+
+    assert compat.main(["--db", str(tmp_path / "todo.sqlite"), "export", "--out", str(output_dir)]) == 0
+
+    assert not (output_dir / "todo-db.json").exists()
+    assert (output_dir.parent / f"{output_dir.name}-lossless" / "todo-db.json").exists()
+
+
+def test_export_never_commits_findings_domain_prose(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """The guard: findings review prose must never reach the committed snapshot.
+
+    Mirrors the phase-2 allowlist pin for the standalone path -- a findings table
+    in the envelope may travel in the lossless recovery artifact, never in --out.
+    """
+    envelope = _envelope()
+    prose = "SENTINEL-findings-review-prose"
+    envelope["tables"]["findings"] = [
+        {
+            "id": "2026-01-02-030405-a-class",
+            "title": f"{prose}-title",
+            "finding_text": f"{prose}-finding",
+            "why_matters": f"{prose}-why",
+            "disposition": "open",
+        }
+    ]
+    envelope["tables"]["finding_evidence"] = [{"finding_id": "2026-01-02-030405-a-class", "path": "x.py"}]
+
+    def fake_delegate(argv: list[str], *, command: str, cwd: Path, capture: bool = True) -> CompletedProcess[str]:
+        Path(argv[argv.index("--output") + 1]).write_text(json.dumps(envelope), encoding="utf-8")
+        return CompletedProcess(argv, 0, stdout="", stderr="")
+
+    monkeypatch.setattr(compat, "_delegate", fake_delegate)
+    monkeypatch.setenv("BENCHBOX_REPO_ROOT", str(tmp_path))
+    output_dir = tmp_path / "snapshot"
+    lossless_dir = tmp_path / "lossless"
+
+    assert (
+        compat.main(
+            [
+                "--db",
+                str(tmp_path / "todo.sqlite"),
+                "export",
+                "--out",
+                str(output_dir),
+                "--lossless-out",
+                str(lossless_dir),
+            ]
+        )
+        == 0
+    )
+
+    for path in sorted(output_dir.rglob("*")):
+        if path.is_file():
+            assert prose not in path.read_text(encoding="utf-8"), f"findings prose leaked into {path.name}"
+            assert "finding_evidence" not in path.read_text(encoding="utf-8")
+    # ...but the recovery artifact is still lossless.
+    assert prose in (lossless_dir / "todo-db.json").read_text(encoding="utf-8")
 
 
 def test_export_views_are_byte_identical_to_legacy_format(tmp_path: Path) -> None:
     envelope = _envelope()
     envelope["tables"]["items"][0]["title"] = "Café | table"
-    compat._write_legacy_export(tmp_path, envelope)
+    compat._write_legacy_export(tmp_path / "out", envelope, tmp_path / "lossless")
+    tmp_path = tmp_path / "out"
     item = compat._item_rows(envelope)[0]
     assert (tmp_path / "items.jsonl").read_text(encoding="utf-8") == json.dumps(item, sort_keys=True) + "\n"
     assert "| sample-item | planning | high | benchbox | Café | table |" in (tmp_path / "index.md").read_text(


### PR DESCRIPTION
## Summary

Follow-up to the phase-2 export boundary (its deferred w4). The committed
snapshot `_project/todo-db-export/` must be **items-domain only** — findings
review prose is deliberately not version-controlled
(`_project/specs/findings-domain.md`, "Export boundary"). Phase 2 pinned that for
the always-on export path. The **opt-in standalone-package path** defeated it in
two ways once `TODO_DB_PACKAGE_VERSION` is set:

1. **Committed lossless envelope (the tracked concern).**
   `_write_legacy_export` wrote the full `todo-db.json` — every table — into
   `--out`, and the workflow's `git add "${EXPORT_DIR}"` committed it. With
   phase 3's findings tables live, that puts review prose in Git.
2. **Events / read-snapshot tear (the second concern, added here).** The
   standalone path emitted no top-level `events.jsonl`, so the committed
   `events.jsonl` was the **stale** one from the *main* path's earlier, separate
   export — a different read snapshot of a live hosted DB. The committed
   `items.jsonl`/`events.jsonl` pair could straddle a concurrent write (an event
   referencing an item absent from items, or an item missing its creation
   event). The main path guarantees a single snapshot (`write_export` reads both
   in one `_read_txn`); standalone silently broke that.

No live leak today — the standalone path is gated behind an unset
`TODO_DB_PACKAGE_VERSION` — so this is hardening *before* that variable is ever
set, not an incident.

## Fix (option B; the tradeoff was reviewed before implementing)

- `_write_legacy_export` writes **only** the items-domain views into `--out`
  (`items.jsonl`, `events.jsonl`, `index.md`), all derived from the **same**
  envelope → one read snapshot, tear closed.
- The lossless envelope moves to a new `--lossless-out` directory, defaulting to
  a sibling **outside** `--out`, so it cannot be staged even if the flag is
  omitted (belt and braces for the `git add "${EXPORT_DIR}"` line).
- `.github/workflows/todo-db-export.yml` points `--lossless-out`, the clean-DB
  restore round-trip, and the 90-day recovery artifact at `LOSSLESS_DIR`.

**The envelope stays complete.** The rejected alternative (filter findings out of
the committed `todo-db.json`) would have broken the restore round-trip's
`source == restored` completeness proof — you cannot recover what you filtered —
*and* left the tear unfixed. Instead the envelope simply travels via the CI
artifact channel only, which is exactly what the directory README and the
findings-domain spec already claimed. The README is updated to match the code.

## Tests

`tests/unit/scripts/test_todo_db_standalone_compat.py` (uses the existing faked
envelope + `_delegate` monkeypatch, so the external standalone package is **not**
required):

- updated `test_export_writes_lossless_envelope_and_legacy_views` — asserts no
  `todo-db.json` under `--out`, a **complete** envelope under `--lossless-out`,
  and `events.jsonl` matching the envelope's events;
- `test_export_lossless_envelope_defaults_outside_the_committed_snapshot` — the
  default path is safe without the flag;
- `test_export_never_commits_findings_domain_prose` — sentinel prose in a
  `findings` table reaches the recovery artifact but **no** committed file.

## Verification

- `tests/unit/scripts/test_todo_db_standalone_compat.py` **40 pass**; full
  `tests/unit/scripts` **1074 pass**; ruff clean; workflow YAML parses; no
  remaining `${EXPORT_DIR}/todo-db.json` reference.

## Note on the tracker item

The item was bare (no work units/scope) and its description named only concern
#1; concern #2 was a known Consider from the phase-2 final sweep. Both are fixed
here. The item was left bare rather than dropped and recreated (`drop` is
terminal and reserves the id forever); this PR body is the record.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
