### PR TITLE
fix(ci): skip gitignored node_modules in the spellcheck gate

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -937,9 +937,14 @@ security-audit:
 	@echo "✅ Security audit passed"
 
 # Spellcheck - exact match for docs.yml spellcheck job
+# node_modules is gitignored and only exists once someone runs the
+# results-explorer npm install, so leaving it unskipped made this gate pass in
+# CI (which never installs it) and fail locally on vendored typos - inverting
+# what a preflight is for. Keep any future vendored/generated tree out the same
+# way; do NOT skip a directory that holds tracked content.
 spellcheck:
 	@echo "Running spellcheck..."
-	uvx codespell --ignore-words=.codespell-ignore.txt --skip="*.pyc,_build,*.json,*.lock,*.svg,*.min.js,*.min.css,_binaries,*.tpl,*.dst,*.tbl,_sources,benchmark_runs,*.dat,*.pdf,_project,_blog,htmlcov,.venv"
+	uvx codespell --ignore-words=.codespell-ignore.txt --skip="*.pyc,_build,*.json,*.lock,*.svg,*.min.js,*.min.css,_binaries,*.tpl,*.dst,*.tbl,_sources,benchmark_runs,*.dat,*.pdf,_project,_blog,htmlcov,.venv,node_modules"
 	@echo "✅ Spellcheck passed"
 
 # Linkcheck - exact match for docs.yml linkcheck job


### PR DESCRIPTION
## Problem

`make spellcheck` passes `--skip` to codespell without `node_modules`.
`results-explorer/.gitignore` ignores `node_modules/`, so the directory only
exists once someone runs the explorer's npm install — which means:

- **CI:** never installs those deps → gate green.
- **Local:** anyone who has → codespell scans thousands of vendored files and
  exits non-zero on *their* typos, failing `make spellcheck` → `make ci-lint` →
  `make pr-preflight`.

A preflight that fails only on developer machines is the inverse of the point,
and it teaches people (and agents) to skip the gate or bypass it. It blocked the
preflight run on #1333, which is where this was found.

Tracker: `spellcheck-scans-gitignored-node-modules` (medium).

## Fix

Add `node_modules` to the skip list.

Measured in a worktree with `results-explorer/node_modules` present:
**exit 65 → exit 0.**

## Must-preserve check: real typos still caught

Appended `recieve` to tracked `docs/README.md` and re-ran the gate:

```
./docs/README.md:59: recieve ==> receive
```

Gate exits 2. Coverage of real source content is intact.

## Sweep, and what I deliberately did not skip

Every other gitignored tree present in the worktree was checked — `.venv`,
`.ruff_cache`, `.pytest_cache`, `.todo-db`, `benchbox.egg-info`, `__pycache__`
— none produce hits today (`*.pyc` and `*.json` were already skipped, `.venv`
already listed).

The one latent same-class risk is the gitignored agent skill mirrors
(`.codex/skills`, `.gemini/skills`, `.antigravity/skills`): prose that will
eventually contain a typo and break the gate the same way. **Not skipped here** —
`.claude/skills` holds *tracked* content, so a blanket skip in that family would
silently cut real coverage. That's a judgment call worth making explicitly
rather than pre-emptively, so it's noted rather than actioned.

## Alternative rejected

A git-aware invocation (`git ls-files --cached --others --exclude-standard |
xargs codespell`) looks structurally cleaner — it would need no skip-list
maintenance and would track `.gitignore` automatically. Measured, it is worse:
passing explicit file paths stops `--skip`'s bare directory names from pruning,
so tracked vendored trees get scanned and the run fails on
`benchbox/_binaries/tpc-h/windows-x86_64/dists.dss` (`psuedo`, `whithout`,
`auxillaries`, …). Converting every directory skip to a path glob to compensate
is more fragile than the one-word fix.

## Verification

- `make spellcheck` — exit 0 with `node_modules` present (tracker ladder rung 1
  recorded pass).
- `todo check-scope` — scope OK, 1 changed file.
