### PR TITLE
fix(results): redact *_key_id platform options from exported metadata

### DIFF
--- a/benchbox/core/results/platform_options.py
+++ b/benchbox/core/results/platform_options.py
@@ -24,6 +24,13 @@ _SECRET_KEY_PARTS = tuple(
         "token",
         "secret",
         "access_key",
+        # Normalizes to "keyid", which "access_key" does not cover: an
+        # ``accessKeyId`` matched only because it also contains "accesskey", so
+        # the shorter provider-prefixed spellings (``s3_key_id``, ``kms_key_id``)
+        # were exported verbatim. Matches only key-id-shaped names - ordinary
+        # data-modelling keys (sort_key, partition_key, primary_key) do not
+        # contain "keyid" and keep exporting their real values.
+        "key_id",
         "private_key",
         "session_token",
         "connection_string",

--- a/tests/unit/core/results/test_platform_options_capture.py
+++ b/tests/unit/core/results/test_platform_options_capture.py
@@ -137,6 +137,77 @@ def test_sanitize_redacts_camelcase_secret_values() -> None:
     assert sanitized["warehouse"] == "WH"
 
 
+@pytest.mark.parametrize(
+    "key",
+    [
+        # Provider-prefixed key-id spellings. `accessKeyId` already matched
+        # because it contains "accesskey"; these do not, so they exported
+        # verbatim until "key_id" joined _SECRET_KEY_PARTS.
+        "s3_key_id",
+        "kms_key_id",
+        "KmsKeyId",
+        "kmsKeyId",
+        "key_id",
+        "keyId",
+    ],
+)
+def test_provider_prefixed_key_id_keys_are_redacted(key: str) -> None:
+    """Regression: a *_key_id option reached exported result metadata in clear.
+
+    Found by the credential-egress sweep on the DuckLake ATTACH leak (#1333):
+    `--platform-option s3_key_id=AKIA...` was published as-is because the
+    matcher only knew "access_key".
+    """
+    from benchbox.core.results.platform_options import is_secret_option_key
+
+    assert is_secret_option_key(key), f"{key!r} should be classified as a secret key"
+
+
+@pytest.mark.parametrize(
+    "key",
+    [
+        # Data-modelling and tuning option names that merely contain "key".
+        # The "keyid" part must not swallow these - over-redaction would strip
+        # real, useful provenance out of published results.
+        "sort_key",
+        "sortKey",
+        "partition_key",
+        "primary_key",
+        "clustering_key",
+        "distkey",
+        "distribution_key",
+        "warehouse",
+        "memory_limit",
+    ],
+)
+def test_non_credential_key_names_are_not_redacted(key: str) -> None:
+    from benchbox.core.results.platform_options import is_secret_option_key
+
+    assert not is_secret_option_key(key), f"{key!r} must keep exporting its real value"
+
+
+def test_sanitize_redacts_key_id_end_to_end_without_touching_sort_keys() -> None:
+    """End-to-end companion: the sanitized payload hides key material and keeps
+    the tuning options a reader needs to interpret the run."""
+    from benchbox.core.results.platform_options import sanitize_platform_options
+
+    sanitized = sanitize_platform_options(
+        {
+            "s3_key_id": "AKIAIOSFODNN7EXAMPLE",
+            "kms_key_id": "arn:aws:kms:us-east-1:111122223333:key/abcd",
+            "s3_secret": "raw-secret",
+            "sort_key": "l_shipdate",
+            "partition_key": "l_orderkey",
+        }
+    )
+
+    assert sanitized["s3_key_id"] == REDACTED_VALUE
+    assert sanitized["kms_key_id"] == REDACTED_VALUE
+    assert sanitized["s3_secret"] == REDACTED_VALUE
+    assert sanitized["sort_key"] == "l_shipdate"
+    assert sanitized["partition_key"] == "l_orderkey"
+
+
 def test_lifecycle_run_config_persists_sanitized_platform_options_with_provenance() -> None:
     benchmark_config = BenchmarkConfig(
         name="tpch",


### PR DESCRIPTION
## Problem

`is_secret_option_key()` matches a normalized key against `_SECRET_KEY_PARTS`,
which contained `access_key` but nothing covering `key_id`. So:

| option key | normalized | redacted before? |
|---|---|---|
| `accessKeyId` / `aws_access_key_id` | `accesskeyid` | ✅ — incidentally, it contains `accesskey` |
| `s3_key_id` | `s3keyid` | ❌ **exported verbatim** |
| `kms_key_id` / `KmsKeyId` | `kmskeyid` | ❌ **exported verbatim** |

`--platform-option s3_key_id=AKIA…` therefore reached published result metadata
in clear. `pg_password` and `s3_secret` were already covered, which is why this
gap survived.

Tracker: `platform-options-key-id-not-redacted` (medium). Found by the
credential-egress sweep on the DuckLake ATTACH leak (#1333).

## Fix

One entry — `"key_id"` (normalizes to `keyid`) — added to `_SECRET_KEY_PARTS`.

**`kms_key_id` was not in the original report.** I swept every `*key_id`-shaped
literal in the codebase before choosing the matcher; all six hits
(`aws_access_key_id`, `InvalidAccessKeyId`, `KmsKeyId`, `kmsKeyId`,
`kms_key_id`, `s3_key_id`) are credential or key-management material and should
all redact, so the single part is the right granularity.

## Guarding the other direction

Broadening a substring matcher risks over-redaction, which would strip real
provenance out of published results. `keyid` was chosen precisely because
ordinary data-modelling options don't contain it, and
`test_non_credential_key_names_are_not_redacted` pins that with 9 cases —
`sort_key`, `sortKey`, `partition_key`, `primary_key`, `clustering_key`,
`distkey`, `distribution_key`, `warehouse`, `memory_limit`. A future widening
to bare `"key"` would fail that test loudly.

## Verification

- `uv run -- python -m pytest tests/unit/core/results/test_platform_options_capture.py -q` — 44 passed.
- Wider blast radius: `tests/unit/core/results/` + `tests/unit/platforms/` — 8792 passed, 1 skipped.
- Mutation check: removing the `"key_id"` part fails 7 tests.
- The only other caller of `is_secret_option_key` is
  `platforms/base/runtime_metadata.py`; it is covered by that 8792-test run.

## Tracker-spec note

The item's `only_modify` and ladder name `tests/unit/core/results/test_platform_options.py`,
which does not exist — the real file is `test_platform_options_capture.py`, and
it already holds the sibling `test_camelcase_kebabcase_secret_keys_are_redacted`
that this regression sits next to. Same promotion-time filename guess as #1345;
item scope is create-time-only, so `todo check-scope` reports that one expected
path violation and I ran the real command instead of the ladder's broken one.
