### PR TITLE
feat(todo): emit a migration snapshot restore-legacy can consume

### DIFF
--- a/_project/scripts/todo_db.py
+++ b/_project/scripts/todo_db.py
@@ -2005,6 +2005,123 @@ def export_events(conn: sqlite3.Connection) -> list[dict[str, Any]]:
         return _export_events_unlocked(conn)
 
 
+# The tables todo-db's `restore-legacy` importer requires in a snapshot
+# (todo_db/database.py::restore_legacy). Stated explicitly so the tie to the
+# committed-export allowlist is checkable rather than incidental.
+RESTORE_LEGACY_REQUIRED_TABLES = frozenset(
+    {
+        "items",
+        "events",
+        "work_units",
+        "work_needs",
+        "item_deps",
+        "scope_rules",
+        "verifications",
+        "preserves",
+        "anti_patterns",
+        "prior_art",
+        "deferrals",
+        "meta",
+    }
+)
+
+# A migration snapshot is a BACKUP artifact, so it is scoped to the full
+# backup/restore set (TRANSFER_TABLES) plus `meta` for schema provenance -- NOT
+# to EXPORT_TABLE_ALLOWLIST. The two happen to hold the same names today, but
+# they answer different questions: the allowlist is "what may be committed to
+# Git", deliberately maintained as an independent literal so the committed
+# surface never widens by accident. Deriving a migration snapshot from it would
+# invert that: legitimately narrowing what gets committed would silently narrow
+# what a migration carries, which is precisely the kind of silent data loss this
+# snapshot exists to avoid. Findings tables stay out because TRANSFER_TABLES
+# excludes them, and restore-legacy would discard them regardless.
+SNAPSHOT_TABLES = frozenset(TRANSFER_TABLES) | {"meta"}
+
+
+def _snapshot_order_by(conn: sqlite3.Connection, table: str) -> str:
+    """ORDER BY the table's primary key so a snapshot is reproducible."""
+    pk = [row["name"] for row in conn.execute(f"PRAGMA table_info({table})") if row["pk"]]
+    return f" ORDER BY {', '.join(pk)}" if pk else ""
+
+
+def build_snapshot(conn: sqlite3.Connection) -> dict[str, list[dict[str, Any]]]:
+    """Raw per-table dump for todo-db's `restore-legacy` importer.
+
+    This is a different SHAPE from the committed export, not a reformatting of
+    it. ``write_export`` denormalizes: child rows are nested inside each item in
+    items.jsonl. ``restore_legacy`` wants the opposite -- normalized tables it
+    can load directly -- and explicitly strips the nested keys, so the committed
+    export is structurally invalid as importer input.
+
+    Note what this does NOT carry: the findings domain. ``restore_legacy``
+    ignores tables outside its required set, so findings rows would be dropped
+    on restore whether or not they appear here. Including them would leak review
+    prose for no benefit, so they are excluded.
+    """
+    # Fail closed. If the backup scope gains a table that restore-legacy does
+    # not know about, that importer would silently DROP it on restore. Refusing
+    # to build the snapshot surfaces the lossiness now, while it is still a
+    # migration-planning problem, rather than after a cutover.
+    if SNAPSHOT_TABLES != RESTORE_LEGACY_REQUIRED_TABLES:
+        only_here = sorted(SNAPSHOT_TABLES - RESTORE_LEGACY_REQUIRED_TABLES)
+        only_there = sorted(RESTORE_LEGACY_REQUIRED_TABLES - SNAPSHOT_TABLES)
+        raise RuntimeError(
+            "snapshot scope and restore-legacy's required tables have diverged; "
+            "a migration would lose data.\n"
+            f"  in the backup scope but not restorable: {only_here}\n"
+            f"  required by restore-legacy but not dumped: {only_there}\n"
+            "Reconcile RESTORE_LEGACY_REQUIRED_TABLES with the importer before migrating."
+        )
+    # One read snapshot across every table. Two independent SELECTs with a
+    # concurrent write between them would produce a bundle that no point in
+    # time ever had -- e.g. a scope_rules row referencing an absent item.
+    with _read_txn(conn):
+        return {
+            # Table names come from a module constant, never from input.
+            table: [dict(row) for row in conn.execute(f"SELECT * FROM {table}{_snapshot_order_by(conn, table)}")]
+            for table in sorted(SNAPSHOT_TABLES)
+        }
+
+
+def _enclosing_work_tree(path: Path) -> Path | None:
+    """The Git work tree containing ``path``, if any.
+
+    Deliberately NOT ``git_main_root()``: agents work in pool worktrees
+    (BenchBox.pool-NN), which are separate roots, so a main-root check passes a
+    destination straight into a checkout. Walk instead, and accept ``.git`` as
+    either a directory (clone) or a file (linked worktree).
+    """
+    probe = path if path.is_dir() else path.parent
+    while True:
+        if (probe / ".git").exists():
+            return probe
+        if probe == probe.parent:
+            return None
+        probe = probe.parent
+
+
+def write_snapshot(conn: sqlite3.Connection, path: Path) -> Path:
+    """Write a migration snapshot, refusing to place it inside the repo.
+
+    A snapshot is a full tracker dump including every deferral and event body.
+    PR #1327 established that such payloads stay out of Git; the committed
+    export is the curated artifact. Rather than trust the caller to remember,
+    refuse a destination inside the work tree.
+    """
+    resolved = path.expanduser().resolve()
+    if _enclosing_work_tree(resolved) is not None:
+        raise SystemExit(
+            f"refusing to write a tracker snapshot inside a Git work tree ({resolved}).\n"
+            "Snapshots carry every deferral and event body and must not reach Git; "
+            "write it outside the checkout, e.g. ~/todo-db-backups/."
+        )
+    resolved.parent.mkdir(parents=True, exist_ok=True)
+    with open(resolved, "w", encoding="utf-8") as handle:
+        json.dump(build_snapshot(conn), handle, sort_keys=True, indent=2)
+        handle.write("\n")
+    return resolved
+
+
 def write_export(conn: sqlite3.Connection, out_dir: Path) -> tuple[Path, Path, Path]:
     # Fail closed: the exporter's own coverage (item-nested tables + events)
     # must equal the committed-snapshot allowlist. If a future change teaches
@@ -2556,7 +2673,17 @@ def main(argv: list[str] | None = None) -> int:
     p.add_argument("value", nargs="?")
 
     p = sub.add_parser("export", help="deterministic JSONL + markdown index")
-    p.add_argument("--out", default=None)
+    g = p.add_mutually_exclusive_group()
+    g.add_argument("--out", default=None)
+    g.add_argument(
+        "--snapshot",
+        default=None,
+        metavar="FILE",
+        help=(
+            "instead of the committed export, write a single-JSON raw table dump for "
+            "todo-db's restore-legacy importer. Must be outside the repository."
+        ),
+    )
 
     pf = sub.add_parser("finding", help="findings domain: capture, sync, triage, promote")
     todo_findings.add_finding_subparsers(pf)
@@ -3027,6 +3154,10 @@ def _cmd_sweep_stale(conn, actor, args):
 
 
 def _cmd_export(conn, actor, args):
+    if args.snapshot:
+        path = write_snapshot(conn, Path(args.snapshot))
+        print(f"wrote {path}")
+        return 0
     out_dir = Path(args.out) if args.out else git_main_root() / ".todo-db" / "export"
     jsonl_path, events_path, index_path = write_export(conn, out_dir)
     print(f"wrote {jsonl_path}, {events_path} and {index_path}")

--- a/tests/unit/scripts/test_todo_db_export_allowlist.py
+++ b/tests/unit/scripts/test_todo_db_export_allowlist.py
@@ -174,3 +174,89 @@ class TestEventsRoundTrip:
         assert len(rows) == db_count
         assert {"action", "actor", "at", "item_id", "seq"} <= set(rows[0].keys())
         assert any(row["action"] == "create" for row in rows)
+
+
+class TestMigrationSnapshotScope:
+    """The snapshot is a BACKUP artifact, scoped separately from the export."""
+
+    def test_snapshot_scope_is_transfer_tables_plus_meta(self):
+        # Scoped to the backup/restore set, NOT to the committed-export
+        # allowlist. The two hold the same names today, but deriving the
+        # snapshot from the allowlist would mean narrowing what may be
+        # committed silently narrows what a migration carries.
+        assert frozenset(todo_db.TRANSFER_TABLES) | {"meta"} == todo_db.SNAPSHOT_TABLES
+
+    def test_snapshot_matches_what_restore_legacy_requires(self):
+        # build_snapshot refuses to run when these diverge; pin it here too so
+        # the divergence is named in a unit test rather than only at runtime.
+        assert todo_db.SNAPSHOT_TABLES == todo_db.RESTORE_LEGACY_REQUIRED_TABLES
+
+    def test_snapshot_excludes_findings_tables(self):
+        leaks = sorted(t for t in todo_db.SNAPSHOT_TABLES if t.startswith("finding"))
+        assert leaks == [], f"findings prose must not reach a migration snapshot: {leaks}"
+
+
+class TestMigrationSnapshotShape:
+    def test_snapshot_covers_every_required_table(self, conn):
+        _mk(conn, item_id="snapshot-item")
+        snapshot = todo_db.build_snapshot(conn)
+        missing = sorted(todo_db.RESTORE_LEGACY_REQUIRED_TABLES - snapshot.keys())
+        assert missing == [], f"restore-legacy would reject this snapshot: missing {missing}"
+
+    def test_items_are_normalized_not_nested(self, conn):
+        # The committed export nests child rows inside each item; restore_legacy
+        # strips exactly those keys and looks for sibling tables instead. A
+        # snapshot carrying nested items is structurally invalid input.
+        _mk(conn, item_id="snapshot-item")
+        snapshot = todo_db.build_snapshot(conn)
+        nested = {"work", "deps", "scope", "verifications", "preserves", "anti_patterns", "prior_art", "deferrals"}
+        leaked = sorted({key for item in snapshot["items"] for key in nested & set(item)})
+        assert leaked == [], f"items must be raw rows, not the export's nested shape: {leaked}"
+
+    def test_child_rows_travel_in_their_own_tables(self, conn):
+        _mk(conn, item_id="snapshot-item", scope=[("only_modify", "src/**")])
+        snapshot = todo_db.build_snapshot(conn)
+        assert snapshot["scope_rules"], "scope rules must survive as their own table"
+        assert all(row["item_id"] == "snapshot-item" for row in snapshot["scope_rules"])
+
+    def test_snapshot_is_deterministic(self, conn):
+        _mk(conn, item_id="b-item")
+        _mk(conn, item_id="a-item")
+        assert todo_db.build_snapshot(conn) == todo_db.build_snapshot(conn)
+
+
+class TestMigrationSnapshotStaysOutOfGit:
+    """A snapshot carries every deferral and event body; it must not reach Git."""
+
+    def test_refuses_a_destination_inside_a_work_tree(self, conn, tmp_path):
+        work_tree = tmp_path / "checkout"
+        (work_tree / ".git").mkdir(parents=True)
+        with pytest.raises(SystemExit, match="refusing to write a tracker snapshot"):
+            todo_db.write_snapshot(conn, work_tree / "snapshot.json")
+        assert not (work_tree / "snapshot.json").exists()
+
+    def test_refuses_a_nested_destination_inside_a_work_tree(self, conn, tmp_path):
+        work_tree = tmp_path / "checkout"
+        (work_tree / ".git").mkdir(parents=True)
+        nested = work_tree / "_project" / "scripts"
+        nested.mkdir(parents=True)
+        with pytest.raises(SystemExit, match="refusing to write a tracker snapshot"):
+            todo_db.write_snapshot(conn, nested / "snapshot.json")
+
+    def test_refuses_inside_a_linked_worktree_where_dot_git_is_a_file(self, conn, tmp_path):
+        # Pool worktrees (BenchBox.pool-NN) carry a `.git` FILE, not a directory,
+        # and are separate roots from the main clone -- a main-root check lets
+        # them through, which is exactly where agents do their work.
+        work_tree = tmp_path / "pool-01"
+        work_tree.mkdir()
+        (work_tree / ".git").write_text("gitdir: /elsewhere/.git/worktrees/pool-01\n", encoding="utf-8")
+        with pytest.raises(SystemExit, match="refusing to write a tracker snapshot"):
+            todo_db.write_snapshot(conn, work_tree / "snapshot.json")
+
+    def test_writes_outside_any_work_tree(self, conn, tmp_path):
+        _mk(conn, item_id="snapshot-item")
+        target = tmp_path / "backups" / "snapshot.json"
+        written = todo_db.write_snapshot(conn, target)
+        assert written.exists()
+        payload = json.loads(written.read_text(encoding="utf-8"))
+        assert payload.keys() >= todo_db.RESTORE_LEGACY_REQUIRED_TABLES


### PR DESCRIPTION
## Why

`todo-db`'s `restore-legacy` importer could not ingest **anything** this repo produced.

It wants **one JSON object of 12 normalized tables**. `todo export` writes a **directory** of denormalized `items.jsonl` + `events.jsonl`. Feeding it the directory gives `Is a directory`; feeding `items.jsonl` gives `Extra data: line 2`, because it `json.load()`s a single object. `restore_legacy` then explicitly *strips* the nested keys (`work`, `deps`, `scope`, …) and looks for sibling tables instead.

The migration path the tracker item assumed simply did not exist. This is the missing half.

## What

`todo export --snapshot FILE` emits that shape — raw rows per table, read inside one `_read_txn` so a concurrent write cannot produce a bundle no point in time ever had, ordered by primary key so it is reproducible.

### Scope: `TRANSFER_TABLES | {meta}`, not the export allowlist

Deliberate, and the more interesting decision here. `EXPORT_TABLE_ALLOWLIST` is maintained as an **independent literal** — the file says so — precisely so the *committed* surface never widens by accident. Deriving a **backup** artifact from it would invert that guarantee: legitimately narrowing what may be committed would silently narrow what a **migration** carries. A snapshot is a backup, so it is scoped to the backup set. Findings stay out because `TRANSFER_TABLES` excludes them.

### Fails closed

`build_snapshot` refuses to run if `SNAPSHOT_TABLES` and the importer's required set ever diverge, naming which side gained a table — so future lossiness surfaces while it is still a planning problem, not after a cutover.

### The guard I got wrong first

`write_snapshot` refuses a destination inside a Git work tree. My first implementation checked `git_main_root()` — and **let a pool worktree straight through**, writing a full tracker dump into `BenchBox.pool-02` during testing. Pool worktrees are separate roots carrying a `.git` **file**, and they are exactly where agents work. The check now walks for an enclosing work tree and accepts both `.git` forms:

```
linked worktree destination: .../pool-01/snapshot.json
  old (git_main_root) refuses: False   <- the hole
  new (_enclosing_work_tree) refuses: True
```

Pinned by a test using the file form.

## Verification

Against the **live hosted tracker**, restoring only into a scratch SQLite DB — never the hosted DB:

```
restored legacy snapshot from ~/todo-db-backups/2026-07-30-snapshot.json
audit verify -> {"algorithm":"sha256-chain-v2","event_count":4187,"head_seq":4187,...}
```

| state | snapshot | restored |
|---|---|---|
| planning | 243 | 243 |
| active | 40 | 40 |
| done | 1365 | 1365 |
| dropped | 35 | 35 |

12/12 required tables, zero nested keys leaking into `items`, findings excluded. `tests/unit/scripts/` — 1168 passed; `-k export` — 30 passed (rung 4, existing export unchanged).

Tests join the existing export-boundary file, which is marked `medium` on purpose, so this consumes **no fast-lane budget**.

## Known limitation — tracked

`restore_legacy` ignores tables outside its required set, so **findings do not transfer** — and a snapshot that carried them would be *accepted while discarding them*, which is the dangerous shape: it looks like a successful migration. Filed as `restore-legacy-drops-the-findings-domain` (medium-high), which also proposes making the importer reject unknown tables rather than ignore them.

## Note on rung 3

The item's third rung invokes a bare `todo-db`, which is not on `PATH` (the standalone runs via `uv run -- todo-db` from `~/Developer/todo-db`), so it fails as recorded. That is a defect in how I wrote the rung, not in the work — its exact logic passes with the correct invocation, output above. Rungs 1, 2 and 4 pass as written. Verifications are create-time-only and `update` is standalone-only, so the rung cannot be amended in place.

Closes `legacy-tracker-snapshot-export-for-restore-legacy`.