### PR TITLE
feat(snowflake): corroborate the clustering key so tuned runs can verify

### DIFF
--- a/benchbox/core/tuning/introspection.py
+++ b/benchbox/core/tuning/introspection.py
@@ -67,6 +67,9 @@ _VERIFIABLE_VERDICTS = frozenset({CORROBORATED, ABSENT, MISMATCH, UNVERIFIABLE})
 KIND_INDEX = "index"
 KIND_SORT_KEY = "sort_key"
 KIND_PARTITION_KEY = "partition_key"
+#: Snowflake/BigQuery-style clustering key, applied by ``CLUSTER BY`` either on
+#: ``CREATE TABLE`` or by a post-load ``ALTER TABLE``.
+KIND_CLUSTER_KEY = "cluster_key"
 
 _DDL_PHASES = frozenset({PHASE_DDL, PHASE_POST_LOAD})
 
@@ -247,6 +250,16 @@ _CREATE_TABLE_RE = re.compile(
     re.IGNORECASE,
 )
 _OPTIMIZE_RE = re.compile(r"^\s*optimize\s+table\s+(?P<table>[^\s;]+)", re.IGNORECASE)
+_CLUSTER_BY_RE = re.compile(rf"\bcluster\s+by\s*\({_KEY_CLAUSE_COLUMNS}\)", re.IGNORECASE | re.DOTALL)
+_CLUSTER_BY_KEYWORD_RE = re.compile(r"\bcluster\s+by\b", re.IGNORECASE)
+# Snowflake applies a clustering key post-load: ``ALTER TABLE T CLUSTER BY (a, b)``.
+_ALTER_TABLE_RE = re.compile(r"^\s*alter\s+table\s+(?P<table>[^\s(]+)", re.IGNORECASE)
+# ``ALTER TABLE T RECLUSTER`` (and the RESUME/SUSPEND forms that toggle
+# Snowflake's automatic reclustering service) reorganize existing data. They
+# have no distinct catalog footprint of their own -- the clustering KEY is what
+# CLUSTERING_KEY reports -- so they are maintenance, exactly like OPTIMIZE:
+# recorded and noted, but they neither earn nor block verification.
+_RECLUSTER_RE = re.compile(r"^\s*alter\s+table\s+\S+\s+(?:(?:resume|suspend)\s+)?recluster\b", re.IGNORECASE)
 # Recognized transient (session/config) and maintenance prefixes.
 _TRANSIENT_PREFIXES = ("set ", "pragma ", "set\t", "pragma\t", "reset ", "use ")
 _MAINTENANCE_PREFIXES = ("optimize ", "vacuum", "analyze", "compact ")
@@ -369,10 +382,17 @@ def _classify(statement: AppliedStatement) -> tuple[str, list[_Intent]]:
         part = _PARTITION_BY_RE.search(text)
         if part:
             intents.append(_Intent(kind=KIND_PARTITION_KEY, table=table, columns=normalize_columns(part.group("cols"))))
+        cluster = _CLUSTER_BY_RE.search(text)
+        if cluster:
+            intents.append(
+                _Intent(kind=KIND_CLUSTER_KEY, table=table, columns=normalize_columns(cluster.group("cols")))
+            )
         # Fail closed: a key clause we can SEE but could not parse must block the
         # upgrade rather than silently vanish while a sibling clause corroborates.
         # Dropping it would recreate exactly the hole this classifier closes.
         if order is None and _ORDER_BY_KEYWORD_RE.search(text) and not _ORDER_BY_NOOP_RE.search(text):
+            return UNVERIFIABLE, []
+        if cluster is None and _CLUSTER_BY_KEYWORD_RE.search(text):
             return UNVERIFIABLE, []
         if part is None and _PARTITION_BY_KEYWORD_RE.search(text):
             return UNVERIFIABLE, []
@@ -380,6 +400,22 @@ def _classify(statement: AppliedStatement) -> tuple[str, list[_Intent]]:
             return "verifiable", intents
         # A plain CREATE TABLE with no recognized key clause is not a tuning
         # footprint we can corroborate -> unverifiable (conservative).
+        return UNVERIFIABLE, []
+
+    # Snowflake applies its clustering key after load, so the tuning footprint
+    # arrives as ALTER TABLE rather than CREATE TABLE.
+    at = _ALTER_TABLE_RE.match(text)
+    if at:
+        if _RECLUSTER_RE.match(text):
+            return MAINTENANCE, []
+        table = normalize_identifier(at.group("table"))
+        cluster = _CLUSTER_BY_RE.search(text)
+        if cluster:
+            return "verifiable", [
+                _Intent(kind=KIND_CLUSTER_KEY, table=table, columns=normalize_columns(cluster.group("cols")))
+            ]
+        # Any other ALTER TABLE (including a CLUSTER BY we could not parse) has
+        # no corroboration rule and must keep blocking the upgrade.
         return UNVERIFIABLE, []
 
     return UNVERIFIABLE, []
@@ -541,6 +577,7 @@ __all__ = [
     "IntrospectedState",
     "IntrospectionReceipt",
     "KIND_INDEX",
+    "KIND_CLUSTER_KEY",
     "KIND_PARTITION_KEY",
     "KIND_SORT_KEY",
     "MAINTENANCE",

--- a/benchbox/platforms/snowflake.py
+++ b/benchbox/platforms/snowflake.py
@@ -1599,6 +1599,19 @@ class SnowflakeAdapter(PlatformAdapter):
         finally:
             cursor.close()
 
+    def get_tuning_introspector(self):
+        """Read ``INFORMATION_SCHEMA`` clustering keys to corroborate the ledger.
+
+        Snowflake's tuning footprint is the clustering key, applied after load
+        by ``ALTER TABLE ... CLUSTER BY``. Those statements already reach the
+        applied ledger (``apply_standard_unified_tuning`` wraps the connection
+        in a recording connection), so this supplies the catalog side that lets
+        them be corroborated instead of classified ``unverifiable``.
+        """
+        from benchbox.platforms.snowflake_introspection import SnowflakeTuningIntrospector
+
+        return SnowflakeTuningIntrospector(schema=self.schema)
+
     def close_connection(self, connection: Any) -> None:
         """Close Snowflake connection."""
         try:

--- a/benchbox/platforms/snowflake_introspection.py
+++ b/benchbox/platforms/snowflake_introspection.py
@@ -1,0 +1,140 @@
+"""Snowflake post-load schema introspector.
+
+Reads ``INFORMATION_SCHEMA.TABLES.CLUSTERING_KEY`` for the tables the
+applied-tuning ledger touched and surfaces them as ``cluster_key`` facts, so a
+recorded ``ALTER TABLE ... CLUSTER BY (cols)`` can be corroborated and earn
+``applied_verified`` (TODO ``snowflake-cluster-key-corroboration-20260730``;
+design note ``docs/development/tuning-introspection-receipts.md``).
+
+Snowflake is the platform whose tuning footprint lands *after* load: the adapter
+applies the clustering key with ``ALTER TABLE``, not in ``CREATE TABLE``. Those
+statements are already captured -- ``apply_standard_unified_tuning`` wraps the
+connection in a recording connection -- so the only thing missing was a catalog
+read to check them against.
+
+Bounded (one query, capped, scoped to the ledger's tables) and non-fatal (any
+failure returns an :class:`IntrospectedState` carrying ``error``, which refuses
+the upgrade rather than guessing).
+
+Copyright 2026 Joe Harris / BenchBox Project
+
+Licensed under the MIT License. See LICENSE file in the project root for details.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from typing import Any
+
+from benchbox.core.tuning.applied_ledger import AppliedTuningLedger
+from benchbox.core.tuning.introspection import (
+    KIND_CLUSTER_KEY,
+    IntrospectedObject,
+    IntrospectedState,
+    ledger_tables,
+    normalize_columns,
+    normalize_identifier,
+)
+
+logger = logging.getLogger(__name__)
+
+#: Hard cap on catalog rows read.
+_MAX_TABLE_ROWS = 1000
+
+#: Snowflake reports a clustering key as ``LINEAR(A, B)``. Older/other paths in
+#: this repo compare against a bare ``(A, B)``, so both forms are accepted --
+#: guessing wrong here would mismatch every clustered table against its own
+#: catalog fact, which fails CLOSED and would be invisible.
+_CLUSTERING_KEY_RE = re.compile(r"^\s*(?:linear\s*)?\((?P<cols>.*)\)\s*$", re.IGNORECASE | re.DOTALL)
+
+
+def parse_clustering_key(raw: Any) -> tuple[str, ...]:
+    """Normalize a Snowflake ``CLUSTERING_KEY`` into comparable columns.
+
+    Accepts ``LINEAR(A, B)``, ``(A, B)`` and a bare ``A, B``; returns ``()`` for
+    NULL/empty (an unclustered table).
+    """
+    if raw is None:
+        return ()
+    text = str(raw).strip()
+    if not text:
+        return ()
+    match = _CLUSTERING_KEY_RE.match(text)
+    if match:
+        text = match.group("cols")
+    return normalize_columns(text)
+
+
+class SnowflakeTuningIntrospector:
+    """Introspect Snowflake ``INFORMATION_SCHEMA`` clustering keys."""
+
+    platform = "snowflake"
+
+    def __init__(self, schema: str | None = None) -> None:
+        self._schema = schema
+
+    def introspect(self, connection: Any, ledger: AppliedTuningLedger) -> IntrospectedState:
+        """Read ``CLUSTERING_KEY`` from ``INFORMATION_SCHEMA.TABLES``.
+
+        Never raises: a failed catalog read degrades to a state carrying
+        ``error``, and corroboration then refuses the upgrade.
+        """
+        tables = ledger_tables(ledger)
+        query = (
+            "SELECT TABLE_NAME, CLUSTERING_KEY FROM INFORMATION_SCHEMA.TABLES "
+            f"WHERE CLUSTERING_KEY IS NOT NULL LIMIT {_MAX_TABLE_ROWS}"
+        )
+        if self._schema:
+            query = (
+                "SELECT TABLE_NAME, CLUSTERING_KEY FROM INFORMATION_SCHEMA.TABLES "
+                f"WHERE TABLE_SCHEMA = '{self._schema}' AND CLUSTERING_KEY IS NOT NULL "
+                f"LIMIT {_MAX_TABLE_ROWS}"
+            )
+
+        try:
+            rows = _fetch(connection, query)
+        except Exception as exc:  # introspection must never break a run
+            logger.debug("snowflake clustering introspection degraded: %s", exc)
+            return IntrospectedState(platform=self.platform, error=f"INFORMATION_SCHEMA read failed: {exc}")
+
+        truncated = len(rows) >= _MAX_TABLE_ROWS
+        objects: list[IntrospectedObject] = []
+        for row in rows:
+            try:
+                name, clustering_key = row[0], row[1]
+            except Exception:  # pragma: no cover - defensive on row shape
+                continue
+            if tables and normalize_identifier(name or "") not in tables:
+                continue
+            columns = parse_clustering_key(clustering_key)
+            if not columns:
+                continue
+            objects.append(
+                IntrospectedObject(
+                    kind=KIND_CLUSTER_KEY,
+                    table=name,
+                    columns=columns,
+                    evidence={"clustering_key": str(clustering_key)},
+                )
+            )
+        return IntrospectedState(platform=self.platform, objects=objects, truncated=truncated)
+
+
+def _fetch(connection: Any, query: str) -> list[Any]:
+    """Run a read through either a cursor-style or execute-style connection."""
+    cursor_factory = getattr(connection, "cursor", None)
+    if callable(cursor_factory):
+        cursor = cursor_factory()
+        try:
+            cursor.execute(query)
+            return list(cursor.fetchall() or [])
+        finally:
+            close = getattr(cursor, "close", None)
+            if callable(close):
+                close()
+    result = connection.execute(query)
+    return list(result) if result is not None else []
+
+
+__all__ = ["SnowflakeTuningIntrospector", "parse_clustering_key"]

--- a/docs/development/tuning-introspection-receipts.md
+++ b/docs/development/tuning-introspection-receipts.md
@@ -44,8 +44,10 @@ platform-agnostic; the per-platform catalog *reads* live in the
 | `CREATE INDEX [IF NOT EXISTS] n ON T (cols)` | ddl/post_load  | `index`       | a catalog `index` fact on `T` whose columns equal `cols` (order- and case-normal)  | yes                  |
 | `CREATE TABLE ... ORDER BY (cols)`           | ddl/post_load  | `sort_key`    | a catalog `sort_key` fact on `T` whose columns equal `cols`                         | yes                  |
 | `CREATE TABLE ... PARTITION BY (cols)`       | ddl/post_load  | `partition_key` | a catalog `partition_key` fact on `T` whose columns equal `cols`                 | yes                  |
+| `ALTER TABLE T CLUSTER BY (cols)`, `CREATE TABLE ... CLUSTER BY (cols)` | ddl/post_load | `cluster_key` | a catalog `cluster_key` fact on `T` whose columns equal `cols`, in order | yes |
 | `SET ...`, `PRAGMA ...`                       | any            | `transient`   | session/config, no persistent catalog footprint -- noted, **non-blocking**         | no                   |
 | `OPTIMIZE TABLE ...` / maintenance           | ddl/post_load  | `maintenance` | merge/compaction op, no distinct catalog footprint -- noted, **non-blocking**      | no                   |
+| `ALTER TABLE T [RESUME/SUSPEND] RECLUSTER`   | ddl/post_load  | `maintenance` | reorganizes existing data; the clustering KEY is the catalog footprint -- **non-blocking** | no          |
 | session-phase statement (any)                | session        | `transient`   | transient SET -- noted, **non-blocking** (documented default below)                | no                   |
 | anything else                                | ddl/post_load  | `unverifiable`| no corroboration rule -- **blocks** the upgrade (conservative: stay unverified)    | n/a (blocks)         |
 

--- a/tests/unit/core/tuning/test_introspection.py
+++ b/tests/unit/core/tuning/test_introspection.py
@@ -28,6 +28,7 @@ from benchbox.core.tuning.applied_ledger import (
 from benchbox.core.tuning.introspection import (
     ABSENT,
     CORROBORATED,
+    KIND_CLUSTER_KEY,
     KIND_INDEX,
     KIND_PARTITION_KEY,
     KIND_SORT_KEY,
@@ -347,3 +348,61 @@ class TestUnparsableKeyClauseFailsClosed:
         receipt = self._corroborate("CREATE TABLE t (a Int64) PARTITION BY (d) ORDER BY tuple()")
         assert [e.kind for e in receipt.entries] == [KIND_PARTITION_KEY]
         assert receipt.corroborated is True
+
+
+class TestClusterKeyClassification:
+    """Snowflake applies its clustering key AFTER load, so the tuning footprint
+    arrives as ``ALTER TABLE ... CLUSTER BY``. Before this rule existed every
+    such statement classified ``unverifiable`` and BLOCKED the upgrade, so a
+    tuned Snowflake run could never reach applied_verified.
+    """
+
+    def _ledger(self, statement: str) -> AppliedTuningLedger:
+        ledger = AppliedTuningLedger()
+        ledger.record(statement, PHASE_DDL, table="lineitem")
+        return ledger
+
+    def _state(self, columns=("a", "b")) -> IntrospectedState:
+        return IntrospectedState(
+            platform="snowflake",
+            objects=[IntrospectedObject(kind=KIND_CLUSTER_KEY, table="lineitem", columns=columns)],
+        )
+
+    def test_alter_table_cluster_by_is_corroboratable(self):
+        receipt = corroborate(self._ledger("ALTER TABLE lineitem CLUSTER BY (a, b)"), self._state())
+        assert [(e.kind, e.verdict) for e in receipt.entries] == [(KIND_CLUSTER_KEY, CORROBORATED)]
+        assert receipt.corroborated is True
+
+    def test_create_table_cluster_by_is_corroboratable(self):
+        receipt = corroborate(self._ledger("CREATE TABLE lineitem (a INT, b INT) CLUSTER BY (a, b)"), self._state())
+        assert [(e.kind, e.verdict) for e in receipt.entries] == [(KIND_CLUSTER_KEY, CORROBORATED)]
+
+    def test_mismatched_cluster_key_blocks(self):
+        receipt = corroborate(self._ledger("ALTER TABLE lineitem CLUSTER BY (a, b)"), self._state(columns=("a",)))
+        assert receipt.entries[0].verdict == MISMATCH
+        assert receipt.corroborated is False
+
+    @pytest.mark.parametrize(
+        "statement",
+        [
+            "ALTER TABLE lineitem RECLUSTER",
+            "ALTER TABLE lineitem RESUME RECLUSTER",
+            "ALTER TABLE lineitem SUSPEND RECLUSTER",
+        ],
+    )
+    def test_recluster_is_maintenance_not_blocking(self, statement):
+        # Reorganizes existing data; the KEY is what the catalog reports, so
+        # these neither earn nor block verification (same class as OPTIMIZE).
+        receipt = corroborate(self._ledger(statement), self._state())
+        assert receipt.entries[0].verdict == MAINTENANCE
+        assert receipt.summary["verifiable_total"] == 0
+
+    def test_unparsable_cluster_clause_fails_closed(self):
+        # Visible CLUSTER BY we cannot parse must keep blocking, never vanish.
+        receipt = corroborate(self._ledger("ALTER TABLE lineitem CLUSTER BY a, b"), self._state())
+        assert receipt.entries[0].verdict == UNVERIFIABLE
+        assert receipt.corroborated is False
+
+    def test_other_alter_table_still_blocks(self):
+        receipt = corroborate(self._ledger("ALTER TABLE lineitem ADD COLUMN c INT"), self._state())
+        assert receipt.entries[0].verdict == UNVERIFIABLE

--- a/tests/unit/platforms/test_snowflake_introspection.py
+++ b/tests/unit/platforms/test_snowflake_introspection.py
@@ -1,0 +1,180 @@
+"""Tests for the Snowflake clustering-key introspector and its corroboration.
+
+Snowflake's tuning footprint lands AFTER load: the adapter applies the
+clustering key with ``ALTER TABLE ... CLUSTER BY``. Those statements were
+already captured (``apply_standard_unified_tuning`` wraps the connection in a
+recording connection) but had no corroboration rule, so they classified as
+``unverifiable`` and BLOCKED the upgrade -- a tuned Snowflake run could never
+reach ``applied_verified``, and its receipt said "no corroboration rule for this
+statement" instead of naming the key. TODO
+``snowflake-cluster-key-corroboration-20260730``.
+
+Copyright 2026 Joe Harris / BenchBox Project
+
+Licensed under the MIT License. See LICENSE file in the project root for details.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from benchbox.core.tuning.applied_ledger import (
+    PHASE_DDL,
+    PHASE_SESSION,
+    AppliedTuningLedger,
+)
+from benchbox.core.tuning.introspection import KIND_CLUSTER_KEY, corroborate
+from benchbox.platforms.snowflake_introspection import (
+    SnowflakeTuningIntrospector,
+    parse_clustering_key,
+)
+
+pytestmark = [pytest.mark.unit, pytest.mark.fast]
+
+
+class _FakeCursor:
+    def __init__(self, rows, fail: bool):
+        self._rows = rows
+        self._fail = fail
+        self.closed = False
+        self.queries: list[str] = []
+
+    def execute(self, query):
+        self.queries.append(str(query))
+        if self._fail:
+            raise RuntimeError("INFORMATION_SCHEMA unavailable")
+
+    def fetchall(self):
+        return self._rows
+
+    def close(self):
+        self.closed = True
+
+
+class _FakeSnowflakeConnection:
+    """Cursor-style connection, as the real Snowflake driver exposes."""
+
+    def __init__(self, rows, fail: bool = False):
+        self._rows = rows
+        self._fail = fail
+        self.cursors: list[_FakeCursor] = []
+
+    def cursor(self):
+        cursor = _FakeCursor(self._rows, self._fail)
+        self.cursors.append(cursor)
+        return cursor
+
+
+def _clustered_ledger(table: str = "LINEITEM") -> AppliedTuningLedger:
+    ledger = AppliedTuningLedger()
+    ledger.record(f"ALTER TABLE {table} CLUSTER BY (l_orderkey, l_shipdate)", PHASE_DDL, table=table)
+    ledger.record(f"ALTER TABLE {table} RESUME RECLUSTER", PHASE_DDL, table=table)
+    ledger.record("ALTER SESSION SET USE_CACHED_RESULT = FALSE", PHASE_SESSION)
+    return ledger
+
+
+class TestParseClusteringKey:
+    """Snowflake reports ``LINEAR(A, B)``; this repo's own adapter compares
+    against a bare ``(A, B)``. Guessing wrong fails CLOSED -- every clustered
+    table would mismatch its own catalog fact and nothing would error -- so both
+    forms are accepted.
+    """
+
+    @pytest.mark.parametrize(
+        "raw",
+        ["LINEAR(L_ORDERKEY, L_SHIPDATE)", "(L_ORDERKEY, L_SHIPDATE)", "L_ORDERKEY, L_SHIPDATE"],
+    )
+    def test_accepts_every_reported_form(self, raw):
+        assert parse_clustering_key(raw) == ("l_orderkey", "l_shipdate")
+
+    @pytest.mark.parametrize("raw", [None, "", "   "])
+    def test_unclustered_table_yields_no_columns(self, raw):
+        assert parse_clustering_key(raw) == ()
+
+    def test_preserves_key_order(self):
+        # Clustering key order is significant to Snowflake's pruning.
+        assert parse_clustering_key("LINEAR(B, A)") == ("b", "a")
+
+
+class TestSnowflakeIntrospector:
+    def test_reports_cluster_key_for_ledger_tables(self):
+        conn = _FakeSnowflakeConnection([("LINEITEM", "LINEAR(L_ORDERKEY, L_SHIPDATE)")])
+        state = SnowflakeTuningIntrospector().introspect(conn, _clustered_ledger())
+        assert state.error is None
+        assert len(state.objects) == 1
+        obj = state.objects[0]
+        assert obj.kind == KIND_CLUSTER_KEY
+        assert obj.columns == ("l_orderkey", "l_shipdate")
+        assert obj.evidence["clustering_key"] == "LINEAR(L_ORDERKEY, L_SHIPDATE)"
+
+    def test_query_reads_information_schema_not_show_create(self):
+        conn = _FakeSnowflakeConnection([("LINEITEM", "LINEAR(A)")])
+        SnowflakeTuningIntrospector(schema="BENCH").introspect(conn, _clustered_ledger())
+        query = conn.cursors[0].queries[0].upper()
+        assert "INFORMATION_SCHEMA.TABLES" in query
+        assert "SHOW CREATE" not in query
+        assert "BENCH" in query
+
+    def test_bounded_to_ledger_tables(self):
+        conn = _FakeSnowflakeConnection(
+            [("LINEITEM", "LINEAR(A)"), ("ORDERS", "LINEAR(B)")],  # ORDERS not in ledger
+        )
+        state = SnowflakeTuningIntrospector().introspect(conn, _clustered_ledger())
+        assert {obj.table for obj in state.objects} == {"LINEITEM"}
+
+    def test_non_fatal_on_query_failure(self):
+        conn = _FakeSnowflakeConnection([], fail=True)
+        state = SnowflakeTuningIntrospector().introspect(conn, _clustered_ledger())
+        assert state.error is not None
+        assert state.objects == []
+
+    def test_closes_its_cursor(self):
+        conn = _FakeSnowflakeConnection([("LINEITEM", "LINEAR(A)")])
+        SnowflakeTuningIntrospector().introspect(conn, _clustered_ledger())
+        assert conn.cursors[0].closed is True
+
+
+class TestSnowflakeCorroboration:
+    def test_matching_cluster_key_earns_verification(self):
+        ledger = _clustered_ledger()
+        conn = _FakeSnowflakeConnection([("LINEITEM", "LINEAR(L_ORDERKEY, L_SHIPDATE)")])
+        receipt = corroborate(ledger, SnowflakeTuningIntrospector().introspect(conn, ledger))
+
+        verdicts = [(e.kind, e.verdict) for e in receipt.entries]
+        assert (KIND_CLUSTER_KEY, "corroborated") in verdicts
+        # RESUME RECLUSTER is maintenance and the session SET is transient:
+        # noted, but neither earns nor blocks.
+        assert receipt.summary["verifiable_total"] == 1
+        assert receipt.corroborated is True
+
+    def test_different_cluster_key_blocks_verification(self):
+        ledger = _clustered_ledger()
+        conn = _FakeSnowflakeConnection([("LINEITEM", "LINEAR(L_SHIPDATE)")])
+        receipt = corroborate(ledger, SnowflakeTuningIntrospector().introspect(conn, ledger))
+
+        entry = next(e for e in receipt.entries if e.kind == KIND_CLUSTER_KEY)
+        assert entry.verdict == "mismatch"
+        assert receipt.corroborated is False
+
+    def test_unclustered_table_blocks_verification(self):
+        # The clustering key never applied: CLUSTERING_KEY is NULL.
+        ledger = _clustered_ledger()
+        conn = _FakeSnowflakeConnection([("LINEITEM", None)])
+        receipt = corroborate(ledger, SnowflakeTuningIntrospector().introspect(conn, ledger))
+
+        entry = next(e for e in receipt.entries if e.kind == KIND_CLUSTER_KEY)
+        assert entry.verdict == "absent"
+        assert receipt.corroborated is False
+
+    def test_degraded_introspection_blocks_verification(self):
+        ledger = _clustered_ledger()
+        conn = _FakeSnowflakeConnection([], fail=True)
+        receipt = corroborate(ledger, SnowflakeTuningIntrospector().introspect(conn, ledger))
+        assert receipt.corroborated is False
+
+    def test_key_order_is_significant(self):
+        # Snowflake prunes on the leading column, so (A, B) != (B, A).
+        ledger = _clustered_ledger()
+        conn = _FakeSnowflakeConnection([("LINEITEM", "LINEAR(L_SHIPDATE, L_ORDERKEY)")])
+        receipt = corroborate(ledger, SnowflakeTuningIntrospector().introspect(conn, ledger))
+        assert receipt.corroborated is False


### PR DESCRIPTION
First step of the Snowflake-before-Snowpark decision: make Snowflake's own
clustering verifiable, so Snowpark can later reuse the same path.

## Correcting the premise

Snowflake **was already capturing** its tuning. `apply_standard_unified_tuning`
wraps the connection in a `recording_connection(PHASE_DDL)` and
`RecordingConnection.cursor()` proxies `execute`, so `snowflake.py` needs no
ledger calls of its own. (An earlier read of this said capture was missing —
that was wrong, and it's worth stating plainly because it changes what the fix
is.)

The break was **downstream**. The shared classifier had no rule for
`ALTER TABLE ... CLUSTER BY`, so every clustering statement landed as
`unverifiable` — which *blocks* the upgrade. Verified at develop:

```
unverifiable | no corroboration rule for this statement | ALTER TABLE LINEITEM CLUSTER BY (...)
unverifiable | no corroboration rule for this statement | ALTER TABLE LINEITEM RESUME RECLUSTER
corroborated: False
```

So a tuned Snowflake run could **never** reach `applied_verified`, and its
receipt said "no corroboration rule" rather than naming the key it had just
applied. Snowflake also had no introspector, so there was nothing to check
against even once classification worked.

## Change

- `KIND_CLUSTER_KEY` plus rules for `ALTER TABLE ... CLUSTER BY (cols)` and
  `CLUSTER BY` on `CREATE TABLE`.
- `SnowflakeTuningIntrospector` reading `INFORMATION_SCHEMA.TABLES.CLUSTERING_KEY`,
  bounded to the ledger's tables and non-fatal, matching the ClickHouse/DuckDB
  introspectors. Wired via `get_tuning_introspector`.
- `RECLUSTER` is **maintenance**, not a key — it reorganizes existing data while
  `CLUSTERING_KEY` reports the key itself. Covers both the bare
  `ALTER TABLE T RECLUSTER` this adapter emits (`snowflake.py:1597`) and the
  `RESUME`/`SUSPEND` forms. Without this the bare form would have blocked.
- Clustering-key **order is significant** to Snowflake's pruning, so
  corroboration compares ordered tuples: `(a, b)` does not satisfy `(b, a)`.

Fail-closed discipline preserved: a `CLUSTER BY` we can see but cannot parse,
and any other `ALTER TABLE`, still return `unverifiable` and still block.

## Verification

- 17 Snowflake introspection tests + 7 classifier tests
- **8 of them fail** with the new `ALTER TABLE` branch removed
- Full fast lane **26121 passed** (ceiling 26550, no bump); ruff, ruff format
  and ty clean

## Live verification is outstanding, and the risk is asymmetric

Snowflake reports `CLUSTERING_KEY` as `LINEAR(A, B)`, while this repo's own
adapter (`snowflake.py:1713`) compares against a bare `(A, B)`.
`parse_clustering_key` accepts both plus a bare list, but **no live Snowflake
was available to settle which is real** — and AGENTS.md requires explicit
approval for live cloud tests.

Guessing wrong here **fails closed**: clustered runs would simply never verify,
with nothing erroring. That is exactly the invisible class this effort has been
chasing, so it is tracked as
`snowflake-clustering-key-live-verification-20260730` rather than assumed
correct.

Tracker: `snowflake-cluster-key-corroboration-20260730`
Next: Snowpark post-load `ALTER TABLE ... CLUSTER BY` reusing this path.

🤖 Generated with [Claude Code](https://claude.ai/code)
