### PR TITLE
feat(ducklake): record the deployment backing in result metadata

### DIFF
--- a/benchbox/platforms/ducklake.py
+++ b/benchbox/platforms/ducklake.py
@@ -48,6 +48,12 @@ _VALID_CATALOGS: tuple[str, ...] = ("duckdb", "sqlite", "postgres")
 # accumulate anonymous secrets.
 _S3_SECRET_NAME = "benchbox_ducklake_s3"
 
+# Connection credentials that must never reach exported result metadata.
+# get_platform_info() already omits these, but the normalized metadata is also
+# built from the unfiltered constructor config, where only pg_password happens
+# to match the shared secret-key matcher - pg_user does not.
+_CREDENTIAL_CONFIG_KEYS = frozenset({"pg_user", "pg_password", "s3_key_id", "s3_secret"})
+
 _REDACTED = "****"
 
 # Backstop for credential material we did NOT emit verbatim: a driver error can
@@ -889,6 +895,49 @@ class DuckLakeAdapter(DuckDBAdapter):
     # against the current catalog/schema search path, i.e. `lake.main`, not
     # the base `main` catalog of the underlying :memory:/file connection.
     # Adding an override here would be redundant with inherited behavior.
+
+    def get_normalized_result_metadata(
+        self,
+        *,
+        connection: Any = None,
+        platform_info: Any = None,
+    ) -> dict[str, Any]:
+        """Record which DuckLake deployment produced this result.
+
+        ADR "DuckLake Maturity, Publishability, Review Path, and Compaction
+        Bias" (decision w12) makes remote-backed DuckLake results publishable
+        and ranking-eligible ON CONDITION that each run records its backing, so
+        a DuckLake-on-S3 number - which partly measures object-store latency -
+        is never silently compared against DuckLake-on-local-disk as though
+        they were the same system. Both axes go into ``platform_storage``,
+        which the generic builder leaves empty for this platform.
+
+        This also scrubs ``pg_user``/``pg_password`` out of the raw config
+        block. ``get_platform_info()`` already omits them deliberately, but the
+        normalized metadata is built from ``adapter.platform_config`` as well,
+        which is the unfiltered constructor config: ``pg_password`` happens to
+        be caught by the shared secret-key matcher and ``pg_user`` is not, so
+        the username was reaching exported results.
+        """
+        metadata = super().get_normalized_result_metadata(connection=connection, platform_info=platform_info)
+
+        storage = dict(metadata.get("platform_storage") or {})
+        storage.update(
+            {
+                "catalog_backend": self.catalog,
+                "data_path_is_cloud": self._data_path_is_cloud,
+                "storage_location": "cloud_object_store" if self._data_path_is_cloud else "local_filesystem",
+            }
+        )
+        metadata["platform_storage"] = storage
+
+        raw_config = metadata.get("platform_raw_config")
+        if isinstance(raw_config, dict):
+            metadata["platform_raw_config"] = {
+                key: value for key, value in raw_config.items() if key not in _CREDENTIAL_CONFIG_KEYS
+            }
+
+        return metadata
 
     def get_platform_info(self, connection: Any = None) -> dict[str, Any]:
         """Get DuckLake platform information."""

--- a/tests/unit/platforms/test_ducklake_adapter.py
+++ b/tests/unit/platforms/test_ducklake_adapter.py
@@ -7,6 +7,7 @@ Licensed under the MIT License. See LICENSE file in the project root for details
 
 from __future__ import annotations
 
+import json
 import logging
 
 import pytest
@@ -1042,6 +1043,70 @@ class TestDuckLakeS3Routing:
             data_path="s3://my-bucket/bench/",
         )
         assert adapter._build_s3_secret_sql().startswith("CREATE OR REPLACE SECRET ")
+
+
+class TestDuckLakeResultMetadataRecordsBacking:
+    """Exported results must say which DuckLake deployment produced them.
+
+    ADR decision w12 makes remote-backed DuckLake results publishable and
+    ranking-eligible ON CONDITION that the backing is recorded - a
+    DuckLake-on-S3 number partly measures object-store latency and must never
+    be silently ranked against DuckLake-on-local-disk as the same system.
+    """
+
+    def _metadata(self, tmp_path, **options):
+        adapter = DuckLakeAdapter.from_config(
+            {"benchmark": "tpch", "scale_factor": 0.01, "output_dir": str(tmp_path), "options": options}
+        )
+        return adapter.get_normalized_result_metadata()
+
+    @pytest.mark.parametrize(
+        "options,catalog,is_cloud,location",
+        [
+            ({}, "duckdb", False, "local_filesystem"),
+            ({"catalog": "sqlite"}, "sqlite", False, "local_filesystem"),
+            ({"catalog": "postgres"}, "postgres", False, "local_filesystem"),
+            ({"data_path": "s3://bucket/x"}, "duckdb", True, "cloud_object_store"),
+            ({"catalog": "postgres", "data_path": "s3://bucket/x"}, "postgres", True, "cloud_object_store"),
+        ],
+    )
+    def test_both_axes_are_recorded(self, tmp_path, options, catalog, is_cloud, location):
+        storage = self._metadata(tmp_path, **options)["platform_storage"]
+
+        assert storage["catalog_backend"] == catalog
+        assert storage["data_path_is_cloud"] is is_cloud
+        assert storage["storage_location"] == location
+
+    def test_no_credential_material_reaches_result_metadata(self, tmp_path):
+        # Regression: pg_user was reaching exported metadata. get_platform_info()
+        # omits it deliberately, but the normalized metadata is also built from
+        # adapter.platform_config - the unfiltered constructor config - where
+        # pg_password happens to match the shared secret-key matcher and
+        # pg_user does not.
+        metadata = self._metadata(
+            tmp_path,
+            catalog="postgres",
+            data_path="s3://bucket/x",
+            pg_user="alice-sentinel",
+            pg_password="hunter2-sentinel",
+            s3_key_id="AKIA-sentinel",
+            s3_secret="shh-sentinel",
+        )
+        blob = json.dumps(metadata, default=str)
+
+        for sentinel in ("alice-sentinel", "hunter2-sentinel", "AKIA-sentinel", "shh-sentinel"):
+            assert sentinel not in blob, f"{sentinel} leaked into exported result metadata"
+
+    def test_non_credential_config_still_exported(self, tmp_path):
+        # The scrub must not gut the raw-config block: pg_host/pg_port/
+        # pg_database are how a reader tells two postgres-backed runs apart.
+        metadata = self._metadata(
+            tmp_path, catalog="postgres", pg_host="db.example.com", pg_port=5433, pg_database="benchdb"
+        )
+        blob = json.dumps(metadata, default=str)
+
+        assert "db.example.com" in blob
+        assert "benchdb" in blob
 
 
 class TestDuckLakeRegistration:


### PR DESCRIPTION
Closes `ducklake-record-catalog-and-storage-in-result-metadata`.

## Why

[ADR decision w12](docs/development/adr/adr-ducklake-maturity-and-publishability.md)
makes remote-backed DuckLake results publishable and ranking-eligible **on
condition** that each run records its backing — a DuckLake-on-S3 number partly
measures object-store latency and must never be silently ranked against
DuckLake-on-local-disk as the same system. The vocabulary existed (four
deployment modes since #1358), but nothing reached exported results.

## What

Both axes now populate `platform_storage`, which the generic metadata builder
leaves empty for this platform:

```json
{"catalog_backend": "postgres", "data_path_is_cloud": true, "storage_location": "cloud_object_store"}
```

Implemented via `get_normalized_result_metadata`, which the base class documents
as the subclass hook for exactly this — no change to the shared builder.

## Also: a live credential leak, found while wiring this up

**`pg_user` was reaching exported result metadata.** `get_platform_info()` omits
`pg_user`/`pg_password` deliberately — but normalized metadata is *also* built
from `adapter.platform_config`, the unfiltered constructor config. There,
`pg_password` happens to be caught by the shared secret-key matcher
(`pgpassword` contains `password`) and **`pg_user` is not**. So the password was
saved only incidentally and the username shipped in clear.

Verified before the fix:

```
credential leaks: ['alice']     # pg_user
```

The raw-config block is now scrubbed of `pg_user`, `pg_password`, `s3_key_id`
and `s3_secret`. `pg_host`/`pg_port`/`pg_database` deliberately stay — those are
how a reader tells two postgres-backed runs apart, and a guard test pins that
the scrub does not gut the block.

This is the fourth instance of the same family found in this effort (#1333
DuckLake ATTACH, #1345 MotherDuck traceback, #1346 `*_key_id` export, now
`pg_user`). Worth noting the pattern: **key-name-based redaction keeps missing
things**, because it only protects keys whose *names* happen to match.

## Verification

- `tests/unit/platforms/test_ducklake_adapter.py` — 112 passed (7 new).
- Broader: `tests/unit/core/results/` + `tests/unit/platforms/` — 8812 passed.
- Mutation: removing the scrub fails the leak test.
- Leak assertion is sentinel-based over the whole serialized metadata blob, not
  a field-by-field check, so it catches a leak through any path.
- Ladder rung recorded pass; `check-scope` OK.
