### PR TITLE
feat(tooling): guard against a uv.lock schema-revision downgrade

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,6 +17,18 @@ repos:
         stages: [pre-commit]
         files: ^results-data/bundles/
 
+      # An older local uv silently rewrites the committed lock schema
+      # (revision 3 -> 2) alongside any real dependency change; reject the
+      # downgrade before it rides into a commit. Stdlib-only, runs only when
+      # uv.lock is staged.
+      - id: uv-lock-revision-guard
+        name: uv.lock revision downgrade guard
+        entry: python3 _project/scripts/check_uv_lock_revision.py
+        language: system
+        pass_filenames: false
+        stages: [pre-commit]
+        files: ^uv\.lock$
+
       - id: uat-loc-table
         name: UAT spec LOC table drift check
         entry: uv run --project _project/scripts -- python _project/scripts/uat_loc_table.py --check

--- a/Makefile
+++ b/Makefile
@@ -646,6 +646,14 @@ lint:
 	$(MAKE) lint-explorer-tokens
 	$(MAKE) lint-site-theme-tokens
 
+# Reject a uv.lock schema-revision downgrade (an older local uv rewrites
+# revision 3 back to 2 as a silent side effect of any `uv add`/`uv lock`).
+# Compares HEAD:uv.lock against the working tree; also wired as a pre-commit
+# hook gated on uv.lock changes. See docs/development/development.md.
+.PHONY: uv-lock-revision-check
+uv-lock-revision-check:
+	python3 _project/scripts/check_uv_lock_revision.py
+
 # Dependency audit - checks that every declared dep has an import site or is allowlisted.
 # Fails if an unused dep is introduced. See _project/scripts/dependency_audit/.
 audit-deps:

--- a/_project/scripts/check_uv_lock_revision.py
+++ b/_project/scripts/check_uv_lock_revision.py
@@ -1,0 +1,92 @@
+"""Reject a uv.lock schema-revision downgrade.
+
+An older local uv (< 0.8) silently rewrites the committed ``revision = 3``
+lockfile back to revision 2 as a side effect of any ``uv add``/``uv lock``
+run, and the downgrade rides along with the intended change. This guard
+fails when the revision DECREASES relative to the committed baseline;
+unchanged and increased revisions pass so legitimate lock updates need no
+ceremony.
+
+Modes:
+  --old N --new N   pure comparison (test interface, no git or files needed)
+  default           compare ``git show HEAD:uv.lock`` against ./uv.lock
+
+Exit status: 0 ok, 1 downgrade (or malformed lock), 2 usage error.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+_REVISION_RE = re.compile(r"^revision\s*=\s*(\d+)\s*$", re.MULTILINE)
+
+
+def parse_revision(lock_text: str, origin: str) -> int:
+    match = _REVISION_RE.search(lock_text)
+    if not match:
+        raise ValueError(f"no 'revision = N' line found in {origin}")
+    return int(match.group(1))
+
+
+def check(old: int, new: int) -> int:
+    if new < old:
+        print(
+            f"uv.lock revision DOWNGRADE rejected: {old} -> {new}.\n"
+            f"An older local uv rewrites the lock schema as a side effect; "
+            f"upgrade uv (see docs/development/development.md) and regenerate "
+            f"the lock, or discard the uv.lock hunk from this change.",
+            file=sys.stderr,
+        )
+        return 1
+    return 0
+
+
+def _committed_lock_text(repo_root: Path) -> str | None:
+    result = subprocess.run(
+        ["git", "show", "HEAD:uv.lock"],
+        cwd=repo_root,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        return None
+    return result.stdout
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--old", type=int, default=None, help="baseline revision (test interface)")
+    parser.add_argument("--new", type=int, default=None, help="candidate revision (test interface)")
+    args = parser.parse_args(argv)
+
+    if (args.old is None) != (args.new is None):
+        parser.error("--old and --new must be given together")
+    if args.old is not None and args.new is not None:
+        return check(args.old, args.new)
+
+    repo_root = Path(__file__).resolve().parents[2]
+    working_lock = repo_root / "uv.lock"
+    if not working_lock.exists():
+        print("uv.lock not found in working tree; nothing to check")
+        return 0
+    committed = _committed_lock_text(repo_root)
+    if committed is None:
+        # No committed baseline (fresh repo / uv.lock not yet tracked).
+        print("no committed uv.lock baseline (HEAD); nothing to compare")
+        return 0
+    try:
+        old = parse_revision(committed, "HEAD:uv.lock")
+        new = parse_revision(working_lock.read_text(encoding="utf-8"), "uv.lock")
+    except ValueError as exc:
+        print(f"uv.lock revision guard: {exc}", file=sys.stderr)
+        return 1
+    return check(old, new)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/docs/development/development.md
+++ b/docs/development/development.md
@@ -12,7 +12,12 @@ This guide provides information for developers who want to contribute to BenchBo
 ### Prerequisites
 
 - Python 3.10+
-- [`uv`](https://docs.astral.sh/uv/) (recommended for environment management)
+- [`uv`](https://docs.astral.sh/uv/) **0.8 or newer** (recommended for environment
+  management). The committed `uv.lock` uses lockfile `revision = 3`; an older uv
+  silently rewrites it to revision 2 as a side effect of any `uv add`/`uv lock`
+  run. A pre-commit guard (`_project/scripts/check_uv_lock_revision.py`, also
+  runnable via `make uv-lock-revision-check`) rejects such a downgrade — if it
+  fires, upgrade uv (`uv self update`) and regenerate the lock.
 - `git`
 
 ### Setting up the Development Environment

--- a/tests/unit/scripts/test_check_uv_lock_revision.py
+++ b/tests/unit/scripts/test_check_uv_lock_revision.py
@@ -1,0 +1,67 @@
+"""Tests for the uv.lock revision downgrade guard.
+
+The guard rejects a lockfile schema-revision DECREASE (an older local uv
+rewrites revision 3 back to 2 as a silent side effect); unchanged and
+increased revisions pass so legitimate lock updates need no ceremony.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+pytestmark = [
+    pytest.mark.unit,
+    pytest.mark.medium,
+]
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+
+
+def _load_script():
+    name = "check_uv_lock_revision_under_test"
+    path = REPO_ROOT / "_project" / "scripts" / "check_uv_lock_revision.py"
+    spec = importlib.util.spec_from_file_location(name, path)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+guard = _load_script()
+
+
+class TestRevisionComparison:
+    def test_downgrade_rejected(self, capsys):
+        assert guard.main(["--old", "3", "--new", "2"]) == 1
+        assert "DOWNGRADE" in capsys.readouterr().err
+
+    def test_unchanged_accepted(self):
+        assert guard.main(["--old", "3", "--new", "3"]) == 0
+
+    def test_upgrade_accepted(self):
+        assert guard.main(["--old", "3", "--new", "4"]) == 0
+
+    def test_old_and_new_must_travel_together(self):
+        with pytest.raises(SystemExit) as excinfo:
+            guard.main(["--old", "3"])
+        assert excinfo.value.code == 2
+
+
+class TestRevisionParsing:
+    def test_parses_committed_style_lock(self):
+        text = 'version = 1\nrevision = 3\nrequires-python = ">=3.10"\n'
+        assert guard.parse_revision(text, "uv.lock") == 3
+
+    def test_malformed_lock_reported(self):
+        with pytest.raises(ValueError, match="uv.lock"):
+            guard.parse_revision("no revision line here\n", "uv.lock")
+
+    def test_repo_lock_has_parseable_revision(self):
+        text = (REPO_ROOT / "uv.lock").read_text(encoding="utf-8")
+        assert guard.parse_revision(text, "uv.lock") >= 3


### PR DESCRIPTION
# Pull Request

## Description

An older local uv (< 0.8) silently rewrites the committed `revision = 3` lockfile back to revision 2 as a side effect of any `uv add`/`uv lock` run, and the downgrade rides along with the intended change. This adds `_project/scripts/check_uv_lock_revision.py` (stdlib-only): rejects a revision decrease, passes unchanged/increased revisions, with a `--old N --new N` test interface plus a default mode comparing `HEAD:uv.lock` against the working tree. Wired as a pre-commit hook gated on `uv.lock` changes and a `make uv-lock-revision-check` target; the contributor prerequisite (uv ≥ 0.8) is documented.

Successor to a dropped TODO whose only rung was the prose placeholder `<new guard invocation>`.

TODO: `uv-lock-revision-downgrade-guard-2`

## Type of Change

- [x] New feature

## Testing

- Ladder rung 1: guard exists, rejects 3→2, accepts 3→3 — exit 1 pre-fix (script absent), exit 0 now
- Ladder rung 2: wiring grep in `.pre-commit-config.yaml`/`Makefile` — exit 1 pre-fix, exit 0 now
- `uv run -- python -m pytest tests/unit/scripts/test_check_uv_lock_revision.py -q` → 7 passed (downgrade/unchanged/upgrade/arg-pairing/malformed/repo-lock-parseable)
- `make uv-lock-revision-check` on a clean tree → exit 0
- `ruff check` / `ruff format --check` clean; `.pre-commit-config.yaml` YAML-parses

## Public Contract Check

- [x] I updated `docs/reference/public-contracts.md`, or this PR does not change public, beta-public, deprecated, generated, experimental, or repo-only contract surfaces.
- [x] I checked result schema fields, MCP tool parameters, platform support status, wrapper facades, adapter subclassing hooks, and generated docs for contract-map impact.
- [x] Any platform/benchmark count claim in docs is generated/checked from registry metadata, or explicitly marked editorial/non-authoritative.

## Documentation

- [x] I updated the relevant user-facing docs. (`docs/development/development.md` prerequisites)
- [x] I added regression notes for behavior changes.
- [x] I confirmed API contract wording remains accurate.

## Code Quality

- [x] I ran formatting and lint/type checks.
- [x] I reviewed impacted modules for backwards compatibility and migration impact.
- [x] I added/updated tests for behavior changes and error paths.
- [x] I confirmed public contracts and release checklists are still valid.

## Artifact Hygiene

- [x] I did not commit raw screenshots, browser reports, generated logs, benchmark outputs, or temporary binary artifacts.
- [x] Any committed binary/raw evidence file has durable repo value and is justified here with its consumer and size: none.

## Notes

The pre-commit hook uses bare `python3` (stdlib-only script, no uv sync at commit time), matching the `explorer-tokens` hook pattern. Not wired into the pr.yml lint job to stay within scope and avoid the CI-local parity contract; pre-commit + the make target cover the authoring path where the downgrade originates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Krk2XGi6cWHTmG55tbQSXF

---
_Generated by [Claude Code](https://claude.ai/code/session_01Krk2XGi6cWHTmG55tbQSXF)_