### PR TITLE
fix(explorer): re-read a cold empty result instead of believing it

### DIFF
--- a/results-explorer/src/__tests__/snapshotReadiness.test.ts
+++ b/results-explorer/src/__tests__/snapshotReadiness.test.ts
@@ -7,7 +7,7 @@ vi.mock("@/lib/performanceMarks", () => ({
   markExplorerError: vi.fn(),
 }));
 
-import { _waitForSnapshotRowsForTest } from "@/db";
+import { _waitForSnapshotRowsForTest, shouldRetryColdEmptyRead } from "@/db";
 
 interface FakeRow {
   result_id: string;
@@ -16,7 +16,7 @@ interface FakeRow {
 function fakeConnection(
   rowsByLabelOrSql: Record<string, FakeRow[]>,
   log: string[],
-): { query: (sql: string) => Promise<{ toArray: () => FakeRow[] }> } {
+): { query: (sql: string) => Promise<{ toArray: () => Array<FakeRow | { n: number }> }> } {
   return {
     query: async (sql: string) => {
       log.push(sql);
@@ -25,6 +25,9 @@ function fakeConnection(
       const tableMatch = sql.match(/FROM bench\.(\w+)/);
       const table = tableMatch?.[1] ?? "";
       const rows = rowsByLabelOrSql[table] ?? [];
+      // The completeness probe asks COUNT(*) (metadata-satisfied) and then
+      // materializes the column; a healthy snapshot agrees on both.
+      if (/COUNT\(\*\)/i.test(sql)) return { toArray: () => [{ n: rows.length }] };
       return { toArray: () => rows };
     },
   };
@@ -77,4 +80,194 @@ describe("waitForSnapshotRows / SNAPSHOT_READY_SCANS (w5)", () => {
       /empty required scan/,
     );
   }, 10000);
+});
+
+// ---------------------------------------------------------------------------
+// Cold-snapshot zero-row race: an unkeyed `LIMIT 1` scan is satisfied by the
+// first reachable row group while `WHERE result_id = ?` for a row further into
+// the file still returns nothing. Readiness used to pass on the scans alone and
+// hand the UI a snapshot whose keyed lookups render "No result found" for real
+// ids. See docs/operations/browser-ci.md (2026-07-29 correction).
+// ---------------------------------------------------------------------------
+
+const READY_TABLES = [
+  "results",
+  "platform_index_rows",
+  "benchmark_rankings",
+  "benchmark_matrix_cells",
+  "result_detail_metrics",
+  "query_executions",
+  "query_display_timings",
+  "short_ids",
+] as const;
+
+/**
+ * Models a cold snapshot: every unkeyed scan answers, but keyed lookups stay
+ * empty until `keyedReadyOnAttempt` keyed probes have been issued.
+ */
+function coldSnapshotConnection(
+  options: { keyedReadyOnAttempt: number; probeId?: string },
+  log: string[],
+): { query: (sql: string) => Promise<{ toArray: () => Array<{ result_id: string } | { n: number }> }> } {
+  const probeId = options.probeId ?? "zzz-last-result";
+  let keyedProbes = 0;
+  return {
+    query: async (sql: string) => {
+      log.push(sql);
+      const isKeyed = /WHERE result_id =/.test(sql);
+      if (isKeyed) {
+        keyedProbes += 1;
+        const ready = keyedProbes >= options.keyedReadyOnAttempt;
+        return { toArray: () => (ready ? [{ result_id: probeId }] : []) };
+      }
+      const table = sql.match(/FROM bench\.(\w+)/)?.[1] ?? "";
+      const known = READY_TABLES.includes(table as (typeof READY_TABLES)[number]);
+      // Rows are fully readable here; these cases isolate the KEYED failure.
+      if (/COUNT\(\*\)/i.test(sql)) return { toArray: () => [{ n: known ? 1 : 0 }] };
+      if (!known) return { toArray: () => [] };
+      return { toArray: () => [{ result_id: probeId }] };
+    },
+  };
+}
+
+/**
+ * Models the partial-readability shape the completeness probe exists for:
+ * COUNT(*) reports the true total from file metadata while the column
+ * materializes fewer rows, until `readyOnAttempt` passes have been made.
+ */
+function partiallyReadableConnection(
+  options: { total: number; visible: number; readyOnAttempt: number },
+  log: string[],
+): { query: (sql: string) => Promise<{ toArray: () => Array<{ result_id: string } | { n: number }> }> } {
+  let passes = 0;
+  const rows = (count: number) =>
+    Array.from({ length: count }, (_, i) => ({ result_id: `r${i}` }));
+  return {
+    query: async (sql: string) => {
+      log.push(sql);
+      if (/COUNT\(\*\)/i.test(sql)) return { toArray: () => [{ n: options.total }] };
+      if (/WHERE result_id =/.test(sql)) return { toArray: () => [{ result_id: "r0" }] };
+      if (/ORDER BY result_id DESC/.test(sql)) return { toArray: () => [{ result_id: "r0" }] };
+      if (/LIMIT 1/.test(sql)) return { toArray: () => rows(1) };
+      // Full column materialization: short until the snapshot finishes
+      // arriving. The probe returns on the FIRST mismatch, so one short read
+      // happens per readiness attempt.
+      passes += 1;
+      const healed = passes > options.readyOnAttempt;
+      return { toArray: () => rows(healed ? options.total : options.visible) };
+    },
+  };
+}
+
+describe("waitForSnapshotRows keyed probe (cold-snapshot zero-row race)", () => {
+  it("rejects when unkeyed scans pass but keyed lookups stay empty", async () => {
+    // The exact shape that used to slip through: every LIMIT 1 scan answers.
+    const log: string[] = [];
+    const conn = coldSnapshotConnection({ keyedReadyOnAttempt: Number.MAX_SAFE_INTEGER }, log);
+
+    await expect(_waitForSnapshotRowsForTest(conn as unknown as never)).rejects.toThrow(
+      /keyed lookup .* returned no rows from result_detail_metrics/,
+    );
+    expect(log.some((sql) => /WHERE result_id =/.test(sql))).toBe(true);
+  }, 10000);
+
+  it("resolves once the keyed lookup starts answering", async () => {
+    // The snapshot warms up between attempts; readiness must retry, not fail.
+    const log: string[] = [];
+    const conn = coldSnapshotConnection({ keyedReadyOnAttempt: 2 }, log);
+
+    await expect(_waitForSnapshotRowsForTest(conn as unknown as never)).resolves.toBeUndefined();
+    expect(log.filter((sql) => /WHERE result_id =/.test(sql)).length).toBe(2);
+  }, 10000);
+
+  it("probes with the last id so it cannot reuse the row the cheap scans reached", async () => {
+    const log: string[] = [];
+    const conn = coldSnapshotConnection({ keyedReadyOnAttempt: 1 }, log);
+
+    await _waitForSnapshotRowsForTest(conn as unknown as never);
+    expect(
+      log.some((sql) => /FROM bench\.results ORDER BY result_id DESC LIMIT 1/.test(sql)),
+    ).toBe(true);
+  }, 10000);
+
+  it("escapes a quote in the probe id rather than breaking the SQL", async () => {
+    const log: string[] = [];
+    const conn = coldSnapshotConnection({ keyedReadyOnAttempt: 1, probeId: "o'brien" }, log);
+
+    await _waitForSnapshotRowsForTest(conn as unknown as never);
+    const keyed = log.find((sql) => /WHERE result_id =/.test(sql)) ?? "";
+    expect(keyed).toContain("'o''brien'");
+  }, 10000);
+
+  it("rejects when results yields no probe id at all", async () => {
+    const log: string[] = [];
+    const conn = {
+      query: async (sql: string) => {
+        log.push(sql);
+        // Every scan answers except the ordered probe, which comes back empty.
+        if (/COUNT\(\*\)/i.test(sql)) return { toArray: () => [{ n: 1 }] };
+        if (/ORDER BY result_id DESC/.test(sql)) return { toArray: () => [] };
+        return { toArray: () => [{ result_id: "r1" }] };
+      },
+    };
+
+    await expect(_waitForSnapshotRowsForTest(conn as unknown as never)).rejects.toThrow(
+      /returned no probe id/,
+    );
+  }, 10000);
+});
+
+describe("waitForSnapshotRows completeness probe (partially readable snapshot)", () => {
+  it("rejects while a table materializes fewer rows than COUNT(*) reports", async () => {
+    // The state that made Compare fail: unkeyed scans and a single keyed probe
+    // both succeed, but most rows are still unreadable.
+    const log: string[] = [];
+    const conn = partiallyReadableConnection(
+      { total: 10, visible: 3, readyOnAttempt: Number.MAX_SAFE_INTEGER },
+      log,
+    );
+
+    await expect(_waitForSnapshotRowsForTest(conn as unknown as never)).rejects.toThrow(
+      /materialized 3 of 10 row\(s\)/,
+    );
+  }, 10000);
+
+  it("resolves once every row is readable", async () => {
+    const log: string[] = [];
+    const conn = partiallyReadableConnection({ total: 10, visible: 3, readyOnAttempt: 1 }, log);
+
+    await expect(_waitForSnapshotRowsForTest(conn as unknown as never)).resolves.toBeUndefined();
+  }, 10000);
+});
+
+// ---------------------------------------------------------------------------
+// Cold empty-read retry. Readiness gating alone cannot close this race:
+// readability is not monotonic per query, so a surface that reads a range no
+// probe forced still gets zero rows. The retry therefore lives at the read.
+// ---------------------------------------------------------------------------
+
+describe("shouldRetryColdEmptyRead", () => {
+  const READY_AT = 1_000_000;
+
+  it("retries an empty read inside the warm-up window", () => {
+    expect(shouldRetryColdEmptyRead(1, READY_AT + 1_000, READY_AT)).toBe(true);
+  });
+
+  it("believes an empty read once the window has passed", () => {
+    // A genuinely missing id must stay fast — no retry cost on not-found.
+    expect(shouldRetryColdEmptyRead(1, READY_AT + 60_000, READY_AT)).toBe(false);
+  });
+
+  it("stops at the final attempt so an empty result is returned, not looped", () => {
+    expect(shouldRetryColdEmptyRead(3, READY_AT + 1_000, READY_AT)).toBe(false);
+  });
+
+  it("does not retry before the snapshot has ever been attached", () => {
+    expect(shouldRetryColdEmptyRead(1, READY_AT, 0)).toBe(false);
+  });
+
+  it("retries exactly at the window boundary", () => {
+    expect(shouldRetryColdEmptyRead(1, READY_AT + 15_000, READY_AT)).toBe(true);
+    expect(shouldRetryColdEmptyRead(1, READY_AT + 15_001, READY_AT)).toBe(false);
+  });
 });

--- a/results-explorer/src/db.ts
+++ b/results-explorer/src/db.ts
@@ -37,6 +37,12 @@ const SNAPSHOT_READY_ATTEMPTS = 8;
 const SNAPSHOT_READY_DELAY_MS = 100;
 const QUERY_RETRY_ATTEMPTS = 3;
 const QUERY_RETRY_DELAY_MS = 100;
+// How long after the snapshot is attached an EMPTY result is treated as a cold
+// read worth re-issuing rather than the truth. Cold init measures P95 ~1s, so
+// this is generous; outside it, empty returns immediately.
+const COLD_SNAPSHOT_EMPTY_RETRY_WINDOW_MS = 15_000;
+// Set when the snapshot is attached and validated; 0 until then.
+let snapshotReadyAt = 0;
 let initError: Error | null = null;
 
 type DuckDBConnection = Awaited<ReturnType<duckdb.AsyncDuckDB["connect"]>>;
@@ -196,6 +202,89 @@ function throwReadModelVersionError(found: number): never {
   );
 }
 
+function quoteSqlLiteral(value: string): string {
+  return `'${value.replace(/'/g, "''")}'`;
+}
+
+/**
+ * Probe that a KEYED lookup works, not just an unkeyed scan.
+ *
+ * The `LIMIT 1` scans above prove a table is attached and has at least one
+ * reachable row. They do NOT prove the snapshot is fully readable: on a cold
+ * HTTP-backed `results.duckdb` those scans are satisfied by the first row group
+ * while `WHERE result_id = ?` for a row further into the file still returns
+ * zero. `queryRows` does not swallow that — it is a genuine empty read — so the
+ * detail page renders "No result found" for a real id, and index surfaces
+ * render a heading with missing rows. That is the flake the e2e suite kept
+ * hitting (see docs/operations/browser-ci.md, 2026-07-29 correction).
+ *
+ * `ORDER BY result_id DESC LIMIT 1` forces the whole `result_id` column to be
+ * materialized, so the id we probe with is deliberately NOT the one the cheap
+ * scans already reached. `result_detail_metrics` is a LEFT JOIN projection over
+ * `results`, so every id in `results` must resolve there — an empty answer
+ * means the snapshot is still incomplete, never that the row legitimately
+ * does not exist.
+ */
+/**
+ * Every snapshot table must be FULLY readable before the snapshot is exposed.
+ *
+ * Narrowing this list does not work: each time it covered only the tables one
+ * failing surface read, the race simply moved to the next surface. A single-id
+ * keyed probe left Compare failing on `short_ids`; adding `short_ids` left it
+ * failing on the per-query evidence tables. The per-query tables are also the
+ * largest, so they are the most likely to be partially readable, not the least.
+ *
+ * Optional tables are included for free: an empty table has COUNT(*) 0 and
+ * materializes 0 rows, so it agrees trivially.
+ */
+const SNAPSHOT_COMPLETENESS_TABLES = SNAPSHOT_READY_SCANS.map((scan) => scan.label);
+
+/**
+ * Probe that every row is readable, not merely the first one.
+ *
+ * `COUNT(*)` is answered from the file's metadata without reading row groups,
+ * so it reports the TRUE total even while the data pages are still arriving.
+ * Materializing the `result_id` column forces those pages to be read. When the
+ * two disagree the snapshot is only partially readable — the state in which a
+ * keyed lookup for a row in a not-yet-readable group returns zero rows.
+ *
+ * This is what a single keyed probe cannot catch: proving one id resolves says
+ * nothing about the other ids a page will ask for. Compare in particular reads
+ * several specific ids at once, and kept failing under a single-id probe.
+ */
+async function probeSnapshotCompleteness(conn: DuckDBConnection): Promise<string | null> {
+  for (const table of SNAPSHOT_COMPLETENESS_TABLES) {
+    const countRows = (await conn.query(`SELECT COUNT(*) AS n FROM bench.${table}`)).toArray() as Array<{
+      n?: unknown;
+    }>;
+    const expected = Number(countRows[0]?.n ?? 0);
+    if (!Number.isFinite(expected)) continue;
+    const materialized = (await conn.query(`SELECT result_id FROM bench.${table}`)).toArray().length;
+    if (materialized !== expected) {
+      return `${table} materialized ${materialized} of ${expected} row(s)`;
+    }
+  }
+  return null;
+}
+
+async function probeKeyedLookup(conn: DuckDBConnection): Promise<string | null> {
+  const idRows = (
+    await conn.query("SELECT result_id FROM bench.results ORDER BY result_id DESC LIMIT 1")
+  ).toArray() as Array<{ result_id?: unknown }>;
+  const probeId = idRows[0]?.result_id;
+  if (typeof probeId !== "string" || probeId === "") return "results returned no probe id";
+
+  const keyed = (
+    await conn.query(
+      `SELECT result_id FROM bench.result_detail_metrics WHERE result_id = ${quoteSqlLiteral(probeId)} LIMIT 1`,
+    )
+  ).toArray();
+  if (keyed.length === 0) {
+    return `keyed lookup for ${probeId} returned no rows from result_detail_metrics`;
+  }
+  return null;
+}
+
 async function waitForSnapshotRows(conn: DuckDBConnection): Promise<void> {
   let lastError: unknown = null;
   for (let attempt = 1; attempt <= SNAPSHOT_READY_ATTEMPTS; attempt += 1) {
@@ -212,10 +301,15 @@ async function waitForSnapshotRows(conn: DuckDBConnection): Promise<void> {
       const emptyRequired = requiredCounts
         .filter(([, rowCount]) => rowCount === 0)
         .map(([label]) => label);
-      if (emptyRequired.length === 0) return;
-      lastError = new Error(
-        `DuckDB snapshot readiness returned empty required scan(s): ${emptyRequired.join(", ")}`,
-      );
+      if (emptyRequired.length === 0) {
+        const failure = (await probeSnapshotCompleteness(conn)) ?? (await probeKeyedLookup(conn));
+        if (failure === null) return;
+        lastError = new Error(`DuckDB snapshot readiness: ${failure}`);
+      } else {
+        lastError = new Error(
+          `DuckDB snapshot readiness returned empty required scan(s): ${emptyRequired.join(", ")}`,
+        );
+      }
     } catch (error: unknown) {
       lastError = error;
       if (!isTransientDuckDbSnapshotError(error)) throw error;
@@ -282,6 +376,7 @@ export async function getDb(): Promise<duckdb.AsyncDuckDB> {
     }
 
     dbInstance = db;
+    snapshotReadyAt = Date.now();
     markExplorerPerformance(EXPLORER_PERFORMANCE_MARKS.DB_INIT_READY, { once: true });
     measureExplorerPerformance(
       EXPLORER_PERFORMANCE_MEASURES.DB_INIT,
@@ -311,7 +406,13 @@ export async function queryRows<T>(
   let lastError: unknown = null;
   for (let attempt = 1; attempt <= QUERY_RETRY_ATTEMPTS; attempt += 1) {
     try {
-      return await queryRowsOnce<T>(sql, params);
+      const rows = await queryRowsOnce<T>(sql, params);
+      if (rows.length > 0 || !isColdEmptyRead(attempt)) return rows;
+      // Empty, and the snapshot is still warming: re-read rather than let a
+      // cold zero-row answer reach the UI as "no such result". See
+      // shouldRetryColdEmptyRead.
+      await sleep(QUERY_RETRY_DELAY_MS * attempt);
+      continue;
     } catch (error: unknown) {
       lastError = error;
       if (!isTransientDuckDbSnapshotError(error) || attempt === QUERY_RETRY_ATTEMPTS) {
@@ -320,7 +421,46 @@ export async function queryRows<T>(
       await sleep(QUERY_RETRY_DELAY_MS * attempt);
     }
   }
-  throw lastError instanceof Error ? lastError : new Error("DuckDB query failed");
+  if (lastError !== null) {
+    throw lastError instanceof Error ? lastError : new Error("DuckDB query failed");
+  }
+  // Every attempt returned empty inside the warm-up window: the result really
+  // is empty (a filtered query, or an id that does not exist).
+  return [];
+}
+
+/**
+ * Whether an empty result should be re-read rather than believed.
+ *
+ * A cold HTTP-backed snapshot answers a keyed lookup with ZERO ROWS — not an
+ * error — while the row group holding that key is still unreadable. `queryRows`
+ * does not swallow errors, so nothing else catches this: the detail page
+ * renders "No result found" for a real id and index surfaces render a heading
+ * with missing rows.
+ *
+ * Gating a readiness probe on it is not enough. Three progressively stricter
+ * gates were measured (keyed probe, then per-table completeness, then
+ * completeness across every table) and each time the race simply moved to
+ * whichever surface read a range the gate had not forced. Readability is not
+ * monotonic per query, so the retry has to live where the read happens.
+ *
+ * Bounded to a short window after init, because that is the only time the
+ * snapshot is cold. Outside it an empty answer returns immediately, so a
+ * genuinely missing id stays fast. Retrying can never invent a row: an empty
+ * result that is really empty stays empty and is returned as such.
+ */
+export function shouldRetryColdEmptyRead(
+  attempt: number,
+  now: number,
+  readyAt: number,
+): boolean {
+  if (attempt >= QUERY_RETRY_ATTEMPTS) return false;
+  if (readyAt === 0) return false;
+  return now - readyAt <= COLD_SNAPSHOT_EMPTY_RETRY_WINDOW_MS;
+}
+
+function isColdEmptyRead(attempt: number): boolean {
+  return shouldRetryColdEmptyRead(attempt, Date.now(), snapshotReadyAt);
 }
 
 async function queryRowsOnce<T>(

--- a/results-explorer/src/lib/__tests__/read-model-version-mismatch.test.ts
+++ b/results-explorer/src/lib/__tests__/read-model-version-mismatch.test.ts
@@ -12,7 +12,13 @@ import {
 } from "@/db";
 
 interface QueryResult {
-  toArray(): { toJSON(): { read_model_version?: number } }[];
+  // Readiness probes read `result_id` / `n` off the row directly; the version
+  // guard reads `read_model_version` via toJSON().
+  toArray(): {
+    result_id?: string;
+    n?: number;
+    toJSON(): { read_model_version?: number; result_id?: string };
+  }[];
 }
 
 interface FakeConn {
@@ -151,10 +157,17 @@ describe("read-model version guard", () => {
             ],
           };
         }
+        // Readiness now also runs a completeness probe (COUNT(*) vs the
+        // materialized column) and a keyed probe (ORDER BY result_id DESC,
+        // then WHERE result_id = ...), so answer both shapes consistently.
+        if (/COUNT\(\*\)/i.test(sql)) {
+          return { toArray: () => [{ n: 1, toJSON: () => ({}) }] };
+        }
         return {
           toArray: () => [
             {
-              toJSON: () => ({}),
+              result_id: "r1",
+              toJSON: () => ({ result_id: "r1" }),
             },
           ],
         };


### PR DESCRIPTION
A cold HTTP-backed snapshot answers a keyed lookup with **zero rows** rather
than an error, while the row group holding that key is still unreadable.
`queryRows` doesn't swallow errors, so nothing caught it: the detail page
rendered "No result found" for a real id, and index surfaces rendered a heading
with rows missing.

#1340 mitigated this in the e2e harness by re-navigating. **This fixes the
app**, and closes the first-load coverage gap that mitigation deliberately
accepted.

## Readiness gating cannot close this — measured, not assumed

This is the obvious approach and it is worth recording that it fails, because
the next person will reach for it. Three progressively stricter gates were
built, and each was defeated in turn:

| Gate | Result |
|---|---|
| Keyed probe on the last `result_id` | Compare still failed, on `short_ids` |
| Completeness (`COUNT(*)` vs materialized column) over `results`, `result_detail_metrics`, `short_ids` | Compare still failed, now on the per-query evidence tables |
| Completeness over **all eight** snapshot tables | Still 3 failures, on other routes again |

Readability is not monotonic per query: a surface that reads a range no probe
forced still gets zero rows. So the retry has to live where the read happens.

## The fix

`queryRows` re-issues an **empty** result inside a 15s window after the
snapshot is attached, bounded by the existing `QUERY_RETRY_ATTEMPTS`. Outside
that window an empty answer returns immediately, so a genuinely missing id
stays fast. Retrying can never invent a row — an empty result that is really
empty is returned as such.

The strengthened readiness gate is kept: it catches a snapshot that is
genuinely incomplete at attach time, and it is cheap.

## Proof the race is closed, not merely mitigated

With #1340's e2e re-navigation reduced to a **single attempt** — i.e. the
harness mitigation switched off — the Chromium suite is green **three runs
running**. That same configuration failed reproducibly before this change (2–4
failures per run, moving between Compare, `responsive`, `direct-route` and
`external-corpus`).

- 14 readiness tests, **5 verified to fail against pre-fix code**
- 844 vitest, 26061 fast lane, typecheck clean
- Chromium e2e green in the normal config too
- **Cold init got faster**: P50 437ms vs 564ms baseline, P95 586ms vs 978ms —
  forcing full reads early avoids repeated partial fetches

## Not doing yet

w3 asks to reassess graduating WebKit/Firefox `@smoke` to blocking. **Not
recommended in this PR**: only Chromium was exercised locally and there is no
post-fix CI flake data. Worth revisiting after this has soaked.

The e2e re-navigation mitigation is deliberately left in place — it is cheap,
and it should not be removed until this fix has real CI history.

Tracker: `explorer-cold-snapshot-zero-row-race`

🤖 Generated with [Claude Code](https://claude.ai/code)
