### PR TITLE
refactor(security): drop dead sanitize_error_message, dedupe motherduck redactor

### DIFF
--- a/benchbox/platforms/credentials/motherduck.py
+++ b/benchbox/platforms/credentials/motherduck.py
@@ -13,7 +13,6 @@ Licensed under the MIT License. See LICENSE file in the project root for details
 from __future__ import annotations
 
 import os
-import re
 from typing import Optional, Union
 
 from rich.console import Console
@@ -138,16 +137,12 @@ def validate_motherduck_credentials(
         adapter.create_connection()
         return True, None
     except Exception as exc:
-        return False, _redact_token(str(exc), resolved_token)
+        from benchbox.platforms.motherduck import _redact_motherduck_token
+
+        return False, _redact_motherduck_token(str(exc), resolved_token)
     finally:
         if adapter is not None:
             adapter.close_connection()
-
-
-def _redact_token(message: str, token: str) -> str:
-    """Remove MotherDuck token material from connection errors."""
-    redacted = message.replace(token, "****") if token else message
-    return re.sub(r"(motherduck_token=)[^&\s,;)]*", r"\1****", redacted, flags=re.IGNORECASE)
 
 
 __all__ = [

--- a/benchbox/utils/input_validation.py
+++ b/benchbox/utils/input_validation.py
@@ -582,34 +582,6 @@ def validate_table_name(name: str, allow_schema_prefix: bool = False) -> str:
     return validate_sql_identifier(name, "table name", MAX_TABLE_NAME_LENGTH, allow_dots=allow_schema_prefix)
 
 
-def sanitize_error_message(message: str, redact_identifiers: bool = True) -> str:
-    """Sanitize error messages to prevent information disclosure.
-
-    Args:
-        message: The error message to sanitize
-        redact_identifiers: Whether to redact table/column names
-
-    Returns:
-        The sanitized error message
-    """
-    if not redact_identifiers:
-        return message
-
-    # Redact potential table/column names in common error patterns
-    patterns = [
-        (r"table '([^']+)'", "table '[REDACTED]'"),
-        (r"column '([^']+)'", "column '[REDACTED]'"),
-        (r"database '([^']+)'", "database '[REDACTED]'"),
-        (r"schema '([^']+)'", "schema '[REDACTED]'"),
-    ]
-
-    result = message
-    for pattern, replacement in patterns:
-        result = re.sub(pattern, replacement, result, flags=re.IGNORECASE)
-
-    return result
-
-
 # ============================================================================
 # Convenience Functions
 # ============================================================================

--- a/tests/unit/utils/test_input_validation.py
+++ b/tests/unit/utils/test_input_validation.py
@@ -26,7 +26,6 @@ from benchbox.utils.input_validation import (
     quote_identifier,
     quote_qualified_identifier,
     safe_format_table_reference,
-    sanitize_error_message,
     validate_benchmark_name,
     validate_platform_name,
     validate_query_complexity,
@@ -446,29 +445,6 @@ class TestValidateScaleFactor:
         """Very large scale factors should raise ValidationError."""
         with pytest.raises(ValidationError, match="too large"):
             validate_scale_factor(200000)
-
-
-class TestSanitizeErrorMessage:
-    """Tests for error message sanitization."""
-
-    def test_redact_table_names(self):
-        """Table names should be redacted."""
-        msg = "Table 'users' not found"
-        result = sanitize_error_message(msg)
-        assert "users" not in result
-        assert "[REDACTED]" in result
-
-    def test_redact_column_names(self):
-        """Column names should be redacted."""
-        msg = "Column 'password' is invalid"
-        result = sanitize_error_message(msg)
-        assert "password" not in result
-
-    def test_preserve_with_flag_false(self):
-        """Messages should not be redacted when flag is False."""
-        msg = "Table 'users' not found"
-        result = sanitize_error_message(msg, redact_identifiers=False)
-        assert msg == result
 
 
 class TestSafeFormatTableReference:


### PR DESCRIPTION
sanitize_error_message had zero production call sites and redacted
table/column identifiers, not credentials - its presence made the
redaction inventory look one entry stronger than it is. The motherduck
token redactor existed as verbatim copies in the adapter and the
credentials wizard; the wizard now reuses the adapter's implementation
via the same lazy-import pattern it already uses for the adapter class.

TODO: dead-sanitize-error-message-and-duplicate-motherduck-redactor
