### PR TITLE
fix(results): redact api_key and account_key on both export layers

### DIFF
--- a/benchbox/core/results/platform_options.py
+++ b/benchbox/core/results/platform_options.py
@@ -35,6 +35,13 @@ _SECRET_KEY_PARTS = tuple(
         "session_token",
         "connection_string",
         "credential",
+        # Found by the 2026-07-31 sentinel sweep leaking through BOTH layers:
+        # api_key/onehouse_api_key (quanton's only credential) and Azure's
+        # storage_account_key matched none of the parts above. Deliberately
+        # narrow - a bare "key" part would redact sort_key/partition_key-class
+        # data-modelling options.
+        "api_key",
+        "account_key",
     )
 )
 # Connection usernames are identity, not secrets, so they are NOT in

--- a/tests/unit/core/results/test_anonymization.py
+++ b/tests/unit/core/results/test_anonymization.py
@@ -765,3 +765,28 @@ class TestPublicPayloadSecretKeys:
 
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])
+
+
+class TestPublicPayloadApiKeyAndAccountKey:
+    """The shared secret list must cover api_key/*_account_key on the public
+    path too — these leaked through anonymize_result_payload verbatim."""
+
+    def test_api_key_and_storage_account_key_are_redacted(self):
+        manager = AnonymizationManager()
+        out = json.dumps(
+            manager.anonymize_result_payload(
+                {
+                    "platform_metadata": {
+                        "platform_raw_config": {
+                            "api_key": "APIKEY-SENTINEL",
+                            "onehouse_api_key": "OH-SENTINEL",
+                            "storage_account_key": "AZKEY-SENTINEL",
+                        }
+                    }
+                }
+            ),
+            default=str,
+        )
+        assert "APIKEY-SENTINEL" not in out
+        assert "OH-SENTINEL" not in out
+        assert "AZKEY-SENTINEL" not in out

--- a/tests/unit/core/results/test_platform_options_capture.py
+++ b/tests/unit/core/results/test_platform_options_capture.py
@@ -443,3 +443,37 @@ class TestUsernameRedactionInternalPath:
         result = sanitize_platform_options({"connection": {"username": "alice-sentinel", "host": "db.internal"}})
         assert result["connection"]["username"] == REDACTED_VALUE
         assert result["connection"]["host"] == "db.internal"
+
+
+class TestApiKeyAndAccountKeyRedaction:
+    """api_key and *_account_key are credentials and must never export
+    verbatim (2026-07-31 sentinel-sweep finding: they leaked through both
+    the internal and the public layer)."""
+
+    def test_api_key_variants_are_redacted(self):
+        from benchbox.core.results.platform_options import sanitize_platform_options
+
+        result = sanitize_platform_options(
+            {"api_key": "APIKEY-SENTINEL", "onehouse_api_key": "OH-SENTINEL", "apiKey": "CAMEL-SENTINEL"}
+        )
+        assert result["api_key"] == REDACTED_VALUE
+        assert result["onehouse_api_key"] == REDACTED_VALUE
+        assert result["apiKey"] == REDACTED_VALUE
+
+    def test_storage_account_key_is_redacted(self):
+        from benchbox.core.results.platform_options import sanitize_platform_options
+
+        assert sanitize_platform_options({"storage_account_key": "AZKEY-SENTINEL"})["storage_account_key"] == (
+            REDACTED_VALUE
+        )
+
+    def test_data_modelling_keys_still_export(self):
+        from benchbox.core.results.platform_options import sanitize_platform_options
+
+        result = sanitize_platform_options(
+            {"sort_key": "l_shipdate", "partition_key": "l_orderkey", "primary_key": "id", "account": "acct-1"}
+        )
+        assert result["sort_key"] == "l_shipdate"
+        assert result["partition_key"] == "l_orderkey"
+        assert result["primary_key"] == "id"
+        assert result["account"] == "acct-1"


### PR DESCRIPTION
# Pull Request

## Description

The 2026-07-31 phase-1 sentinel sweep (construct every registered adapter with sentinel credentials, drive the real export entry points) found `api_key`/`onehouse_api_key` — quanton's **only** credential — and Azure's `storage_account_key` exported **verbatim by both layers**: `sanitize_platform_options` (internal bundles) and `anonymize_result_payload` (the default public export). Neither key matched any part of the secret-key list. With the list now shared (#1379), this is a single edit covering both consumers: add `api_key` and `account_key` parts. Deliberately narrow — a bare `key` part would redact `sort_key`/`partition_key`-class data-modelling options, which tests now pin.

Unlike the `keyid` gap (masked upstream on the standard path), these keys had **no upstream mask** — this was the one live end-to-end public credential leak found in the review.

TODO: `public-export-misses-api-key-and-storage-account-key`

## Type of Change

- [x] Bug fix

## Testing

- Ladder rungs 1+2 (public + internal sentinel probes): exit 1 pre-fix (re-validated on merged develop), exit 0 post-fix
- `uv run -- python -m pytest tests/unit/core/results -q` → 786 passed, 4 skipped
- New tests: `api_key` variants (camelCase, `onehouse_` prefix), `storage_account_key`, over-redaction guards (`sort_key`, `partition_key`, `primary_key`, `account` untouched)
- `ruff check` / `ruff format --check` clean

## Public Contract Check

- [x] I updated `docs/reference/public-contracts.md`, or this PR does not change public, beta-public, deprecated, generated, experimental, or repo-only contract surfaces. (Redaction strictly widens.)
- [x] I checked result schema fields, MCP tool parameters, platform support status, wrapper facades, adapter subclassing hooks, and generated docs for contract-map impact.
- [x] Any platform/benchmark count claim in docs is generated/checked from registry metadata, or explicitly marked editorial/non-authoritative.

## Documentation

- [x] I updated the relevant user-facing docs. (Rationale at the definition site.)
- [x] I added regression notes for behavior changes.
- [x] I confirmed API contract wording remains accurate.

## Code Quality

- [x] I ran formatting and lint/type checks.
- [x] I reviewed impacted modules for backwards compatibility and migration impact.
- [x] I added/updated tests for behavior changes and error paths.
- [x] I confirmed public contracts and release checklists are still valid.

## Artifact Hygiene

- [x] I did not commit raw screenshots, browser reports, generated logs, benchmark outputs, or temporary binary artifacts.
- [x] Any committed binary/raw evidence file has durable repo value and is justified here with its consumer and size: none.

## Notes

Sibling findings from the same sweep are tracked separately: `databend-dsn-password-exported-verbatim-in-result-metadata`, `public-export-pg-user-and-tenant-id-bypass-pseudonymization`, and five more egress items logged 2026-07-31.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Krk2XGi6cWHTmG55tbQSXF

---
_Generated by [Claude Code](https://claude.ai/code/session_01Krk2XGi6cWHTmG55tbQSXF)_