### PR TITLE
test(ducklake): gate the in-process adapter tests in a lane CI runs

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -524,6 +524,21 @@ jobs:
             tests/integration/test_tpcds_power_test.py \
             -m "slow" -n 0 -k "test_execute_one_query_drains_raw_cursor_before_commit" --tb=short -q
 
+      - name: Run DuckLake in-process adapter integration tests
+        run: |
+          # ducklake-post-merge-review-followups w3: this module is
+          # [integration, slow], so no PR-lane marker expression selects it -
+          # core adapter behaviour (cursor catalog scoping, ATTACH, catalog
+          # reuse, sqlite catalog end-to-end) was gated only by the release-time
+          # non-fast lane. The service-dependent Postgres/S3 classes keep
+          # live_integration and are excluded here; what remains needs nothing
+          # but a real DuckDB, and skips cleanly - loudly, via the probe's
+          # warning - when the ducklake extension cannot be installed.
+          # Bounded: one file, 7 tests at SF=0.01.
+          uv run -- python -m pytest \
+            tests/integration/test_ducklake_integration.py \
+            -m "slow and not live_integration" -n 0 --tb=short -q
+
       - name: Run promoted DuckDB FK tuning load-ordering reproducers
         run: |
           # tuning-fk-load-ordering-fix-20260716: TPCHBenchmark.get_table_loading_order

--- a/tests/integration/test_ducklake_integration.py
+++ b/tests/integration/test_ducklake_integration.py
@@ -41,6 +41,7 @@ from __future__ import annotations
 import json
 import os
 import uuid
+import warnings
 from functools import cache
 from pathlib import Path
 
@@ -79,6 +80,14 @@ pytestmark = [
 # deferring the probe there means an excluded/deselected run never pays for it.
 
 
+# Why a failed probe must be loud: @cache means the FIRST probe outcome decides
+# every later skip in the session, so one transient network error silently
+# disables this entire module - and a silent skip reads exactly like a pass in
+# CI output. The reason is recorded here and re-surfaced in every skip message
+# it causes, and warned once so it appears in pytest's warnings summary.
+_PROBE_FAILURES: dict[str, str] = {}
+
+
 @cache
 def _probe_extension(name: str) -> bool:
     """Return True if the named DuckDB extension can be INSTALL/LOAD'd here."""
@@ -90,7 +99,15 @@ def _probe_extension(name: str) -> bool:
             return True
         finally:
             conn.close()
-    except Exception:
+    except Exception as exc:
+        reason = f"{type(exc).__name__}: {exc}"
+        _PROBE_FAILURES[name] = reason
+        warnings.warn(
+            f"DuckDB extension probe failed for {name!r} ({reason}). This result is cached for the "
+            f"whole session, so every DuckLake test depending on {name!r} will now skip. If this was "
+            "a transient extension-repository/network failure, re-run rather than trusting the skips.",
+            stacklevel=2,
+        )
         return False
 
 
@@ -98,7 +115,8 @@ def _skip_unless_extensions(*names: str) -> None:
     """Skip the calling test unless every named DuckDB extension is available."""
     missing = [name for name in names if not _probe_extension(name)]
     if missing:
-        pytest.skip(f"DuckDB extension(s) not available: {', '.join(missing)}")
+        detail = ", ".join(f"{name} [{_PROBE_FAILURES.get(name, 'reason not recorded')}]" for name in missing)
+        pytest.skip(f"DuckDB extension(s) not available: {detail}")
 
 
 # =============================================================================
@@ -106,15 +124,22 @@ def _skip_unless_extensions(*names: str) -> None:
 # =============================================================================
 
 
-@pytest.mark.live_integration
 class TestDuckLakeLiveConnection:
     """End-to-end tests exercising a real INSTALL/LOAD/ATTACH of the ducklake extension.
 
-    Marked live_integration (deselected from the default/fast lane) because
-    they perform a real, potentially-networked INSTALL ducklake; they also skip
-    entirely when the extension cannot be installed/loaded (checked in
-    setup_method, not a collection-time skipif - see the probe docstring
-    above for why).
+    Deliberately NOT live_integration. In this repo that marker means "needs a
+    live external service" and every tree-wide lane deselects it, so carrying it
+    here left the core in-process adapter behaviour - cursor catalog scoping,
+    ATTACH, reuse - running in no CI lane at all. These tests need nothing but a
+    real DuckDB and the ducklake extension, exactly like
+    TestDuckLakeSqliteCatalogLive below, which never carried the marker. They
+    inherit the module's [integration, slow], which the non-fast lanes do run,
+    and still skip cleanly when the extension cannot be installed/loaded
+    (checked in setup_method, not a collection-time skipif - see the probe
+    docstring above for why).
+
+    The genuinely service-dependent classes (Postgres catalog, S3 data_path)
+    keep live_integration.
     """
 
     def setup_method(self) -> None:

--- a/tests/unit/test_marker_strategy.py
+++ b/tests/unit/test_marker_strategy.py
@@ -21,6 +21,37 @@ _FAST_MEDIUM_DECORATOR_RE = re.compile(r"(?m)^\s*@pytest\.mark\.(fast|medium)\b"
 _SPEED_MARKERS = {"fast", "medium", "slow"}
 _SCOPE_MARKERS = {"unit", "integration", "performance"}
 _E2E_QUICK_INCOMPATIBLE = {"stress", "resource_heavy", "live_integration"}
+# Marker expressions of the lanes that run over the whole tree (or all of
+# tests/integration), i.e. the ones a module gets selected by without anyone
+# naming it. Path-scoped one-off steps are handled separately by
+# _explicitly_invoked_test_paths(). Sources: Makefile test-* targets and the
+# pytest invocations in .github/workflows/{test,nightly,pr,release-canary,
+# validate-release-pr}.yml.
+_TREE_WIDE_LANES = (
+    "fast and not (slow or stress or resource_heavy or live_integration)",
+    "integration and not live_integration and not stress",
+    "integration and not (slow or stress or resource_heavy or live_integration)",
+    "(slow or resource_heavy) and not (stress or live_integration)",
+    "slow and not (stress or live_integration)",
+    "medium and not (slow or stress or resource_heavy or live_integration)",
+    "platform_smoke or (integration and fast)",
+)
+_WORKFLOW_TEST_PATH_RE = re.compile(r"tests/[\w/]+/test_\w+\.py")
+# Declaring one of these at MODULE level says "this whole module is opt-in and
+# runs outside the automatic lanes" (credentialed cloud suites, stress runs).
+_OPT_IN_LANE_MARKERS = {"live_integration", "stress"}
+# Test classes that carry live_integration INSIDE a module that presents itself
+# as lane-run. Each genuinely needs an external service, so no lane can run it;
+# each is listed deliberately, because the same shape with a service-FREE class
+# is how DuckLake's core adapter coverage silently ran nowhere (w3/w4). Adding
+# an entry is the reviewed way to say "this really does need live infra".
+_SERVICE_DEPENDENT_CLASSES = {
+    "tests/integration/test_ducklake_integration.py::TestDuckLakePostgresCatalogLive": "needs a live PostgreSQL server",
+    "tests/integration/test_ducklake_integration.py::TestDuckLakeS3DataPathLive": "needs a real S3 bucket + AWS creds",
+    "tests/integration/test_todo_db_hosted_live.py::TestHostedLiveLifecycle": "needs the hosted Turso tracker DB",
+    "tests/integration/test_throughput_session_isolation.py"
+    "::TestPostgreSQLIndependentConnectionIsolatesSessions": "needs a live PostgreSQL server on :5432",
+}
 _PERSISTENT_DATABASE_FIXTURES = {
     "basic_test_db",
     "tpch_test_db",
@@ -229,6 +260,118 @@ def test_starrocks_resource_heavy_smoke_stays_in_integration_smoke_lane():
 
     assert path.exists()
     assert "platform_smoke" in _top_level_marker_names(path)
+
+
+def _selects(expression: str, markers: set[str]) -> bool:
+    """Evaluate a pytest ``-m`` expression against one test's marker set.
+
+    pytest marker expressions are Python boolean expressions over marker names,
+    so evaluating them with every present marker bound to True and every absent
+    one defaulting to False reproduces the selection exactly - without shelling
+    out to a collection run per lane per module (minutes, not milliseconds).
+    """
+
+    class _MarkerNamespace(dict):
+        def __missing__(self, key: str) -> bool:
+            return False
+
+    return bool(eval(expression, {"__builtins__": {}}, _MarkerNamespace.fromkeys(markers, True)))  # noqa: S307
+
+
+def _explicitly_invoked_test_paths() -> set[str]:
+    """Test paths named directly in a workflow's pytest invocation.
+
+    The escape hatch for a module no tree-wide lane selects is a dedicated step
+    that names the file (see pr.yml's promoted-reproducer steps). Those count as
+    covered, so scan for them rather than reporting a false positive.
+    """
+    paths: set[str] = set()
+    for workflow in sorted((_REPO_ROOT / ".github" / "workflows").glob("*.yml")):
+        for match in _WORKFLOW_TEST_PATH_RE.finditer(workflow.read_text(encoding="utf-8")):
+            paths.add(match.group(0))
+    return paths
+
+
+def test_every_integration_module_is_selected_by_at_least_one_lane():
+    """A module no lane selects is dead coverage that still reads as green.
+
+    ducklake-post-merge-review-followups w4: test_ducklake_integration.py
+    declared ``[integration, slow]`` at module level - i.e. an ordinary non-fast
+    integration module - while carrying ``live_integration`` on most of its
+    classes. Every tree-wide lane deselects live_integration, so 8 of its 9
+    tests were selected by nothing at all: the file existed, passed locally, and
+    gated nothing in CI.
+
+    That mismatch is the signature this checks for. A module that declares an
+    opt-in marker at MODULE level (``live_integration`` for credentialed cloud
+    suites, ``stress``) is deliberately out of the automatic lanes and exempt;
+    the bug is a module that presents as lane-run while no lane runs it.
+    """
+    uncovered: list[str] = []
+    explicit_paths = _explicitly_invoked_test_paths()
+
+    for path in _iter_test_modules():
+        rel = path.relative_to(_REPO_ROOT).as_posix()
+        if not rel.startswith("tests/integration/"):
+            continue
+        # Declared opt-in at module level: intentional, runs via a dedicated
+        # credentialed/manual workflow rather than a tree-wide lane.
+        if _top_level_marker_names(path) & _OPT_IN_LANE_MARKERS:
+            continue
+        # Named directly by a workflow step - the sanctioned escape hatch.
+        if rel in explicit_paths:
+            continue
+        marker_sets = [markers for _name, markers in _iter_test_marker_sets(path)]
+        if not marker_sets:
+            continue
+        if not any(_selects(expression, markers) for expression in _TREE_WIDE_LANES for markers in marker_sets):
+            uncovered.append(rel)
+
+    assert uncovered == [], (
+        "integration modules that present as lane-run but are selected by no configured lane and "
+        f"named by no workflow step: {uncovered}. Either give the service-free tests a marker a real "
+        "lane runs, declare the opt-in marker at module level if the whole module needs live infra, "
+        "or add an explicit pytest step naming the file (see pr.yml's promoted-reproducer steps)."
+    )
+
+
+def test_opt_in_markers_below_module_level_are_declared_service_dependent():
+    """Catch the DuckLake shape: a lane-run module hiding uncovered classes.
+
+    A per-module coverage check cannot see this - one lane-selected test in the
+    module makes the whole file look covered no matter how many of its classes
+    run nowhere. test_ducklake_integration.py had exactly that: its sqlite class
+    was lane-selected while TestDuckLakeLiveConnection, which needs no external
+    service at all, sat behind live_integration and ran in no lane.
+
+    So every live_integration class inside a module that does NOT declare the
+    marker at module level must be justified in _SERVICE_DEPENDENT_CLASSES.
+    Drop the marker (and gain lane coverage) or record why the service is real.
+    """
+    undeclared: list[str] = []
+
+    for path in _iter_test_modules():
+        rel = path.relative_to(_REPO_ROOT).as_posix()
+        if not rel.startswith("tests/integration/"):
+            continue
+        if _top_level_marker_names(path) & _OPT_IN_LANE_MARKERS:
+            continue
+        tree = ast.parse(path.read_text(encoding="utf-8"))
+        for node in tree.body:
+            if not isinstance(node, ast.ClassDef) or not (node.name.startswith("Test") or node.name.endswith("Tests")):
+                continue
+            class_markers = _decorator_marker_names(node) | _pytestmark_assignment_names(node.body)
+            if not (class_markers & _OPT_IN_LANE_MARKERS):
+                continue
+            if f"{rel}::{node.name}" not in _SERVICE_DEPENDENT_CLASSES:
+                undeclared.append(f"{rel}::{node.name}")
+
+    assert undeclared == [], (
+        f"opt-in marker below module level, not declared service-dependent: {undeclared}. No lane "
+        "selects these, so they gate nothing. If the class needs no external service, drop the "
+        "marker so a real lane runs it; if it does, add it to _SERVICE_DEPENDENT_CLASSES with the "
+        "service it requires."
+    )
 
 
 def test_e2e_quick_does_not_select_opt_in_heavy_tests():


### PR DESCRIPTION
Partial delivery of `ducklake-post-merge-review-followups`: **w3, w4, w5** — the
CI-coverage units that need no live infrastructure and no policy decisions. The
item stays open; 11 units remain (see bottom).

## The gap, measured

`tests/integration/test_ducklake_integration.py` has 9 tests. Collection counts
per configured lane, before this PR:

| lane marker expression | collected |
|---|---|
| `fast and not (slow or …)` | 0 |
| `integration and not (slow or stress or resource_heavy or live_integration)` | 0 |
| `(slow or resource_heavy) and not (stress or live_integration)` | **1 / 9** |
| `live_integration` (only ever run scoped to `validation/test_cross_platform.py`) | 8 / 9 |

So **8 of 9 tests ran in no lane at all**, and the 1 that did ran only at
release time. The module is `[integration, slow]` — excluded from the fast lanes
for being slow and from the PR/nightly integration lanes for the same reason —
and then most of its classes carried `live_integration`, which every tree-wide
lane deselects. Core adapter behaviour (cursor catalog scoping, ATTACH, catalog
reuse) was gated by nothing.

## w3 — give the service-free tests a lane

`TestDuckLakeLiveConnection` needs nothing but a real DuckDB and the `ducklake`
extension. It is not a live-service suite — `TestDuckLakeSqliteCatalogLive`
directly below it does the same `INSTALL`, runs a full CLI TPC-H run, and never
carried the marker. Dropping `live_integration` takes the module from **1/9 to
7/9** in the non-fast lane. The Postgres-catalog and S3 classes keep it.

Release-time-only gating is still weak for core adapter behaviour, so this also
adds a `pr.yml` step running the file with `-m "slow and not live_integration"`,
following the existing promoted-reproducer precedent in that job. Measured
locally: **7 passed, 2 deselected, 31s**.

## w5 — a cached probe failure must be loud

`_probe_extension` is `@cache`d, so the *first* outcome decides every skip for
the rest of the session: one transient extension-repository failure silently
disables the whole module, and a silent skip is indistinguishable from a pass in
CI output. The failure reason is now recorded, warned once (so it lands in
pytest's warnings summary), and quoted in every skip message it causes.

## w4 — meta-check, and why the obvious version doesn't work

The unit as specified is "fail when an integration module is selected by zero
lanes". I implemented that first. **It failed its own mutation test:** with the
DuckLake defect reintroduced, it still passed — because one lane-selected
sibling test (the sqlite class) makes the whole file look covered no matter how
many classes run nowhere. Per-module granularity is near-powerless here, and
shipping only that would have been a green check asserting coverage it never
verified.

Both checks are included, the second being the one with teeth:

1. `test_every_integration_module_is_selected_by_at_least_one_lane` — per-module
   backstop. Evaluates the 7 tree-wide lane expressions against each test's
   effective marker set (pytest `-m` expressions are Python boolean expressions,
   so they evaluate directly against a marker namespace — no collection run per
   lane per module). Exempts modules that declare an opt-in marker at *module*
   level and modules a workflow step names by path.
2. `test_opt_in_markers_below_module_level_are_declared_service_dependent` —
   per-class. A `live_integration` class inside a module that presents as
   lane-run must be declared in `_SERVICE_DEPENDENT_CLASSES` with the service it
   requires, or drop the marker and gain lane coverage.

**Mutation-verified:** restoring `live_integration` on the service-free class
now fails check 2, naming the class and both remedies.

The signature check 2 keys on is precise because every legitimate opt-in suite
(Athena, BigQuery, Snowflake, Databricks, …) declares `live_integration` at
*module* level. Only 4 classes tree-wide hide it below module level, and all 4
genuinely need a service — including one my own ad-hoc scan missed and the check
caught, because it was declared via class-level `pytestmark` rather than a
decorator.

## Verification

- `make lint-markers` — 10 passed (the gate that runs these meta-checks in CI).
- `tests/unit/test_marker_strategy.py` + `tests/unit/platforms/test_ducklake_adapter.py` — 104 passed.
- The new PR-lane invocation, exactly as CI will run it — 7 passed, 2 deselected.
- `pr.yml` parses as YAML.

## Not in this PR

`todo check-scope` reports `SCOPE_UNCHECKED` — this item carries no scope rules,
so the 3 changed files were not gated by one. Remaining units, and why they are
not here: **w1/w2** need a live PostgreSQL server and a real S3 bucket; **w6/w7**
(catalog reuse/`--force` semantics) are behaviour changes deserving their own PR;
**w8/w9** are packaging and CHANGELOG; **w10–w14** are policy decisions for the
maintainer (deployment-mode modelling, experimental→beta exit criteria,
publishability of remote-backed results, CODEOWNERS review paths, and whether
missing compaction biases cross-engine comparisons).
