### PR TITLE
feat(tracker): lint verification commands that cannot execute

### DIFF
--- a/_project/scripts/todo_db.py
+++ b/_project/scripts/todo_db.py
@@ -38,6 +38,7 @@ import getpass
 import json
 import os
 import re
+import shlex
 import socket
 import sqlite3
 import subprocess
@@ -1959,6 +1960,43 @@ def _command_asserts_on_output(command: str) -> bool:
     return bool(_COMMAND_ASSERTS_ON_OUTPUT_RE.search(command) or _JQ_EXIT_STATUS_RE.search(command))
 
 
+# A rung whose whole command is angle-bracketed prose ("<record the run ids>")
+# is a note to a future author, not a command: it exits non-zero on every tree,
+# so it satisfies "must fail on the unfixed tree" without gating anything.
+_PLACEHOLDER_COMMAND_RE = re.compile(r"^\s*<[^<>]*>\s*$")
+
+
+def _command_unrunnable_reason(command: str) -> str | None:
+    """Why this verification command can never execute, or None if it can.
+
+    Deliberately conservative: piped, multi-line, `!`-negated, env-prefixed and
+    compound commands are all legitimate and must not be flagged, so the only
+    signals used are a whole-command placeholder shape and a failed shell parse.
+    """
+    if _PLACEHOLDER_COMMAND_RE.match(command):
+        return "prose placeholder, not a runnable command"
+    try:
+        tokens = shlex.split(command, posix=True)
+    except ValueError as exc:
+        return f"fails shell parse: {exc}"
+    if not tokens:
+        return "empty after shell parsing"
+    return None
+
+
+def _unrunnable_verifications(item: dict) -> list[tuple[int, str, str]]:
+    """Return (seq, reason, command) for rungs whose command cannot execute."""
+    offenders = []
+    for ver in item["verifications"]:
+        command = ver.get("command") or ""
+        if not command.strip():
+            continue
+        reason = _command_unrunnable_reason(command)
+        if reason:
+            offenders.append((ver["seq"], reason, command))
+    return offenders
+
+
 def _unsatisfiable_verifications(item: dict) -> list[int]:
     """Return seqs of rungs whose command cannot express their expectation."""
     offenders = []
@@ -1979,6 +2017,8 @@ def lint_item(conn: sqlite3.Connection, item_id: str) -> list[str]:
         findings.append("no verification steps recorded")
     elif not any(v["command"] for v in item["verifications"]):
         findings.append("verification steps exist but none has a runnable command")
+    for seq, reason, command in _unrunnable_verifications(item):
+        findings.append(f"verification seq {seq} command cannot execute ({reason}): {command}")
     unsatisfiable = _unsatisfiable_verifications(item)
     if unsatisfiable:
         findings.append(

--- a/tests/unit/scripts/test_todo_db_v2.py
+++ b/tests/unit/scripts/test_todo_db_v2.py
@@ -357,6 +357,61 @@ class TestLintConfigGating:
         assert "config" in todo_db._HANDLERS
 
 
+class TestLintUnrunnableCommands:
+    """A rung command that cannot execute exits non-zero on every tree, so it
+    vacuously satisfies "must fail on the unfixed tree" — lint must report it."""
+
+    def _mk_with_command(self, conn, item_id, command):
+        todo_db.create_item(
+            conn,
+            "tester",
+            item_id=item_id,
+            title="Item with a verification rung",
+            worktree="spike",
+            priority="medium",
+            description="A description longer than ten characters.",
+            work=[{"id": "w1", "summary": "one unit of work"}],
+            verifications=[{"description": "rung", "command": command, "expected": "whatever"}],
+        )
+
+    def test_placeholder_command_is_reported_with_its_text(self, conn):
+        self._mk_with_command(conn, "ph-item", "<record the four run ids on this item>")
+        findings = todo_db.lint_item(conn, "ph-item")
+        assert any("cannot execute" in f and "record the four run ids" in f for f in findings)
+
+    def test_shell_parse_failure_is_reported(self, conn):
+        self._mk_with_command(conn, "parse-item", "echo 'unterminated")
+        findings = todo_db.lint_item(conn, "parse-item")
+        assert any("cannot execute" in f and "shell parse" in f for f in findings)
+
+    def test_runnable_command_is_not_flagged(self, conn):
+        self._mk_with_command(conn, "ok-item", "uv run -- python -m pytest tests -q")
+        assert not any("cannot execute" in f for f in todo_db.lint_item(conn, "ok-item"))
+
+    def test_piped_command_is_not_flagged(self, conn):
+        self._mk_with_command(conn, "piped-item", "_project/scripts/todo lint some-item | grep -qi 'pattern'")
+        assert not any("cannot execute" in f for f in todo_db.lint_item(conn, "piped-item"))
+
+    def test_multiline_negated_command_is_not_flagged(self, conn):
+        self._mk_with_command(conn, "ml-item", "set -e\nmake regen\n! grep -q 'stale' out.log")
+        assert not any("cannot execute" in f for f in todo_db.lint_item(conn, "ml-item"))
+
+    def test_rung_without_command_is_not_flagged_as_unrunnable(self, conn):
+        self._mk_with_command(conn, "nocmd-item", "uv run -- true")
+        todo_db.create_item(
+            conn,
+            "tester",
+            item_id="desc-only-item",
+            title="Item whose rung is description-only",
+            worktree="spike",
+            priority="medium",
+            description="A description longer than ten characters.",
+            work=[{"id": "w1", "summary": "one unit of work"}],
+            verifications=[{"description": "manual acceptance only"}],
+        )
+        assert not any("cannot execute" in f for f in todo_db.lint_item(conn, "desc-only-item"))
+
+
 class TestInstructiveGateErrors:
     """Every gate refusal must name its recovery command — the error messages
     are the harness-portable instruction layer."""


### PR DESCRIPTION
# Pull Request

## Description

`todo lint` now reports verification rungs whose command can never execute: a whole-command angle-bracket prose placeholder (`<record the four run ids ...>`) or a command that fails a shell parse (e.g. unbalanced quote). Such a rung exits non-zero on every tree, so it vacuously satisfies "must fail on the unfixed tree" while gating nothing — a defect class found on real items (one done item, one open item) during the 2026-07-31 credential-egress TODO audit. The finding message includes the offending command text so ladder rungs can assert on it.

This is the brokenness-rejection that `todo-lint-rung-falsifiability-and-scope-completeness-2` depends on.

TODO: `todo-lint-unrunnable-verification-commands-2`

## Type of Change

- [x] New feature

## Testing

- `uv run -- python -m pytest tests/unit/scripts/test_todo_db_v2.py -q` → 51 passed
- `uv run -- python -m pytest tests/unit/scripts/test_todo_db.py tests/unit/scripts/test_todo_db_hardening.py tests/unit/scripts/test_todo_wrapper.py -q` → 111 passed
- Ladder rung 1 against the hosted DB flipped from exit 1 (0 findings) to exit 0 (placeholder reported)
- `todo lint --all` on the hosted backlog: exactly one new finding, a genuinely unrunnable rung (unbalanced quote) on `test-export-invalid-output-dir-assumes-non-root` — no false positives across 306 items
- `uv run -- ruff check` / `ruff format --check` clean

## Public Contract Check

- [x] I updated `docs/reference/public-contracts.md`, or this PR does not change public, beta-public, deprecated, generated, experimental, or repo-only contract surfaces.
- [x] I checked result schema fields, MCP tool parameters, platform support status, wrapper facades, adapter subclassing hooks, and generated docs for contract-map impact.
- [x] Any platform/benchmark count claim in docs is generated/checked from registry metadata, or explicitly marked editorial/non-authoritative.

## Documentation

- [x] I updated the relevant user-facing docs. (None needed — internal tracker tooling; behavior documented in the lint finding text itself.)
- [x] I added regression notes for behavior changes.
- [x] I confirmed API contract wording remains accurate.

## Code Quality

- [x] I ran formatting and lint/type checks.
- [x] I reviewed impacted modules for backwards compatibility and migration impact.
- [x] I added/updated tests for behavior changes and error paths.
- [x] I confirmed public contracts and release checklists are still valid.

## Artifact Hygiene

- [x] I did not commit raw screenshots, browser reports, generated logs, benchmark outputs, or temporary binary artifacts.
- [x] Any committed binary/raw evidence file has durable repo value and is justified here with its consumer and size: none.

## Notes

Conservative by design: only two signals (whole-command `<...>` shape, shlex parse failure). Piped, multi-line, `!`-negated, env-prefixed and compound commands are never flagged — covered by tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Krk2XGi6cWHTmG55tbQSXF

---
_Generated by [Claude Code](https://claude.ai/code/session_01Krk2XGi6cWHTmG55tbQSXF)_