### PR TITLE
fix(tuning): every tuned key clause must corroborate before applied_verified

### DIFF
--- a/benchbox/core/tuning/introspection.py
+++ b/benchbox/core/tuning/introspection.py
@@ -228,8 +228,20 @@ _CREATE_INDEX_RE = re.compile(
     r"(?P<name>[^\s(]+)\s+on\s+(?P<table>[^\s(]+)\s*\((?P<cols>[^)]*)\)",
     re.IGNORECASE | re.DOTALL,
 )
-_ORDER_BY_RE = re.compile(r"\border\s+by\s*\((?P<cols>[^)]*)\)", re.IGNORECASE | re.DOTALL)
-_PARTITION_BY_RE = re.compile(r"\bpartition\s+by\s*\((?P<cols>[^)]*)\)", re.IGNORECASE | re.DOTALL)
+# Key clauses may hold function expressions -- ClickHouse renders a date
+# partition as ``PARTITION BY (toYYYYMM(l_shipdate))``. Allow one level of
+# nested parens so the captured list is not truncated at the inner ``)``,
+# which would make every expression key mismatch its own catalog fact.
+_KEY_CLAUSE_COLUMNS = r"(?P<cols>(?:[^()]|\([^()]*\))*)"
+_ORDER_BY_RE = re.compile(rf"\border\s+by\s*\({_KEY_CLAUSE_COLUMNS}\)", re.IGNORECASE | re.DOTALL)
+_PARTITION_BY_RE = re.compile(rf"\bpartition\s+by\s*\({_KEY_CLAUSE_COLUMNS}\)", re.IGNORECASE | re.DOTALL)
+# Bare keyword probes: used to fail closed when a key clause is visibly present
+# but its column list did not parse (see _classify).
+_ORDER_BY_KEYWORD_RE = re.compile(r"\border\s+by\b", re.IGNORECASE)
+_PARTITION_BY_KEYWORD_RE = re.compile(r"\bpartition\s+by\b", re.IGNORECASE)
+# ``ORDER BY tuple()`` is MergeTree's explicit "no sort key" form, not an
+# unparsed clause -- it carries no columns to corroborate.
+_ORDER_BY_NOOP_RE = re.compile(r"\border\s+by\s+tuple\s*\(\s*\)", re.IGNORECASE)
 _CREATE_TABLE_RE = re.compile(
     r"^\s*create\s+(?:or\s+replace\s+)?table\s+(?:if\s+not\s+exists\s+)?(?P<table>[^\s(]+)",
     re.IGNORECASE,
@@ -308,51 +320,65 @@ def ledger_tables(ledger: AppliedTuningLedger) -> set[str]:
     return tables
 
 
-def _classify(statement: AppliedStatement) -> tuple[str, _Intent | None]:
-    """Classify one executed statement into a verdict-class and optional intent.
+def _classify(statement: AppliedStatement) -> tuple[str, list[_Intent]]:
+    """Classify one executed statement into a verdict-class and its intents.
 
-    Returns ``(class, intent)`` where ``class`` is one of ``"verifiable"``,
+    Returns ``(class, intents)`` where ``class`` is one of ``"verifiable"``,
     ``TRANSIENT``, ``MAINTENANCE`` or ``UNVERIFIABLE``. Session-phase statements
     and SET/PRAGMA are transient; OPTIMIZE/VACUUM are maintenance; a recognized
     ddl-shape (CREATE INDEX / CREATE TABLE ORDER BY|PARTITION BY) yields a
     verifiable intent; anything else in a ddl/post_load phase is unverifiable
     (blocks the upgrade -- we do not guess an unknown statement into verified).
+
+    A ``CREATE TABLE`` carrying BOTH an ``ORDER BY`` and a ``PARTITION BY``
+    yields one intent per clause, so each must corroborate independently. One
+    statement can physically apply two distinct key layouts (ClickHouse
+    MergeTree does exactly this), and corroborating only the first would let a
+    run reach ``applied_verified`` while the other key silently never applied.
     """
     text = str(statement.statement or "").strip()
     lowered = text.lower()
 
     if statement.phase == PHASE_SESSION or lowered.startswith(_TRANSIENT_PREFIXES):
-        return TRANSIENT, None
+        return TRANSIENT, []
     if lowered.startswith(_MAINTENANCE_PREFIXES):
-        return MAINTENANCE, None
+        return MAINTENANCE, []
 
     m = _CREATE_INDEX_RE.match(text)
     if m:
-        return "verifiable", _Intent(
-            kind=KIND_INDEX,
-            table=normalize_identifier(m.group("table")),
-            columns=normalize_columns(m.group("cols")),
-            name=normalize_identifier(m.group("name")),
-        )
+        return "verifiable", [
+            _Intent(
+                kind=KIND_INDEX,
+                table=normalize_identifier(m.group("table")),
+                columns=normalize_columns(m.group("cols")),
+                name=normalize_identifier(m.group("name")),
+            )
+        ]
 
     ct = _CREATE_TABLE_RE.match(text)
     if ct:
         table = normalize_identifier(ct.group("table"))
+        intents: list[_Intent] = []
         order = _ORDER_BY_RE.search(text)
         if order:
-            return "verifiable", _Intent(
-                kind=KIND_SORT_KEY, table=table, columns=normalize_columns(order.group("cols"))
-            )
+            intents.append(_Intent(kind=KIND_SORT_KEY, table=table, columns=normalize_columns(order.group("cols"))))
         part = _PARTITION_BY_RE.search(text)
         if part:
-            return "verifiable", _Intent(
-                kind=KIND_PARTITION_KEY, table=table, columns=normalize_columns(part.group("cols"))
-            )
+            intents.append(_Intent(kind=KIND_PARTITION_KEY, table=table, columns=normalize_columns(part.group("cols"))))
+        # Fail closed: a key clause we can SEE but could not parse must block the
+        # upgrade rather than silently vanish while a sibling clause corroborates.
+        # Dropping it would recreate exactly the hole this classifier closes.
+        if order is None and _ORDER_BY_KEYWORD_RE.search(text) and not _ORDER_BY_NOOP_RE.search(text):
+            return UNVERIFIABLE, []
+        if part is None and _PARTITION_BY_KEYWORD_RE.search(text):
+            return UNVERIFIABLE, []
+        if intents:
+            return "verifiable", intents
         # A plain CREATE TABLE with no recognized key clause is not a tuning
         # footprint we can corroborate -> unverifiable (conservative).
-        return UNVERIFIABLE, None
+        return UNVERIFIABLE, []
 
-    return UNVERIFIABLE, None
+    return UNVERIFIABLE, []
 
 
 # ---------------------------------------------------------------------------
@@ -413,7 +439,7 @@ def corroborate(ledger: AppliedTuningLedger, introspected_state: IntrospectedSta
 
     entries: list[ReceiptEntry] = []
     for stmt in ledger.executed_statements:
-        klass, intent = _classify(stmt)
+        klass, intents = _classify(stmt)
 
         if klass == TRANSIENT:
             entries.append(
@@ -436,7 +462,7 @@ def corroborate(ledger: AppliedTuningLedger, introspected_state: IntrospectedSta
                 )
             )
             continue
-        if klass == UNVERIFIABLE or intent is None:
+        if klass == UNVERIFIABLE or not intents:
             entries.append(
                 ReceiptEntry(
                     statement=stmt.statement,
@@ -448,41 +474,44 @@ def corroborate(ledger: AppliedTuningLedger, introspected_state: IntrospectedSta
             )
             continue
 
-        # Verifiable intent. If introspection degraded we cannot confirm it.
-        if state_error is not None or introspected_state is None:
-            entries.append(
-                ReceiptEntry(
-                    statement=stmt.statement,
-                    phase=stmt.phase,
-                    verdict=UNVERIFIABLE,
-                    kind=intent.kind,
-                    table=intent.table,
-                    name=intent.name,
-                    expected_columns=intent.columns,
-                    reason=f"introspection degraded: {state_error}",
+        # One entry per verifiable intent: a statement that applies two key
+        # layouts must have BOTH corroborated to count toward the upgrade.
+        for intent in intents:
+            # If introspection degraded we cannot confirm the intent.
+            if state_error is not None or introspected_state is None:
+                entries.append(
+                    ReceiptEntry(
+                        statement=stmt.statement,
+                        phase=stmt.phase,
+                        verdict=UNVERIFIABLE,
+                        kind=intent.kind,
+                        table=intent.table,
+                        name=intent.name,
+                        expected_columns=intent.columns,
+                        reason=f"introspection degraded: {state_error}",
+                    )
                 )
-            )
-            continue
+                continue
 
-        verdict, fact = _match_object(intent, introspected_state)
-        entry = ReceiptEntry(
-            statement=stmt.statement,
-            phase=stmt.phase,
-            verdict=verdict,
-            kind=intent.kind,
-            table=intent.table,
-            name=intent.name,
-            expected_columns=intent.columns,
-        )
-        if fact is not None:
-            entry.observed_columns = fact.columns
-            entry.evidence = dict(fact.evidence) if fact.evidence else None
-        if verdict == MISMATCH:
-            observed = fact.columns if fact is not None else ()
-            entry.diff = _short_diff(intent.columns, observed)
-        elif verdict == ABSENT:
-            entry.reason = f"no {intent.kind} on {intent.table} found in catalog"
-        entries.append(entry)
+            verdict, fact = _match_object(intent, introspected_state)
+            entry = ReceiptEntry(
+                statement=stmt.statement,
+                phase=stmt.phase,
+                verdict=verdict,
+                kind=intent.kind,
+                table=intent.table,
+                name=intent.name,
+                expected_columns=intent.columns,
+            )
+            if fact is not None:
+                entry.observed_columns = fact.columns
+                entry.evidence = dict(fact.evidence) if fact.evidence else None
+            if verdict == MISMATCH:
+                observed = fact.columns if fact is not None else ()
+                entry.diff = _short_diff(intent.columns, observed)
+            elif verdict == ABSENT:
+                entry.reason = f"no {intent.kind} on {intent.table} found in catalog"
+            entries.append(entry)
 
     verifiable = [e for e in entries if e.verdict in _VERIFIABLE_VERDICTS]
     corroborated = bool(verifiable) and all(e.verdict == CORROBORATED for e in verifiable)

--- a/benchbox/platforms/clickhouse/adapter.py
+++ b/benchbox/platforms/clickhouse/adapter.py
@@ -138,10 +138,11 @@ class ClickHouseAdapter(
         """Read ``system.tables`` keys to corroborate the applied ledger.
 
         Surfaces ClickHouse ``sorting_key`` / ``partition_key`` as receipt
-        evidence (see ``benchbox.platforms.clickhouse.introspection``). Note the
-        documented limitation: ClickHouse's key-bearing DDL runs at
-        ``CREATE TABLE`` time outside the tuning ledger, so this reports the
-        physical keys but does not, on its own, mint ``applied_verified``.
+        evidence (see ``benchbox.platforms.clickhouse.introspection``).
+        ClickHouse's key-bearing DDL runs at ``CREATE TABLE`` time outside the
+        recording connection, so ``create_schema`` records the tuned statement
+        onto the ledger itself; every tuned clause it carries must corroborate
+        here before the run reaches ``applied_verified``.
         """
         from benchbox.platforms.clickhouse.introspection import ClickHouseTuningIntrospector
 

--- a/benchbox/platforms/clickhouse/introspection.py
+++ b/benchbox/platforms/clickhouse/introspection.py
@@ -13,11 +13,14 @@ DDL text.
 
 ClickHouse applies ``ORDER BY`` / ``PARTITION BY`` at ``CREATE TABLE`` time in
 the schema phase, which is not wrapped by the tuning recording connection. A
-*tuned* sort key is therefore folded into the applied ledger explicitly by
-``create_schema`` (``_record_tuned_sort_key_op`` records the executed
-``CREATE TABLE ... ORDER BY (cols)`` as a ``PHASE_DDL`` statement), so this
+*tuned* ``CREATE TABLE`` is therefore recorded into the applied ledger
+explicitly by ``create_schema`` (``_record_tuned_sort_key_op`` records the
+executed statement as a ``PHASE_DDL`` statement at execute time), so this
 introspector's ``sorting_key`` read can corroborate that recorded intent and
-earn ``applied_verified``. The *engine-mandatory baseline* ``ORDER BY``
+earn ``applied_verified``. When the tuned DDL also rendered a ``PARTITION BY``,
+the ``partition_key`` read must corroborate too -- both clauses are classified
+independently, so an unapplied partition key keeps the run unverified. The
+*engine-mandatory baseline* ``ORDER BY``
 (primary-key derived or ``tuple()``) is not tuning and is deliberately NOT
 recorded -- a MergeTree table's ``sorting_key`` is always present, so
 corroborating it against nothing would be an unearned upgrade. The ledger's

--- a/benchbox/platforms/clickhouse/workload.py
+++ b/benchbox/platforms/clickhouse/workload.py
@@ -65,12 +65,14 @@ class ClickHouseWorkloadMixin:
                     nullable_columns=nullable_columns,
                 )
                 connection.execute(optimized)
-                # Fold a tuned MergeTree ORDER BY into the applied ledger. The
-                # tuned sort key is rendered into the CREATE TABLE executed here
-                # on the raw connection (outside the tuning RecordingConnection),
-                # so without this it never enters the ledger and the run cannot
-                # reach applied_verified even though system.tables.sorting_key
-                # carries the key.
+                # Record a tuned MergeTree CREATE TABLE into the applied ledger
+                # here, immediately after it executes. The tuned keys are
+                # rendered into the CREATE TABLE executed on the raw connection
+                # (outside the tuning RecordingConnection), so without this it
+                # never enters the ledger and the run cannot reach
+                # applied_verified even though system.tables.sorting_key carries
+                # the key. Recording at execute time also keeps the
+                # order-sensitive applied_ledger_hash in true chronology.
                 self._record_tuned_sort_key_op(statement, optimized, table_name, table_tunings)
                 self.logger.debug(f"Executed schema statement: {optimized[:100]}...")
 
@@ -187,19 +189,32 @@ class ClickHouseWorkloadMixin:
         table_name: str | None,
         table_tunings: dict[str, Any] | None,
     ) -> None:
-        """Record a tuned MergeTree ORDER BY as a post-load layout op.
+        """Record a tuned MergeTree CREATE TABLE into the applied ledger.
 
-        ``_fold_layout_operations_into_ledger`` folds this into the applied
-        ledger as a ``PHASE_DDL`` statement, so the introspection receipt can
-        corroborate the recorded ``CREATE TABLE ... ORDER BY (cols)`` against the
-        catalog ``system.tables.sorting_key`` and upgrade the run to
-        ``applied_verified``.
+        The introspection receipt corroborates the recorded key clauses against
+        ``system.tables`` -- ``ORDER BY (cols)`` against ``sorting_key`` and
+        ``PARTITION BY (expr)`` against ``partition_key`` -- and upgrades the run
+        to ``applied_verified`` only when every one of them corroborates.
 
-        Only the *tuned* sort key is recorded. The engine-mandatory baseline
-        ``ORDER BY`` (primary-key derived or ``tuple()``) is not tuning and stays
-        out of the ledger, matching the tuned-branch condition in
-        ``_optimize_table_definition`` (rendered only when the source statement
-        carried no ``ORDER BY`` and the tuned generator produced a ``sort_by``).
+        Recorded straight onto ``self._applied_tuning_ledger`` at
+        ``connection.execute`` time rather than queued on
+        ``_applied_layout_operations``: that queue is folded only after data
+        validation, which would place this ``CREATE TABLE`` *after* the
+        ``OPTIMIZE TABLE`` statements the recording connection captures during
+        load, and the order-sensitive ``applied_ledger_hash`` would then attest
+        an impossible chronology.
+
+        Recorded when the tuned generator produced EITHER a sort key or a
+        partition key. A partition-only tuned table must be recorded too: left
+        out, its unapplied partition key is never corroborated, and another
+        table's sort key could carry the whole run to ``applied_verified``.
+        A table with no tuned clause at all stays out of the ledger entirely --
+        its engine-mandatory ``ORDER BY`` (primary-key derived or ``tuple()``)
+        is not tuning, and corroborating it against nothing would be an unearned
+        upgrade. When only the partition is tuned, the baseline ``ORDER BY``
+        rides along in the recorded statement and is corroborated as a plain
+        catalog fact; it cannot mint verification on its own because the tuned
+        partition key must corroborate as well.
         Never breaks a run: any failure degrades to a debug log.
         """
         try:
@@ -208,25 +223,32 @@ class ClickHouseWorkloadMixin:
             if "ORDER BY" in original_statement.upper():
                 return  # pre-existing ORDER BY was not overridden by tuning
             tuning_clauses = self._resolve_tuned_ddl_clauses(original_statement, table_tunings)
-            if tuning_clauses is None or not tuning_clauses.sort_by:
+            if tuning_clauses is None:
+                return
+            tuned_sort = bool(tuning_clauses.sort_by)
+            tuned_partition = bool(tuning_clauses.partition_by)
+            if not (tuned_sort or tuned_partition):
+                return
+            ledger = getattr(self, "_applied_tuning_ledger", None)
+            if ledger is None:
+                self.logger.debug("clickhouse tuned key ledger record skipped: no applied-tuning ledger on adapter")
                 return
             from benchbox.core.tuning.applied_ledger import PHASE_DDL
 
-            ops = getattr(self, "_applied_layout_operations", None)
-            if ops is None:
-                ops = []
-                self._applied_layout_operations = ops
-            ops.append(
-                {
-                    "statement": executed_statement,
-                    "phase": PHASE_DDL,
-                    "status": "applied",
-                    "mechanism": "sort_key",
-                    "table": table_name,
-                }
+            if tuned_sort and tuned_partition:
+                mechanism = "table_keys"
+            elif tuned_sort:
+                mechanism = "sort_key"
+            else:
+                mechanism = "partition_key"
+            ledger.record(
+                executed_statement,
+                PHASE_DDL,
+                mechanism=mechanism,
+                table=table_name,
             )
         except Exception as exc:  # capture must never break a run
-            self.logger.debug("clickhouse tuned sort-key ledger fold degraded: %s", exc)
+            self.logger.debug("clickhouse tuned key ledger record degraded: %s", exc)
 
     @staticmethod
     def _extract_table_name(statement: str) -> str | None:

--- a/docs/development/tuning-introspection-receipts.md
+++ b/docs/development/tuning-introspection-receipts.md
@@ -49,6 +49,12 @@ platform-agnostic; the per-platform catalog *reads* live in the
 | session-phase statement (any)                | session        | `transient`   | transient SET -- noted, **non-blocking** (documented default below)                | no                   |
 | anything else                                | ddl/post_load  | `unverifiable`| no corroboration rule -- **blocks** the upgrade (conservative: stay unverified)    | n/a (blocks)         |
 
+A `CREATE TABLE` carrying **both** an `ORDER BY` and a `PARTITION BY` (the
+ClickHouse MergeTree shape) classifies as both `sort_key` and `partition_key`
+and emits one receipt entry per clause, so each key must corroborate on its
+own. Corroborating only the first clause would let a run reach
+`applied_verified` while the other configured key never applied.
+
 **Verdicts** (per statement): `corroborated`, `absent` (expected object not
 in catalog), `mismatch` (object present, columns differ -- carries a short
 diff), plus the non-blocking notes `transient` / `maintenance` and the
@@ -102,16 +108,18 @@ catalog exists.
   ledger's tables. Returns `sort_key` / `partition_key` facts as receipt
   **evidence**.
 
-  Limitation (documented, follow-up): ClickHouse applies `ORDER BY` /
-  `PARTITION BY` at `CREATE TABLE` time in the *schema* phase, which is not
-  wrapped by the tuning recording connection, so those column-bearing DDLs
-  never enter the applied ledger. The ledger's ClickHouse tuning entries are
-  `OPTIMIZE TABLE` (maintenance, `non-blocking`) and session SETs. The
-  introspector therefore surfaces the physical keys as evidence but does
-  **not** mint `applied_verified` from a MergeTree table's always-present
-  `sorting_key` (that would be a trivially-true, unearned upgrade). Making
-  ClickHouse verification-eligible requires routing the schema `ORDER BY` /
-  `PARTITION BY` DDL through a recording connection -- out of scope here.
+  ClickHouse applies `ORDER BY` / `PARTITION BY` at `CREATE TABLE` time in the
+  *schema* phase, which is not wrapped by the tuning recording connection, so
+  `create_schema` records the executed statement onto the ledger itself
+  (`_record_tuned_sort_key_op`, at `connection.execute` time so the
+  order-sensitive `applied_ledger_hash` keeps true chronology). Only a table
+  carrying a *tuned* clause is recorded: a MergeTree table's `sorting_key` is
+  always present, so corroborating an untuned table's engine-mandatory
+  `ORDER BY` would be a trivially-true, unearned upgrade. A table tuned with a
+  partition key only is recorded too -- omitting it would leave an unapplied
+  partition uncorroborated while a sibling table's sort key carried the run to
+  `applied_verified`. The ledger's other ClickHouse entries stay
+  `OPTIMIZE TABLE` (maintenance, `non-blocking`) and session SETs.
 
 ## Wiring
 

--- a/tests/unit/core/tuning/test_introspection.py
+++ b/tests/unit/core/tuning/test_introspection.py
@@ -259,3 +259,91 @@ class TestPayloadAndProtocol:
                 return IntrospectedState(platform="x")
 
         assert isinstance(_Impl(), Introspector)
+
+
+class TestMultiClauseCreateTable:
+    """A CREATE TABLE can apply two key layouts at once (ClickHouse MergeTree).
+    Each clause is classified independently, so each must corroborate on its
+    own -- corroborating the first while ignoring the second would let a run
+    reach applied_verified with a key that never applied (#1275 review).
+    """
+
+    _DDL = "CREATE TABLE lineitem (a Int64) ENGINE = MergeTree() PARTITION BY (toYYYYMM(d)) ORDER BY (a, b)"
+
+    def _ledger(self) -> AppliedTuningLedger:
+        ledger = AppliedTuningLedger()
+        ledger.record(self._DDL, PHASE_DDL, table="lineitem")
+        return ledger
+
+    def _state(self, *, sort_cols=("a", "b"), partition_cols=("toyyyymm(d)",)) -> IntrospectedState:
+        objects = []
+        if sort_cols:
+            objects.append(IntrospectedObject(kind=KIND_SORT_KEY, table="lineitem", columns=sort_cols))
+        if partition_cols:
+            objects.append(IntrospectedObject(kind=KIND_PARTITION_KEY, table="lineitem", columns=partition_cols))
+        return IntrospectedState(platform="clickhouse", objects=objects)
+
+    def test_both_clauses_yield_separate_entries(self):
+        receipt = corroborate(self._ledger(), self._state())
+        kinds = [e.kind for e in receipt.entries]
+        assert kinds == [KIND_SORT_KEY, KIND_PARTITION_KEY]
+        assert receipt.summary["verifiable_total"] == 2
+        assert receipt.corroborated is True
+
+    def test_uncorroborated_partition_blocks_upgrade(self):
+        receipt = corroborate(self._ledger(), self._state(partition_cols=("wrong",)))
+        assert receipt.corroborated is False
+        verdicts = {e.kind: e.verdict for e in receipt.entries}
+        assert verdicts[KIND_SORT_KEY] == CORROBORATED
+        assert verdicts[KIND_PARTITION_KEY] == MISMATCH
+
+    def test_absent_partition_blocks_upgrade(self):
+        receipt = corroborate(self._ledger(), self._state(partition_cols=()))
+        assert receipt.corroborated is False
+        assert {e.kind: e.verdict for e in receipt.entries}[KIND_PARTITION_KEY] == ABSENT
+
+    def test_expression_clause_keeps_its_closing_paren(self):
+        receipt = corroborate(self._ledger(), self._state())
+        partition = next(e for e in receipt.entries if e.kind == KIND_PARTITION_KEY)
+        assert partition.expected_columns == ("toyyyymm(d)",)
+
+    def test_degraded_state_marks_every_clause_unverifiable(self):
+        degraded = IntrospectedState(platform="clickhouse", error="catalog read failed")
+        receipt = corroborate(self._ledger(), degraded)
+        assert receipt.corroborated is False
+        assert [e.verdict for e in receipt.entries] == [UNVERIFIABLE, UNVERIFIABLE]
+
+
+class TestUnparsableKeyClauseFailsClosed:
+    """A key clause we can see but cannot parse must block the upgrade, never
+    silently vanish while a sibling clause corroborates.
+    """
+
+    def _corroborate(self, ddl: str) -> object:
+        ledger = AppliedTuningLedger()
+        ledger.record(ddl, PHASE_DDL, table="t")
+        state = IntrospectedState(
+            platform="clickhouse",
+            objects=[
+                IntrospectedObject(kind=KIND_SORT_KEY, table="t", columns=("a",)),
+                IntrospectedObject(kind=KIND_PARTITION_KEY, table="t", columns=("d",)),
+            ],
+        )
+        return corroborate(ledger, state)
+
+    def test_unparenthesized_partition_clause_blocks(self):
+        receipt = self._corroborate("CREATE TABLE t (a Int64) PARTITION BY toYYYYMM(d) ORDER BY (a)")
+        assert receipt.corroborated is False
+        assert [e.verdict for e in receipt.entries] == [UNVERIFIABLE]
+
+    def test_double_nested_expression_blocks(self):
+        receipt = self._corroborate("CREATE TABLE t (a Int64) PARTITION BY (toYYYYMM(toDate(d))) ORDER BY (a)")
+        assert receipt.corroborated is False
+        assert [e.verdict for e in receipt.entries] == [UNVERIFIABLE]
+
+    def test_order_by_tuple_is_an_explicit_no_sort_key_not_a_dropped_clause(self):
+        # MergeTree's "no sort key" form carries no columns to corroborate; the
+        # tuned PARTITION BY alongside it must still be checked.
+        receipt = self._corroborate("CREATE TABLE t (a Int64) PARTITION BY (d) ORDER BY tuple()")
+        assert [e.kind for e in receipt.entries] == [KIND_PARTITION_KEY]
+        assert receipt.corroborated is True

--- a/tests/unit/platforms/test_clickhouse_introspection.py
+++ b/tests/unit/platforms/test_clickhouse_introspection.py
@@ -86,7 +86,7 @@ class TestClickHouseIntrospector:
         # A ClickHouse ledger carrying only OPTIMIZE (maintenance) + SET
         # (transient) statements is non-blocking and has nothing catalog-backed
         # to earn verification. The observed keys still surface as evidence.
-        # (The tuned sort key IS folded into the ledger separately -- see
+        # (The tuned CREATE TABLE IS recorded into the ledger separately -- see
         # TestTunedSortKeyFold below.)
         rows = [("lineitem", "l_orderkey, l_linenumber", "")]
         ledger = _optimize_ledger()
@@ -96,7 +96,7 @@ class TestClickHouseIntrospector:
         assert any(o.kind == KIND_SORT_KEY for o in receipt.observed)
 
 
-def _sorted_tuning_config() -> UnifiedTuningConfiguration:
+def _sorted_tuning_config(*, partition_on: str | None = None) -> UnifiedTuningConfiguration:
     config = UnifiedTuningConfiguration()
     config.table_tunings["LINEITEM"] = TableTuning(
         table_name="LINEITEM",
@@ -104,13 +104,28 @@ def _sorted_tuning_config() -> UnifiedTuningConfiguration:
             TuningColumn(name="l_orderkey", type="INTEGER", order=1),
             TuningColumn(name="l_linenumber", type="INTEGER", order=2),
         ],
+        partitioning=([TuningColumn(name=partition_on, type="DATE", order=1)] if partition_on else []),
     )
     return config
 
 
+def _partitioned_only_tuning_config() -> UnifiedTuningConfiguration:
+    """A table tuned with a partition key and no sort/clustering columns."""
+    config = UnifiedTuningConfiguration()
+    config.table_tunings["ORDERS"] = TableTuning(
+        table_name="ORDERS",
+        partitioning=[TuningColumn(name="o_orderdate", type="DATE", order=1)],
+    )
+    return config
+
+
+def _sort_key_statements(ledger: AppliedTuningLedger) -> list:
+    return [s for s in ledger.executed_statements if s.mechanism in {"sort_key", "table_keys"}]
+
+
 class TestTunedSortKeyFold:
-    """The tuned MergeTree ORDER BY is folded into the applied ledger so it can
-    corroborate against ``system.tables.sorting_key`` and earn verification.
+    """The tuned MergeTree CREATE TABLE is recorded into the applied ledger so
+    it can corroborate against ``system.tables`` keys and earn verification.
     """
 
     def _tuned_adapter(self) -> ClickHouseAdapter:
@@ -120,7 +135,7 @@ class TestTunedSortKeyFold:
         adapter._applied_layout_operations = []
         return adapter
 
-    def test_tuned_order_by_records_sort_key_op(self):
+    def test_tuned_order_by_records_sort_key_statement(self):
         adapter = self._tuned_adapter()
         tunings = _sorted_tuning_config().table_tunings
         original = "CREATE TABLE lineitem (l_orderkey INTEGER, l_linenumber INTEGER, l_comment VARCHAR)"
@@ -128,9 +143,27 @@ class TestTunedSortKeyFold:
         assert "ORDER BY (l_orderkey, l_linenumber)" in optimized
 
         adapter._record_tuned_sort_key_op(original, optimized, "lineitem", tunings)
-        ops = [op for op in adapter._applied_layout_operations if op["mechanism"] == "sort_key"]
-        assert len(ops) == 1
-        assert ops[0]["phase"] == PHASE_DDL and ops[0]["table"] == "lineitem"
+        recorded = _sort_key_statements(adapter._applied_tuning_ledger)
+        assert len(recorded) == 1
+        assert recorded[0].phase == PHASE_DDL and recorded[0].table == "lineitem"
+
+    def test_create_table_recorded_before_optimize(self):
+        # Finding B (#1275 review): the tuned CREATE TABLE must enter the ledger
+        # at execute time. Queuing it on _applied_layout_operations deferred it
+        # past data validation, so the order-sensitive applied_ledger_hash
+        # attested OPTIMIZE TABLE *before* the CREATE TABLE that it optimizes.
+        adapter = self._tuned_adapter()
+        tunings = _sorted_tuning_config().table_tunings
+        original = "CREATE TABLE lineitem (l_orderkey INTEGER, l_linenumber INTEGER, l_comment VARCHAR)"
+        optimized = adapter._optimize_table_definition(original, tunings, nullable_columns=set())
+
+        adapter._record_tuned_sort_key_op(original, optimized, "lineitem", tunings)
+        # Post-load maintenance executes later, through the recording connection.
+        adapter._applied_tuning_ledger.record("OPTIMIZE TABLE lineitem FINAL", PHASE_DDL)
+        adapter._fold_layout_operations_into_ledger()
+
+        order = [s.statement.split()[0].upper() for s in adapter._applied_tuning_ledger.executed_statements]
+        assert order == ["CREATE", "OPTIMIZE"]
 
     def test_full_flow_reaches_applied_verified(self):
         adapter = self._tuned_adapter()
@@ -138,7 +171,6 @@ class TestTunedSortKeyFold:
         original = "CREATE TABLE lineitem (l_orderkey INTEGER, l_linenumber INTEGER, l_comment VARCHAR)"
         optimized = adapter._optimize_table_definition(original, tunings, nullable_columns=set())
         adapter._record_tuned_sort_key_op(original, optimized, "lineitem", tunings)
-        adapter._fold_layout_operations_into_ledger()
 
         conn = _FakeCHConnection([("lineitem", "l_orderkey, l_linenumber", "")])
         status, receipt = adapter._corroborate_applied_ledger(conn, APPLIED_UNVERIFIED)
@@ -153,7 +185,7 @@ class TestTunedSortKeyFold:
         original = "CREATE TABLE nation (n_nationkey INTEGER PRIMARY KEY, n_name VARCHAR)"
         optimized = adapter._optimize_table_definition(original, tunings, nullable_columns=set())
         adapter._record_tuned_sort_key_op(original, optimized, "nation", tunings)
-        assert not [op for op in adapter._applied_layout_operations if op["mechanism"] == "sort_key"]
+        assert _sort_key_statements(adapter._applied_tuning_ledger) == []
 
     def test_no_record_when_tuning_disabled(self):
         adapter = self._tuned_adapter()
@@ -161,4 +193,125 @@ class TestTunedSortKeyFold:
         tunings = _sorted_tuning_config().table_tunings
         original = "CREATE TABLE lineitem (l_orderkey INTEGER, l_linenumber INTEGER)"
         adapter._record_tuned_sort_key_op(original, original, "lineitem", tunings)
-        assert adapter._applied_layout_operations == []
+        assert adapter._applied_tuning_ledger.executed_statements == []
+
+
+class TestCombinedPartitionAndSortKey:
+    """Finding A (#1275 review): a CREATE TABLE that renders BOTH a tuned
+    PARTITION BY and a tuned ORDER BY must have both keys corroborated against
+    the catalog. Corroborating the sort key alone let a run reach
+    ``applied_verified`` while the configured partition key never applied.
+    """
+
+    def _tuned_adapter(self) -> ClickHouseAdapter:
+        adapter = ClickHouseAdapter()
+        adapter.tuning_enabled = True
+        adapter._applied_tuning_ledger = AppliedTuningLedger()
+        adapter._applied_layout_operations = []
+        return adapter
+
+    def _record_combined(self, adapter: ClickHouseAdapter) -> str:
+        tunings = _sorted_tuning_config(partition_on="l_shipdate").table_tunings
+        original = (
+            "CREATE TABLE lineitem (l_orderkey INTEGER, l_linenumber INTEGER, l_shipdate DATE, l_comment VARCHAR)"
+        )
+        optimized = adapter._optimize_table_definition(original, tunings, nullable_columns=set())
+        adapter._record_tuned_sort_key_op(original, optimized, "lineitem", tunings)
+        return optimized
+
+    def test_combined_ddl_renders_both_clauses(self):
+        adapter = self._tuned_adapter()
+        optimized = self._record_combined(adapter)
+        assert "PARTITION BY" in optimized.upper()
+        assert "ORDER BY (l_orderkey, l_linenumber)" in optimized
+
+    def test_uncorroborated_partition_key_blocks_verification(self):
+        adapter = self._tuned_adapter()
+        self._record_combined(adapter)
+        # Catalog carries the tuned sort key but NOT the configured partition.
+        conn = _FakeCHConnection([("lineitem", "l_orderkey, l_linenumber", "tuple()")])
+        status, receipt = adapter._corroborate_applied_ledger(conn, APPLIED_UNVERIFIED)
+        assert status == APPLIED_UNVERIFIED
+        assert receipt["corroborated"] is False
+        verdicts = {e["kind"]: e["verdict"] for e in receipt["entries"] if e.get("kind")}
+        assert verdicts[KIND_SORT_KEY] == "corroborated"
+        assert verdicts[KIND_PARTITION_KEY] == "mismatch"
+
+    def test_absent_partition_key_blocks_verification(self):
+        adapter = self._tuned_adapter()
+        self._record_combined(adapter)
+        # Catalog reports no partition key at all for the table.
+        conn = _FakeCHConnection([("lineitem", "l_orderkey, l_linenumber", "")])
+        status, receipt = adapter._corroborate_applied_ledger(conn, APPLIED_UNVERIFIED)
+        assert status == APPLIED_UNVERIFIED
+        assert receipt["corroborated"] is False
+
+    def test_both_keys_corroborated_earns_verification(self):
+        adapter = self._tuned_adapter()
+        self._record_combined(adapter)
+        # system.tables.partition_key reports the whole expression, parens and
+        # all -- exactly what the generator rendered for a DATE column.
+        conn = _FakeCHConnection([("lineitem", "l_orderkey, l_linenumber", "toYYYYMM(l_shipdate)")])
+        status, receipt = adapter._corroborate_applied_ledger(conn, APPLIED_UNVERIFIED)
+        assert status == APPLIED_VERIFIED
+        assert receipt["corroborated"] is True
+
+    def test_partition_only_table_is_recorded(self):
+        # A table tuned with ONLY a partition key must still enter the ledger.
+        # Left out, its unapplied partition is never corroborated and a sibling
+        # table's sort key carries the whole run to applied_verified.
+        adapter = self._tuned_adapter()
+        tunings = _partitioned_only_tuning_config().table_tunings
+        original = "CREATE TABLE orders (o_orderkey INTEGER PRIMARY KEY, o_orderdate DATE)"
+        optimized = adapter._optimize_table_definition(original, tunings, nullable_columns=set())
+        assert "PARTITION BY (toYYYYMM(o_orderdate))" in optimized
+
+        adapter._record_tuned_sort_key_op(original, optimized, "orders", tunings)
+        recorded = adapter._applied_tuning_ledger.executed_statements
+        assert len(recorded) == 1 and recorded[0].mechanism == "partition_key"
+
+    def test_partition_only_table_with_unapplied_partition_blocks_run(self):
+        adapter = self._tuned_adapter()
+        # One sort-tuned table whose key DID apply...
+        sort_tunings = _sorted_tuning_config().table_tunings
+        lineitem = "CREATE TABLE lineitem (l_orderkey INTEGER, l_linenumber INTEGER)"
+        adapter._record_tuned_sort_key_op(
+            lineitem,
+            adapter._optimize_table_definition(lineitem, sort_tunings, nullable_columns=set()),
+            "lineitem",
+            sort_tunings,
+        )
+        # ...and one partition-tuned table whose partition did NOT apply.
+        part_tunings = _partitioned_only_tuning_config().table_tunings
+        orders = "CREATE TABLE orders (o_orderkey INTEGER PRIMARY KEY, o_orderdate DATE)"
+        adapter._record_tuned_sort_key_op(
+            orders,
+            adapter._optimize_table_definition(orders, part_tunings, nullable_columns=set()),
+            "orders",
+            part_tunings,
+        )
+
+        conn = _FakeCHConnection(
+            [
+                ("lineitem", "l_orderkey, l_linenumber", ""),
+                ("orders", "o_orderkey", ""),  # no partition key in the catalog
+            ]
+        )
+        status, receipt = adapter._corroborate_applied_ledger(conn, APPLIED_UNVERIFIED)
+        assert status == APPLIED_UNVERIFIED
+        assert receipt["corroborated"] is False
+
+    def test_expression_partition_key_is_not_truncated(self):
+        # The clause regex must capture the full function expression. Truncating
+        # at the inner ")" made the expected columns ("toyyyymm(l_shipdate") a
+        # permanent mismatch against the catalog's "toYYYYMM(l_shipdate)", so no
+        # date-partitioned ClickHouse table could ever corroborate.
+        adapter = self._tuned_adapter()
+        optimized = self._record_combined(adapter)
+        assert "PARTITION BY (toYYYYMM(l_shipdate))" in optimized
+
+        conn = _FakeCHConnection([("lineitem", "l_orderkey, l_linenumber", "toYYYYMM(l_shipdate)")])
+        _, receipt = adapter._corroborate_applied_ledger(conn, APPLIED_UNVERIFIED)
+        partition_entry = next(e for e in receipt["entries"] if e.get("kind") == KIND_PARTITION_KEY)
+        assert partition_entry["expected_columns"] == ["toyyyymm(l_shipdate)"]
+        assert partition_entry["verdict"] == "corroborated"


### PR DESCRIPTION
Closes the two reviewer findings left open on merged #1275, plus two more
over-certification paths found while reviewing the fix.

The governing invariant throughout: `applied_verified` is EARNED via catalog
corroboration, and the system may only ever record LESS, never over-certify.
Every change here can only move a run from verified to unverified, never the
reverse.

## Finding A — combined `PARTITION BY` / `ORDER BY` verified on the sort key alone

A ClickHouse MergeTree `CREATE TABLE` applies two key layouts in one statement,
but `_classify` returned a single intent and the `ORDER BY` branch returned
first. The partition key was never compared against the catalog, so a run
reached `applied_verified` while its configured partition key had never applied.

`_classify` now returns one intent per clause and `corroborate` emits one
receipt entry each, so both must match. Reproduced at develop before the fix
(`corroborated=True` with `partition_key=tuple()` in the catalog); now
`applied_unverified` with an explicit `partition_key: mismatch` entry.

## Finding B — `applied_ledger_hash` attested an impossible chronology

The tuned `CREATE TABLE` was queued on `_applied_layout_operations`, which is
folded into the ledger only after data validation — landing it *after* the
`OPTIMIZE TABLE` statements the recording connection captures during load. It
is now recorded at `connection.execute()` time.

**This changes `applied_ledger_hash` for tuned ClickHouse runs.** Hashes from
#1275-era results are not comparable with post-merge ones; that is the point of
the fix, but it is worth knowing before comparing stored results.

## Two further holes found in self-review

**Partition-only tuned tables never entered the ledger.** The record guard
tested `sort_by` only, so a table tuned with just a partition key was invisible
to corroboration — an unapplied partition went unnoticed while a sibling
table's sort key carried the whole run to `applied_verified`. Recording now
triggers on either tuned clause. A table with *no* tuned clause still stays
out: a MergeTree `sorting_key` is always present, so corroborating an untuned
one would be a trivially-true, unearned upgrade.

**The clause regexes truncated function expressions.** `[^)]*` stopped at the
first inner paren, so ClickHouse's own date partition
`PARTITION BY (toYYYYMM(l_shipdate))` was captured as `toYYYYMM(l_shipdate` and
could never match the catalog's `toYYYYMM(l_shipdate)` — a permanent false
negative for every date-partitioned table. The regexes now allow one level of
nesting, and a clause that is visibly present but still unparsable fails
*closed* as `unverifiable` rather than silently vanishing while a sibling
clause verifies.

## Verification

- `tests/unit/platforms/test_clickhouse_introspection.py` — 8 new cases
  (combined-clause blocking, partition-only recording, expression truncation,
  CREATE-before-OPTIMIZE ordering).
- `tests/unit/core/tuning/test_introspection.py` — 9 new cases for the shared
  classifier (per-clause entries, fail-closed, `ORDER BY tuple()` no-op).
- Each new blocking assertion was confirmed to FAIL against pre-fix code by
  reverting the production files and re-running.
- Full fast lane green (25964 passed); ruff / ruff format / ty clean;
  `make pr-preflight` CI-lint gates pass.

### Live verification is still outstanding

No live ClickHouse was available in this session. Ladder step 2 — *"a combined
`PARTITION BY`/`ORDER BY` table does not reach `applied_verified` unless
`partition_key` is corroborated"* — is proven here only against a fake
`system.tables` connection. **A live run should confirm it before this is
trusted end to end.**

## Notes for the reviewer

- **No auto-merge** (CODEOWNERS soundness path) — this is left for maintainer
  merge.
- **Scope deviation, flagged deliberately.** The tracker item scopes edits to
  `benchbox/platforms/clickhouse/**` and `tests/unit/platforms/clickhouse/**`.
  Finding A's real defect is in the shared classifier
  (`benchbox/core/tuning/introspection.py`), which is where the fix landed; a
  ClickHouse-local workaround would have had to either overload
  `IntrospectedState.error` (misreporting a genuine mismatch as a tooling
  failure) or withhold a sort-key fact (writing a false "not found in catalog"
  reason into the receipt) — both dishonest in a receipt whose whole purpose is
  honesty. The blast radius is small: only ClickHouse and DuckDB have
  introspectors, and only statements carrying both clauses change behavior.
  Also note `tests/unit/platforms/clickhouse/**` does not exist — the ClickHouse
  tests are flat `tests/unit/platforms/test_clickhouse_*.py` — so the item's
  test glob and its ladder command (`pytest tests/unit/platforms/clickhouse`,
  which collects zero tests) are both unusable as authored and want correcting
  on the item.
- `benchbox/platforms/base/adapter.py:818-821` has a now-stale comment listing
  "ClickHouse tuned sort-key DDL" as an `_applied_layout_operations` producer.
  Left untouched because the item marks `benchbox/platforms/base/**`
  `do_not_modify`.

Tracker: `clickhouse-tuning-ledger-soundness-1275-followups-20260724`
Review-sweep deferrals: #1293

🤖 Generated with [Claude Code](https://claude.ai/code)
