### PR TITLE
fix(datafusion): coerce string table paths in load_data

### DIFF
--- a/benchbox/platforms/datafusion.py
+++ b/benchbox/platforms/datafusion.py
@@ -33,7 +33,12 @@ except ImportError:
 from benchbox.core.dataframe.schema_utils import extract_schema_columns
 from benchbox.core.errors import PlanCaptureError
 from benchbox.platforms.base import DriverIsolationCapability, PlatformAdapter
-from benchbox.platforms.base.data_loading import NO_BENCHMARK, DataSource, resolve_csv_dialect
+from benchbox.platforms.base.data_loading import (
+    NO_BENCHMARK,
+    DataSource,
+    normalize_table_paths,
+    resolve_csv_dialect,
+)
 from benchbox.platforms.base.no_constraint_mixin import NoConstraintEnforcementMixin
 from benchbox.utils.clock import elapsed_seconds, mono_time
 from benchbox.utils.file_format import (
@@ -753,9 +758,10 @@ class DataFusionAdapter(NoConstraintEnforcementMixin, PlatformAdapter):
         for table_name, file_paths in data_source.tables.items():
             table_start = mono_time()
 
-            # Ensure file_paths is a list
-            if not isinstance(file_paths, list):
-                file_paths = [file_paths]
+            # Normalize to a list of Paths. Generator-supplied `tables` values may be
+            # plain strings (fresh generate -> load in the same run), while the manifest
+            # source yields Paths, so downstream Path-only calls need the coercion here.
+            file_paths = normalize_table_paths(file_paths)
 
             # Normalize table name to lowercase
             table_name_lower = table_name.lower()

--- a/tests/unit/platforms/test_datafusion_load_data_path_coercion.py
+++ b/tests/unit/platforms/test_datafusion_load_data_path_coercion.py
@@ -1,0 +1,150 @@
+"""Regression: DataFusion load_data coerces string table paths to Path.
+
+``DataSource.tables`` is typed ``dict[str, Any]`` on purpose - the value may be a
+single path, a list of paths, or in-memory rows - and the two providers that read
+straight from a benchmark's generated ``tables`` attribute
+(``BenchmarkTablesSource``/``BenchmarkImplTablesSource``) hand back whatever the
+generator recorded, which is a plain ``str``. ``ManifestFileSource`` hands back
+``Path``.
+
+``DataFusionAdapter.load_data`` normalized only the *shape* of that payload
+(wrapping a scalar in a list) and never the *type*, so a fresh
+``generate -> load`` in one process reached ``_detect_directory_format`` with a
+``str`` and died on ``'str' object has no attribute 'is_dir'``. A second run in
+the same output directory resolved through the manifest instead and passed, which
+is why the Seed Corpus workflow failed only on the DataFusion cells and only on a
+clean runner.
+
+The shared ``normalize_table_paths`` helper exists for exactly this and is
+documented as the funnel adapters must use; postgresql, questdb, mysql_wire and
+the DataFrame mixin already do.
+
+Copyright 2026 Joe Harris / BenchBox Project
+
+Licensed under the MIT License. See LICENSE file in the project root for details.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import Mock, patch
+
+import pytest
+
+from benchbox.platforms.base.data_loading import DataSource
+
+pytestmark = [
+    pytest.mark.unit,
+    pytest.mark.fast,
+]
+
+
+def _capturing_adapter(tmp_path: Path, table_path: str):
+    """Build a DataFusionAdapter whose per-table loader records the paths it receives."""
+    from benchbox.platforms.datafusion import DataFusionAdapter
+
+    data_source = DataSource(
+        source_type="benchmark_tables",
+        tables={"customer": table_path},
+        table_formats={"customer": "tbl"},
+    )
+
+    received: list[object] = []
+
+    def record(connection, table_name, file_paths, data_dir, **kwargs):
+        received.extend(file_paths)
+        return 2
+
+    with patch("benchbox.platforms.datafusion.SessionContext"):
+        adapter = DataFusionAdapter(working_dir=str(tmp_path / "wd"), data_format="parquet")
+
+    resolver = Mock()
+    resolver.resolve.return_value = data_source
+
+    with (
+        patch("benchbox.platforms.base.data_loading.DataSourceResolver", return_value=resolver),
+        patch.object(adapter, "_load_table_parquet", side_effect=record),
+        patch.object(adapter, "_load_table_csv", side_effect=record),
+    ):
+        table_stats, _duration, _timings = adapter.load_data(Mock(), Mock(), tmp_path)
+
+    return table_stats, received
+
+
+def test_load_data_coerces_string_table_path_to_path(tmp_path):
+    """A str-valued ``tables`` entry must not raise and must arrive as a Path."""
+    data_file = tmp_path / "customer.tbl.zst"
+    data_file.write_bytes(b"")
+
+    table_stats, received = _capturing_adapter(tmp_path, str(data_file))
+
+    assert table_stats == {"customer": 2}
+    assert received == [data_file]
+    assert all(isinstance(path, Path) for path in received), f"expected Paths, got {[type(p) for p in received]}"
+
+
+def test_load_data_accepts_list_of_string_table_paths(tmp_path):
+    """Chunked tables recorded as a list of strings are coerced element-wise."""
+    from benchbox.platforms.datafusion import DataFusionAdapter
+
+    chunks = []
+    for index in (1, 2):
+        chunk = tmp_path / f"lineitem.tbl.{index}"
+        chunk.write_bytes(b"")
+        chunks.append(chunk)
+
+    data_source = DataSource(
+        source_type="benchmark_tables",
+        tables={"lineitem": [str(chunk) for chunk in chunks]},
+        table_formats={"lineitem": "tbl"},
+    )
+
+    received: list[object] = []
+
+    def record(connection, table_name, file_paths, data_dir, **kwargs):
+        received.extend(file_paths)
+        return 4
+
+    with patch("benchbox.platforms.datafusion.SessionContext"):
+        adapter = DataFusionAdapter(working_dir=str(tmp_path / "wd"), data_format="parquet")
+
+    resolver = Mock()
+    resolver.resolve.return_value = data_source
+
+    with (
+        patch("benchbox.platforms.base.data_loading.DataSourceResolver", return_value=resolver),
+        patch.object(adapter, "_load_table_parquet", side_effect=record),
+        patch.object(adapter, "_load_table_csv", side_effect=record),
+    ):
+        adapter.load_data(Mock(), Mock(), tmp_path)
+
+    assert received == chunks
+    assert all(isinstance(path, Path) for path in received)
+
+
+def test_load_data_still_detects_directory_format_from_string_path(tmp_path):
+    """Delta detection must survive the coercion: a str pointing at a Delta dir loads as Delta."""
+    from benchbox.platforms.datafusion import DataFusionAdapter
+
+    delta_dir = tmp_path / "customer"
+    (delta_dir / "_delta_log").mkdir(parents=True)
+
+    data_source = DataSource(
+        source_type="benchmark_tables",
+        tables={"customer": str(delta_dir)},
+    )
+
+    with patch("benchbox.platforms.datafusion.SessionContext"):
+        adapter = DataFusionAdapter(working_dir=str(tmp_path / "wd"), data_format="parquet")
+
+    resolver = Mock()
+    resolver.resolve.return_value = data_source
+
+    with (
+        patch("benchbox.platforms.base.data_loading.DataSourceResolver", return_value=resolver),
+        patch.object(adapter, "_load_table_delta", return_value=7) as load_delta,
+    ):
+        table_stats, _duration, _timings = adapter.load_data(Mock(), Mock(), tmp_path)
+
+    assert table_stats == {"customer": 7}
+    assert load_delta.call_args.args[2] == delta_dir


### PR DESCRIPTION
# Pull Request

## Description

Fixes the `Seed Corpus` workflow's DataFusion cells, which failed with:

```
❌ Benchmark execution failed: 'str' object has no attribute 'is_dir'
```

**Root cause.** `DataFusionAdapter.load_data` normalized only the *shape* of a
`DataSource.tables` value (wrapping a scalar in a list) and never its *type*:

```python
if not isinstance(file_paths, list):
    file_paths = [file_paths]
```

`DataSource.tables` is typed `dict[str, Any]` deliberately — the value may be a
path, a list of paths, or in-memory rows. The two providers that read a
benchmark's generated `tables` attribute directly (`BenchmarkTablesSource` /
`BenchmarkImplTablesSource`) return whatever the generator recorded, which is a
plain `str`; `ManifestFileSource` returns `Path`. The `str` then reached
`_detect_directory_format` — annotated `list[Path]` — and died on `path.is_dir()`
(`benchbox/platforms/datafusion.py:1190`).

The fix routes the payload through the shared `normalize_table_paths` helper,
whose docstring already names itself the funnel adapters must use, and which
`postgresql`, `questdb`, `mysql_wire` and the DataFrame mixin already use. This
repairs the boundary that admits the `str` rather than sprinkling `isinstance`
guards at each `is_dir()` call site.

**Evidence.** Captured a real traceback rather than trusting the reported symptom:

```
File "benchbox/platforms/datafusion.py", line 764, in load_data
    dir_format = self._detect_directory_format(file_paths)
File "benchbox/platforms/datafusion.py", line 1190, in _detect_directory_format
    if not path.is_dir():
AttributeError: 'str' object has no attribute 'is_dir'
```

Instrumenting the call site showed the value arriving as
`('str', '/…/datagen/ssb_sf001/date.tbl.zst')`.

This also explains the failure's shape. A **fresh** `generate → load` in one
process takes the generator path and fails; a **second** run against the same
output directory resolves through the manifest and passes. That is why only the
DataFusion cells failed, and only on a clean runner — my first local reproduction
attempt passed for exactly this reason until I cleared the output directory.

## Notes for reviewers — the failing run had *two* unrelated causes

Run `30455422794` was dispatched with `benchmark=ssb`, so only the 6 `ssb` jobs
ran. They failed in two different ways, and the reported "no result bundle found"
message belongs to the *second*, not this bug:

| Cells | Failing step | Cause |
|---|---|---|
| `datafusion` sf0.01, sf0.1 | **Run benchmark** | this PR |
| `duckdb` + `polars-df` (4 cells) | **Locate result bundle** | already fixed on develop |

For the four non-DataFusion cells the benchmark step *succeeded*; results were
written to the default output directory (`~/benchmark_runs/results`), outside the
workspace, so `find benchmark_runs/results` found nothing. Commit `6c988da`
("fix(ci): keep seed corpus output in workspace", #1337) added the job-level
`BENCHBOX_OUTPUT_DIR: ${{ github.workspace }}/benchmark_runs` that fixes it, and
is already on develop. **No workflow change is needed here** — I confirmed
`.github/workflows/seed-corpus.yml` at HEAD carries it, and that the earlier
`23f6e89a3` start-up fix is unrelated to both failures.

## Type of Change

- [x] Bug fix

## Testing

Reproduced and verified against real benchmark runs, each from a **clean** output
directory (the flakiness is directory-state dependent, so this matters):

```
ssb / datafusion / sf0.01   PASSED   # was the reported failure
ssb / datafusion / sf0.1    PASSED   # was the reported failure
tpch / datafusion / sf0.01  PASSED   # multi-chunk regression check
```

Targeted and regression tests:

```
uv run -- python -m pytest tests/unit/platforms/test_datafusion_load_data_path_coercion.py   # 3 passed
uv run -- python -m pytest tests/unit/platforms/ -k "datafusion or data_loading or data_source"  # 556 passed
```

New file `tests/unit/platforms/test_datafusion_load_data_path_coercion.py` pins
the boundary: str-valued entry, list-of-str entry, and a str pointing at a Delta
directory (so the coercion cannot silently break directory-format detection).
**All three fail with the exact production `AttributeError` when the fix is
reverted** — verified, so they are not vacuous.

CI-only gates that `make lint` and `make pr-preflight` do not cover:

```
make lint-imports                                             # 3 contracts kept, 0 broken
make lint-markers                                             # 8 passed
uv run -- python _project/scripts/timing_policy_check.py --strict   # 0 violations
uv run -- ruff check / ruff format --check (changed files)     # clean
```

Fast-lane cap: 26033 collected against `max_fast_tests` 26550 — the 3 new tests
fit inside existing headroom, so no ceiling bump is needed.

## Public Contract Check

- [x] I updated `docs/reference/public-contracts.md`, or this PR does not change
      public, beta-public, deprecated, generated, experimental, or repo-only
      contract surfaces.
- [x] I checked result schema fields, MCP tool parameters, platform support
      status, wrapper facades, adapter subclassing hooks, and generated docs for
      contract-map impact.
- [x] Any platform/benchmark count claim in docs is generated/checked from
      registry metadata, or explicitly marked editorial/non-authoritative.

Internal adapter behavior only. `_detect_directory_format`'s `list[Path]`
annotation is now actually honored by its caller; no signature changed.

## Documentation

- [x] I updated the relevant user-facing docs.
- [x] I added regression notes for behavior changes.
- [x] I confirmed API contract wording remains accurate.

No user-facing behavior change beyond the bug fix; the regression rationale is
recorded in the new test module's docstring.

## Code Quality

- [x] I ran formatting and lint/type checks.
- [x] I reviewed impacted modules for backwards compatibility and migration impact.
- [x] I added/updated tests for behavior changes and error paths.
- [x] I confirmed public contracts and release checklists are still valid.

`normalize_table_paths` accepts str and Path alike, so manifest-resolved runs
(which already passed `Path`) are unaffected.

## Artifact Hygiene

- [x] I did not commit raw screenshots, browser reports, generated logs,
      benchmark outputs, or temporary binary artifacts.
- [x] Any committed binary/raw evidence file has durable repo value and is
      justified here with its consumer and size:

None committed.

## Notes

**Deliberately not changed:**

- `.github/workflows/seed-corpus.yml` — the bundle-location half is already fixed
  on develop by `6c988da`; changing the `Locate result bundle` check would have
  masked a symptom.
- The `isinstance(full_path, Path)` guard at `runner.py:1500` and the unguarded
  `is_dir()` calls in `conversion.py` / `results/loader.py` / `dataframe/data_loader.py`.
  None of them is on this traceback. They may deserve the same boundary
  treatment, but not on this PR's evidence.
- Other adapters that hand-roll path normalization were left alone — only
  DataFusion is implicated here.

**Scope note.** This branch is deliberately limited to the Seed Corpus root
cause. The other two chronically-red develop workflows are separate
investigations with separate root causes and are not bundled here; findings for
both are reported back to the requester, including one that needs an
authorization decision (a sync PR against the community-facing
`published-results` branch) and one that is blocked from tracker capture.

---
_Generated by [Claude Code](https://claude.ai/code/session_01A8FPL8N9aravcM3HnMS1gZ)_