### PR TITLE
feat(tracker): lint unresolvable scope globs and ladder file paths

### DIFF
--- a/_project/scripts/todo_db.py
+++ b/_project/scripts/todo_db.py
@@ -33,6 +33,7 @@ Deviations from the spec DDL (recorded in the spec):
 from __future__ import annotations
 
 import argparse
+import difflib
 import fnmatch
 import getpass
 import json
@@ -2129,6 +2130,114 @@ def _unrunnable_verifications(item: dict) -> list[tuple[int, str, str]]:
     return offenders
 
 
+# Scope globs and rung file arguments are authored against the working tree,
+# but nothing ever resolved them - a typo'd path (test_motherduck_adapter.py
+# for the real test_motherduck.py) lints clean and quietly makes the item's
+# work un-landable in scope. Resolution is deliberately state-aware and
+# conservative, calibrated against the live backlog:
+#   - OPEN items: only a nonexistent LITERAL that closely matches an existing
+#     sibling (a probable typo) is a finding. Wildcard globs are prospective
+#     allowlists - check-scope fnmatches them against future changed files,
+#     so "matches nothing today" is normal for planned outputs - and a plain
+#     nonexistent literal is a legal planned new file.
+#   - DONE/DROPPED items: anything that resolves to nothing is a finding;
+#     by completion the paths had their chance to exist.
+#   - Absolute paths are skipped: out-of-repo scopes are policy statements
+#     about other machines, not references into this tree.
+
+_PATHLIKE_TOKEN_RE = re.compile(
+    r"^(?:benchbox|tests|docs|scripts|_project|results-data|results-explorer|"
+    r"Makefile|pyproject\.toml|uv\.lock)(?:/|$)"
+)
+
+# 0.87 keeps real slips (test_todo_db_v3.py for test_todo_db_v2.py, 0.94) and
+# releases planned new files for genuinely new components
+# (test_ballista_adapter.py vs test_base_adapter.py, 0.86).
+_NEAR_MISS_CUTOFF = 0.87
+
+
+def _lint_repo_root() -> Path | None:
+    result = subprocess.run(["git", "rev-parse", "--show-toplevel"], capture_output=True, text=True, check=False)
+    if result.returncode != 0:
+        return None
+    return Path(result.stdout.strip())
+
+
+def _glob_resolves(root: Path, pattern: str) -> bool:
+    """Whether ``pattern`` (repo-relative; trailing-slash means directory)
+    matches anything in the working tree."""
+    try:
+        return next(iter(root.glob(pattern.rstrip("/"))), None) is not None
+    except (ValueError, OSError, NotImplementedError):
+        return False
+
+
+def _near_miss(root: Path, literal: str) -> str | None:
+    """An existing sibling whose name closely matches ``literal``'s, if any."""
+    target = root / literal
+    if not target.parent.is_dir():
+        return None
+    names = [entry.name for entry in target.parent.iterdir()]
+    close = difflib.get_close_matches(target.name, names, n=1, cutoff=_NEAR_MISS_CUTOFF)
+    if not close:
+        return None
+    return str(Path(literal).parent / close[0])
+
+
+def _unresolved_path_finding(root: Path, path: str, *, settled: bool) -> str | None:
+    """Why ``path`` failing to resolve is a finding, or None if it is legal."""
+    if Path(path).is_absolute() or path.startswith("~"):
+        return None
+    if settled:
+        return "names a path that resolves to nothing"
+    if any(ch in path for ch in "*?["):
+        return None  # prospective allowlist glob - legal while the item is open
+    close = _near_miss(root, path)
+    if close:
+        return f"names a nonexistent path suspiciously close to existing '{close}'"
+    return None
+
+
+def _unresolvable_scope_findings(item: dict) -> list[str]:
+    root = _lint_repo_root()
+    if root is None:
+        return []
+    settled = item["state"] in ("done", "dropped")
+    findings = []
+    for rule in item["scope"]:
+        pattern = rule["path_glob"]
+        if _glob_resolves(root, pattern):
+            continue
+        reason = _unresolved_path_finding(root, pattern, settled=settled)
+        if reason:
+            findings.append(f"scope {rule['kind']} {reason}: {pattern}")
+    return findings
+
+
+def _unresolvable_command_path_findings(item: dict) -> list[str]:
+    root = _lint_repo_root()
+    if root is None:
+        return []
+    settled = item["state"] in ("done", "dropped")
+    findings = []
+    for ver in item["verifications"]:
+        command = ver.get("command") or ""
+        if not command.strip() or _command_unrunnable_reason(command):
+            continue  # an unrunnable rung is already its own finding
+        for token in shlex.split(command):
+            # Strip pytest node-id suffixes and shell separators shlex leaves
+            # glued to the token ("tests/x.py;" in "cmd tests/x.py; next").
+            path_part = token.split("::", 1)[0].rstrip(";,)")
+            if "$" in token or "=" in token or not _PATHLIKE_TOKEN_RE.match(path_part):
+                continue
+            if _glob_resolves(root, path_part):
+                continue
+            reason = _unresolved_path_finding(root, path_part, settled=settled)
+            if reason:
+                findings.append(f"verification seq {ver['seq']} {reason}: {path_part}")
+    return findings
+
+
 def _unsatisfiable_verifications(item: dict) -> list[int]:
     """Return seqs of rungs whose command cannot express their expectation."""
     offenders = []
@@ -2151,6 +2260,8 @@ def lint_item(conn: sqlite3.Connection, item_id: str) -> list[str]:
         findings.append("verification steps exist but none has a runnable command")
     for seq, reason, command in _unrunnable_verifications(item):
         findings.append(f"verification seq {seq} command cannot execute ({reason}): {command}")
+    findings.extend(_unresolvable_scope_findings(item))
+    findings.extend(_unresolvable_command_path_findings(item))
     unsatisfiable = _unsatisfiable_verifications(item)
     if unsatisfiable:
         findings.append(

--- a/tests/unit/scripts/test_todo_db_v2.py
+++ b/tests/unit/scripts/test_todo_db_v2.py
@@ -412,6 +412,105 @@ class TestLintUnrunnableCommands:
         assert not any("cannot execute" in f for f in todo_db.lint_item(conn, "desc-only-item"))
 
 
+class TestLintUnresolvableScopeAndLadderPaths:
+    """Scope globs and rung file arguments must resolve against the working
+    tree — with planned-new-file literals staying legal on open items."""
+
+    def _mk_scoped(self, conn, item_id, scope=None, verifications=None):
+        todo_db.create_item(
+            conn,
+            "tester",
+            item_id=item_id,
+            title="Item exercising scope/path resolution",
+            worktree="spike",
+            priority="medium",
+            description="A description longer than ten characters.",
+            work=[{"id": "w1", "summary": "one unit of work"}],
+            scope=scope or [],
+            verifications=verifications or [],
+        )
+
+    def test_resolvable_glob_is_clean(self, conn):
+        self._mk_scoped(
+            conn,
+            "ok-scope",
+            scope=[("only_modify", "tests/unit/scripts/test_todo_db_v2.py"), ("only_modify", "_project/scripts/**")],
+        )
+        assert not any("matches nothing" in f or "does not exist" in f for f in todo_db.lint_item(conn, "ok-scope"))
+
+    def test_open_item_wildcard_glob_matching_nothing_is_legal(self, conn):
+        # A prospective allowlist for planned outputs: check-scope fnmatches
+        # it against future changed files, so emptiness today is normal.
+        self._mk_scoped(conn, "prospective-glob", scope=[("only_modify", "_project/decisions/planned-out-*.md")])
+        findings = todo_db.lint_item(conn, "prospective-glob")
+        assert not any("planned-out" in f for f in findings)
+
+    def test_settled_item_unresolvable_paths_are_flagged(self):
+        item = {
+            "state": "done",
+            "scope": [
+                {"kind": "only_modify", "path_glob": "tests/no-such-dir/**"},
+                {"kind": "only_modify", "path_glob": "tests/unit/scripts/test_never_materialized.py"},
+            ],
+            "verifications": [
+                {"seq": 1, "command": "uv run -- python -m pytest tests/unit/scripts/test_never_materialized.py -q"}
+            ],
+        }
+        scope_findings = todo_db._unresolvable_scope_findings(item)
+        assert any("resolves to nothing" in f and "tests/no-such-dir/**" in f for f in scope_findings)
+        assert any("test_never_materialized" in f for f in scope_findings)
+        command_findings = todo_db._unresolvable_command_path_findings(item)
+        assert any("resolves to nothing" in f and "test_never_materialized" in f for f in command_findings)
+
+    def test_absolute_paths_are_skipped_even_when_settled(self):
+        item = {
+            "state": "done",
+            "scope": [{"kind": "do_not_modify", "path_glob": "/Users/someone/.claude/projects/**"}],
+            "verifications": [],
+        }
+        assert todo_db._unresolvable_scope_findings(item) == []
+
+    def test_planned_new_file_literal_stays_legal_on_open_item(self, conn):
+        self._mk_scoped(conn, "planned-file", scope=[("only_modify", "tests/unit/scripts/test_zq_upcoming_widget.py")])
+        findings = todo_db.lint_item(conn, "planned-file")
+        assert not any("test_zq_upcoming_widget" in f for f in findings)
+
+    def test_near_miss_literal_is_flagged_on_open_item(self, conn):
+        self._mk_scoped(conn, "typo-file", scope=[("only_modify", "tests/unit/scripts/test_todo_db_v3.py")])
+        findings = todo_db.lint_item(conn, "typo-file")
+        assert any("suspiciously close" in f and "test_todo_db_v3.py" in f for f in findings)
+
+    def test_command_path_argument_is_resolved(self, conn):
+        self._mk_scoped(
+            conn,
+            "bad-cmd-path",
+            verifications=[
+                {
+                    "description": "rung",
+                    "command": "uv run -- python -m pytest tests/unit/scripts/test_todo_db_v9000.py -q",
+                    "expected": "whatever",
+                }
+            ],
+        )
+        findings = todo_db.lint_item(conn, "bad-cmd-path")
+        assert any("suspiciously close" in f and "test_todo_db_v9000.py" in f for f in findings)
+
+    def test_command_path_with_pytest_node_id_resolves_file_part(self, conn):
+        self._mk_scoped(
+            conn,
+            "node-id-cmd",
+            verifications=[
+                {
+                    "description": "rung",
+                    "command": "uv run -- python -m pytest tests/unit/scripts/test_todo_db_v2.py::TestLintUnresolvableScopeAndLadderPaths -q",
+                    "expected": "whatever",
+                }
+            ],
+        )
+        findings = todo_db.lint_item(conn, "node-id-cmd")
+        assert not any("test_todo_db_v2" in f for f in findings)
+
+
 class TestInstructiveGateErrors:
     """Every gate refusal must name its recovery command — the error messages
     are the harness-portable instruction layer."""


### PR DESCRIPTION
# Pull Request

## Description

Scope globs and rung file arguments were never resolved against the working tree, so a typo'd path (`tests/unit/platforms/test_motherduck_adapter.py` for the real `test_motherduck.py`, on a done item) linted clean while quietly making the item's work un-landable in scope. `todo lint` now resolves both.

Resolution is state-aware and calibrated against the live backlog:
- **done/dropped items**: anything that resolves to nothing is a finding — the paths had their chance to exist
- **open items**: only a nonexistent literal suspiciously close to an existing sibling (difflib cutoff 0.87) is a finding; planned new files and prospective wildcard allowlists (which `check-scope` fnmatches against *future* changed files) stay legal
- absolute out-of-repo paths are skipped; command tokens strip pytest node-ids and glued shell separators

TODO: `todo-lint-unresolvable-scope-and-ladder-paths-2`

## Type of Change

- [x] New feature

## Testing

- Ladder rung 1 against the hosted DB flipped from exit 1 to exit 0 — the motivating done item now reports the bad path on both its scope rule and its rung command
- Calibration measured, not guessed: naive rules produced **65 findings** on the open hosted backlog (planned adapter test files, decision-file globs, out-of-repo scopes); the shipped rules produce **0 false positives** there
- `uv run -- python -m pytest tests/unit/scripts/test_todo_db_v2.py -q` → 59 passed (new `TestLintUnresolvableScopeAndLadderPaths`: resolvable clean, prospective glob legal, planned file legal, near-miss flagged, settled-state flagged, node-id handling, absolute-path skip)
- `ruff check` / `ruff format --check` clean

## Public Contract Check

- [x] I updated `docs/reference/public-contracts.md`, or this PR does not change public, beta-public, deprecated, generated, experimental, or repo-only contract surfaces.
- [x] I checked result schema fields, MCP tool parameters, platform support status, wrapper facades, adapter subclassing hooks, and generated docs for contract-map impact.
- [x] Any platform/benchmark count claim in docs is generated/checked from registry metadata, or explicitly marked editorial/non-authoritative.

## Documentation

- [x] I updated the relevant user-facing docs. (Internal tracker tooling; rationale documented at the definition site.)
- [x] I added regression notes for behavior changes.
- [x] I confirmed API contract wording remains accurate.

## Code Quality

- [x] I ran formatting and lint/type checks.
- [x] I reviewed impacted modules for backwards compatibility and migration impact.
- [x] I added/updated tests for behavior changes and error paths.
- [x] I confirmed public contracts and release checklists are still valid.

## Artifact Hygiene

- [x] I did not commit raw screenshots, browser reports, generated logs, benchmark outputs, or temporary binary artifacts.
- [x] Any committed binary/raw evidence file has durable repo value and is justified here with its consumer and size: none.

## Notes

One known transient: a done item whose rung references a file merged by a *parallel* PR can be flagged until both are on the same tree; default `lint`/`lint --all` covers planning/active items only, so this appears only in explicit done-item lints.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Krk2XGi6cWHTmG55tbQSXF

---
_Generated by [Claude Code](https://claude.ai/code/session_01Krk2XGi6cWHTmG55tbQSXF)_