### PR TITLE
fix(agents): let a disposable clone declare itself to the write preflight

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -65,6 +65,12 @@ there require explicit user authorization and
 destructive Git/filesystem commands without explicit approval. Use `rg`, and
 stage only authorized paths; never `git add -A`.
 
+A disposable clone — a remote agent session, a CI runner — has no canonical
+clone to protect and no worktree pool to claim from, so it declares itself with
+`BENCHBOX_EPHEMERAL_CLONE=1` instead of reaching for the emergency override.
+The declaration is ignored wherever a pool is present, so it cannot weaken the
+guard on a machine that uses one.
+
 ## Tooling and implementation
 
 - Prefer repository `make` targets and existing helpers.

--- a/scripts/agent_write_preflight.sh
+++ b/scripts/agent_write_preflight.sh
@@ -18,7 +18,25 @@ primary_abs=$(realpath "$primary_clone")
 
 allow_main=${BENCHBOX_ALLOW_MAIN_CLONE_WRITE:-${ALLOW_MAIN_CLONE_WRITE:-}}
 
-if [ "$top_abs" = "$primary_abs" ] && [ "$allow_main" != "1" ]; then
+# A disposable clone -- a remote agent session, a CI runner -- is structurally
+# identical to the maintainer's primary clone: both are plain clones, neither is
+# a linked worktree. Nothing in the filesystem distinguishes them, so the
+# session has to say so. What keeps that declaration from becoming another
+# blanket override is that it is honored ONLY where the worktree pool this
+# guard exists to protect is absent. On a machine running the pool,
+# BENCHBOX_EPHEMERAL_CLONE cannot switch the guard off, so a session that
+# declares it wrongly there still refuses.
+pool_worktrees=$(git worktree list 2>/dev/null | wc -l | tr -d ' ')
+pool_siblings=$(find "$(dirname "$top_abs")" -maxdepth 1 -name '*.pool-*' 2>/dev/null | wc -l | tr -d ' ')
+
+ephemeral=no
+if [ "${BENCHBOX_EPHEMERAL_CLONE:-}" = "1" ] &&
+  [ "$pool_worktrees" -eq 1 ] &&
+  [ "$pool_siblings" -eq 0 ]; then
+  ephemeral=yes
+fi
+
+if [ "$top_abs" = "$primary_abs" ] && [ "$allow_main" != "1" ] && [ "$ephemeral" != "yes" ]; then
   cat >&2 <<EOF
 Refusing BenchBox write preflight in the primary clone:
   $top_abs
@@ -27,6 +45,12 @@ Claim a pool worktree before write work:
   make worktree-claim BRANCH=fix/descriptive-slug
   cd <WORKTREE_PATH>
 
+If this is instead a disposable, ephemeral clone with no canonical clone to
+protect -- a remote agent session or a CI runner -- declare that:
+  BENCHBOX_EPHEMERAL_CLONE=1 make agent-write-preflight
+It is ignored wherever a worktree pool is present, so it cannot disable this
+guard on a machine that uses one.
+
 Read-only review/research may stay in the primary clone. Emergency main-clone
 hotfix work requires explicit user authorization and:
   BENCHBOX_ALLOW_MAIN_CLONE_WRITE=1 make agent-write-preflight
@@ -34,4 +58,8 @@ EOF
   exit 1
 fi
 
-printf 'BenchBox write preflight OK: %s\n' "$top_abs"
+if [ "$ephemeral" = "yes" ]; then
+  printf 'BenchBox write preflight OK (ephemeral clone, no worktree pool present): %s\n' "$top_abs"
+else
+  printf 'BenchBox write preflight OK: %s\n' "$top_abs"
+fi

--- a/tests/unit/test_agent_write_preflight.py
+++ b/tests/unit/test_agent_write_preflight.py
@@ -73,3 +73,69 @@ def test_skill_sync_write_target_runs_preflight() -> None:
     target = makefile.split("\nskill-sync:", maxsplit=1)[1].split("\nskill-sync-check:", maxsplit=1)[0]
 
     assert "$(MAKE) -s agent-write-preflight" in target
+
+
+def _init_clone(path: Path) -> Path:
+    """A fresh plain clone: one worktree, no pool — i.e. what a remote agent
+    session or CI runner actually looks like on disk."""
+    path.mkdir(parents=True)
+    subprocess.run(["git", "init", "-q"], cwd=path, check=True)
+    return path
+
+
+def _run_in_clone(repo: Path, *, ephemeral: bool = False) -> subprocess.CompletedProcess[str]:
+    env = {**os.environ}
+    # Let the script derive the primary clone naturally from this repo.
+    env.pop("BENCHBOX_AGENT_PRIMARY_CLONE", None)
+    env.pop("BENCHBOX_ALLOW_MAIN_CLONE_WRITE", None)
+    env.pop("ALLOW_MAIN_CLONE_WRITE", None)
+    if ephemeral:
+        env["BENCHBOX_EPHEMERAL_CLONE"] = "1"
+    else:
+        env.pop("BENCHBOX_EPHEMERAL_CLONE", None)
+
+    return subprocess.run(
+        ["sh", str(SCRIPT.resolve())],
+        cwd=repo,
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+def test_preflight_still_refuses_an_undeclared_plain_clone(tmp_path: Path) -> None:
+    """The declaration is opt-in: absent it, behavior is exactly as before."""
+    result = _run_in_clone(_init_clone(tmp_path / "BenchBox"))
+
+    assert result.returncode == 1
+    assert "Refusing BenchBox write preflight in the primary clone" in result.stderr
+
+
+def test_preflight_allows_a_declared_ephemeral_clone(tmp_path: Path) -> None:
+    result = _run_in_clone(_init_clone(tmp_path / "BenchBox"), ephemeral=True)
+
+    assert result.returncode == 0
+    assert "ephemeral clone" in result.stdout
+
+
+def test_ephemeral_declaration_is_ignored_when_a_worktree_pool_is_present(tmp_path: Path) -> None:
+    """The load-bearing safety property: on a machine running the pool this
+    guard protects, declaring the clone ephemeral must NOT switch it off."""
+    repo = _init_clone(tmp_path / "BenchBox")
+    (tmp_path / "BenchBox.pool-01").mkdir()
+
+    result = _run_in_clone(repo, ephemeral=True)
+
+    assert result.returncode == 1
+    assert "Refusing BenchBox write preflight in the primary clone" in result.stderr
+
+
+def test_refusal_names_the_ephemeral_escape_not_only_the_broad_override(tmp_path: Path) -> None:
+    """The refusal used to offer BENCHBOX_ALLOW_MAIN_CLONE_WRITE as the only way
+    out, which trained agents to reach for the blanket override routinely."""
+    result = _run_in_clone(_init_clone(tmp_path / "BenchBox"))
+
+    assert "BENCHBOX_EPHEMERAL_CLONE=1" in result.stderr
+    assert "ephemeral" in result.stderr
+    assert "make worktree-claim" in result.stderr


### PR DESCRIPTION
# Pull Request

## Description

`scripts/agent_write_preflight.sh` refuses whenever the working tree is not a
linked worktree — it derives the primary clone from
`dirname(git rev-parse --git-common-dir)` and rejects when that equals the
toplevel. In a remote agent session or a CI runner the repo is a plain fresh
clone, so the guard fires even though there is no canonical clone to protect,
and the remedy it names (`make worktree-claim`) targets a sibling worktree pool
that does not exist there.

That left `BENCHBOX_ALLOW_MAIN_CLONE_WRITE=1` as the only documented way out.
It is scoped to emergency main-clone hotfixes requiring explicit user
authorization, so reaching for it routinely in containers erodes the guard in
the one place it does matter. That habit, not the friction, is the actual harm.

**The fix.** `BENCHBOX_EPHEMERAL_CLONE=1`. Nothing on disk distinguishes a
disposable clone from a real primary clone — both are plain clones, neither is
a linked worktree — so the session declares it rather than the script guessing.
What keeps that from becoming a second blanket override is that it is honored
**only where the pool this guard protects is absent**: no `*.pool-*` sibling and
a single `git worktree` entry. On a machine running the pool, declaring it
wrongly still refuses. Neither half disables the guard alone.

**Auto-detection was considered and rejected.** The tempting signal — "no pool
siblings present" — would silently disable the guard on the maintainer's machine
after a `worktree-pool-reset`, which is precisely the case it exists to catch.
Buying container convenience with that would be a bad trade. No standard CI
variable covers these sessions either: `CI` and `GITHUB_ACTIONS` are both unset
in the environment that hit this.

The refusal message now leads with the pool path, offers the declaration second,
and demotes the emergency override to last.

## Type of Change

- [x] Bug fix

## Testing

Four tests added to `tests/unit/test_agent_write_preflight.py` (9 total, all
pass), each running the script against a hermetic throwaway `git init` clone in
`tmp_path` rather than the repo itself.

**Non-vacuity checked in both directions**, because a one-directional check
would not have proven the safety property:

| Mutation | Fails |
|---|---|
| pre-change script (`git show HEAD:...`) | `test_preflight_allows_a_declared_ephemeral_clone`, `test_refusal_names_the_ephemeral_escape_not_only_the_broad_override` |
| honor the declaration unconditionally (drop the pool gating) | `test_ephemeral_declaration_is_ignored_when_a_worktree_pool_is_present` |

The second is the one that matters: that test passes against the *old* code
trivially, so only the mutation proves it is actually guarding something.

```
uv run -- python -m pytest tests/unit/test_agent_write_preflight.py -q   9 passed
uv run -- python -m pytest tests/unit/scripts/ -q                        1210 passed
uv run -- ruff check / ruff format --check (changed test file)           clean
sh -n scripts/agent_write_preflight.sh                                   syntax OK
agent-instructions audit (AGENTS.md budget)                              PASS
```

Dogfooded: `BENCHBOX_EPHEMERAL_CLONE=1 make agent-write-preflight` now succeeds
in the container that could not run it before, and `make agent-write-preflight`
without the declaration still exits non-zero there.

`make pr-preflight` reports **7 failed, 26067 passed**. All 7 fail identically on
clean `origin/develop` at `a1e1328` — verified by checking out that commit and
re-running exactly those node IDs:

- `test_cli_output.py::...::test_export_with_invalid_output_dir` and
  `test_cli_dryrun.py::...::test_dry_run_with_missing_output_dir` —
  `DID NOT RAISE FileNotFoundError`, the known root-user artifact of this
  container; documented as pre-existing back in #1352.
- `test_changelog_tag_guard.py::test_repo_changelog_has_no_untagged_released_section_on_this_branch`
  and
  `test_file_format.py::TestHasTrailingDelimiterSurfacesReadFailures::test_unreadable_file_raises_rather_than_reporting_clean`
  — both new since `e29ef9e`, i.e. they arrived with upstream `develop`, not
  with this branch. The latter looks related to in-flight work on
  `trailing-delimiter-probe-swallows-read-errors`.
- two `test_dataframe_csv_empty_string_null_semantics.py` `[pyspark]` cases and
  `test_open_table_formats.py::...::test_delta_duckdb_query_via_delta_scan` —
  environment-dependent integration tests.

None of the seven touches `scripts/` or `AGENTS.md`.

## Public Contract Check

- [x] I updated `docs/reference/public-contracts.md`, or this PR does not change
      public, beta-public, deprecated, generated, experimental, or repo-only
      contract surfaces.
- [x] I checked result schema fields, MCP tool parameters, platform support
      status, wrapper facades, adapter subclassing hooks, and generated docs for
      contract-map impact.
- [x] Any platform/benchmark count claim in docs is generated/checked from
      registry metadata, or explicitly marked editorial/non-authoritative.

The guard's observable contract changes only additively: a new opt-in variable,
and a longer refusal message. Exit statuses for every previously-reachable case
are unchanged.

## Documentation

- [x] I updated the relevant user-facing docs.
- [x] I added regression notes for behavior changes.
- [x] I confirmed API contract wording remains accurate.

`AGENTS.md`'s worktree-safety section gains a short paragraph; the
agent-instructions size audit still passes. The reasoning for the pool gating
lives in a comment at the decision site in the script.

## Code Quality

- [x] I ran formatting and lint/type checks.
- [x] I reviewed impacted modules for backwards compatibility and migration impact.
- [x] I added/updated tests for behavior changes and error paths.
- [x] I confirmed public contracts and release checklists are still valid.

## Artifact Hygiene

- [x] I did not commit raw screenshots, browser reports, generated logs,
      benchmark outputs, or temporary binary artifacts.
- [x] Any committed binary/raw evidence file has durable repo value and is
      justified here with its consumer and size:

None. Three files changed, all source or docs.

## Notes

**Reviewer focus.** The pool gating is the load-bearing part. If you would rather
`BENCHBOX_EPHEMERAL_CLONE` be honored unconditionally — simpler, and arguably the
declaring session should be trusted — that is a two-line change, but it removes
the property that a wrong declaration on your machine is inert. I chose the
conservative side deliberately.

Worth knowing: `BENCHBOX_AGENT_PRIMARY_CLONE` already existed and could repoint
the comparison without granting main-clone write, so a targeted escape was
technically available before this. It is undocumented for this purpose and
semantically odd ("pretend the primary is elsewhere"), which is why this adds a
purpose-named variable rather than blessing that one — but it means the previous
situation was less of a dead end than the refusal message implied.

**Provenance.** Found while opening #1374 from a container, where this guard
blocked `make pr-open`. Tracked as `agent-write-preflight-blocks-ephemeral-clones`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LnJvDZPn6fdTLZjHymU7gM

---
_Generated by [Claude Code](https://claude.ai/code/session_01LnJvDZPn6fdTLZjHymU7gM)_