### PR TITLE
feat/findings lossless mapping

### DIFF
--- a/_project/scripts/todo_findings.py
+++ b/_project/scripts/todo_findings.py
@@ -153,6 +153,57 @@ DEFAULT_DRAFTS_DIR = vbs.DEFAULT_DRAFTS_DIR
 SYNCED_SUFFIX = ".synced"
 SYNCED_PRUNE_DAYS = 30
 
+# ---------------------------------------------------------------------------
+# Parser-completeness contract
+#
+# `validate_blind_spot.py` decides what a draft may CONTAIN; `parse_draft` below
+# decides what actually reaches the DB. Those two sets drifted silently: the
+# validator accepts 13 frontmatter keys and `_split_body` parses EVERY `## `
+# section, but parse_draft read 5 keys plus `evidence` and only 4 sections --
+# and `sync` still printed "synced 1". Measured over the live 65-record corpus
+# (2026-07-29): 65 of 65 records lost content this way.
+#
+# These maps make the contract explicit and TOTAL, so a NEW validator field
+# fails the guard test immediately instead of vanishing at sync time. The guard
+# in tests/unit/scripts/test_todo_findings.py derives its expectation from
+# `vbs.ALLOWED_FIELDS` itself -- never a hand-copied list, which would drift the
+# same way parse_draft already drifted.
+
+# Frontmatter keys parse_draft lands today, and where each one goes.
+FRONTMATTER_HOMES = {
+    "id": "findings.id",
+    "date": "findings.date",
+    "status": "findings.disposition",
+    "finding_kind": "findings.finding_kind",
+    "review_context": "findings.review_context",
+    "observed_sha": "findings.observed_sha",
+    "urgency": "findings.urgency",
+    "breadth": "findings.breadth",
+    "confidence": "findings.confidence",
+    "evidence": "finding_evidence rows",
+}
+
+# Validator-accepted keys with NO home in schema v3. Every entry is a named,
+# measured loss -- never a licensed omission -- and names the v4 home that will
+# take it (see "Legacy field mapping (schema v4)" in
+# _project/specs/findings-domain.md). The v4 migration empties this map; it must
+# never be used to silence a newly added field.
+FRONTMATTER_HOMES_PENDING_V4 = {
+    "related_paths": "findings.related_paths (v4 column)",
+    "suggested_sweep": "findings.suggested_sweep (v4 column)",
+    "todo_id": "finding_links row, kind by status (v4 mapping)",
+}
+
+# Body sections parse_draft lands today. Any OTHER `## ` heading has no v3 home
+# and is reported as unmapped until the v4 `finding_sections` table exists.
+SECTION_HOMES = {
+    "Finding": "findings.finding_text",
+    "Why this matters": "findings.why_matters",
+    "Suggested next steps": "findings.next_steps",
+    "Triage log": "finding_events rows",
+}
+PENDING_SECTION_HOME_V4 = "finding_sections table (v4)"
+
 # YYYY-MM-DD-HHMMSS-<kebab-slug> (matches the phase-1 validator's FILENAME_RE).
 FINDING_ID_RE = vbs.FILENAME_RE
 
@@ -264,7 +315,28 @@ def parse_draft(path: Path) -> dict[str, Any]:
         "confidence": _str_or_none(data.get("confidence")),
         "evidence": list(data.get("evidence") or []),
         "triage_log": triage_log,
+        # Content the validator accepted but that has no v3 column. Reported, not
+        # dropped: silent loss here is what made `sync` print "synced 1" over 65
+        # records that each lost content. v4 empties both lists.
+        "unmapped": unmapped_content(data, sections),
     }
+
+
+def unmapped_content(data: dict[str, Any], sections: dict[str, str]) -> dict[str, list[str]]:
+    """Validator-accepted content with no home in the current schema.
+
+    Returns ``{"frontmatter": [...], "sections": [...]}`` naming keys and `## `
+    headings that carry a value but that ``parse_draft`` cannot land. Empty lists
+    mean the draft round-trips completely. Keys present but null/empty are NOT
+    reported -- there is nothing to lose.
+    """
+    frontmatter = [
+        key for key in sorted(FRONTMATTER_HOMES_PENDING_V4) if key in data and data[key] not in (None, "", [], {})
+    ]
+    unmapped_sections = [
+        heading for heading in sorted(sections) if heading not in SECTION_HOMES and sections[heading].strip()
+    ]
+    return {"frontmatter": frontmatter, "sections": unmapped_sections}
 
 
 # ---------------------------------------------------------------------------
@@ -477,26 +549,40 @@ def sync_drafts(conn: Any, actor: str, drafts_dir: str | Path) -> dict[str, Any]
     Idempotent: an identical already-landed finding is skipped (and its draft
     marked synced). Same-id/different-content is a loud error naming the id --
     never a merge (silent data loss in an audit-trail domain).
+
+    A draft carrying validator-accepted content with no column in the current
+    schema is still inserted, but is deliberately NOT marked ``.synced``: it stays
+    in the unsynced glob so the planning banner keeps surfacing it and the file
+    survives until v4 gives that content a home. Marking it synced would hide the
+    one copy of the un-landed prose behind a rename.
     """
     drafts_dir = Path(drafts_dir).expanduser()
-    result: dict[str, Any] = {"synced": [], "skipped": [], "conflicts": [], "pruned": 0}
+    result: dict[str, Any] = {"synced": [], "skipped": [], "conflicts": [], "pruned": 0, "unmapped": {}}
     if not drafts_dir.is_dir():
         return result
     for path in sorted(drafts_dir.glob("*.md")):
         if path.name == "README.md":
             continue
         fields = parse_draft(path)
+        unmapped = fields.get("unmapped") or {}
+        lossy = bool(unmapped.get("frontmatter") or unmapped.get("sections"))
+        if lossy:
+            # Surfaced, never swallowed: the caller warns. Until v4 lands there is
+            # nowhere to put this content, so the only honest option is to say so.
+            result["unmapped"][fields["id"]] = unmapped
         existing = get_finding(conn, fields["id"])
         if existing is not None:
             if _finding_matches(existing, fields):
                 result["skipped"].append(fields["id"])
-                _mark_synced(path)
+                if not lossy:
+                    _mark_synced(path)
             else:
                 result["conflicts"].append(fields["id"])
             continue
         with todo_db._write_txn(conn):
             insert_finding(conn, actor, fields)
-        _mark_synced(path)
+        if not lossy:
+            _mark_synced(path)
         result["synced"].append(fields["id"])
     result["pruned"] = _prune_synced(drafts_dir)
     if result["conflicts"]:
@@ -872,6 +958,7 @@ def dispatch_finding(conn: Any, actor: str, args: argparse.Namespace) -> int:
             f"synced {len(result['synced'])}, skipped {len(result['skipped'])} (already landed),"
             f" pruned {result['pruned']} old .synced draft(s)"
         )
+        _warn_unmapped(result.get("unmapped") or {})
         return 0
     if command == "dismiss":
         with todo_db._write_txn(conn):
@@ -931,6 +1018,30 @@ def _cmd_triage(conn: Any, actor: str, args: argparse.Namespace) -> int:
             _set_disposition(conn, actor, args.id, args.disposition, args.reason)
     print(f"{args.id} triaged")
     return 0
+
+
+def _warn_unmapped(unmapped: dict[str, dict[str, list[str]]]) -> None:
+    """Warn on stderr about validator-accepted content with no column yet.
+
+    Stderr, so the stdout summary line stays machine-readable. Naming the ids and
+    the exact keys/headings turns what used to be a silent "synced 1" into a
+    reviewable statement of what did NOT land.
+    """
+    if not unmapped:
+        return
+    print(
+        f"warning: {len(unmapped)} draft(s) carry content with no column in schema "
+        f"{todo_db.SCHEMA_VERSION} -- it did NOT land:",
+        file=todo_db.sys.stderr,
+    )
+    for finding_id, detail in sorted(unmapped.items()):
+        lost = [*detail.get("frontmatter", []), *(f"## {h}" for h in detail.get("sections", []))]
+        print(f"  {finding_id}: {', '.join(lost)}", file=todo_db.sys.stderr)
+    print(
+        "  These drafts were left unsynced on purpose so the file survives until "
+        "schema v4 lands a home (see _project/specs/findings-domain.md).",
+        file=todo_db.sys.stderr,
+    )
 
 
 def _print_finding(finding: dict[str, Any]) -> None:

--- a/_project/scripts/todo_findings.py
+++ b/_project/scripts/todo_findings.py
@@ -1065,6 +1065,11 @@ def _print_finding(finding: dict[str, Any]) -> None:
             if evidence.get("line_end"):
                 loc += f"-{evidence['line_end']}"
         print(f"evidence: {evidence['path']}{loc} {evidence.get('pattern') or ''}".rstrip())
+        if evidence.get("note"):
+            # The note is where the reviewer said WHY the path is evidence, so
+            # hiding it from the default `show` withheld the reason for the row.
+            # Indented continuation, so a long note never crowds the locator.
+            print(f"    note: {evidence['note']}")
     for link in finding.get("links", []):
         target = link.get("target_item") or link.get("target_finding") or "(dangling)"
         print(f"link: {link['kind']} -> {target}")

--- a/_project/scripts/todo_findings.py
+++ b/_project/scripts/todo_findings.py
@@ -337,6 +337,11 @@ def parse_draft(path: Path) -> dict[str, Any]:
         "breadth": _str_or_none(data.get("breadth")),
         "confidence": _str_or_none(data.get("confidence")),
         "evidence": list(data.get("evidence") or []),
+        # Whether the draft ASSERTS an evidence list at all. An absent key means
+        # "no assertion", which is not the same as "no evidence": stored rows may
+        # have been curated at triage (or hand-mapped during an import) and must
+        # not be deleted just because the capture file never mentioned them.
+        "evidence_declared": "evidence" in data,
         "triage_log": triage_log,
         # Content the validator accepted but that has no v3 column. Reported, not
         # dropped: silent loss here is what made `sync` print "synced 1" over 65
@@ -539,6 +544,15 @@ def _normalize_evidence(entries: Any) -> list[tuple[Any, ...]]:
 
 
 def _evidence_differs(existing: dict[str, Any], fields: dict[str, Any]) -> bool:
+    """Whether a re-parsed draft's evidence disagrees with what is stored.
+
+    A draft that declares no ``evidence:`` key makes no assertion, so it never
+    counts as a difference. Treating an absent key as an empty list would let a
+    re-sync DELETE evidence rows the draft never knew about -- exactly the case of
+    a legacy record whose rows were hand-mapped at import time.
+    """
+    if not fields.get("evidence_declared"):
+        return False
     return _normalize_evidence(existing.get("evidence")) != _normalize_evidence(fields.get("evidence"))
 
 

--- a/_project/scripts/todo_findings.py
+++ b/_project/scripts/todo_findings.py
@@ -489,6 +489,76 @@ def _finding_matches(existing: dict[str, Any], fields: dict[str, Any]) -> bool:
     return True
 
 
+# Evidence-row fields compared to decide whether a re-parsed draft's evidence
+# differs from what is stored. Order is significant: the draft's list order is
+# the record, and `get_finding` reads evidence back `ORDER BY id`.
+_EVIDENCE_FIELDS = ("path", "pattern", "line_start", "line_end", "note")
+
+# Judgement fields are deliberately ABSENT from every comparison below. They are
+# DB-owned once `todo finding triage` sets them, and a draft file captured before
+# triage carries them as null -- reconciling them "from the draft" would silently
+# wipe the triage judgement on every re-sync.
+_DB_OWNED_FIELDS = ("urgency", "breadth", "confidence", "reconsider_after", "disposition_reason")
+
+
+def _normalize_evidence(entries: Any) -> list[tuple[Any, ...]]:
+    """Evidence entries as an ordered list of comparable tuples.
+
+    Normalizes the two shapes that must compare equal: parsed-draft mappings
+    (which omit absent keys) and stored rows (which carry explicit NULLs).
+    """
+    normalized: list[tuple[Any, ...]] = []
+    for entry in entries or []:
+        if not isinstance(entry, dict):
+            continue
+        normalized.append(tuple(entry.get(name) if entry.get(name) != "" else None for name in _EVIDENCE_FIELDS))
+    return normalized
+
+
+def _evidence_differs(existing: dict[str, Any], fields: dict[str, Any]) -> bool:
+    return _normalize_evidence(existing.get("evidence")) != _normalize_evidence(fields.get("evidence"))
+
+
+def _reconcile_evidence(conn: Any, actor: str, finding_id: str, fields: dict[str, Any]) -> None:
+    """Replace a finding's evidence rows with the draft's, in ONE write txn.
+
+    The draft file is authoritative for capture-owned payload, so an evidence-only
+    edit is persisted rather than silently marked synced (which lost the edit) or
+    reported as a content conflict (which the prose did not justify). The
+    before/after is recorded in ``finding_events``, so the audit trail carries the
+    change instead of the row quietly differing from its draft.
+    """
+    before = _normalize_evidence(get_finding(conn, finding_id).get("evidence"))
+    after = _normalize_evidence(fields.get("evidence"))
+    with todo_db._write_txn(conn):
+        conn.execute("DELETE FROM finding_evidence WHERE finding_id = ?", (finding_id,))
+        for entry in fields.get("evidence") or []:
+            if not isinstance(entry, dict):
+                raise todo_db.TodoError(f"finding {finding_id!r} evidence entry must be a mapping, got {entry!r}")
+            path = entry.get("path")
+            if not (isinstance(path, str) and path.strip()):
+                raise todo_db.TodoError(f"finding {finding_id!r} evidence entry needs a non-empty path")
+            conn.execute(
+                "INSERT INTO finding_evidence (finding_id, path, pattern, line_start, line_end, note)"
+                " VALUES (?, ?, ?, ?, ?, ?)",
+                (
+                    finding_id,
+                    path,
+                    entry.get("pattern"),
+                    entry.get("line_start"),
+                    entry.get("line_end"),
+                    entry.get("note"),
+                ),
+            )
+        log_finding_event(
+            conn,
+            actor,
+            finding_id,
+            "resync_evidence",
+            {"rows_before": len(before), "rows_after": len(after)},
+        )
+
+
 def _set_disposition(conn: Any, actor: str, finding_id: str, new: str, reason: str | None) -> None:
     """Apply a legal disposition transition with a conditional UPDATE (the same
     defense-in-depth as claim_item), INSIDE a caller-held write transaction."""
@@ -547,8 +617,16 @@ def sync_drafts(conn: Any, actor: str, drafts_dir: str | Path) -> dict[str, Any]
     """Insert-if-absent every draft under ``drafts_dir`` by filename-stem id.
 
     Idempotent: an identical already-landed finding is skipped (and its draft
-    marked synced). Same-id/different-content is a loud error naming the id --
+    marked synced). Same-id/different *prose* is a loud error naming the id --
     never a merge (silent data loss in an audit-trail domain).
+
+    Capture-owned payload the prose comparison does not cover -- today the
+    evidence rows -- is reconciled IN PLACE from the draft and recorded in
+    ``finding_events``. Comparing only the prose fields meant an evidence-only
+    edit was marked ``.synced`` and lost with `sync` reporting success. Judgement
+    fields (urgency/breadth/confidence/reconsider_after) are excluded from every
+    comparison: they are DB-owned once triage sets them, so reconciling them from
+    a pre-triage draft would wipe the judgement.
 
     A draft carrying validator-accepted content with no column in the current
     schema is still inserted, but is deliberately NOT marked ``.synced``: it stays
@@ -557,7 +635,14 @@ def sync_drafts(conn: Any, actor: str, drafts_dir: str | Path) -> dict[str, Any]
     one copy of the un-landed prose behind a rename.
     """
     drafts_dir = Path(drafts_dir).expanduser()
-    result: dict[str, Any] = {"synced": [], "skipped": [], "conflicts": [], "pruned": 0, "unmapped": {}}
+    result: dict[str, Any] = {
+        "synced": [],
+        "updated": [],
+        "skipped": [],
+        "conflicts": [],
+        "pruned": 0,
+        "unmapped": {},
+    }
     if not drafts_dir.is_dir():
         return result
     for path in sorted(drafts_dir.glob("*.md")):
@@ -572,12 +657,19 @@ def sync_drafts(conn: Any, actor: str, drafts_dir: str | Path) -> dict[str, Any]
             result["unmapped"][fields["id"]] = unmapped
         existing = get_finding(conn, fields["id"])
         if existing is not None:
-            if _finding_matches(existing, fields):
-                result["skipped"].append(fields["id"])
-                if not lossy:
-                    _mark_synced(path)
-            else:
+            if not _finding_matches(existing, fields):
+                # Prose disagreement is still a loud conflict, never a merge.
                 result["conflicts"].append(fields["id"])
+                continue
+            if _evidence_differs(existing, fields):
+                # Capture-owned payload the old comparison ignored entirely: the
+                # draft used to be marked .synced and the edit lost silently.
+                _reconcile_evidence(conn, actor, fields["id"], fields)
+                result["updated"].append(fields["id"])
+            else:
+                result["skipped"].append(fields["id"])
+            if not lossy:
+                _mark_synced(path)
             continue
         with todo_db._write_txn(conn):
             insert_finding(conn, actor, fields)
@@ -955,7 +1047,8 @@ def dispatch_finding(conn: Any, actor: str, args: argparse.Namespace) -> int:
     if command == "sync":
         result = sync_drafts(conn, actor, args.drafts_dir)
         print(
-            f"synced {len(result['synced'])}, skipped {len(result['skipped'])} (already landed),"
+            f"synced {len(result['synced'])}, updated {len(result['updated'])} (evidence reconciled),"
+            f" skipped {len(result['skipped'])} (already landed),"
             f" pruned {result['pruned']} old .synced draft(s)"
         )
         _warn_unmapped(result.get("unmapped") or {})

--- a/_project/scripts/todo_findings.py
+++ b/_project/scripts/todo_findings.py
@@ -556,16 +556,19 @@ def _evidence_differs(existing: dict[str, Any], fields: dict[str, Any]) -> bool:
     return _normalize_evidence(existing.get("evidence")) != _normalize_evidence(fields.get("evidence"))
 
 
-def _reconcile_evidence(conn: Any, actor: str, finding_id: str, fields: dict[str, Any]) -> None:
+def _reconcile_evidence(conn: Any, actor: str, existing: dict[str, Any], fields: dict[str, Any]) -> None:
     """Replace a finding's evidence rows with the draft's, in ONE write txn.
 
     The draft file is authoritative for capture-owned payload, so an evidence-only
     edit is persisted rather than silently marked synced (which lost the edit) or
     reported as a content conflict (which the prose did not justify). The
     before/after is recorded in ``finding_events``, so the audit trail carries the
-    change instead of the row quietly differing from its draft.
+    change instead of the row quietly differing from its draft. ``existing`` is the
+    row the caller already fetched -- re-reading it here would cost an extra hosted
+    round-trip for no new information.
     """
-    before = _normalize_evidence(get_finding(conn, finding_id).get("evidence"))
+    finding_id = str(existing["id"])
+    before = _normalize_evidence(existing.get("evidence"))
     after = _normalize_evidence(fields.get("evidence"))
     with todo_db._write_txn(conn):
         conn.execute("DELETE FROM finding_evidence WHERE finding_id = ?", (finding_id,))
@@ -701,7 +704,7 @@ def sync_drafts(conn: Any, actor: str, drafts_dir: str | Path) -> dict[str, Any]
             if _evidence_differs(existing, fields):
                 # Capture-owned payload the old comparison ignored entirely: the
                 # draft used to be marked .synced and the edit lost silently.
-                _reconcile_evidence(conn, actor, fields["id"], fields)
+                _reconcile_evidence(conn, actor, existing, fields)
                 result["updated"].append(fields["id"])
             else:
                 result["skipped"].append(fields["id"])

--- a/_project/scripts/todo_findings.py
+++ b/_project/scripts/todo_findings.py
@@ -26,6 +26,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
 import re
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
@@ -152,6 +153,28 @@ STATUS_TO_DISPOSITION = {
 DEFAULT_DRAFTS_DIR = vbs.DEFAULT_DRAFTS_DIR
 SYNCED_SUFFIX = ".synced"
 SYNCED_PRUNE_DAYS = 30
+
+# Bridge to the standalone todo-db drafts convention. BenchBox binds drafts to
+# ~/.benchbox/finding-drafts/ while the standalone CLI defaults to
+# ~/.todo-db/finding-drafts/<project-id>/. Those diverge silently, not loudly:
+# at cutover `sync` reports "synced 0" and the banner counts zero unsynced
+# drafts while a real draft sits stranded in the BenchBox directory. Honouring
+# one env var in BOTH tools means the bound directory can be pinned once and
+# every surface -- create, candidates, sync, and the planning banner -- agrees.
+# The frontmatter schemas are already compatible; only the location diverged.
+DRAFTS_DIR_ENV = "TODO_DB_FINDING_DRAFTS_DIR"
+
+
+def resolve_drafts_dir() -> str:
+    """The drafts directory every findings surface should use.
+
+    ``TODO_DB_FINDING_DRAFTS_DIR`` wins when set and non-empty, so the same pin
+    works before and after the standalone cutover; otherwise the BenchBox default.
+    Reads the module global as its fallback (not a bound copy) so tests that
+    override ``DEFAULT_DRAFTS_DIR`` keep working.
+    """
+    return os.environ.get(DRAFTS_DIR_ENV) or DEFAULT_DRAFTS_DIR
+
 
 # ---------------------------------------------------------------------------
 # Parser-completeness contract
@@ -686,13 +709,13 @@ def sync_drafts(conn: Any, actor: str, drafts_dir: str | Path) -> dict[str, Any]
     return result
 
 
-def count_unsynced_drafts(drafts_dir: str | Path = DEFAULT_DRAFTS_DIR) -> int:
+def count_unsynced_drafts(drafts_dir: str | Path | None = None) -> int:
     """Local directory glob of unsynced drafts -- no credentials, no network.
 
     A draft is 'unsynced' until ``sync`` renames it to ``*.md.synced``; this is
     the count the phase-4 ``todo ready`` / ``todo stats`` banner shows.
     """
-    directory = Path(drafts_dir).expanduser()
+    directory = Path(drafts_dir if drafts_dir is not None else resolve_drafts_dir()).expanduser()
     if not directory.is_dir():
         return 0
     return sum(1 for p in directory.glob("*.md") if p.name != "README.md")
@@ -728,7 +751,7 @@ def surfacing_banner(conn, drafts_dir: str | Path | None = None, open_count: int
     aggregate entirely.
     """
     if drafts_dir is None:
-        drafts_dir = DEFAULT_DRAFTS_DIR
+        drafts_dir = resolve_drafts_dir()
     if open_count is None:
         open_count = open_findings_count(conn)
     draft_count = count_unsynced_drafts(drafts_dir)
@@ -963,10 +986,10 @@ def add_finding_subparsers(parser: argparse.ArgumentParser) -> None:
     p.add_argument("--why", help="## Why this matters body text")
     p.add_argument("--next-steps", dest="next_steps", help="## Suggested next steps body text")
     p.add_argument("--observed-sha", help="provenance SHA (not a lookup key)")
-    p.add_argument("--drafts-dir", default=DEFAULT_DRAFTS_DIR)
+    p.add_argument("--drafts-dir", default=resolve_drafts_dir())
 
     p = sub.add_parser("candidates", help="list unsynced drafts (local glob, zero-credential)")
-    p.add_argument("--drafts-dir", default=DEFAULT_DRAFTS_DIR)
+    p.add_argument("--drafts-dir", default=resolve_drafts_dir())
 
     p = sub.add_parser("list", help="list findings")
     p.add_argument("--disposition", choices=DISPOSITIONS)
@@ -977,7 +1000,7 @@ def add_finding_subparsers(parser: argparse.ArgumentParser) -> None:
     p.add_argument("--json", action="store_true")
 
     p = sub.add_parser("sync", help="land drafts into the tracker (authorized landing step)")
-    p.add_argument("--drafts-dir", default=DEFAULT_DRAFTS_DIR)
+    p.add_argument("--drafts-dir", default=resolve_drafts_dir())
 
     p = sub.add_parser("dismiss", help="dismiss a finding with a reason")
     p.add_argument("id")

--- a/_project/specs/findings-domain.md
+++ b/_project/specs/findings-domain.md
@@ -118,6 +118,78 @@ so the `SCHEMA_VERSION` 2 → 3 migration is accepted against the live
 > until it runs, every collaborator's CLI is inert against the live DB. Land
 > the code and run the hosted migration together.
 
+## Legacy field mapping (schema v4)
+
+Phase 3 shipped a home for the fields `todo finding create` writes, not for
+every field `validate_blind_spot.py` *accepts*. The gap is not theoretical:
+measured over the live 65-record corpus (2026-07-29), **65 of 65** records lose
+content when pushed through `parse_draft` — `related_paths` (170 path entries),
+`suggested_sweep` (11,559 chars), `todo_id` (36 records; no column existed), and
+8 stray `## ` sections (5,779 chars, including seven "why the review missed it"
+meta-analysis sections). `sync` reported success throughout. Because phase 5
+pushes the whole corpus through this parser and phase 6 then deletes the tracked
+originals, the mapping below is a **precondition of phase 5**, and
+`SCHEMA_VERSION` 3 → 4 adds the missing homes.
+
+Every field the validator accepts, and every body section it permits, has
+exactly one home. This table is the parity gate's reference: an entry with no
+home is a bug in this table, not a licensed omission.
+
+| Capture field | v4 home | Notes |
+| --- | --- | --- |
+| `id` | `findings.id` | = filename stem, regex-enforced |
+| `date` | `findings.date` | |
+| `status` | `findings.disposition` | via `STATUS_TO_DISPOSITION` |
+| `finding_kind` | `findings.finding_kind` | |
+| `review_context` | `findings.review_context` | |
+| `observed_sha` | `findings.observed_sha` | provenance, not a lookup key |
+| `urgency`, `breadth`, `confidence` | same-named nullable columns | set at triage |
+| `evidence[]` | `finding_evidence` rows | one row per entry, insertion-ordered |
+| `related_paths[]` | **`findings.related_paths`** (new) | JSON array TEXT; `NULL` when absent |
+| `suggested_sweep` | **`findings.suggested_sweep`** (new) | TEXT, one line (validator-enforced) |
+| `todo_id` | **`finding_links` row** (new mapping) | kind by status — see below |
+| `# <title>` | `findings.title` | |
+| `## Finding` | `findings.finding_text` | verbatim |
+| `## Why this matters` | `findings.why_matters` | verbatim |
+| `## Suggested next steps` | `findings.next_steps` | verbatim |
+| `## Triage log` | `finding_events` rows | one row per line, `action='imported_triage_log'` |
+| any other `## ` section | **`finding_sections`** (new table) | `(finding_id, position, heading, text)` |
+
+`findings.reconsider_after`, `disposition_reason`, `created_at` and
+`imported_from` are DB-side only — they have no capture-format counterpart and
+are therefore outside the parity gate.
+
+**Why explicit columns and not evidence rows.** `related_paths` and
+`suggested_sweep` must *not* be folded into `finding_evidence`: a
+`related_paths`-derived row and a genuine `evidence` entry are
+indistinguishable on the way back out (both are a bare `path` with no
+`pattern`), so the round-trip is lossy without a discriminator column. Explicit
+columns make the round-trip exact and keep the parity gate's promise of
+*field-level* preservation, which free text cannot satisfy. `finding_sections`
+is a table rather than four more columns because it subsumes the problem class —
+any future heading lands losslessly without a further migration.
+
+**`todo_id` → link kind.** The 36 records split by `status`, and the kind must
+follow, because a `promoted-to` edge asserts the finding's disposition is
+`promoted`:
+
+| `status` | Records | Link kind | Rationale |
+| --- | --- | --- | --- |
+| `merged-to-todo` | 32 | `promoted-to` | disposition maps to `promoted`; the edge is accurate |
+| `actioned` | 4 | `resolved-by` | disposition is `actioned`; `promoted-to` would misstate history and break the promote invariant |
+
+Both kinds are already in the `finding_links.kind` CHECK, so this mapping needs
+**no table rebuild**. A new kind would force one, which is why none is added.
+
+**Parity criterion (falsifiable).** For every record in the import set, a
+round-trip through the importer and back out of the DB reproduces: every
+accepted frontmatter key with its value and, for lists, its order; every body
+section's text byte-for-byte under its original heading; and each `## Triage
+log` line as one `finding_events` row. The check is mechanical — the phase-5
+parity report emits a per-record field diff plus counts of **unmapped keys** and
+**unmapped sections**, and both counts must be zero. A record whose key has no
+row in the table above fails the gate.
+
 ## CLI (phase 3)
 
 `todo finding create | list | show | candidates | dismiss | triage | link |
@@ -191,10 +263,21 @@ written, since triage history is free-text `## Triage log` prose):
   `finding_events` row, `action = 'imported_triage_log'`, prose intact.
 - **Status map**: `open→open`, `actionable→actionable`, `actioned→actioned`,
   `dismissed→dismissed`, `merged-to-todo→promoted`.
-- **Dangling `todo_id` policy**: drop semantics reserve ids forever and
-  YAML-era ids may not exist, so resolve each `todo_id` against the live DB;
-  danglers import as `finding_links(kind='promoted-to', target_item=NULL)` plus
-  a note, and the parity report counts them explicitly.
+- **Field-level parity**: every accepted frontmatter key and every `## `
+  section round-trips per [Legacy field mapping](#legacy-field-mapping-schema-v4),
+  with zero unmapped keys and zero unmapped sections. This makes v4 a hard
+  precondition of this phase.
+- **`todo_id` policy**: resolve each `todo_id` against the live DB and map it to
+  a `finding_links` row whose kind follows the record's `status` (see the
+  mapping section). `finding_links.target_item` is a real FK, so a `todo_id`
+  naming a missing item **fails the insert** — the pre-flight is mandatory and
+  missing targets are **reported, not silently skipped**.
+  Drop semantics reserve ids forever and YAML-era ids may not exist, so
+  danglers remain possible in principle: they import as
+  `finding_links(target_item=NULL)` plus a note, and the parity report counts
+  them explicitly. **Measured 2026-07-29: zero danglers** — all 19 unique
+  `todo_id` values across the 36 records resolve to live items, so the counter
+  is expected to read zero and a non-zero count means the corpus changed.
 
 Process: dry-run into a scratch DB first, produce a machine-checkable parity
 report (all-records-imported count, per-record field diff, dangling-link

--- a/tests/unit/scripts/test_todo_findings.py
+++ b/tests/unit/scripts/test_todo_findings.py
@@ -605,3 +605,141 @@ class TestSurfacingFlow:
         captured = capsys.readouterr()
         assert "ready-item" in captured.out
         assert "finding" not in captured.err  # zero-state: no banner
+
+
+# ---------------------------------------------------------------------------
+# Parser-completeness guard (findings-parser-completeness-guard)
+#
+# The root cause of the silent-loss class: `validate_blind_spot.py` decides what a
+# draft may contain, `parse_draft` decides what reaches the DB, and nothing
+# compared the two. Measured over the live 65-record corpus (2026-07-29), 65 of 65
+# records lost content while `sync` printed "synced 1".
+#
+# Every expectation below is derived from the validator's OWN constants. A
+# hand-copied field list would drift exactly the way parse_draft drifted, which is
+# the defect under test.
+
+vbs = importlib.import_module("validate_blind_spot")
+
+
+class TestParserCompletenessGuard:
+    def test_every_accepted_frontmatter_key_has_a_declared_home(self):
+        declared = set(todo_findings.FRONTMATTER_HOMES) | set(todo_findings.FRONTMATTER_HOMES_PENDING_V4)
+        undeclared = vbs.ALLOWED_FIELDS - declared
+        assert not undeclared, (
+            f"validator accepts {sorted(undeclared)} with no entry in FRONTMATTER_HOMES or "
+            "FRONTMATTER_HOMES_PENDING_V4 -- add a home, or name it pending with its v4 target. "
+            "An undeclared field is silently dropped at sync time."
+        )
+
+    def test_no_declared_home_for_a_field_the_validator_rejects(self):
+        # The other direction: a home for a field the validator will never accept is
+        # dead weight that misleads the next reader about what can arrive.
+        declared = set(todo_findings.FRONTMATTER_HOMES) | set(todo_findings.FRONTMATTER_HOMES_PENDING_V4)
+        assert not (declared - vbs.ALLOWED_FIELDS)
+
+    def test_pending_set_is_exactly_the_known_v3_gap(self):
+        # Pins the measured gap so v4 must EMPTY this set deliberately rather than
+        # a future field quietly joining it.
+        assert set(todo_findings.FRONTMATTER_HOMES_PENDING_V4) == {
+            "related_paths",
+            "suggested_sweep",
+            "todo_id",
+        }
+
+    def test_declared_section_homes_cover_the_required_headings(self):
+        required = {heading.removeprefix("## ") for heading in vbs.REQUIRED_BODY_HEADINGS}
+        assert required <= set(todo_findings.SECTION_HOMES)
+
+    def test_guard_fails_closed_on_a_new_validator_field(self, monkeypatch):
+        # Proves the guard actually fails rather than merely passing today: add a
+        # field to the validator's accepted set and the completeness check must break.
+        monkeypatch.setattr(vbs, "ALLOWED_FIELDS", vbs.ALLOWED_FIELDS | {"newly_added_field"})
+        declared = set(todo_findings.FRONTMATTER_HOMES) | set(todo_findings.FRONTMATTER_HOMES_PENDING_V4)
+        assert vbs.ALLOWED_FIELDS - declared == {"newly_added_field"}
+
+
+class TestUnmappedContentIsReported:
+    def test_parse_draft_reports_unmapped_frontmatter_and_sections(self, tmp_path):
+        stem = "2026-01-02-030405-legacy-shaped-record"
+        (tmp_path / f"{stem}.md").write_text(
+            "---\n"
+            f"id: {stem}\n"
+            "date: 2026-01-02\n"
+            "status: open\n"
+            "finding_kind: framework-gap\n"
+            'review_context: "ultrareview X"\n'
+            "related_paths:\n  - benchbox/core/thing.py\n"
+            "suggested_sweep: rg -n 'thing' benchbox/\n"
+            "---\n\n"
+            "# A legacy-shaped record\n\n"
+            "## Finding\nthe review never checks axis Y\n\n"
+            "## Why this matters\naxis Y is a whole dimension\n\n"
+            "## Suggested next steps\n- [ ] add a gate\n\n"
+            "## Why the five-axis review missed it\nthe rubric had no axis for it\n",
+            encoding="utf-8",
+        )
+        fields = todo_findings.parse_draft(tmp_path / f"{stem}.md")
+        assert fields["unmapped"]["frontmatter"] == ["related_paths", "suggested_sweep"]
+        assert fields["unmapped"]["sections"] == ["Why the five-axis review missed it"]
+
+    def test_clean_draft_reports_nothing_unmapped(self, tmp_path):
+        path = _draft(tmp_path / "d", "2026-01-02-030405-a-clean-record")
+        fields = todo_findings.parse_draft(path)
+        assert fields["unmapped"] == {"frontmatter": [], "sections": []}
+
+    def test_empty_optional_keys_are_not_reported_as_loss(self, tmp_path):
+        # A key present but null carries nothing, so reporting it would be noise.
+        stem = "2026-01-02-030405-null-optionals"
+        (tmp_path / f"{stem}.md").write_text(
+            "---\n"
+            f"id: {stem}\n"
+            "date: 2026-01-02\n"
+            "status: open\n"
+            "finding_kind: framework-gap\n"
+            'review_context: "ultrareview X"\n'
+            "related_paths:\n"
+            "suggested_sweep:\n"
+            "todo_id:\n"
+            "---\n\n"
+            "# Null optionals\n\n"
+            "## Finding\nf\n\n## Why this matters\nw\n\n## Suggested next steps\n- [ ] s\n",
+            encoding="utf-8",
+        )
+        fields = todo_findings.parse_draft(tmp_path / f"{stem}.md")
+        assert fields["unmapped"] == {"frontmatter": [], "sections": []}
+
+    def test_sync_warns_and_leaves_a_lossy_draft_unsynced(self, conn, tmp_path, capsys):
+        stem = "2026-01-02-030405-lossy-record"
+        (tmp_path / f"{stem}.md").write_text(
+            "---\n"
+            f"id: {stem}\n"
+            "date: 2026-01-02\n"
+            "status: open\n"
+            "finding_kind: framework-gap\n"
+            'review_context: "ultrareview X"\n'
+            "suggested_sweep: rg -n 'thing' benchbox/\n"
+            "---\n\n"
+            "# Lossy record\n\n"
+            "## Finding\nf\n\n## Why this matters\nw\n\n## Suggested next steps\n- [ ] s\n",
+            encoding="utf-8",
+        )
+        result = todo_findings.sync_drafts(conn, "tester", tmp_path)
+        assert result["synced"] == [stem]
+        assert result["unmapped"][stem]["frontmatter"] == ["suggested_sweep"]
+        # The row landed, but the file stays visible: it holds the only copy of the
+        # prose that did not land, so hiding it behind a .synced rename would be the
+        # silent loss this guard exists to stop.
+        assert (tmp_path / f"{stem}.md").exists()
+        assert not (tmp_path / f"{stem}.md.synced").exists()
+        assert todo_findings.count_unsynced_drafts(tmp_path) == 1
+        todo_findings._warn_unmapped(result["unmapped"])
+        assert "did NOT land" in capsys.readouterr().err
+
+    def test_sync_marks_a_clean_draft_synced_as_before(self, conn, tmp_path):
+        path = _draft(tmp_path / "d", "2026-01-02-030405-a-clean-record")
+        result = todo_findings.sync_drafts(conn, "tester", tmp_path)
+        assert result["synced"] == ["2026-01-02-030405-a-clean-record"]
+        assert result["unmapped"] == {}
+        assert not path.exists()
+        assert path.with_name(path.name + ".synced").exists()

--- a/tests/unit/scripts/test_todo_findings.py
+++ b/tests/unit/scripts/test_todo_findings.py
@@ -743,3 +743,31 @@ class TestUnmappedContentIsReported:
         assert result["unmapped"] == {}
         assert not path.exists()
         assert path.with_name(path.name + ".synced").exists()
+
+
+class TestShowRendersEvidenceNote:
+    """`show --json` always carried evidence `note`; the human rendering dropped it,
+    so the default `todo finding show` hid the reviewer's reason for each row."""
+
+    def _finding_with_evidence(self, conn, evidence):
+        fid = _mk_finding(conn, evidence=evidence)
+        return todo_findings.get_finding(conn, fid)
+
+    def test_note_reaches_human_output(self, conn, capsys):
+        finding = self._finding_with_evidence(
+            conn, [{"path": "benchbox/core/thing.py", "pattern": "def thing", "note": "only the SQL path is guarded"}]
+        )
+        todo_findings._print_finding(finding)
+        out = capsys.readouterr().out
+        assert "evidence: benchbox/core/thing.py def thing" in out
+        assert "note: only the SQL path is guarded" in out
+
+    def test_note_less_evidence_row_renders_as_before(self, conn, capsys):
+        finding = self._finding_with_evidence(conn, [{"path": "benchbox/core/thing.py", "pattern": "def thing"}])
+        todo_findings._print_finding(finding)
+        lines = [line for line in capsys.readouterr().out.splitlines() if "thing.py" in line or "note:" in line]
+        assert lines == ["evidence: benchbox/core/thing.py def thing"]
+
+    def test_json_payload_is_unchanged_and_already_included_the_note(self, conn):
+        finding = self._finding_with_evidence(conn, [{"path": "p.py", "pattern": None, "note": "why p matters"}])
+        assert finding["evidence"][0]["note"] == "why p matters"

--- a/tests/unit/scripts/test_todo_findings.py
+++ b/tests/unit/scripts/test_todo_findings.py
@@ -901,3 +901,58 @@ class TestDraftsDirBridge:
         banner = todo_findings.surfacing_banner(conn)
         assert banner is not None
         assert "1 unsynced draft(s)" in banner
+
+
+class TestEvidenceReconcileIsNotDestructive:
+    """A draft with no `evidence:` key makes no assertion about evidence. Treating
+    that as an empty list would delete rows curated at triage or hand-mapped during
+    an import — the live record 2026-07-18-190500-evidence-tree-sha-provenance-mismatch
+    has exactly that shape: no key in the file, three rows in the DB."""
+
+    def test_absent_evidence_key_never_deletes_stored_rows(self, conn, tmp_path):
+        stem = "2026-01-02-030405-hand-mapped-record"
+        fid = _mk_finding(
+            conn,
+            finding_id=stem,
+            title="A sample class",
+            review_context="ultrareview X",
+            why_matters="axis Y is a whole dimension",
+            evidence=[{"path": "a.py", "note": "hand-mapped from related_paths"}],
+        )
+        # A draft file that carries no `evidence:` key at all.
+        _draft(tmp_path / "d", stem)
+
+        result = todo_findings.sync_drafts(conn, "tester", tmp_path)
+        assert result["updated"] == []
+        assert result["skipped"] == [fid]
+        stored = todo_findings.get_finding(conn, fid)["evidence"]
+        assert [(row["path"], row["note"]) for row in stored] == [("a.py", "hand-mapped from related_paths")]
+
+    def test_explicitly_empty_evidence_list_does_clear_stored_rows(self, conn, tmp_path):
+        # An explicit `evidence: []` IS an assertion, so it is honoured.
+        stem = "2026-01-02-030405-explicitly-cleared"
+        _mk_finding(
+            conn,
+            finding_id=stem,
+            review_context="ultrareview X",
+            why_matters="axis Y is a whole dimension",
+            evidence=[{"path": "a.py"}],
+        )
+        (tmp_path / f"{stem}.md").write_text(
+            "---\n"
+            f"id: {stem}\n"
+            "date: 2026-01-02\n"
+            "status: open\n"
+            "finding_kind: framework-gap\n"
+            'review_context: "ultrareview X"\n'
+            "evidence: []\n"
+            "---\n\n"
+            "# A sample blind-spot class\n\n"
+            "## Finding\nthe review never checks axis Y\n\n"
+            "## Why this matters\naxis Y is a whole dimension\n\n"
+            "## Suggested next steps\n- [ ] add a gate for axis Y\n",
+            encoding="utf-8",
+        )
+        result = todo_findings.sync_drafts(conn, "tester", tmp_path)
+        assert result["updated"] == [stem]
+        assert todo_findings.get_finding(conn, stem)["evidence"] == []

--- a/tests/unit/scripts/test_todo_findings.py
+++ b/tests/unit/scripts/test_todo_findings.py
@@ -771,3 +771,97 @@ class TestShowRendersEvidenceNote:
     def test_json_payload_is_unchanged_and_already_included_the_note(self, conn):
         finding = self._finding_with_evidence(conn, [{"path": "p.py", "pattern": None, "note": "why p matters"}])
         assert finding["evidence"][0]["note"] == "why p matters"
+
+
+class TestSyncFullPayloadComparison:
+    """`_finding_matches` compared only `_CONTENT_FIELDS`, so an evidence-only draft
+    edit was marked `.synced` and lost while `sync` printed success."""
+
+    def _write(self, directory: Path, stem: str, *, evidence_block: str = "", extra_front: str = ""):
+        directory.mkdir(parents=True, exist_ok=True)
+        (directory / f"{stem}.md").write_text(
+            "---\n"
+            f"id: {stem}\n"
+            "date: 2026-01-02\n"
+            "status: open\n"
+            "finding_kind: framework-gap\n"
+            'review_context: "ultrareview X"\n'
+            f"{extra_front}{evidence_block}"
+            "---\n\n"
+            "# A sample class\n\n"
+            "## Finding\nthe review never checks axis Y\n\n"
+            "## Why this matters\naxis Y is a whole dimension\n\n"
+            "## Suggested next steps\n- [ ] add a gate for axis Y\n",
+            encoding="utf-8",
+        )
+        return directory / f"{stem}.md"
+
+    def test_evidence_only_edit_is_persisted_not_silently_synced(self, conn, tmp_path):
+        stem = "2026-01-02-030405-evidence-edited"
+        path = self._write(tmp_path, stem, evidence_block="evidence:\n  - path: a.py\n    note: first\n")
+        assert todo_findings.sync_drafts(conn, "tester", tmp_path)["synced"] == [stem]
+
+        # Edit only the evidence, then re-sync from the same drafts directory.
+        path.with_name(path.name + ".synced").rename(path)
+        self._write(tmp_path, stem, evidence_block="evidence:\n  - path: a.py\n    note: SECOND\n  - path: b.py\n")
+        result = todo_findings.sync_drafts(conn, "tester", tmp_path)
+
+        assert result["updated"] == [stem]
+        assert result["conflicts"] == []
+        stored = todo_findings.get_finding(conn, stem)["evidence"]
+        assert [(row["path"], row["note"]) for row in stored] == [("a.py", "SECOND"), ("b.py", None)]
+
+    def test_evidence_reconcile_is_recorded_in_finding_events(self, conn, tmp_path):
+        stem = "2026-01-02-030405-evidence-audited"
+        path = self._write(tmp_path, stem, evidence_block="evidence:\n  - path: a.py\n")
+        todo_findings.sync_drafts(conn, "tester", tmp_path)
+        path.with_name(path.name + ".synced").rename(path)
+        self._write(tmp_path, stem, evidence_block="evidence:\n  - path: a.py\n  - path: b.py\n")
+        todo_findings.sync_drafts(conn, "tester", tmp_path)
+
+        actions = [event["action"] for event in todo_findings.get_finding(conn, stem)["events"]]
+        assert "resync_evidence" in actions
+        detail = json.loads(
+            next(
+                e["detail"] for e in todo_findings.get_finding(conn, stem)["events"] if e["action"] == "resync_evidence"
+            )
+        )
+        assert detail == {"rows_before": 1, "rows_after": 2}
+
+    def test_unchanged_draft_is_still_skipped_and_marked_synced(self, conn, tmp_path):
+        stem = "2026-01-02-030405-unchanged-record"
+        path = self._write(tmp_path, stem, evidence_block="evidence:\n  - path: a.py\n    note: same\n")
+        todo_findings.sync_drafts(conn, "tester", tmp_path)
+        path.with_name(path.name + ".synced").rename(path)
+
+        result = todo_findings.sync_drafts(conn, "tester", tmp_path)
+        assert result["skipped"] == [stem]
+        assert result["updated"] == []
+        assert path.with_name(path.name + ".synced").exists()
+
+    def test_prose_difference_is_still_a_loud_conflict(self, conn, tmp_path):
+        stem = "2026-01-02-030405-prose-changed"
+        path = self._write(tmp_path, stem)
+        todo_findings.sync_drafts(conn, "tester", tmp_path)
+        path.with_name(path.name + ".synced").rename(path)
+        path.write_text(path.read_text(encoding="utf-8").replace("axis Y", "axis Z"), encoding="utf-8")
+
+        with pytest.raises(todo_db.TodoError, match="sync conflict"):
+            todo_findings.sync_drafts(conn, "tester", tmp_path)
+
+    def test_triage_judgement_survives_a_resync(self, conn, tmp_path):
+        # The draft predates triage and carries no urgency; reconciling judgement
+        # fields "from the draft" would wipe what triage recorded.
+        stem = "2026-01-02-030405-triaged-record"
+        path = self._write(tmp_path, stem, evidence_block="evidence:\n  - path: a.py\n")
+        todo_findings.sync_drafts(conn, "tester", tmp_path)
+        with todo_db._write_txn(conn):
+            conn.execute("UPDATE findings SET urgency = 'high', breadth = 'wide' WHERE id = ?", (stem,))
+
+        path.with_name(path.name + ".synced").rename(path)
+        self._write(tmp_path, stem, evidence_block="evidence:\n  - path: a.py\n  - path: b.py\n")
+        todo_findings.sync_drafts(conn, "tester", tmp_path)
+
+        stored = todo_findings.get_finding(conn, stem)
+        assert (stored["urgency"], stored["breadth"]) == ("high", "wide")
+        assert len(stored["evidence"]) == 2

--- a/tests/unit/scripts/test_todo_findings.py
+++ b/tests/unit/scripts/test_todo_findings.py
@@ -865,3 +865,39 @@ class TestSyncFullPayloadComparison:
         stored = todo_findings.get_finding(conn, stem)
         assert (stored["urgency"], stored["breadth"]) == ("high", "wide")
         assert len(stored["evidence"]) == 2
+
+
+class TestDraftsDirBridge:
+    """BenchBox binds drafts to ~/.benchbox/finding-drafts/ while the standalone
+    todo-db defaults to ~/.todo-db/finding-drafts/<project-id>/. The divergence is
+    silent — `sync` reports "synced 0" and the banner counts zero while a real draft
+    sits stranded — so one env var has to bind every surface."""
+
+    def test_env_var_wins_over_the_benchbox_default(self, monkeypatch, tmp_path):
+        monkeypatch.setenv(todo_findings.DRAFTS_DIR_ENV, str(tmp_path / "pinned"))
+        assert todo_findings.resolve_drafts_dir() == str(tmp_path / "pinned")
+
+    def test_falls_back_to_the_benchbox_default_when_unset(self, monkeypatch):
+        monkeypatch.delenv(todo_findings.DRAFTS_DIR_ENV, raising=False)
+        assert todo_findings.resolve_drafts_dir() == todo_findings.DEFAULT_DRAFTS_DIR
+
+    def test_empty_env_var_is_ignored(self, monkeypatch):
+        # An exported-but-empty var must not resolve drafts to the process cwd.
+        monkeypatch.setenv(todo_findings.DRAFTS_DIR_ENV, "")
+        assert todo_findings.resolve_drafts_dir() == todo_findings.DEFAULT_DRAFTS_DIR
+
+    def test_a_stranded_draft_becomes_visible_to_the_pinned_dir(self, monkeypatch, tmp_path):
+        # The item's own scenario: a real draft in the bound directory must be
+        # counted, not silently missed.
+        drafts = tmp_path / "benchbox-drafts"
+        _draft(drafts / "d", "2026-07-24-150447-guards-only-cover-configured-root")
+        monkeypatch.setenv(todo_findings.DRAFTS_DIR_ENV, str(drafts))
+        assert todo_findings.count_unsynced_drafts() == 1
+
+    def test_banner_follows_the_pinned_dir(self, conn, monkeypatch, tmp_path):
+        drafts = tmp_path / "pinned-drafts"
+        _draft(drafts / "d", "2026-07-24-150447-guards-only-cover-configured-root")
+        monkeypatch.setenv(todo_findings.DRAFTS_DIR_ENV, str(drafts))
+        banner = todo_findings.surfacing_banner(conn)
+        assert banner is not None
+        assert "1 unsynced draft(s)" in banner


### PR DESCRIPTION
- **docs(findings): document the v4 lossless mapping for legacy capture fields**
- **fix(tracker): make the findings parser's field contract total and fail-closed**
- **fix(tracker): show evidence notes in `todo finding show` human output**
- **fix(tracker): reconcile evidence on sync instead of losing the edit silently**
- **fix(tracker): bind the findings drafts dir through TODO_DB_FINDING_DRAFTS_DIR**
- **fix(tracker): never delete stored evidence a draft does not mention**
- **perf(tracker): reuse the fetched finding row in the evidence reconcile**
