### PR TITLE
fix(motherduck): stop the token re-leaking through the chained cause

### DIFF
--- a/benchbox/platforms/motherduck.py
+++ b/benchbox/platforms/motherduck.py
@@ -223,9 +223,16 @@ class MotherDuckAdapter(PlatformAdapter):
         except Exception as e:
             safe_error = _redact_motherduck_token(str(e), self.token)
             logger.error(f"Failed to connect to MotherDuck: {safe_error}")
+            # `from None`, not `from e`: the cause would carry the unredacted
+            # connection string (token included) into any printed traceback,
+            # undoing the redaction above. Unconditional because __init__
+            # rejects a missing token, so there is no credential-free run whose
+            # chain is worth keeping - unlike ducklake.py, which gates the same
+            # suppression on actually holding a secret. safe_error preserves the
+            # driver's diagnosis, so only the raw duplicate is dropped.
             raise ConnectionError(
                 f"Failed to connect to MotherDuck: {safe_error}\nCheck your MOTHERDUCK_TOKEN and network connection."
-            ) from e
+            ) from None
 
     def close_connection(self, connection=None):
         """Close MotherDuck connection."""

--- a/tests/unit/platforms/test_motherduck.py
+++ b/tests/unit/platforms/test_motherduck.py
@@ -371,6 +371,44 @@ class TestMotherDuckCreateConnection:
         assert "motherduck_token=****" in str(exc_info.value)
         assert "motherduck_token=****" in caplog.text
 
+    def test_create_connection_does_not_leak_token_through_chained_cause(self):
+        """Redacting the message is not enough on its own.
+
+        ``raise ... from e`` keeps the original driver exception as __cause__,
+        and Python prints its text in the "direct cause" section of any
+        traceback - so a token scrubbed from the message still reaches logs and
+        CI output through the chain. The raised error must expose the token
+        neither in its message nor anywhere in its cause/context chain.
+        """
+        import traceback
+
+        from benchbox.platforms.motherduck import MotherDuckAdapter
+
+        adapter = MotherDuckAdapter(token="secret-token", database="benchbox")
+
+        with (
+            patch("benchbox.platforms.motherduck.duckdb") as mock_duckdb,
+            pytest.raises(ConnectionError) as exc_info,
+        ):
+            mock_duckdb.connect.side_effect = RuntimeError(
+                "failed to connect to md:benchbox?motherduck_token=secret-token"
+            )
+            adapter.create_connection()
+
+        assert exc_info.value.__cause__ is None
+        # __suppress_context__ is what stops the implicit "During handling of
+        # the above exception" section from printing the raw driver error;
+        # `from None` sets it, a plain `raise ConnectionError(...)` would not.
+        assert exc_info.value.__suppress_context__ is True
+
+        # End-to-end: the rendered traceback - the form that actually reaches a
+        # log file or CI console - carries no token material at all.
+        rendered = "".join(
+            traceback.format_exception(type(exc_info.value), exc_info.value, exc_info.value.__traceback__)
+        )
+        assert "secret-token" not in rendered
+        assert "motherduck_token=****" in rendered
+
 
 class TestMotherDuckAddCliArguments:
     """Test add_cli_arguments registers expected flags."""


### PR DESCRIPTION
## Problem

`MotherDuckAdapter.create_connection()` builds `md:<db>?motherduck_token=<token>`
and, on failure, redacted the token out of the raised `ConnectionError`'s
message — but still raised `from e`. The original driver exception keeps the
unredacted connection string, and Python prints it under *"The above exception
was the direct cause…"* in any rendered traceback. So the token still reached
log files and CI consoles; only the one-line message was clean.

Same defect class as the DuckLake postgres password leak fixed in #1333, found
by that item's out-of-scope sweep.

Tracker: `motherduck-token-leak-via-chained-cause` (high).

## Fix

`raise … from None`, which both clears `__cause__` and sets
`__suppress_context__` (a plain `raise ConnectionError(...)` would leave the
implicit *"During handling of the above exception"* chain printing the raw
error).

**This is unconditional, unlike #1333.** DuckLake gates cause-suppression on
`holds_secret_material` because its postgres/S3 credentials are optional.
MotherDuck's `__init__` rejects a missing token (motherduck.py:116), so an
adapter instance always holds one and there is no credential-free run whose
chain is worth preserving — a conditional there would be dead code. The item's
"token-free failures keep their chained cause" must-preserve is therefore
vacuous for this adapter, and the comment records why.

The redacted `safe_error` still carries the driver's diagnosis, so only the
duplicate raw copy is dropped.

## Verification

- `uv run -- python -m pytest tests/unit/platforms/test_motherduck.py -q` — 48 passed.
- New test asserts on the **rendered traceback** (`traceback.format_exception`),
  not just `str(exc)` — that is the form that actually reaches a log — plus
  `__cause__ is None` and `__suppress_context__ is True`.
- Mutation check: restoring `from e` fails exactly that one test, and the
  failure output confirms the *message* stayed redacted — so the test isolates
  the cause path rather than re-testing the existing message redaction.

## Two tracker-spec defects in the item itself (authored during promotion, not code problems)

Both stem from me guessing a filename when promoting this item out of #1333's
sweep; item scope and ladders are create-time-only, so neither could be amended
in place:

1. **`only_modify` names `tests/unit/platforms/test_motherduck_adapter.py`,
   which does not exist.** The real file is `test_motherduck.py`, and it already
   contains the sibling `test_create_connection_redacts_token_from_error_and_log`
   in `TestMotherDuckCreateConnection`. The new test belongs beside it; creating
   a second file to satisfy the glob would have fragmented the suite for no
   benefit. `todo check-scope` therefore reports
   `tests/unit/platforms/test_motherduck.py: outside only_modify allowlist` —
   expected, and the only scope deviation.
2. **The verification ladder's command targets that same non-existent file**, so
   `todo verify --run 1` would exit non-zero on a correct implementation. I did
   not run it rather than record a misleading failure or a fake pass; the
   equivalent real command is in the Verification section above.
