### PR TITLE
fix(analysis): resolve staged gates in the oracle-map scale lookup and close the provenance vocabulary

### DIFF
--- a/_project/scripts/generate_oracle_coverage_map.py
+++ b/_project/scripts/generate_oracle_coverage_map.py
@@ -93,6 +93,14 @@ PROVENANCE_MIXED = "mixed-provenance"  # mixes generated/shared and bespoke impl
 PROVENANCE_SEPARATE = "separate-handwritten"  # DataFrame families separately handwritten
 PROVENANCE_NONE = "—"  # not a cross-surface gate: the axis does not apply
 
+# The closed vocabulary this column may render. Pinning the three constants above to
+# the live ``cross_surface`` constants catches a RENAME, but not an ADDITION: a new
+# ``SURFACE_INDEPENDENCE_*`` label on a newly registered gate would pass through
+# unvalidated and render a label the map's own prose does not define, leaving the
+# legend quietly contradicting the table. Validating membership keeps the value read
+# live from the gate while making an unknown label a loud failure.
+_KNOWN_PROVENANCE_LABELS = frozenset({PROVENANCE_SHARED_SPEC, PROVENANCE_MIXED, PROVENANCE_SEPARATE})
+
 # Sentinel for "no scale guarantee" (UNGUARDED rows).
 SCALE_NONE = "—"
 
@@ -178,10 +186,16 @@ def _bounded_value_gate_scale(benchmark_id: str) -> str:
     fall back to the shared default for the TPC-Havoc variant gates, which are not
     in the cross-surface ``GATES`` registry. Reading it live keeps the artifact
     honest rather than hand-labelled.
-    """
-    from benchbox.core.equivalence.cross_surface import EQUIVALENCE_SCALE, GATES
 
-    gate = GATES.get(benchmark_id)
+    Both gate registries are consulted. ``classify_oracles`` already treats a
+    STAGED gate as a cross-surface oracle, so looking in ``GATES`` alone would
+    silently render the shared default for a staged gate that declares its own
+    ``scale_factor`` -- overstating the scale at which the gate actually holds,
+    on exactly the path every gate takes before promotion.
+    """
+    from benchbox.core.equivalence.cross_surface import EQUIVALENCE_SCALE, GATES, STAGED_GATES
+
+    gate = GATES.get(benchmark_id) or STAGED_GATES.get(benchmark_id)
     scale = gate.scale_factor if gate is not None else EQUIVALENCE_SCALE
     return f"SF={scale}"
 
@@ -294,6 +308,13 @@ def oracle_surface_provenance(primary: str, benchmark_id: str) -> tuple[str, str
         return (
             PROVENANCE_NONE,
             "Cross-surface gate metadata is unavailable; provenance is undisclosed until the gate is registered.",
+        )
+    if gate.surface_independence not in _KNOWN_PROVENANCE_LABELS:
+        raise ValueError(
+            f"{benchmark_id}: unknown surface-provenance label {gate.surface_independence!r}. "
+            f"Known labels: {sorted(_KNOWN_PROVENANCE_LABELS)}. Add a PROVENANCE_* constant in "
+            "this module AND describe the new label in the Surface-provenance disclosure prose "
+            "in render_markdown(), otherwise the map renders a label its own legend never defines."
         )
     return gate.surface_independence, gate.surface_independence_rationale
 

--- a/tests/unit/test_oracle_coverage_map.py
+++ b/tests/unit/test_oracle_coverage_map.py
@@ -16,6 +16,7 @@ honest and current:
 from __future__ import annotations
 
 import sys
+from dataclasses import replace
 from pathlib import Path
 
 import pytest
@@ -316,6 +317,64 @@ def test_provenance_never_changes_independence(rows):
     # A variant gate has no cross-surface gate entry, so it discloses no provenance.
     assert oracle_surface_provenance(ORACLE_VARIANT_EQUIVALENCE, "tpchavoc") == (PROVENANCE_NONE, PROVENANCE_NONE)
     assert oracle_surface_provenance(ORACLE_CROSS_SURFACE, "coffeeshop")[0] == PROVENANCE_SEPARATE
+
+
+def test_staged_gate_scale_is_read_from_its_own_metadata(monkeypatch):
+    """A STAGED gate's bounded scale must come from the gate, not the shared default.
+
+    ``classify_oracles`` counts a STAGED gate as a cross-surface oracle, so the Scale
+    cell has to resolve through ``STAGED_GATES`` too. Reading only ``GATES`` silently
+    rendered the shared ``EQUIVALENCE_SCALE`` for a staged gate that declares its own
+    ``scale_factor`` -- overstating the scale at which the gate actually holds, on the
+    exact path every cross-surface gate takes before it is promoted to ``GATES``.
+    """
+    from benchbox.core.equivalence.cross_surface import (
+        EQUIVALENCE_SCALE,
+        GATES,
+        STAGED_GATES,
+        SURFACE_INDEPENDENCE_MIXED,
+    )
+
+    staged_scale = EQUIVALENCE_SCALE / 100
+    assert staged_scale != EQUIVALENCE_SCALE, "probe scale must differ from the shared default"
+
+    # Stage a real gate object under a benchmark that has no oracle today, so the row
+    # is classified purely through the STAGED path.
+    probe_id = "nyctaxi"
+    assert probe_id not in GATES, f"{probe_id} gained an enforced gate; pick another staged probe"
+    template = GATES["coffeeshop"]
+    staged = replace(
+        template,
+        name=probe_id,
+        surface_independence=SURFACE_INDEPENDENCE_MIXED,
+        scale_factor=staged_scale,
+    )
+    monkeypatch.setitem(STAGED_GATES, probe_id, staged)
+
+    row = {r["benchmark"]: r for r in build_coverage_map()}[probe_id]
+    assert row["primary_oracle"] == ORACLE_CROSS_SURFACE
+    assert row["cross_surface_enforced"] is False, "a STAGED gate must not report as CI-enforced"
+    assert row["scale"] == f"SF={staged_scale}", (
+        f"staged gate scale must be read from its own metadata, got {row['scale']!r}"
+    )
+
+
+def test_unknown_surface_provenance_label_is_rejected(monkeypatch):
+    """A provenance label outside the closed vocabulary must fail loudly, not render.
+
+    Pinning the PROVENANCE_* constants to the live ``SURFACE_INDEPENDENCE_*`` constants
+    catches a RENAME but not an ADDITION. Without this guard a newly registered gate
+    carrying a brand-new label rendered straight into the table, while the map's
+    Surface-provenance prose still defined only the original three -- the legend
+    silently contradicting the row.
+    """
+    from benchbox.core.equivalence.cross_surface import GATES
+
+    bogus = replace(GATES["coffeeshop"], surface_independence="transpiled-from-sql")
+    monkeypatch.setitem(GATES, "coffeeshop", bogus)
+
+    with pytest.raises(ValueError, match="unknown surface-provenance label"):
+        oracle_surface_provenance(ORACLE_CROSS_SURFACE, "coffeeshop")
 
 
 def test_markdown_renders_independence_and_provenance_as_distinct_columns(rows):


### PR DESCRIPTION
Two holes in how the oracle coverage map reads live cross-surface gate metadata.
Both are latent today (STAGED_GATES is empty, every live label is known), so
neither moves the committed artifact -- they misreport the moment a gate is
staged or a label is added.

1. Scale. `_bounded_value_gate_scale()` resolved only `GATES`, but
   `classify_oracles()` already counts a STAGED gate as a cross-surface oracle,
   and `oracle_surface_provenance()` twelve lines away already resolves
   `GATES or STAGED_GATES`. A staged gate declaring its own `scale_factor`
   therefore rendered the shared `EQUIVALENCE_SCALE` instead. Staging a probe
   gate with `scale_factor=0.001` rendered `SF=0.1` -- overstating the scale at
   which the gate actually holds, on the exact path every cross-surface gate
   takes before promotion (`h2odb` and `read_primitives` both carry custom
   scales, and the GATES comment records that gates are promoted from STAGED).

2. Vocabulary. The provenance label was returned straight from
   `gate.surface_independence` unvalidated. The existing test pins the three
   `PROVENANCE_*` constants to the live `SURFACE_INDEPENDENCE_*` constants,
   which catches a RENAME but not an ADDITION: adding
   `SURFACE_INDEPENDENCE_TRANSPILED` and registering it rendered the new label
   straight into the table, while the map's Surface-provenance prose still
   defined only three -- the legend silently contradicting the row. The label is
   still READ LIVE from the gate; membership in a closed set is now checked, and
   an unknown label raises naming both edits it needs.

Each fix is pinned by a test that fails only against its own defect: reverting
just the staged lookup fails only the scale test, reverting just the guard fails
only the vocabulary test, and neither changes `make oracle-coverage-map-check`.
