### PR TITLE
fix(results): redact connection usernames in internal result metadata

### DIFF
--- a/benchbox/core/results/platform_options.py
+++ b/benchbox/core/results/platform_options.py
@@ -37,6 +37,20 @@ _SECRET_KEY_PARTS = tuple(
         "credential",
     )
 )
+# Connection usernames are identity, not secrets, so they are NOT in
+# _SECRET_KEY_PARTS (the public anonymization path shares that list and must
+# keep PSEUDONYMIZING usernames for grouping, not redacting them). But the
+# internal capture path has no pseudonymizer, so before this set existed a
+# username rode into every internal bundle verbatim. Exact normalized match
+# only - a substring rule on "user" would nuke user_agent/num_users-class
+# options.
+_USERNAME_KEYS = frozenset({"user", "username", "userid", "pguser", "dbuser"})
+
+
+def _is_username_key(key: str) -> bool:
+    return _normalize_secret_key(key) in _USERNAME_KEYS
+
+
 _INTERNAL_OPTION_KEYS = {
     "_explicit_platform_options",
     "verbosity_settings",
@@ -93,7 +107,7 @@ def sanitize_platform_options(
         key_str = str(key)
         if exclude_internal and (key_str.startswith("_") or key_str in _INTERNAL_OPTION_KEYS):
             continue
-        if is_secret_option_key(key_str):
+        if is_secret_option_key(key_str) or _is_username_key(key_str):
             sanitized[key_str] = REDACTED_VALUE
         else:
             sanitized[key_str] = _sanitize_option_value(value, exclude_internal=exclude_internal)

--- a/tests/unit/core/results/test_platform_options_capture.py
+++ b/tests/unit/core/results/test_platform_options_capture.py
@@ -401,3 +401,45 @@ def test_result_payload_exports_platform_option_sources_from_run_config() -> Non
         "warehouse": "cli_option",
         "password": "cli_option",
     }
+
+
+class TestUsernameRedactionInternalPath:
+    """Connection usernames must not ride into internal bundles verbatim.
+
+    They are identity, not secrets: the public path pseudonymizes them for
+    grouping, but the internal capture path has no pseudonymizer, so it
+    redacts them instead. Exact normalized match only, so user_agent-class
+    option keys keep their real values.
+    """
+
+    def test_username_keys_are_redacted(self):
+        from benchbox.core.results.platform_options import sanitize_platform_options
+
+        result = sanitize_platform_options(
+            {"username": "alice-sentinel", "user": "bob-sentinel", "pg_user": "carol-sentinel"}
+        )
+        assert result["username"] == REDACTED_VALUE
+        assert result["user"] == REDACTED_VALUE
+        assert result["pg_user"] == REDACTED_VALUE
+
+    def test_user_lookalike_keys_are_not_over_redacted(self):
+        from benchbox.core.results.platform_options import sanitize_platform_options
+
+        result = sanitize_platform_options({"user_agent": "ua/1.0", "num_users": 7, "users_table": "users"})
+        assert result["user_agent"] == "ua/1.0"
+        assert result["num_users"] == 7
+        assert result["users_table"] == "users"
+
+    def test_secret_keys_keep_current_behavior(self):
+        from benchbox.core.results.platform_options import sanitize_platform_options
+
+        result = sanitize_platform_options({"password": "pw-sentinel", "s3_key_id": "AKIA-sentinel"})
+        assert result["password"] == REDACTED_VALUE
+        assert result["s3_key_id"] == REDACTED_VALUE
+
+    def test_nested_username_is_redacted(self):
+        from benchbox.core.results.platform_options import sanitize_platform_options
+
+        result = sanitize_platform_options({"connection": {"username": "alice-sentinel", "host": "db.internal"}})
+        assert result["connection"]["username"] == REDACTED_VALUE
+        assert result["connection"]["host"] == "db.internal"


### PR DESCRIPTION
# Pull Request

## Description

`sanitize_platform_options` exported `username`/`user`/`pg_user` values verbatim into internal result bundles, while the public/anonymized path pseudonymizes them (`user_<hash>`) — the protection vanished exactly where bundles get shared without the anonymize pass. Usernames are identity, not secrets, so they deliberately stay OUT of the shared secret-key list (the public path must keep pseudonymizing for grouping); the capture path now redacts them via an exact-normalized-match set (`user`, `username`, `userid`, `pguser`, `dbuser`), so `user_agent`/`num_users`-class options keep their real values.

TODO: `internal-result-metadata-exports-connection-usernames`

## Type of Change

- [x] Bug fix

## Testing

- Ladder rung 1: `sanitize_platform_options({'username':'alice-sentinel'})` — exit 1 pre-fix (verbatim), exit 0 post-fix (redacted)
- Ladder rung 2 (over-redaction guard): `user_agent`/`num_users` untouched — passes before and after
- Must-preserve driven: public path still pseudonymizes (`user_b860e7bd6314`)
- `tests/unit/core/results tests/unit/platforms` → 8775 passed, 74 skipped
- New `TestUsernameRedactionInternalPath` incl. nested-dict redaction and lookalike guards
- `ruff check` / `ruff format --check` clean

## Public Contract Check

- [x] I updated `docs/reference/public-contracts.md`, or this PR does not change public, beta-public, deprecated, generated, experimental, or repo-only contract surfaces. (Internal metadata values only; no schema/field changes.)
- [x] I checked result schema fields, MCP tool parameters, platform support status, wrapper facades, adapter subclassing hooks, and generated docs for contract-map impact.
- [x] Any platform/benchmark count claim in docs is generated/checked from registry metadata, or explicitly marked editorial/non-authoritative.

## Documentation

- [x] I updated the relevant user-facing docs. (Rationale documented at the definition site.)
- [x] I added regression notes for behavior changes.
- [x] I confirmed API contract wording remains accurate.

## Code Quality

- [x] I ran formatting and lint/type checks.
- [x] I reviewed impacted modules for backwards compatibility and migration impact.
- [x] I added/updated tests for behavior changes and error paths.
- [x] I confirmed public contracts and release checklists are still valid.

## Artifact Hygiene

- [x] I did not commit raw screenshots, browser reports, generated logs, benchmark outputs, or temporary binary artifacts.
- [x] Any committed binary/raw evidence file has durable repo value and is justified here with its consumer and size: none.

## Notes

Decision (item w1): redact rather than pseudonymize on the internal path — the capture layer has no salted-hash infrastructure and must not duplicate anonymization's. The public-path `pg_user`/`tenant_id` pseudonymization gap is tracked separately as `public-export-pg-user-and-tenant-id-bypass-pseudonymization`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Krk2XGi6cWHTmG55tbQSXF

---
_Generated by [Claude Code](https://claude.ai/code/session_01Krk2XGi6cWHTmG55tbQSXF)_