### PR TITLE
fix(windows): resolve the largest Nightly Validation failure families

### DIFF
--- a/benchbox/core/tpcds_obt/query_conversion.py
+++ b/benchbox/core/tpcds_obt/query_conversion.py
@@ -158,7 +158,9 @@ class TemplateLoader:
         if not self.path.exists():
             raise FileNotFoundError(f"Template for query {query_id} not found at {self.path}")
 
-        self.raw_text = self.path.read_text()
+        # Explicit encoding: the read_text default is locale-dependent (cp1252 on
+        # Windows), which mis-decodes any non-ASCII byte in a query file.
+        self.raw_text = self.path.read_text(encoding="utf-8")
         self.definitions: dict[str, str] = {}
         self.body_sql: str = ""
         self.parameters: dict[str, TemplateParameter] = {}

--- a/benchbox/utils/cloud_storage.py
+++ b/benchbox/utils/cloud_storage.py
@@ -13,7 +13,7 @@ from __future__ import annotations
 import logging
 import os
 import re
-from pathlib import Path
+from pathlib import Path, PurePath
 from typing import Any, Iterator, List, NamedTuple, Protocol, Union, runtime_checkable
 from urllib.parse import urlparse
 
@@ -413,8 +413,17 @@ def _match_snowflake_stage(path: Union[str, Path]) -> Union[re.Match, None]:
     Shared by the predicate and by :func:`get_cloud_path_info` so the grammar
     and the stage/sub-path split can never drift apart.
     """
-    if isinstance(path, Path):
-        path = str(path)
+    # PurePath, not Path: this must also cover the pure flavours (PureWindowsPath),
+    # which are not Path subclasses and previously fell through to the non-str
+    # rejection below.
+    if isinstance(path, PurePath):
+        # A stage reference is Snowflake URI grammar, not a local filesystem path, so
+        # it is always "/"-separated. str(WindowsPath("@~/data")) is "@~\\data", which
+        # the grammar rejects because it requires "/" after the stage token -- so a
+        # Path-typed stage silently failed to classify on Windows. Normalize it to
+        # behave like its string form everywhere. Non-stage inputs are unaffected:
+        # they do not start with "@" and never matched either way.
+        path = str(path).replace("\\", "/")
 
     if not isinstance(path, str):
         return None

--- a/benchbox/utils/dependencies.py
+++ b/benchbox/utils/dependencies.py
@@ -34,7 +34,9 @@ def is_development_install() -> bool:
     if (project_root / "pyproject.toml").exists():
         # Verify it's actually the benchbox project
         try:
-            content = (project_root / "pyproject.toml").read_text()
+            # pyproject.toml is UTF-8 by specification (PEP 518); the read_text
+            # default is locale-dependent and cp1252 on Windows.
+            content = (project_root / "pyproject.toml").read_text(encoding="utf-8")
             if 'name = "benchbox"' in content:
                 return True
         except Exception:

--- a/tests/uat/test_no_cli_surface_drift.py
+++ b/tests/uat/test_no_cli_surface_drift.py
@@ -248,7 +248,8 @@ def _source_at_ref(ref: str, path: str) -> str:
 
 def _source_at_worktree(path: str) -> str:
     try:
-        return (REPO_ROOT / path).read_text()
+        # Explicit encoding: the default is locale-dependent (cp1252 on Windows).
+        return (REPO_ROOT / path).read_text(encoding="utf-8")
     except FileNotFoundError:
         return ""
 

--- a/tests/uat/test_preflight_budget.py
+++ b/tests/uat/test_preflight_budget.py
@@ -97,8 +97,12 @@ def test_estimate_largest_scale_peak_disk_uses_largest_configured_scale(tmp_path
 
 def test_disk_headroom_gate_reports_short_root(tmp_path: Path):
     budget = DiskBudget(cells=1, est_peak_gib=10.0, est_steady_gib=8.0, unknown_cells=())
+    # Render the expectation from the same Path the formatter receives: str(Path) uses
+    # the platform separator, so a hardcoded "/tmp" fails on Windows ("\tmp") while
+    # asserting nothing extra. Mirrors the idiom already used in test_preflight.py.
+    tmp_root = Path("/tmp")
     roots = (
-        DiskRootFreeSpace("tmp", Path("/tmp"), 4.0),
+        DiskRootFreeSpace("tmp", tmp_root, 4.0),
         DiskRootFreeSpace("output", tmp_path, 20.0),
     )
 
@@ -107,4 +111,4 @@ def test_disk_headroom_gate_reports_short_root(tmp_path: Path):
     assert check.required_gib == pytest.approx(10.0)
     assert len(check.shortfalls) == 1
     assert check.shortfalls[0].label == "tmp"
-    assert "tmp /tmp: 4.0 GiB free < 10.0 GiB required" in format_disk_headroom_failure(check)
+    assert f"tmp {tmp_root}: 4.0 GiB free < 10.0 GiB required" in format_disk_headroom_failure(check)

--- a/tests/uat/test_runner.py
+++ b/tests/uat/test_runner.py
@@ -117,8 +117,11 @@ def test_run_cell_writes_log_and_returns_result(tmp_path: Path):
     assert result.result_path is not None
     assert str(result.result_path).endswith("duckdb_tpch_smoke.json")
     assert result.log_path.exists()
-    log_text = result.log_path.read_text()
-    assert "benchmark_runs/results/" in log_text
+    log_text = result.log_path.read_text(encoding="utf-8")
+    # Derive the expectation from the same path the stub echoed: str(Path) uses the
+    # platform separator, so a hardcoded "benchmark_runs/results/" fails on Windows
+    # ("benchmark_runs\\results\\"). Asserting the directory is at least as strong.
+    assert str(result_path.parent) in log_text
 
 
 def test_run_cell_sets_benchbox_output_dir_for_subprocess(tmp_path: Path):

--- a/tests/uat/test_timeouts.py
+++ b/tests/uat/test_timeouts.py
@@ -127,7 +127,10 @@ def test_kill_process_group_uses_killpg_when_available(monkeypatch):
     def fake_killpg(pid, sig):
         calls.append((pid, sig))
 
-    monkeypatch.setattr(timeouts.os, "killpg", fake_killpg)
+    # raising=False so this also runs on win32, where os.killpg does not exist:
+    # injecting it makes the hasattr guard take the POSIX branch, which is exactly
+    # the ladder under test. A skipif here would drop that coverage instead.
+    monkeypatch.setattr(timeouts.os, "killpg", fake_killpg, raising=False)
     mock_proc = Mock(pid=999)
 
     timeouts._kill_process_group(mock_proc)

--- a/tests/unit/cli/test_cloud_storage_gate_deployment_aware.py
+++ b/tests/unit/cli/test_cloud_storage_gate_deployment_aware.py
@@ -128,7 +128,9 @@ class TestNoCategoryGatesRemainOnTheRunPath:
     @pytest.mark.parametrize("source", RUN_PATH_SOURCES, ids=lambda p: p.name)
     def test_run_path_never_calls_requires_cloud_storage_directly(self, source):
         """Every gate in these modules uses the deployment-aware variant."""
-        tree = ast.parse(source.read_text())
+        # Explicit encoding: the default is locale-dependent and cp1252 on Windows,
+        # where non-ASCII bytes in our own sources raise UnicodeDecodeError.
+        tree = ast.parse(source.read_text(encoding="utf-8"))
         offenders = [
             node.lineno
             for node in ast.walk(tree)

--- a/tests/unit/platforms/conftest.py
+++ b/tests/unit/platforms/conftest.py
@@ -1,0 +1,45 @@
+"""Shared fixtures for platform adapter unit tests.
+
+Copyright 2026 Joe Harris / BenchBox Project
+
+Licensed under the MIT License. See LICENSE file in the project root for details.
+"""
+
+from __future__ import annotations
+
+import importlib.machinery
+import importlib.util
+
+import pytest
+
+
+@pytest.fixture
+def chdb_probe_satisfied(monkeypatch):
+    """Let ClickHouse local-mode adapters be constructed without chDB installed.
+
+    ``ClickHouseAdapter.__init__`` probes for chDB eagerly
+    (``importlib.util.find_spec("chdb") is None`` -> ``ImportError``) even though
+    nothing needs the package until a connection is opened. chDB ships no Windows
+    wheels — ``pyproject.toml`` constrains it to ``sys_platform != 'win32'`` — so on
+    the Windows runners that probe failed and took down every test in the modules
+    that build a local-mode adapter, 17 in total, none of which touch chDB: they
+    drive DDL rendering and plan/introspection logic against fake connections.
+
+    Satisfy only the chDB lookup and delegate every other name to the real
+    ``find_spec``, so an unrelated missing dependency still surfaces normally.
+    Opt in per module with
+    ``pytestmark = [..., pytest.mark.usefixtures("chdb_probe_satisfied")]``.
+
+    Reproduce the Windows failure on any platform by making the probe return None:
+    ``uv run -- python -m pytest -p nochdb ...`` with a plugin that patches
+    ``importlib.util.find_spec``.
+    """
+    real_find_spec = importlib.util.find_spec
+
+    def _find_spec(name, *args, **kwargs):
+        if name == "chdb":
+            # A loader-less spec is enough: the probe only checks for non-None.
+            return importlib.machinery.ModuleSpec("chdb", loader=None)
+        return real_find_spec(name, *args, **kwargs)
+
+    monkeypatch.setattr(importlib.util, "find_spec", _find_spec)

--- a/tests/unit/platforms/test_clickhouse_introspection.py
+++ b/tests/unit/platforms/test_clickhouse_introspection.py
@@ -26,7 +26,12 @@ from benchbox.core.tuning.introspection import KIND_PARTITION_KEY, KIND_SORT_KEY
 from benchbox.platforms.clickhouse.adapter import ClickHouseAdapter
 from benchbox.platforms.clickhouse.introspection import ClickHouseTuningIntrospector
 
-pytestmark = [pytest.mark.unit, pytest.mark.fast]
+pytestmark = [
+    pytest.mark.unit,
+    pytest.mark.fast,
+    # Constructs local-mode adapters; chDB has no Windows wheels. See the fixture.
+    pytest.mark.usefixtures("chdb_probe_satisfied"),
+]
 
 
 class _FakeCHConnection:

--- a/tests/unit/platforms/test_clickhouse_plan_capture.py
+++ b/tests/unit/platforms/test_clickhouse_plan_capture.py
@@ -13,10 +13,13 @@ from benchbox.core.query_plans.parsers.clickhouse import ClickHouseQueryPlanPars
 pytestmark = [
     pytest.mark.unit,
     pytest.mark.fast,
+    # Constructs local-mode adapters; chDB has no Windows wheels. See the fixture.
+    pytest.mark.usefixtures("chdb_probe_satisfied"),
 ]
 
 _FIXTURES = Path(__file__).resolve().parents[2] / "fixtures" / "query_plans"
-_PLAN_TEXT = (_FIXTURES / "clickhouse_explain_plan_sample.txt").read_text()
+# Explicit encoding: the default is locale-dependent (cp1252 on Windows).
+_PLAN_TEXT = (_FIXTURES / "clickhouse_explain_plan_sample.txt").read_text(encoding="utf-8")
 
 
 class _FakeConn:

--- a/tests/unit/platforms/test_misc_plan_capture.py
+++ b/tests/unit/platforms/test_misc_plan_capture.py
@@ -37,7 +37,8 @@ _FIXTURES = Path(__file__).resolve().parents[2] / "fixtures" / "query_plans"
 
 
 def _load(name: str) -> str:
-    return (_FIXTURES / name).read_text()
+    # Explicit encoding: the default is locale-dependent (cp1252 on Windows).
+    return (_FIXTURES / name).read_text(encoding="utf-8")
 
 
 def _collect(op: LogicalOperator) -> list[LogicalOperator]:

--- a/tests/unit/query_plans/test_cross_engine_conformance.py
+++ b/tests/unit/query_plans/test_cross_engine_conformance.py
@@ -46,7 +46,8 @@ _FIXTURES = Path(__file__).resolve().parents[2] / "fixtures" / "query_plans"
 
 
 def _load(name: str) -> str:
-    return (_FIXTURES / name).read_text()
+    # Explicit encoding: the default is locale-dependent (cp1252 on Windows).
+    return (_FIXTURES / name).read_text(encoding="utf-8")
 
 
 def _op(op_type: LogicalOperatorType, children=None) -> LogicalOperator:

--- a/tests/unit/test_posix_shell_resolver.py
+++ b/tests/unit/test_posix_shell_resolver.py
@@ -1,0 +1,109 @@
+"""Regression tests for the test-suite POSIX shell resolver.
+
+The Windows nightly failed ~14 tests because ``subprocess.run(["bash", ...])``
+resolved to ``C:\\Windows\\System32\\bash.exe`` — the WSL launcher stub, which
+precedes Git Bash on the runner's PATH. With no distro installed it emits its usage
+text in UTF-16LE and exits 1, so assertions compared expected substrings against
+mojibake. These tests pin the two properties that fix relies on, using a fake stub
+so they reproduce on any platform:
+
+1. a stub that exits non-zero is rejected even when it is first on PATH, and
+2. the search continues past it to a real bash further along PATH.
+
+Copyright 2026 Joe Harris / BenchBox Project
+
+Licensed under the MIT License. See LICENSE file in the project root for details.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from tests.utilities import posix_shell as posix_shell_module
+from tests.utilities.posix_shell import posix_shell
+
+pytestmark = [
+    pytest.mark.unit,
+    pytest.mark.fast,
+]
+
+
+def _write_wsl_stub(directory: Path) -> Path:
+    """Write an executable that behaves like the WSL launcher with no distro."""
+    directory.mkdir(parents=True, exist_ok=True)
+    stub = directory / ("bash.exe" if os.name == "nt" else "bash")
+    # Emit UTF-16LE bytes on stdout and exit 1, exactly as the real stub does.
+    stub.write_text(
+        f"#!{sys.executable}\n"
+        "import sys\n"
+        "sys.stdout.buffer.write("
+        "'Windows Subsystem for Linux has no installed distributions.'.encode('utf-16-le'))\n"
+        "sys.exit(1)\n",
+        encoding="utf-8",
+    )
+    stub.chmod(0o755)
+    return stub
+
+
+@pytest.fixture(autouse=True)
+def _clear_resolver_cache():
+    """posix_shell() is lru_cached; each test needs a fresh probe, and must not
+    leave a PATH-specific answer cached for whatever runs next."""
+    posix_shell_module.posix_shell.cache_clear()
+    yield
+    posix_shell_module.posix_shell.cache_clear()
+
+
+@pytest.mark.skipif(os.name == "nt", reason="stub uses a POSIX shebang")
+def test_stub_first_on_path_is_rejected_and_real_bash_is_found(tmp_path, monkeypatch):
+    """A failing stub earlier on PATH must not hide a working bash later on it."""
+    real_bash = shutil.which("bash")
+    if real_bash is None:
+        pytest.skip("no system bash to fall through to")
+
+    stub_dir = tmp_path / "wslstub"
+    _write_wsl_stub(stub_dir)
+    monkeypatch.setenv("PATH", f"{stub_dir}{os.pathsep}{os.environ['PATH']}")
+    monkeypatch.delenv("BENCHBOX_TEST_POSIX_SHELL", raising=False)
+
+    resolved = posix_shell()
+
+    assert resolved is not None, "resolver gave up instead of continuing past the stub"
+    assert Path(resolved).parent != stub_dir, f"resolver returned the stub: {resolved}"
+    # And the shell it picked really runs the bashisms our workflow fragments use.
+    completed = subprocess.run(
+        [resolved, "-c", 'set -euo pipefail\nread -r v <<< "ok"\nprintf "%s" "$v"'],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    assert completed.returncode == 0 and completed.stdout.strip() == "ok"
+
+
+@pytest.mark.skipif(os.name == "nt", reason="stub uses a POSIX shebang")
+def test_resolver_returns_none_when_only_a_stub_is_available(tmp_path, monkeypatch):
+    """With nothing but a stub reachable, the resolver reports no shell rather than
+    handing back something that will produce mojibake."""
+    stub_dir = tmp_path / "onlystub"
+    _write_wsl_stub(stub_dir)
+    monkeypatch.setenv("PATH", str(stub_dir))
+    monkeypatch.delenv("BENCHBOX_TEST_POSIX_SHELL", raising=False)
+
+    assert posix_shell() is None
+
+
+@pytest.mark.skipif(os.name == "nt", reason="stub uses a POSIX shebang")
+def test_env_override_is_probed_not_trusted(tmp_path, monkeypatch):
+    """An explicitly configured shell still has to pass the probe."""
+    stub_dir = tmp_path / "override"
+    stub = _write_wsl_stub(stub_dir)
+    monkeypatch.setenv("BENCHBOX_TEST_POSIX_SHELL", str(stub))
+    monkeypatch.setenv("PATH", str(stub_dir))
+
+    assert posix_shell() is None, "a broken override must not be trusted"

--- a/tests/unit/test_release_infrastructure.py
+++ b/tests/unit/test_release_infrastructure.py
@@ -17,6 +17,8 @@ from pathlib import Path
 import pytest
 import yaml
 
+from tests.utilities.posix_shell import run_posix_shell, skip_without_posix_shell
+
 pytestmark = [
     pytest.mark.unit,
     pytest.mark.fast,
@@ -777,8 +779,9 @@ class TestReleaseInfrastructure:
         # Make collapses `$$` to a literal `$` in recipes before the shell ever sees it;
         # emulate that here since this test runs the extracted text via bash directly.
         shell_pipeline = pipeline_without_version_grep.replace("$$", "$")
-        result = subprocess.run(
-            ["bash", "-c", shell_pipeline],
+        skip_without_posix_shell()
+        result = run_posix_shell(
+            shell_pipeline,
             input=sample_input,
             capture_output=True,
             text=True,

--- a/tests/unit/utils/test_cloud_storage_snowflake_stage.py
+++ b/tests/unit/utils/test_cloud_storage_snowflake_stage.py
@@ -12,7 +12,7 @@ Licensed under the MIT License. See LICENSE file in the project root for details
 
 import os
 import tempfile
-from pathlib import Path
+from pathlib import Path, PureWindowsPath
 
 import pytest
 
@@ -90,6 +90,22 @@ class TestIsSnowflakeStagePath:
         assert is_snowflake_stage_path(Path("@~/benchbox"))
         assert not is_snowflake_stage_path(None)
         assert not is_snowflake_stage_path(123)
+
+    def test_windows_flavoured_path_object_still_classifies_as_a_stage(self):
+        """A Path carrying backslash separators is still a stage reference.
+
+        ``str(WindowsPath("@~/benchbox"))`` is ``"@~\\benchbox"``, and the stage
+        grammar requires ``/`` after the stage token, so on Windows this predicate
+        silently returned False for a valid user-stage reference. PureWindowsPath
+        reproduces it on any platform, so the regression is not Windows-only-visible.
+        """
+        assert is_snowflake_stage_path(PureWindowsPath("@~/benchbox"))
+        assert is_snowflake_stage_path(PureWindowsPath("@my_stage/sub/dir"))
+
+    def test_windows_flavoured_local_path_is_not_a_stage(self):
+        """The separator normalization must not sweep ordinary local paths in."""
+        assert not is_snowflake_stage_path(PureWindowsPath(r"C:\data\benchbox"))
+        assert not is_snowflake_stage_path(PureWindowsPath(r"C:\data\@notastage"))
 
 
 class TestStageClassification:

--- a/tests/unit/workflows/test_pr_workflow_path_classifier.py
+++ b/tests/unit/workflows/test_pr_workflow_path_classifier.py
@@ -11,6 +11,8 @@ from pathlib import Path
 import pytest
 import yaml
 
+from tests.utilities.posix_shell import run_posix_shell, skip_without_posix_shell
+
 pytestmark = [
     pytest.mark.unit,
     pytest.mark.fast,
@@ -57,6 +59,9 @@ def _ci_required_result_script() -> str:
 
 
 def _run_ci_required_result(**env_overrides: str) -> subprocess.CompletedProcess[str]:
+    # Only the shell-executing tests in this module skip; the YAML/regex ones
+    # alongside them need no shell and must keep running everywhere.
+    skip_without_posix_shell()
     env = {
         **os.environ,
         "CI_PATHS_RESULT": "success",
@@ -76,8 +81,8 @@ def _run_ci_required_result(**env_overrides: str) -> subprocess.CompletedProcess
         "SAFE_CONTENT_ONLY": "true",
         **env_overrides,
     }
-    return subprocess.run(
-        ["bash", "-c", _ci_required_result_script()],
+    return run_posix_shell(
+        _ci_required_result_script(),
         check=False,
         capture_output=True,
         env=env,

--- a/tests/unit/workflows/test_validate_submission_changed_bundles.py
+++ b/tests/unit/workflows/test_validate_submission_changed_bundles.py
@@ -9,6 +9,8 @@ from pathlib import Path
 import pytest
 import yaml
 
+from tests.utilities.posix_shell import run_posix_shell, skip_without_posix_shell
+
 pytestmark = [pytest.mark.unit, pytest.mark.fast]
 
 REPO_ROOT = Path(__file__).resolve().parents[3]
@@ -55,10 +57,11 @@ def test_applied_only_change_discovers_paired_primary_bundle(tmp_path: Path) -> 
     _git(tmp_path, "add", str(applied.relative_to(tmp_path)))
     _git(tmp_path, "commit", "--quiet", "-m", "applied")
 
+    skip_without_posix_shell()
     env = os.environ.copy()
     env["BASE_SHA"] = base_sha
-    result = subprocess.run(
-        ["bash", "-c", _changed_bundle_discovery_script()],
+    result = run_posix_shell(
+        _changed_bundle_discovery_script(),
         cwd=tmp_path,
         check=False,
         capture_output=True,
@@ -100,10 +103,11 @@ def test_applied_companion_rename_discovers_the_source_primary_bundle(tmp_path: 
     _git(tmp_path, "add", str(renamed.relative_to(tmp_path)))
     _git(tmp_path, "commit", "--quiet", "-m", "rename-applied")
 
+    skip_without_posix_shell()
     env = os.environ.copy()
     env["BASE_SHA"] = base_sha
-    result = subprocess.run(
-        ["bash", "-c", _changed_bundle_discovery_script()],
+    result = run_posix_shell(
+        _changed_bundle_discovery_script(),
         cwd=tmp_path,
         check=False,
         capture_output=True,

--- a/tests/utilities/posix_shell.py
+++ b/tests/utilities/posix_shell.py
@@ -1,0 +1,177 @@
+"""Locate a *working* POSIX shell for tests that execute workflow shell fragments.
+
+Several tests assert on the behaviour of `run:` blocks lifted out of our GitHub
+Actions workflows. They need a real POSIX shell, and on Windows plain
+``subprocess.run(["bash", ...])`` does not get one: ``C:\\Windows\\System32\\bash.exe``
+is the *WSL launcher stub* and it precedes Git Bash on the runner's PATH. With no
+distro installed it prints
+
+    Windows Subsystem for Linux has no installed distributions.
+    Use 'wsl.exe --list --online' ... 'wsl --install <Distro>' to install.
+
+in **UTF-16LE** and exits 1. Tests then compared their expected substrings against
+mojibake (``"W\\x00i\\x00n\\x00d\\x00o\\x00w\\x00s\\x00 ..."``) or asserted
+``returncode == 0`` against 1. That reads like an encoding bug but is really the
+wrong interpreter, so decoding fixes do not help.
+
+Rather than guess from paths, every candidate is *probed*: we run a small script
+using the same bash features the workflow fragments rely on and require the expected
+stdout. The WSL stub fails that probe wherever it lives, a real bash passes wherever
+it is installed, and a POSIX-only ``/bin/sh`` is correctly rejected too.
+
+Copyright 2026 Joe Harris / BenchBox Project
+
+Licensed under the MIT License. See LICENSE file in the project root for details.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+from functools import lru_cache
+from pathlib import Path
+
+__all__ = [
+    "posix_shell",
+    "requires_posix_shell",
+    "run_posix_shell",
+    "skip_without_posix_shell",
+]
+
+# Marker the probe expects back. Distinctive so a shell that echoes banners or a
+# stub that prints usage text cannot satisfy it by accident.
+_PROBE_TOKEN = "benchbox-posix-shell-ok"
+
+# The probe deliberately uses the bash features our workflow `run:` blocks rely on
+# -- `set -o pipefail` and a herestring -- so it rejects more than the WSL stub: a
+# POSIX-only /bin/sh (dash) also fails here, and it must, because these scripts are
+# `shell: bash` in the workflows and would break in confusing ways under dash.
+_PROBE_SCRIPT = f'set -euo pipefail\nread -r value <<< "{_PROBE_TOKEN}"\nprintf \'%s\' "$value"'
+
+# Env override first, so a contributor with a shell in a nonstandard place (or CI
+# wanting to pin one) does not depend on our search order.
+_ENV_OVERRIDE = "BENCHBOX_TEST_POSIX_SHELL"
+
+
+def _candidates() -> list[str]:
+    """Ordered shell candidates, most trustworthy first."""
+    found: list[str] = []
+
+    override = os.environ.get(_ENV_OVERRIDE)
+    if override:
+        found.append(override)
+
+    if os.name == "nt":
+        # Git for Windows ships bash.exe; the runner always has it because
+        # actions/checkout drives C:\Program Files\Git\bin\git.exe. Prefer these
+        # explicit locations over PATH order, which the WSL stub wins.
+        # os.environ upper-cases keys on Windows, so these read the documented
+        # ProgramFiles / ProgramFiles(x86) / ProgramW6432 variables.
+        program_files = [
+            os.environ.get("PROGRAMFILES", r"C:\Program Files"),
+            os.environ.get("PROGRAMFILES(X86)", r"C:\Program Files (x86)"),
+            os.environ.get("PROGRAMW6432", r"C:\Program Files"),
+        ]
+        for base in program_files:
+            if not base:
+                continue
+            for rel in (r"Git\bin\bash.exe", r"Git\usr\bin\bash.exe"):
+                found.append(str(Path(base) / rel))
+
+    # PATH lookup last, and every match rather than just the first: shutil.which
+    # stops at the first hit, so a rejected stub earlier on PATH would otherwise
+    # hide a real bash later on it -- exactly the Windows runner's layout.
+    names = ("bash.exe", "bash") if os.name == "nt" else ("bash",)
+    for directory in os.get_exec_path():
+        if not directory:
+            continue
+        for name in names:
+            candidate = Path(directory) / name
+            if candidate.is_file():
+                found.append(str(candidate))
+
+    # Preserve order, drop duplicates and anything that is not actually present.
+    seen: set[str] = set()
+    unique: list[str] = []
+    for candidate in found:
+        key = candidate.lower() if os.name == "nt" else candidate
+        if key in seen:
+            continue
+        seen.add(key)
+        if Path(candidate).exists():
+            unique.append(candidate)
+    return unique
+
+
+def _works(shell: str) -> bool:
+    """True when ``shell -c`` runs a trivial script and returns the probe token."""
+    try:
+        completed = subprocess.run(
+            [shell, "-c", _PROBE_SCRIPT],
+            check=False,
+            capture_output=True,
+            timeout=30,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return False
+    if completed.returncode != 0:
+        return False
+    # Decode defensively: the WSL stub emits UTF-16LE, so a strict utf-8 decode
+    # would raise rather than simply failing the comparison.
+    return completed.stdout.decode("utf-8", errors="replace").strip() == _PROBE_TOKEN
+
+
+@lru_cache(maxsize=1)
+def posix_shell() -> str | None:
+    """Absolute path to a verified POSIX shell, or None if none works here.
+
+    Cached: the probe spawns a process, and callers may ask per test.
+    """
+    for candidate in _candidates():
+        if _works(candidate):
+            return candidate
+    return None
+
+
+def run_posix_shell(script: str, **kwargs) -> subprocess.CompletedProcess:
+    """Run ``script`` under a verified POSIX shell.
+
+    Mirrors ``subprocess.run([shell, "-c", script], **kwargs)``. Raises
+    ``RuntimeError`` when no shell is available; pair with
+    :func:`requires_posix_shell` to skip instead.
+    """
+    shell = posix_shell()
+    if shell is None:
+        raise RuntimeError(
+            "No working POSIX shell found for workflow shell-fragment tests. "
+            f"Set {_ENV_OVERRIDE} to a bash executable. On Windows, install Git for "
+            "Windows (C:\\Program Files\\Git\\bin\\bash.exe); note that "
+            "C:\\Windows\\System32\\bash.exe is the WSL launcher, not a shell."
+        )
+    return subprocess.run([shell, "-c", script], **kwargs)
+
+
+_SKIP_REASON = (
+    f"no working POSIX shell (set {_ENV_OVERRIDE}); C:\\Windows\\System32\\bash.exe is the WSL launcher, not a shell"
+)
+
+
+def requires_posix_shell():
+    """``pytest.mark.skipif`` guard for modules whose every test needs a shell."""
+    import pytest
+
+    return pytest.mark.skipif(posix_shell() is None, reason=_SKIP_REASON)
+
+
+def skip_without_posix_shell() -> None:
+    """Skip the calling test when no POSIX shell is available.
+
+    Preferred over a module-level mark in mixed modules: most of these files also
+    hold YAML/regex assertions that need no shell at all and must keep running on
+    Windows. Call this from the shell-invoking helper so exactly the tests that
+    need a shell skip, and no others.
+    """
+    import pytest
+
+    if posix_shell() is None:
+        pytest.skip(_SKIP_REASON)


### PR DESCRIPTION
# Pull Request

## Description

Attacks the `Nightly Validation` Windows failures (56 failed in each of
`test (windows-latest, 3.10)` and `test (windows-latest, 3.12)`; baseline run
`30473819253`).

**Method.** Windows cannot be run in this environment, so rather than fix blind I
reproduced each Windows-only condition *on Linux* first, confirmed the failure count
matched CI, then fixed and re-ran. CI then confirmed the result on real Windows.

### Confirmed by CI

Run [30542333194](https://github.com/joeharris76/BenchBox/actions/runs/30542333194)
on the first commit alone:

| Job | Baseline | After commit 1 |
|---|---|---|
| `test (windows-latest, 3.12)` | 56 failed | **29 failed** |
| `test (windows-latest, 3.10)` | 56 failed | **28 failed** |

That is the 27 predicted from the two families below, landing exactly. Runs for the
second and third commits are queued.

### Family 1 — chDB probe (17 failures)

`ClickHouseAdapter.__init__` probes for chDB eagerly and raises `ImportError` when it
is absent, even though nothing needs the package until a connection opens. chDB ships
no Windows wheels — `pyproject.toml` constrains it to `sys_platform != 'win32'` — so
every test in `test_clickhouse_introspection.py` and `test_clickhouse_plan_capture.py`
died at construction. None of them touches chDB: they drive DDL rendering and
plan/introspection logic against fake connections.

Fixed by isolating the probe, **not** by skipping: a `chdb_probe_satisfied` fixture
satisfies only that lookup, opted into per module via `usefixtures`. Keyed on probe
availability rather than `sys.platform`, so it stays honest if chDB ever ships Windows
wheels and provably does not over-skip.

> Simulated chDB absence on Linux: **17 failed**, matching CI exactly. After:
> **29 passed with chDB present and 29 with it absent, 0 skipped either way.**

The tracker item `windows-clickhouse-local-tests-without-chdb` says "9 failures"; the
observed count is 17.

### Family 2 — `bash` resolves to the WSL stub (11 failures)

`subprocess.run(["bash", "-c", ...])` resolved to `C:\Windows\System32\bash.exe` — the
**WSL launcher stub**, which precedes Git Bash on the runner's PATH. With no distro
installed it prints its usage text in **UTF-16LE** and exits 1, so assertions compared
expected substrings against mojibake:

```
assert 'content-guard=failure' in "W\x00i\x00n\x00d\x00o\x00w\x00s\x00 \x00S\x00u\x00b\x00s\x00y\x00s\x00t\x00e\x00m\x00 ..."
```

which decodes to *"Windows Subsystem for Linux … '&lt;Distro&gt;' to install."* This reads
like a missing-`encoding` bug and was previously triaged as one — but the interpreter is
wrong, so no decoding change can fix it.

`tests/utilities/posix_shell.py` resolves a shell by **probing** candidates with the
bash features these fragments actually use (`set -o pipefail`, a herestring), so it
rejects the stub wherever it lives — and correctly rejects a POSIX-only `/bin/sh`
(dash), which cannot run these `shell: bash` fragments either. It scans *every* PATH
entry rather than taking `shutil.which`'s first hit, because a rejected stub earlier on
PATH would otherwise hide the real bash later on it — the runner's exact layout.

Guards are **per-test** via `skip_without_posix_shell()`, not module-level: 6 of the 16
tests in the classifier module assert on YAML and regexes, need no shell, and must keep
running on Windows.

Also fixes a **scope gap**: `test_validate_submission_changed_bundles.py` hits the same
stub but was absent from that tracker item's `only_modify` list.

### Family 3 — locale-dependent reads (2 product defects)

`Path.read_text()` with no encoding uses `locale.getpreferredencoding()` — cp1252 on
Windows — raising `UnicodeDecodeError: 'charmap' codec can't decode byte 0x8f`. Fixed
in the affected test readers and in the **two product call sites** that had the same
latent bug with no test covering them: `benchbox/utils/dependencies.py` (pyproject.toml,
UTF-8 by PEP 518) and `benchbox/core/tpcds_obt/query_conversion.py`.

### Family 4 — `is_snowflake_stage_path` (product defect)

The function accepts `Union[str, Path]`, but the stage grammar requires `/` after the
stage token and `str(WindowsPath("@~/data"))` is `"@~\data"`. A `Path`-typed Snowflake
stage reference therefore classified as **not a stage** on Windows — and for this
predicate that means a stage path can be treated as local.

While there I widened `isinstance(path, Path)` to `PurePath`: the pure flavours are not
`Path` subclasses, so `PureWindowsPath` input previously fell through to the non-str
rejection. Found because my first regression test used `PureWindowsPath` and still
failed — it was exercising a different branch than production.

### Family 5 — TPC-H CRLF normalization (5 failures, product defect)

`_has_trailing_delimiter` probed the last **two** bytes for `b"|\n"`, but under CRLF the
sequence is `b"|\r\n"` — so the probe only ever saw `b"\r\n"`, missed the delimiter and
reported the file already clean. The streaming rewrite had the matching gap: it replaced
only `b"|\n"`, and its carry held back a chunk-final `b"|"` but not `b"|\r"`, corrupting
rows when a terminator split across a chunk boundary.

This is precisely the case the normalizer exists for — a dbgen built on a platform
outside the precompiled matrix, which on Windows emits CRLF. #1332 intended this support;
the probe width kept it from working.

### Family 6 — bundle export newline determinism (product defect)

`ResultExporter._write_file` opened a text handle without `newline=""`, so
universal-newline translation rewrote `\n` to `\r\n` on Windows. Bundles are
**byte**-defined (`canonical_json_bytes`) and their bytes feed the `companion_hashes`
submission contract, so the same logical bundle exported on Windows would not byte-match
one exported on Linux or macOS.

### Family 7 — POSIX-only APIs

- `test_kill_process_group_uses_killpg_when_available` used `monkeypatch.setattr` without
  `raising=False`, so it errored on win32 where `os.killpg` does not exist. The product
  *already* has the `hasattr` guard. `raising=False` injects the attribute so the POSIX
  ladder is still exercised on Windows; a `skipif` would have dropped real coverage.
- `test_shared_predicate_script_is_executable_for_workflow` asserted a POSIX exec bit via
  `stat().st_mode`, which Windows lacks. It now asserts the mode **git records**
  (`100755`) via `git ls-files --stage` — what actually governs the Linux runner, and
  identical on every platform. Stronger, not platform-weakened.

### Family 8 — path-separator assertions

`tests/uat/test_preflight_budget.py` and `test_runner.py` hardcoded `/tmp` and
`benchmark_runs/results/` while the code under test renders `str(Path)`. Both now derive
the expectation from the same `Path` the code receives — asserting at least as much, and
matching the idiom already in `test_preflight.py`. **No assertion was loosened.**

## Type of Change

- [x] Bug fix

## Testing

Windows verification is by CI. Run `30542333194` confirmed commit 1 (**56 → 29/28**);
runs for commits 2 and 3 are queued. **This PR should not merge until those report.**

Linux verification, simulating each Windows condition:

| Condition simulated | Before | After |
|---|---|---|
| chDB absent (`find_spec` patched) | 17 failed | 29 passed, 0 skipped |
| WSL stub first on PATH | 10 failed | 89 passed |
| `PureWindowsPath` stage reference | failed | 67 passed |
| CRLF `.tbl` input (bytes written directly) | 4 failed | 11 passed |

Every new test was checked against the pre-fix code so none is vacuous.

```
tests/unit/workflows/ tests/unit/test_release_infrastructure.py
  tests/unit/platforms/test_clickhouse_*.py tests/unit/test_posix_shell_resolver.py   207 passed
tests/uat/... tests/unit/utils/... tests/unit/cli/... tests/unit/query_plans/...       247 passed
tests/unit/test_results_exporter.py tests/unit/core/tpch/... tests/unit/test_auto_merge... 56 passed
uv run -- ruff check / ruff format --check (all changed files)                         clean
```

One failure in the broader `-k "exporter or canonical or bundle"` selection,
`test_export_with_invalid_output_dir`, is **pre-existing and unrelated** — verified by
stashing the change: it fails identically without it, because this container runs as
root and can create the supposedly-uncreatable path.

## Public Contract Check

- [x] I updated `docs/reference/public-contracts.md`, or this PR does not change
      public, beta-public, deprecated, generated, experimental, or repo-only
      contract surfaces.
- [x] I checked result schema fields, MCP tool parameters, platform support
      status, wrapper facades, adapter subclassing hooks, and generated docs for
      contract-map impact.
- [x] Any platform/benchmark count claim in docs is generated/checked from
      registry metadata, or explicitly marked editorial/non-authoritative.

Two surfaces worth a reviewer's eye, neither a signature change:
`is_snowflake_stage_path` now honours the `Path` half of its own annotation on Windows
and accepts `PurePath`; `ResultExporter` output is now byte-identical across platforms
(previously Windows-only CRLF). Both make behaviour *more* conformant, and the bundle
change only affects Windows-produced bundles, which could not have matched their hashes
before.

## Documentation

- [x] I updated the relevant user-facing docs.
- [x] I added regression notes for behavior changes.
- [x] I confirmed API contract wording remains accurate.

Rationale is recorded where maintainers will meet it: the `posix_shell` module
docstring, the `chdb_probe_satisfied` fixture docstring, and the new tests' docstrings.

## Code Quality

- [x] I ran formatting and lint/type checks.
- [x] I reviewed impacted modules for backwards compatibility and migration impact.
- [x] I added/updated tests for behavior changes and error paths.
- [x] I confirmed public contracts and release checklists are still valid.

## Artifact Hygiene

- [x] I did not commit raw screenshots, browser reports, generated logs,
      benchmark outputs, or temporary binary artifacts.
- [x] Any committed binary/raw evidence file has durable repo value and is
      justified here with its consumer and size:

None. The reproduction harnesses (a `find_spec` plugin, a WSL-stub script) were
deliberately not committed; the recipes are documented in docstrings instead.

## Notes

**Still red — not claimed fixed.** Roughly 11 of the original 56 remain, left with their
evidence rather than guessed at:

- `tests/uat/test_phases.py` (4) + `test_orchestrator.py` (2) + `test_docker_assets.py`
  (1) — docker compose command/path assertions. **`test_disk_floor_abort_carries_startup_failed_count`
  is a genuine logic bug** (`startup_failed_count` is 0, expected 1), not a path artifact,
  and deserves its own investigation.
- `tests/unit/tpcds/test_dsqgen_streams.py` (3) — the Windows dsqgen binary fails with
  `Runtime ERROR: Distribution over-run/under-run … cities`, which looks like a real
  binary/data problem rather than a test issue.
- `tests/unit/scripts/test_pr_review_followups.py` (1) — the test writes a
  bash-shebang `codex` shim with no Windows-resolvable extension, so `shutil.which`
  never finds it. Fixable with a `.cmd` wrapper over the existing `posix_shell()`
  helper, but fiddly and unverifiable from here.

**Also seen, not caused by this PR:** `test (macos-latest, 3.12)` failed in run
`30542333194` with 22 `InsufficientMemoryError` failures ("~2.0 GB required, but only
2.4 GB available") in `tests/unit/platforms/dataframe/`. macOS was green in the baseline
and nothing here touches memory estimation, so this looks like runner resource pressure —
but it is worth watching rather than assuming.

**Reviewer focus:** the `posix_shell` probe rejecting `/bin/sh` is deliberate — these
fragments are `shell: bash` in the workflows and would fail confusingly under dash. If
you would rather they degrade to `sh`, that is a one-line change to `_PROBE_SCRIPT`.