### PR TITLE
test(utils): pin CRLF framing detection and the text-mode invariant

### DIFF
--- a/benchbox/utils/file_format.py
+++ b/benchbox/utils/file_format.py
@@ -445,7 +445,23 @@ def has_trailing_delimiter(
 
 
 def _check_first_nonempty_line(path: Path, checker, CompressionError, CompressionManager) -> bool:
-    """Read the first non-empty line from a (possibly compressed) file and apply checker."""
+    r"""Read the first non-empty line from a (possibly compressed) file and apply checker.
+
+    TEXT MODE IS REQUIRED, not incidental. Both reads below open ``"rt"``, so
+    universal newlines translate ``\r\n`` to ``\n`` before the checker sees the
+    line -- and every checker in ``has_trailing_delimiter`` strips only ``\n``.
+    A file written on Windows ends ``|\r\n``, so switching either read to binary
+    for throughput would leave a stray ``\r``: the field-count checker would see
+    an extra field, the ends-with checker would stop matching, and on bytes
+    ``rstrip("\n")`` raises outright -- which the blanket ``except`` below turns
+    into a confident "no trailing delimiter". That is the exact Windows
+    misdetection PR #1332 fixed, and it would come back silently across all ten
+    platform callers.
+
+    Pinned by ``tests/unit/utils/test_file_format.py::
+    TestHasTrailingDelimiterFraming``, which asserts all four
+    framing/terminator combinations.
+    """
     compression_type = detect_compression(path)
     try:
         if compression_type:

--- a/tests/unit/core/data_organization/test_sorting.py
+++ b/tests/unit/core/data_organization/test_sorting.py
@@ -162,15 +162,22 @@ def _write_tbl_clean(path: Path, rows: list[tuple[object, ...]]) -> None:
             f.write("|".join(str(v) for v in row) + "\n")
 
 
-def _write_tbl_crlf(path: Path, rows: list[tuple[object, ...]]) -> None:
-    """Write trailing-delimiter TBL rows with explicit CRLF line endings.
+def _write_tbl_crlf(path: Path, rows: list[tuple[object, ...]], *, trailing_delimiter: bool = True) -> None:
+    """Write TBL rows with explicit CRLF line endings, either framing.
 
     The other helpers open in text mode, so they emit the platform's native
     line ending - LF on macOS/Linux, CRLF on Windows. These bytes are written
     explicitly so the CRLF framing is exercised on every platform rather than
     only on the Windows nightly leg.
+
+    ``trailing_delimiter`` selects the framing. Terminator and framing are
+    independent, and the clean/CRLF combination is the one that would otherwise
+    go unexercised: the LF clean case is covered by
+    ``test_reads_normalized_tbl_with_no_trailing_delimiter``, so without this
+    flag a reader that mishandled *only* clean CRLF input would pass everything.
     """
-    payload = b"".join(("|".join(str(v) for v in row) + "|\r\n").encode("utf-8") for row in rows)
+    suffix = "|\r\n" if trailing_delimiter else "\r\n"
+    payload = b"".join(("|".join(str(v) for v in row) + suffix).encode("utf-8") for row in rows)
     path.write_bytes(payload)
 
 
@@ -275,6 +282,39 @@ class TestSortedParquetWriterSingleColumn:
 
         with pytest.raises(ValueError, match="Sort column 'missing_col' not found"):
             writer.write_sorted_parquet("orders", [source], tmp_path)
+
+    def test_reads_clean_tbl_with_crlf_line_endings(self, tmp_path: Path):
+        r"""The fourth cell: CRLF *without* a trailing delimiter.
+
+        Framing and terminator are independent, so there are four combinations.
+        Three were already covered - LF/clean by
+        test_reads_normalized_tbl_with_no_trailing_delimiter, LF/trailing by the
+        ordinary fixtures, CRLF/trailing above. Without this case a reader that
+        mishandled only clean CRLF input would pass the whole suite: it would
+        add the synthetic column to a file that has N fields, and PyArrow would
+        fail with a column-count mismatch on the *correct* input.
+        """
+        source = tmp_path / "lineitem.tbl"
+        _write_tbl_crlf(
+            source,
+            [
+                (3, "1998-03-01"),
+                (1, "1992-01-02"),
+                (2, "1996-05-17"),
+            ],
+            trailing_delimiter=False,
+        )
+        schema_registry = {"lineitem": {"columns": [{"name": "id"}, {"name": "l_shipdate"}]}}
+        config = DataOrganizationConfig(sort_columns=[SortColumn(name="l_shipdate")], compression="none")
+        writer = SortedParquetWriter(config=config, schema_registry=schema_registry)
+
+        output = writer.write_sorted_parquet("lineitem", [source], tmp_path)
+
+        table = pq.read_table(output)
+        # No synthetic trailing column may survive into the output schema.
+        assert table.column_names == ["id", "l_shipdate"]
+        assert table.column("l_shipdate").to_pylist() == [date(1992, 1, 2), date(1996, 5, 17), date(1998, 3, 1)]
+        assert table.column("id").to_pylist() == [1, 2, 3]
 
 
 class TestSortedParquetWriterMultiColumn:

--- a/tests/unit/utils/test_file_format.py
+++ b/tests/unit/utils/test_file_format.py
@@ -24,6 +24,7 @@ from benchbox.utils.file_format import (
     get_base_name_without_compression,
     get_data_extension,
     get_delimiter_for_file,
+    has_trailing_delimiter,
     is_compression_extension,
     is_csv_format,
     is_data_format_extension,
@@ -575,3 +576,61 @@ class TestGetDataExtension:
         """Critical: .dat must be returned as '.dat', not '.tbl' (unlike detect_data_format)."""
         assert get_data_extension(Path("store_sales.dat")) == ".dat"
         assert get_data_extension(Path("store_sales.dat")) != ".tbl"
+
+
+class TestHasTrailingDelimiterFraming:
+    r"""Row framing and line terminator are INDEPENDENT; all four cells pinned.
+
+    A TBL file written on Windows ends ``|\r\n``, not ``|\n``. PR #1332 fixed
+    Windows misdetection by routing the sorted-parquet reader through this
+    helper, and it is correct for a reason that is easy to lose: the read path
+    opens ``"rt"``, so universal newlines translate ``\r\n`` to ``\n`` before
+    either checker runs -- both only ``rstrip("\n")``.
+
+    Nothing else pins that. Switching either read to binary for throughput on
+    multi-GB TBL files would make ``line.rstrip("\n")`` raise on bytes, and the
+    blanket ``except Exception: return False`` would convert that into a
+    confident "no trailing delimiter" -- silently reviving the original Windows
+    bug across all ten platform callers. These cases are what fails if that
+    happens, so they are the invariant's enforcement, not just coverage.
+
+    Fixtures are written as explicit bytes so CRLF is exercised on every
+    platform rather than only on a Windows runner.
+    """
+
+    FRAMING_CASES = [
+        pytest.param(b"1|x|\r\n", True, id="crlf-trailing-delimiter"),
+        pytest.param(b"1|x\r\n", False, id="crlf-clean"),
+        pytest.param(b"1|x|\n", True, id="lf-trailing-delimiter"),
+        pytest.param(b"1|x\n", False, id="lf-clean"),
+    ]
+
+    @pytest.mark.parametrize("raw,expected", FRAMING_CASES)
+    def test_field_count_checker_handles_both_terminators(self, tmp_path, raw, expected):
+        # The column_names path: the checker every one of the ten platform
+        # callers actually uses.
+        path = tmp_path / "region.tbl"
+        path.write_bytes(raw)
+        assert has_trailing_delimiter(path, "|", ["a", "b"]) is expected
+
+    @pytest.mark.parametrize("raw,expected", FRAMING_CASES)
+    def test_ends_with_checker_handles_both_terminators(self, tmp_path, raw, expected):
+        # The column_names=None fallback is a different checker (ends-with, not
+        # field-count) and is reachable, though no current caller takes it. It
+        # must agree with the field-count path on every framing.
+        path = tmp_path / "region.tbl"
+        path.write_bytes(raw)
+        assert has_trailing_delimiter(path, "|") is expected
+
+    def test_classification_is_taken_from_the_first_row_of_a_multi_row_file(self, tmp_path):
+        # Framing is uniform per file (dbgen/dsdgen decide once per run), so the
+        # helper reads only the first non-empty line. Pin that a realistic
+        # multi-row CRLF file still classifies correctly.
+        path = tmp_path / "region.tbl"
+        path.write_bytes(b"0|AFRICA|comment|\r\n1|AMERICA|comment|\r\n2|ASIA|comment|\r\n")
+        assert has_trailing_delimiter(path, "|", ["r_regionkey", "r_name", "r_comment"]) is True
+
+    def test_leading_blank_lines_do_not_decide_the_framing(self, tmp_path):
+        path = tmp_path / "region.tbl"
+        path.write_bytes(b"\r\n\r\n0|AFRICA|comment|\r\n")
+        assert has_trailing_delimiter(path, "|", ["r_regionkey", "r_name", "r_comment"]) is True


### PR DESCRIPTION
## Why

PR #1332 fixed Windows trailing-delimiter misdetection by routing the sorted-parquet reader through `has_trailing_delimiter`. The fix is correct — but for an **implicit** reason.

Both reads in `_check_first_nonempty_line` open `"rt"`, so universal newlines translate `\r\n` → `\n` *before* either checker runs, and both checkers strip only `\n`. Nothing pinned that.

Switch either read to binary for throughput on multi-GB TBL files and a stray `\r` survives: the field-count checker sees an extra field, the ends-with checker stops matching, and on bytes `rstrip("\n")` raises outright — which the blanket `except Exception: return False` converts into a confident *"no trailing delimiter"*. That is the original Windows bug, returning silently across all **ten** platform callers (`duckdb.py:408`, `datafusion.py:903/1425`, six dataframe adapters, `polars_platform.py:544`).

`has_trailing_delimiter` had **no direct unit test at all** — the only coverage was indirect, through three platform test files.

## What

Pins all four framing/terminator cells against **both** checkers:

| | trailing `\|` | clean |
|---|---|---|
| **CRLF** | `True` | `False` |
| **LF** | `True` | `False` |

— the `column_names` field-count path every caller uses, *and* the `column_names=None` ends-with fallback, which is reachable but currently taken by none. Plus a multi-row CRLF file and one with leading blank CRLF lines. Fixtures are explicit bytes, so CRLF is exercised everywhere rather than only on the Windows nightly leg.

Also completes the writer's matrix: `_write_tbl_crlf` gains a `trailing_delimiter` flag (default `True`, existing callers unchanged) and a clean-CRLF case asserts no synthetic column survives on input that has none.

The requirement is now stated where it lives — `_check_first_nonempty_line`'s docstring says text mode is **required, not incidental**, spells out the causal chain, and points at the enforcing test.

## Enforcement is behavioural, not a source grep

Simulating the regression by switching the uncompressed read to `"rb"`:

```
6 failed, 4 passed    # framing tests
2 failed, 1 passed    # writer CRLF tests
```

Reverted; file restored byte-for-byte.

**One honest detail:** the new clean-CRLF case *passes* under that regression — a failed probe returns `False`, and clean input needs no synthetic column. It guards the **opposite** direction: a probe that wrongly *reports* a trailing delimiter would add a column to an N-field file and fail there. The trailing-delimiter cases catch false negatives; the clean cases catch false positives. Both directions are now pinned, which is the actual gap.

## Verification

- `tests/unit/utils/test_file_format.py` + `tests/unit/core/data_organization/` — 229 passed
- All four recorded rungs pass; `check-scope --strict` — scope OK, 3 changed files
- Fast lane **26055 → 26066** against a 26550 cap (484 headroom remaining)
- No behaviour change for the ten platform callers — this is a docstring plus tests, with the one test-helper flag defaulting to today's behaviour

Closes `crlf-framing-coverage-and-text-mode-invariant`.