### PR TITLE
fix(data-org): detect TBL trailing delimiters under CRLF line endings

### DIFF
--- a/benchbox/core/data_organization/sorting.py
+++ b/benchbox/core/data_organization/sorting.py
@@ -24,6 +24,7 @@ from benchbox.core.data_organization.config import (
     SortColumn,
     SortOrder,
 )
+from benchbox.utils.file_format import has_trailing_delimiter
 
 logger = logging.getLogger(__name__)
 
@@ -31,25 +32,23 @@ _TRAILING_DELIMITER_COLUMN = "__benchbox_trailing_delimiter__"
 _DEFAULT_MAX_IN_MEMORY_BYTES = 2 * 1024 * 1024 * 1024
 
 
-def _source_has_trailing_delimiter(source_files: list[Path]) -> bool:
-    """Probe the first source file's tail for a raw dbgen/dsdgen trailing delimiter.
+def _source_has_trailing_delimiter(source_files: list[Path], column_names: list[str]) -> bool:
+    """Report whether raw dbgen/dsdgen trailing delimiters are present.
 
     Row framing (trailing ``|`` before the newline, or not) is uniform across
     an entire TBL file - dbgen/dsdgen decide it once per run/compile - so
-    checking one file's tail classifies the whole batch. The bundled binaries
-    are all built to emit no trailing delimiter, but this probe keeps the
-    reader robust to either framing.
+    classifying one file classifies the whole batch. The bundled binaries are
+    all built to emit no trailing delimiter, but this probe keeps the reader
+    robust to either framing.
+
+    Delegates to the shared ingest-side helper so every reader classifies
+    framing the same way. The helper reads in text mode, so CRLF line endings
+    are normalized before the field count is taken - a byte-level tail probe
+    for ``b"|\\n"`` silently misses ``|\\r\\n`` and under-counts the columns.
     """
     if not source_files:
         return False
-    path = source_files[0]
-    size = path.stat().st_size
-    if size == 0:
-        return False
-    with path.open("rb") as handle:
-        handle.seek(max(0, size - 2))
-        tail = handle.read()
-    return tail.endswith((b"|\n", b"|"))
+    return has_trailing_delimiter(source_files[0], "|", column_names)
 
 
 class SortedParquetWriter:
@@ -299,7 +298,7 @@ class SortedParquetWriter:
         normalization pass strips it; see ``_source_has_trailing_delimiter``).
         """
         read_column_names = column_names
-        if column_names is not None and _source_has_trailing_delimiter(source_files):
+        if column_names is not None and _source_has_trailing_delimiter(source_files, column_names):
             # File-mode output still carries a trailing delimiter, so provide a
             # synthetic final column to keep parser arity aligned with the
             # explicit schema names. Normalized files have exactly N fields for

--- a/tests/unit/core/data_organization/test_sorting.py
+++ b/tests/unit/core/data_organization/test_sorting.py
@@ -162,6 +162,18 @@ def _write_tbl_clean(path: Path, rows: list[tuple[object, ...]]) -> None:
             f.write("|".join(str(v) for v in row) + "\n")
 
 
+def _write_tbl_crlf(path: Path, rows: list[tuple[object, ...]]) -> None:
+    """Write trailing-delimiter TBL rows with explicit CRLF line endings.
+
+    The other helpers open in text mode, so they emit the platform's native
+    line ending - LF on macOS/Linux, CRLF on Windows. These bytes are written
+    explicitly so the CRLF framing is exercised on every platform rather than
+    only on the Windows nightly leg.
+    """
+    payload = b"".join(("|".join(str(v) for v in row) + "|\r\n").encode("utf-8") for row in rows)
+    path.write_bytes(payload)
+
+
 class TestSortedParquetWriterSingleColumn:
     def test_single_column_sorting_writes_sorted_parquet(self, tmp_path: Path):
         source = tmp_path / "lineitem.tbl"
@@ -219,6 +231,50 @@ class TestSortedParquetWriterSingleColumn:
         assert table.column_names == ["id", "l_shipdate"]
         assert table.column("l_shipdate").to_pylist() == [date(1992, 1, 2), date(1996, 5, 17), date(1998, 3, 1)]
         assert table.column("id").to_pylist() == [1, 2, 3]
+
+    def test_reads_trailing_delimiter_tbl_with_crlf_line_endings(self, tmp_path: Path):
+        """Trailing-delimiter framing must be detected under CRLF line endings.
+
+        The framing probe used to read the file's last two bytes and look for
+        b"|\\n", which a CRLF file never matches - its tail is b"|\\r\\n". The
+        reader then omitted the synthetic trailing column and PyArrow failed
+        with "Expected N columns, got N+1". This only reproduced on the Windows
+        nightly leg, where the test helpers emit CRLF natively."""
+        source = tmp_path / "lineitem.tbl"
+        _write_tbl_crlf(
+            source,
+            [
+                (3, "1998-03-01"),
+                (1, "1992-01-02"),
+                (2, "1996-05-17"),
+            ],
+        )
+        schema_registry = {"lineitem": {"columns": [{"name": "id"}, {"name": "l_shipdate"}]}}
+        config = DataOrganizationConfig(sort_columns=[SortColumn(name="l_shipdate")], compression="none")
+        writer = SortedParquetWriter(config=config, schema_registry=schema_registry)
+
+        output = writer.write_sorted_parquet("lineitem", [source], tmp_path)
+
+        table = pq.read_table(output)
+        assert table.column_names == ["id", "l_shipdate"]
+        assert table.column("l_shipdate").to_pylist() == [date(1992, 1, 2), date(1996, 5, 17), date(1998, 3, 1)]
+        assert table.column("id").to_pylist() == [1, 2, 3]
+
+    def test_crlf_source_still_reports_unknown_sort_column(self, tmp_path: Path):
+        """Column validation must outrank a framing misread on CRLF input.
+
+        _read_tbl_files() runs before _sort_table(), so a framing misread threw
+        ArrowInvalid before the sort-column check could raise ValueError. That
+        is what made the "unknown column" assertions fail on Windows - the
+        error message never drifted, the exception type did."""
+        source = tmp_path / "orders.tbl"
+        _write_tbl_crlf(source, [(1, "2024-01-01")])
+        schema_registry = {"orders": {"columns": [{"name": "o_orderkey"}, {"name": "o_orderdate"}]}}
+        config = DataOrganizationConfig(sort_columns=[SortColumn(name="missing_col")], compression="none")
+        writer = SortedParquetWriter(config=config, schema_registry=schema_registry)
+
+        with pytest.raises(ValueError, match="Sort column 'missing_col' not found"):
+            writer.write_sorted_parquet("orders", [source], tmp_path)
 
 
 class TestSortedParquetWriterMultiColumn:


### PR DESCRIPTION
The Windows nightly leg failed 8+ tests in test_sorting.py with
pyarrow.lib.ArrowInvalid "CSV parse error: Expected N columns, got N+1"
on rows like `3|1998-03-01|`.

_source_has_trailing_delimiter() classified framing by seeking to the
last two bytes and testing `tail.endswith((b"|\n", b"|"))`. A CRLF file's
tail is `b"|\r\n"`, which matches neither, so trailing-delimiter framing
was reported as absent. The reader then omitted the synthetic trailing
column and handed PyArrow N column names for N+1 parsed fields.

The test helpers open in text mode, so they emit LF on macOS/Linux and
CRLF on Windows - the same source file, different bytes. That is why this
only ever reproduced on the nightly windows-latest legs.

Replaced the private byte probe with the shared ingest-side helper
benchbox.utils.file_format.has_trailing_delimiter, already used by every
other reader (duckdb, datafusion, polars, and the DataFrame adapters). It
reads in text mode, so universal newlines normalize CRLF before the field
count is taken, and it compares field counts against the schema instead
of matching a byte tail - which also fixes the latent TPC-DS case where a
10-column table whose generator emits 9 values plus a trailing delimiter
was misclassified as needing a dummy column.

The two "regex assertion" failures in the same file were the same root
cause, not message drift: _read_tbl_files() runs before _sort_table(), so
ArrowInvalid was raised before the sort/partition column validation could
raise ValueError. pytest.raises(ValueError, match=...) failed on the
exception type; the messages are identical on every platform. No regex
changes were needed.

Both new tests write explicit CRLF bytes so the framing is exercised on
every platform rather than only on the Windows nightly leg, and both were
confirmed to fail with the exact nightly signature when the production
fix is reverted.

## Review notes — skipped considerations

- **Fast-lane ceiling not bumped.** This PR adds 2 fast tests. `timing_policy_check.py --strict` exits 0 with **0 violations**; it emits only `FAST_LANE_WARNING: headroom 82 below 100`. That warning is **pre-existing** — develop's headroom was 84 before these 2 tests — and `_project/config/**` is outside this item's scope globs (`todo check-scope` passes with exactly 2 changed files). Per the ceiling log's own post-2026-07-24 convention the +500 quantum bump should be a standalone structural entry, not folded into a test-adding PR. Flagged for a separate bump.
- **`_write_tbl`/`_write_tbl_clean` left in text mode.** They emit the platform-native line ending, which is precisely what surfaced this bug on Windows. Converting them to explicit bytes would have removed that coverage, so the new CRLF helper was added alongside rather than replacing them.
- **`_source_has_trailing_delimiter` kept as a wrapper** rather than inlined at its single call site: it still carries the empty-`source_files` guard and the framing rationale.
- **Behavior change beyond the reported failure:** delegating to the shared helper also switches classification from "last line ends with `|`" to "field count exceeds schema width". This is strictly more correct (it fixes the latent TPC-DS 10-column/9-value case the byte probe got wrong) but is a real semantic change worth a reviewer's eye.
- **`_check_first_nonempty_line` swallows read errors** (`except Exception: return False`) where the old probe would propagate. Accepted for consistency with every other reader; `False` matches the bundled binaries' normalized output.
- **No Windows proof yet.** These paths cannot be reproduced on macOS; local rungs are the LF+explicit-CRLF equivalents. Nightly Validation supports `workflow_dispatch` and will be triggered after merge.
