### PR TITLE
fix(ducklake): a stale local catalog file must not skip the postgres data load

### DIFF
--- a/benchbox/platforms/ducklake.py
+++ b/benchbox/platforms/ducklake.py
@@ -563,15 +563,30 @@ class DuckLakeAdapter(DuckDBAdapter):
           data loading are skipped and queries run against the existing catalog.
           Pass ``--force`` to wipe the catalog + data dir for a clean rebuild.
 
-        Postgres catalog: this hook runs BEFORE any connection exists and keys
-        off the local ``metadata_path`` file, which a server-side catalog never
-        has - so it can only ever take the "does not exist yet" branch here.
-        Reuse/force for ``catalog == "postgres"`` is therefore resolved after
-        the ATTACH instead, in ``_resolve_postgres_catalog_reuse()``, which
-        inspects the attached catalog itself; the framework reads
-        ``database_was_reused`` after ``create_connection()`` returns, so
-        deciding it there is equivalent for the runner.
+        Postgres catalog: this hook runs BEFORE any connection exists, and the
+        only thing it can inspect is the local ``metadata_path`` - which
+        describes no part of a server-side catalog. ``metadata_path`` is still
+        always *computed* to a default, so a leftover ``.ducklake`` file from an
+        earlier duckdb-catalog run at the same benchmark/scale would otherwise
+        read as "the database exists, reuse it": the runner then skips schema
+        creation and data loading and fails validation against a PostgreSQL
+        catalog that is in fact empty. Observed at TPC-H SF=1 - "Empty tables
+        detected: region, nation, supplier, ...".
+
+        So this hook declines to decide for the postgres backend, and
+        reuse/force is resolved after the ATTACH in
+        ``_resolve_postgres_catalog_reuse()``, which inspects the attached
+        catalog itself. The framework reads ``database_was_reused`` after
+        ``create_connection()`` returns, so deciding it there is equivalent for
+        the runner.
         """
+        if self.catalog == "postgres":
+            self.log_very_verbose(
+                "DuckLake postgres catalog: deferring the reuse/force decision to the post-ATTACH "
+                "check (a local metadata_path describes no part of a server-side catalog)"
+            )
+            return
+
         if self.dry_run:
             # Never mutate on-disk artifacts during a dry run.
             self.log_verbose("DuckLake catalog validation skipped (dry run mode)")

--- a/tests/unit/platforms/test_ducklake_adapter.py
+++ b/tests/unit/platforms/test_ducklake_adapter.py
@@ -832,6 +832,39 @@ class TestDuckLakePostgresCatalogReuse:
         assert adapter.database_was_reused is False
         assert not any(sql.startswith("DROP TABLE") for sql in conn.executed)
 
+    def test_stale_local_metadata_file_does_not_mark_a_postgres_run_reused(self, tmp_path):
+        """A leftover .ducklake file must not stand in for a server-side catalog.
+
+        Regression found by the first TPC-H SF=1 postgres run: metadata_path is
+        always computed to a default even for catalog=postgres, so a file left
+        by an earlier duckdb-catalog run at the same benchmark/scale made
+        handle_existing_database() report the database as reused. The runner
+        then skipped schema creation and data loading and failed validation
+        against an empty PostgreSQL catalog - "Empty tables detected: region,
+        nation, supplier, ...".
+        """
+        adapter = self._adapter(tmp_path)
+        adapter.metadata_path.parent.mkdir(parents=True, exist_ok=True)
+        adapter.metadata_path.write_text("stale catalog from a duckdb-backed run")
+
+        adapter.handle_existing_database()
+
+        assert adapter.database_was_reused is False
+        # ...and the stale file is left alone: it is not this backend's to delete.
+        assert adapter.metadata_path.exists()
+
+    def test_local_catalog_still_decides_reuse_from_metadata_path(self, tmp_path):
+        # Must-preserve: duckdb/sqlite keep the pre-connection behaviour.
+        adapter = DuckLakeAdapter(
+            metadata_path=str(tmp_path / "catalog.ducklake"),
+            data_path=str(tmp_path / "data"),
+        )
+        adapter.metadata_path.write_text("existing catalog")
+
+        adapter.handle_existing_database()
+
+        assert adapter.database_was_reused is True
+
     def test_dry_run_never_drops_anything(self, tmp_path):
         adapter = self._adapter(tmp_path, force_recreate=True)
         adapter.dry_run = True


### PR DESCRIPTION
Closes `ducklake-postgres-reuse-keys-off-local-metadata-path`. **Blocks any real
postgres-catalog benchmark run** — found by the first TPC-H SF=1 attempt.

## The failure

```
✅ Database being reused - skipping schema creation and data loading
❌ Data validation failed - benchmark execution halted
⚠️  Empty tables detected: region, nation, supplier, part, partsupp, customer, ...
```

Against a **genuinely fresh** PostgreSQL catalog (`ducklake_table` empty).

## Cause

`handle_existing_database()` decides reuse from `self.metadata_path.exists()`.
For `catalog=postgres` that path describes no part of the catalog — but it is
still always *computed* to a default. So a leftover `.ducklake` file from an
earlier **duckdb-catalog** run at the same benchmark/scale read as "database
exists, reuse it", the runner skipped schema creation and data loading, and
validation then correctly failed against an empty PG catalog.

Reproduced directly:

```
metadata_path exists: True
database_was_reused : True     # on a fresh PG catalog
```

**This is a gap in my own #1358.** That PR added post-ATTACH reuse resolution
for postgres (`_resolve_postgres_catalog_reuse`) but did not stop the
pre-connection check from firing — so the local file still won, and won in the
wrong direction. Its docstring also asserted that a postgres catalog "never has"
a local metadata file, which is simply false.

## Fix

`handle_existing_database()` now declines to decide for the postgres backend and
leaves it to `_resolve_postgres_catalog_reuse`, which inspects the attached
catalog. `duckdb`/`sqlite` are untouched, pinned by a must-preserve test. The
stale file is deliberately not deleted — it is not this backend's to remove.

## Verification

- **The same SF=1 run now passes**: data validation passed, Power@Size
  72118.63 / 76298.44 / 85338.69 across three streams.
- `tests/unit/platforms/test_ducklake_adapter.py` — 107 passed (2 new).
- Mutation: removing the early-return fails the new regression test.
- `check-scope` OK (2 files); ruff/format clean.

## Note on how this was found

Only a real scale run surfaced it. The unit tests for #1358 passed, the live
smoke test passed, and the defect still sat there — it needs a *pre-existing
local catalog file at the default path* plus a postgres backend, which no
hermetic test constructed. That combination is exactly what an ordinary second
run on a developer machine produces.
