### PR TITLE
docs(explorer): sync browser schema doc with the built DDL, and pin it there

### DIFF
--- a/docs/development/browser-duckdb-schema.sql
+++ b/docs/development/browser-duckdb-schema.sql
@@ -74,6 +74,19 @@ CREATE TABLE IF NOT EXISTS results (
     execution_mode       VARCHAR,
     tuning_mode          VARCHAR,
     tuning_hash          VARCHAR,
+    -- ADR-1 bundle-emitted tuning identities (display-only, never a join/dedup
+    -- key): canonical requested-config hash and the physical applied-ledger
+    -- hash. NULL for legacy bundles.
+    requested_config_hash VARCHAR,
+    applied_ledger_hash   VARCHAR,
+    -- ADR-1 tuning verified-state (not_applicable / noop / applied_unverified
+    -- / applied_verified / failed). NULL for legacy bundles; distinct from the
+    -- run/query validation_status column below.
+    tuning_validation_status VARCHAR,
+    -- ADR-3 seam: explicit tuning-policy generation marker (display-only,
+    -- never a join/dedup key). NULL for legacy bundles, treated downstream as
+    -- the "pre-seam" generation.
+    tuning_policy_generation VARCHAR,
     test_type            VARCHAR,
     validation_status    VARCHAR,
     cost_usd             DOUBLE,
@@ -99,7 +112,13 @@ CREATE TABLE IF NOT EXISTS results (
     has_plans            BOOLEAN  NOT NULL,
     plans_published      BOOLEAN  NOT NULL,
     has_tuning           BOOLEAN  NOT NULL,
-    bundle_download_url  VARCHAR  NOT NULL
+    bundle_download_url  VARCHAR  NOT NULL,
+    -- ADR-2 section 3: platform-rendered physical tuning mechanisms
+    -- (comma-joined, sorted) and, for platforms that expose one, the physical
+    -- rendering strategy id. NULL when the bundle never recorded a logical
+    -- tuning profile.
+    physical_mechanisms   VARCHAR,
+    physical_rendering_id VARCHAR
 );
 
 -- ---------------------------------------------------------------------------
@@ -172,6 +191,10 @@ SELECT
     r.execution_mode,
     r.tuning_mode,
     r.tuning_hash,
+    r.requested_config_hash,
+    r.applied_ledger_hash,
+    r.tuning_validation_status,
+    r.tuning_policy_generation,
     r.test_type,
     r.validation_status,
     r.cost_usd,
@@ -197,6 +220,8 @@ SELECT
     r.plans_published,
     r.has_tuning,
     r.bundle_download_url,
+    r.physical_mechanisms,
+    r.physical_rendering_id,
     e.os,
     e.arch,
     e.cpu_count,

--- a/tests/unit/scripts/explorer_pipeline/test_duckdb_browser_contract.py
+++ b/tests/unit/scripts/explorer_pipeline/test_duckdb_browser_contract.py
@@ -977,3 +977,82 @@ class TestBenchmarkRankingSpeedupParity:
             ).fetchone()
         assert rows is not None
         assert rows[0] == pytest.approx(1.0, abs=1e-12)
+
+
+# ---------------------------------------------------------------------------
+# Documentation drift: browser-duckdb-schema.sql vs the schema actually built
+# ---------------------------------------------------------------------------
+
+
+def _doc_block_columns(text: str, start: str, end: str, prefix: str = "") -> list[str]:
+    """Column names between two markers in the schema doc, in declaration order.
+
+    Comment and blank lines are skipped. ``prefix`` selects the qualified
+    projections of a view body (``r.`` for the results side of a join).
+    """
+    body = text.split(start, 1)[1].split(end, 1)[0]
+    columns: list[str] = []
+    for line in body.splitlines():
+        stripped = line.strip().rstrip(",")
+        if not stripped or stripped.startswith("--"):
+            continue
+        if prefix:
+            if not stripped.startswith(prefix):
+                continue
+            columns.append(stripped[len(prefix) :])
+            continue
+        token = stripped.split()[0]
+        if token.upper() in {"PRIMARY", "FOREIGN", "UNIQUE", "CHECK"}:
+            continue
+        columns.append(token)
+    return columns
+
+
+class TestSchemaDocMatchesBuiltSchema:
+    """`docs/development/browser-duckdb-schema.sql` documents the browser store.
+
+    It is prose, not executed, so nothing forced it to keep up: it silently
+    fell six columns behind the builder (the ADR-1 tuning identities and
+    verified-state, the ADR-3 policy-generation marker, and the ADR-2 physical
+    columns) across four read-model versions. These compare the doc against the
+    schema `build_full()` actually produces, so the next column that lands
+    without a doc update fails here instead of drifting for another four.
+
+    `duckdb_builder.py` is the source of truth; fix the doc, never the builder.
+    """
+
+    DOC_PATH = Path(__file__).resolve().parents[4] / "docs" / "development" / "browser-duckdb-schema.sql"
+
+    def _doc_text(self) -> str:
+        return self.DOC_PATH.read_text(encoding="utf-8")
+
+    def test_doc_exists(self) -> None:
+        assert self.DOC_PATH.is_file(), f"schema doc not found at {self.DOC_PATH}"
+
+    def test_results_table_columns_match(self, db_path: Path) -> None:
+        documented = _doc_block_columns(self._doc_text(), "CREATE TABLE IF NOT EXISTS results (", "\n);")
+        with _connect(db_path) as con:
+            actual = [row[0] for row in con.execute("DESCRIBE results").fetchall()]
+        assert documented == actual, (
+            "browser-duckdb-schema.sql `results` is out of sync with duckdb_builder.py.\n"
+            f"  undocumented columns: {[c for c in actual if c not in documented]}\n"
+            f"  documented but absent: {[c for c in documented if c not in actual]}\n"
+            "  (order matters: the doc mirrors the builder's declaration order)"
+        )
+
+    def test_result_detail_metrics_view_columns_match(self, db_path: Path) -> None:
+        documented = _doc_block_columns(
+            self._doc_text(),
+            "CREATE VIEW IF NOT EXISTS result_detail_metrics AS",
+            "FROM results r",
+            prefix="r.",
+        )
+        with _connect(db_path) as con:
+            view_columns = [row[0] for row in con.execute("DESCRIBE result_detail_metrics").fetchall()]
+            results_columns = {row[0] for row in con.execute("DESCRIBE results").fetchall()}
+        actual = [column for column in view_columns if column in results_columns]
+        assert documented == actual, (
+            "browser-duckdb-schema.sql `result_detail_metrics` is out of sync with duckdb_builder.py.\n"
+            f"  undocumented projections: {[c for c in actual if c not in documented]}\n"
+            f"  documented but absent: {[c for c in documented if c not in actual]}"
+        )


### PR DESCRIPTION
`docs/development/browser-duckdb-schema.sql` documents the browser DuckDB
store, but nothing executed or checked it — so it quietly fell behind
`duckdb_builder.py`.

**The gap was wider than the TODO reported.** Comparing the doc against the
schema `build_full()` actually produces, the `results` table and the
`result_detail_metrics` view were each missing **six** columns, not the two
ADR-2 ones:

| Missing column | Landed in |
|---|---|
| `requested_config_hash` | ADR-1 tuning identities |
| `applied_ledger_hash` | ADR-1 tuning identities |
| `tuning_validation_status` | ADR-1 verified-state (read model v5) |
| `tuning_policy_generation` | ADR-3 policy-generation seam |
| `physical_mechanisms` | ADR-2 §3 |
| `physical_rendering_id` | ADR-2 §3 (read model v4) |

It had been drifting across four read-model versions.

## Change

All six added to both the table and the view, in the builder's declaration
order and carrying the builder's own comments. `duckdb_builder.py` is untouched
— it is the source of truth, and the doc is aligned to it, not the reverse.

## Drift guard (the stretch goal)

`TestSchemaDocMatchesBuiltSchema` compares the doc against the schema the
pipeline actually builds, reusing the existing module-scoped `db_path` fixture.
Order-sensitive equality in **both** directions: a new column that lands
undocumented fails, and so does a column the doc invents.

The pre-existing contract test could not have caught this — it asserts a
hardcoded column set is a `issubset` of the real schema, and never reads the
doc at all.

**Verified the guard actually fires**: deleting `physical_rendering_id` from
the doc fails with `undocumented columns: ['physical_rendering_id']` (and the
matching view assertion), and both pass again once restored.

## Verification

- Item ladder: `grep -c 'physical_rendering_id\|physical_mechanisms'` → **4**
  (expected ≥ 4)
- `pytest tests/unit/scripts/explorer_pipeline -q` → **295 passed**
- Full fast lane → **26000 passed**
- `todo check-scope` → **scope OK** (2 changed files, both in the allowlist)

## Sequencing note

PR #1343 (applied-receipt drill-down) adds a further `results.applied_receipt`
column. Whichever of the two merges second must add that column to this doc, or
the new guard will correctly fail. I'll keep #1343 consistent with whatever
lands first.

Tracker: `docs-browser-duckdb-schema-column-drift-20260724`

🤖 Generated with [Claude Code](https://claude.ai/code)
