### PR TITLE
fix(tests): patch get_config_manager through the module, not by string

### DIFF
--- a/tests/unit/cli/test_run_dataframe_platform_options.py
+++ b/tests/unit/cli/test_run_dataframe_platform_options.py
@@ -31,6 +31,14 @@ from benchbox.core.schemas import DatabaseConfig
 __import__("benchbox.cli.commands.run")
 _run_module = _sys.modules["benchbox.cli.commands.run"]
 
+# `benchbox.cli` lazily caches the *function* ``main`` into its globals, which
+# shadows the same-named submodule.  Python >= 3.11 resolves a patch target via
+# ``pkgutil.resolve_name`` (imports the dotted path, so the module wins), but
+# 3.10 walks it with ``getattr`` and lands on the function:
+#     AttributeError: <function main ...> does not have the attribute 'get_config_manager'
+# Resolve the module once, up front, and patch through it instead of by string.
+_main_module = _sys.modules["benchbox.cli.main"]
+
 # Import for its spec-registration side effects so the registry is populated
 # regardless of test collection order.
 import benchbox.cli.platform_defaults  # noqa: E402,F401
@@ -140,7 +148,7 @@ class TestDataFrameOptionReachesConfig:
             patch.object(_run_module, "BenchmarkManager", return_value=mock_bench_manager),
             patch.object(_run_module, "BenchmarkOrchestrator", return_value=mock_orchestrator),
             patch.object(_run_module, "SystemProfiler") as mock_profiler_cls,
-            patch("benchbox.cli.main.get_config_manager") as mock_cfg,
+            patch.object(_main_module, "get_config_manager") as mock_cfg,
             patch.object(_run_module, "_execute_orchestrated_run", return_value=mock_result),
             patch.object(_run_module, "_export_orchestrated_result", return_value={"json": "/tmp/t.json"}),
             patch.object(_run_module, "_render_post_run_charts"),


### PR DESCRIPTION
## What

The 2026-07-29 Nightly Validation failed on `ubuntu-latest / 3.10` — one test, one error:

```
AttributeError: <function main at 0x7f08c9300c10> does not have the attribute 'get_config_manager'
```

## Why it happened

The attribute is **not** missing. `get_config_manager` is defined at `benchbox/cli/main.py:63` on every Python version. The patch *target* resolves to the wrong object.

`benchbox/cli/__init__.py` handles the lazy `main` export like this:

```python
if name == "main":
    from benchbox.cli.main import main
    globals()[name] = main      # binds the FUNCTION under the SUBMODULE's name
    return main
```

Whichever happens first in a process wins:

| First touch | `benchbox.cli.main` resolves to |
|---|---|
| `import benchbox.cli.main` | the module (Python sets the parent attribute on submodule import) |
| `benchbox.cli.main` attribute access | the **function** — the lazy path overwrites the module binding |

Python ≥ 3.11 hides the consequence: `unittest.mock._get_target` resolves via `pkgutil.resolve_name`, which imports the dotted path, so the module wins. Python 3.10 walks it with `getattr` and lands on the function.

That also explains why exactly *one* test failed rather than all eleven call sites — it depends on which xdist worker touched the attribute first.

## Evidence

Replaying 3.10's resolver (`_importer`/`_dot_lookup`) against the **real** package:

```
3.10 resolves benchbox.cli.main -> function
  has get_config_manager: False   <- PRE-FIX target
sys.modules indirection    -> module
  has get_config_manager: True    <- POST-FIX target
```

A minimal package with the same `__getattr__` shape, on a real 3.10.17 interpreter, reproduces the nightly message verbatim — and the module indirection is immune on both 3.10 and 3.12.

## The fix

Resolve the module once via `sys.modules` and patch through it. This is the indirection the file **already** uses for `_run_module`, and the one `test_quiet_mode.py:19` already uses for this exact symbol.

## Scope

The shadow itself is production behaviour in `benchbox/cli/__init__.py`, outside this item's scope (`tests/unit/cli/**`). Tracked as `cli-package-shadows-main-submodule-with-function`, which also lists the **seven remaining string-target patches** (`tests/unit/conftest.py:51`, `test_run_driver_version_announcement.py:83`, `test_cli_main.py`, `test_compression_cli.py`) that are one test-distribution away from the same failure. Removing the shadow fixes them all at once; patching each file individually is a band-aid.

## Verification

- `tests/unit/cli/test_run_dataframe_platform_options.py` — 13 passed
- `tests/unit/cli/` — 1604 passed
- `check-scope --strict` — scope OK, 1 changed file
- No vacuous pass: the DataFusion class is not skipped, and the assertion that `target_partitions=4` reaches `create_config` under the normalized `"datafusion"` key is unchanged.

Closes `nightly-py310-dataframe-options-mock-target`.