### PR TITLE
fix(ducklake): apply the selected deployment mode instead of ignoring it

### DIFF
--- a/benchbox/platforms/ducklake.py
+++ b/benchbox/platforms/ducklake.py
@@ -90,6 +90,71 @@ def _redact_secrets(message: str, *secrets: str | None) -> str:
     return _S3_SECRET_CLAUSE_RE.sub(rf"\1{_REDACTED}", redacted)
 
 
+# Deployment modes are a naming of the two independent axes (catalog backend x
+# storage location) registered in platform_registry.py. The mapping is declared
+# here so the adapter can honour a mode instead of accepting and ignoring it;
+# `None` on an axis means the mode says nothing about it.
+_DEPLOYMENT_MODE_AXES: dict[str, tuple[str | None, bool | None]] = {
+    # mode: (catalog backend, data_path is cloud)
+    "local": ("duckdb", False),
+    "local_catalog_s3": ("duckdb", True),
+    "postgres_catalog": ("postgres", False),
+    "postgres_catalog_s3": ("postgres", True),
+}
+
+
+def _resolve_catalog_with_deployment_mode(deployment_mode: Any, catalog: Any) -> Any:
+    """Fill in the catalog axis from *deployment_mode* when it was not given.
+
+    An explicit ``catalog`` always wins - it is the more specific statement - but
+    a contradiction is logged rather than passing silently, because the caller
+    asked for two different things and only one of them can happen.
+    """
+    axes = _DEPLOYMENT_MODE_AXES.get(str(deployment_mode or "").strip().lower())
+    if axes is None:
+        return catalog
+    mode_catalog, _ = axes
+    if mode_catalog is None:
+        return catalog
+    if catalog is None:
+        return mode_catalog
+    if str(catalog).strip().lower() != mode_catalog:
+        logger.warning(
+            "DuckLake deployment mode %r implies catalog=%s, but catalog=%s was requested explicitly; "
+            "using the explicit catalog=%s.",
+            deployment_mode,
+            mode_catalog,
+            catalog,
+            catalog,
+        )
+    return catalog
+
+
+def _warn_if_deployment_mode_contradicts_storage(deployment_mode: Any, data_path: Any) -> None:
+    """Warn when *deployment_mode* names a storage axis the data_path does not match.
+
+    Unlike the catalog axis this cannot be defaulted: an ``s3://`` mode needs a
+    bucket, and inventing one would be worse than saying nothing. So the
+    mismatch is reported and the supplied ``data_path`` is used as-is.
+    """
+    axes = _DEPLOYMENT_MODE_AXES.get(str(deployment_mode or "").strip().lower())
+    if axes is None or data_path is None:
+        return
+    _, mode_is_cloud = axes
+    if mode_is_cloud is None:
+        return
+    actual_is_cloud = is_cloud_path(str(data_path))
+    if actual_is_cloud is not mode_is_cloud:
+        expected = "a cloud (s3://) data_path" if mode_is_cloud else "a local data_path"
+        logger.warning(
+            "DuckLake deployment mode %r implies %s, but data_path=%s was given; using it as-is. "
+            "Pass a matching --platform-option data_path to run the deployment you selected.",
+            deployment_mode,
+            expected,
+            data_path,
+        )
+
+
 def _libpq_quote_value(value: str) -> str:
     """Quote/escape one libpq ``keyword=value`` component for a connection string.
 
@@ -359,6 +424,18 @@ class DuckLakeAdapter(DuckDBAdapter):
         # --platform-option catalog=... form, matching the metadata_path/
         # data_path precedence above.
         catalog = config.get("ducklake_catalog") or _resolve_option("catalog")
+
+        # A deployment mode names a point on the two axes (catalog backend x
+        # storage location). It used to be accepted and then dropped on the
+        # floor: `--platform ducklake:postgres_catalog_s3` ran a local
+        # DuckDB-file catalog on local disk, so the caller got something other
+        # than what they selected. The mode now fills in an axis the caller
+        # left unspecified. Explicit options stay authoritative - a
+        # contradiction warns rather than being overridden, because whoever
+        # typed `--platform-option catalog=...` said the more specific thing.
+        catalog = _resolve_catalog_with_deployment_mode(config.get("deployment_mode"), catalog)
+        _warn_if_deployment_mode_contradicts_storage(config.get("deployment_mode"), data_path)
+
         if catalog is not None:
             adapter_config["catalog"] = catalog
 

--- a/tests/unit/platforms/test_ducklake_adapter.py
+++ b/tests/unit/platforms/test_ducklake_adapter.py
@@ -654,6 +654,94 @@ class TestRedactSecretsHelper:
         assert _redact_secrets(message, None) == message
 
 
+class TestDuckLakeDeploymentModeIsApplied:
+    """A selected deployment mode must actually select something.
+
+    Regression: adapter_factory resolved `--platform ducklake:<mode>` and passed
+    config["deployment_mode"], but the adapter never read it - so
+    `ducklake:postgres_catalog_s3` silently ran a local DuckDB-file catalog on
+    local disk. The caller got a different deployment than the one they named.
+    """
+
+    def _from_config(self, tmp_path, **extra):
+        config = {"benchmark": "tpch", "scale_factor": 0.01, "output_dir": str(tmp_path)}
+        config.update(extra)
+        return DuckLakeAdapter.from_config(config)
+
+    @pytest.mark.parametrize(
+        "mode,expected_catalog",
+        [
+            ("local", "duckdb"),
+            ("local_catalog_s3", "duckdb"),
+            ("postgres_catalog", "postgres"),
+            ("postgres_catalog_s3", "postgres"),
+        ],
+    )
+    def test_mode_supplies_the_catalog_axis(self, tmp_path, mode, expected_catalog):
+        assert self._from_config(tmp_path, deployment_mode=mode).catalog == expected_catalog
+
+    def test_no_deployment_mode_leaves_behaviour_unchanged(self, tmp_path):
+        # Must-preserve: runs that pass no mode keep working exactly as today.
+        assert self._from_config(tmp_path).catalog == "duckdb"
+
+    def test_explicit_catalog_option_beats_the_mode(self, tmp_path, caplog):
+        # Must-preserve: explicit --platform-option stays authoritative. The
+        # contradiction is warned, not silently resolved either way.
+        with caplog.at_level(logging.WARNING, logger="benchbox.platforms.ducklake"):
+            adapter = self._from_config(tmp_path, deployment_mode="postgres_catalog", options={"catalog": "sqlite"})
+
+        assert adapter.catalog == "sqlite"
+        assert "implies catalog=postgres" in caplog.text
+        assert "using the explicit catalog=sqlite" in caplog.text
+
+    def test_s3_mode_with_a_local_data_path_warns_and_uses_the_given_path(self, tmp_path, caplog):
+        # The storage axis cannot be defaulted - an s3:// mode needs a bucket
+        # and inventing one would be worse than saying nothing.
+        with caplog.at_level(logging.WARNING, logger="benchbox.platforms.ducklake"):
+            adapter = self._from_config(tmp_path, deployment_mode="postgres_catalog_s3")
+
+        assert adapter._data_path_is_cloud is False
+        assert "implies a cloud (s3://) data_path" in caplog.text
+
+    def test_local_mode_with_an_s3_data_path_warns(self, tmp_path, caplog):
+        with caplog.at_level(logging.WARNING, logger="benchbox.platforms.ducklake"):
+            adapter = self._from_config(
+                tmp_path, deployment_mode="postgres_catalog", options={"data_path": "s3://bucket/x"}
+            )
+
+        assert adapter._data_path_is_cloud is True
+        assert "implies a local data_path" in caplog.text
+
+    def test_matching_mode_and_options_produce_no_warning(self, tmp_path, caplog):
+        with caplog.at_level(logging.WARNING, logger="benchbox.platforms.ducklake"):
+            adapter = self._from_config(
+                tmp_path,
+                deployment_mode="postgres_catalog_s3",
+                options={"catalog": "postgres", "data_path": "s3://bucket/x"},
+            )
+
+        assert adapter.catalog == "postgres"
+        assert adapter._data_path_is_cloud is True
+        assert "implies" not in caplog.text
+
+    def test_unknown_mode_is_ignored_rather_than_crashing(self, tmp_path):
+        # adapter_factory validates modes against the registry, so an unknown
+        # one should not reach here - but a stray value must not break a run.
+        assert self._from_config(tmp_path, deployment_mode="not-a-mode").catalog == "duckdb"
+
+    def test_every_registered_mode_is_mapped(self):
+        # Guard against the registry and the adapter drifting apart: a mode
+        # added to platform_registry.py without an axis mapping here would
+        # silently go back to selecting nothing.
+        from benchbox.core.platform_registry import PlatformRegistry
+        from benchbox.platforms.ducklake import _DEPLOYMENT_MODE_AXES
+
+        registered = set(PlatformRegistry.get_available_deployment_modes("ducklake"))
+        assert registered == set(_DEPLOYMENT_MODE_AXES), (
+            "ducklake deployment modes in the registry and _DEPLOYMENT_MODE_AXES have drifted"
+        )
+
+
 class TestDuckLakeFromConfigCatalogOptions:
     """Test from_config() resolves catalog/pg_*/s3_* from both config shapes (w1-w3).
 


### PR DESCRIPTION
Closes `ducklake-deployment-mode-selector-is-inert`.

## Problem

`adapter_factory` resolves `--platform ducklake:<mode>`, validates it against the
registry, and sets `config["deployment_mode"]` — and the DuckLake adapter never
read it. So:

```
benchbox run --platform ducklake:postgres_catalog_s3 ...
```

ran a **local DuckDB-file catalog on local disk**, with nothing to indicate the
selection had been dropped. The mode was accepted, validated, and discarded.

Found while fixing the *modelling* of these modes in #1358 (w10), which corrected
three mutually-exclusive pseudo-modes into four on the real catalog × storage
axes but deliberately left behaviour alone.

## Fix

The mode now fills in an axis the caller left unspecified:

| mode | catalog | storage |
|---|---|---|
| `local` | duckdb | local |
| `local_catalog_s3` | duckdb | s3 |
| `postgres_catalog` | postgres | local |
| `postgres_catalog_s3` | postgres | s3 |

**Explicit `--platform-option` stays authoritative** — that is the item's
must-preserve, and it is the right precedence: whoever typed `catalog=...` said
the more specific thing. A contradiction is *warned*, not silently resolved in
either direction:

```
DuckLake deployment mode 'postgres_catalog' implies catalog=postgres, but
catalog=sqlite was requested explicitly; using the explicit catalog=sqlite.
```

**The storage axis warns rather than defaulting.** An `s3://` mode needs a
bucket and inventing one would be worse than saying nothing, so a mismatch
reports and uses the supplied `data_path` as-is.

## Drift guard

`test_every_registered_mode_is_mapped` asserts the registry's ducklake modes and
the adapter's `_DEPLOYMENT_MODE_AXES` stay in sync. A mode added to the registry
alone would otherwise silently go back to selecting nothing — the exact failure
being fixed here.

## Verification

- `tests/unit/platforms/test_ducklake_adapter.py` — 116 passed (12 new).
- Mutation: removing the two calls from `from_config` fails 5 tests.
- Ladder rung recorded pass; `check-scope` OK (2 files).
- `ruff`, `ruff format`, `ty check` clean.
