### PR TITLE
fix(ducklake): redact the postgres password from ATTACH-failure errors

### DIFF
--- a/benchbox/platforms/ducklake.py
+++ b/benchbox/platforms/ducklake.py
@@ -48,6 +48,47 @@ _VALID_CATALOGS: tuple[str, ...] = ("duckdb", "sqlite", "postgres")
 # accumulate anonymous secrets.
 _S3_SECRET_NAME = "benchbox_ducklake_s3"
 
+_REDACTED = "****"
+
+# Backstop for credential material we did NOT emit verbatim: a driver error can
+# echo the libpq connstring back in a re-encoded form (extra quoting layers,
+# normalized whitespace), so an exact-value replace alone is not sufficient.
+# Bounded by the NEXT libpq `keyword=` token rather than by whitespace, because
+# a quoted password may legally contain spaces and quotes; `password` is emitted
+# before `port` (see _build_postgres_connstring), so a trailing keyword is the
+# usual terminator and only a same-line tail is lost when it is not.
+_PASSWORD_COMPONENT_RE = re.compile(r"(password\s*=\s*).*?(?=\s+\w+\s*=|$)", flags=re.IGNORECASE | re.MULTILINE)
+# Matches the `SECRET '<value>'` clause of CREATE SECRET; the secret NAME is an
+# unquoted identifier, so only the quoted key material is caught here.
+_S3_SECRET_CLAUSE_RE = re.compile(r"(\bSECRET\s+)'(?:[^']|'')*'", flags=re.IGNORECASE)
+
+
+def _redact_secrets(message: str, *secrets: str | None) -> str:
+    """Strip credential material out of a DuckLake adapter error/log message.
+
+    Two layers, because neither alone is complete:
+
+    1. Exact replacement of every secret value we hold, in each encoding this
+       adapter can emit it in - raw, libpq-quoted, and libpq-quoted-then-SQL-
+       escaped (the form that reaches DuckDB inside the ATTACH literal).
+    2. Pattern redaction of `password=...` / `SECRET '...'` for anything the
+       driver re-encoded on its way back out.
+    """
+    redacted: str = message
+    encodings: set[str] = set()
+    for secret in secrets:
+        if not secret:
+            continue
+        quoted = _libpq_quote_value(secret)
+        encodings.update({secret, quoted, escape_sql_string_literal(quoted), escape_sql_string_literal(secret)})
+    # Longest first: a shorter encoding is often a substring of a longer one,
+    # and replacing it first would leave the remainder of the longer form intact.
+    longest_first: list[str] = sorted(encodings, key=len, reverse=True)
+    for encoding in longest_first:
+        redacted = redacted.replace(encoding, _REDACTED)
+    redacted = _PASSWORD_COMPONENT_RE.sub(rf"\1{_REDACTED}", redacted)
+    return _S3_SECRET_CLAUSE_RE.sub(rf"\1{_REDACTED}", redacted)
+
 
 def _libpq_quote_value(value: str) -> str:
     """Quote/escape one libpq ``keyword=value`` component for a connection string.
@@ -688,7 +729,15 @@ class DuckLakeAdapter(DuckDBAdapter):
                         "Failed to create the DuckDB S3 secret for DuckLake DATA_PATH "
                         f"(provider={'explicit key/secret' if using_explicit_creds else 'credential_chain'}). "
                         f"Underlying error type: {type(secret_exc).__name__}."
-                        + ("" if using_explicit_creds else f" Underlying error: {secret_exc}")
+                        + (
+                            ""
+                            if using_explicit_creds
+                            # credential_chain mode holds no explicit key material,
+                            # but the error text still passes through the redactor
+                            # so ambient credentials echoed by httpfs cannot ride
+                            # out on this branch either.
+                            else f" Underlying error: {_redact_secrets(str(secret_exc))}"
+                        )
                     ) from None
 
             attach_target = self._build_catalog_attach_target()
@@ -700,13 +749,22 @@ class DuckLakeAdapter(DuckDBAdapter):
                 setup_conn.close()
             except Exception:
                 logger.debug("Failed to close base connection after DuckLake ATTACH failure", exc_info=True)
+            # A failed postgres ATTACH echoes the whole libpq connstring -
+            # password included - back through the driver error, so the
+            # underlying message is redacted before it is composed in. The
+            # chained cause carries the same unredacted text into any traceback,
+            # so it is suppressed whenever this adapter holds secret material;
+            # runs without credentials (duckdb/sqlite catalogs, credential_chain
+            # S3) keep the full chain for debuggability.
+            holds_secret_material = bool(self.pg_password or self.s3_secret or self.s3_key_id)
+            underlying = _redact_secrets(str(e), self.pg_password, self.s3_secret, self.s3_key_id)
             raise RuntimeError(
                 "Failed to initialize the DuckLake catalog (INSTALL/LOAD/ATTACH "
                 f"'ducklake' extension, catalog={self.catalog}). DuckLake requires "
                 f"DuckDB >= 1.3; detected DuckDB version: {live_version or 'unknown'}. "
                 f"metadata_path={self.metadata_path if self.catalog != 'postgres' else '(postgres catalog - N/A)'}, "
-                f"data_path={self.data_path}. Underlying error: {e}"
-            ) from e
+                f"data_path={self.data_path}. Underlying error: {underlying}"
+            ) from (None if holds_secret_material else e)
 
         # Wrap so that framework seams calling connection.cursor() (e.g.
         # phase_tracking._validate_data_integrity's accessibility probe) get a

--- a/tests/unit/platforms/test_ducklake_adapter.py
+++ b/tests/unit/platforms/test_ducklake_adapter.py
@@ -17,6 +17,7 @@ from benchbox.platforms.ducklake import (
     _duckdb_version_supports_ducklake,
     _libpq_quote_value,
     _parse_duckdb_major_minor,
+    _redact_secrets,
 )
 
 pytestmark = [
@@ -468,6 +469,183 @@ class TestDuckLakePostgresAttachInjection:
         # Outer SQL layer only doubles single quotes; balance still holds.
         assert literal.startswith("'") and literal.endswith("'")
         assert "'" not in literal[1:-1].replace("''", "")
+
+
+class TestDuckLakeCredentialRedaction:
+    """Regression: no credential material may reach a DuckLake ATTACH-failure.
+
+    The postgres catalog embeds the libpq connstring (password included) in the
+    ATTACH literal, so a driver error that echoes the failing statement carries
+    the password with it. These tests pin the redaction at both egress points:
+    the raised message AND the chained ``__cause__`` a traceback would print.
+    """
+
+    SENTINEL = "s3nt1nel-pg-passw0rd"
+
+    def _failing_adapter(self, tmp_path, monkeypatch, error_message, **kwargs):
+        """Adapter whose ATTACH fails with ``error_message`` (no live DuckDB).
+
+        Mirrors test_cloud_data_path_skips_local_mkdir_on_connect's stub: the
+        base DuckDBAdapter.create_connection() is replaced so the fast lane
+        stays hermetic, and the stub raises on ATTACH the way a real postgres
+        connection failure does - by quoting the statement back at us.
+        """
+        from benchbox.platforms.duckdb import DuckDBAdapter
+
+        adapter = DuckLakeAdapter(
+            metadata_path=str(tmp_path / "catalog.ducklake"),
+            data_path=kwargs.pop("data_path", str(tmp_path / "data")),
+            **kwargs,
+        )
+
+        class _StubSetupConn:
+            def execute(self, sql):
+                if sql.startswith("ATTACH"):
+                    raise RuntimeError(error_message(sql))
+                return self
+
+            def close(self):
+                pass
+
+        monkeypatch.setattr(DuckDBAdapter, "create_connection", lambda self, **_: _StubSetupConn())
+        return adapter
+
+    @pytest.mark.parametrize(
+        "password",
+        [
+            "s3nt1nel-pg-passw0rd",
+            # Quoting-sensitive shapes: these reach DuckDB libpq-quoted and then
+            # SQL-escaped, so an exact-value replace of the raw form alone would
+            # miss them.
+            "pass word with spaces",
+            "pass'word",
+            "a\\b'c",
+        ],
+    )
+    def test_postgres_attach_failure_never_leaks_the_password(self, tmp_path, monkeypatch, password):
+        # The driver echoes the failing statement - the classic leak path.
+        adapter = self._failing_adapter(
+            tmp_path,
+            monkeypatch,
+            lambda sql: f"Connection Error: could not connect: {sql} port=5432: FATAL: password authentication failed",
+            catalog="postgres",
+            pg_database="benchdb",
+            pg_user="alice",
+            pg_password=password,
+        )
+
+        with pytest.raises(RuntimeError) as excinfo:
+            adapter.create_connection()
+
+        message = str(excinfo.value)
+        assert password not in message
+        # Every encoding this adapter can emit the password in is gone too.
+        libpq_quoted = _libpq_quote_value(password)
+        assert libpq_quoted not in message
+        assert escape_sql_string_literal(libpq_quoted) not in message
+        # The chained cause would re-print the unredacted driver text in a
+        # traceback, so it must be suppressed for a credential-bearing run.
+        assert excinfo.value.__cause__ is None
+        # Redacted, not merely truncated: the useful context survives.
+        assert "Failed to initialize the DuckLake catalog" in message
+        assert "catalog=postgres" in message
+
+    def test_postgres_attach_failure_keeps_non_secret_context(self, tmp_path, monkeypatch):
+        adapter = self._failing_adapter(
+            tmp_path,
+            monkeypatch,
+            lambda sql: "Connection Error: connection to server at 'db.example.com' failed: refused",
+            catalog="postgres",
+            pg_database="benchdb",
+            pg_user="alice",
+            pg_password=self.SENTINEL,
+        )
+
+        with pytest.raises(RuntimeError) as excinfo:
+            adapter.create_connection()
+
+        message = str(excinfo.value)
+        assert self.SENTINEL not in message
+        # A driver error carrying no credential material is passed through
+        # intact - redaction must not swallow the diagnosis.
+        assert "connection to server at 'db.example.com' failed: refused" in message
+
+    def test_non_postgres_attach_failure_keeps_paths_and_cause(self, tmp_path, monkeypatch):
+        # Must-preserve: duckdb/sqlite catalogs hold no credentials, so they
+        # keep both the metadata_path/data_path context and the chained cause.
+        adapter = self._failing_adapter(
+            tmp_path,
+            monkeypatch,
+            lambda sql: "IO Error: catalog file is locked",
+        )
+
+        with pytest.raises(RuntimeError) as excinfo:
+            adapter.create_connection()
+
+        message = str(excinfo.value)
+        assert "catalog.ducklake" in message
+        assert str(tmp_path / "data") in message
+        assert "IO Error: catalog file is locked" in message
+        assert isinstance(excinfo.value.__cause__, RuntimeError)
+
+    def test_s3_secret_never_leaks_through_attach_failure(self, tmp_path, monkeypatch):
+        # w3 sweep: explicit S3 key material takes the same egress path.
+        adapter = self._failing_adapter(
+            tmp_path,
+            monkeypatch,
+            lambda sql: "IO Error: HTTP 403 using SECRET 'top-s3cret-key' for bucket",
+            data_path="s3://my-bucket/bench/",
+            s3_key_id="AKIAEXAMPLE",
+            s3_secret="top-s3cret-key",
+        )
+
+        with pytest.raises(RuntimeError) as excinfo:
+            adapter.create_connection()
+
+        message = str(excinfo.value)
+        assert "top-s3cret-key" not in message
+        assert "AKIAEXAMPLE" not in message
+        assert excinfo.value.__cause__ is None
+
+
+class TestRedactSecretsHelper:
+    """Unit coverage for the redaction primitive itself (w1/w3)."""
+
+    def test_redacts_every_encoding_of_a_supplied_secret(self):
+        secret = "pass word'x"
+        quoted = _libpq_quote_value(secret)
+        message = f"raw={secret} quoted={quoted} sql={escape_sql_string_literal(quoted)}"
+        redacted = _redact_secrets(message, secret)
+        assert secret not in redacted
+        assert quoted not in redacted
+
+    def test_redacts_password_component_without_knowing_the_value(self):
+        # Backstop layer: the driver re-encoded the value, so no exact match
+        # is available - the `password=` component is still cut out, and the
+        # following libpq keyword bounds the redaction.
+        message = "dbname=benchdb host=db user=alice password=hunter2 port=5432: FATAL"
+        redacted = _redact_secrets(message)
+        assert "hunter2" not in redacted
+        assert "port=5432" in redacted
+        assert "dbname=benchdb" in redacted
+
+    def test_redacts_quoted_password_containing_spaces(self):
+        message = "dbname=benchdb password='hunter 2 with spaces' port=5432"
+        redacted = _redact_secrets(message)
+        assert "hunter" not in redacted
+        assert "port=5432" in redacted
+
+    def test_redacts_secret_clause(self):
+        message = "CREATE OR REPLACE SECRET benchbox_ducklake_s3 (TYPE s3, KEY_ID 'AKIA', SECRET 'topsecret')"
+        redacted = _redact_secrets(message)
+        assert "topsecret" not in redacted
+        # The secret NAME is an unquoted identifier and is not credential
+        # material - it stays, so the message still says what failed.
+        assert "benchbox_ducklake_s3" in redacted
+
+    def test_leaves_credential_free_messages_untouched(self):
+        message = "IO Error: catalog file is locked"
+        assert _redact_secrets(message, None) == message
 
 
 class TestDuckLakeFromConfigCatalogOptions:


### PR DESCRIPTION
## Problem

The DuckLake `postgres` catalog builds a libpq connection string — password
included — and embeds it in the `ATTACH 'ducklake:postgres:...'` literal. When
that ATTACH failed, `create_connection()` composed the driver's error straight
into the raised `RuntimeError` (`Underlying error: {e}`), and `raise ... from e`
kept the same unredacted text reachable from the chained traceback. A driver
error that quotes the failing statement therefore printed the plaintext
PostgreSQL password into logs and CI output.

Tracker: `ducklake-postgres-credential-leak-redaction` (critical, confirmed leak).

## Fix

`_redact_secrets()` in [ducklake.py](benchbox/platforms/ducklake.py) strips
credential material in two layers, because neither alone is complete:

1. **Exact replacement** of every encoding this adapter can emit a secret in —
   raw, libpq-quoted, and libpq-quoted-then-SQL-escaped (the form that actually
   reaches DuckDB inside the ATTACH literal).
2. **Pattern redaction** of `password=...` and `SECRET '...'` for anything the
   driver re-encoded on its way back out. The `password=` backstop is bounded by
   the *next* libpq `keyword=` token rather than by whitespace, since a quoted
   password may legally contain spaces and quotes.

The chained cause is suppressed only when the adapter actually holds secret
material — otherwise the redaction would be undone by the traceback. The
credential_chain S3 branch now routes its underlying error through the same
redactor.

## Preserved

- duckdb/sqlite ATTACH failures keep their `metadata_path`/`data_path` context
  **and** the full chained cause (no credentials to protect).
- A postgres failure carrying no credential material passes through intact —
  redaction does not swallow the diagnosis.
- The existing S3 `CREATE SECRET` redaction and `get_platform_info()`'s
  omission of `pg_user`/`pg_password` are unchanged.

## Verification

- `uv run -- python -m pytest tests/unit/platforms/test_ducklake_adapter.py -q`
  — 93 passed (14 new).
- Mutation-sensitivity: neutering `_redact_secrets()` flips 9 tests red;
  restoring the unconditional `from e` alone flips 5 red.
- `make ci-lint` guards pass (the local `spellcheck` failure is pre-existing —
  `codespell`'s skip list omits gitignored `node_modules`, so it only fires for
  developers who have installed the results-explorer npm deps; CI is unaffected).
- `make pr-preflight-fast-tests` — 25945 passed, 18 skipped.
