### PR TITLE
feat(todo): carry findings in the migration snapshot

### DIFF
--- a/_project/scripts/todo_db.py
+++ b/_project/scripts/todo_db.py
@@ -2040,9 +2040,23 @@ RESTORE_LEGACY_REQUIRED_TABLES = frozenset(
 # surface never widens by accident. Deriving a migration snapshot from it would
 # invert that: legitimately narrowing what gets committed would silently narrow
 # what a migration carries, which is precisely the kind of silent data loss this
-# snapshot exists to avoid. Findings tables stay out because TRANSFER_TABLES
-# excludes them, and restore-legacy would discard them regardless.
-SNAPSHOT_TABLES = frozenset(TRANSFER_TABLES) | {"meta"}
+# snapshot exists to avoid.
+#
+# Findings ARE carried, as of todo-db PR #1. They were excluded before only
+# because restore-legacy discarded unknown tables, so shipping review prose
+# would have leaked it for nothing. That importer now loads the findings domain
+# and rejects anything it does not recognise, so omitting them here would make
+# the migration silently lossy instead.
+RESTORE_LEGACY_OPTIONAL_TABLES = frozenset(
+    {
+        "findings",
+        "finding_evidence",
+        "finding_links",
+        "finding_events",
+        "finding_sections",
+    }
+)
+SNAPSHOT_TABLES = frozenset(TRANSFER_TABLES) | {"meta"} | RESTORE_LEGACY_OPTIONAL_TABLES
 
 
 def _snapshot_order_by(conn: sqlite3.Connection, table: str) -> str:
@@ -2060,24 +2074,25 @@ def build_snapshot(conn: sqlite3.Connection) -> dict[str, list[dict[str, Any]]]:
     can load directly -- and explicitly strips the nested keys, so the committed
     export is structurally invalid as importer input.
 
-    Note what this does NOT carry: the findings domain. ``restore_legacy``
-    ignores tables outside its required set, so findings rows would be dropped
-    on restore whether or not they appear here. Including them would leak review
-    prose for no benefit, so they are excluded.
+    Carries the findings domain as well as the tracker tables. It is safe to
+    include review prose here precisely because a snapshot is never committed:
+    ``write_snapshot`` refuses any destination inside a Git work tree. The
+    committed export remains findings-free via a separate allowlist.
     """
-    # Fail closed. If the backup scope gains a table that restore-legacy does
-    # not know about, that importer would silently DROP it on restore. Refusing
-    # to build the snapshot surfaces the lossiness now, while it is still a
-    # migration-planning problem, rather than after a cutover.
-    if SNAPSHOT_TABLES != RESTORE_LEGACY_REQUIRED_TABLES:
-        only_here = sorted(SNAPSHOT_TABLES - RESTORE_LEGACY_REQUIRED_TABLES)
-        only_there = sorted(RESTORE_LEGACY_REQUIRED_TABLES - SNAPSHOT_TABLES)
+    # Fail closed against the importer's contract, which is: every required
+    # table must be present, and nothing outside required|optional may be --
+    # todo-db rejects unrecognised tables rather than ignoring them. Checking
+    # both directions here turns a future mismatch into a build-time error
+    # instead of a failed or silently lossy cutover.
+    missing = sorted(RESTORE_LEGACY_REQUIRED_TABLES - SNAPSHOT_TABLES)
+    unacceptable = sorted(SNAPSHOT_TABLES - RESTORE_LEGACY_REQUIRED_TABLES - RESTORE_LEGACY_OPTIONAL_TABLES)
+    if missing or unacceptable:
         raise RuntimeError(
-            "snapshot scope and restore-legacy's required tables have diverged; "
-            "a migration would lose data.\n"
-            f"  in the backup scope but not restorable: {only_here}\n"
-            f"  required by restore-legacy but not dumped: {only_there}\n"
-            "Reconcile RESTORE_LEGACY_REQUIRED_TABLES with the importer before migrating."
+            "snapshot scope disagrees with restore-legacy's contract; a migration "
+            "would fail or lose data.\n"
+            f"  required by restore-legacy but not dumped: {missing}\n"
+            f"  dumped but the importer would reject: {unacceptable}\n"
+            "Reconcile RESTORE_LEGACY_REQUIRED_TABLES / RESTORE_LEGACY_OPTIONAL_TABLES with the importer."
         )
     # One read snapshot across every table. Two independent SELECTs with a
     # concurrent write between them would produce a bundle that no point in

--- a/tests/unit/scripts/test_todo_db_export_allowlist.py
+++ b/tests/unit/scripts/test_todo_db_export_allowlist.py
@@ -179,21 +179,34 @@ class TestEventsRoundTrip:
 class TestMigrationSnapshotScope:
     """The snapshot is a BACKUP artifact, scoped separately from the export."""
 
-    def test_snapshot_scope_is_transfer_tables_plus_meta(self):
+    def test_snapshot_scope_is_backup_scope_plus_meta_plus_findings(self):
         # Scoped to the backup/restore set, NOT to the committed-export
-        # allowlist. The two hold the same names today, but deriving the
-        # snapshot from the allowlist would mean narrowing what may be
-        # committed silently narrows what a migration carries.
-        assert frozenset(todo_db.TRANSFER_TABLES) | {"meta"} == todo_db.SNAPSHOT_TABLES
+        # allowlist. The two overlap, but deriving the snapshot from the
+        # allowlist would mean narrowing what may be committed silently narrows
+        # what a migration carries.
+        expected = frozenset(todo_db.TRANSFER_TABLES) | {"meta"} | todo_db.RESTORE_LEGACY_OPTIONAL_TABLES
+        assert expected == todo_db.SNAPSHOT_TABLES
 
-    def test_snapshot_matches_what_restore_legacy_requires(self):
-        # build_snapshot refuses to run when these diverge; pin it here too so
-        # the divergence is named in a unit test rather than only at runtime.
-        assert todo_db.SNAPSHOT_TABLES == todo_db.RESTORE_LEGACY_REQUIRED_TABLES
+    def test_snapshot_satisfies_the_importer_contract_in_both_directions(self):
+        # restore-legacy requires its 12 tables and REJECTS anything outside
+        # required|optional, so the snapshot must be a superset of one and a
+        # subset of the other. build_snapshot enforces this at runtime; pin it
+        # here so a divergence is named by a unit test rather than a cutover.
+        assert todo_db.RESTORE_LEGACY_REQUIRED_TABLES <= todo_db.SNAPSHOT_TABLES
+        rejected = (
+            todo_db.SNAPSHOT_TABLES - todo_db.RESTORE_LEGACY_REQUIRED_TABLES - todo_db.RESTORE_LEGACY_OPTIONAL_TABLES
+        )
+        assert rejected == set(), f"importer would reject: {sorted(rejected)}"
 
-    def test_snapshot_excludes_findings_tables(self):
-        leaks = sorted(t for t in todo_db.SNAPSHOT_TABLES if t.startswith("finding"))
-        assert leaks == [], f"findings prose must not reach a migration snapshot: {leaks}"
+    def test_snapshot_includes_findings_tables(self):
+        # Deliberately inverted from the original assertion. Findings were
+        # excluded while restore-legacy discarded unknown tables -- shipping
+        # prose that would be thrown away only risked leaking it. That importer
+        # now loads findings, so excluding them here would make the migration
+        # silently lossy instead. Safe because write_snapshot refuses any
+        # destination inside a Git work tree.
+        expected = {"findings", "finding_evidence", "finding_links", "finding_events", "finding_sections"}
+        assert expected <= todo_db.SNAPSHOT_TABLES
 
 
 class TestMigrationSnapshotShape:
@@ -260,3 +273,57 @@ class TestMigrationSnapshotStaysOutOfGit:
         assert written.exists()
         payload = json.loads(written.read_text(encoding="utf-8"))
         assert payload.keys() >= todo_db.RESTORE_LEGACY_REQUIRED_TABLES
+
+
+class TestSnapshotCarriesFindingsButExportDoesNot:
+    """Two boundaries that must not drift into each other.
+
+    The committed export is findings-free on purpose: review prose is not
+    version-controlled. A migration snapshot is the opposite — it must carry
+    findings or the migration silently drops them — and that is safe only
+    because write_snapshot refuses any destination inside a Git work tree.
+    """
+
+    def test_committed_export_allowlist_stays_findings_free(self):
+        leaks = sorted(t for t in todo_db.EXPORT_TABLE_ALLOWLIST if t.startswith("finding"))
+        assert leaks == [], f"findings must never reach the committed export: {leaks}"
+
+    def test_a_finding_reaches_the_snapshot_but_not_the_committed_export(self, conn, tmp_path):
+        _mk(conn, item_id="real-item")
+        sentinel = "SNAPSHOT-ONLY-finding-prose"
+        fid = "2026-01-01-000000-snapshot-class"
+        conn.execute(
+            "INSERT INTO findings (id, date, finding_kind, review_context, title,"
+            " finding_text, why_matters, next_steps, created_at)"
+            " VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            (
+                fid,
+                "2026-01-01",
+                "framework-gap",
+                "ctx",
+                f"{sentinel}-title",
+                f"{sentinel}-finding",
+                "why",
+                "next",
+                "2026-01-01T00:00:00Z",
+            ),
+        )
+        conn.commit()
+
+        snapshot = todo_db.build_snapshot(conn)
+        assert [row["id"] for row in snapshot["findings"]] == [fid]
+        assert sentinel in json.dumps(snapshot)
+
+        out_dir = tmp_path / "export"
+        todo_db.write_export(conn, out_dir)
+        for produced in sorted(out_dir.iterdir()):
+            assert sentinel not in produced.read_text(encoding="utf-8"), (
+                f"findings prose leaked into the committed export file {produced.name}"
+            )
+
+    def test_build_snapshot_refuses_a_scope_the_importer_would_reject(self, conn, monkeypatch):
+        # Fail closed: a table the importer neither requires nor accepts must
+        # stop the snapshot being built, not be discovered during a cutover.
+        monkeypatch.setattr(todo_db, "SNAPSHOT_TABLES", todo_db.SNAPSHOT_TABLES | {"some_future_table"})
+        with pytest.raises(RuntimeError, match="importer would reject"):
+            todo_db.build_snapshot(conn)


### PR DESCRIPTION
## Why

The migration snapshot excluded the findings domain — deliberately, at the time. `restore-legacy` discarded unknown tables, so shipping review prose that would be thrown away only risked leaking it.

**todo-db #1 inverted that reasoning.** The importer now loads findings *and rejects anything it does not recognise*. Excluding them here would make a migration silently lossy.

Against the live tracker, the snapshot goes from **12 tables to 17** and picks up:

| table | rows |
|---|---|
| findings | 65 |
| finding_events | 325 |
| finding_links | 36 |
| finding_sections | 8 |
| finding_evidence | 3 |

All of it previously dropped without a word.

## The guard now matches the real contract

`restore-legacy` **requires** its 12 tables and **rejects** anything outside `required|optional`. A single equality check couldn't express that, so `build_snapshot` now asserts `required ⊆ snapshot ⊆ required|optional` and names which direction broke.

## The two boundaries stay separate

`EXPORT_TABLE_ALLOWLIST` is untouched — the **committed export stays findings-free**, because review prose is not version-controlled. Carrying prose in a *snapshot* is safe only because `write_snapshot` refuses any destination inside a Git work tree.

A test pins both halves: a sentinel finding reaches the snapshot and appears in **no file** `write_export` produces.

## Three tests from #1354 now fail by design

They asserted the old contract:

- `test_snapshot_scope_is_transfer_tables_plus_meta`
- `test_snapshot_matches_what_restore_legacy_requires`
- `test_snapshot_excludes_findings_tables`

Rewritten to the new one — composition including findings, the two-direction importer check, and **inclusion instead of exclusion** with a comment explaining the inversion — rather than deleted, so coverage is preserved and the change of intent is visible in the diff.

## Verification

End-to-end through the merged todo-db importer, restoring into a scratch SQLite DB:

```
all 17 tables match exactly — items 1706, findings 65,
finding_events 325, finding_sections 8
audit verify -> event_count 4286, chain valid
```

`tests/unit/scripts/` — 1186 passed. `check-scope --strict` — scope OK, 2 files.

Tests live in the existing export-boundary file, which is marked `medium`, so no fast-lane budget is consumed.

*Aside:* a stale `~/.benchbox/test.lock` (dead pid 7766 from pool-03) blocked the suite; cleared with `make test-unlock`.

Closes `snapshot-carry-findings-in-migration-snapshot`.