### PR TITLE
feat(tracker): lint claim-level quality — falsifiable ladders and test-file scope completeness

### DIFF
--- a/_project/scripts/todo_db.py
+++ b/_project/scripts/todo_db.py
@@ -262,6 +262,17 @@ def default_actor() -> str:
 CONFIG_KEYS: dict[str, tuple[str, ...]] = {
     "lint.require_w0_revalidation": ("on", "off"),
     "lint.require_scope_rules": ("on", "off"),
+    # Claim-level checks (falsifiable ladder, test-file scope completeness)
+    # default OFF: they judge authoring conventions, so a database opts in
+    # explicitly (the shared BenchBox DB does) instead of every fresh/test
+    # database inheriting them.
+    "lint.require_falsifiable_rung": ("on", "off"),
+    "lint.require_scope_test_files": ("on", "off"),
+}
+
+_CONFIG_DEFAULTS: dict[str, str] = {
+    "lint.require_falsifiable_rung": "off",
+    "lint.require_scope_test_files": "off",
 }
 
 
@@ -356,7 +367,7 @@ def get_config(conn: sqlite3.Connection, key: str) -> str:
     if key not in CONFIG_KEYS:
         raise TodoError(f"unknown config key {key!r}; known: {', '.join(sorted(CONFIG_KEYS))}")
     row = conn.execute("SELECT value FROM meta WHERE key = ?", (key,)).fetchone()
-    return row["value"] if row else "on"
+    return row["value"] if row else _CONFIG_DEFAULTS.get(key, "on")
 
 
 def set_config(conn: sqlite3.Connection, actor: str, key: str, value: str) -> None:
@@ -2238,6 +2249,85 @@ def _unresolvable_command_path_findings(item: dict) -> list[str]:
     return findings
 
 
+# Falsifiability: a ladder in which every rung passes on the unfixed tree can
+# "verify" work that was never done - the audit that motivated this found five
+# open items whose rungs were green pre-fix. Lint cannot run rung commands, so
+# the check is declarative: at least one rung must DECLARE unfixed-tree
+# failure in its expected text ("exits 1 on an unfixed tree", "fails today",
+# "removed once the table is re-measured", ...), and a rung that cannot
+# execute never counts - a broken rung exits non-zero everywhere, which is
+# exactly the vacuous satisfaction this check exists to reject. Items in
+# observational categories (flake tripwires) are exempt: their rungs watch
+# for recurrence and legitimately pass until it happens.
+
+_GATING_EXPECTED_RE = re.compile(
+    r"unfixed|must fail|pre-?fix|before the fix|fail(?:s|ed|ing)? (?:on|when|while|as)|"
+    r"exits? [1-9]\d* (?:today|on|when|until)|today|\bonce\b|\buntil\b",
+    re.IGNORECASE,
+)
+
+# flake = tripwires that legitimately pass until a recurrence; validation =
+# confirmation runs whose rungs describe acceptance, not a defect gate.
+_FALSIFIABILITY_EXEMPT_CATEGORIES = frozenset({"flake", "validation"})
+
+
+def _has_falsifiable_rung(item: dict) -> bool:
+    unrunnable = {seq for seq, _reason, _command in _unrunnable_verifications(item)}
+    for ver in item["verifications"]:
+        if not (ver.get("command") or "").strip():
+            continue
+        if ver["seq"] in unrunnable:
+            continue
+        if _GATING_EXPECTED_RE.search(ver.get("expected") or ""):
+            return True
+    return False
+
+
+# Scope completeness: work that promises tests cannot land when only_modify
+# names a source file but omits that file's existing tests. The conventional
+# family is tests/unit/<subpath>/test_<name>*.py - the wildcard admits split
+# suites (test_todo_db.py, test_todo_db_v2.py, ...); scope is complete when
+# it covers ANY existing member. Only EXISTING test files are demanded - a
+# module without tests today stays createable.
+
+_SOURCE_SCOPE_RE = re.compile(r"^(benchbox/(?:[\w./-]+/)?|_project/scripts/)(\w+)\.py$")
+
+
+def _conventional_test_family(source_path: str) -> tuple[str, str] | None:
+    """(test directory, filename glob) for ``source_path``, or None."""
+    match = _SOURCE_SCOPE_RE.match(source_path)
+    if not match:
+        return None
+    prefix, stem = match.groups()
+    if prefix.startswith("_project/scripts"):
+        return "tests/unit/scripts", f"test_{stem}*.py"
+    subpath = prefix[len("benchbox/") :].rstrip("/")
+    return (f"tests/unit/{subpath}" if subpath else "tests/unit"), f"test_{stem}*.py"
+
+
+def _missing_scope_test_files(item: dict) -> list[str]:
+    root = _lint_repo_root()
+    if root is None:
+        return []
+    only = [rule["path_glob"] for rule in item["scope"] if rule["kind"] == "only_modify"]
+    findings = []
+    for pattern in only:
+        family = _conventional_test_family(pattern)
+        if family is None:
+            continue
+        test_dir, name_glob = family
+        existing = sorted(str(Path(test_dir) / p.name) for p in (root / test_dir).glob(name_glob))
+        if not existing:
+            continue
+        if any(_scope_glob_matches(test_path, glob) for test_path in existing for glob in only):
+            continue
+        findings.append(
+            f"scope completeness: only_modify names {pattern} but omits its existing test file(s) "
+            f"({', '.join(existing[:3])})"
+        )
+    return findings
+
+
 def _unsatisfiable_verifications(item: dict) -> list[int]:
     """Return seqs of rungs whose command cannot express their expectation."""
     offenders = []
@@ -2279,6 +2369,20 @@ def lint_item(conn: sqlite3.Connection, item_id: str) -> list[str]:
         findings.append("description cites point-in-time evidence but has no w0 re-validation unit")
     if not item["work"] and item["state"] in ("planning", "active"):
         findings.append("no work breakdown")
+    if (
+        get_config(conn, "lint.require_falsifiable_rung") == "on"
+        and item["state"] in ("planning", "active")
+        and (item.get("category") or "") not in _FALSIFIABILITY_EXEMPT_CATEGORIES
+        and any((v.get("command") or "").strip() for v in item["verifications"])
+        and not _has_falsifiable_rung(item)
+    ):
+        findings.append(
+            "no falsifiability: every rung's expected text reads as passing on the unfixed tree "
+            "(an unrunnable rung does not count) - at least one rung must fail while the defect "
+            "exists, e.g. 'exits 1 on an unfixed tree'"
+        )
+    if get_config(conn, "lint.require_scope_test_files") == "on" and item["state"] in ("planning", "active"):
+        findings.extend(_missing_scope_test_files(item))
     return findings
 
 

--- a/tests/unit/scripts/test_todo_db_v2.py
+++ b/tests/unit/scripts/test_todo_db_v2.py
@@ -511,6 +511,114 @@ class TestLintUnresolvableScopeAndLadderPaths:
         assert not any("test_todo_db_v2" in f for f in findings)
 
 
+class TestLintFalsifiabilityAndScopeCompleteness:
+    """A ladder must contain at least one rung that FAILS on the unfixed tree
+    (declared in its expected text), and only_modify must not orphan a source
+    file's existing test file."""
+
+    def _mk_item(self, conn, item_id, verifications=None, scope=None, category=None):
+        # Claim-level checks are per-database opt-in (the shared DB turns them
+        # on); enable them here so the tests exercise the checks.
+        todo_db.set_config(conn, "tester", "lint.require_falsifiable_rung", "on")
+        todo_db.set_config(conn, "tester", "lint.require_scope_test_files", "on")
+        todo_db.create_item(
+            conn,
+            "tester",
+            item_id=item_id,
+            title="Item exercising claim-level lint",
+            worktree="spike",
+            priority="medium",
+            description="A description longer than ten characters.",
+            category=category,
+            work=[{"id": "w1", "summary": "one unit of work"}],
+            scope=scope or [],
+            verifications=verifications or [],
+        )
+
+    def test_falsifiability_flags_pass_only_ladder(self, conn):
+        self._mk_item(
+            conn,
+            "pass-only",
+            verifications=[
+                {"description": "suite green", "command": "uv run -- pytest tests -q", "expected": "all pass"}
+            ],
+        )
+        assert any("falsifiability" in f for f in todo_db.lint_item(conn, "pass-only"))
+
+    def test_falsifiability_accepts_a_gating_rung(self, conn):
+        self._mk_item(
+            conn,
+            "gated",
+            verifications=[
+                {
+                    "description": "defect gate",
+                    "command": "uv run -- python -c 'raise SystemExit(1)'",
+                    "expected": "exits 1 on an unfixed tree, 0 once fixed",
+                },
+                {"description": "suite green", "command": "uv run -- pytest tests -q", "expected": "all pass"},
+            ],
+        )
+        assert not any("falsifiability" in f for f in todo_db.lint_item(conn, "gated"))
+
+    def test_falsifiability_broken_rung_does_not_vacuously_satisfy(self, conn):
+        # The only rung declaring unfixed-tree failure cannot execute; it exits
+        # non-zero on EVERY tree, so it must not count as the gating rung.
+        self._mk_item(
+            conn,
+            "broken-gate",
+            verifications=[
+                {
+                    "description": "defect gate",
+                    "command": "<run the real check here>",
+                    "expected": "exits 1 on an unfixed tree",
+                }
+            ],
+        )
+        findings = todo_db.lint_item(conn, "broken-gate")
+        assert any("falsifiability" in f for f in findings)
+        assert any("cannot execute" in f for f in findings)
+
+    def test_falsifiability_exempts_flake_tripwires(self, conn):
+        self._mk_item(
+            conn,
+            "flake-watch",
+            category="flake",
+            verifications=[
+                {"description": "still green", "command": "uv run -- pytest tests -q", "expected": "passes"}
+            ],
+        )
+        assert not any("falsifiability" in f for f in todo_db.lint_item(conn, "flake-watch"))
+
+    def test_scope_completeness_flags_omitted_existing_test_file(self, conn):
+        self._mk_item(
+            conn,
+            "orphan-scope",
+            scope=[("only_modify", "benchbox/core/results/anonymization.py")],
+        )
+        findings = todo_db.lint_item(conn, "orphan-scope")
+        assert any("scope completeness" in f and "tests/unit/core/results/test_anonymization.py" in f for f in findings)
+
+    def test_scope_completeness_satisfied_by_covering_glob(self, conn):
+        self._mk_item(
+            conn,
+            "covered-scope",
+            scope=[
+                ("only_modify", "_project/scripts/todo_db.py"),
+                ("only_modify", "tests/unit/scripts/test_todo_db.py"),
+                ("only_modify", "tests/unit/scripts/test_todo_db_*.py"),
+            ],
+        )
+        assert not any("scope completeness" in f for f in todo_db.lint_item(conn, "covered-scope"))
+
+    def test_scope_completeness_ignores_sources_without_existing_tests(self, conn):
+        self._mk_item(
+            conn,
+            "no-test-yet",
+            scope=[("only_modify", "benchbox/core/results/no_such_module.py")],
+        )
+        assert not any("scope completeness" in f for f in todo_db.lint_item(conn, "no-test-yet"))
+
+
 class TestInstructiveGateErrors:
     """Every gate refusal must name its recovery command — the error messages
     are the harness-portable instruction layer."""


### PR DESCRIPTION
# Pull Request

## Description

Two claim-level lint checks, closing out the tracker-lint trilogy (#1378 unrunnable commands, #1383 unresolvable paths):

- **Falsifiability**: an item whose every rung reads as passing on the unfixed tree can "verify" work that was never done — the 2026-07-31 audit found five open items in exactly that state. Lint now requires at least one *runnable* rung whose expected text declares unfixed-tree failure; an unrunnable rung never counts, so a broken placeholder cannot vacuously satisfy the check (the vacuous-satisfaction trap is pinned by a dedicated test). Flake tripwires and validation confirmation runs are exempt by category.
- **Scope completeness**: `only_modify` naming a source file while omitting its existing conventional test family (`tests/unit/<subpath>/test_<stem>*.py`) makes the item's promised tests un-landable in scope. Flagged only when family members actually exist; the wildcard admits split suites (`test_todo_db.py` / `test_todo_db_v2.py`).

Both are per-database config keys (`lint.require_falsifiable_rung`, `lint.require_scope_test_files`) that **default off** in code — existing lint findings and test fixtures are untouched — and are now turned **on** in the shared hosted DB via `todo config`.

TODO: `todo-lint-rung-falsifiability-and-scope-completeness-2` (dep `todo-lint-unrunnable-verification-commands-2` merged as #1378)

## Type of Change

- [x] New feature

## Testing

- Ladder rung 1 (`lint_item` implements a falsifiability check): exit 1 pre-fix, exit 0 now
- Ladder rung 2 (`pytest -k 'falsifiability or scope_completeness'`): exit 5 pre-fix (no tests collected), 7 passed now
- Full suites: `test_todo_db_v2.py` + `test_todo_db.py` + `test_todo_db_hardening.py` + `test_todo_wrapper.py` → 177 passed
- With the checks ON against the hosted DB: the 19 open items from the 2026-07-31 audit set lint at 0 findings; the wider legacy backlog surfaces ~137 falsifiability + 15 scope-completeness warn findings (genuine pass-only ladders — the check working; maintainer opt-out is one `todo config` command)
- `ruff check` / `ruff format --check` clean

## Public Contract Check

- [x] I updated `docs/reference/public-contracts.md`, or this PR does not change public, beta-public, deprecated, generated, experimental, or repo-only contract surfaces.
- [x] I checked result schema fields, MCP tool parameters, platform support status, wrapper facades, adapter subclassing hooks, and generated docs for contract-map impact.
- [x] Any platform/benchmark count claim in docs is generated/checked from registry metadata, or explicitly marked editorial/non-authoritative.

## Documentation

- [x] I updated the relevant user-facing docs. (Behavior documented in the finding text and at the definition sites; config keys self-describe via `todo config`.)
- [x] I added regression notes for behavior changes.
- [x] I confirmed API contract wording remains accurate.

## Code Quality

- [x] I ran formatting and lint/type checks.
- [x] I reviewed impacted modules for backwards compatibility and migration impact.
- [x] I added/updated tests for behavior changes and error paths.
- [x] I confirmed public contracts and release checklists are still valid.

## Artifact Hygiene

- [x] I did not commit raw screenshots, browser reports, generated logs, benchmark outputs, or temporary binary artifacts.
- [x] Any committed binary/raw evidence file has durable repo value and is justified here with its consumer and size: none.

## Notes

Default-off in code was a deliberate choice: two existing test fixtures (out of this item's scope) pin `lint_item == []` on gate-less rungs, and convention checks judging authoring style should be a database's opt-in, mirroring how a fresh tracker shouldn't inherit BenchBox's conventions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Krk2XGi6cWHTmG55tbQSXF

---
_Generated by [Claude Code](https://claude.ai/code/session_01Krk2XGi6cWHTmG55tbQSXF)_