### PR TITLE
fix(tracker): make the write freeze fail closed and cover migrate

### DIFF
--- a/_project/decisions/todo-db-cutover-write-freeze-2026-08-01.md
+++ b/_project/decisions/todo-db-cutover-write-freeze-2026-08-01.md
@@ -1,0 +1,165 @@
+# Hosted tracker cutover: write freeze, quiescence, and rollback
+
+**Date**: 2026-08-01
+**Status**: decisions D1–D6 recorded; **cutover NOT authorized** (see "Current
+verdict"). Supersedes the claim-check precondition on
+`migrate-hosted-tracker-db-to-todo-db-0-3-schema`.
+**Related**: PR #1377 (freeze landed), PR #1386 (freeze hardening),
+`todo-cli-schema-bump-must-ship-with-db-migration-v2`.
+
+## Context
+
+`migrate-hosted-tracker-db-to-todo-db-0-3-schema` restores the hosted
+`benchbox-todo` database from a snapshot using `restore-legacy --replace`. That
+rebuilds every table. **Any write landing between snapshot and restore is
+destroyed silently**, and the destruction is invisible afterwards because the
+audit chain is rehashed from the same snapshot it was rebuilt from — a corrupted
+cutover still verifies.
+
+The original precondition was a **claim check**: refuse the restore while another
+actor holds a live claim. That is not a gate. Claims cover
+`claim`/`start`/`done`/`complete` on *existing* items; `create`, `defer`,
+`promote`, `block`, `drop` and every config write take no claim at all. On
+2026-08-01 the tracker took 21 unclaimed `create`/`drop` events from a single
+actor in under four minutes. A claim check would have permitted the restore
+throughout.
+
+PR #1377 replaced it with a **leased write freeze**: `todo freeze` refuses every
+mutating command from any other actor, reads are untouched, the holder keeps
+writing so it can run the cutover and lift its own freeze, and the lease expires
+on its own so a holder that dies mid-cutover cannot wedge the tracker.
+
+## Decisions
+
+| ID | Decision | Choice | Reason |
+|---|---|---|---|
+| D1 | What gates the destructive restore | The **leased write freeze**, never a claim check. | Claims do not cover unclaimed writes, which are the majority of tracker mutation. Empirically the dominant write mode. |
+| D2 | Enforce the freeze by bumping `SCHEMA_VERSION` so stale clones hard-fail? | **No.** `SCHEMA_VERSION` stays 4; the freeze remains **advisory** against clones running a pre-#1377 CLI. | See "D2 rationale" below. This is the change's known, accepted weakness. |
+| D3 | Consequence of D2 for the runbook | The freeze is **necessary but not sufficient**. The runbook MUST pair it with independently verified quiescence. Neither gate alone authorizes the restore. | A stale clone writes straight through a live freeze. Quiescence alone was never a gate. Both, together, or not at all. |
+| D4 | How quiescence is measured | The `stats["events"]` fingerprint (`count`, `last_seq`, `latest`) compared across a window, by a probe that **fails when it cannot read the fingerprint**. | The previous probe shelled out to `todo stats --json`, which does not exist; it compared two empty strings and passed unconditionally. See "The vacuous rung". |
+| D5 | Freeze TTL bounds | Finite, positive, `<= MAX_FREEZE_TTL_HOURS` (168h); default 2h. Malformed/torn freeze state reads as **live** (fails closed); `freeze` itself stays exempt from the gate so a torn freeze is always liftable. | A freeze is a maintenance window, not a standing state. A safety gate whose degraded state is "unlocked" is the wrong default; one that cannot be lifted is the other wrong default. Both were real defects (PR #1386). |
+| D6 | Rollback storage | A durable local backup **outside** the repo (`~/todo-db-backups/`) plus a 17-table snapshot, both taken immediately before the restore and retained until an audit verify passes against the hosted DB post-cutover. | The prior attempt ran in an ephemeral container that restarted mid-session. Ephemeral disk is not a rollback path. |
+
+### D2 rationale — why `SCHEMA_VERSION` is not bumped
+
+Enforcement lives only in the new `main()`. A session running a pre-#1377
+`todo_db.py` has no gate and writes through a live freeze. Bumping
+`SCHEMA_VERSION` would force those clones to upgrade — genuine enforcement —
+but the cost is disqualifying:
+
+- The version check runs **before every subcommand, including read-only ones**.
+  A bump makes `list`/`stats`/`show` fail for every session until someone runs
+  `todo migrate` manually. This is not hypothetical: PR #1347 did exactly this
+  on 2026-07-30 and caused a **total tracker outage**, which is why
+  `todo-cli-schema-bump-must-ship-with-db-migration-v2` exists.
+- The coercion is permanent and borne by every session forever, to close a
+  transient ~2h window that occurs once.
+- It interacts badly with the freeze itself. Since PR #1386, `migrate` is gated
+  by the freeze. A bump landing during a cutover would leave a stale session
+  unable to read (schema mismatch) *and* unable to migrate (frozen) until the
+  holder lifts the freeze. Correct, but a hard lockout.
+
+**Accepted residual risk**: a stale clone can corrupt a cutover. D3 is the
+mitigation — quiescence is verified independently, so a stale writer is
+*detected* even though it is not *blocked*. If enforcement is ever wanted, the
+right vehicle is `-v2`'s "graceful read-only degradation" option (reads keep
+working across a version gap, writes refuse), not a bare bump.
+
+### The vacuous rung
+
+Rung 1 of the freeze item's verification ladder read:
+
+```
+g=lambda: subprocess.run(['_project/scripts/todo','stats','--json'],
+                         capture_output=True, text=True).stdout
+a=g(); time.sleep(60); sys.exit(0 if a==g() else 1)
+```
+
+`todo stats` has no `--json` flag. Both calls exit 2 with empty stdout, `"" ==
+""`, and the rung passes **unconditionally**. Executed verbatim against
+production on 2026-08-01 it exited 0 ("no writer is active") while the event
+count moved **4534 → 4538 during the very 60 seconds it was measuring**.
+
+`stats["events"]` (added by #1377) makes a correct probe writable. Rung text is
+create-time-only, so the replacement ships on a successor item.
+
+## Cutover runbook
+
+Each step is a gate. A failure at any step aborts; do not continue and do not
+"verify by success message".
+
+1. **Preconditions.** `todo-db >= 0.3` CLI reachable and at `origin/main`.
+   Durable backup dir exists outside the repo. No other session active.
+2. **Backup.** `~/todo-db-backups/benchbox-todo-<UTC>.db` **plus**
+   `todo export --snapshot <file>` outside the repo.
+3. **Assert the snapshot is complete.** Per-table row counts, not a success
+   message: **17 tables**, `findings=65`, `finding_sections=8`,
+   `finding_links=36`. A 12-table snapshot with `findings=0` is the known silent
+   failure — the findings tables are deliberately excluded from
+   `TRANSFER_TABLES` and `EXPORT_TABLE_ALLOWLIST`, so any path iterating those
+   constants moves zero findings rows **and reports success**.
+4. **Freeze.** `todo freeze --reason "0.3 cutover" --ttl 2`. Confirm
+   `freeze --status` shows you as holder.
+5. **Verify quiescence independently (D3/D4).** Compare the `events` fingerprint
+   across a window with a probe that fails on unreadable output. The freeze does
+   not substitute for this; a stale clone is invisible to it.
+6. **Rehearse** into a scratch SQLite DB **seeded from the real snapshot**, never
+   an empty one — an empty target hides PK-collision bugs (this is exactly how
+   the `finding_events.seq=1` collision reached production). Use a dedicated
+   `TODO_DB_REPLICA`.
+7. **Verify the rehearsal by counting rows per table**, not by trusting
+   `restored legacy snapshot`. A prior attempt printed success, returned a valid
+   4,187-event chain, and had `finding_sections` empty.
+8. **Re-verify quiescence** (step 5 again). The window between rehearsal and the
+   hosted run is itself exposure.
+9. **Hosted restore.**
+10. **Sync or reopen before verifying anything you just wrote.** Hosted reads go
+    through an embedded replica; a connection opened earlier sees stale data.
+    This produced a false `PARITY FAILED` on a fully correct import.
+11. **Post-cutover verify**: per-table counts again, audit verify, `todo stats`.
+12. **Credential rotation** (below).
+13. **Lift the freeze**; retain backup + snapshot until step 11 has passed.
+
+### Credential change: `TODO_DB_RO_AUTH_TOKEN`
+
+`.github/workflows/todo-db-export.yml` reads the hosted DB with a **read-only**
+token supplied as the repo secret `TODO_DB_RO_AUTH_TOKEN`. If the cutover
+replaces or re-creates the database, that token stops resolving and the nightly
+export silently loses its source. Re-mint the read-only token against the
+post-cutover database and update the GitHub secret **as part of the cutover**,
+not afterwards. Tokens must always be minted with `--expiration`; they never
+expire by default. Never write a token to a file in the repo.
+
+Also confirm `hosted_db_name` still parses the post-cutover URL: it strips the
+last hyphenated component assuming `<db>-<org>`. A wrong parse makes
+`--confirm-target` unmatchable — it fails *safe* (refuses), but the bulk path
+becomes unusable until corrected.
+
+### Rollback
+
+Trigger rollback on any per-table count mismatch, any audit-verify failure, or
+any unexplained event-chain discrepancy — **not** on the absence of an error
+message, which the known failure mode does not produce.
+
+Restore `~/todo-db-backups/benchbox-todo-<UTC>.db` to the hosted primary, then
+re-run step 11's counts against the restored state. The freeze stays held across
+the rollback; lift it only once counts match. `_project/blind-spots/` is frozen
+(2026-07-30) and **is** the findings rollback window — do not delete the corpus
+until after a successful cutover is verified.
+
+## Current verdict — the cutover is NOT authorized
+
+As of 2026-08-01 three conditions block it:
+
+1. **The tracker is provably not quiescent.** `root@vm` wrote 21 events between
+   12:29Z and 12:33Z and 4 more during a 60s probe window. Items moved
+   1726 → 1758 and events 4440 → 4538 inside a single session.
+2. **The quiescence probe is vacuous** (D4) and its replacement has not shipped.
+3. **Two findings-domain fixes are unmerged** — #1359 (replica sync before the
+   bulk import's parity check) and #1373 (reconcile the v4 capture-owned
+   columns; stop wiping undeclared evidence). Neither
+   `_capture_owned_differs`/`_reconcile_capture_owned` nor the `replace_evidence`
+   guard exists on `develop`. Running a cutover from `develop` runs code without
+   the evidence-wipe fix.
+
+D3 is the standing rule: the freeze plus verified quiescence, or no cutover.

--- a/_project/scripts/todo_db.py
+++ b/_project/scripts/todo_db.py
@@ -37,6 +37,7 @@ import difflib
 import fnmatch
 import getpass
 import json
+import math
 import os
 import re
 import shlex
@@ -289,11 +290,50 @@ FREEZE_AT_KEY = "maintenance.frozen_at"
 FREEZE_REASON_KEY = "maintenance.freeze_reason"
 FREEZE_TTL_KEY = "maintenance.freeze_ttl_hours"
 DEFAULT_FREEZE_TTL_HOURS = 2.0
+# A freeze is a maintenance window, not a standing state. The ceiling exists to
+# keep the TTL inside timedelta's range: `timedelta(hours=inf)` (and any value
+# past ~2.4e10 hours) raises, and that raise used to escape through every
+# mutating command -- including `freeze --release`, the designated escape hatch.
+MAX_FREEZE_TTL_HOURS = 168.0  # 7 days
 
 
 def _meta_get(conn: sqlite3.Connection, key: str) -> str | None:
     row = conn.execute("SELECT value FROM meta WHERE key = ?", (key,)).fetchone()
     return row["value"] if row else None
+
+
+def _coerce_freeze_ttl(raw: str | None) -> float:
+    """A finite, positive, bounded TTL. Anything else falls back to the default.
+
+    Only reachable with a tampered or torn `meta` row now that `set_freeze`
+    validates, but this is the read path for a safety gate: it must not raise.
+    """
+    try:
+        ttl = float(raw) if raw is not None else DEFAULT_FREEZE_TTL_HOURS
+    except (TypeError, ValueError):
+        return DEFAULT_FREEZE_TTL_HOURS
+    if not math.isfinite(ttl) or ttl <= 0:
+        return DEFAULT_FREEZE_TTL_HOURS
+    return min(ttl, MAX_FREEZE_TTL_HOURS)
+
+
+def _freeze_lease_expired(started: str | None, ttl_hours: float) -> bool:
+    """Freeze liveness, failing CLOSED where claim leases fail open.
+
+    A claim with a missing or corrupt `claimed_at` should lapse so the item can
+    be reclaimed. A *freeze* is the opposite: it guards a destructive cutover,
+    so a half-written or unparseable stamp must read as still-frozen. Returning
+    "expired" here would let every other actor write straight through a torn
+    freeze -- a safety gate whose degraded state is "unlocked".
+
+    The freeze stays liftable regardless: `freeze` is exempt from the gate.
+    """
+    if not started:
+        return False
+    try:
+        return _lease_expired(started, ttl_hours)
+    except (ValueError, OverflowError):
+        return False
 
 
 def get_freeze(conn: sqlite3.Connection) -> dict[str, Any] | None:
@@ -302,17 +342,16 @@ def get_freeze(conn: sqlite3.Connection) -> dict[str, Any] | None:
     if not holder:
         return None
     started = _meta_get(conn, FREEZE_AT_KEY)
-    try:
-        ttl = float(_meta_get(conn, FREEZE_TTL_KEY) or DEFAULT_FREEZE_TTL_HOURS)
-    except ValueError:
-        ttl = DEFAULT_FREEZE_TTL_HOURS
-    expired = _lease_expired(started, ttl)
+    ttl = _coerce_freeze_ttl(_meta_get(conn, FREEZE_TTL_KEY))
+    expired = _freeze_lease_expired(started, ttl)
     return (
         None
         if expired
         else {
             "holder": holder,
-            "since": started,
+            # A torn freeze (holder written, stamp not) still reads as live;
+            # say so rather than interpolating a bare None into the message.
+            "since": started or "unknown",
             "ttl_hours": ttl,
             "reason": _meta_get(conn, FREEZE_REASON_KEY) or "",
         }
@@ -325,16 +364,26 @@ def set_freeze(
     reason: str,
     ttl_hours: float = DEFAULT_FREEZE_TTL_HOURS,
 ) -> dict[str, Any]:
-    if ttl_hours <= 0:
-        raise TodoError("freeze --ttl must be positive; an unbounded freeze is exactly the stuck lock this avoids")
-    live = get_freeze(conn)
-    if live and live["holder"] != actor:
+    if not math.isfinite(ttl_hours) or ttl_hours <= 0:
         raise TodoError(
-            f"tracker already frozen by {live['holder']} since {live['since']} "
-            f"({live['reason'] or 'no reason given'}); it lapses after {live['ttl_hours']}h"
+            "freeze --ttl must be positive and finite; an unbounded freeze is exactly the stuck lock this avoids"
+        )
+    if ttl_hours > MAX_FREEZE_TTL_HOURS:
+        raise TodoError(
+            f"freeze --ttl must not exceed {MAX_FREEZE_TTL_HOURS:g}h; "
+            "a longer maintenance window should be re-taken, not held open"
         )
     stamp = utc_now()
+    # Read the incumbent inside the write transaction: BEGIN IMMEDIATE holds the
+    # write lock across the check-then-act, so two actors racing to freeze cannot
+    # both observe "no live freeze" and both install themselves as holder.
     with _write_txn(conn):
+        live = get_freeze(conn)
+        if live and live["holder"] != actor:
+            raise TodoError(
+                f"tracker already frozen by {live['holder']} since {live['since']} "
+                f"({live['reason'] or 'no reason given'}); it lapses after {live['ttl_hours']}h"
+            )
         for key, value in (
             (FREEZE_HOLDER_KEY, actor),
             (FREEZE_AT_KEY, stamp),
@@ -348,14 +397,16 @@ def set_freeze(
 
 def clear_freeze(conn: sqlite3.Connection, actor: str, *, force: bool = False) -> bool:
     """Lift the freeze. Returns False when there was no live freeze to lift."""
-    live = get_freeze(conn)
-    if live and live["holder"] != actor and not force:
-        raise TodoError(
-            f"freeze is held by {live['holder']}, not {actor}; "
-            "wait for its lease to lapse or override with `todo freeze --release --force`"
-        )
-    had_rows = _meta_get(conn, FREEZE_HOLDER_KEY) is not None
+    # Same check-then-act discipline as set_freeze: hold the write lock across
+    # the ownership check so a concurrent freeze cannot slip in behind it.
     with _write_txn(conn):
+        live = get_freeze(conn)
+        if live and live["holder"] != actor and not force:
+            raise TodoError(
+                f"freeze is held by {live['holder']}, not {actor}; "
+                "wait for its lease to lapse or override with `todo freeze --release --force`"
+            )
+        had_rows = _meta_get(conn, FREEZE_HOLDER_KEY) is not None
         for key in (FREEZE_HOLDER_KEY, FREEZE_AT_KEY, FREEZE_REASON_KEY, FREEZE_TTL_KEY):
             conn.execute("DELETE FROM meta WHERE key = ?", (key,))
         if had_rows:
@@ -1077,13 +1128,50 @@ def _freeze_refusal(conn: sqlite3.Connection, actor: str, args: argparse.Namespa
         return 2
     if not live or live["holder"] == actor:
         return None
-    print(
+    print(_freeze_refusal_message(live), file=sys.stderr)
+    return 2
+
+
+def _freeze_refusal_message(live: dict[str, Any]) -> str:
+    return (
         f"error: tracker is frozen for maintenance by {live['holder']} since {live['since']}"
         f"{': ' + live['reason'] if live['reason'] else ''}. "
         f"Reads still work; writes resume when the holder runs `todo freeze --release` "
-        f"or the {live['ttl_hours']}h lease lapses.",
-        file=sys.stderr,
+        f"or the {live['ttl_hours']}h lease lapses."
     )
+
+
+def _premigrate_freeze_refusal(backend: Path | str, actor: str) -> int | None:
+    """Freeze gate for `migrate`, which necessarily runs before connect_backend().
+
+    `migrate` cannot use the normal gate: connect_backend() refuses an outdated
+    schema, so `_freeze_refusal` is unreachable on exactly the databases that
+    have migrations pending -- letting a schema change land mid-cutover through
+    a live freeze. Read the freeze off a raw connection instead.
+    """
+    try:
+        if isinstance(backend, Path):
+            if not backend.exists():
+                return None  # nothing to migrate, nothing to protect
+            conn: Any = sqlite3.connect(backend)
+            conn.row_factory = sqlite3.Row
+        else:
+            conn = _hosted_raw_connect(backend, sync_required=True)
+        try:
+            if _schema_version(conn) is None:
+                return None  # fresh/schemaless database: no freeze can be stored
+            live = get_freeze(conn)
+        finally:
+            conn.close()
+    except TodoError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 2
+    except sqlite3.Error as exc:
+        print(f"error: database failure: {_redacted(exc, _auth_token())}", file=sys.stderr)
+        return 2
+    if not live or live["holder"] == actor:
+        return None
+    print(_freeze_refusal_message(live), file=sys.stderr)
     return 2
 
 
@@ -2288,7 +2376,7 @@ def _has_falsifiable_rung(item: dict) -> bool:
 # family is tests/unit/<subpath>/test_<name>*.py - the wildcard admits split
 # suites (test_todo_db.py, test_todo_db_v2.py, ...); scope is complete when
 # it covers ANY existing member. Only EXISTING test files are demanded - a
-# module without tests today stays createable.
+# module without tests today stays creatable.
 
 _SOURCE_SCOPE_RE = re.compile(r"^(benchbox/(?:[\w./-]+/)?|_project/scripts/)(\w+)\.py$")
 
@@ -3224,7 +3312,12 @@ def main(argv: list[str] | None = None) -> int:
         )
         return 2
     if args.command == "migrate":
-        # Must run before connect(): connect refuses an outdated schema.
+        # Must run before connect(): connect refuses an outdated schema. That
+        # also puts it ahead of the normal freeze gate, so run the gate here --
+        # otherwise `migrate` is the one mutating command a freeze never covers.
+        refusal = _premigrate_freeze_refusal(backend, actor)
+        if refusal is not None:
+            return refusal
         try:
             applied = migrate_backend(backend)
         except TodoError as exc:

--- a/tests/unit/scripts/test_todo_db_freeze.py
+++ b/tests/unit/scripts/test_todo_db_freeze.py
@@ -11,6 +11,8 @@ config writes take no claim at all.
 from __future__ import annotations
 
 import importlib.util
+import math
+import sqlite3
 import sys
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
@@ -286,3 +288,159 @@ class TestFreezeGate:
         connection = todo_db.connect(db)
         assert todo_db.write_activity(connection) == before
         connection.close()
+
+
+class TestFreezeTtlIsBounded:
+    """A TTL that timedelta cannot represent used to wedge the tracker through
+    the documented `--ttl` flag: every mutating command, `--status`, `--release`
+    and even `--release --force` raised OverflowError, leaving raw SQL as the
+    only recovery. The lease exists precisely so that cannot happen.
+    """
+
+    @pytest.mark.parametrize("bad", ["inf", "-inf", "nan"])
+    def test_non_finite_ttl_is_refused(self, conn, bad):
+        with pytest.raises(todo_db.TodoError):
+            todo_db.set_freeze(conn, "alice", "cutover", ttl_hours=float(bad))
+        assert todo_db.get_freeze(conn) is None
+
+    def test_ttl_beyond_the_ceiling_is_refused(self, conn):
+        with pytest.raises(todo_db.TodoError):
+            todo_db.set_freeze(conn, "alice", "cutover", ttl_hours=todo_db.MAX_FREEZE_TTL_HOURS + 1)
+        assert todo_db.get_freeze(conn) is None
+
+    def test_ttl_at_the_ceiling_is_allowed(self, conn):
+        todo_db.set_freeze(conn, "alice", "cutover", ttl_hours=todo_db.MAX_FREEZE_TTL_HOURS)
+        assert todo_db.get_freeze(conn)["ttl_hours"] == todo_db.MAX_FREEZE_TTL_HOURS
+
+    @pytest.mark.parametrize("stored", ["inf", "nan", "1e308", "not-a-number", "-5"])
+    def test_a_tampered_ttl_row_never_raises(self, conn, stored):
+        """Recovery path for a database wedged before the validation landed."""
+        todo_db.set_freeze(conn, "alice", "cutover", ttl_hours=1)
+        conn.execute(
+            "INSERT OR REPLACE INTO meta (key, value) VALUES (?, ?)",
+            (todo_db.FREEZE_TTL_KEY, stored),
+        )
+        live = todo_db.get_freeze(conn)  # must not raise
+        assert live is not None
+        assert math.isfinite(live["ttl_hours"])
+        assert 0 < live["ttl_hours"] <= todo_db.MAX_FREEZE_TTL_HOURS
+
+    def test_a_wedged_database_can_still_be_released(self, tmp_path):
+        db = tmp_path / "todo.sqlite"
+        connection = todo_db.connect(db)
+        todo_db.set_freeze(connection, "alice", "cutover", ttl_hours=1)
+        connection.execute(
+            "INSERT OR REPLACE INTO meta (key, value) VALUES (?, ?)",
+            (todo_db.FREEZE_TTL_KEY, "inf"),
+        )
+        connection.commit()
+        connection.close()
+        assert _run(db, "freeze", "--release", "--force", actor="bob") == 0
+
+
+class TestTornFreezeFailsClosed:
+    """A half-written freeze must read as still-frozen. Returning "expired" let
+    every other actor write straight through it -- a safety gate whose degraded
+    state is "unlocked".
+    """
+
+    def _tear(self, conn, value=None):
+        if value is None:
+            conn.execute("DELETE FROM meta WHERE key = ?", (todo_db.FREEZE_AT_KEY,))
+        else:
+            conn.execute(
+                "INSERT OR REPLACE INTO meta (key, value) VALUES (?, ?)",
+                (todo_db.FREEZE_AT_KEY, value),
+            )
+
+    def test_missing_stamp_reads_as_live(self, conn):
+        todo_db.set_freeze(conn, "alice", "cutover", ttl_hours=1)
+        self._tear(conn)
+        live = todo_db.get_freeze(conn)
+        assert live is not None
+        assert live["holder"] == "alice"
+
+    def test_malformed_stamp_reads_as_live(self, conn):
+        todo_db.set_freeze(conn, "alice", "cutover", ttl_hours=1)
+        self._tear(conn, "not-a-timestamp")
+        assert todo_db.get_freeze(conn) is not None
+
+    @pytest.mark.parametrize("stamp", [None, "not-a-timestamp"])
+    def test_torn_freeze_refuses_a_foreign_write_cleanly(self, tmp_path, stamp):
+        db = tmp_path / "todo.sqlite"
+        connection = todo_db.connect(db)
+        _mk(connection, "existing-item")
+        todo_db.set_freeze(connection, "alice", "cutover", ttl_hours=1)
+        self._tear(connection, stamp)
+        connection.commit()
+        connection.close()
+        # exit 2, not an uncaught ValueError escaping main()
+        assert _run(db, "claim", "existing-item", actor="bob") == 2
+
+    @pytest.mark.parametrize("stamp", [None, "not-a-timestamp"])
+    def test_torn_freeze_is_still_liftable(self, tmp_path, stamp):
+        db = tmp_path / "todo.sqlite"
+        connection = todo_db.connect(db)
+        todo_db.set_freeze(connection, "alice", "cutover", ttl_hours=1)
+        self._tear(connection, stamp)
+        connection.commit()
+        connection.close()
+        assert _run(db, "freeze", "--release", "--force", actor="bob") == 0
+
+
+class TestMigrateIsGatedByTheFreeze:
+    """`migrate` runs before connect_backend() -- which refuses an outdated
+    schema -- so the normal gate is unreachable on exactly the databases that
+    have migrations pending. Without its own check, a schema change lands
+    mid-cutover through a live freeze.
+    """
+
+    def _v3_db(self, tmp_path, holder):
+        db = tmp_path / "todo.sqlite"
+        raw = sqlite3.connect(db)
+        raw.row_factory = sqlite3.Row
+        raw.executescript(todo_db._CORE_SCHEMA_SQL)
+        # Climb to v3 only; v4 is what the CLI under test should (or should not)
+        # apply. _CORE_SCHEMA_SQL already carries the v2 columns.
+        for statement in todo_db.MIGRATIONS[3]:
+            raw.execute(statement)
+        raw.execute("INSERT OR REPLACE INTO meta (key, value) VALUES ('schema_version', '3')")
+        for key, value in (
+            (todo_db.FREEZE_HOLDER_KEY, holder),
+            (todo_db.FREEZE_AT_KEY, todo_db.utc_now()),
+            (todo_db.FREEZE_REASON_KEY, "cutover"),
+            (todo_db.FREEZE_TTL_KEY, "2.0"),
+        ):
+            raw.execute("INSERT OR REPLACE INTO meta (key, value) VALUES (?, ?)", (key, value))
+        raw.commit()
+        raw.close()
+        return db
+
+    def _version(self, db):
+        raw = sqlite3.connect(db)
+        raw.row_factory = sqlite3.Row
+        try:
+            return todo_db._schema_version(raw)
+        finally:
+            raw.close()
+
+    def test_foreign_actor_cannot_migrate_through_a_freeze(self, tmp_path):
+        db = self._v3_db(tmp_path, holder="alice")
+        assert self._version(db) == 3
+        assert _run(db, "migrate", actor="bob") == 2
+        assert self._version(db) == 3, "schema changed under a live freeze"
+
+    def test_the_holder_may_still_migrate(self, tmp_path):
+        """The holder runs the cutover, so it must keep its own write access."""
+        db = self._v3_db(tmp_path, holder="alice")
+        assert _run(db, "migrate", actor="alice") == 0
+        assert self._version(db) == todo_db.SCHEMA_VERSION
+
+    def test_migrate_is_unaffected_with_no_freeze(self, tmp_path):
+        db = self._v3_db(tmp_path, holder="alice")
+        raw = sqlite3.connect(db)
+        raw.execute("DELETE FROM meta WHERE key LIKE 'maintenance.%'")
+        raw.commit()
+        raw.close()
+        assert _run(db, "migrate", actor="bob") == 0
+        assert self._version(db) == todo_db.SCHEMA_VERSION


### PR DESCRIPTION
Follow-up defect fixes for the leased write freeze landed in #1377.

**Every defect here was found by running something against the merged commit.** CI was green on #1377 throughout — none of these were caught by the suite as shipped, and the gate's own tests passed while the gate had a hole in it.

## Defects fixed

| # | Defect | Severity | How found |
|---|---|---|---|
| 1 | Non-finite `--ttl` permanently wedges the tracker | **high** | executed `todo freeze --ttl inf` |
| 2 | Malformed freeze stamp escapes as a raw traceback | medium | tampered `meta` row |
| 3 | Torn freeze fails **open** | **high** | deleted the stamp row |
| 4 | `migrate` bypasses the gate entirely | **high** | built a genuine v3 DB |
| 5 | `set_freeze`/`clear_freeze` check-then-act across two txns | low | inspection |

### 1. `--ttl inf` wedges the tracker (new, not previously known)

`set_freeze` validated `ttl_hours <= 0` but not finiteness, so `inf`/`nan` were accepted through the documented flag. `timedelta(hours=inf)` then raised `OverflowError` inside **every** mutating command, `--status`, `--release`, *and* `--release --force` — destroying the designated escape hatch and leaving raw SQL against the hosted DB as the only recovery.

This defeats the stated rationale of the leased design: *"a holder that dies mid-cutover cannot wedge the tracker for every other session forever."*

`--ttl` is now finite, positive and bounded by `MAX_FREEZE_TTL_HOURS` (168h). The read path coerces a tampered row instead of raising, so a database already wedged by this bug is recoverable.

### 3. Torn freeze failed open

Holder row present, stamp row absent → `_lease_expired(None, ttl)` returned `True` → `get_freeze` returned `None` → **writes proceeded**. Freeze liveness now fails **closed**, deliberately opposite to claim leases (which must fail open so items can be reclaimed). The escape hatch is unaffected — `freeze` is exempt from the gate, so a torn freeze is still liftable, verified by test.

### 4. `migrate` bypassed the gate

`migrate` must run before `connect_backend()`, which refuses an outdated schema — so the gate was unreachable on exactly the databases with migrations pending, and returned early on `if applied:`. A schema change could land mid-cutover through a live freeze. Confirmed by building a genuine v3 database (a forced `schema_version` downgrade re-runs a migration that dies on `duplicate column name`, which is why the previous attempt couldn't reproduce it).

`migrate` now gates against a raw connection. The freeze **holder** can still migrate, since it runs the cutover.

## Verification

- **Mutation-tested**: neutering each fix independently fails a test (4 failures across 3 mutations). The pre-existing gate tests were mutation-tested too and are not vacuous.
- 1281 unit tests pass (52 in the freeze file, up from 32)
- `ruff check` / `ruff format --check` clean; diff hunks confined to edit sites
- `timing_policy_check.py --strict` exit 0 — 26214/26550
- `lint-imports`, `lint-markers` pass

Also fixes a pre-existing `codespell` typo in the same file that blocks pre-commit for anyone touching it.

## Not addressed here

The §5.1 design question — a stale clone running the pre-#1377 CLI has no gate at all, and `SCHEMA_VERSION` was deliberately left at 4 with no migration, so nothing forces those sessions to upgrade. The freeze remains **advisory** against stale clones. That is a deliberate decision requiring sign-off, documented separately in the cutover ADR; it is not defaulted here.