### PR TITLE
fix: close merged PR review follow-ups

### DIFF
--- a/.github/workflows/validate-submission.yml
+++ b/.github/workflows/validate-submission.yml
@@ -114,7 +114,7 @@ jobs:
         run: |
           # Find new/modified bundle JSONs in this PR (exclude companions and metadata files).
           # Use the base SHA directly rather than a ref name for reliability.
-          CHANGED=$(git diff --name-only --diff-filter=ACMR ${{ github.event.pull_request.base.sha }}...HEAD -- 'results-data/bundles/*.json' 'results-data/bundles/**/*.json' \
+          CHANGED=$(git diff --no-renames --name-only --diff-filter=ACMR ${{ github.event.pull_request.base.sha }}...HEAD -- 'results-data/bundles/*.json' 'results-data/bundles/**/*.json' \
             | grep -v '\.plans\.json$' \
             | grep -v '\.tuning\.json$' \
             | grep -v '\.applied\.json$' \
@@ -132,7 +132,7 @@ jobs:
           # Include deletions (D): removing a manifest while leaving its paired
           # bundle is a contract change that must still trip validation and the
           # corpus inventory drift check, so a manifest removal cannot bypass it.
-          CHANGED_MANIFESTS=$(git diff --name-only --diff-filter=ACMRD \
+          CHANGED_MANIFESTS=$(git diff --no-renames --name-only --diff-filter=ACMRD \
             ${{ github.event.pull_request.base.sha }}...HEAD -- \
             'results-data/bundles/*.json' 'results-data/bundles/**/*.json' \
             | grep '\.manifest\.json$' \
@@ -157,7 +157,7 @@ jobs:
           # Derive the paired primary bundle so validate_submission.py checks the
           # edited companion hash against the manifest. Include deletions: a
           # removed companion is still a contract change while its bundle exists.
-          CHANGED_APPLIED=$(git diff --name-only --diff-filter=ACMRD \
+          CHANGED_APPLIED=$(git diff --no-renames --name-only --diff-filter=ACMRD \
             ${{ github.event.pull_request.base.sha }}...HEAD -- \
             'results-data/bundles/*.json' 'results-data/bundles/**/*.json' \
             | grep '\.applied\.json$' \

--- a/_project/scripts/todo_db_standalone_compat.py
+++ b/_project/scripts/todo_db_standalone_compat.py
@@ -257,6 +257,11 @@ def _write_legacy_export(
     output_dir.mkdir(parents=True, exist_ok=True)
     lossless_dir = lossless_dir if lossless_dir is not None else output_dir.parent / f"{output_dir.name}-lossless"
     lossless_dir.mkdir(parents=True, exist_ok=True)
+    legacy_envelope = output_dir / "todo-db.json"
+    if legacy_envelope.exists() or legacy_envelope.is_symlink():
+        if not legacy_envelope.is_file() and not legacy_envelope.is_symlink():
+            raise ValueError(f"legacy export path is not a file: {legacy_envelope}")
+        legacy_envelope.unlink()
     lossless_path = lossless_dir / "todo-db.json"
     items_path = output_dir / "items.jsonl"
     events_path = output_dir / "events.jsonl"

--- a/_project/scripts/todo_findings.py
+++ b/_project/scripts/todo_findings.py
@@ -561,7 +561,12 @@ def surfacing_banner(conn, drafts_dir: str | Path | None = None, open_count: int
         parts.append(f"{open_count} open finding(s)")
     if draft_count:
         parts.append(f"{draft_count} unsynced draft(s)")
-    return f"→ {', '.join(parts)} awaiting triage — see: todo finding candidates"
+    destinations = []
+    if open_count:
+        destinations.append("todo finding list --disposition open")
+    if draft_count:
+        destinations.append("todo finding candidates")
+    return f"→ {', '.join(parts)} awaiting triage — see: {'; '.join(destinations)}"
 
 
 # ---------------------------------------------------------------------------

--- a/benchbox/cli/commands/run.py
+++ b/benchbox/cli/commands/run.py
@@ -81,6 +81,7 @@ from benchbox.utils.verbosity import VerbositySettings
 
 logger = logging.getLogger(__name__)
 DATA_ORGANIZATION_ENV = "BENCHBOX_DATA_ORGANIZATION_CONFIG_JSON"
+_GUIDED_CREDENTIAL_PLATFORMS = frozenset({"athena", "bigquery", "databricks", "motherduck", "redshift", "snowflake"})
 
 # Benchmark name aliases - maps common variations to canonical names
 BENCHMARK_ALIASES: dict[str, str] = {
@@ -2221,16 +2222,21 @@ def _interactive_cloud_setup_if_needed(s: types.SimpleNamespace) -> None:
     if not stages_remotely and not _run_requires_platform_credentials(s):
         return
 
-    credentials_ok = check_and_setup_platform_credentials(
-        platform=s.database_config.type,
-        console_obj=console,
-        interactive=not s.non_interactive,
-    )
+    if s.database_config.type.casefold() in _GUIDED_CREDENTIAL_PLATFORMS:
+        credentials_ok = check_and_setup_platform_credentials(
+            platform=s.database_config.type,
+            console_obj=console,
+            interactive=not s.non_interactive,
+        )
 
-    if not credentials_ok:
-        console.print(f"\n[red]❌ Cannot proceed without {s.database_config.type.upper()} credentials[/red]")
-        console.print(f"\n[dim]To configure later: benchbox setup --platform {s.database_config.type}[/dim]")
-        ctx.exit(1)
+        if not credentials_ok:
+            console.print(f"\n[red]❌ Cannot proceed without {s.database_config.type.upper()} credentials[/red]")
+            console.print(f"\n[dim]To configure later: benchbox setup --platform {s.database_config.type}[/dim]")
+            ctx.exit(1)
+    elif not stages_remotely:
+        # Server platforms validate credentials from their connection options;
+        # they do not have a CredentialManager setup flow.
+        return
 
     if not stages_remotely or s.output:
         return

--- a/benchbox/core/publishing/bundle_publisher.py
+++ b/benchbox/core/publishing/bundle_publisher.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 
 import json
 import logging
+import os
 import shutil
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -325,10 +326,15 @@ def _copy_to_adls(files: list[Path], destination: str) -> None:
     except ImportError as exc:
         raise RuntimeError("ADLS publishing requires azure-identity and azure-storage-file-datalake") from exc
 
-    service = DataLakeServiceClient(
-        account_url=f"https://{account_host}",
-        credential=DefaultAzureCredential(),
-    )
+    account_name = os.environ.get("AZURE_STORAGE_ACCOUNT_NAME")
+    account_key = os.environ.get("AZURE_STORAGE_ACCOUNT_KEY")
+    if account_name and account_key:
+        from azure.core.credentials import AzureNamedKeyCredential
+
+        credential = AzureNamedKeyCredential(account_name, account_key)
+    else:
+        credential = DefaultAzureCredential()
+    service = DataLakeServiceClient(account_url=f"https://{account_host}", credential=credential)
     filesystem = service.get_file_system_client(container)
     for file in files:
         remote_path = "/".join(part for part in (prefix, file.name) if part)

--- a/benchbox/core/tuning/introspection.py
+++ b/benchbox/core/tuning/introspection.py
@@ -272,8 +272,10 @@ def normalize_columns(raw: Any) -> tuple[str, ...]:
     """Normalize a comma-separated column list (or a bracketed catalog list).
 
     Accepts ``"a, b"``, ``"[a, b]"`` (DuckDB ``expressions``), or an already
-    split iterable. Returns a case-folded, order-preserving tuple with empty
-    entries dropped.
+    split iterable. ClickHouse may represent a multi-column partition key as
+    ``tuple(a, b)``; its outer function wrapper is catalog syntax rather than
+    a column name and is removed before splitting. Returns a case-folded,
+    order-preserving tuple with empty entries dropped.
     """
     if raw is None:
         return ()
@@ -283,6 +285,8 @@ def normalize_columns(raw: Any) -> tuple[str, ...]:
         text = str(raw).strip()
         if text.startswith("[") and text.endswith("]"):
             text = text[1:-1]
+        elif text[:6].casefold() == "tuple(" and text.endswith(")"):
+            text = text[6:-1].strip()
         items = text.split(",") if text else []
     normalized = [normalize_identifier(item) for item in items]
     return tuple(col for col in normalized if col)

--- a/benchbox/platforms/azure_synapse.py
+++ b/benchbox/platforms/azure_synapse.py
@@ -95,9 +95,9 @@ class AzureSynapseAdapter(PlatformAdapter):
             # while rejecting the documented "azure://" form.
             if cloud_provider_family(staging_root) == "azure":
                 self.storage_account = (
-                    config.get("storage_account")
-                    or path_info.get("account")
+                    path_info.get("account")
                     or self._extract_storage_account(staging_root)
+                    or config.get("storage_account")
                 )
                 if not self.storage_account:
                     raise ValueError(

--- a/benchbox/platforms/ducklake.py
+++ b/benchbox/platforms/ducklake.py
@@ -53,11 +53,11 @@ _REDACTED = "****"
 # Backstop for credential material we did NOT emit verbatim: a driver error can
 # echo the libpq connstring back in a re-encoded form (extra quoting layers,
 # normalized whitespace), so an exact-value replace alone is not sufficient.
-# Bounded by the NEXT libpq `keyword=` token rather than by whitespace, because
-# a quoted password may legally contain spaces and quotes; `password` is emitted
-# before `port` (see _build_postgres_connstring), so a trailing keyword is the
-# usual terminator and only a same-line tail is lost when it is not.
-_PASSWORD_COMPONENT_RE = re.compile(r"(password\s*=\s*).*?(?=\s+\w+\s*=|$)", flags=re.IGNORECASE | re.MULTILINE)
+# Bounded by the known trailing libpq `port=` component rather than any
+# `keyword=` token: a quoted password may legally contain keyword-shaped text.
+# `password` is emitted before `port` (see _build_postgres_connstring), and the
+# end-of-line fallback covers driver messages that omit the port.
+_PASSWORD_COMPONENT_RE = re.compile(r"(password\s*=\s*).*?(?=\s+port\s*=|$)", flags=re.IGNORECASE | re.MULTILINE)
 # Matches the `SECRET '<value>'` clause of CREATE SECRET; the secret NAME is an
 # unquoted identifier, so only the quoted key material is caught here.
 _S3_SECRET_CLAUSE_RE = re.compile(r"(\bSECRET\s+)'(?:[^']|'')*'", flags=re.IGNORECASE)

--- a/tests/unit/cli/test_run_command_interactive_paths.py
+++ b/tests/unit/cli/test_run_command_interactive_paths.py
@@ -102,6 +102,25 @@ def test_interactive_header_shown_for_prompted_tty_run():
     mock_console.print.assert_called_once()
 
 
+def test_interactive_cloud_setup_leaves_server_credentials_to_adapter():
+    state = SimpleNamespace(
+        database_config=SimpleNamespace(type="postgresql"),
+        non_interactive=False,
+        output=None,
+        ctx=Mock(),
+    )
+
+    with (
+        patch.object(_run_module, "_run_stages_through_cloud_storage", return_value=False),
+        patch.object(_run_module, "_run_requires_platform_credentials", return_value=True),
+        patch.object(_run_module, "check_and_setup_platform_credentials") as check_credentials,
+    ):
+        _run_module._interactive_cloud_setup_if_needed(state)
+
+    check_credentials.assert_not_called()
+    state.ctx.exit.assert_not_called()
+
+
 def test_interactive_guided_flow_uses_prompted_values_and_saves_preferences(tmp_path: Path):
     runner = CliRunner()
 

--- a/tests/unit/core/publishing/test_bundle_publisher_adls.py
+++ b/tests/unit/core/publishing/test_bundle_publisher_adls.py
@@ -58,3 +58,57 @@ def test_copy_to_cloud_uploads_adls_files_directly(tmp_path, monkeypatch):
     _copy_to_cloud([source], "abfss://container@account.dfs.core.windows.net/prefix")
 
     assert uploaded == [("prefix/bundle.json", b"bundle", True)]
+
+
+def test_copy_to_cloud_uses_documented_account_key_when_available(tmp_path, monkeypatch):
+    captured: dict[str, object] = {}
+
+    class NamedKeyCredential:
+        def __init__(self, account_name: str, account_key: str) -> None:
+            captured["credential"] = (account_name, account_key)
+
+    class FileClient:
+        def upload_data(self, payload: bytes, *, overwrite: bool) -> None:
+            captured["upload"] = (payload, overwrite)
+
+    class FileSystem:
+        def get_file_client(self, path: str) -> FileClient:
+            captured["path"] = path
+            return FileClient()
+
+    class Service:
+        def __init__(self, *, account_url: str, credential: object) -> None:
+            captured["account_url"] = account_url
+            captured["service_credential"] = credential
+
+        def get_file_system_client(self, container: str) -> FileSystem:
+            captured["container"] = container
+            return FileSystem()
+
+    azure = ModuleType("azure")
+    azure.__path__ = []  # type: ignore[attr-defined]
+    identity = ModuleType("azure.identity")
+    identity.DefaultAzureCredential = lambda: pytest.fail("account-key auth should not use a default credential")  # type: ignore[attr-defined]
+    core = ModuleType("azure.core")
+    core.__path__ = []  # type: ignore[attr-defined]
+    credentials = ModuleType("azure.core.credentials")
+    credentials.AzureNamedKeyCredential = NamedKeyCredential  # type: ignore[attr-defined]
+    storage = ModuleType("azure.storage")
+    storage.__path__ = []  # type: ignore[attr-defined]
+    filedatalake = ModuleType("azure.storage.filedatalake")
+    filedatalake.DataLakeServiceClient = Service  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "azure", azure)
+    monkeypatch.setitem(sys.modules, "azure.identity", identity)
+    monkeypatch.setitem(sys.modules, "azure.core", core)
+    monkeypatch.setitem(sys.modules, "azure.core.credentials", credentials)
+    monkeypatch.setitem(sys.modules, "azure.storage", storage)
+    monkeypatch.setitem(sys.modules, "azure.storage.filedatalake", filedatalake)
+    monkeypatch.setenv("AZURE_STORAGE_ACCOUNT_NAME", "account")
+    monkeypatch.setenv("AZURE_STORAGE_ACCOUNT_KEY", "account-key")
+
+    source = tmp_path / "bundle.json"
+    source.write_bytes(b"bundle")
+    _copy_to_cloud([source], "abfss://container@account.dfs.core.windows.net/prefix")
+
+    assert captured["credential"] == ("account", "account-key")
+    assert captured["account_url"] == "https://account.dfs.core.windows.net"

--- a/tests/unit/platforms/test_azure_synapse_adapter.py
+++ b/tests/unit/platforms/test_azure_synapse_adapter.py
@@ -1209,6 +1209,16 @@ class TestSynapseStagingRootAcceptsEveryAzureSpelling:
         assert adapter.container == "container"
         assert adapter.storage_account == (storage_account or "account")
 
+    def test_adls_uri_account_takes_precedence_over_explicit_account(self, synapse_stubs):
+        adapter = AzureSynapseAdapter(
+            server="myworkspace.sql.azuresynapse.net",
+            username="admin",
+            password="secret",
+            staging_root="abfss://container@uri-account.dfs.core.windows.net/benchbox",
+            storage_account="explicit-account",
+        )
+        assert adapter.storage_account == "uri-account"
+
     def test_blob_staging_root_requires_account_or_explicit_option(self, synapse_stubs):
         with pytest.raises(ValueError, match="must include a storage account"):
             AzureSynapseAdapter(

--- a/tests/unit/platforms/test_clickhouse_introspection.py
+++ b/tests/unit/platforms/test_clickhouse_introspection.py
@@ -61,6 +61,12 @@ class TestClickHouseIntrospector:
         assert kinds[KIND_SORT_KEY].columns == ("l_orderkey", "l_linenumber")
         assert kinds[KIND_PARTITION_KEY].table == "lineitem"
 
+    def test_canonicalizes_tuple_valued_partition_key(self):
+        rows = [("lineitem", "l_orderkey", "tuple(region, shard)")]
+        state = ClickHouseTuningIntrospector().introspect(_FakeCHConnection(rows), _optimize_ledger())
+        partition = next(obj for obj in state.objects if obj.kind == KIND_PARTITION_KEY)
+        assert partition.columns == ("region", "shard")
+
     def test_query_uses_structured_catalog_not_show_create(self):
         conn = _FakeCHConnection([("lineitem", "l_orderkey", "")])
         ClickHouseTuningIntrospector().introspect(conn, _optimize_ledger())

--- a/tests/unit/platforms/test_ducklake_adapter.py
+++ b/tests/unit/platforms/test_ducklake_adapter.py
@@ -550,6 +550,10 @@ class TestDuckLakeCredentialRedaction:
         assert "Failed to initialize the DuckLake catalog" in message
         assert "catalog=postgres" in message
 
+    def test_redaction_handles_keyword_shaped_text_inside_quoted_password(self):
+        message = r"""Connection Error: password="abc key=value tail\'xyz" port=5432"""
+        assert _redact_secrets(message) == "Connection Error: password=**** port=5432"
+
     def test_postgres_attach_failure_keeps_non_secret_context(self, tmp_path, monkeypatch):
         adapter = self._failing_adapter(
             tmp_path,

--- a/tests/unit/scripts/test_todo_db_standalone_compat.py
+++ b/tests/unit/scripts/test_todo_db_standalone_compat.py
@@ -298,6 +298,22 @@ def test_export_lossless_envelope_defaults_outside_the_committed_snapshot(
     assert (output_dir.parent / f"{output_dir.name}-lossless" / "todo-db.json").exists()
 
 
+def test_export_rerun_removes_legacy_in_tree_envelope(tmp_path: Path) -> None:
+    output_dir = tmp_path / "snapshot"
+    lossless_dir = tmp_path / "lossless"
+    envelope = _envelope()
+    compat._write_legacy_export(output_dir, envelope, lossless_dir)
+
+    legacy_envelope = output_dir / "todo-db.json"
+    legacy_envelope.write_text('{"legacy": true}\n', encoding="utf-8")
+    updated = {**envelope, "metadata": {"rerun": True}}
+
+    compat._write_legacy_export(output_dir, updated, lossless_dir)
+
+    assert not legacy_envelope.exists()
+    assert json.loads((lossless_dir / "todo-db.json").read_text(encoding="utf-8")) == updated
+
+
 def test_export_never_commits_findings_domain_prose(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     """The guard: findings review prose must never reach the committed snapshot.
 

--- a/tests/unit/scripts/test_todo_findings.py
+++ b/tests/unit/scripts/test_todo_findings.py
@@ -464,6 +464,7 @@ class TestSurfacingBanner:
         assert banner is not None
         assert "1 open finding(s)" in banner  # 'dismissed' is not 'open'
         assert "1 unsynced draft(s)" in banner  # README.md not counted
+        assert "todo finding list --disposition open" in banner
         assert "todo finding candidates" in banner
 
     def test_banner_open_findings_only(self, conn, tmp_path):
@@ -471,6 +472,8 @@ class TestSurfacingBanner:
         banner = todo_findings.surfacing_banner(conn, drafts_dir=tmp_path / "empty")
         assert "1 open finding(s)" in banner
         assert "draft" not in banner
+        assert "todo finding list --disposition open" in banner
+        assert "todo finding candidates" not in banner
 
     def test_banner_unsynced_drafts_only(self, conn, tmp_path):
         drafts = tmp_path / "drafts"
@@ -540,7 +543,7 @@ class TestSurfacingBanner:
         # The hint degrades to readable ASCII rather than vanishing or crashing.
         emitted = buffer.getvalue().decode("ascii")
         assert "open finding(s)" in emitted
-        assert "todo finding candidates" in emitted
+        assert "todo finding list --disposition open" in emitted
         assert "-> " in emitted  # transliterated, not "?"-replaced
         # ...and the degraded path still never touches stdout.
         assert "finding" not in capfd.readouterr().out
@@ -593,7 +596,7 @@ class TestSurfacingFlow:
         captured = capsys.readouterr()
         assert "ready-item" in captured.out
         assert "1 open finding(s)" in captured.err
-        assert "todo finding candidates" in captured.err
+        assert "todo finding list --disposition open" in captured.err
 
     def test_surfacing_flow_silent_when_nothing_untriaged(self, conn, capsys, tmp_path, monkeypatch):
         monkeypatch.setattr(todo_findings, "DEFAULT_DRAFTS_DIR", str(tmp_path / "no-drafts"))

--- a/tests/unit/workflows/test_validate_submission_changed_bundles.py
+++ b/tests/unit/workflows/test_validate_submission_changed_bundles.py
@@ -77,3 +77,39 @@ def test_applied_companion_derivation_is_deletion_aware() -> None:
     assert "CHANGED_APPLIED" in script
     assert 'bundle="${applied%.applied.json}.json"' in script
     assert 'git cat-file -e "HEAD:${bundle}"' in script
+
+
+def test_applied_companion_rename_discovers_the_source_primary_bundle(tmp_path: Path) -> None:
+    """A companion rename must validate the source primary bundle still in HEAD."""
+    _git(tmp_path, "init", "--quiet")
+    _git(tmp_path, "config", "user.name", "Test")
+    _git(tmp_path, "config", "user.email", "test@example.invalid")
+
+    primary = tmp_path / "results-data" / "bundles" / "result.json"
+    primary.parent.mkdir(parents=True)
+    primary.write_text("{}\n", encoding="utf-8")
+    applied = primary.with_name("result.applied.json")
+    applied.write_text('{"status": "passed"}\n', encoding="utf-8")
+    _git(tmp_path, "add", str(primary.relative_to(tmp_path)), str(applied.relative_to(tmp_path)))
+    _git(tmp_path, "commit", "--quiet", "-m", "base")
+    base_sha = _git(tmp_path, "rev-parse", "HEAD")
+
+    renamed = applied.with_name("renamed.applied.json")
+    applied.rename(renamed)
+    _git(tmp_path, "add", "-u", str(applied.relative_to(tmp_path)))
+    _git(tmp_path, "add", str(renamed.relative_to(tmp_path)))
+    _git(tmp_path, "commit", "--quiet", "-m", "rename-applied")
+
+    env = os.environ.copy()
+    env["BASE_SHA"] = base_sha
+    result = subprocess.run(
+        ["bash", "-c", _changed_bundle_discovery_script()],
+        cwd=tmp_path,
+        check=False,
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.strip().splitlines() == ["results-data/bundles/result.json"]


### PR DESCRIPTION
## Summary

- validate both source and destination paths for renamed bundle companions
- canonicalize ClickHouse tuple-valued partition keys
- prevent keyword-shaped text inside quoted DuckLake passwords from leaking
- direct DB-backed open findings to `todo finding list --disposition open`
- remove obsolete in-tree standalone export envelopes on rerun
- limit interactive credential setup to platforms with guided setup flows
- honor documented ADLS account-key credentials and URI-encoded account precedence

This closes the actionable follow-ups from #1334, #1333, #1331, #1325, #1327, and #1315. The #1335 identity finding was already corrected in its merged commit and was acknowledged in-thread. Late review results for #1317 were already fixed by #1334/current develop; older #1292 findings were acknowledged as separate tracked follow-ups outside this sweep.

## Verification

- `uv run -- python -m pytest tests/unit/ -x -q`
- `make pr-preflight`
- 36-PR union thread rescan: 54 threads, 0 unresolved