### PR TITLE
feat(tracker): gate the cutover on a leased write freeze, not a claim check

### DIFF
--- a/_project/scripts/todo_db.py
+++ b/_project/scripts/todo_db.py
@@ -263,6 +263,93 @@ CONFIG_KEYS: dict[str, tuple[str, ...]] = {
 }
 
 
+# Maintenance freeze. A cutover that rebuilds every table from a snapshot
+# destroys any write landing between snapshot and restore -- silently, because
+# the rebuilt audit chain rehashes cleanly from the snapshot. Claims cannot gate
+# that: they cover claim/start/done/complete on existing items, not `create`,
+# `defer`, `promote`, `block` or config writes, all of which are unclaimed.
+#
+# The freeze is leased rather than a plain on/off flag so a holder that dies
+# mid-cutover cannot wedge the tracker for every other session forever.
+FREEZE_HOLDER_KEY = "maintenance.frozen_by"
+FREEZE_AT_KEY = "maintenance.frozen_at"
+FREEZE_REASON_KEY = "maintenance.freeze_reason"
+FREEZE_TTL_KEY = "maintenance.freeze_ttl_hours"
+DEFAULT_FREEZE_TTL_HOURS = 2.0
+
+
+def _meta_get(conn: sqlite3.Connection, key: str) -> str | None:
+    row = conn.execute("SELECT value FROM meta WHERE key = ?", (key,)).fetchone()
+    return row["value"] if row else None
+
+
+def get_freeze(conn: sqlite3.Connection) -> dict[str, Any] | None:
+    """The live freeze, or None when absent or its lease has expired."""
+    holder = _meta_get(conn, FREEZE_HOLDER_KEY)
+    if not holder:
+        return None
+    started = _meta_get(conn, FREEZE_AT_KEY)
+    try:
+        ttl = float(_meta_get(conn, FREEZE_TTL_KEY) or DEFAULT_FREEZE_TTL_HOURS)
+    except ValueError:
+        ttl = DEFAULT_FREEZE_TTL_HOURS
+    expired = _lease_expired(started, ttl)
+    return (
+        None
+        if expired
+        else {
+            "holder": holder,
+            "since": started,
+            "ttl_hours": ttl,
+            "reason": _meta_get(conn, FREEZE_REASON_KEY) or "",
+        }
+    )
+
+
+def set_freeze(
+    conn: sqlite3.Connection,
+    actor: str,
+    reason: str,
+    ttl_hours: float = DEFAULT_FREEZE_TTL_HOURS,
+) -> dict[str, Any]:
+    if ttl_hours <= 0:
+        raise TodoError("freeze --ttl must be positive; an unbounded freeze is exactly the stuck lock this avoids")
+    live = get_freeze(conn)
+    if live and live["holder"] != actor:
+        raise TodoError(
+            f"tracker already frozen by {live['holder']} since {live['since']} "
+            f"({live['reason'] or 'no reason given'}); it lapses after {live['ttl_hours']}h"
+        )
+    stamp = utc_now()
+    with _write_txn(conn):
+        for key, value in (
+            (FREEZE_HOLDER_KEY, actor),
+            (FREEZE_AT_KEY, stamp),
+            (FREEZE_REASON_KEY, reason),
+            (FREEZE_TTL_KEY, str(ttl_hours)),
+        ):
+            conn.execute("INSERT OR REPLACE INTO meta (key, value) VALUES (?, ?)", (key, value))
+        log_event(conn, actor, None, "freeze", {"reason": reason, "ttl_hours": ttl_hours})
+    return {"holder": actor, "since": stamp, "ttl_hours": ttl_hours, "reason": reason}
+
+
+def clear_freeze(conn: sqlite3.Connection, actor: str, *, force: bool = False) -> bool:
+    """Lift the freeze. Returns False when there was no live freeze to lift."""
+    live = get_freeze(conn)
+    if live and live["holder"] != actor and not force:
+        raise TodoError(
+            f"freeze is held by {live['holder']}, not {actor}; "
+            "wait for its lease to lapse or override with `todo freeze --release --force`"
+        )
+    had_rows = _meta_get(conn, FREEZE_HOLDER_KEY) is not None
+    with _write_txn(conn):
+        for key in (FREEZE_HOLDER_KEY, FREEZE_AT_KEY, FREEZE_REASON_KEY, FREEZE_TTL_KEY):
+            conn.execute("DELETE FROM meta WHERE key = ?", (key,))
+        if had_rows:
+            log_event(conn, actor, None, "unfreeze", {"released_holder": live["holder"] if live else None})
+    return live is not None
+
+
 def get_config(conn: sqlite3.Connection, key: str) -> str:
     if key not in CONFIG_KEYS:
         raise TodoError(f"unknown config key {key!r}; known: {', '.join(sorted(CONFIG_KEYS))}")
@@ -943,6 +1030,9 @@ def _command_mutates_tracker(args: argparse.Namespace) -> bool:
     """Whether the parsed command can modify tracker state (fail closed)."""
     if args.command == "init":
         return False
+    if args.command == "freeze":
+        # `--status` is a pure read; setting or lifting a freeze is a write.
+        return not args.status
     if args.command == "import-yaml":
         return not args.dry_run
     if args.command == "verify":
@@ -957,6 +1047,31 @@ def _command_mutates_tracker(args: argparse.Namespace) -> bool:
         # `list`/`show`, so they are absent from READ_ONLY_COMMANDS by design.
         return todo_findings.finding_command_mutates(args)
     return args.command not in _IMPLICIT_LOCAL_READ_COMMANDS
+
+
+def _freeze_refusal(conn: sqlite3.Connection, actor: str, args: argparse.Namespace) -> int | None:
+    """Exit code to return when a maintenance freeze blocks this command, else None.
+
+    `freeze` itself is exempt -- its own handler decides who may set or lift one
+    -- so a freeze can always be lifted by its holder even while it is in force.
+    """
+    if args.command == "freeze" or not _command_mutates_tracker(args):
+        return None
+    try:
+        live = get_freeze(conn)
+    except sqlite3.Error as exc:
+        print(f"error: database failure: {_redacted(exc, _auth_token())}", file=sys.stderr)
+        return 2
+    if not live or live["holder"] == actor:
+        return None
+    print(
+        f"error: tracker is frozen for maintenance by {live['holder']} since {live['since']}"
+        f"{': ' + live['reason'] if live['reason'] else ''}. "
+        f"Reads still work; writes resume when the holder runs `todo freeze --release` "
+        f"or the {live['ttl_hours']}h lease lapses.",
+        file=sys.stderr,
+    )
+    return 2
 
 
 def _report_backend(backend: Path | str, *, implicit_default_local: bool) -> None:
@@ -1857,7 +1972,24 @@ def stats(conn: sqlite3.Connection) -> dict[str, Any]:
         # Additive findings-domain key (phase 4). Present but empty when there are
         # no findings; existing items-domain keys above are untouched.
         "findings_by_disposition": todo_findings.findings_by_disposition(conn),
+        # Write-activity fingerprint. Every mutation logs an event, so this pair
+        # moves whenever *any* actor writes -- claimed or not. Two reads a few
+        # minutes apart that agree are the only sound "nobody is writing" test;
+        # a claim check cannot see `create`/`defer`/`promote`/`block`/config,
+        # none of which take a claim. See write_activity().
+        "events": write_activity(conn),
     }
+
+
+def write_activity(conn: sqlite3.Connection) -> dict[str, Any]:
+    """A fingerprint that changes if any actor has written since the last read.
+
+    `count` alone would miss a delete-plus-insert; `latest` alone would miss two
+    writes landing inside the same whole second. Together they are stable under
+    no writes and move under any write, which is what a cutover needs to gate on.
+    """
+    row = conn.execute("SELECT count(*) AS n, max(seq) AS last_seq, max(at) AS last_at FROM events").fetchone()
+    return {"count": row["n"] or 0, "last_seq": row["last_seq"], "latest": row["last_at"]}
 
 
 # ---------------------------------------------------------------------------
@@ -2784,6 +2916,20 @@ def main(argv: list[str] | None = None) -> int:
     p.add_argument("key", nargs="?")
     p.add_argument("value", nargs="?")
 
+    p = sub.add_parser("freeze", help="hold a leased maintenance freeze for a destructive cutover")
+    g = p.add_mutually_exclusive_group()
+    g.add_argument("--status", action="store_true", help="report the live freeze, if any, and exit")
+    g.add_argument("--release", action="store_true", help="lift a freeze you hold")
+    p.add_argument("--reason", default="", help="why the tracker is frozen; shown to blocked writers")
+    p.add_argument(
+        "--ttl",
+        type=float,
+        default=DEFAULT_FREEZE_TTL_HOURS,
+        metavar="HOURS",
+        help=f"lease length before the freeze lapses on its own (default {DEFAULT_FREEZE_TTL_HOURS})",
+    )
+    p.add_argument("--force", action="store_true", help="with --release, break another actor's freeze")
+
     p = sub.add_parser("export", help="deterministic JSONL + markdown index")
     g = p.add_mutually_exclusive_group()
     g.add_argument("--out", default=None)
@@ -2843,6 +2989,11 @@ def main(argv: list[str] | None = None) -> int:
     except sqlite3.Error as exc:
         print(f"error: database failure: {_redacted(exc, _auth_token())}", file=sys.stderr)
         return 2
+
+    refusal = _freeze_refusal(conn, actor, args)
+    if refusal is not None:
+        conn.close()
+        return refusal
 
     try:
         return _dispatch(conn, actor, args)
@@ -3293,6 +3444,26 @@ def _cmd_config(conn, actor, args):
     return 0
 
 
+def _cmd_freeze(conn, actor, args):
+    if args.status:
+        live = get_freeze(conn)
+        print(json.dumps(live, indent=2, sort_keys=True) if live else "no live freeze")
+        return 0
+    if args.release:
+        if clear_freeze(conn, actor, force=args.force):
+            print("freeze lifted")
+        else:
+            print("no live freeze to lift")
+        return 0
+    held = set_freeze(conn, actor, args.reason, args.ttl)
+    print(
+        f"tracker frozen by {held['holder']} at {held['since']} for {held['ttl_hours']}h"
+        f"{': ' + held['reason'] if held['reason'] else ''}"
+    )
+    print("other actors' writes now fail; reads are unaffected. Lift with `todo freeze --release`.")
+    return 0
+
+
 def _cmd_migrate(conn, actor, args):
     # Reached only when the DB is already current (main() migrates before
     # connecting for this command); report the no-op for clarity.
@@ -3328,6 +3499,7 @@ _HANDLERS = {
     "export": _cmd_export,
     "migrate": _cmd_migrate,
     "config": _cmd_config,
+    "freeze": _cmd_freeze,
 }
 
 

--- a/tests/unit/scripts/test_todo_db_freeze.py
+++ b/tests/unit/scripts/test_todo_db_freeze.py
@@ -1,0 +1,288 @@
+"""Tests for the leased maintenance freeze and the write-activity fingerprint.
+
+The freeze exists because `restore-legacy --replace` rebuilds every table from a
+snapshot: any write landing between snapshot and restore is destroyed silently,
+and the rebuilt audit chain still verifies because it is rehashed from that same
+snapshot. A claim check cannot gate this -- claims cover claim/start/done/
+complete on existing items, while `create`, `defer`, `promote`, `block` and
+config writes take no claim at all.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+
+pytestmark = [
+    pytest.mark.unit,
+    pytest.mark.fast,
+]
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+
+
+def _load_script():
+    name = "todo_db"
+    path = REPO_ROOT / "_project" / "scripts" / f"{name}.py"
+    spec = importlib.util.spec_from_file_location(name, path)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+todo_db = _load_script()
+
+
+@pytest.fixture()
+def conn(tmp_path):
+    connection = todo_db.connect(tmp_path / "todo.sqlite")
+    yield connection
+    connection.close()
+
+
+def _mk(conn, item_id, actor="tester"):
+    todo_db.create_item(
+        conn,
+        actor,
+        item_id=item_id,
+        title=f"Item {item_id} title",
+        worktree="main",
+        priority="medium",
+        description="A description longer than ten characters.",
+    )
+    return item_id
+
+
+def _run(db_path, *argv, actor):
+    """Invoke main() the way a session does, so the gate in main() is exercised."""
+    return todo_db.main(["--db", str(db_path), "--actor", actor, *argv])
+
+
+class TestWriteActivityFingerprint:
+    def test_absent_before_any_write(self, conn):
+        activity = todo_db.write_activity(conn)
+        assert activity["count"] == 0
+        assert activity["last_seq"] is None
+
+    def test_moves_on_an_unclaimed_create(self, conn):
+        before = todo_db.write_activity(conn)
+        _mk(conn, "some-item")
+        after = todo_db.write_activity(conn)
+        assert after["count"] > before["count"]
+        assert after["last_seq"] != before["last_seq"]
+
+    def test_stable_across_reads_when_nobody_writes(self, conn):
+        _mk(conn, "some-item")
+        first = todo_db.write_activity(conn)
+        # Reads must not perturb the fingerprint, or the quiescence check that
+        # gates the cutover would never converge.
+        todo_db.stats(conn)
+        conn.execute("SELECT count(*) FROM items").fetchone()
+        assert todo_db.write_activity(conn) == first
+
+    def test_exposed_through_stats(self, conn):
+        _mk(conn, "some-item")
+        computed = todo_db.stats(conn)
+        assert computed["events"] == todo_db.write_activity(conn)
+        assert computed["events"]["count"] > 0
+
+    def test_stats_keeps_its_existing_keys(self, conn):
+        _mk(conn, "some-item")
+        computed = todo_db.stats(conn)
+        for key in (
+            "items_by_state",
+            "open_by_priority",
+            "open_by_worktree",
+            "deferrals_by_resolution",
+            "claimed",
+            "findings_by_disposition",
+        ):
+            assert key in computed
+
+
+class TestFreezeLifecycle:
+    def test_no_freeze_by_default(self, conn):
+        assert todo_db.get_freeze(conn) is None
+
+    def test_set_then_get(self, conn):
+        todo_db.set_freeze(conn, "alice", "cutover", ttl_hours=1)
+        live = todo_db.get_freeze(conn)
+        assert live["holder"] == "alice"
+        assert live["reason"] == "cutover"
+
+    def test_holder_may_re_freeze(self, conn):
+        todo_db.set_freeze(conn, "alice", "cutover", ttl_hours=1)
+        todo_db.set_freeze(conn, "alice", "cutover round two", ttl_hours=1)
+        assert todo_db.get_freeze(conn)["reason"] == "cutover round two"
+
+    def test_second_actor_cannot_steal_a_live_freeze(self, conn):
+        todo_db.set_freeze(conn, "alice", "cutover", ttl_hours=1)
+        with pytest.raises(todo_db.TodoError, match="already frozen by alice"):
+            todo_db.set_freeze(conn, "bob", "my turn", ttl_hours=1)
+
+    def test_release_by_holder(self, conn):
+        todo_db.set_freeze(conn, "alice", "cutover", ttl_hours=1)
+        assert todo_db.clear_freeze(conn, "alice") is True
+        assert todo_db.get_freeze(conn) is None
+
+    def test_release_by_other_actor_refused(self, conn):
+        todo_db.set_freeze(conn, "alice", "cutover", ttl_hours=1)
+        with pytest.raises(todo_db.TodoError, match="held by alice"):
+            todo_db.clear_freeze(conn, "bob")
+        assert todo_db.get_freeze(conn) is not None
+
+    def test_release_by_other_actor_with_force(self, conn):
+        todo_db.set_freeze(conn, "alice", "cutover", ttl_hours=1)
+        assert todo_db.clear_freeze(conn, "bob", force=True) is True
+        assert todo_db.get_freeze(conn) is None
+
+    def test_release_with_no_freeze_is_not_an_error(self, conn):
+        assert todo_db.clear_freeze(conn, "alice") is False
+
+    def test_freeze_is_audited(self, conn):
+        todo_db.set_freeze(conn, "alice", "cutover", ttl_hours=1)
+        todo_db.clear_freeze(conn, "alice")
+        actions = [r["action"] for r in conn.execute("SELECT action FROM events ORDER BY seq")]
+        assert "freeze" in actions
+        assert "unfreeze" in actions
+
+
+class TestFreezeCannotWedgeTheTracker:
+    """must-preserve: a maintenance mode cannot become a permanently stuck lock
+    if the holder dies."""
+
+    def _backdate(self, conn, hours):
+        stale = (datetime.now(timezone.utc) - timedelta(hours=hours)).strftime("%Y-%m-%dT%H:%M:%SZ")
+        conn.execute(
+            "INSERT OR REPLACE INTO meta (key, value) VALUES (?, ?)",
+            (todo_db.FREEZE_AT_KEY, stale),
+        )
+
+    def test_expired_freeze_reads_as_absent(self, conn):
+        todo_db.set_freeze(conn, "alice", "cutover", ttl_hours=1)
+        self._backdate(conn, hours=3)
+        assert todo_db.get_freeze(conn) is None
+
+    def test_expired_freeze_lets_another_actor_take_over(self, conn):
+        todo_db.set_freeze(conn, "alice", "cutover", ttl_hours=1)
+        self._backdate(conn, hours=3)
+        todo_db.set_freeze(conn, "bob", "alice never came back", ttl_hours=1)
+        assert todo_db.get_freeze(conn)["holder"] == "bob"
+
+    def test_expired_freeze_does_not_block_writes(self, tmp_path):
+        db = tmp_path / "todo.sqlite"
+        connection = todo_db.connect(db)
+        todo_db.set_freeze(connection, "alice", "cutover", ttl_hours=1)
+        self._backdate(connection, hours=3)
+        connection.commit()
+        connection.close()
+        assert (
+            _run(
+                db,
+                "create",
+                "bob-item",
+                "--title",
+                "Bob item title",
+                "--worktree",
+                "main",
+                "--priority",
+                "medium",
+                "--description",
+                "A description longer than ten characters.",
+                actor="bob",
+            )
+            == 0
+        )
+
+    def test_unbounded_freeze_refused(self, conn):
+        with pytest.raises(todo_db.TodoError, match="must be positive"):
+            todo_db.set_freeze(conn, "alice", "forever", ttl_hours=0)
+
+
+class TestFreezeGate:
+    @pytest.fixture()
+    def frozen_db(self, tmp_path):
+        db = tmp_path / "todo.sqlite"
+        connection = todo_db.connect(db)
+        _mk(connection, "existing-item")
+        todo_db.set_freeze(connection, "alice", "cutover", ttl_hours=1)
+        connection.commit()
+        connection.close()
+        return db
+
+    @pytest.mark.parametrize(
+        "argv",
+        [
+            # The unclaimed write paths a claim check is blind to.
+            (
+                "create",
+                "new-item",
+                "--title",
+                "New item title",
+                "--worktree",
+                "main",
+                "--priority",
+                "medium",
+                "--description",
+                "A description longer than ten characters.",
+            ),
+            ("config", "lint.require_scope_rules", "off"),
+            ("block", "existing-item", "--reason", "blocked during the cutover window"),
+            # ...and a claimed one, for completeness.
+            ("claim", "existing-item"),
+        ],
+        ids=["create", "config", "block", "claim"],
+    )
+    def test_foreign_writes_are_refused(self, frozen_db, argv):
+        assert _run(frozen_db, *argv, actor="bob") == 2
+
+    @pytest.mark.parametrize(
+        "argv",
+        [("list",), ("stats",), ("show", "existing-item"), ("ready",)],
+        ids=["list", "stats", "show", "ready"],
+    )
+    def test_reads_still_work(self, frozen_db, argv):
+        assert _run(frozen_db, *argv, actor="bob") == 0
+
+    def test_holder_can_still_write(self, frozen_db):
+        assert _run(frozen_db, "claim", "existing-item", actor="alice") == 0
+
+    def test_holder_can_always_lift_its_own_freeze(self, frozen_db):
+        assert _run(frozen_db, "freeze", "--release", actor="alice") == 0
+        assert _run(frozen_db, "claim", "existing-item", actor="bob") == 0
+
+    def test_status_is_readable_by_anyone(self, frozen_db):
+        assert _run(frozen_db, "freeze", "--status", actor="bob") == 0
+
+    def test_foreign_actor_cannot_lift(self, frozen_db):
+        assert _run(frozen_db, "freeze", "--release", actor="bob") == 2
+
+    def test_writes_flow_normally_with_no_freeze(self, tmp_path):
+        """must-preserve: normal multi-session operation is unaffected when no
+        cutover is in progress."""
+        db = tmp_path / "todo.sqlite"
+        connection = todo_db.connect(db)
+        _mk(connection, "existing-item")
+        connection.commit()
+        connection.close()
+        assert _run(db, "claim", "existing-item", actor="bob") == 0
+        assert _run(db, "config", "lint.require_scope_rules", "off", actor="carol") == 0
+
+    def test_status_does_not_mutate(self, tmp_path):
+        db = tmp_path / "todo.sqlite"
+        connection = todo_db.connect(db)
+        _mk(connection, "existing-item")
+        connection.commit()
+        before = todo_db.write_activity(connection)
+        connection.close()
+        assert _run(db, "freeze", "--status", actor="bob") == 0
+        connection = todo_db.connect(db)
+        assert todo_db.write_activity(connection) == before
+        connection.close()


### PR DESCRIPTION
## Description

`restore-legacy --replace` rebuilds every table from a snapshot, so any write landing between snapshot and restore is destroyed **silently** — and the rebuilt audit chain still verifies, because it is re-hashed from that same snapshot.

The migration item gated that destructive step on *"no other actor holds a live claim."* That test cannot work. Claims cover `claim`/`start`/`done`/`complete` on existing items; `create`, `defer`, `promote`, `block` and config writes take **no claim at all**. Two items were created during the previous cutover window by an actor that held no claim at any point.

This PR replaces that precondition with a mechanism that actually holds:

- **`todo freeze [--reason R] [--ttl H]`** refuses every mutating command from any other actor. Reads are untouched, and the holder keeps writing — so the holder can run the cutover and lift its own freeze.
- The lease **expires on its own**, so a holder that dies mid-cutover cannot wedge the tracker permanently. `--release --force` breaks a foreign freeze.
- With no freeze set the gate is a **no-op**, leaving normal multi-session operation unaffected.
- **`stats["events"]`** now exposes a write-activity fingerprint (`count`, `last_seq`, `latest`) as a corroborating quiescence probe.

That last point is its own bug fix. The quiescence check the runbook calls for was previously impossible to write: `stats` takes no `--json` flag and reported no event count at all, so the intended check compared two empty strings and **passed while writers were active**.

## Type of Change

- [x] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactor / chore

## Testing

- `uv run -- python -m pytest tests/unit/scripts/ -q` → **1233 passed** (32 new)
- `uv run -- ruff check` / `ruff format --check` on the two changed files → clean (base was already clean, so no unrelated reformatting)
- `uv run -- python _project/scripts/timing_policy_check.py --strict` → exit 0, 26175 collected vs the 26550 cap, 0 violations
- `todo check-scope tracker-cutover-needs-a-write-freeze-not-a-claim-check` → scope OK (2 changed files)
- Manual smoke on a scratch SQLite DB: with a freeze held by `alice`, `bob`'s `create` / `claim` / `config` are refused with exit 2 while `list` / `stats` / `show` / `ready` still return 0; `alice` keeps writing and lifts her own freeze; a backdated lease stops blocking anyone.

New coverage in `tests/unit/scripts/test_todo_db_freeze.py` pins both must-preserve invariants directly: the expiry tests cover *"cannot become a permanently stuck lock if the holder dies"*, and `test_writes_flow_normally_with_no_freeze` covers *"normal multi-session operation is unaffected."*

## Public Contract Check

- [x] I updated `docs/reference/public-contracts.md`, or this PR does not change public, beta-public, deprecated, generated, experimental, or repo-only contract surfaces.
- [x] I checked result schema fields, MCP tool parameters, platform support status, wrapper facades, adapter subclassing hooks, and generated docs for contract-map impact.
- [x] Any platform/benchmark count claim in docs is generated/checked from registry metadata, or explicitly marked editorial/non-authoritative.

`stats` gains one additive key; all existing keys are untouched and a regression test pins them. The shell wrapper is a pass-through and needed no change.

## Documentation

- [ ] I updated the relevant user-facing docs.
- [x] I added regression notes for behavior changes.
- [x] I confirmed API contract wording remains accurate.

The cutover runbook ADR under `_project/decisions/` is **not** in this PR — that path is outside this item's scope rules and belongs to the migration item. Flagged as follow-up below.

## Code Quality

- [x] I ran formatting and lint/type checks.
- [x] I reviewed impacted modules for backwards compatibility and migration impact.
- [x] I added/updated tests for behavior changes and error paths.
- [x] I confirmed public contracts and release checklists are still valid.

## Artifact Hygiene

- [x] I did not commit raw screenshots, browser reports, generated logs, benchmark outputs, or temporary binary artifacts.
- [x] Any committed binary/raw evidence file has durable repo value and is justified here with its consumer and size: n/a.

## Notes

**The destructive cutover was deliberately not run.** Three independent blockers, any one of which is disqualifying:

1. **No `todo-db` >= 0.3 CLI is reachable** from this environment — not on PyPI, and the sibling repo is not in session scope. Rehearsal and hosted restore both need it.
2. **The rollback backup cannot be made durable here.** This container's disk is reclaimed with the session, and it *already restarted once mid-session*, killing an in-flight process. Had that been `restore-legacy --replace`, the tracker would have been left half-rebuilt with its only backup on the same disposable disk.
3. **Quiescence is not a freeze.** The tracker was quiet across three reads 5 min apart (`count=4440`, `last_seq=4440`, `latest=2026-07-31T16:38:10Z`), but it had still moved 1720→1726 items and 4424→4440 events earlier the same day, and `joe@joe-mac-mini.local` holds a live claim. Quiet now is not quiet during the restore — which is the whole reason this PR exists. The freeze also has to be *merged and present* on the machine running the cutover before it can protect anything.

**Follow-ups for the migration item:**

- Its `must-preserve` still literally reads *"never restored with `--replace` while another actor holds a live claim."* `must-preserve` is create-time-only, and the item has **5 dependents** whose dep edges are create-time-only too, so a drop-and-re-create would cascade into re-creating all five. I superseded it in the block reason instead, naming the freeze as the operative precondition. Clearing the stale text structurally needs that cascade, or `update-scope-rules` (todo-db) landing first.
- Rung 1 of *this* item's own verification ladder is vacuous for the same `stats --json` reason: it shells out to a command that exits 2, compares two empty strings, and passes unconditionally. `stats["events"]` now makes a correct probe writable, but the rung text itself is create-time-only and still needs replacing.

---
_Generated by [Claude Code](https://claude.ai/code/session_01LEp12XPnUmvJkCyL44jNCc)_