### PR TITLE
fix(analysis): split oracle-map Independence into independence + surface provenance

### DIFF
--- a/_project/analysis/oracle-coverage-map.json
+++ b/_project/analysis/oracle-coverage-map.json
@@ -12,6 +12,8 @@
       "primary_oracle": "NONE",
       "scale": "\u2014",
       "strength": "\u2014",
+      "surface_provenance": "\u2014",
+      "surface_provenance_rationale": "\u2014",
       "surfaces": [
         "sql"
       ]
@@ -22,14 +24,16 @@
       "cross_surface_enforced": true,
       "dual_surface": true,
       "guarded": true,
-      "independence": "separate-handwritten",
-      "independence_rationale": "Expression and pandas DataFrame implementations are separately handwritten for each query, so the gate has stronger cross-implementation signal than shared-spec generators.",
+      "independence": "self-referential",
+      "independence_rationale": "Both compared surfaces are benchbox's own implementations; see Surface provenance for how far apart they were authored.",
       "oracles": [
         "cross-surface"
       ],
       "primary_oracle": "cross-surface",
       "scale": "SF=0.1",
       "strength": "value-level",
+      "surface_provenance": "separate-handwritten",
+      "surface_provenance_rationale": "Expression and pandas DataFrame implementations are separately handwritten for each query, so the gate has stronger cross-implementation signal than shared-spec generators.",
       "surfaces": [
         "sql",
         "dataframe"
@@ -41,14 +45,16 @@
       "cross_surface_enforced": true,
       "dual_surface": true,
       "guarded": true,
-      "independence": "mixed-provenance",
-      "independence_rationale": "Most ClickBench DataFrame cells are generated from shared compact specs, with a small set of bespoke implementations; read as mixed provenance, not fully independent implementations.",
+      "independence": "self-referential",
+      "independence_rationale": "Both compared surfaces are benchbox's own implementations; see Surface provenance for how far apart they were authored.",
       "oracles": [
         "cross-surface"
       ],
       "primary_oracle": "cross-surface",
       "scale": "SF=0.1",
       "strength": "value-level",
+      "surface_provenance": "mixed-provenance",
+      "surface_provenance_rationale": "Most ClickBench DataFrame cells are generated from shared compact specs, with a small set of bespoke implementations; read as mixed provenance, not fully independent implementations.",
       "surfaces": [
         "sql",
         "dataframe"
@@ -60,14 +66,16 @@
       "cross_surface_enforced": true,
       "dual_surface": true,
       "guarded": true,
-      "independence": "separate-handwritten",
-      "independence_rationale": "Expression and pandas DataFrame implementations are separately handwritten for each query, so the gate has stronger cross-implementation signal than shared-spec generators.",
+      "independence": "self-referential",
+      "independence_rationale": "Both compared surfaces are benchbox's own implementations; see Surface provenance for how far apart they were authored.",
       "oracles": [
         "cross-surface"
       ],
       "primary_oracle": "cross-surface",
       "scale": "SF=0.1",
       "strength": "value-level",
+      "surface_provenance": "separate-handwritten",
+      "surface_provenance_rationale": "Expression and pandas DataFrame implementations are separately handwritten for each query, so the gate has stronger cross-implementation signal than shared-spec generators.",
       "surfaces": [
         "sql",
         "dataframe"
@@ -85,6 +93,8 @@
       "primary_oracle": "NONE",
       "scale": "\u2014",
       "strength": "\u2014",
+      "surface_provenance": "\u2014",
+      "surface_provenance_rationale": "\u2014",
       "surfaces": [
         "sql",
         "dataframe"
@@ -102,6 +112,8 @@
       "primary_oracle": "NONE",
       "scale": "\u2014",
       "strength": "\u2014",
+      "surface_provenance": "\u2014",
+      "surface_provenance_rationale": "\u2014",
       "surfaces": [
         "sql",
         "dataframe"
@@ -113,14 +125,16 @@
       "cross_surface_enforced": true,
       "dual_surface": true,
       "guarded": true,
-      "independence": "separate-handwritten",
-      "independence_rationale": "H2O-DB expression and pandas DataFrame implementations are separately handwritten for each query.",
+      "independence": "self-referential",
+      "independence_rationale": "Both compared surfaces are benchbox's own implementations; see Surface provenance for how far apart they were authored.",
       "oracles": [
         "cross-surface"
       ],
       "primary_oracle": "cross-surface",
       "scale": "SF=0.01",
       "strength": "value-level",
+      "surface_provenance": "separate-handwritten",
+      "surface_provenance_rationale": "H2O-DB expression and pandas DataFrame implementations are separately handwritten for each query.",
       "surfaces": [
         "sql",
         "dataframe"
@@ -138,6 +152,8 @@
       "primary_oracle": "NONE",
       "scale": "\u2014",
       "strength": "\u2014",
+      "surface_provenance": "\u2014",
+      "surface_provenance_rationale": "\u2014",
       "surfaces": [
         "sql",
         "dataframe"
@@ -149,14 +165,16 @@
       "cross_surface_enforced": true,
       "dual_surface": true,
       "guarded": true,
-      "independence": "shared-spec",
-      "independence_rationale": "Both DataFrame families are generated through shared JoinOrder translation helpers, so the gate primarily catches SQL-vs-generated-DataFrame transcription drift.",
+      "independence": "self-referential",
+      "independence_rationale": "Both compared surfaces are benchbox's own implementations; see Surface provenance for how far apart they were authored.",
       "oracles": [
         "cross-surface"
       ],
       "primary_oracle": "cross-surface",
       "scale": "SF=0.1",
       "strength": "value-level",
+      "surface_provenance": "shared-spec",
+      "surface_provenance_rationale": "Both DataFrame families are generated through shared JoinOrder translation helpers, so the gate primarily catches SQL-vs-generated-DataFrame transcription drift.",
       "surfaces": [
         "sql",
         "dataframe"
@@ -174,6 +192,8 @@
       "primary_oracle": "NONE",
       "scale": "\u2014",
       "strength": "\u2014",
+      "surface_provenance": "\u2014",
+      "surface_provenance_rationale": "\u2014",
       "surfaces": [
         "sql",
         "dataframe"
@@ -191,6 +211,8 @@
       "primary_oracle": "NONE",
       "scale": "\u2014",
       "strength": "\u2014",
+      "surface_provenance": "\u2014",
+      "surface_provenance_rationale": "\u2014",
       "surfaces": [
         "sql",
         "dataframe"
@@ -202,14 +224,16 @@
       "cross_surface_enforced": true,
       "dual_surface": true,
       "guarded": true,
-      "independence": "mixed-provenance",
-      "independence_rationale": "Read Primitives combines explicit family implementations with factory-built/query-catalog implementations, so provenance is mixed rather than wholly independent.",
+      "independence": "self-referential",
+      "independence_rationale": "Both compared surfaces are benchbox's own implementations; see Surface provenance for how far apart they were authored.",
       "oracles": [
         "cross-surface"
       ],
       "primary_oracle": "cross-surface",
       "scale": "SF=0.05",
       "strength": "value-level",
+      "surface_provenance": "mixed-provenance",
+      "surface_provenance_rationale": "Read Primitives combines explicit family implementations with factory-built/query-catalog implementations, so provenance is mixed rather than wholly independent.",
       "surfaces": [
         "sql",
         "dataframe"
@@ -221,14 +245,16 @@
       "cross_surface_enforced": true,
       "dual_surface": true,
       "guarded": true,
-      "independence": "shared-spec",
-      "independence_rationale": "Both DataFrame backends are generated from compact SSB query metadata; the independent signal is SQL text versus the shared generated DataFrame spec.",
+      "independence": "self-referential",
+      "independence_rationale": "Both compared surfaces are benchbox's own implementations; see Surface provenance for how far apart they were authored.",
       "oracles": [
         "cross-surface"
       ],
       "primary_oracle": "cross-surface",
       "scale": "SF=0.1",
       "strength": "value-level",
+      "surface_provenance": "shared-spec",
+      "surface_provenance_rationale": "Both DataFrame backends are generated from compact SSB query metadata; the independent signal is SQL text versus the shared generated DataFrame spec.",
       "surfaces": [
         "sql",
         "dataframe"
@@ -246,6 +272,8 @@
       "primary_oracle": "NONE",
       "scale": "\u2014",
       "strength": "\u2014",
+      "surface_provenance": "\u2014",
+      "surface_provenance_rationale": "\u2014",
       "surfaces": [
         "sql",
         "dataframe"
@@ -265,6 +293,8 @@
       "primary_oracle": "expected-results",
       "scale": "SF=1",
       "strength": "cardinality-only",
+      "surface_provenance": "\u2014",
+      "surface_provenance_rationale": "\u2014",
       "surfaces": [
         "sql",
         "dataframe"
@@ -282,6 +312,8 @@
       "primary_oracle": "NONE",
       "scale": "\u2014",
       "strength": "\u2014",
+      "surface_provenance": "\u2014",
+      "surface_provenance_rationale": "\u2014",
       "surfaces": [
         "sql",
         "dataframe"
@@ -294,13 +326,15 @@
       "dual_surface": true,
       "guarded": true,
       "independence": "self-referential",
-      "independence_rationale": "Reference is a shared/generated surface or frozen benchbox snapshot, not an external authority.",
+      "independence_rationale": "Reference is a frozen benchbox snapshot, not an external authority.",
       "oracles": [
         "expected-results"
       ],
       "primary_oracle": "expected-results",
       "scale": "SF=1",
       "strength": "value+cardinality",
+      "surface_provenance": "\u2014",
+      "surface_provenance_rationale": "\u2014",
       "surfaces": [
         "sql",
         "dataframe"
@@ -318,6 +352,8 @@
       "primary_oracle": "NONE",
       "scale": "\u2014",
       "strength": "\u2014",
+      "surface_provenance": "\u2014",
+      "surface_provenance_rationale": "\u2014",
       "surfaces": [
         "sql",
         "dataframe"
@@ -330,7 +366,7 @@
       "dual_surface": true,
       "guarded": true,
       "independence": "self-referential",
-      "independence_rationale": "Reference is a shared/generated surface or frozen benchbox snapshot, not an external authority.",
+      "independence_rationale": "Reference is another benchbox surface of the same benchmark family, not an external authority.",
       "oracles": [
         "variant-equivalence",
         "cross-surface-variant"
@@ -338,6 +374,8 @@
       "primary_oracle": "variant-equivalence",
       "scale": "SF=0.1",
       "strength": "value-level",
+      "surface_provenance": "\u2014",
+      "surface_provenance_rationale": "\u2014",
       "surfaces": [
         "sql",
         "dataframe"
@@ -355,6 +393,8 @@
       "primary_oracle": "NONE",
       "scale": "\u2014",
       "strength": "\u2014",
+      "surface_provenance": "\u2014",
+      "surface_provenance_rationale": "\u2014",
       "surfaces": [
         "sql",
         "dataframe"
@@ -372,6 +412,8 @@
       "primary_oracle": "NONE",
       "scale": "\u2014",
       "strength": "\u2014",
+      "surface_provenance": "\u2014",
+      "surface_provenance_rationale": "\u2014",
       "surfaces": [
         "sql",
         "dataframe"
@@ -389,6 +431,8 @@
       "primary_oracle": "NONE",
       "scale": "\u2014",
       "strength": "\u2014",
+      "surface_provenance": "\u2014",
+      "surface_provenance_rationale": "\u2014",
       "surfaces": [
         "sql"
       ]
@@ -405,6 +449,8 @@
       "primary_oracle": "NONE",
       "scale": "\u2014",
       "strength": "\u2014",
+      "surface_provenance": "\u2014",
+      "surface_provenance_rationale": "\u2014",
       "surfaces": [
         "sql",
         "dataframe"

--- a/_project/analysis/oracle-coverage-map.md
+++ b/_project/analysis/oracle-coverage-map.md
@@ -1,6 +1,6 @@
 <!-- PROVENANCE
-generated: 2026-06-28
-content-revision: sha256:edf87a710c067205
+generated: 2026-07-29
+content-revision: sha256:2a84af0397babc60
 This header is drift-IGNORED by `--check` (see _strip_provenance). content-revision
 is a hash of the generated body (markdown + json), NOT a git SHA: a PR-branch SHA is
 orphaned by squash-merge, so to verify this artifact, regenerate it with
@@ -17,33 +17,35 @@ does this). Do not rely on this header for diffs.
 
 **Strength + scale disclosure:** a guarded cell is not a uniform guarantee. The **Strength** column says what the oracle proves — `value-level` (full result values compared) vs `cardinality-only` (row counts only) vs `value+cardinality` (both) — and the **Scale** column says at which scale it actually holds. Both are derived from live sources (the provider's stored answers/digests and the equivalence gate's bounded scale), not hand-labelled. No expected-results oracle exists above SF=1 (the loader raises for other scales), so `tpch`/`tpcds` values are unguarded above SF=1 — the tpch **Strength** cell states this inline so the row is self-contained.
 
-**Reference-independence disclosure:** the **Independence** column says how independent the oracle reference is from the implementation under test — orthogonal to Strength (a `value-level` oracle can still be weak). For cross-surface gates it is per-gate surface provenance from the live `CrossSurfaceGate` metadata: `shared-spec` means DataFrame backends are generated/maintained from one shared spec, `mixed-provenance` means some cells are shared/generated and some bespoke, and `separate-handwritten` means the DataFrame families are separately written implementations. For expected-results oracles, `self-referential` is a frozen benchbox snapshot and `semi-independent` is external TPC authority on cardinality only. The **Independence rationale** column gives the per-row reason.
+**Reference-independence disclosure:** the **Independence** column answers one question — is the oracle's reference an authority *outside* benchbox? It is orthogonal to Strength (a `value-level` oracle can still be weak). `semi-independent` means an external authority is consulted for part of the claim only: the published TPC answer sets pin `tpcds` row counts, never its values. `self-referential` means benchbox is compared against benchbox — either two of its own surfaces (every cross-surface and variant gate) or a frozen snapshot of its own past output (the `tpch` value digests). A self-referential oracle catches drift and regressions; it cannot catch a mistake both sides share. The **Independence rationale** column gives the per-row reason.
 
-| Benchmark | Surfaces | Oracle | Strength | Scale | Independence | Independence rationale | Enforced | Notes |
-| --- | --- | --- | --- | --- | --- | --- | --- | --- |
-| ai_primitives | sql | NONE | — | — | — | — | — | single-surface → needs fallback oracle (w2) |
-| amplab | sql+dataframe | cross-surface | value-level | SF=0.1 | separate-handwritten | Expression and pandas DataFrame implementations are separately handwritten for each query, so the gate has stronger cross-implementation signal than shared-spec generators. | enforced (CI-blocking) | cross-surface |
-| clickbench | sql+dataframe | cross-surface | value-level | SF=0.1 | mixed-provenance | Most ClickBench DataFrame cells are generated from shared compact specs, with a small set of bespoke implementations; read as mixed provenance, not fully independent implementations. | enforced (CI-blocking) | cross-surface |
-| coffeeshop | sql+dataframe | cross-surface | value-level | SF=0.1 | separate-handwritten | Expression and pandas DataFrame implementations are separately handwritten for each query, so the gate has stronger cross-implementation signal than shared-spec generators. | enforced (CI-blocking) | cross-surface |
-| datavault | sql+dataframe | NONE | — | — | — | — | — | dual-surface → dispatch to cross-surface gate (w1) |
-| flightdata | sql+dataframe | NONE | — | — | — | — | — | dual-surface → dispatch to cross-surface gate (w1) |
-| h2odb | sql+dataframe | cross-surface | value-level | SF=0.01 | separate-handwritten | H2O-DB expression and pandas DataFrame implementations are separately handwritten for each query. | enforced (CI-blocking) | cross-surface |
-| joinorder | sql+dataframe | NONE | — | — | — | — | — | dual-surface → dispatch to cross-surface gate (w1) |
-| joinorder_synthetic | sql+dataframe | cross-surface | value-level | SF=0.1 | shared-spec | Both DataFrame families are generated through shared JoinOrder translation helpers, so the gate primarily catches SQL-vs-generated-DataFrame transcription drift. | enforced (CI-blocking) | cross-surface |
-| metadata_primitives | sql+dataframe | NONE | — | — | — | — | — | dual-surface → dispatch to cross-surface gate (w1) |
-| nyctaxi | sql+dataframe | NONE | — | — | — | — | — | dual-surface → dispatch to cross-surface gate (w1) |
-| read_primitives | sql+dataframe | cross-surface | value-level | SF=0.05 | mixed-provenance | Read Primitives combines explicit family implementations with factory-built/query-catalog implementations, so provenance is mixed rather than wholly independent. | enforced (CI-blocking) | cross-surface |
-| ssb | sql+dataframe | cross-surface | value-level | SF=0.1 | shared-spec | Both DataFrame backends are generated from compact SSB query metadata; the independent signal is SQL text versus the shared generated DataFrame spec. | enforced (CI-blocking) | cross-surface |
-| tpcdi | sql+dataframe | NONE | — | — | — | — | — | dual-surface → dispatch to cross-surface gate (w1) |
-| tpcds | sql+dataframe | expected-results | cardinality-only | SF=1 | semi-independent | External TPC answer sets provide row-count authority only; result values are not checked. | — | expected-results |
-| tpcds_obt | sql+dataframe | NONE | — | — | — | — | — | dual-surface → dispatch to cross-surface gate (w1) |
-| tpch | sql+dataframe | expected-results | value+cardinality (SF=1 only; values UNGUARDED above SF=1) | SF=1 | self-referential | Reference is a shared/generated surface or frozen benchbox snapshot, not an external authority. | — | expected-results |
-| tpch_skew | sql+dataframe | NONE | — | — | — | — | — | dual-surface → dispatch to cross-surface gate (w1) |
-| tpchavoc | sql+dataframe | variant-equivalence | value-level | SF=0.1 | self-referential | Reference is a shared/generated surface or frozen benchbox snapshot, not an external authority. | — | variant-equivalence, cross-surface-variant |
-| transaction_primitives | sql+dataframe | NONE | — | — | — | — | — | dual-surface → dispatch to cross-surface gate (w1) |
-| tsbs_devops | sql+dataframe | NONE | — | — | — | — | — | dual-surface → dispatch to cross-surface gate (w1) |
-| vector_search | sql | NONE | — | — | — | — | — | single-surface → needs fallback oracle (w2) |
-| write_primitives | sql+dataframe | NONE | — | — | — | — | — | dual-surface → dispatch to cross-surface gate (w1) |
+**Surface-provenance disclosure:** the **Surface provenance** column is a SEPARATE axis that grades, for a cross-surface gate, how far apart the two compared surfaces were *authored*: `shared-spec` (both DataFrame backends generated/maintained from one shared spec), `mixed-provenance` (some cells shared/generated, some bespoke), or `separate-handwritten` (the DataFrame families are separately written implementations). It is read per-gate from the live `CrossSurfaceGate` metadata and is `—` for every non-cross-surface row, where the axis does not apply. Read it as *how much internal signal the gate carries* — separately handwritten surfaces catch more than two surfaces generated from one spec — and **not** as independence: a `separate-handwritten` gate is still benchbox checking its own DataFrame code against its own SQL, which is why its Independence stays `self-referential`. The **Provenance rationale** column gives the per-gate reason.
+
+| Benchmark | Surfaces | Oracle | Strength | Scale | Independence | Independence rationale | Surface provenance | Provenance rationale | Enforced | Notes |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| ai_primitives | sql | NONE | — | — | — | — | — | — | — | single-surface → needs fallback oracle (w2) |
+| amplab | sql+dataframe | cross-surface | value-level | SF=0.1 | self-referential | Both compared surfaces are benchbox's own implementations; see Surface provenance for how far apart they were authored. | separate-handwritten | Expression and pandas DataFrame implementations are separately handwritten for each query, so the gate has stronger cross-implementation signal than shared-spec generators. | enforced (CI-blocking) | cross-surface |
+| clickbench | sql+dataframe | cross-surface | value-level | SF=0.1 | self-referential | Both compared surfaces are benchbox's own implementations; see Surface provenance for how far apart they were authored. | mixed-provenance | Most ClickBench DataFrame cells are generated from shared compact specs, with a small set of bespoke implementations; read as mixed provenance, not fully independent implementations. | enforced (CI-blocking) | cross-surface |
+| coffeeshop | sql+dataframe | cross-surface | value-level | SF=0.1 | self-referential | Both compared surfaces are benchbox's own implementations; see Surface provenance for how far apart they were authored. | separate-handwritten | Expression and pandas DataFrame implementations are separately handwritten for each query, so the gate has stronger cross-implementation signal than shared-spec generators. | enforced (CI-blocking) | cross-surface |
+| datavault | sql+dataframe | NONE | — | — | — | — | — | — | — | dual-surface → dispatch to cross-surface gate (w1) |
+| flightdata | sql+dataframe | NONE | — | — | — | — | — | — | — | dual-surface → dispatch to cross-surface gate (w1) |
+| h2odb | sql+dataframe | cross-surface | value-level | SF=0.01 | self-referential | Both compared surfaces are benchbox's own implementations; see Surface provenance for how far apart they were authored. | separate-handwritten | H2O-DB expression and pandas DataFrame implementations are separately handwritten for each query. | enforced (CI-blocking) | cross-surface |
+| joinorder | sql+dataframe | NONE | — | — | — | — | — | — | — | dual-surface → dispatch to cross-surface gate (w1) |
+| joinorder_synthetic | sql+dataframe | cross-surface | value-level | SF=0.1 | self-referential | Both compared surfaces are benchbox's own implementations; see Surface provenance for how far apart they were authored. | shared-spec | Both DataFrame families are generated through shared JoinOrder translation helpers, so the gate primarily catches SQL-vs-generated-DataFrame transcription drift. | enforced (CI-blocking) | cross-surface |
+| metadata_primitives | sql+dataframe | NONE | — | — | — | — | — | — | — | dual-surface → dispatch to cross-surface gate (w1) |
+| nyctaxi | sql+dataframe | NONE | — | — | — | — | — | — | — | dual-surface → dispatch to cross-surface gate (w1) |
+| read_primitives | sql+dataframe | cross-surface | value-level | SF=0.05 | self-referential | Both compared surfaces are benchbox's own implementations; see Surface provenance for how far apart they were authored. | mixed-provenance | Read Primitives combines explicit family implementations with factory-built/query-catalog implementations, so provenance is mixed rather than wholly independent. | enforced (CI-blocking) | cross-surface |
+| ssb | sql+dataframe | cross-surface | value-level | SF=0.1 | self-referential | Both compared surfaces are benchbox's own implementations; see Surface provenance for how far apart they were authored. | shared-spec | Both DataFrame backends are generated from compact SSB query metadata; the independent signal is SQL text versus the shared generated DataFrame spec. | enforced (CI-blocking) | cross-surface |
+| tpcdi | sql+dataframe | NONE | — | — | — | — | — | — | — | dual-surface → dispatch to cross-surface gate (w1) |
+| tpcds | sql+dataframe | expected-results | cardinality-only | SF=1 | semi-independent | External TPC answer sets provide row-count authority only; result values are not checked. | — | — | — | expected-results |
+| tpcds_obt | sql+dataframe | NONE | — | — | — | — | — | — | — | dual-surface → dispatch to cross-surface gate (w1) |
+| tpch | sql+dataframe | expected-results | value+cardinality (SF=1 only; values UNGUARDED above SF=1) | SF=1 | self-referential | Reference is a frozen benchbox snapshot, not an external authority. | — | — | — | expected-results |
+| tpch_skew | sql+dataframe | NONE | — | — | — | — | — | — | — | dual-surface → dispatch to cross-surface gate (w1) |
+| tpchavoc | sql+dataframe | variant-equivalence | value-level | SF=0.1 | self-referential | Reference is another benchbox surface of the same benchmark family, not an external authority. | — | — | — | variant-equivalence, cross-surface-variant |
+| transaction_primitives | sql+dataframe | NONE | — | — | — | — | — | — | — | dual-surface → dispatch to cross-surface gate (w1) |
+| tsbs_devops | sql+dataframe | NONE | — | — | — | — | — | — | — | dual-surface → dispatch to cross-surface gate (w1) |
+| vector_search | sql | NONE | — | — | — | — | — | — | — | single-surface → needs fallback oracle (w2) |
+| write_primitives | sql+dataframe | NONE | — | — | — | — | — | — | — | dual-surface → dispatch to cross-surface gate (w1) |
 
 ## UNGUARDED benchmarks
 

--- a/_project/scripts/generate_oracle_coverage_map.py
+++ b/_project/scripts/generate_oracle_coverage_map.py
@@ -55,13 +55,17 @@ STRENGTH_VALUE_AND_CARDINALITY = "value+cardinality"  # row counts AND stored va
 STRENGTH_NONE = "—"
 
 # Oracle REFERENCE-INDEPENDENCE: how independent the guarded reference is from the
-# implementation under test. This is ORTHOGONAL to Strength (a value-level oracle
-# can still be weak), so it is a SEPARATE column, never folded into Strength.
-# Derived from live source metadata, never hand-labelled in the generated artifact:
-#   * cross-surface gates: per-gate ``CrossSurfaceGate.surface_independence`` and
-#     rationale (shared-spec, mixed-provenance, or separate-handwritten).
+# implementation under test -- i.e. is the reference an authority OUTSIDE benchbox, or
+# benchbox comparing against itself? This is ORTHOGONAL to Strength (a value-level
+# oracle can still be weak), so it is a SEPARATE column, never folded into Strength.
+# It is also ORTHOGONAL to Surface-provenance below: provenance grades how far apart
+# two benchbox surfaces are, which never makes either surface an external authority.
+# Derived from the oracle KIND plus the live strength signal, never hand-labelled:
+#   * cross-surface gates: BOTH sides are benchbox's own SQL and DataFrame surfaces,
+#     so the reference is always self-referential regardless of how the two surfaces
+#     were authored (that is the Surface-provenance axis).
 #   * variant gates: canonical/variant surfaces from the same BenchBox family, so
-#     they remain self-referential.
+#     they are likewise self-referential.
 #   * expected-results VALUE digests (tpch): a frozen benchbox-on-DuckDB snapshot, so
 #     the value axis is self-referential (a regression snapshot, not an authority).
 #   * expected-results ROW COUNTS (tpch/tpcds cardinality): the cardinalities come
@@ -70,10 +74,24 @@ STRENGTH_NONE = "—"
 INDEPENDENCE_INDEPENDENT = "independent"  # reference is an external authority (full values)
 INDEPENDENCE_SEMI = "semi-independent"  # external authority on cardinality only (TPC answer-set row counts)
 INDEPENDENCE_SELF = "self-referential"  # compared against itself (shared spec / frozen self-snapshot)
-INDEPENDENCE_SHARED_SPEC = "shared-spec"  # cross-surface gate generated from one shared DataFrame spec
-INDEPENDENCE_MIXED = "mixed-provenance"  # cross-surface gate mixes generated/shared and bespoke implementations
-INDEPENDENCE_SEPARATE = "separate-handwritten"  # cross-surface gate has separately handwritten DataFrame impls
 INDEPENDENCE_NONE = "—"
+
+# Oracle SURFACE-PROVENANCE: for a cross-surface gate, how far apart the two compared
+# benchbox surfaces were AUTHORED. A deliberately DISTINCT vocabulary from
+# INDEPENDENCE_* above: folding these labels into the Independence column made a
+# `separate-handwritten` cell read as an external reference, when the reference is
+# still benchbox's own DataFrame code. Provenance grades the STRENGTH OF THE INTERNAL
+# SIGNAL (separately handwritten surfaces catch more than two generated-from-one-spec
+# surfaces); it never buys independence.
+#
+# These strings mirror ``cross_surface.SURFACE_INDEPENDENCE_*`` -- the live per-gate
+# metadata this column is read from -- rather than importing them, so the module stays
+# import-light; ``tests/unit/test_oracle_coverage_map.py`` pins them to the live
+# constants so they cannot drift apart.
+PROVENANCE_SHARED_SPEC = "shared-spec"  # both DataFrame backends generated from one shared spec
+PROVENANCE_MIXED = "mixed-provenance"  # mixes generated/shared and bespoke implementations
+PROVENANCE_SEPARATE = "separate-handwritten"  # DataFrame families separately handwritten
+PROVENANCE_NONE = "—"  # not a cross-surface gate: the axis does not apply
 
 # Sentinel for "no scale guarantee" (UNGUARDED rows).
 SCALE_NONE = "—"
@@ -192,29 +210,17 @@ def oracle_strength_and_scale(primary: str, benchmark_id: str) -> tuple[str, str
     return STRENGTH_NONE, SCALE_NONE
 
 
-def _cross_surface_independence(benchmark_id: str) -> tuple[str, str]:
-    """Return cross-surface implementation-provenance metadata for ``benchmark_id``."""
-    from benchbox.core.equivalence.cross_surface import GATES, STAGED_GATES
-
-    gate = GATES.get(benchmark_id) or STAGED_GATES.get(benchmark_id)
-    if gate is None:
-        return (
-            INDEPENDENCE_SELF,
-            "Cross-surface gate metadata is unavailable; treat as self-referential until registered.",
-        )
-    return gate.surface_independence, gate.surface_independence_rationale
-
-
-def oracle_reference_independence(primary: str, strength: str, benchmark_id: str | None = None) -> str:
+def oracle_reference_independence(primary: str, strength: str) -> str:
     """Return the reference-independence axis for a benchmark's primary oracle.
 
-    Orthogonal to Strength and derived from the oracle KIND + the strength signal
-    (which already encodes whether stored VALUE digests exist), so it tracks the
-    classifier without a new hand-maintained field:
+    Answers one question only: is the reference an authority OUTSIDE benchbox?
+    Orthogonal to Strength and to Surface-provenance, and derived from the oracle KIND
+    plus the strength signal (which already encodes whether stored VALUE digests
+    exist), so it tracks the classifier without a hand-maintained field:
 
-      * cross-surface gates -> per-gate surface provenance from
-        ``CrossSurfaceGate.surface_independence`` (shared-spec, mixed-provenance,
-        or separate-handwritten).
+      * cross-surface gates -> self-referential. Both compared surfaces are benchbox's
+        own SQL and DataFrame implementations, so no authoring distance between them
+        (see ``oracle_surface_provenance``) turns either into an external authority.
       * variant gates -> self-referential (canonical SQL variant is the reference
         for generated/variant surfaces).
       * expected-results with value+cardinality (tpch) -> self-referential: the value
@@ -225,11 +231,7 @@ def oracle_reference_independence(primary: str, strength: str, benchmark_id: str
         from the published TPC answer sets (an authority outside benchbox), but only
         the cardinality is checked, never the values.
     """
-    if primary == ORACLE_CROSS_SURFACE:
-        if benchmark_id is None:
-            return INDEPENDENCE_SELF
-        return _cross_surface_independence(benchmark_id)[0]
-    if primary in (ORACLE_VARIANT_EQUIVALENCE, ORACLE_CROSS_SURFACE_VARIANT):
+    if primary in (ORACLE_CROSS_SURFACE, ORACLE_VARIANT_EQUIVALENCE, ORACLE_CROSS_SURFACE_VARIANT):
         return INDEPENDENCE_SELF
     if primary == ORACLE_EXPECTED_RESULTS:
         # A stored value digest is a frozen self-snapshot, so the (stronger) value
@@ -241,21 +243,59 @@ def oracle_reference_independence(primary: str, strength: str, benchmark_id: str
     return INDEPENDENCE_NONE
 
 
-def oracle_independence_and_rationale(primary: str, strength: str, benchmark_id: str) -> tuple[str, str]:
+def oracle_independence_and_rationale(primary: str, strength: str) -> tuple[str, str]:
     """Return the independence label plus one-line rationale rendered in the map."""
-    if primary == ORACLE_CROSS_SURFACE:
-        return _cross_surface_independence(benchmark_id)
-    independence = oracle_reference_independence(primary, strength, benchmark_id)
+    independence = oracle_reference_independence(primary, strength)
     if independence == INDEPENDENCE_SELF:
+        # Only a cross-surface gate has a Surface-provenance cell to point at; a variant
+        # gate's provenance axis is `—`, so it must not send the reader to an empty cell.
+        if primary == ORACLE_CROSS_SURFACE:
+            return (
+                independence,
+                "Both compared surfaces are benchbox's own implementations; see Surface provenance "
+                "for how far apart they were authored.",
+            )
+        if primary in (ORACLE_VARIANT_EQUIVALENCE, ORACLE_CROSS_SURFACE_VARIANT):
+            return (
+                independence,
+                "Reference is another benchbox surface of the same benchmark family, not an external authority.",
+            )
         return (
             independence,
-            "Reference is a shared/generated surface or frozen benchbox snapshot, not an external authority.",
+            "Reference is a frozen benchbox snapshot, not an external authority.",
         )
     if independence == INDEPENDENCE_SEMI:
         return independence, "External TPC answer sets provide row-count authority only; result values are not checked."
     if independence == INDEPENDENCE_INDEPENDENT:
         return independence, "Full result values are checked against an external authority."
     return independence, INDEPENDENCE_NONE
+
+
+def oracle_surface_provenance(primary: str, benchmark_id: str) -> tuple[str, str]:
+    """Return ``(surface_provenance, rationale)`` for a benchmark's primary oracle.
+
+    A SEPARATE axis from reference-independence: it grades how far apart the two
+    compared benchbox surfaces were AUTHORED, which sets how much internal signal the
+    gate carries (separately handwritten surfaces catch more than two surfaces
+    generated from one spec) without ever making the reference external.
+
+    Read live from the per-gate ``CrossSurfaceGate.surface_independence`` metadata, so
+    re-registering a gate with different provenance reclassifies the row on the next
+    regeneration. The axis applies only to cross-surface gates; every other oracle --
+    and every UNGUARDED row -- reports ``—``.
+    """
+    if primary != ORACLE_CROSS_SURFACE:
+        return PROVENANCE_NONE, PROVENANCE_NONE
+
+    from benchbox.core.equivalence.cross_surface import GATES, STAGED_GATES
+
+    gate = GATES.get(benchmark_id) or STAGED_GATES.get(benchmark_id)
+    if gate is None:  # pragma: no cover - a cross-surface primary implies a registered gate
+        return (
+            PROVENANCE_NONE,
+            "Cross-surface gate metadata is unavailable; provenance is undisclosed until the gate is registered.",
+        )
+    return gate.surface_independence, gate.surface_independence_rationale
 
 
 def _surfaces(metadata: dict[str, Any]) -> tuple[bool, bool]:
@@ -292,7 +332,8 @@ def build_coverage_map() -> list[dict[str, Any]]:
         )
         primary = primary_oracle(oracles)
         strength, scale = oracle_strength_and_scale(primary, benchmark_id)
-        independence, independence_rationale = oracle_independence_and_rationale(primary, strength, benchmark_id)
+        independence, independence_rationale = oracle_independence_and_rationale(primary, strength)
+        surface_provenance, surface_provenance_rationale = oracle_surface_provenance(primary, benchmark_id)
         # A dual-surface benchmark with no oracle is reachable by the cross-surface
         # SQL<->DataFrame gate (the w1 dispatch target). A single-surface benchmark
         # is not and needs a fallback oracle (w2).
@@ -316,6 +357,8 @@ def build_coverage_map() -> list[dict[str, Any]]:
                 "scale": scale,
                 "independence": independence,
                 "independence_rationale": independence_rationale,
+                "surface_provenance": surface_provenance,
+                "surface_provenance_rationale": surface_provenance_rationale,
                 "guarded": primary != ORACLE_NONE,
                 "cross_surface_enforced": cross_surface_enforced,
                 "cross_surface_applicable": dual_surface and primary == ORACLE_NONE,
@@ -414,23 +457,40 @@ def render_markdown(rows: list[dict[str, Any]]) -> str:
     )
     lines.append("")
     lines.append(
-        "**Reference-independence disclosure:** the **Independence** column says how "
-        "independent the oracle reference is from the implementation under test — "
-        "orthogonal to Strength (a `value-level` oracle can still be weak). For "
-        "cross-surface gates it is per-gate surface provenance from the live "
-        "`CrossSurfaceGate` metadata: `shared-spec` means DataFrame backends are "
-        "generated/maintained from one shared spec, `mixed-provenance` means some "
-        "cells are shared/generated and some bespoke, and `separate-handwritten` means "
-        "the DataFrame families are separately written implementations. For "
-        "expected-results oracles, `self-referential` is a frozen benchbox snapshot "
-        "and `semi-independent` is external TPC authority on cardinality only. The "
-        "**Independence rationale** column gives the per-row reason."
+        "**Reference-independence disclosure:** the **Independence** column answers one "
+        "question — is the oracle's reference an authority *outside* benchbox? It is "
+        "orthogonal to Strength (a `value-level` oracle can still be weak). "
+        "`semi-independent` means an external authority is consulted for part of the "
+        "claim only: the published TPC answer sets pin `tpcds` row counts, never its "
+        "values. `self-referential` means benchbox is compared against benchbox — "
+        "either two of its own surfaces (every cross-surface and variant gate) or a "
+        "frozen snapshot of its own past output (the `tpch` value digests). A "
+        "self-referential oracle catches drift and regressions; it cannot catch a "
+        "mistake both sides share. The **Independence rationale** column gives the "
+        "per-row reason."
     )
     lines.append("")
     lines.append(
-        "| Benchmark | Surfaces | Oracle | Strength | Scale | Independence | Independence rationale | Enforced | Notes |"
+        "**Surface-provenance disclosure:** the **Surface provenance** column is a "
+        "SEPARATE axis that grades, for a cross-surface gate, how far apart the two "
+        "compared surfaces were *authored*: `shared-spec` (both DataFrame backends "
+        "generated/maintained from one shared spec), `mixed-provenance` (some cells "
+        "shared/generated, some bespoke), or `separate-handwritten` (the DataFrame "
+        "families are separately written implementations). It is read per-gate from "
+        "the live `CrossSurfaceGate` metadata and is `—` for every non-cross-surface "
+        "row, where the axis does not apply. Read it as *how much internal signal the "
+        "gate carries* — separately handwritten surfaces catch more than two surfaces "
+        "generated from one spec — and **not** as independence: a "
+        "`separate-handwritten` gate is still benchbox checking its own DataFrame code "
+        "against its own SQL, which is why its Independence stays `self-referential`. "
+        "The **Provenance rationale** column gives the per-gate reason."
     )
-    lines.append("| --- | --- | --- | --- | --- | --- | --- | --- | --- |")
+    lines.append("")
+    lines.append(
+        "| Benchmark | Surfaces | Oracle | Strength | Scale | Independence | Independence rationale | "
+        "Surface provenance | Provenance rationale | Enforced | Notes |"
+    )
+    lines.append("| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |")
     for r in rows:
         surfaces = "+".join(r["surfaces"]) or "—"
         oracle = r["primary_oracle"]
@@ -448,7 +508,8 @@ def render_markdown(rows: list[dict[str, Any]]) -> str:
         enforced = _enforcement_label(r)
         lines.append(
             f"| {r['benchmark']} | {surfaces} | {oracle} | {_strength_cell(r)} | {r['scale']} | "
-            f"{r['independence']} | {r['independence_rationale']} | {enforced} | {note} |"
+            f"{r['independence']} | {r['independence_rationale']} | "
+            f"{r['surface_provenance']} | {r['surface_provenance_rationale']} | {enforced} | {note} |"
         )
     lines.append("")
     lines.append("## UNGUARDED benchmarks")

--- a/tests/unit/test_oracle_coverage_map.py
+++ b/tests/unit/test_oracle_coverage_map.py
@@ -27,16 +27,18 @@ if str(_REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(_REPO_ROOT))
 
 from _project.scripts.generate_oracle_coverage_map import (  # noqa: E402
-    INDEPENDENCE_MIXED,
     INDEPENDENCE_NONE,
     INDEPENDENCE_SELF,
     INDEPENDENCE_SEMI,
-    INDEPENDENCE_SEPARATE,
-    INDEPENDENCE_SHARED_SPEC,
     ORACLE_CROSS_SURFACE,
+    ORACLE_CROSS_SURFACE_VARIANT,
     ORACLE_EXPECTED_RESULTS,
     ORACLE_NONE,
     ORACLE_VARIANT_EQUIVALENCE,
+    PROVENANCE_MIXED,
+    PROVENANCE_NONE,
+    PROVENANCE_SEPARATE,
+    PROVENANCE_SHARED_SPEC,
     STRENGTH_CARDINALITY,
     STRENGTH_NONE,
     STRENGTH_VALUE,
@@ -45,6 +47,7 @@ from _project.scripts.generate_oracle_coverage_map import (  # noqa: E402
     check_artifacts,
     oracle_reference_independence,
     oracle_strength_and_scale,
+    oracle_surface_provenance,
     render_markdown,
 )
 
@@ -197,10 +200,10 @@ def test_independence_column_present(rows):
 def test_known_oracle_independence_truth(rows):
     """Pin the TRUTH of reference-independence for known oracles (classifier-truth, w4).
 
-    Orthogonal to Strength: a `value-level` oracle can be independent or
-    self-referential. This pins what each known oracle's reference ACTUALLY is, so a
-    future change that mislabels independence fails here even if the artifact is
-    internally consistent.
+    Orthogonal to Strength AND to Surface-provenance: this column answers only "is the
+    reference an authority OUTSIDE benchbox?". This pins what each known oracle's
+    reference ACTUALLY is, so a future change that mislabels independence fails here
+    even if the artifact is internally consistent.
     """
     by_id = {r["benchmark"]: r for r in rows}
 
@@ -210,18 +213,130 @@ def test_known_oracle_independence_truth(rows):
     # tpcds is cardinality-only: row counts come from the published TPC answer sets
     # (an authority on cardinality), values unchecked -> semi-independent.
     assert by_id["tpcds"]["independence"] == INDEPENDENCE_SEMI
-    # cross-surface gates now disclose surface provenance, not one coarse label.
-    for benchmark in ("ssb", "joinorder_synthetic"):
-        assert by_id[benchmark]["independence"] == INDEPENDENCE_SHARED_SPEC
-    for benchmark in ("clickbench", "read_primitives"):
-        assert by_id[benchmark]["independence"] == INDEPENDENCE_MIXED
-    for benchmark in ("amplab", "coffeeshop", "h2odb"):
-        assert by_id[benchmark]["independence"] == INDEPENDENCE_SEPARATE
-    assert "separately handwritten" in by_id["coffeeshop"]["independence_rationale"]
+
+    # Every cross-surface gate compares benchbox SQL against benchbox DataFrame code,
+    # so NO authoring provenance -- not even `separate-handwritten` -- makes the
+    # reference external. This is the conflation the split exists to prevent.
+    for benchmark in ("ssb", "joinorder_synthetic", "clickbench", "read_primitives", "amplab", "coffeeshop", "h2odb"):
+        assert by_id[benchmark]["independence"] == INDEPENDENCE_SELF, (
+            f"{benchmark} cross-surface reference is benchbox's own DataFrame code, not an external authority"
+        )
 
     # TPC-Havoc variant gates still compare against their own canonical/variant
     # surfaces rather than an external authority.
     assert by_id["tpchavoc"]["independence"] == INDEPENDENCE_SELF
+
+    # No provenance label may leak into the Independence column (the pre-split bug).
+    provenance_labels = {PROVENANCE_SHARED_SPEC, PROVENANCE_MIXED, PROVENANCE_SEPARATE}
+    leaked = {r["benchmark"] for r in rows if r["independence"] in provenance_labels}
+    assert not leaked, f"surface-provenance labels leaked into the Independence column: {sorted(leaked)}"
+
+
+# --- Surface-provenance axis (oracle-coverage-map-independence-provenance-split) ---
+
+
+def test_surface_provenance_column_present(rows):
+    """Every row carries the provenance fields; only cross-surface rows disclose a label."""
+    for r in rows:
+        assert "surface_provenance" in r and r["surface_provenance"], f"{r['benchmark']} missing surface_provenance"
+        assert "surface_provenance_rationale" in r and r["surface_provenance_rationale"], (
+            f"{r['benchmark']} missing surface_provenance_rationale"
+        )
+        # The axis only applies to cross-surface gates; everything else reports `—`.
+        if r["primary_oracle"] != ORACLE_CROSS_SURFACE:
+            assert r["surface_provenance"] == PROVENANCE_NONE, (
+                f"{r['benchmark']} is not cross-surface but discloses provenance={r['surface_provenance']}"
+            )
+            assert r["surface_provenance_rationale"] == PROVENANCE_NONE, (
+                f"{r['benchmark']} is not cross-surface but carries a provenance rationale"
+            )
+
+
+def test_known_surface_provenance_truth(rows):
+    """Pin the TRUTH of surface provenance per gate (classifier-truth, w4).
+
+    The labels that used to sit in the Independence column now live here, and this
+    pins which gate has which, so a mislabel fails even when the artifact is
+    internally consistent.
+    """
+    by_id = {r["benchmark"]: r for r in rows}
+
+    for benchmark in ("ssb", "joinorder_synthetic"):
+        assert by_id[benchmark]["surface_provenance"] == PROVENANCE_SHARED_SPEC
+    for benchmark in ("clickbench", "read_primitives"):
+        assert by_id[benchmark]["surface_provenance"] == PROVENANCE_MIXED
+    for benchmark in ("amplab", "coffeeshop", "h2odb"):
+        assert by_id[benchmark]["surface_provenance"] == PROVENANCE_SEPARATE
+    assert "separately handwritten" in by_id["coffeeshop"]["surface_provenance_rationale"]
+
+
+def test_surface_provenance_is_read_live_from_gate_metadata(rows):
+    """Provenance must equal the live per-gate metadata, never a hand-kept table.
+
+    Re-registering a gate with different provenance must reclassify the row, so assert
+    against ``CrossSurfaceGate.surface_independence`` itself rather than a copy, and
+    pin the generator's label vocabulary to the live constants so the two cannot drift.
+    """
+    from benchbox.core.equivalence.cross_surface import (
+        GATES,
+        STAGED_GATES,
+        SURFACE_INDEPENDENCE_MIXED,
+        SURFACE_INDEPENDENCE_SEPARATE,
+        SURFACE_INDEPENDENCE_SHARED_SPEC,
+    )
+
+    assert PROVENANCE_SHARED_SPEC == SURFACE_INDEPENDENCE_SHARED_SPEC
+    assert PROVENANCE_MIXED == SURFACE_INDEPENDENCE_MIXED
+    assert PROVENANCE_SEPARATE == SURFACE_INDEPENDENCE_SEPARATE
+
+    by_id = {r["benchmark"]: r for r in rows}
+    for benchmark_id, gate in {**GATES, **STAGED_GATES}.items():
+        assert by_id[benchmark_id]["surface_provenance"] == gate.surface_independence, (
+            f"{benchmark_id} provenance is not read live from CrossSurfaceGate metadata"
+        )
+        assert by_id[benchmark_id]["surface_provenance_rationale"] == gate.surface_independence_rationale
+
+
+def test_provenance_never_changes_independence(rows):
+    """The two axes are INDEPENDENT columns: provenance must not move independence.
+
+    Gates that span the whole provenance range (`shared-spec` through
+    `separate-handwritten`) must all read `self-referential`, and the pure classifiers
+    must agree -- `oracle_reference_independence` takes no benchmark id at all, so a
+    per-gate provenance value has no path back into the independence label.
+    """
+    by_id = {r["benchmark"]: r for r in rows}
+    spread = {by_id[b]["surface_provenance"] for b in ("ssb", "clickbench", "coffeeshop")}
+    assert spread == {PROVENANCE_SHARED_SPEC, PROVENANCE_MIXED, PROVENANCE_SEPARATE}
+    assert {by_id[b]["independence"] for b in ("ssb", "clickbench", "coffeeshop")} == {INDEPENDENCE_SELF}
+
+    assert oracle_reference_independence(ORACLE_CROSS_SURFACE, STRENGTH_VALUE) == INDEPENDENCE_SELF
+    assert oracle_reference_independence(ORACLE_VARIANT_EQUIVALENCE, STRENGTH_VALUE) == INDEPENDENCE_SELF
+    assert oracle_reference_independence(ORACLE_CROSS_SURFACE_VARIANT, STRENGTH_VALUE) == INDEPENDENCE_SELF
+    # A variant gate has no cross-surface gate entry, so it discloses no provenance.
+    assert oracle_surface_provenance(ORACLE_VARIANT_EQUIVALENCE, "tpchavoc") == (PROVENANCE_NONE, PROVENANCE_NONE)
+    assert oracle_surface_provenance(ORACLE_CROSS_SURFACE, "coffeeshop")[0] == PROVENANCE_SEPARATE
+
+
+def test_markdown_renders_independence_and_provenance_as_distinct_columns(rows):
+    """The map must show two separate columns, and the prose must keep them apart."""
+    markdown = render_markdown(rows)
+    header = next(line for line in markdown.splitlines() if line.startswith("| Benchmark |"))
+    columns = [c.strip() for c in header.strip().strip("|").split("|")]
+    assert "Independence" in columns
+    assert "Surface provenance" in columns
+    assert columns.index("Independence") != columns.index("Surface provenance")
+
+    # A separately-handwritten gate: provenance in its own cell, independence still self.
+    coffeeshop = next(line for line in markdown.splitlines() if line.startswith("| coffeeshop |"))
+    cells = [c.strip() for c in coffeeshop.strip().strip("|").split("|")]
+    assert cells[columns.index("Independence")] == INDEPENDENCE_SELF
+    assert cells[columns.index("Surface provenance")] == PROVENANCE_SEPARATE
+
+    # The prose must explicitly warn that provenance is not independence, or the
+    # reader re-makes exactly the conflation this split removed.
+    assert "Surface-provenance disclosure:" in markdown
+    assert "not** as independence" in markdown
 
 
 def test_independence_is_derived_from_value_digest_signal(monkeypatch):
@@ -247,11 +362,9 @@ def test_independence_is_derived_from_value_digest_signal(monkeypatch):
     assert flipped_off["tpch"]["strength"] == STRENGTH_CARDINALITY
     assert flipped_off["tpch"]["independence"] == INDEPENDENCE_SEMI
 
-    # And the pure classifier agrees (orthogonal to the cross-surface KIND). A
-    # cross-surface row needs benchmark metadata to refine beyond the conservative
-    # fallback; variant gates remain self-referential.
+    # And the pure classifier agrees (orthogonal to the cross-surface KIND): both gate
+    # kinds compare benchbox against benchbox, so both stay self-referential.
     assert oracle_reference_independence(ORACLE_CROSS_SURFACE, STRENGTH_VALUE) == INDEPENDENCE_SELF
-    assert oracle_reference_independence(ORACLE_CROSS_SURFACE, STRENGTH_VALUE, "coffeeshop") == INDEPENDENCE_SEPARATE
     assert oracle_reference_independence(ORACLE_VARIANT_EQUIVALENCE, STRENGTH_VALUE) == INDEPENDENCE_SELF
 
 


### PR DESCRIPTION
## Problem

The oracle coverage map's **Independence** column carried two different questions at once. Cross-surface rows rendered `shared-spec` / `mixed-provenance` / `separate-handwritten` — labels about how the two compared surfaces were *authored*. Read as independence, `separate-handwritten` implies an external reference, when it is still benchbox's own DataFrame code checked against benchbox's own SQL.

## Change

Two orthogonal axes, two columns, two vocabularies:

| Axis | Question | Labels |
| --- | --- | --- |
| **Independence** | Is the reference an authority *outside* benchbox? | `independent` / `semi-independent` / `self-referential` / `—` |
| **Surface provenance** (new) | How far apart were the two benchbox surfaces authored? | `shared-spec` / `mixed-provenance` / `separate-handwritten` / `—` |

- Every cross-surface and variant gate now reports Independence = `self-referential`; no authoring provenance can change that (`oracle_reference_independence` no longer takes a benchmark id, so there is no path back).
- New `PROVENANCE_*` constants — deliberately *not* the `INDEPENDENCE_*` names — plus `oracle_surface_provenance()`, read live per-gate from `CrossSurfaceGate.surface_independence`.
- JSON rows gain `surface_provenance` + `surface_provenance_rationale`; markdown gains **Surface provenance** + **Provenance rationale** columns and a prose paragraph that states provenance is *not* independence.
- A variant gate's independence rationale no longer points at a Surface-provenance cell that is `—`.

Unchanged (additive): Strength, Scale, Enforced, the drift check, and the expected-results independence labels (`tpch` self-referential, `tpcds` semi-independent). Both axes stay generated from live sources; the provenance stamp stays out of the drift-compared body.

## Verification

- `make oracle-coverage-map && make oracle-coverage-map-check` → regenerates, reports up to date.
- `uv run -- python -m pytest tests/unit/test_oracle_coverage_map.py -q` → 20 passed.
- Mutation-checked both axes: forcing cross-surface Independence to `separate-handwritten`, and mislabelling a gate's provenance as `shared-spec`, each fail dedicated truth tests (`test_known_oracle_independence_truth`, `test_provenance_never_changes_independence`, `test_known_surface_provenance_truth`, `test_surface_provenance_is_read_live_from_gate_metadata`) — not only the drift check.
- CI-only gates run locally: `make lint`, `lint-imports`, `lint-markers`, `timing_policy_check.py --strict` (0 fast-lane violations).

Tracker: `oracle-coverage-map-independence-provenance-split` (w1–w4).