### PR TITLE
fix(tooling): spellcheck scans tracked files so gitignored paths cannot break it

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -956,9 +956,33 @@ security-audit:
 # CI (which never installs it) and fail locally on vendored typos - inverting
 # what a preflight is for. Keep any future vendored/generated tree out the same
 # way; do NOT skip a directory that holds tracked content.
+# Spellcheck scans the TRACKED file list rather than walking the working tree, so
+# a gitignored directory can never be scanned. Walking the tree made the gate
+# environment-dependent: it stayed green in CI and in fresh pool worktrees, but
+# failed in the maintainer's primary clone on gitignored paths that only exist
+# there (`@~/`, `results-explorer/dist/`). Chasing those names in --skip fixes one
+# clone at a time; deriving the file list from git fixes the class.
+#
+# --skip keeps only the FILENAME globs. Its directory entries are dropped on
+# purpose: codespell prunes directories while traversing, so a directory name in
+# --skip has no effect once explicit paths are passed. Tracked directories that
+# must stay unscanned are excluded as git pathspecs instead (the rest of the old
+# list -- _build, benchmark_runs, htmlcov, .venv, node_modules -- is gitignored,
+# so `git ls-files` already excludes it).
+SPELLCHECK_SKIP_GLOBS := *.pyc,*.json,*.lock,*.svg,*.min.js,*.min.css,*.tpl,*.dst,*.tbl,*.dat,*.pdf
+# `**/` matches at any depth, so these exclude the directory NAME wherever it
+# appears (e.g. both `_binaries/` and `benchbox/_binaries/`), matching how
+# codespell's --skip pruned directory names during traversal.
+SPELLCHECK_EXCLUDE_PATHS := \
+	':(exclude,glob)**/_binaries/**' ':(exclude,glob)_binaries/**' \
+	':(exclude,glob)**/_sources/**'  ':(exclude,glob)_sources/**' \
+	':(exclude,glob)**/_project/**'  ':(exclude,glob)_project/**' \
+	':(exclude,glob)**/_blog/**'     ':(exclude,glob)_blog/**'
+
 spellcheck:
 	@echo "Running spellcheck..."
-	uvx codespell --ignore-words=.codespell-ignore.txt --skip="*.pyc,_build,*.json,*.lock,*.svg,*.min.js,*.min.css,_binaries,*.tpl,*.dst,*.tbl,_sources,benchmark_runs,*.dat,*.pdf,_project,_blog,htmlcov,.venv,node_modules"
+	git ls-files -z -- $(SPELLCHECK_EXCLUDE_PATHS) \
+		| xargs -0 uvx codespell --ignore-words=.codespell-ignore.txt --skip="$(SPELLCHECK_SKIP_GLOBS)"
 	@echo "✅ Spellcheck passed"
 
 # Linkcheck - exact match for docs.yml linkcheck job


### PR DESCRIPTION
`make spellcheck` walked the working tree, so any gitignored directory that
happened to exist locally was scanned. That made the gate environment-dependent:
green in CI and in fresh pool worktrees, red in the maintainer's primary clone.

The primary clone fails on TWO gitignored paths, not the one previously
recorded: `@~/benchbox/dists.dss` (.gitignore:72) and
`results-explorer/dist/assets/*.js` (results-explorer/.gitignore:2). Adding
names to --skip fixes one clone at a time; more ignored dirs are already present
(.codex/, .gemini/, .todo-db/), so this derives the file list from git instead.

spellcheck now feeds codespell the TRACKED file list, which by construction can
never contain a gitignored path. --skip keeps only its FILENAME globs: codespell
prunes directories while traversing, so a directory name in --skip stops having
any effect once explicit paths are passed. The four tracked directories that
must stay unscanned (_binaries, _sources, _project, _blog) are excluded as git
pathspecs, matched at any depth since they appear both at the repo root and
under benchbox/. The rest of the old directory list is itself gitignored, so
`git ls-files` already excludes it.

Verified: both ladder rungs exit 0 (gitignored `@~/` present; node_modules skip
from #1348 not regressed), a `results-explorer/dist/` fixture exits 0, and a
planted typo in the tracked benchbox/utils/clock.py still fails the gate, so
real source-tree typos are still caught and --ignore-words is unchanged.
