### PR TITLE
fix(results): pseudonymize pg_user and tenant_id on the public path

### DIFF
--- a/benchbox/core/results/anonymization_specs.yaml
+++ b/benchbox/core/results/anonymization_specs.yaml
@@ -37,6 +37,10 @@ identifier_keys:
   username: user
   user: user
   userid: user
+  pguser: user
+  dbuser: user
+  tenant: tenant
+  tenantid: tenant
   role: role
   rolename: role
   rolearn: role

--- a/tests/unit/core/results/test_anonymization.py
+++ b/tests/unit/core/results/test_anonymization.py
@@ -790,3 +790,37 @@ class TestPublicPayloadApiKeyAndAccountKey:
         assert "APIKEY-SENTINEL" not in out
         assert "OH-SENTINEL" not in out
         assert "AZKEY-SENTINEL" not in out
+
+
+class TestPublicPayloadPgUserAndTenantId:
+    """pg_user must pseudonymize like every other username spelling, and a
+    tenant id (an org-identifying GUID) must hash — both escaped the public
+    identifier map because their compact keys matched nothing."""
+
+    @staticmethod
+    def _payload(config):
+        return {"platform_metadata": {"platform_raw_config": config}}
+
+    def test_pg_user_pseudonymizes_like_username(self):
+        manager = AnonymizationManager()
+        out = manager.anonymize_result_payload(self._payload({"pg_user": "PGUSER-SENTINEL"}))["platform_metadata"][
+            "platform_raw_config"
+        ]
+        assert out["pg_user"] != "PGUSER-SENTINEL"
+        assert out["pg_user"].startswith("user_")
+
+    def test_tenant_id_is_hashed(self):
+        manager = AnonymizationManager()
+        out = manager.anonymize_result_payload(self._payload({"tenant_id": "TENANT-SENTINEL"}))["platform_metadata"][
+            "platform_raw_config"
+        ]
+        assert out["tenant_id"] != "TENANT-SENTINEL"
+        assert out["tenant_id"].startswith("tenant_")
+
+    def test_existing_identifier_behavior_unchanged(self):
+        manager = AnonymizationManager()
+        out = manager.anonymize_result_payload(
+            self._payload({"username": "alice-sentinel", "account": "acct-sentinel"})
+        )["platform_metadata"]["platform_raw_config"]
+        assert out["username"].startswith("user_")
+        assert out["account"].startswith("account_")


### PR DESCRIPTION
The compact keys pguser and tenantid matched nothing in the public
identifier map, so a pg_user survived verbatim wherever raw config
reaches the public payload without passing internal capture, and a
tenant id (an org-identifying GUID) always exported verbatim. Map the
pg/db user spellings to the user pseudonym family and hash tenant ids.

TODO: public-export-pg-user-and-tenant-id-bypass-pseudonymization
