### PR TITLE
feat(tracker): lint deny rules that cannot match any real path

### DIFF
--- a/_project/scripts/todo_db.py
+++ b/_project/scripts/todo_db.py
@@ -2146,11 +2146,16 @@ def _unrunnable_verifications(item: dict) -> list[tuple[int, str, str]]:
 # for the real test_motherduck.py) lints clean and quietly makes the item's
 # work un-landable in scope. Resolution is deliberately state-aware and
 # conservative, calibrated against the live backlog:
-#   - OPEN items: only a nonexistent LITERAL that closely matches an existing
-#     sibling (a probable typo) is a finding. Wildcard globs are prospective
-#     allowlists - check-scope fnmatches them against future changed files,
-#     so "matches nothing today" is normal for planned outputs - and a plain
-#     nonexistent literal is a legal planned new file.
+#   - OPEN items, only_modify: only a nonexistent LITERAL that closely matches
+#     an existing sibling (a probable typo) is a finding. Wildcard globs are
+#     prospective allowlists - check-scope fnmatches them against future
+#     changed files, so "matches nothing today" is normal for planned outputs -
+#     and a plain nonexistent literal is a legal planned new file.
+#   - OPEN items, do_not_modify: stricter, because a deny that matches nothing
+#     protects nothing. Annotated globs ("foo.py (frozen)") and near-named or
+#     package-shadowed literals (runner.py beside runner/) are findings at a
+#     lower cutoff; a clean nonexistent literal/wildcard stays legal (it
+#     forbids creating the match).
 #   - DONE/DROPPED items: anything that resolves to nothing is a finding;
 #     by completion the paths had their chance to exist.
 #   - Absolute paths are skipped: out-of-repo scopes are policy statements
@@ -2165,6 +2170,17 @@ _PATHLIKE_TOKEN_RE = re.compile(
 # releases planned new files for genuinely new components
 # (test_ballista_adapter.py vs test_base_adapter.py, 0.86).
 _NEAR_MISS_CUTOFF = 0.87
+
+# Deny rules get a lower bar: a do_not_modify that matches nothing protects
+# nothing, and the false-positive cost is one lint line, not a blocked plan.
+# 0.75 catches the live slips the allowlist cutoff released (runner.py for the
+# runner/ package, 0.80; result_capture.py for result_factory.py, 0.76).
+_DENY_NEAR_MISS_CUTOFF = 0.75
+
+# Characters that cannot appear in this repo's tracked paths. Authors annotate
+# scope globs in prose ("scripts/foo.py (item 4, done)"); such a glob can never
+# fnmatch a changed file, so as a deny rule it silently protects nothing.
+_GLOB_ANNOTATION_CHARS = " ()"
 
 
 def _lint_repo_root() -> Path | None:
@@ -2183,13 +2199,13 @@ def _glob_resolves(root: Path, pattern: str) -> bool:
         return False
 
 
-def _near_miss(root: Path, literal: str) -> str | None:
+def _near_miss(root: Path, literal: str, cutoff: float = _NEAR_MISS_CUTOFF) -> str | None:
     """An existing sibling whose name closely matches ``literal``'s, if any."""
     target = root / literal
     if not target.parent.is_dir():
         return None
     names = [entry.name for entry in target.parent.iterdir()]
-    close = difflib.get_close_matches(target.name, names, n=1, cutoff=_NEAR_MISS_CUTOFF)
+    close = difflib.get_close_matches(target.name, names, n=1, cutoff=cutoff)
     if not close:
         return None
     return str(Path(literal).parent / close[0])
@@ -2209,6 +2225,26 @@ def _unresolved_path_finding(root: Path, path: str, *, settled: bool) -> str | N
     return None
 
 
+def _deny_unresolved_finding(root: Path, glob: str) -> str | None:
+    """Why an open item's non-resolving deny glob is inert, or None if legal.
+
+    A do_not_modify that can never match a changed file protects nothing —
+    unlike only_modify there is no prospective-allowlist reading that excuses
+    it. A CLEAN nonexistent literal or wildcard stays legal: it forbids
+    creating the named file(s), and fnmatch will catch a created match.
+    """
+    if any(ch in glob for ch in _GLOB_ANNOTATION_CHARS):
+        return "contains annotation text so it can never match a repository path"
+    if any(ch in glob for ch in "*?["):
+        return None  # prospective family deny — forbids creating matches
+    if glob.endswith(".py") and (root / glob[: -len(".py")]).is_dir():
+        return f"names a module shadowed by existing package directory '{glob[: -len('.py')]}/'"
+    close = _near_miss(root, glob, cutoff=_DENY_NEAR_MISS_CUTOFF)
+    if close:
+        return f"names a nonexistent path suspiciously close to existing '{close}'"
+    return None
+
+
 def _unresolvable_scope_findings(item: dict) -> list[str]:
     root = _lint_repo_root()
     if root is None:
@@ -2219,7 +2255,12 @@ def _unresolvable_scope_findings(item: dict) -> list[str]:
         pattern = rule["path_glob"]
         if _glob_resolves(root, pattern):
             continue
-        reason = _unresolved_path_finding(root, pattern, settled=settled)
+        if not settled and rule["kind"] == "do_not_modify":
+            if Path(pattern).is_absolute() or pattern.startswith("~"):
+                continue
+            reason = _deny_unresolved_finding(root, pattern)
+        else:
+            reason = _unresolved_path_finding(root, pattern, settled=settled)
         if reason:
             findings.append(f"scope {rule['kind']} {reason}: {pattern}")
     return findings
@@ -2288,7 +2329,7 @@ def _has_falsifiable_rung(item: dict) -> bool:
 # family is tests/unit/<subpath>/test_<name>*.py - the wildcard admits split
 # suites (test_todo_db.py, test_todo_db_v2.py, ...); scope is complete when
 # it covers ANY existing member. Only EXISTING test files are demanded - a
-# module without tests today stays createable.
+# module without tests today stays creatable.
 
 _SOURCE_SCOPE_RE = re.compile(r"^(benchbox/(?:[\w./-]+/)?|_project/scripts/)(\w+)\.py$")
 

--- a/tests/unit/scripts/test_todo_db_v2.py
+++ b/tests/unit/scripts/test_todo_db_v2.py
@@ -510,6 +510,63 @@ class TestLintUnresolvableScopeAndLadderPaths:
         findings = todo_db.lint_item(conn, "node-id-cmd")
         assert not any("test_todo_db_v2" in f for f in findings)
 
+    def test_inert_deny_rule_annotated_glob_is_flagged_on_open_item(self, conn):
+        # "path (prose)" can never fnmatch a changed file, so the deny rule
+        # silently protects nothing — exactly the enforcement hole to surface.
+        self._mk_scoped(
+            conn,
+            "annotated-deny",
+            scope=[("do_not_modify", "_project/scripts/todo_db.py (frozen during review)")],
+        )
+        findings = todo_db.lint_item(conn, "annotated-deny")
+        assert any("do_not_modify" in f and "annotation" in f for f in findings)
+
+    def test_inert_deny_rule_package_dir_shadow_is_flagged_on_open_item(self, conn):
+        # benchbox/core/runner.py does not exist; the runner/ package does.
+        # The deny intent (protect the runner) can never fire.
+        self._mk_scoped(conn, "shadowed-deny", scope=[("do_not_modify", "benchbox/core/runner.py")])
+        findings = todo_db.lint_item(conn, "shadowed-deny")
+        assert any("do_not_modify" in f and "package directory" in f for f in findings)
+
+    def test_inert_deny_rule_near_named_sibling_below_allowlist_cutoff(self, conn):
+        # 0.76 to result_factory.py — released by the 0.87 only_modify cutoff,
+        # caught by the stricter deny cutoff.
+        self._mk_scoped(
+            conn,
+            "near-named-deny",
+            scope=[("do_not_modify", "benchbox/core/results/result_capture.py")],
+        )
+        findings = todo_db.lint_item(conn, "near-named-deny")
+        assert any("do_not_modify" in f and "suspiciously close" in f for f in findings)
+
+    def test_inert_deny_rule_clean_future_path_stays_legal(self, conn):
+        # A deny naming a clean nonexistent file forbids creating it; fnmatch
+        # will catch a created match, so the rule is NOT inert.
+        self._mk_scoped(
+            conn,
+            "future-deny",
+            scope=[("do_not_modify", "tests/unit/scripts/test_zq_forbidden_future.py")],
+        )
+        findings = todo_db.lint_item(conn, "future-deny")
+        assert not any("test_zq_forbidden_future" in f for f in findings)
+
+    def test_inert_deny_rule_wildcard_family_stays_legal(self, conn):
+        self._mk_scoped(conn, "family-deny", scope=[("do_not_modify", "benchbox/core/zq_forbidden_*.py")])
+        findings = todo_db.lint_item(conn, "family-deny")
+        assert not any("zq_forbidden" in f for f in findings)
+
+    def test_inert_deny_rule_checks_do_not_apply_when_settled(self):
+        # Settled items keep the blanket resolves-to-nothing finding; the
+        # deny-specific classification is an open-item aid.
+        item = {
+            "state": "done",
+            "scope": [{"kind": "do_not_modify", "path_glob": "benchbox/core/runner.py"}],
+            "verifications": [],
+        }
+        findings = todo_db._unresolvable_scope_findings(item)
+        assert any("resolves to nothing" in f for f in findings)
+        assert not any("package directory" in f for f in findings)
+
 
 class TestLintFalsifiabilityAndScopeCompleteness:
     """A ladder must contain at least one rung that FAILS on the unfixed tree


### PR DESCRIPTION
A do_not_modify glob that resolves to nothing was exempted by the same
prospective-allowlist reading as only_modify, but a deny that matches
nothing protects nothing: check_paths returns zero violations for an
annotated glob ("foo.py (frozen)") or a package-shadowed literal
(benchbox/core/runner.py beside runner/). Open-item deny rules now get
their own classification: annotation text, package-directory shadow, and
a near-named sibling at a stricter 0.75 cutoff are findings; a clean
nonexistent literal or wildcard stays legal because it forbids creating
the match.

Standing corpus instances: 6 items deny benchbox/core/runner.py, 3 deny
the never-existed result_capture.py, plus an annotated-glob cluster.

TODO: todo-lint-inert-deny-rules
