### PR TITLE
fix(cli): preserve main submodule identity

### DIFF
--- a/benchbox/cli/__init__.py
+++ b/benchbox/cli/__init__.py
@@ -19,12 +19,7 @@ __all__ = ["main"]
 
 
 def __getattr__(name: str) -> Any:
-    if name == "main":
-        from benchbox.cli.main import main
-
-        globals()[name] = main
-        return main
-    # Lazy-load any submodule (commands, orchestrator, cloud_storage, etc.)
+    # Lazy-load any submodule (main, commands, orchestrator, cloud_storage, etc.)
     try:
         module = importlib.import_module(f"{__name__}.{name}")
     except ModuleNotFoundError:

--- a/benchbox/cli/main.py
+++ b/benchbox/cli/main.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 import importlib
+import sys
+from types import ModuleType
 from typing import Any
 
 _EXPORTS = {
@@ -66,6 +68,16 @@ def get_config_manager() -> Any:
     if config_manager is None:
         config_manager = __getattr__("ConfigManager")
     return config_manager()
+
+
+class _CallableMainModule(ModuleType):
+    """Preserve the historic callable package export while remaining a module."""
+
+    def __call__(self) -> None:
+        self.main()
+
+
+sys.modules[__name__].__class__ = _CallableMainModule
 
 
 if __name__ == "__main__":

--- a/tests/unit/cli/test_cli_startup_imports.py
+++ b/tests/unit/cli/test_cli_startup_imports.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import importlib
+import subprocess
 import sys
 
 import pytest
@@ -19,6 +20,27 @@ def _clear_modules(monkeypatch: pytest.MonkeyPatch, *prefixes: str) -> None:
     for module_name in list(sys.modules):
         if any(module_name == prefix or module_name.startswith(f"{prefix}.") for prefix in prefixes):
             monkeypatch.delitem(sys.modules, module_name, raising=False)
+
+
+def test_main_attribute_resolves_to_submodule_before_explicit_import() -> None:
+    """Attribute-first resolution must not shadow the main submodule with its function."""
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            (
+                "import benchbox.cli; import types; "
+                "target = getattr(benchbox.cli, 'main'); "
+                "assert isinstance(target, types.ModuleType), type(target); "
+                "assert hasattr(target, 'get_config_manager')"
+            ),
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
 
 
 def test_importing_conversion_submodule_does_not_import_lifecycle_runner(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/unit/cli/test_cli_startup_imports.py
+++ b/tests/unit/cli/test_cli_startup_imports.py
@@ -32,6 +32,7 @@ def test_main_attribute_resolves_to_submodule_before_explicit_import() -> None:
                 "import benchbox.cli; import types; "
                 "target = getattr(benchbox.cli, 'main'); "
                 "assert isinstance(target, types.ModuleType), type(target); "
+                "assert callable(target); "
                 "assert hasattr(target, 'get_config_manager')"
             ),
         ],
@@ -41,6 +42,17 @@ def test_main_attribute_resolves_to_submodule_before_explicit_import() -> None:
     )
 
     assert result.returncode == 0, result.stderr
+
+
+def test_calling_main_module_delegates_to_lazy_entrypoint(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Calling the compatibility module should resolve and invoke its lazy main export."""
+    main_module = importlib.import_module("benchbox.cli.main")
+    calls: list[str] = []
+    monkeypatch.setattr(main_module, "main", lambda: calls.append("main"), raising=False)
+
+    main_module()
+
+    assert calls == ["main"]
 
 
 def test_importing_conversion_submodule_does_not_import_lifecycle_runner(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/unit/cli/test_run_dataframe_platform_options.py
+++ b/tests/unit/cli/test_run_dataframe_platform_options.py
@@ -31,14 +31,6 @@ from benchbox.core.schemas import DatabaseConfig
 __import__("benchbox.cli.commands.run")
 _run_module = _sys.modules["benchbox.cli.commands.run"]
 
-# `benchbox.cli` lazily caches the *function* ``main`` into its globals, which
-# shadows the same-named submodule.  Python >= 3.11 resolves a patch target via
-# ``pkgutil.resolve_name`` (imports the dotted path, so the module wins), but
-# 3.10 walks it with ``getattr`` and lands on the function:
-#     AttributeError: <function main ...> does not have the attribute 'get_config_manager'
-# Resolve the module once, up front, and patch through it instead of by string.
-_main_module = _sys.modules["benchbox.cli.main"]
-
 # Import for its spec-registration side effects so the registry is populated
 # regardless of test collection order.
 import benchbox.cli.platform_defaults  # noqa: E402,F401
@@ -148,7 +140,7 @@ class TestDataFrameOptionReachesConfig:
             patch.object(_run_module, "BenchmarkManager", return_value=mock_bench_manager),
             patch.object(_run_module, "BenchmarkOrchestrator", return_value=mock_orchestrator),
             patch.object(_run_module, "SystemProfiler") as mock_profiler_cls,
-            patch.object(_main_module, "get_config_manager") as mock_cfg,
+            patch("benchbox.cli.main.get_config_manager") as mock_cfg,
             patch.object(_run_module, "_execute_orchestrated_run", return_value=mock_result),
             patch.object(_run_module, "_export_orchestrated_result", return_value={"json": "/tmp/t.json"}),
             patch.object(_run_module, "_render_post_run_charts"),

--- a/tests/unit/test_lazy_modules_fast.py
+++ b/tests/unit/test_lazy_modules_fast.py
@@ -101,6 +101,7 @@ def test_cli_package_lazy_getattr_supports_main_submodules_and_missing_attr(
 ) -> None:
     main = cli_pkg.__getattr__("main")
     assert isinstance(main, ModuleType)
+    assert callable(main)
     assert hasattr(main, "get_config_manager")
 
     commands_module = ModuleType("benchbox.cli.commands")

--- a/tests/unit/test_lazy_modules_fast.py
+++ b/tests/unit/test_lazy_modules_fast.py
@@ -100,7 +100,8 @@ def test_cli_package_lazy_getattr_supports_main_submodules_and_missing_attr(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     main = cli_pkg.__getattr__("main")
-    assert callable(main)
+    assert isinstance(main, ModuleType)
+    assert hasattr(main, "get_config_manager")
 
     commands_module = ModuleType("benchbox.cli.commands")
 


### PR DESCRIPTION
## Summary
- stop `benchbox.cli` from caching the exported `main()` function over the real `benchbox.cli.main` submodule
- make the compatibility submodule callable so `from benchbox.cli import main; main()` remains supported
- preserve generic lazy submodule imports and heavy-dependency isolation
- restore ordinary string patch targets such as `benchbox.cli.main.get_config_manager`

## Root cause
The package-level `__getattr__` special-cased `main`, imported the function from the submodule, and cached that function on the package. Attribute-first access therefore replaced the submodule identity, which breaks Python 3.10-era import and patch resolution. Returning only the submodule fixed resolver behavior but silently removed the historic callable package export, so the compatibility module now uses a small `ModuleType` subclass whose call delegates lazily to its public `main` attribute.

## Verification
- original tracker verification ladder passed, including CLI entrypoint, lazy import, Python 3.10 semantic probe, and the CLI suite
- review-follow-up tracker rungs 1-4 passed: module and callable identity, dotted patching, lazy dependencies, and focused tests
- broader focused regression surface: 23 passed
- Python 3.10.17 compatibility probe passed against the actual CLI package files with a minimal parent-package shim (the standalone interpreter lacks project PyYAML)
- hosted tracker strict scope check passed for all five PR paths
- `make pr-preflight`: all substantive checks passed, including 25,976 fast tests; the final report-only artifact-hygiene guard identified 3.18 MB of pre-existing pool artifacts, which were preserved

## Compatibility
- `benchbox.cli.main` remains a real module for dotted imports, patching, and introspection
- `from benchbox.cli import main` remains callable
- the installed console entrypoint remains `benchbox.cli.app:main`
- importing `benchbox.cli` or `benchbox.cli.main` still does not import Polars or DataFusion
