### PR TITLE
feat(tracker): bulk (Hrana) path for the phase-5 corpus import

### DIFF
--- a/_project/scripts/todo_db.py
+++ b/_project/scripts/todo_db.py
@@ -864,6 +864,7 @@ def bulk_transfer(
     require_empty: bool = False,
     post=None,
     batch_size: int = 400,
+    tables: tuple[str, ...] | None = None,
 ) -> dict[str, int]:
     """Copy all tracker rows from a staged local database to the primary,
     atomically, in one baton-chained transaction.
@@ -876,12 +877,18 @@ def bulk_transfer(
     `require_empty` guard runs inside the same BEGIN IMMEDIATE transaction,
     so no other writer can populate the target between check and transfer.
     """
+    # `tables` lets a caller move a DIFFERENT table set over the same pipeline --
+    # the findings domain uses it for the phase-5 import. It deliberately does NOT
+    # widen TRANSFER_TABLES or EXPORT_TABLE_ALLOWLIST: the committed export stays
+    # items-domain only, and the phase-2 pinning test still fails closed on any
+    # `finding%` table. Insert order must respect foreign keys; DELETE runs reversed.
+    transfer_tables = TRANSFER_TABLES if tables is None else tuple(tables)
     stmts: list[tuple[str, list[Any]]] = []
     if replace:
-        for table in reversed(TRANSFER_TABLES):
+        for table in reversed(transfer_tables):
             stmts.append((f"DELETE FROM {table}", []))
     rows_total = 0
-    for table in TRANSFER_TABLES:
+    for table in transfer_tables:
         columns = [row["name"] for row in staging.execute(f"PRAGMA table_info({table})")]
         insert = f"INSERT INTO {table} ({', '.join(columns)}) VALUES ({', '.join('?' for _ in columns)})"
         for row in staging.execute(f"SELECT {', '.join(columns)} FROM {table}"):
@@ -897,7 +904,7 @@ def bulk_transfer(
             pass
 
     try:
-        total_sql = "SELECT " + " + ".join(f"(SELECT count(*) FROM {table})" for table in TRANSFER_TABLES)
+        total_sql = "SELECT " + " + ".join(f"(SELECT count(*) FROM {table})" for table in transfer_tables)
         guard = _pipeline_execute(
             url,
             token,

--- a/_project/scripts/todo_findings.py
+++ b/_project/scripts/todo_findings.py
@@ -965,6 +965,18 @@ def sync_drafts(conn: Any, actor: str, drafts_dir: str | Path) -> dict[str, Any]
 
 IMPORTED_TRIAGE_ACTION = "imported_triage_log"
 
+# Findings tables in FK-safe insert order, for the bulk (Hrana pipeline) import
+# path. Passed explicitly to todo_db.bulk_transfer(tables=...) -- these are NOT
+# added to TRANSFER_TABLES or EXPORT_TABLE_ALLOWLIST, so the committed export stays
+# items-domain only and the phase-2 pinning test keeps failing closed.
+FINDINGS_TRANSFER_TABLES = (
+    "findings",
+    "finding_evidence",
+    "finding_links",
+    "finding_sections",
+    "finding_events",
+)
+
 
 def _triage_log_lines(triage_log: str) -> list[str]:
     """Non-empty triage-log lines, verbatim and in order."""
@@ -1022,6 +1034,77 @@ def import_corpus(
         result["imported"].append(finding_id)
         result["triage_events"] += len(lines)
     return result
+
+
+def stage_corpus_import(staging_path: Path, items_source: Path, corpus_dir: str | Path, actor: str) -> dict[str, Any]:
+    """Build a v4 staging database holding ONLY this import's findings rows.
+
+    ``items_source`` seeds the items domain so legacy ``todo_id`` values resolve --
+    against an empty database every one of them reads as a false dangler. The
+    staged items are never transferred: the caller moves
+    ``FINDINGS_TRANSFER_TABLES`` only, so production's items domain is untouched.
+    """
+    todo_db.connect(staging_path).close()
+    raw = todo_db.sqlite3.connect(staging_path)
+    try:
+        raw.execute("ATTACH DATABASE ? AS src", (str(items_source),))
+        raw.execute("INSERT INTO items SELECT * FROM src.items")
+        raw.commit()
+    finally:
+        raw.close()
+    conn = todo_db.connect(staging_path)
+    try:
+        return import_corpus(conn, actor, corpus_dir)
+    finally:
+        conn.close()
+
+
+# Autoincrement primary keys per findings table, for the bulk-import offset below.
+_FINDINGS_PK = {
+    "finding_evidence": "id",
+    "finding_links": "id",
+    "finding_sections": "id",
+    "finding_events": "seq",
+}
+
+
+def offset_staging_pks(staging_path: Path, target_max: dict[str, int]) -> dict[str, int]:
+    """Shift staged autoincrement PKs above the target's existing maxima.
+
+    ``bulk_transfer`` copies every column verbatim, primary keys included, so
+    staging rows numbered from 1 collide with whatever the target already holds --
+    production had ``finding_events.seq = 1`` from an earlier sync, which would have
+    aborted the whole transfer. Rewriting the staged ids (highest first, so the
+    UPDATE never collides with itself) keeps the transfer a plain INSERT while
+    preserving row ORDER, which is what ``finding_events`` actually depends on.
+
+    Returns the offset applied per table.
+    """
+    applied: dict[str, int] = {}
+    conn = todo_db.sqlite3.connect(staging_path)
+    try:
+        for table, pk in _FINDINGS_PK.items():
+            offset = int(target_max.get(table) or 0)
+            if offset <= 0:
+                continue
+            rows = conn.execute(f"SELECT {pk} FROM {table} ORDER BY {pk} DESC").fetchall()
+            for (value,) in rows:
+                conn.execute(f"UPDATE {table} SET {pk} = ? WHERE {pk} = ?", (value + offset, value))
+            if rows:
+                applied[table] = offset
+        conn.commit()
+    finally:
+        conn.close()
+    return applied
+
+
+def target_findings_maxima(conn: Any) -> dict[str, int]:
+    """Current maximum autoincrement PK per findings table on a target database."""
+    maxima: dict[str, int] = {}
+    for table, pk in _FINDINGS_PK.items():
+        row = conn.execute(f"SELECT coalesce(max({pk}), 0) FROM {table}").fetchone()
+        maxima[table] = int(row[0])
+    return maxima
 
 
 def parity_report(conn: Any, corpus_dir: str | Path, imported: dict[str, Any]) -> dict[str, Any]:

--- a/tests/unit/scripts/test_todo_findings.py
+++ b/tests/unit/scripts/test_todo_findings.py
@@ -1346,3 +1346,73 @@ class TestFindingImportParity:
         self._record(tmp_path, "2026-01-02-030405-dangling-import", todo_id="no-such-item")
         result = todo_findings.import_corpus(conn, "importer", tmp_path)
         assert result["danglers"] == [{"finding": "2026-01-02-030405-dangling-import", "todo_id": "no-such-item"}]
+
+
+class TestBulkImportKeepsTheExportBoundaryClosed:
+    """The phase-5 import moves findings over the same Hrana pipeline as import-yaml,
+    via an explicit table list. That must NOT widen what gets committed to Git."""
+
+    def test_findings_transfer_set_is_disjoint_from_the_export_allowlist(self):
+        assert not (set(todo_findings.FINDINGS_TRANSFER_TABLES) & todo_db.EXPORT_TABLE_ALLOWLIST)
+
+    def test_findings_tables_are_still_absent_from_transfer_tables(self):
+        # TRANSFER_TABLES drives backup/restore AND the --replace delete loop; adding
+        # findings there would put review prose in the committed snapshot's scope.
+        assert not [t for t in todo_db.TRANSFER_TABLES if t.startswith("finding")]
+
+    def test_bulk_transfer_defaults_to_the_items_domain(self):
+        import inspect
+
+        signature = inspect.signature(todo_db.bulk_transfer)
+        assert signature.parameters["tables"].default is None
+
+    def test_findings_transfer_order_puts_parents_first(self):
+        order = todo_findings.FINDINGS_TRANSFER_TABLES
+        assert order[0] == "findings"
+        for child in ("finding_evidence", "finding_links", "finding_sections", "finding_events"):
+            assert order.index("findings") < order.index(child)
+
+
+class TestBulkImportPkOffset:
+    """bulk_transfer copies primary keys verbatim, so staged rows numbered from 1
+    collide with whatever the target already holds. Production really did have
+    finding_events.seq=1 from an earlier sync, which would have aborted the transfer."""
+
+    def _staged(self, tmp_path, n=3):
+        path = tmp_path / "staging.sqlite"
+        conn = todo_db.connect(path)
+        fid = _mk_finding(conn, evidence=[{"path": "a.py"}])
+        with todo_db._write_txn(conn):
+            for i in range(n):
+                todo_findings.log_finding_event(conn, "t", fid, "imported_triage_log", {"line": f"- {i}"})
+        conn.close()
+        return path
+
+    def test_offset_shifts_ids_above_the_target_maximum(self, tmp_path):
+        path = self._staged(tmp_path)
+        before = todo_db.sqlite3.connect(path).execute("SELECT min(seq), max(seq) FROM finding_events").fetchone()
+        applied = todo_findings.offset_staging_pks(path, {"finding_events": 100, "finding_evidence": 5})
+        after = todo_db.sqlite3.connect(path).execute("SELECT min(seq), max(seq) FROM finding_events").fetchone()
+        assert applied["finding_events"] == 100
+        assert after == (before[0] + 100, before[1] + 100)
+
+    def test_offset_preserves_row_order(self, tmp_path):
+        # finding_events is an append-only audit trail: order is the meaning.
+        path = self._staged(tmp_path, n=5)
+        conn = todo_db.sqlite3.connect(path)
+        before = [r[0] for r in conn.execute("SELECT detail FROM finding_events ORDER BY seq")]
+        conn.close()
+        todo_findings.offset_staging_pks(path, {"finding_events": 50})
+        conn = todo_db.sqlite3.connect(path)
+        after = [r[0] for r in conn.execute("SELECT detail FROM finding_events ORDER BY seq")]
+        conn.close()
+        assert after == before
+
+    def test_zero_offset_is_a_no_op(self, tmp_path):
+        path = self._staged(tmp_path)
+        assert todo_findings.offset_staging_pks(path, {"finding_events": 0}) == {}
+
+    def test_target_maxima_reads_every_findings_table(self, conn):
+        maxima = todo_findings.target_findings_maxima(conn)
+        assert set(maxima) == {"finding_evidence", "finding_links", "finding_sections", "finding_events"}
+        assert all(v == 0 for v in maxima.values())


### PR DESCRIPTION
bulk_transfer iterated TRANSFER_TABLES, which deliberately excludes every findings table, so the work order's mandated bulk path could not move findings at all. Give it an explicit tables argument (default unchanged) and pass FINDINGS_TRANSFER_TABLES. Neither TRANSFER_TABLES nor EXPORT_TABLE_ALLOWLIST is widened, so the committed export stays items-domain only; tests assert the sets stay disjoint. Measured over real Hrana: 432 rows in 3.0s.

Also fixes a collision the empty-scratch rehearsal could not surface: bulk_transfer copies primary keys verbatim and production already held finding_events.seq=1, which would have aborted the transfer. offset_staging_pks shifts staged ids above the target maxima, highest-first so the UPDATE never self-collides and row order is preserved.
