### PR TITLE
fix(tracker): sync the replica before the bulk import's parity check

### DIFF
--- a/_project/blind-spots/README.md
+++ b/_project/blind-spots/README.md
@@ -1,8 +1,29 @@
 # Blind-Spot Findings
 
+> **FROZEN — 2026-07-30. This directory is read-only.**
+>
+> All 65 records now live in the shared tracker's findings tables
+> (`SCHEMA_VERSION` 4), imported with verified field-level parity: every
+> frontmatter key, every body section byte-for-byte, and each `## Triage log`
+> line as one `imported_triage_log` event. **Do not add, edit, or delete files
+> here.**
+>
+> - **Capture a new finding**: `todo finding create` — writes a draft to
+>   `~/.benchbox/finding-drafts/`, outside every worktree, with no credentials.
+> - **Land a draft**: `todo finding sync` (a separate authorized step).
+> - **Read or triage**: `todo finding list | show | candidates | triage |
+>   promote`.
+>
+> The freeze runs for one planning cycle, then `findings-phase6-demolition`
+> deletes these records and retires the `make blind-spots-*` machinery. The
+> freeze *is* the rollback window: until it ends, these files remain the
+> fallback if a parity problem surfaces. Git history is untouched either way.
+
 Storage for **blind-spot audit (L2)** findings: framework gaps, post-fix
 pattern notes, and dormant assumptions. One file per finding, sweepable
-later without PR merge collisions.
+later without PR merge collisions. Superseded by the findings domain — see
+`_project/specs/findings-domain.md`; the schema below is retained because it
+remains the **capture format** for drafts.
 
 ## Behavior is governed elsewhere
 

--- a/_project/blind-spots/README.md
+++ b/_project/blind-spots/README.md
@@ -2,7 +2,7 @@
 
 > **FROZEN — 2026-07-30. This directory is read-only.**
 >
-> All 65 records now live in the shared tracker's findings tables
+> All 64 records now live in the shared tracker's findings tables
 > (`SCHEMA_VERSION` 4), imported with verified field-level parity: every
 > frontmatter key, every body section byte-for-byte, and each `## Triage log`
 > line as one `imported_triage_log` event. **Do not add, edit, or delete files

--- a/_project/scripts/todo_db.py
+++ b/_project/scripts/todo_db.py
@@ -742,6 +742,24 @@ def _replica_setup_lock(replica: Path):
         os.close(fd)
 
 
+def sync_hosted_replica(conn: _HostedConnection) -> None:
+    """Refresh an embedded replica under the per-worktree synchronization lock.
+
+    Commands that write directly to the hosted primary may need a second sync
+    before reading through an already-open replica.  Keep that sync under the
+    same cross-process lock as connection setup, and keep raw libsql exceptions
+    behind the tracker's redacted ``TodoError`` boundary.
+    """
+    token = _auth_token()
+    with _replica_setup_lock(hosted_replica_path()):
+        try:
+            conn.sync()
+        except Exception as exc:
+            raise TodoError(
+                f"hosted tracker: cannot refresh the replica after the primary write: {_redacted(exc, token)}"
+            ) from exc
+
+
 def _import_libsql():
     try:
         import libsql  # deferred: only hosted mode needs it

--- a/_project/scripts/todo_findings.py
+++ b/_project/scripts/todo_findings.py
@@ -1786,9 +1786,7 @@ def _cmd_import_bulk(conn: Any, actor: str, args: argparse.Namespace) -> int:
     # false PARITY FAILED on a correct import, which is exactly what the first
     # production run printed. It fails safe (never the reverse), but it makes the
     # exit code untrustworthy, so sync the replica before comparing.
-    replica_sync = getattr(conn, "sync", None)
-    if callable(replica_sync):
-        replica_sync()
+    todo_db.sync_hosted_replica(conn)
     report = parity_report(conn, args.corpus, staged)
     if args.report:
         print(json.dumps(report, indent=2, sort_keys=True))

--- a/_project/scripts/todo_findings.py
+++ b/_project/scripts/todo_findings.py
@@ -1780,6 +1780,15 @@ def _cmd_import_bulk(conn: Any, actor: str, args: argparse.Namespace) -> int:
         f" {moved['rows']} row(s) in {moved['batches']} batch(es);"
         f" skipped {len(staged['skipped'])} already present; pk offsets {applied or 'none'}"
     )
+    # Read-after-write: the transfer went straight to the PRIMARY, while `conn` reads
+    # through a local embedded replica opened before it. Without an explicit sync the
+    # parity check sees none of the new rows and reports every record absent -- a
+    # false PARITY FAILED on a correct import, which is exactly what the first
+    # production run printed. It fails safe (never the reverse), but it makes the
+    # exit code untrustworthy, so sync the replica before comparing.
+    replica_sync = getattr(conn, "sync", None)
+    if callable(replica_sync):
+        replica_sync()
     report = parity_report(conn, args.corpus, staged)
     if args.report:
         print(json.dumps(report, indent=2, sort_keys=True))

--- a/tests/unit/scripts/test_todo_db_hosted.py
+++ b/tests/unit/scripts/test_todo_db_hosted.py
@@ -22,6 +22,7 @@ import json
 import sqlite3
 import sys
 import types
+from contextlib import contextmanager
 from pathlib import Path
 
 import pytest
@@ -350,6 +351,43 @@ class TestHostedConnect:
             # non-blocking acquire succeeds only if connect released the lock
             fcntl.flock(handle, fcntl.LOCK_EX | fcntl.LOCK_NB)
             fcntl.flock(handle, fcntl.LOCK_UN)
+
+    def test_explicit_replica_sync_uses_the_setup_lock(self, monkeypatch, tmp_path):
+        events = []
+        replica = tmp_path / "replica.db"
+
+        @contextmanager
+        def recording_lock(path):
+            events.append(("lock", path))
+            yield
+            events.append(("unlock", path))
+
+        class _Conn:
+            def sync(self):
+                events.append(("sync", replica))
+
+        monkeypatch.setattr(todo_db, "hosted_replica_path", lambda: replica)
+        monkeypatch.setattr(todo_db, "_replica_setup_lock", recording_lock)
+
+        todo_db.sync_hosted_replica(_Conn())
+
+        assert events == [("lock", replica), ("sync", replica), ("unlock", replica)]
+
+    def test_explicit_replica_sync_maps_and_redacts_errors(self, monkeypatch, tmp_path):
+        token = "sync-secret-token"
+
+        class _Conn:
+            def sync(self):
+                raise ValueError(f"connection failed with {token}")
+
+        monkeypatch.setenv("TODO_DB_AUTH_TOKEN", token)
+        monkeypatch.setenv("TODO_DB_REPLICA", str(tmp_path / "replica.db"))
+
+        with pytest.raises(todo_db.TodoError, match="cannot refresh the replica") as caught:
+            todo_db.sync_hosted_replica(_Conn())
+
+        assert token not in str(caught.value)
+        assert "<redacted>" in str(caught.value)
 
     def test_plaintext_http_url_is_refused(self, fake_libsql, capsys):
         with pytest.raises(todo_db.TodoError, match="https"):

--- a/tests/unit/scripts/test_todo_findings.py
+++ b/tests/unit/scripts/test_todo_findings.py
@@ -1663,10 +1663,7 @@ class TestBulkImportSyncsBeforeParity:
         calls = []
 
         class _Conn:
-            """Stands in for a hosted connection whose reads are stale until sync()."""
-
-            def sync(self):
-                calls.append("sync")
+            """Stands in for the hosted connection passed to the parity reader."""
 
             def execute(self, *_a, **_k):
                 calls.append("read")
@@ -1679,6 +1676,10 @@ class TestBulkImportSyncsBeforeParity:
                         return iter(())
 
                 return _Cur()
+
+        def _parity_report(*_a, **_k):
+            calls.append("read")
+            return {"ok": True, "stored_records": 1, "corpus_records": 1}
 
         monkeypatch.setattr(todo_db, "resolve_backend", lambda _db: "libsql://benchbox-todo-org.turso.io")
         monkeypatch.setenv("TODO_DB_AUTH_TOKEN", "t")
@@ -1693,12 +1694,9 @@ class TestBulkImportSyncsBeforeParity:
         )
         monkeypatch.setattr(todo_findings, "offset_staging_pks", lambda *_a, **_k: {})
         monkeypatch.setattr(todo_db, "bulk_transfer", lambda *_a, **_k: {"rows": 1, "batches": 1})
+        monkeypatch.setattr(todo_db, "sync_hosted_replica", lambda _conn: calls.append("sync"))
         monkeypatch.setattr(todo_db.sqlite3, "connect", lambda *_a, **_k: SimpleNamespace(close=lambda: None))
-        monkeypatch.setattr(
-            todo_findings,
-            "parity_report",
-            lambda *_a, **_k: {"ok": True, "stored_records": 1, "corpus_records": 1},
-        )
+        monkeypatch.setattr(todo_findings, "parity_report", _parity_report)
 
         args = SimpleNamespace(
             finding_command="import",
@@ -1710,4 +1708,4 @@ class TestBulkImportSyncsBeforeParity:
             db=None,
         )
         assert todo_findings._cmd_import_bulk(_Conn(), "tester", args) == 0
-        assert "sync" in calls, "parity must not be computed against an unsynced replica"
+        assert calls == ["sync", "read"], "parity must not read before the replica sync"

--- a/tests/unit/scripts/test_todo_findings.py
+++ b/tests/unit/scripts/test_todo_findings.py
@@ -1651,3 +1651,63 @@ class TestReconcileNeverWipesUndeclaredEvidence:
         assert json.loads(stored["related_paths"]) == ["benchbox/core/new.py"]
         # The curated evidence row survives: the draft never asserted an evidence list.
         assert [(r["path"], r["note"]) for r in stored["evidence"]] == [("curated.py", "added at triage")]
+
+
+class TestBulkImportSyncsBeforeParity:
+    """The bulk transfer writes to the PRIMARY while the command's connection reads a
+    local embedded replica opened beforehand. Without an explicit sync, parity sees
+    none of the new rows and reports a false PARITY FAILED on a correct import — which
+    is exactly what the first production run printed."""
+
+    def test_replica_is_synced_before_the_parity_comparison(self, tmp_path, monkeypatch):
+        calls = []
+
+        class _Conn:
+            """Stands in for a hosted connection whose reads are stale until sync()."""
+
+            def sync(self):
+                calls.append("sync")
+
+            def execute(self, *_a, **_k):
+                calls.append("read")
+
+                class _Cur:
+                    def fetchone(self):
+                        return (0,)
+
+                    def __iter__(self):
+                        return iter(())
+
+                return _Cur()
+
+        monkeypatch.setattr(todo_db, "resolve_backend", lambda _db: "libsql://benchbox-todo-org.turso.io")
+        monkeypatch.setenv("TODO_DB_AUTH_TOKEN", "t")
+        replica = tmp_path / "replica.db"
+        replica.write_bytes(b"")
+        monkeypatch.setattr(todo_db, "hosted_replica_path", lambda: replica)
+        monkeypatch.setattr(todo_findings, "target_findings_maxima", lambda _c: {})
+        monkeypatch.setattr(
+            todo_findings,
+            "stage_corpus_import",
+            lambda *_a, **_k: {"imported": ["x"], "skipped": [], "failed": [], "records": {}, "danglers": []},
+        )
+        monkeypatch.setattr(todo_findings, "offset_staging_pks", lambda *_a, **_k: {})
+        monkeypatch.setattr(todo_db, "bulk_transfer", lambda *_a, **_k: {"rows": 1, "batches": 1})
+        monkeypatch.setattr(todo_db.sqlite3, "connect", lambda *_a, **_k: SimpleNamespace(close=lambda: None))
+        monkeypatch.setattr(
+            todo_findings,
+            "parity_report",
+            lambda *_a, **_k: {"ok": True, "stored_records": 1, "corpus_records": 1},
+        )
+
+        args = SimpleNamespace(
+            finding_command="import",
+            corpus=str(tmp_path),
+            dry_run=False,
+            report=False,
+            bulk=True,
+            confirm_target="benchbox-todo",
+            db=None,
+        )
+        assert todo_findings._cmd_import_bulk(_Conn(), "tester", args) == 0
+        assert "sync" in calls, "parity must not be computed against an unsynced replica"


### PR DESCRIPTION
The bulk transfer writes straight to the primary, while the command's connection reads through a local embedded replica opened before it. Parity was computed against that stale replica, so a CORRECT import reported every record absent: the first production run printed 'PARITY FAILED' immediately after transferring all 432 rows successfully, and a fresh connection then confirmed parity OK 64/64 with zero diffs.

It fails safe -- staleness can only under-report presence, never invent it -- but it makes the exit code untrustworthy, which defeats the point of a self-asserting rung. Sync before comparing, with a regression test asserting parity is never computed against an unsynced replica.
