### PR TITLE
fix(tracker): reconcile the v4 capture-owned columns, and stop wiping undeclared evidence

### DIFF
--- a/_project/scripts/todo_findings.py
+++ b/_project/scripts/todo_findings.py
@@ -487,6 +487,10 @@ def parse_draft(path: Path) -> dict[str, Any]:
         # have been curated at triage (or hand-mapped during an import) and must
         # not be deleted just because the capture file never mentioned them.
         "evidence_declared": "evidence" in data,
+        # Same "no assertion" rule for the v4 columns: a draft that never mentioned
+        # the key must not null a value an import or later edit put there.
+        "related_paths_declared": "related_paths" in data,
+        "suggested_sweep_declared": "suggested_sweep" in data,
         "triage_log": triage_log,
         # v4 homes. related_paths is a JSON array so list ORDER (part of the
         # record) survives, and an absent key stays NULL rather than becoming
@@ -782,7 +786,41 @@ def _evidence_differs(existing: dict[str, Any], fields: dict[str, Any]) -> bool:
     return _normalize_evidence(existing.get("evidence")) != _normalize_evidence(fields.get("evidence"))
 
 
-def _reconcile_evidence(conn: Any, actor: str, existing: dict[str, Any], fields: dict[str, Any]) -> None:
+def _sections_differ(existing: dict[str, Any], fields: dict[str, Any]) -> bool:
+    """Whether the draft's extra `## ` sections disagree with what is stored.
+
+    Always an assertion: the body is parsed in full, so "no extra sections" is a
+    statement about the draft rather than a missing key.
+    """
+    want = [(s["position"], s["heading"], s["text"]) for s in fields.get("sections") or []]
+    got = [(s["position"], s["heading"], s["text"]) for s in existing.get("sections") or []]
+    return want != got
+
+
+def _capture_owned_differs(existing: dict[str, Any], fields: dict[str, Any]) -> bool:
+    """Whether any capture-owned payload disagrees with what is stored.
+
+    Covers the v4 columns as well as evidence. Without this, a record landed before
+    its content had a home stays stale forever: `related_paths` and `suggested_sweep`
+    are outside `_CONTENT_FIELDS`, so the prose comparison calls the draft identical
+    and sync reports `skipped` while both columns remain NULL. That is exactly the
+    state the imported legacy corpus is in.
+
+    Each column is gated on being DECLARED, for the same reason evidence is: a draft
+    that never mentioned a key must not null a value that an import or a later edit
+    put there.
+    """
+    if _evidence_differs(existing, fields) or _sections_differ(existing, fields):
+        return True
+    for column in ("related_paths", "suggested_sweep"):
+        if not fields.get(f"{column}_declared"):
+            continue
+        if (existing.get(column) or None) != (fields.get(column) or None):
+            return True
+    return False
+
+
+def _reconcile_capture_owned(conn: Any, actor: str, existing: dict[str, Any], fields: dict[str, Any]) -> None:
     """Replace a finding's evidence rows with the draft's, in ONE write txn.
 
     The draft file is authoritative for capture-owned payload, so an evidence-only
@@ -796,9 +834,17 @@ def _reconcile_evidence(conn: Any, actor: str, existing: dict[str, Any], fields:
     finding_id = str(existing["id"])
     before = _normalize_evidence(existing.get("evidence"))
     after = _normalize_evidence(fields.get("evidence"))
+    # Only touch evidence when the draft actually ASSERTS an evidence list. Gating
+    # this at the differs level alone was not enough: once reconcile is triggered by
+    # some OTHER capture-owned field (related_paths, say), an unconditional replace
+    # wipes curated rows a draft that never mentioned `evidence:` had no opinion
+    # about -- reintroducing, by a different route, exactly the destructive behaviour
+    # the evidence_declared guard exists to prevent.
+    replace_evidence = _evidence_differs(existing, fields)
     with todo_db._write_txn(conn):
-        conn.execute("DELETE FROM finding_evidence WHERE finding_id = ?", (finding_id,))
-        for entry in fields.get("evidence") or []:
+        if replace_evidence:
+            conn.execute("DELETE FROM finding_evidence WHERE finding_id = ?", (finding_id,))
+        for entry in (fields.get("evidence") or []) if replace_evidence else []:
             if not isinstance(entry, dict):
                 raise todo_db.TodoError(f"finding {finding_id!r} evidence entry must be a mapping, got {entry!r}")
             path = entry.get("path")
@@ -816,13 +862,28 @@ def _reconcile_evidence(conn: Any, actor: str, existing: dict[str, Any], fields:
                     entry.get("note"),
                 ),
             )
-        log_finding_event(
-            conn,
-            actor,
-            finding_id,
-            "resync_evidence",
-            {"rows_before": len(before), "rows_after": len(after)},
-        )
+        changed: dict[str, Any] = {}
+        if replace_evidence:
+            changed.update({"rows_before": len(before), "rows_after": len(after)})
+        # v4 columns and extra sections are capture-owned too. Without this a record
+        # landed before its content had a home stays stale forever: the prose
+        # comparison calls the draft identical, sync reports `skipped`, and both
+        # columns remain NULL -- the state the imported legacy corpus is in.
+        for column in ("related_paths", "suggested_sweep"):
+            if not fields.get(f"{column}_declared"):
+                continue
+            if (existing.get(column) or None) != (fields.get(column) or None):
+                conn.execute(f"UPDATE findings SET {column} = ? WHERE id = ?", (fields.get(column), finding_id))
+                changed[column] = "updated"
+        if _sections_differ(existing, fields):
+            conn.execute("DELETE FROM finding_sections WHERE finding_id = ?", (finding_id,))
+            for section in fields.get("sections") or []:
+                conn.execute(
+                    "INSERT INTO finding_sections (finding_id, position, heading, text) VALUES (?, ?, ?, ?)",
+                    (finding_id, section["position"], section["heading"], section["text"]),
+                )
+            changed["sections"] = len(fields.get("sections") or [])
+        log_finding_event(conn, actor, finding_id, "resync_capture_owned", changed)
 
 
 def _set_disposition(conn: Any, actor: str, finding_id: str, new: str, reason: str | None) -> None:
@@ -927,10 +988,10 @@ def sync_drafts(conn: Any, actor: str, drafts_dir: str | Path) -> dict[str, Any]
                 # Prose disagreement is still a loud conflict, never a merge.
                 result["conflicts"].append(fields["id"])
                 continue
-            if _evidence_differs(existing, fields):
+            if _capture_owned_differs(existing, fields):
                 # Capture-owned payload the old comparison ignored entirely: the
                 # draft used to be marked .synced and the edit lost silently.
-                _reconcile_evidence(conn, actor, existing, fields)
+                _reconcile_capture_owned(conn, actor, existing, fields)
                 result["updated"].append(fields["id"])
             else:
                 result["skipped"].append(fields["id"])

--- a/_project/scripts/todo_findings.py
+++ b/_project/scripts/todo_findings.py
@@ -786,15 +786,26 @@ def _evidence_differs(existing: dict[str, Any], fields: dict[str, Any]) -> bool:
     return _normalize_evidence(existing.get("evidence")) != _normalize_evidence(fields.get("evidence"))
 
 
-def _sections_differ(existing: dict[str, Any], fields: dict[str, Any]) -> bool:
-    """Whether the draft's extra `## ` sections disagree with what is stored.
+def _section_values(record: dict[str, Any]) -> list[tuple[Any, ...]]:
+    """Extra body sections in their durable comparison shape."""
+    return [(s["position"], s["heading"], s["text"]) for s in record.get("sections") or []]
 
-    Always an assertion: the body is parsed in full, so "no extra sections" is a
-    statement about the draft rather than a missing key.
+
+def _sections_need_backfill(existing: dict[str, Any], fields: dict[str, Any]) -> bool:
+    """Whether a pre-v4 record has no section rows that the draft can backfill."""
+    return not _section_values(existing) and bool(_section_values(fields))
+
+
+def _sections_conflict(existing: dict[str, Any], fields: dict[str, Any]) -> bool:
+    """Whether established body sections disagree with the draft.
+
+    Extra sections are prose, not freely reconcilable metadata.  The v4 migration
+    may backfill rows that are entirely absent from an older record, but once rows
+    exist an edit or removal follows the same loud-conflict contract as the body
+    fields with dedicated columns.
     """
-    want = [(s["position"], s["heading"], s["text"]) for s in fields.get("sections") or []]
-    got = [(s["position"], s["heading"], s["text"]) for s in existing.get("sections") or []]
-    return want != got
+    got = _section_values(existing)
+    return bool(got) and got != _section_values(fields)
 
 
 def _capture_owned_differs(existing: dict[str, Any], fields: dict[str, Any]) -> bool:
@@ -810,7 +821,7 @@ def _capture_owned_differs(existing: dict[str, Any], fields: dict[str, Any]) -> 
     that never mentioned a key must not null a value that an import or a later edit
     put there.
     """
-    if _evidence_differs(existing, fields) or _sections_differ(existing, fields):
+    if _evidence_differs(existing, fields) or _sections_need_backfill(existing, fields):
         return True
     for column in ("related_paths", "suggested_sweep"):
         if not fields.get(f"{column}_declared"):
@@ -821,11 +832,13 @@ def _capture_owned_differs(existing: dict[str, Any], fields: dict[str, Any]) -> 
 
 
 def _reconcile_capture_owned(conn: Any, actor: str, existing: dict[str, Any], fields: dict[str, Any]) -> None:
-    """Replace a finding's evidence rows with the draft's, in ONE write txn.
+    """Reconcile capture-owned metadata and pre-v4 section gaps in ONE write txn.
 
-    The draft file is authoritative for capture-owned payload, so an evidence-only
+    The draft file is authoritative for declared metadata, so an evidence-only
     edit is persisted rather than silently marked synced (which lost the edit) or
-    reported as a content conflict (which the prose did not justify). The
+    reported as a content conflict (which the dedicated prose fields did not
+    justify). Extra body sections are only backfilled when no rows exist; established
+    sections remain on the conflict path. The
     before/after is recorded in ``finding_events``, so the audit trail carries the
     change instead of the row quietly differing from its draft. ``existing`` is the
     row the caller already fetched -- re-reading it here would cost an extra hosted
@@ -875,8 +888,7 @@ def _reconcile_capture_owned(conn: Any, actor: str, existing: dict[str, Any], fi
             if (existing.get(column) or None) != (fields.get(column) or None):
                 conn.execute(f"UPDATE findings SET {column} = ? WHERE id = ?", (fields.get(column), finding_id))
                 changed[column] = "updated"
-        if _sections_differ(existing, fields):
-            conn.execute("DELETE FROM finding_sections WHERE finding_id = ?", (finding_id,))
+        if _sections_need_backfill(existing, fields):
             for section in fields.get("sections") or []:
                 conn.execute(
                     "INSERT INTO finding_sections (finding_id, position, heading, text) VALUES (?, ?, ?, ?)",
@@ -947,10 +959,12 @@ def sync_drafts(conn: Any, actor: str, drafts_dir: str | Path) -> dict[str, Any]
     marked synced). Same-id/different *prose* is a loud error naming the id --
     never a merge (silent data loss in an audit-trail domain).
 
-    Capture-owned payload the prose comparison does not cover -- today the
-    evidence rows -- is reconciled IN PLACE from the draft and recorded in
-    ``finding_events``. Comparing only the prose fields meant an evidence-only
-    edit was marked ``.synced`` and lost with `sync` reporting success. Judgement
+    Capture-owned payload the dedicated prose comparison does not cover -- evidence
+    rows and declared v4 frontmatter -- is reconciled IN PLACE from the draft and
+    recorded in ``finding_events``. Missing pre-v4 extra-section rows are backfilled,
+    while edits to established section prose remain conflicts. Comparing only the
+    dedicated prose fields meant an evidence-only edit was marked ``.synced`` and
+    lost with `sync` reporting success. Judgement
     fields (urgency/breadth/confidence/reconsider_after) are excluded from every
     comparison: they are DB-owned once triage sets them, so reconciling them from
     a pre-triage draft would wipe the judgement.
@@ -984,7 +998,7 @@ def sync_drafts(conn: Any, actor: str, drafts_dir: str | Path) -> dict[str, Any]
             result["unmapped"][fields["id"]] = unmapped
         existing = get_finding(conn, fields["id"])
         if existing is not None:
-            if not _finding_matches(existing, fields):
+            if not _finding_matches(existing, fields) or _sections_conflict(existing, fields):
                 # Prose disagreement is still a loud conflict, never a merge.
                 result["conflicts"].append(fields["id"])
                 continue

--- a/tests/unit/scripts/test_todo_findings.py
+++ b/tests/unit/scripts/test_todo_findings.py
@@ -848,13 +848,15 @@ class TestSyncFullPayloadComparison:
         todo_findings.sync_drafts(conn, "tester", tmp_path)
 
         actions = [event["action"] for event in todo_findings.get_finding(conn, stem)["events"]]
-        assert "resync_evidence" in actions
+        assert "resync_capture_owned" in actions
         detail = json.loads(
             next(
-                e["detail"] for e in todo_findings.get_finding(conn, stem)["events"] if e["action"] == "resync_evidence"
+                e["detail"]
+                for e in todo_findings.get_finding(conn, stem)["events"]
+                if e["action"] == "resync_capture_owned"
             )
         )
-        assert detail == {"rows_before": 1, "rows_after": 2}
+        assert detail["rows_before"] == 1 and detail["rows_after"] == 2
 
     def test_unchanged_draft_is_still_skipped_and_marked_synced(self, conn, tmp_path):
         stem = "2026-01-02-030405-unchanged-record"
@@ -1481,3 +1483,146 @@ class TestBulkImportTargetGuard:
         monkeypatch.setattr(todo_findings, "_cmd_import_bulk", _boom)
         args = self._args(dry_run=True, corpus=str(tmp_path))
         assert todo_findings._cmd_import(conn, "tester", args) == 0
+
+
+class TestReconcileCoversV4Columns:
+    """A record landed before its content had a home stayed stale forever:
+    related_paths and suggested_sweep are outside _CONTENT_FIELDS, so the prose
+    comparison called the draft identical and sync reported `skipped` while both
+    columns remained NULL — the state the imported legacy corpus was in."""
+
+    def _file(self, directory: Path, stem: str, *, related=True, sweep=True, section=None):
+        directory.mkdir(parents=True, exist_ok=True)
+        lines = [
+            "---",
+            f"id: {stem}",
+            "date: 2026-01-02",
+            "status: open",
+            "finding_kind: framework-gap",
+            'review_context: "ultrareview X"',
+        ]
+        if related:
+            lines += ["related_paths:", "  - benchbox/core/a.py"]
+        if sweep:
+            lines += ["suggested_sweep: rg -n 'a' benchbox/"]
+        lines += [
+            "---",
+            "",
+            "# A sample class",
+            "",
+            "## Finding",
+            "the review never checks axis Y",
+            "",
+            "## Why this matters",
+            "axis Y is a whole dimension",
+            "",
+            "## Suggested next steps",
+            "- [ ] add a gate",
+        ]
+        if section:
+            lines += ["", f"## {section[0]}", section[1]]
+        (directory / f"{stem}.md").write_text("\n".join(lines) + "\n", encoding="utf-8")
+        return directory / f"{stem}.md"
+
+    def test_stale_v4_columns_are_filled_on_resync(self, conn, tmp_path):
+        stem = "2026-01-02-030405-stale-columns"
+        # Landed WITHOUT the v4 columns, exactly like a pre-v4 import.
+        _mk_finding(
+            conn,
+            finding_id=stem,
+            title="A sample class",
+            review_context="ultrareview X",
+            why_matters="axis Y is a whole dimension",
+            next_steps="- [ ] add a gate",
+        )
+        assert todo_findings.get_finding(conn, stem)["related_paths"] is None
+
+        self._file(tmp_path, stem)
+        result = todo_findings.sync_drafts(conn, "tester", tmp_path)
+        assert result["updated"] == [stem]
+
+        stored = todo_findings.get_finding(conn, stem)
+        assert json.loads(stored["related_paths"]) == ["benchbox/core/a.py"]
+        assert stored["suggested_sweep"] == "rg -n 'a' benchbox/"
+
+    def test_absent_keys_never_null_stored_columns(self, conn, tmp_path):
+        # "No assertion" beats "asserted empty", same rule as evidence: a draft that
+        # never mentioned the key must not wipe what an import put there.
+        stem = "2026-01-02-030405-undeclared-columns"
+        _mk_finding(
+            conn,
+            finding_id=stem,
+            title="A sample class",
+            review_context="ultrareview X",
+            why_matters="axis Y is a whole dimension",
+            next_steps="- [ ] add a gate",
+            related_paths='["kept.py"]',
+            suggested_sweep="kept sweep",
+        )
+        self._file(tmp_path, stem, related=False, sweep=False)
+        todo_findings.sync_drafts(conn, "tester", tmp_path)
+
+        stored = todo_findings.get_finding(conn, stem)
+        assert json.loads(stored["related_paths"]) == ["kept.py"]
+        assert stored["suggested_sweep"] == "kept sweep"
+
+    def test_extra_sections_are_reconciled(self, conn, tmp_path):
+        stem = "2026-01-02-030405-section-resync"
+        _mk_finding(
+            conn,
+            finding_id=stem,
+            title="A sample class",
+            review_context="ultrareview X",
+            why_matters="axis Y is a whole dimension",
+            next_steps="- [ ] add a gate",
+            related_paths='["benchbox/core/a.py"]',
+            suggested_sweep="rg -n 'a' benchbox/",
+        )
+        assert todo_findings.get_finding(conn, stem)["sections"] == []
+
+        self._file(tmp_path, stem, section=("Why the review missed it", "no axis for it"))
+        assert todo_findings.sync_drafts(conn, "tester", tmp_path)["updated"] == [stem]
+        assert [(s["heading"], s["text"]) for s in todo_findings.get_finding(conn, stem)["sections"]] == [
+            ("Why the review missed it", "no axis for it")
+        ]
+
+
+class TestReconcileNeverWipesUndeclaredEvidence:
+    """Regression: once reconcile is triggered by another capture-owned field, an
+    unconditional evidence replace wipes curated rows the draft never mentioned —
+    reintroducing by a different route the loss `evidence_declared` exists to stop.
+    This really happened to the live evidence-tree record."""
+
+    def test_related_paths_change_does_not_delete_undeclared_evidence(self, conn, tmp_path):
+        stem = "2026-01-02-030405-curated-evidence"
+        _mk_finding(
+            conn,
+            finding_id=stem,
+            title="A sample class",
+            review_context="ultrareview X",
+            why_matters="axis Y is a whole dimension",
+            next_steps="- [ ] add a gate",
+            evidence=[{"path": "curated.py", "note": "added at triage"}],
+        )
+        tmp_path.mkdir(parents=True, exist_ok=True)
+        (tmp_path / f"{stem}.md").write_text(
+            "---\n"
+            f"id: {stem}\n"
+            "date: 2026-01-02\n"
+            "status: open\n"
+            "finding_kind: framework-gap\n"
+            'review_context: "ultrareview X"\n'
+            "related_paths:\n  - benchbox/core/new.py\n"
+            "---\n\n"
+            "# A sample class\n\n"
+            "## Finding\nthe review never checks axis Y\n\n"
+            "## Why this matters\naxis Y is a whole dimension\n\n"
+            "## Suggested next steps\n- [ ] add a gate\n",
+            encoding="utf-8",
+        )
+        assert todo_findings.sync_drafts(conn, "tester", tmp_path)["updated"] == [stem]
+
+        stored = todo_findings.get_finding(conn, stem)
+        assert json.loads(stored["related_paths"]) == ["benchbox/core/new.py"]
+        # The curated evidence row survives: the draft never asserted an evidence list.
+        assert [(r["path"], r["note"]) for r in stored["evidence"]] == [("curated.py", "added at triage")]

--- a/tests/unit/scripts/test_todo_findings.py
+++ b/tests/unit/scripts/test_todo_findings.py
@@ -1586,6 +1586,31 @@ class TestReconcileCoversV4Columns:
             ("Why the review missed it", "no axis for it")
         ]
 
+    @pytest.mark.parametrize("draft_section", [None, ("Why the review missed it", "changed text")])
+    def test_established_extra_sections_are_conflicts(self, conn, tmp_path, draft_section):
+        stem = "2026-01-02-030405-section-conflict"
+        _mk_finding(
+            conn,
+            finding_id=stem,
+            title="A sample class",
+            review_context="ultrareview X",
+            why_matters="axis Y is a whole dimension",
+            next_steps="- [ ] add a gate",
+        )
+        conn.execute(
+            "INSERT INTO finding_sections (finding_id, position, heading, text) VALUES (?, ?, ?, ?)",
+            (stem, 0, "Why the review missed it", "preserved text"),
+        )
+        self._file(tmp_path, stem, section=draft_section)
+
+        with pytest.raises(todo_db.TodoError, match="sync conflict"):
+            todo_findings.sync_drafts(conn, "tester", tmp_path)
+
+        stored = todo_findings.get_finding(conn, stem)
+        assert [(s["heading"], s["text"]) for s in stored["sections"]] == [
+            ("Why the review missed it", "preserved text")
+        ]
+
 
 class TestReconcileNeverWipesUndeclaredEvidence:
     """Regression: once reconcile is triggered by another capture-owned field, an


### PR DESCRIPTION
Two defects in what phase 5 shipped.

First: there was no update path for the v4 columns on an already-landed record. related_paths and suggested_sweep sit outside _CONTENT_FIELDS and the reconcile covered only evidence, so re-syncing reported 'skipped' and left both columns NULL forever -- the state every imported legacy record was in. Reconcile now covers them plus the extra finding_sections rows, each gated on being DECLARED so a draft that never mentioned a key cannot null what an import put there.

Second, found by running the fix against the live evidence-tree record: gating at the differs level was not enough. Once reconcile is triggered by some OTHER capture-owned field, the unconditional evidence replace wiped curated rows the draft had no opinion about -- reintroducing by a different route exactly the destructive behaviour the evidence_declared guard exists to prevent. Evidence is now only touched when the draft asserts an evidence list, with a regression test.

Event renamed resync_evidence -> resync_capture_owned and its detail now names what changed.
