### PR TITLE
fix(cli): sanitize platform options in debug logging extras

### DIFF
--- a/benchbox/cli/database.py
+++ b/benchbox/cli/database.py
@@ -17,6 +17,7 @@ from rich.table import Table
 import benchbox.cli.platform_defaults as _platform_defaults  # noqa: F401  # registers builders
 from benchbox.core.databases.manager import check_connection as core_check_connection
 from benchbox.core.platform_registry import PlatformRegistry
+from benchbox.core.results.platform_options import sanitize_platform_options
 from benchbox.core.schemas import DatabaseConfig, SystemProfile
 from benchbox.utils.printing import quiet_console
 from benchbox.utils.runtime_env import ensure_driver_version
@@ -421,12 +422,14 @@ class DatabaseManager:
         """Build a database configuration using registered platform hooks."""
 
         platform_lower = platform.lower()
+        # Structured/JSON log handlers serialize `extra` in full, so option
+        # values must pass the same redaction as exported result metadata.
         logger.debug(
             "Building database config",
             extra={
                 "platform": platform_lower,
-                "platform_options": platform_options,
-                "runtime_overrides": runtime_overrides,
+                "platform_options": sanitize_platform_options(platform_options or {}),
+                "runtime_overrides": sanitize_platform_options(runtime_overrides or {}),
             },
         )
 
@@ -483,9 +486,15 @@ class DatabaseManager:
         else:
             config.driver_version_resolved = config.driver_version
 
+        # The config object carries connection_string, options, and arbitrary
+        # platform extras (extra="allow"), any of which can hold credentials.
         logger.debug(
             "Database configuration built",
-            extra={"platform": platform_lower, "config": config, "options": config.options},
+            extra={
+                "platform": platform_lower,
+                "config": sanitize_platform_options(config.model_dump()),
+                "options": sanitize_platform_options(config.options),
+            },
         )
         return config
 

--- a/benchbox/core/results/platform_options.py
+++ b/benchbox/core/results/platform_options.py
@@ -35,6 +35,12 @@ _SECRET_KEY_PARTS = tuple(
         "session_token",
         "connection_string",
         "credential",
+        # DSNs can embed URI userinfo (for example, user:password@host), and
+        # Azure Hadoop ``fs.azure.sas.*`` configuration values are bearer
+        # credentials. Redact the whole option rather than trying to preserve
+        # a partially parsed value across provider-specific formats.
+        "dsn",
+        "sas",
         # Found by the 2026-07-31 sentinel sweep leaking through BOTH layers:
         # api_key/onehouse_api_key (quanton's only credential) and Azure's
         # storage_account_key matched none of the parts above. Deliberately

--- a/benchbox/platforms/pyspark/session.py
+++ b/benchbox/platforms/pyspark/session.py
@@ -24,10 +24,11 @@ import subprocess
 import sys
 import threading
 from collections.abc import Mapping
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from pathlib import Path
 from typing import Any
 
+from benchbox.core.results.platform_options import sanitize_platform_options
 from benchbox.platforms.base.spark_logging import suppress_window_exec_warning
 from benchbox.utils.dependencies import get_package_install_message
 
@@ -345,7 +346,15 @@ class SparkSessionManager:
 
         with cls._lock:
             if cls._session is None:
-                logger.debug("Creating SparkSession with config: %s", config)
+                # extra_configs can carry credential-bearing Spark conf keys
+                # (fs.s3a.secret.key and friends) - redact before logging.
+                logger.debug(
+                    "Creating SparkSession with config: %s",
+                    replace(
+                        config,
+                        extra_configs=tuple(sorted(sanitize_platform_options(dict(config.extra_configs)).items())),
+                    ),
+                )
                 if not cls._java_validated:
                     _validate_java_version()
                     cls._java_validated = True

--- a/tests/uat/test_no_cli_surface_drift.py
+++ b/tests/uat/test_no_cli_surface_drift.py
@@ -57,6 +57,9 @@ ALLOWED_INTERNAL_CLI_FILES = {
     "benchbox/cli/commands/visualize.py",
     "benchbox/cli/composite_params.py",
     "benchbox/cli/config.py",
+    # cli-debug-logging-raw-options: sanitizes values attached to internal
+    # DEBUG records. No Click decorator or command signature changes.
+    "benchbox/cli/database.py",
     "benchbox/cli/display.py",
     "benchbox/cli/dryrun.py",
     # tuning-author-experience-honesty-quickfixes: reordered resolve_tuning's

--- a/tests/unit/cli/test_database_config_logging.py
+++ b/tests/unit/cli/test_database_config_logging.py
@@ -1,0 +1,65 @@
+"""Debug logging in DatabaseManager.create_config must never carry raw
+credential values: structured/JSON handlers serialize the ``extra`` dict in
+full, so the log path gets the same redaction as exported result metadata.
+
+Copyright 2026 Joe Harris / BenchBox Project
+Licensed under the MIT License. See LICENSE file in the project root for details.
+"""
+
+import logging
+
+import pytest
+
+from benchbox.cli.database import DatabaseManager
+
+pytestmark = [
+    pytest.mark.unit,
+    pytest.mark.fast,
+]
+
+
+class _CapturingHandler(logging.Handler):
+    def __init__(self):
+        super().__init__(logging.DEBUG)
+        self.records = []
+
+    def emit(self, record):
+        self.records.append(record)
+
+
+@pytest.fixture
+def captured_debug_records():
+    logger = logging.getLogger("benchbox.cli.database")
+    handler = _CapturingHandler()
+    previous_level = logger.level
+    logger.addHandler(handler)
+    logger.setLevel(logging.DEBUG)
+    try:
+        yield handler.records
+    finally:
+        logger.removeHandler(handler)
+        logger.setLevel(previous_level)
+
+
+class TestCreateConfigDebugLogging:
+    def test_platform_options_extra_is_sanitized(self, captured_debug_records):
+        DatabaseManager().create_config("duckdb", platform_options={"motherduck_token": "TOK-SENTINEL"})
+        building = [r for r in captured_debug_records if r.getMessage() == "Building database config"]
+        assert building, "the Building database config record must still be emitted"
+        options = building[0].platform_options
+        assert "motherduck_token" in options, "option KEYS must stay visible for debugging"
+        assert options["motherduck_token"] != "TOK-SENTINEL"
+
+    def test_built_config_extra_is_sanitized(self, captured_debug_records):
+        DatabaseManager().create_config("duckdb", platform_options={"motherduck_token": "TOK-SENTINEL"})
+        built = [r for r in captured_debug_records if r.getMessage() == "Database configuration built"]
+        assert built, "the Database configuration built record must still be emitted"
+        record = built[0]
+        assert "TOK-SENTINEL" not in str(record.config)
+        assert "TOK-SENTINEL" not in str(record.options)
+        assert "motherduck_token" in record.options
+
+    def test_non_secret_options_keep_real_values(self, captured_debug_records):
+        DatabaseManager().create_config("duckdb", platform_options={"memory_limit": "4GB"})
+        building = [r for r in captured_debug_records if r.getMessage() == "Building database config"]
+        assert building[0].platform_options["memory_limit"] == "4GB"

--- a/tests/unit/cli/test_database_config_logging.py
+++ b/tests/unit/cli/test_database_config_logging.py
@@ -7,6 +7,7 @@ Licensed under the MIT License. See LICENSE file in the project root for details
 """
 
 import logging
+from types import SimpleNamespace
 
 import pytest
 
@@ -63,3 +64,28 @@ class TestCreateConfigDebugLogging:
         DatabaseManager().create_config("duckdb", platform_options={"memory_limit": "4GB"})
         building = [r for r in captured_debug_records if r.getMessage() == "Building database config"]
         assert building[0].platform_options["memory_limit"] == "4GB"
+
+    def test_credential_bearing_dsn_is_sanitized(self, captured_debug_records, monkeypatch):
+        dsn = "databend+http://user:DSN-SENTINEL@host/database"
+        monkeypatch.setattr(
+            "benchbox.cli.database.ensure_driver_version",
+            lambda **_: SimpleNamespace(
+                requested=None,
+                resolved="test",
+                actual="test",
+                runtime_strategy="current-process",
+                runtime_path=None,
+                runtime_python_executable=None,
+                auto_install_used=False,
+            ),
+        )
+
+        DatabaseManager().create_config("databend", platform_options={"dsn": dsn})
+
+        matching = [
+            r
+            for r in captured_debug_records
+            if r.getMessage() in {"Building database config", "Database configuration built"}
+        ]
+        assert matching
+        assert all("DSN-SENTINEL" not in str(record.__dict__) for record in matching)

--- a/tests/unit/core/results/test_platform_options_capture.py
+++ b/tests/unit/core/results/test_platform_options_capture.py
@@ -477,3 +477,18 @@ class TestApiKeyAndAccountKeyRedaction:
         assert result["partition_key"] == "l_orderkey"
         assert result["primary_key"] == "id"
         assert result["account"] == "acct-1"
+
+
+@pytest.mark.parametrize(
+    "key",
+    [
+        "dsn",
+        "database_dsn",
+        "spark.hadoop.fs.azure.sas.container.account.blob.core.windows.net",
+    ],
+)
+def test_dsn_and_sas_credential_keys_are_redacted(key: str) -> None:
+    """Connection DSNs and Azure SAS settings can both carry bearer secrets."""
+    from benchbox.core.results.platform_options import sanitize_platform_options
+
+    assert sanitize_platform_options({key: "CREDENTIAL-SENTINEL"})[key] == REDACTED_VALUE

--- a/tests/unit/platforms/pyspark/test_session_manager.py
+++ b/tests/unit/platforms/pyspark/test_session_manager.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 import os
 from types import SimpleNamespace
 from unittest.mock import MagicMock
@@ -59,6 +60,35 @@ def test_get_or_create_returns_singleton(monkeypatch: pytest.MonkeyPatch) -> Non
 
     SparkSessionManager.release()
     assert SparkSessionManager._session is None
+
+
+def test_get_or_create_redacts_azure_sas_config_in_debug_log(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Azure Hadoop SAS values are bearer credentials and must not reach logs."""
+    fake_session = SimpleNamespace(stop=lambda: None)
+    sas_key = "spark.hadoop.fs.azure.sas.container.account.blob.core.windows.net"
+
+    monkeypatch.setattr(session_module, "PYSPARK_AVAILABLE", True)
+    monkeypatch.setattr(session_module, "_validate_java_version", lambda: None)
+    _patch_classmethod(monkeypatch, "_create_session", lambda cls, config: fake_session)
+
+    with caplog.at_level(logging.DEBUG, logger="benchbox.platforms.pyspark.session"):
+        SparkSessionManager.get_or_create(
+            master="local[*]",
+            app_name="BenchBox-Tests",
+            driver_memory="2g",
+            executor_memory=None,
+            shuffle_partitions=8,
+            enable_aqe=True,
+            extra_configs={sas_key: "SAS-SENTINEL"},
+        )
+
+    messages = [record.getMessage() for record in caplog.records if "Creating SparkSession" in record.getMessage()]
+    assert messages
+    assert all("SAS-SENTINEL" not in message for message in messages)
+    assert any(sas_key in message for message in messages)
 
 
 def test_configuration_mismatch_raises(monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
logger.debug attached raw platform_options, the full DatabaseConfig
object (connection_string, options, arbitrary platform extras), and the
raw SparkSessionConfig with its extra_configs to log records. Plain
formatters never show extras, but structured/JSON handlers serialize
them in full. Route all three sites through sanitize_platform_options
so log records get the same redaction as exported result metadata while
keeping option keys visible for debugging.

TODO: cli-debug-logging-carries-raw-platform-options
