### PR TITLE
fix(tests): compare worktree-claim paths on a canonical form

### DIFF
--- a/tests/integration/worktree/test_worktree_claim_benchbox_scratch.py
+++ b/tests/integration/worktree/test_worktree_claim_benchbox_scratch.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import os
+import re
 import subprocess
 from pathlib import Path
 
@@ -13,6 +15,34 @@ pytestmark = [
 ]
 
 REPO_ROOT = Path(__file__).resolve().parents[3]
+
+# Git Bash/MSYS — which hosts the Makefile recipe on Windows — renders
+# ``C:\Users\...`` as ``/c/Users/...``.
+_MSYS_DRIVE_RE = re.compile(r"^/([A-Za-z])/")
+
+
+def normalize_path(raw: str) -> str:
+    """Canonical form for comparing a shell-emitted path with a pathlib one.
+
+    The recipe prints whatever its own shell considers the path to be, which on
+    Windows is the MSYS spelling, not the native one ``Path.resolve()`` returns.
+    The two differ only in spelling, so compare them on a canonical form rather
+    than weakening the assertion.
+    """
+    text = raw.strip().replace("\\", "/")
+    if os.name == "nt":
+        # Only translate on Windows: on POSIX a leading single-letter segment
+        # (``/a/b``) is an ordinary directory, not a drive letter.
+        text = _MSYS_DRIVE_RE.sub(lambda m: f"{m.group(1)}:/", text)
+        text = text.lower()  # Windows paths are case-insensitive
+    return text.rstrip("/")
+
+
+def emitted_worktree_path(stdout: str) -> str:
+    """The single WORKTREE_PATH the claim announced, in canonical form."""
+    emitted = [line.partition("=")[2] for line in stdout.splitlines() if line.startswith("WORKTREE_PATH=")]
+    assert len(emitted) == 1, f"expected exactly one WORKTREE_PATH= line, got {emitted!r}"
+    return normalize_path(emitted[0])
 
 
 def run(cmd: list[str], cwd: Path, **kwargs) -> subprocess.CompletedProcess[str]:
@@ -73,7 +103,7 @@ def test_worktree_claim_ignores_untracked_benchbox_scratch(tmp_path: Path) -> No
     )
 
     assert result.returncode == 0, result.stderr
-    assert f"WORKTREE_PATH={pool.resolve()}" in result.stdout
+    assert emitted_worktree_path(result.stdout) == normalize_path(str(pool.resolve()))
     assert run(["git", "branch", "--show-current"], pool).stdout.strip() == "feature/scratch-ok"
     assert (pool / ".benchbox" / "cache" / "scratch").exists()
 
@@ -151,7 +181,7 @@ def test_worktree_claim_preserves_dirty_detached_slots(tmp_path: Path) -> None:
 
     assert result.returncode == 0, result.stderr
     assert "claim skip pool-01: porcelain non-empty before reset" in result.stderr
-    assert f"WORKTREE_PATH={clean_pool.resolve()}" in result.stdout
+    assert emitted_worktree_path(result.stdout) == normalize_path(str(clean_pool.resolve()))
     assert run(["git", "branch", "--show-current"], dirty_pool).stdout.strip() == ""
     assert run(["git", "branch", "--show-current"], clean_pool).stdout.strip() == "feature/preserve-dirty"
     assert (dirty_pool / "README.md").read_text(encoding="utf-8") == "tracked WIP\n"

--- a/tests/integration/worktree/test_worktree_claim_signal_exit.py
+++ b/tests/integration/worktree/test_worktree_claim_signal_exit.py
@@ -12,6 +12,17 @@ import pytest
 pytestmark = [
     pytest.mark.integration,
     pytest.mark.fast,
+    pytest.mark.skipif(
+        os.name == "nt",
+        reason=(
+            "POSIX-only by construction. The test shims `git` with an extensionless "
+            "`#!/bin/sh` script placed first on PATH, but Windows resolves `git.exe`/`git.cmd` "
+            "and never runs an extensionless file, so the shim is bypassed; it then drives the "
+            "recipe's INT trap with `kill -INT $PPID`, which has no Windows equivalent. On the "
+            "2026-07-29 nightly this surfaced as `assert 0 != 0` — the real git ran, the claim "
+            "succeeded cleanly, and there was no interrupt to trap."
+        ),
+    ),
 ]
 
 REPO_ROOT = Path(__file__).resolve().parents[3]


### PR DESCRIPTION
## What

Three `windows-latest` nightly failures in `tests/integration/worktree/`, two distinct causes.

## 1. Path assertions (2 tests)

The Makefile recipe prints whatever *its own shell* considers the path to be. On Windows that shell is Git Bash/MSYS, which renders `C:\Users\...` as `/c/Users/...`:

```
assert 'WORKTREE_PATH=C:\\Users\\...\\BenchBox.pool-01'
    in 'WORKTREE_PATH=/c/Users/.../BenchBox.pool-01\n'
```

The claim was **correct** — the assertion failed on spelling alone.

Replaced the substring check with an exact comparison on a canonical form. Two deliberate choices:

- **The drive translation is gated on `os.name == "nt"`.** On POSIX a leading single-letter segment (`/a/b`) is an ordinary directory; rewriting it to `A:/b` would be a real bug. Verified `/a/b/c` is untouched on POSIX.
- **`emitted_worktree_path()` asserts there is exactly one `WORKTREE_PATH=` line**, so this is *strictly stronger* than the substring test it replaces, not a loosened one.

## 2. INT trap (1 test)

Platform-gated, not fixed — the behaviour does not exist on Windows. The test:

- shims `git` with an extensionless `#!/bin/sh` script placed first on `PATH`, but Windows resolves `git.exe`/`git.cmd` and never executes an extensionless file, so **the shim is bypassed entirely**;
- drives the recipe's INT trap with `kill -INT $PPID`, which has no Windows equivalent.

The nightly shows exactly that: `returncode 0`, `stderr="Switched to a new branch 'feature/signal-test'"` — real git ran, the claim succeeded cleanly, there was no interrupt to trap, so `assert result.returncode != 0` failed as `assert 0 != 0`. Skipping is the honest outcome; making it "pass" on Windows would mean asserting nothing.

## Verification

The Windows branch cannot run here, so I exercised `normalize_path` directly against the **literal strings from the nightly log**:

```
windows: match = True
  -> c:/users/runneradmin/appdata/local/temp/.../benchbox.pool-01
windows: stdout parse = True
posix  : /a/b/c stays = True
posix  : case preserved = True
```

- `test_worktree_claim_benchbox_scratch.py` + `test_worktree_claim_signal_exit.py` — 4 passed on macOS (the signal test still runs on POSIX)
- `check-scope --strict` — scope OK, 2 changed files
- **Must-preserve holds**: no script under `_project/scripts/` was touched; POSIX behaviour is unchanged. Collected test count is unchanged (the helpers are not test functions), so no fast-lane cap movement.

Windows proof arrives with the next Nightly Validation run.

Closes `nightly-windows-worktree-claim-path-assertions`.