### PR TITLE
fix(ci): keep seed corpus output in workspace

### DIFF
--- a/.github/workflows/seed-corpus.yml
+++ b/.github/workflows/seed-corpus.yml
@@ -117,6 +117,10 @@ jobs:
     # matrix, so the condition is computed once here and each step guards on it.
     env:
       SELECTED: ${{ github.event.inputs.benchmark == '' || github.event.inputs.benchmark == matrix.benchmark }}
+      # BenchBox normally keeps generated data beside the checkout so worktrees
+      # can share it. CI must keep the run inside the workspace because the
+      # later staging steps intentionally collect and commit result bundles.
+      BENCHBOX_OUTPUT_DIR: ${{ github.workspace }}/benchmark_runs
 
     steps:
       - name: Checkout code


### PR DESCRIPTION
## Summary
- pin `BENCHBOX_OUTPUT_DIR` to the GitHub workspace for Seed Corpus matrix jobs
- keep generated bundles where the workflow locate and staging steps intentionally collect them
- preserve the workflow_dispatch-only trigger and the existing single-benchmark filter

## Failure evidence
Filtered dispatch [30455422794](https://github.com/joeharris76/BenchBox/actions/runs/30455422794) used `benchmark=ssb`. All 11 non-SSB cells completed as no-op successes and all 6 selected cells ran. DuckDB and Polars completed benchmark execution but failed because `Locate result bundle` searched checkout-local `benchmark_runs/results` while BenchBox had exported to the checkout sibling. The two DataFusion cells exposed a separate production path-normalization defect and are tracked independently as `datafusion-normalize-seed-corpus-table-paths`.

## Verification
- focused workflow tests: 45 passed
- Ruff on focused workflow tests: pass
- YAML/pre-commit checks: pass
- hosted tracker scope check: exactly 1 changed file, allowed by the item
- `make pr-preflight`: all substantive checks pass, including 25975 fast tests; final report-only artifact hygiene identifies 10.5 MB of pre-existing pool artifacts dated July 8-10, which were preserved

## Completion boundary
The tracker item remains blocked after this PR until a post-merge filtered dispatch succeeds. Its original no-failure-since timestamp rung became permanently false after the proof run and is captured by migration-dependent follow-up `seed-corpus-proof-verification-window-v2`. No schedule was added.