### PR TITLE
fix(results): share one secret-key list between capture and anonymization

### DIFF
--- a/benchbox/core/results/anonymization.py
+++ b/benchbox/core/results/anonymization.py
@@ -21,6 +21,8 @@ from urllib.parse import urlparse
 
 import yaml
 
+from benchbox.core.results.platform_options import _SECRET_KEY_PARTS
+
 logger = logging.getLogger(__name__)
 
 PUBLIC_REDACTED_VALUE = "<redacted>"
@@ -33,7 +35,12 @@ def _load_anonymization_specs() -> dict[str, Any]:
 
 _ANONYMIZATION_SPECS = _load_anonymization_specs()
 
-_SECRET_KEY_PARTS = tuple(_ANONYMIZATION_SPECS["secret_key_parts"])
+# Secret-key matching is shared with the internal capture path: both consumers
+# read platform_options._SECRET_KEY_PARTS (imported above) so the lists cannot
+# diverge again. The spec file deliberately no longer carries its own copy -
+# the two hand-synced lists drifted within a month of #1346 ('keyid' was added
+# to platform_options only), which left *_key_id values unredacted on this
+# public path.
 _IDENTIFIER_KEYS = dict(_ANONYMIZATION_SPECS["identifier_keys"])
 _ENDPOINT_KEYS = set(_ANONYMIZATION_SPECS["endpoint_keys"])
 _PATH_KEYS = set(_ANONYMIZATION_SPECS["path_keys"])

--- a/benchbox/core/results/anonymization_specs.yaml
+++ b/benchbox/core/results/anonymization_specs.yaml
@@ -1,12 +1,7 @@
-secret_key_parts:
-- password
-- token
-- secret
-- accesskey
-- privatekey
-- sessiontoken
-- connectionstring
-- credential
+# secret_key_parts intentionally lives in code, not here: both the internal
+# capture path and this public anonymization path read the single list in
+# benchbox/core/results/platform_options.py (_SECRET_KEY_PARTS). A second
+# hand-synced copy in this file diverged within a month of being split out.
 identifier_keys:
   account: account
   accountid: account

--- a/tests/unit/core/results/test_anonymization.py
+++ b/tests/unit/core/results/test_anonymization.py
@@ -7,13 +7,14 @@ Copyright 2026 Joe Harris / BenchBox Project
 Licensed under the MIT License. See LICENSE file in the project root for details.
 """
 
+import json
 import subprocess
 import sys
 from unittest.mock import MagicMock, Mock, mock_open, patch
 
 import pytest
 
-from benchbox.core.results.anonymization import AnonymizationConfig, AnonymizationManager
+from benchbox.core.results.anonymization import PUBLIC_REDACTED_VALUE, AnonymizationConfig, AnonymizationManager
 
 pytestmark = [
     pytest.mark.unit,
@@ -718,6 +719,48 @@ class TestValidateAnonymization:
         validation = manager.validate_anonymization({}, {"result": "ok"})
         assert any("machine" in e.lower() for e in validation["errors"])
         assert validation["is_valid"] is False
+
+
+class TestPublicPayloadSecretKeys:
+    """The public export path must honor every secret part the internal
+    capture path honors — both consumers read one shared list, so a key that
+    is redacted at capture time can never be published by re-export either."""
+
+    @staticmethod
+    def _payload(config):
+        return {"platform_metadata": {"platform_raw_config": config}}
+
+    def test_key_id_values_are_redacted(self):
+        manager = AnonymizationManager()
+        out = manager.anonymize_result_payload(
+            self._payload({"s3_key_id": "AKIA-SENTINEL", "kms_key_id": "KMS-SENTINEL"})
+        )
+        raw = json.dumps(out, default=str)
+        assert "AKIA-SENTINEL" not in raw
+        assert "KMS-SENTINEL" not in raw
+
+    def test_already_covered_keys_keep_behavior(self):
+        manager = AnonymizationManager()
+        out = manager.anonymize_result_payload(
+            self._payload({"pg_password": "PW-SENTINEL", "username": "alice-sentinel"})
+        )["platform_metadata"]["platform_raw_config"]
+        assert out["pg_password"] == PUBLIC_REDACTED_VALUE
+        assert out["username"] != "alice-sentinel"
+        assert out["username"].startswith("user_")
+
+    def test_secret_parts_shared_with_platform_options(self):
+        from benchbox.core.results.anonymization import _SECRET_KEY_PARTS as anon_parts
+        from benchbox.core.results.platform_options import _SECRET_KEY_PARTS as capture_parts
+
+        assert set(capture_parts) <= set(anon_parts)
+
+    def test_data_modelling_keys_are_not_over_redacted(self):
+        manager = AnonymizationManager()
+        out = manager.anonymize_result_payload(
+            self._payload({"sort_key": "l_shipdate", "partition_key": "l_orderkey"})
+        )["platform_metadata"]["platform_raw_config"]
+        assert out["sort_key"] == "l_shipdate"
+        assert out["partition_key"] == "l_orderkey"
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
# Pull Request

## Description

The public anonymization path kept its own copy of the secret-key parts in `anonymization_specs.yaml`, and it diverged from `platform_options.py` within a month of #1346: `keyid` was added to the capture-time list only, so `s3_key_id`/`kms_key_id` values passed `anonymize_result_payload` verbatim (driven with sentinels, 2026-07-31). Both consumers now read the single `_SECRET_KEY_PARTS` list in `platform_options.py`; the yaml copy is removed and replaced with a pointer comment so it cannot drift again.

Severity note (from the phase-1 egress review): the standard capture path already masks `*_key_id` upstream via `sanitize_platform_options`, so the live exposure was re-export of raw or historical payloads — defense-in-depth restoration, plus that conditional leak.

TODO: `anonymization-path-misses-key-id-secrets`

## Type of Change

- [x] Bug fix

## Testing

- Ladder rung 1: `anonymize_result_payload` with an `s3_key_id` sentinel — exit 1 pre-fix, exit 0 post-fix
- Ladder rung 2: `set(platform_options parts) <= set(anonymization parts)` — `AssertionError: ['keyid']` pre-fix, exit 0 post-fix
- `uv run -- python -m pytest tests/unit/core/results/ -q` → 778 passed, 4 skipped
- New `TestPublicPayloadSecretKeys`: key-id redaction, preserved `pg_password`/`username` behavior, list-consistency subset, over-redaction guard (`sort_key`/`partition_key` untouched)
- `ruff check` / `ruff format --check` clean

## Public Contract Check

- [x] I updated `docs/reference/public-contracts.md`, or this PR does not change public, beta-public, deprecated, generated, experimental, or repo-only contract surfaces. (Redaction strictly widens; no schema/field changes.)
- [x] I checked result schema fields, MCP tool parameters, platform support status, wrapper facades, adapter subclassing hooks, and generated docs for contract-map impact.
- [x] Any platform/benchmark count claim in docs is generated/checked from registry metadata, or explicitly marked editorial/non-authoritative.

## Documentation

- [x] I updated the relevant user-facing docs. (None needed — the yaml carries the pointer comment.)
- [x] I added regression notes for behavior changes.
- [x] I confirmed API contract wording remains accurate.

## Code Quality

- [x] I ran formatting and lint/type checks.
- [x] I reviewed impacted modules for backwards compatibility and migration impact.
- [x] I added/updated tests for behavior changes and error paths.
- [x] I confirmed public contracts and release checklists are still valid.

## Artifact Hygiene

- [x] I did not commit raw screenshots, browser reports, generated logs, benchmark outputs, or temporary binary artifacts.
- [x] Any committed binary/raw evidence file has durable repo value and is justified here with its consumer and size: none.

## Notes

Follow-up already tracked: `public-export-misses-api-key-and-storage-account-key` (high) adds `apikey`/`accountkey` to this now-single list — those keys leak on BOTH paths today and were found by the same phase-1 sentinel sweep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Krk2XGi6cWHTmG55tbQSXF

---
_Generated by [Claude Code](https://claude.ai/code/session_01Krk2XGi6cWHTmG55tbQSXF)_