### PR TITLE
fix(make): let guards-fix finish its report when the skill-sync step fails

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -825,7 +825,13 @@ guards-fix:
 	@echo "-- UAT spec module-LOC table --"
 	@uv run --project _project/scripts -- python _project/scripts/uat_loc_table.py
 	@echo "-- skill-sync (no-ops with a notice if the skill-sync CLI is not installed) --"
-	@$(MAKE) -s skill-sync
+	@# Last regen step, contained: a failing skill-sync CLI (e.g. "unable to
+	@# read tree <sha>" in a fresh worktree) used to abort guards-fix here,
+	@# AFTER every other artifact had already been rewritten -- the summary and
+	@# the reviewable diff below never printed. Surface the failure loudly and
+	@# still finish the report; direct `make skill-sync` keeps its hard failure,
+	@# and genuine mirror drift is still enforced by skill-sync-check in CI.
+	@$(MAKE) -s skill-sync || echo "guards-fix: WARNING - the skill-sync step FAILED (see its output above); every other drift-guard artifact was still regenerated. Fix and re-run 'make skill-sync' separately."
 	@echo ""
 	@echo "No regen mode -- these are reviewed hand edits, guards-fix does not touch them:"
 	@echo "  - module-size guard: tests/system/test_module_size_thresholds.py (see its failure output for the ALLOWLIST entry to paste)"


### PR DESCRIPTION
# Pull Request

## Description

`skill-sync` is the last regen step of `make guards-fix`; a failing CLI (the reported "unable to read tree \<sha\>" in a fresh worktree) aborted the whole target after every other artifact had already been rewritten — the completion summary and the reviewable-diff footer never printed. The guards-fix recipe now contains the failure: it surfaces the error, prints a loud warning, and still finishes the report. Direct `make skill-sync` keeps its hard failure, and genuine mirror drift is still gated by `skill-sync-check` in CI.

TODO: `guards-fix-aborts-on-skill-sync-unreadable-tree-2`

## Type of Change

- [x] Bug fix

## Testing

Deterministic stub reproduction (a fake CLI printing `unable to read tree deadbeef` and exiting 1):
- Before: `make guards-fix SKILL_SYNC=<stub>` → `make: *** [guards-fix] Error 2`, no summary
- After: exit 0, `guards-fix done` summary prints, the underlying error text and a WARNING naming the failed step appear in the output
- `make guards-fix` (normal path, CLI absent) still exits 0 with its skip notice

Confirmation on the machine with the real skill-sync CLI is tracked as `guards-fix-skill-sync-real-cli-manual-confirmation` (promoted deferral — this container has no real CLI).

## Public Contract Check

- [x] I updated `docs/reference/public-contracts.md`, or this PR does not change public, beta-public, deprecated, generated, experimental, or repo-only contract surfaces.
- [x] I checked result schema fields, MCP tool parameters, platform support status, wrapper facades, adapter subclassing hooks, and generated docs for contract-map impact.
- [x] Any platform/benchmark count claim in docs is generated/checked from registry metadata, or explicitly marked editorial/non-authoritative.

## Documentation

- [x] I updated the relevant user-facing docs. (The recipe comment documents the containment rationale in place.)
- [x] I added regression notes for behavior changes.
- [x] I confirmed API contract wording remains accurate.

## Code Quality

- [x] I ran formatting and lint/type checks.
- [x] I reviewed impacted modules for backwards compatibility and migration impact.
- [x] I added/updated tests for behavior changes and error paths. (Makefile recipe; verified by the deterministic stub runs above — no pytest surface.)
- [x] I confirmed public contracts and release checklists are still valid.

## Artifact Hygiene

- [x] I did not commit raw screenshots, browser reports, generated logs, benchmark outputs, or temporary binary artifacts.
- [x] Any committed binary/raw evidence file has durable repo value and is justified here with its consumer and size: none.

## Notes

Design choice: skip-with-notice (exit 0 + warning) rather than fail-after-reporting, so a broken local skill-sync install can never block regenerating the other drift artifacts; CI's `skill-sync-check` remains the drift gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Krk2XGi6cWHTmG55tbQSXF

---
_Generated by [Claude Code](https://claude.ai/code/session_01Krk2XGi6cWHTmG55tbQSXF)_