### PR TITLE
fix(tpch): make trailing-delimiter normalization CRLF-safe

### DIFF
--- a/benchbox/core/tpch/generator.py
+++ b/benchbox/core/tpch/generator.py
@@ -55,14 +55,21 @@ def _has_trailing_delimiter(path: Path) -> bool:
     dbgen row framing is decided at compile time (EOL_HANDLING), so every row
     in a file shares the same framing; inspecting the file tail is sufficient
     to classify the whole file.
+
+    The line terminator is an independent variable: a file produced on Windows
+    ends ``|\r\n``, not ``|\n``. Strip the terminator before looking for the
+    delimiter rather than matching one spelling of it, or a CRLF file reads as
+    already-clean and is never normalized.
     """
     size = path.stat().st_size
     if size == 0:
         return False
+    # 3 bytes covers the longest terminator ("|\r\n"); the clamped seek handles
+    # files shorter than that.
     with path.open("rb") as handle:
-        handle.seek(max(0, size - 2))
+        handle.seek(max(0, size - 3))
         tail = handle.read()
-    return tail.endswith((b"|\n", b"|"))
+    return tail.rstrip(b"\r\n").endswith(b"|")
 
 
 def normalize_tbl_trailing_delimiters(path: Path) -> bool:
@@ -105,19 +112,27 @@ def normalize_tbl_trailing_delimiters(path: Path) -> bool:
                 if not chunk:
                     break
                 data = carry + chunk
-                # Hold back a chunk-final "|": it may be followed by "\n" in
-                # the next chunk and must be stripped together with it.
+                # Hold back a chunk-final "|" or "|\r": the terminator may
+                # continue into the next chunk and must be stripped together
+                # with the delimiter. Two bytes are needed because a chunk
+                # boundary can fall inside "|\r\n".
                 if data.endswith(b"|"):
                     carry = b"|"
                     data = data[:-1]
+                elif data.endswith(b"|\r"):
+                    carry = b"|\r"
+                    data = data[:-2]
                 else:
                     carry = b""
-                # "\n" only occurs at row boundaries, so "|\n" is always the
-                # trailing delimiter; str.replace removes exactly one "|" per
-                # newline and never touches interior empty fields.
-                dst.write(data.replace(b"|\n", b"\n"))
-            # A held-back "|" at EOF means the final row is unterminated but
-            # still carries the trailing delimiter; drop it.
+                # A newline only occurs at a row boundary, so "|" immediately
+                # before one is always the trailing delimiter. Both terminators
+                # are handled: replacing exactly one "|" per row never touches
+                # interior empty fields, and the line ending is preserved as-is.
+                dst.write(data.replace(b"|\r\n", b"\r\n").replace(b"|\n", b"\n"))
+            # A held-back delimiter at EOF means the final row is unterminated
+            # but still carries it; drop the "|" and keep any terminator bytes.
+            if carry == b"|\r":
+                dst.write(b"\r")
         with contextlib.suppress(OSError):
             shutil.copystat(path, tmp_path)
         os.replace(tmp_path, path)

--- a/tests/unit/core/tpch/test_tpch_trailing_delimiter_normalization.py
+++ b/tests/unit/core/tpch/test_tpch_trailing_delimiter_normalization.py
@@ -106,3 +106,79 @@ def test_finalize_generation_normalizes_fallback_file_mode_output(tmp_path: Path
     gen._finalize_generation(tmp_path)
 
     assert dirty_path.read_text(encoding="utf-8") == "1|Customer#1|BUILDING|comment.\n"
+
+
+class TestCRLFFraming:
+    r"""Row framing and line terminator are independent variables.
+
+    The helpers above use ``write_text``, so they emit the platform's native
+    terminator: LF on macOS/Linux, CRLF on Windows. That is why all five of
+    these regressions passed locally and failed only on the windows-latest
+    nightly leg -- the probe read the last two bytes looking for ``b"|\n"``,
+    which a CRLF file never matches (its tail is ``b"|\r\n"``), so the file was
+    classified already-clean and never rewritten; and the rewrite replaced only
+    ``b"|\n"``, so even a detected file would have kept its delimiters.
+
+    These fixtures are written as explicit bytes so both framings are exercised
+    on every platform rather than only on the Windows runner.
+    """
+
+    def test_detects_and_strips_a_trailing_delimiter_under_crlf(self, tmp_path: Path) -> None:
+        path = tmp_path / "customer.tbl"
+        path.write_bytes(b"1|Customer#1|BUILDING|comment.|\r\n2|Customer#2|AUTOMOBILE|comment2.|\r\n")
+
+        assert normalize_tbl_trailing_delimiters(path) is True
+        # The delimiter goes; the CRLF terminator is preserved exactly.
+        assert path.read_bytes() == b"1|Customer#1|BUILDING|comment.\r\n2|Customer#2|AUTOMOBILE|comment2.\r\n"
+
+    def test_interior_empty_fields_are_preserved_under_crlf(self, tmp_path: Path) -> None:
+        path = tmp_path / "customer.tbl"
+        path.write_bytes(b"1||BUILDING||comment.|\r\n")
+
+        assert normalize_tbl_trailing_delimiters(path) is True
+        assert path.read_bytes() == b"1||BUILDING||comment.\r\n"
+
+    def test_already_clean_crlf_file_is_byte_stable(self, tmp_path: Path) -> None:
+        # The must-preserve: a normalized CRLF file must not be rewritten, and
+        # in particular its terminators must not be rewritten to LF.
+        original = b"1|Customer#1|BUILDING|comment.\r\n2|Customer#2|AUTOMOBILE|comment2.\r\n"
+        path = tmp_path / "customer.tbl"
+        path.write_bytes(original)
+
+        assert normalize_tbl_trailing_delimiters(path) is False
+        assert path.read_bytes() == original
+
+    def test_idempotent_on_repeated_calls_under_crlf(self, tmp_path: Path) -> None:
+        path = tmp_path / "region.tbl"
+        path.write_bytes(b"0|AFRICA|comment.|\r\n")
+
+        assert normalize_tbl_trailing_delimiters(path) is True
+        after_first = path.read_bytes()
+        assert normalize_tbl_trailing_delimiters(path) is False
+        assert path.read_bytes() == after_first
+
+    def test_chunk_boundary_inside_the_crlf_terminator(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        r"""A chunk may end mid-``|\r\n``, which needs a two-byte carry.
+
+        With a one-byte carry the boundary splits ``|`` from ``\r\n`` and the
+        delimiter survives into the output.
+        """
+        import benchbox.core.tpch.generator as generator_module
+
+        payload = b"1|AB|\r\n2|CD|\r\n"
+        for chunk_size in range(1, len(payload) + 1):
+            monkeypatch.setattr(generator_module, "_NORMALIZE_CHUNK_SIZE", chunk_size)
+            path = tmp_path / f"supplier.tbl.{chunk_size}"
+            path.write_bytes(payload)
+
+            normalize_tbl_trailing_delimiters(path)
+
+            assert path.read_bytes() == b"1|AB\r\n2|CD\r\n", f"corrupted at chunk size {chunk_size}"
+
+    def test_unterminated_final_row_under_crlf(self, tmp_path: Path) -> None:
+        # "|\r" at EOF: drop the delimiter, keep the terminator byte.
+        path = tmp_path / "region.tbl"
+        path.write_bytes(b"0|AFRICA|comment.|\r")
+
+        assert normalize_tbl_trailing_delimiters(path) is True
+        assert path.read_bytes() == b"0|AFRICA|comment.\r"


### PR DESCRIPTION
## Why

Five Windows nightly failures in `test_tpch_trailing_delimiter_normalization.py` — **two independent bugs**, and the second would have kept the file broken even after fixing the first.

**1. Detection.** `_has_trailing_delimiter` read the last two bytes and matched `b"|\n"`. A CRLF file never matches — its tail is `b"|\r\n"` — so a file produced on Windows was classified *already-clean* and never rewritten. Now reads three bytes and strips the terminator before looking for the delimiter, the same shape as the `sorting.py` fix in #1332.

**2. Rewrite.** The streaming rewrite replaced only `b"|\n"`. Even a correctly detected CRLF file would have kept every delimiter. It now replaces `b"|\r\n"` and `b"|\n"`, preserving whichever terminator it found.

**3. Chunk carry.** A chunk boundary can fall *inside* `|\r\n`. The one-byte carry splits the `|` from its terminator, so the delimiter survives into the output. Carry is now two bytes.

## Why the tests passed locally

The existing fixtures use `write_text`, which emits the platform's native terminator — LF on macOS/Linux, CRLF on Windows. So all five regressions were green locally and red only on the `windows-latest` leg.

The six new fixtures are written as **explicit bytes**, so both framings are exercised everywhere:

- detect and strip under CRLF
- interior empty fields preserved
- **already-clean CRLF is byte-stable** — the must-preserve, including that terminators are not silently rewritten to LF
- idempotence
- an unterminated `|\r` final row
- a chunk-boundary test sweeping **every** chunk size from 1 to the payload length

## Proven to fail, not just pass

| Reverted | Result |
|---|---|
| both fixes | 5 of 6 CRLF tests fail |
| only the two-byte carry | exactly the chunk-boundary test fails |

Each fix is independently guarded.

## Scope note

`benchbox/utils/file_format.py` is in this item's `only_modify` list but needed **no change** — both bugs were in the generator. `check-scope --strict` — scope OK, 2 files.

`tests/unit/core/tpch/` — 295 passed. Fast lane 26085 / 26550.

Closes `windows-tpch-trailing-delimiter-crlf-normalization`.