### PR TITLE
fix: close asynchronous PR review follow-ups

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -240,6 +240,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Set up Python
         uses: actions/setup-python@v5
@@ -263,6 +265,13 @@ jobs:
       # which is what `ci-required-result` actually gates on. Setup steps
       # above (checkout/setup-python/setup-uv/install deps) are not
       # guards and carry neither `id: guard-*` nor `continue-on-error`.
+      - name: Validate uv.lock revision against the PR base
+        id: guard-uv-lock-revision
+        continue-on-error: true
+        env:
+          BASE_REF: ${{ github.event.pull_request.base.sha }}
+        run: make uv-lock-revision-check
+
       - name: Lint and format check with ruff
         id: guard-ruff
         continue-on-error: true

--- a/Makefile
+++ b/Makefile
@@ -652,7 +652,7 @@ lint:
 # hook gated on uv.lock changes. See docs/development/development.md.
 .PHONY: uv-lock-revision-check
 uv-lock-revision-check:
-	python3 _project/scripts/check_uv_lock_revision.py
+	uv run -- python _project/scripts/check_uv_lock_revision.py $(if $(BASE_REF),--baseline-ref "$(BASE_REF)",)
 
 # Dependency audit - checks that every declared dep has an import site or is allowlisted.
 # Fails if an unused dep is introduced. See _project/scripts/dependency_audit/.
@@ -839,15 +839,19 @@ guards-fix:
 	@# the reviewable diff below never printed. Surface the failure loudly and
 	@# still finish the report; direct `make skill-sync` keeps its hard failure,
 	@# and genuine mirror drift is still enforced by skill-sync-check in CI.
-	@$(MAKE) -s skill-sync || echo "guards-fix: WARNING - the skill-sync step FAILED (see its output above); every other drift-guard artifact was still regenerated. Fix and re-run 'make skill-sync' separately."
-	@echo ""
-	@echo "No regen mode -- these are reviewed hand edits, guards-fix does not touch them:"
-	@echo "  - module-size guard: tests/system/test_module_size_thresholds.py (see its failure output for the ALLOWLIST entry to paste)"
-	@echo "  - DDL governance drift: benchbox/sql_compat/inventory.py --check-ddl-drift (register the transform, alias it, or exempt it)"
-	@echo "  - release curation list: scripts/check_release_curation.py (classify the path as main-only or release-cut curated)"
-	@echo ""
-	@echo "== guards-fix done. Review the diff below, then commit what you intend to keep. =="
-	@git status --porcelain
+	@status=0; $(MAKE) -s skill-sync || status=$$?; \
+	if [ "$$status" -ne 0 ]; then \
+		echo "guards-fix: WARNING - the skill-sync step FAILED (see its output above); every other drift-guard artifact was still regenerated. Fix and re-run 'make skill-sync' separately."; \
+	fi; \
+	echo ""; \
+	echo "No regen mode -- these are reviewed hand edits, guards-fix does not touch them:"; \
+	echo "  - module-size guard: tests/system/test_module_size_thresholds.py (see its failure output for the ALLOWLIST entry to paste)"; \
+	echo "  - DDL governance drift: benchbox/sql_compat/inventory.py --check-ddl-drift (register the transform, alias it, or exempt it)"; \
+	echo "  - release curation list: scripts/check_release_curation.py (classify the path as main-only or release-cut curated)"; \
+	echo ""; \
+	echo "== guards-fix done. Review the diff below, then commit what you intend to keep. =="; \
+	git status --porcelain; \
+	exit "$$status"
 
 ##@ CI Local Equivalents
 # These targets mirror GitHub Actions workflows for local validation
@@ -882,6 +886,8 @@ ci-lint:
 	[ $$? -eq 0 ] || failed="$$failed ruff-format"; \
 	uv run ty check; \
 	[ $$? -eq 0 ] || failed="$$failed ty-check"; \
+	$(MAKE) uv-lock-revision-check; \
+	[ $$? -eq 0 ] || failed="$$failed uv-lock-revision"; \
 	$(MAKE) lint-markers; \
 	[ $$? -eq 0 ] || failed="$$failed lint-markers"; \
 	$(MAKE) lint-imports; \
@@ -960,20 +966,18 @@ security-audit:
 # a gitignored directory can never be scanned. Walking the tree made the gate
 # environment-dependent: it stayed green in CI and in fresh pool worktrees, but
 # failed in the maintainer's primary clone on gitignored paths that only exist
-# there (`@~/`, `results-explorer/dist/`). Chasing those names in --skip fixes one
-# clone at a time; deriving the file list from git fixes the class.
+# there. Deriving the file list from git fixes the class.
 #
 # --skip keeps only the FILENAME globs. Its directory entries are dropped on
 # purpose: codespell prunes directories while traversing, so a directory name in
-# --skip has no effect once explicit paths are passed. Tracked directories that
-# must stay unscanned are excluded as git pathspecs instead (the rest of the old
-# list -- _build, benchmark_runs, htmlcov, .venv, node_modules -- is gitignored,
-# so `git ls-files` already excludes it).
+# --skip has no effect once explicit paths are passed. Hidden paths are excluded
+# as Git pathspecs too, preserving codespell's default hidden-directory filtering.
+# Tracked directories that must stay unscanned are excluded as Git pathspecs; the
+# remaining old directory list is gitignored, so `git ls-files` already excludes it.
 SPELLCHECK_SKIP_GLOBS := *.pyc,*.json,*.lock,*.svg,*.min.js,*.min.css,*.tpl,*.dst,*.tbl,*.dat,*.pdf
-# `**/` matches at any depth, so these exclude the directory NAME wherever it
-# appears (e.g. both `_binaries/` and `benchbox/_binaries/`), matching how
-# codespell's --skip pruned directory names during traversal.
 SPELLCHECK_EXCLUDE_PATHS := \
+	':(exclude,glob).*'             ':(exclude,glob).*/**' \
+	':(exclude,glob)**/.*'          ':(exclude,glob)**/.*/**' \
 	':(exclude,glob)**/_binaries/**' ':(exclude,glob)_binaries/**' \
 	':(exclude,glob)**/_sources/**'  ':(exclude,glob)_sources/**' \
 	':(exclude,glob)**/_project/**'  ':(exclude,glob)_project/**' \

--- a/_project/scripts/check_uv_lock_revision.py
+++ b/_project/scripts/check_uv_lock_revision.py
@@ -9,6 +9,7 @@ ceremony.
 
 Modes:
   --old N --new N   pure comparison (test interface, no git or files needed)
+  --baseline-ref R compare ``git show R:uv.lock`` against ./uv.lock
   default           compare ``git show HEAD:uv.lock`` against ./uv.lock
 
 Exit status: 0 ok, 1 downgrade (or malformed lock), 2 usage error.
@@ -45,9 +46,9 @@ def check(old: int, new: int) -> int:
     return 0
 
 
-def _committed_lock_text(repo_root: Path) -> str | None:
+def _committed_lock_text(repo_root: Path, ref: str = "HEAD") -> str | None:
     result = subprocess.run(
-        ["git", "show", "HEAD:uv.lock"],
+        ["git", "show", f"{ref}:uv.lock"],
         cwd=repo_root,
         capture_output=True,
         text=True,
@@ -62,6 +63,7 @@ def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--old", type=int, default=None, help="baseline revision (test interface)")
     parser.add_argument("--new", type=int, default=None, help="candidate revision (test interface)")
+    parser.add_argument("--baseline-ref", help="git ref containing the baseline uv.lock (default: HEAD)")
     args = parser.parse_args(argv)
 
     if (args.old is None) != (args.new is None):
@@ -74,13 +76,20 @@ def main(argv: list[str] | None = None) -> int:
     if not working_lock.exists():
         print("uv.lock not found in working tree; nothing to check")
         return 0
-    committed = _committed_lock_text(repo_root)
+    baseline_ref = args.baseline_ref or "HEAD"
+    committed = _committed_lock_text(repo_root, baseline_ref)
     if committed is None:
+        if args.baseline_ref is not None:
+            print(
+                f"uv.lock revision guard: explicitly requested baseline {baseline_ref!r} is unavailable",
+                file=sys.stderr,
+            )
+            return 1
         # No committed baseline (fresh repo / uv.lock not yet tracked).
-        print("no committed uv.lock baseline (HEAD); nothing to compare")
+        print(f"no committed uv.lock baseline ({baseline_ref}); nothing to compare")
         return 0
     try:
-        old = parse_revision(committed, "HEAD:uv.lock")
+        old = parse_revision(committed, f"{baseline_ref}:uv.lock")
         new = parse_revision(working_lock.read_text(encoding="utf-8"), "uv.lock")
     except ValueError as exc:
         print(f"uv.lock revision guard: {exc}", file=sys.stderr)

--- a/_project/scripts/todo_db.py
+++ b/_project/scripts/todo_db.py
@@ -45,6 +45,7 @@ import socket
 import sqlite3
 import subprocess
 import sys
+import tempfile
 from contextlib import contextmanager
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
@@ -1213,10 +1214,22 @@ def connect_backend(backend: Path | str, *, read_only: bool = False) -> sqlite3.
     return connect_hosted(backend, read_only=read_only)
 
 
-def migrate_backend(backend: Path | str) -> list[int]:
+def _migration_freeze_guard(conn: sqlite3.Connection, actor: str | None) -> None:
+    """Reject a migration while another actor holds a live maintenance freeze."""
+    if not actor:
+        return
+    live = get_freeze(conn)
+    if live and live["holder"] != actor:
+        raise TodoError(
+            f"tracker is frozen for maintenance by {live['holder']} since {live['since']}; "
+            "migrations must run under the freeze holder or after release"
+        )
+
+
+def migrate_backend(backend: Path | str, actor: str | None = None) -> list[int]:
     """Apply pending schema migrations on either backend; returns versions applied."""
     if isinstance(backend, Path):
-        return migrate_db(backend)
+        return migrate_db(backend, actor=actor)
     # Hosted: a fresh sync is a hard requirement — migrating a stale replica
     # against an already-migrated primary would corrupt the version record.
     conn = _hosted_raw_connect(backend, sync_required=True)
@@ -1229,6 +1242,7 @@ def migrate_backend(backend: Path | str) -> list[int]:
         for target in sorted(MIGRATIONS):
             if version < target:
                 with _write_txn(conn):
+                    _migration_freeze_guard(conn, actor)
                     current = _schema_version(conn)
                     if current is not None and current >= target:
                         # a concurrent migrator won the race; not an error
@@ -1244,7 +1258,7 @@ def migrate_backend(backend: Path | str) -> list[int]:
         conn.close()
 
 
-def migrate_db(db_path: Path) -> list[int]:
+def migrate_db(db_path: Path, *, actor: str | None = None) -> list[int]:
     """Apply pending schema migrations; returns the versions applied."""
     if not db_path.exists():
         # Nothing to migrate — a fresh connect() creates the current schema.
@@ -1259,10 +1273,11 @@ def migrate_db(db_path: Path) -> list[int]:
         applied: list[int] = []
         for target in sorted(MIGRATIONS):
             if version < target:
-                for statement in MIGRATIONS[target]:
-                    raw.execute(statement)
-                raw.execute("UPDATE meta SET value = ? WHERE key = 'schema_version'", (str(target),))
-                raw.commit()
+                with _write_txn(raw):
+                    _migration_freeze_guard(raw, actor)
+                    for statement in MIGRATIONS[target]:
+                        raw.execute(statement)
+                    raw.execute("UPDATE meta SET value = ? WHERE key = 'schema_version'", (str(target),))
                 version = target
                 applied.append(target)
         return applied
@@ -1661,6 +1676,8 @@ def renew_claim(
 def start_unit(conn: sqlite3.Connection, actor: str, item_id: str, wid: str) -> None:
     with _write_txn(conn):
         _require_item(conn, item_id)
+        if not _touch_lease(conn, actor, item_id):
+            raise TodoError(f"{item_id!r}'s lease is expired, missing, or held by another actor; re-acquire it")
         unit = _require_unit(conn, item_id, wid)
         if unit["status"] == "done":
             raise TodoError(f"{item_id}:{wid} is already done")
@@ -1672,7 +1689,6 @@ def start_unit(conn: sqlite3.Connection, actor: str, item_id: str, wid: str) -> 
             " WHERE item_id = ? AND wid = ?",
             (utc_now(), worktree, branch, item_id, wid),
         )
-        _touch_lease(conn, actor, item_id)
         log_event(conn, actor, item_id, "start", {"wid": wid, "worktree": worktree, "branch": branch})
 
 
@@ -1683,6 +1699,8 @@ def done_unit(conn: sqlite3.Connection, actor: str, item_id: str, wid: str, evid
         _require_item(conn, item_id)
         _require_unit(conn, item_id, wid)
         _require_unit_needs_done(conn, item_id, wid)
+        if not _touch_lease(conn, actor, item_id):
+            raise TodoError(f"{item_id!r}'s lease is expired, missing, or held by another actor; re-acquire it")
         # Implicit start: stamp the location if `start` was skipped, so the
         # record of where the work happened survives either path.
         worktree, branch = _git_location()
@@ -1694,7 +1712,6 @@ def done_unit(conn: sqlite3.Connection, actor: str, item_id: str, wid: str, evid
             " WHERE item_id = ? AND wid = ?",
             (evidence, utc_now(), worktree, branch, item_id, wid),
         )
-        _touch_lease(conn, actor, item_id)
         log_event(conn, actor, item_id, "done", {"wid": wid, "evidence": evidence})
 
 
@@ -2107,8 +2124,14 @@ def write_activity(conn: sqlite3.Connection) -> dict[str, Any]:
     writes landing inside the same whole second. Together they are stable under
     no writes and move under any write, which is what a cutover needs to gate on.
     """
-    row = conn.execute("SELECT count(*) AS n, max(seq) AS last_seq, max(at) AS last_at FROM events").fetchone()
-    return {"count": row["n"] or 0, "last_seq": row["last_seq"], "latest": row["last_at"]}
+
+    def fingerprint(table: str) -> dict[str, Any]:
+        row = conn.execute(f"SELECT count(*) AS n, max(seq) AS last_seq, max(at) AS last_at FROM {table}").fetchone()
+        return {"count": row["n"] or 0, "last_seq": row["last_seq"], "latest": row["last_at"]}
+
+    activity = fingerprint("events")
+    activity["findings"] = fingerprint("finding_events")
+    return activity
 
 
 # ---------------------------------------------------------------------------
@@ -2174,11 +2197,12 @@ def run_verification(conn: sqlite3.Connection, actor: str, item_id: str, seq: in
     passed = proc.returncode == 0
     result = "pass" if passed else "fail"
     with _write_txn(conn):
+        if not _touch_lease(conn, actor, item_id):
+            raise TodoError(f"{item_id!r}'s lease is expired, missing, or held by another actor; re-acquire it")
         conn.execute(
             "UPDATE verifications SET last_run = ?, last_result = ? WHERE item_id = ? AND seq = ?",
             (utc_now(), result, item_id, seq),
         )
-        _touch_lease(conn, actor, item_id)
         log_event(conn, actor, item_id, "verify", {"seq": seq, "result": result})
     return result, output
 
@@ -2219,18 +2243,31 @@ _PLACEHOLDER_COMMAND_RE = re.compile(r"^\s*<[^<>]*>\s*$")
 def _command_unrunnable_reason(command: str) -> str | None:
     """Why this verification command can never execute, or None if it can.
 
-    Deliberately conservative: piped, multi-line, `!`-negated, env-prefixed and
-    compound commands are all legitimate and must not be flagged, so the only
-    signals used are a whole-command placeholder shape and a failed shell parse.
+    The command is parsed by the same POSIX shell used by ``subprocess.run(...,
+    shell=True)``. Syntax-only parsing catches malformed pipelines and accepts
+    valid heredocs without executing any command.
     """
     if _PLACEHOLDER_COMMAND_RE.match(command):
         return "prose placeholder, not a runnable command"
-    try:
-        tokens = shlex.split(command, posix=True)
-    except ValueError as exc:
-        return f"fails shell parse: {exc}"
-    if not tokens:
+    if not command.strip():
         return "empty after shell parsing"
+    if os.name == "nt":
+        # ``shell=True`` delegates to cmd.exe on Windows, which has no
+        # portable syntax-only equivalent. Do not invent a shlex grammar here.
+        return None
+    try:
+        parsed = subprocess.run(
+            ["/bin/sh", "-n"],
+            input=command,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+    except OSError:
+        return None
+    if parsed.returncode != 0:
+        detail = (parsed.stderr or "shell syntax error").strip().splitlines()[0]
+        return f"fails shell parse: {detail}"
     return None
 
 
@@ -2272,6 +2309,21 @@ _PATHLIKE_TOKEN_RE = re.compile(
     r"Makefile|pyproject\.toml|uv\.lock)(?:/|$)"
 )
 
+
+def _is_pathlike_token(token: str) -> bool:
+    """Recognize repository-relative path tokens without a root allowlist."""
+    if not token or token.startswith(("-", "$", "~", "/")) or "$" in token or "=" in token:
+        return False
+    if token.startswith(("http://", "https://")):
+        return False
+    if "/" in token:
+        return True
+    return Path(token).suffix in {".py", ".toml", ".yaml", ".yml", ".json", ".md", ".sh"} or token in {
+        "Makefile",
+        "Dockerfile",
+    }
+
+
 # 0.87 keeps real slips (test_todo_db_v3.py for test_todo_db_v2.py, 0.94) and
 # releases planned new files for genuinely new components
 # (test_ballista_adapter.py vs test_base_adapter.py, 0.86).
@@ -2283,10 +2335,9 @@ _NEAR_MISS_CUTOFF = 0.87
 # runner/ package, 0.80; result_capture.py for result_factory.py, 0.76).
 _DENY_NEAR_MISS_CUTOFF = 0.75
 
-# Characters that cannot appear in this repo's tracked paths. Authors annotate
-# scope globs in prose ("scripts/foo.py (item 4, done)"); such a glob can never
-# fnmatch a changed file, so as a deny rule it silently protects nothing.
-_GLOB_ANNOTATION_CHARS = " ()"
+# Scope annotations are prose appended after a path, rather than arbitrary
+# spaces inside a valid repository path (for example, "New Tool.rules").
+_GLOB_ANNOTATION_RE = re.compile(r"\s+\([^()]*\)\s*$")
 
 
 def _lint_repo_root() -> Path | None:
@@ -2300,7 +2351,10 @@ def _glob_resolves(root: Path, pattern: str) -> bool:
     """Whether ``pattern`` (repo-relative; trailing-slash means directory)
     matches anything in the working tree."""
     try:
-        return next(iter(root.glob(pattern.rstrip("/"))), None) is not None
+        normalized = pattern.rstrip("/")
+        if not any(ch in normalized for ch in "*?["):
+            return (root / normalized).exists()
+        return any(_scope_glob_matches(path.relative_to(root).as_posix(), pattern) for path in root.rglob("*"))
     except (ValueError, OSError, NotImplementedError):
         return False
 
@@ -2339,13 +2393,16 @@ def _deny_unresolved_finding(root: Path, glob: str) -> str | None:
     it. A CLEAN nonexistent literal or wildcard stays legal: it forbids
     creating the named file(s), and fnmatch will catch a created match.
     """
-    if any(ch in glob for ch in _GLOB_ANNOTATION_CHARS):
+    if _GLOB_ANNOTATION_RE.search(glob):
         return "contains annotation text so it can never match a repository path"
     if any(ch in glob for ch in "*?["):
         return None  # prospective family deny — forbids creating matches
     if glob.endswith(".py") and (root / glob[: -len(".py")]).is_dir():
         return f"names a module shadowed by existing package directory '{glob[: -len('.py')]}/'"
-    close = _near_miss(root, glob, cutoff=_DENY_NEAR_MISS_CUTOFF)
+    # A space is valid in a repository path; after the explicit annotation
+    # check above, do not reinterpret a prospective spaced path as prose or a
+    # typo merely because it resembles a sibling.
+    close = None if " " in glob else _near_miss(root, glob, cutoff=_DENY_NEAR_MISS_CUTOFF)
     if close:
         return f"names a nonexistent path suspiciously close to existing '{close}'"
     return None
@@ -2355,18 +2412,24 @@ def _unresolvable_scope_findings(item: dict) -> list[str]:
     root = _lint_repo_root()
     if root is None:
         return []
-    settled = item["state"] in ("done", "dropped")
+    if item["state"] in ("done", "dropped"):
+        return []
     findings = []
     for rule in item["scope"]:
         pattern = rule["path_glob"]
+        # Open-item wildcards are prospective policy: they can legitimately
+        # match only files the work will create, and neither finding path below
+        # flags a miss. Avoid walking the repository for an answer we discard.
+        if any(ch in pattern for ch in "*?["):
+            continue
         if _glob_resolves(root, pattern):
             continue
-        if not settled and rule["kind"] == "do_not_modify":
+        if rule["kind"] == "do_not_modify":
             if Path(pattern).is_absolute() or pattern.startswith("~"):
                 continue
             reason = _deny_unresolved_finding(root, pattern)
         else:
-            reason = _unresolved_path_finding(root, pattern, settled=settled)
+            reason = _unresolved_path_finding(root, pattern, settled=False)
         if reason:
             findings.append(f"scope {rule['kind']} {reason}: {pattern}")
     return findings
@@ -2376,21 +2439,31 @@ def _unresolvable_command_path_findings(item: dict) -> list[str]:
     root = _lint_repo_root()
     if root is None:
         return []
-    settled = item["state"] in ("done", "dropped")
+    if item["state"] in ("done", "dropped"):
+        return []
     findings = []
     for ver in item["verifications"]:
         command = ver.get("command") or ""
         if not command.strip() or _command_unrunnable_reason(command):
             continue  # an unrunnable rung is already its own finding
-        for token in shlex.split(command):
+        try:
+            tokens = shlex.split(command)
+        except ValueError:
+            # The shell parser above is authoritative. Valid heredocs may
+            # contain unmatched quotes in their body, which shlex cannot
+            # represent; skip path-token linting rather than rejecting them.
+            continue
+        for token in tokens:
             # Strip pytest node-id suffixes and shell separators shlex leaves
             # glued to the token ("tests/x.py;" in "cmd tests/x.py; next").
             path_part = token.split("::", 1)[0].rstrip(";,)")
-            if "$" in token or "=" in token or not _PATHLIKE_TOKEN_RE.match(path_part):
+            if not _is_pathlike_token(path_part):
                 continue
+            if any(ch in path_part for ch in "*?["):
+                continue  # prospective path family; a miss is legal on open items
             if _glob_resolves(root, path_part):
                 continue
-            reason = _unresolved_path_finding(root, path_part, settled=settled)
+            reason = _unresolved_path_finding(root, path_part, settled=False)
             if reason:
                 findings.append(f"verification seq {ver['seq']} {reason}: {path_part}")
     return findings
@@ -2408,8 +2481,10 @@ def _unresolvable_command_path_findings(item: dict) -> list[str]:
 # for recurrence and legitimately pass until it happens.
 
 _GATING_EXPECTED_RE = re.compile(
-    r"unfixed|must fail|pre-?fix|before the fix|fail(?:s|ed|ing)? (?:on|when|while|as)|"
-    r"exits? [1-9]\d* (?:today|on|when|until)|today|\bonce\b|\buntil\b",
+    r"(?:\b(?:unfixed|pre-?fix|before the fix|before this fix|prior to the fix)\b.{0,100}"
+    r"\b(?:fail|fails|failed|failing|exit|exits|non[- ]zero)\b|"
+    r"\b(?:fail|fails|failed|failing|exit|exits|non[- ]zero)\b.{0,100}"
+    r"\b(?:unfixed|pre-?fix|before the fix|before this fix|prior to the fix)\b)",
     re.IGNORECASE,
 )
 
@@ -2432,8 +2507,9 @@ def _has_falsifiable_rung(item: dict) -> bool:
 
 # Scope completeness: work that promises tests cannot land when only_modify
 # names a source file but omits that file's existing tests. The conventional
-# family is tests/unit/<subpath>/test_<name>*.py - the wildcard admits split
-# suites (test_todo_db.py, test_todo_db_v2.py, ...); scope is complete when
+# family is tests/unit/<subpath>/test_<name>.py plus test_<name>_*.py; the
+# suffix boundary avoids treating test_tpchavoc.py as part of test_tpch.py's
+# family. Scope is complete when
 # it covers ANY existing member. Only EXISTING test files are demanded - a
 # module without tests today stays creatable.
 
@@ -2447,9 +2523,9 @@ def _conventional_test_family(source_path: str) -> tuple[str, str] | None:
         return None
     prefix, stem = match.groups()
     if prefix.startswith("_project/scripts"):
-        return "tests/unit/scripts", f"test_{stem}*.py"
+        return "tests/unit/scripts", f"test_{stem}"
     subpath = prefix[len("benchbox/") :].rstrip("/")
-    return (f"tests/unit/{subpath}" if subpath else "tests/unit"), f"test_{stem}*.py"
+    return (f"tests/unit/{subpath}" if subpath else "tests/unit"), f"test_{stem}"
 
 
 def _missing_scope_test_files(item: dict) -> list[str]:
@@ -2463,7 +2539,11 @@ def _missing_scope_test_files(item: dict) -> list[str]:
         if family is None:
             continue
         test_dir, name_glob = family
-        existing = sorted(str(Path(test_dir) / p.name) for p in (root / test_dir).glob(name_glob))
+        existing = sorted(
+            str(Path(test_dir) / path.name)
+            for path in (root / test_dir).glob("*.py")
+            if path.name == f"{name_glob}.py" or (path.name.startswith(f"{name_glob}_") and path.suffix == ".py")
+        )
         if not existing:
             continue
         if any(_scope_glob_matches(test_path, glob) for test_path in existing for glob in only):
@@ -2753,9 +2833,20 @@ def write_snapshot(conn: sqlite3.Connection, path: Path) -> Path:
             "write it outside the checkout, e.g. ~/todo-db-backups/."
         )
     resolved.parent.mkdir(parents=True, exist_ok=True)
-    with open(resolved, "w", encoding="utf-8") as handle:
-        json.dump(build_snapshot(conn), handle, sort_keys=True, indent=2)
-        handle.write("\n")
+    # Build before touching the destination, then replace it atomically. A
+    # failed SELECT/serialization must leave an existing backup intact.
+    payload = json.dumps(build_snapshot(conn), sort_keys=True, indent=2) + "\n"
+    descriptor, temporary = tempfile.mkstemp(prefix=f".{resolved.name}.", dir=resolved.parent)
+    try:
+        with os.fdopen(descriptor, "w", encoding="utf-8") as handle:
+            handle.write(payload)
+        os.replace(temporary, resolved)
+    except BaseException:
+        try:
+            os.unlink(temporary)
+        except FileNotFoundError:
+            pass
+        raise
     return resolved
 
 
@@ -3378,7 +3469,7 @@ def main(argv: list[str] | None = None) -> int:
         if refusal is not None:
             return refusal
         try:
-            applied = migrate_backend(backend)
+            applied = migrate_backend(backend, actor=actor)
         except TodoError as exc:
             print(f"error: {exc}", file=sys.stderr)
             return 2

--- a/_project/scripts/todo_db_shadow.py
+++ b/_project/scripts/todo_db_shadow.py
@@ -33,6 +33,13 @@ TABLE_NAMES = (
     "prior_art",
     "deferrals",
 )
+FINDING_TABLE_NAMES = (
+    "findings",
+    "finding_evidence",
+    "finding_links",
+    "finding_events",
+    "finding_sections",
+)
 
 
 class ShadowMigrationError(RuntimeError):
@@ -86,7 +93,7 @@ def write_hosted_legacy_snapshot(connection: Any, output: Path) -> dict[str, int
 
     if output.exists() or output.is_symlink():
         raise ShadowMigrationError(f"hosted snapshot target must not already exist: {output}")
-    table_names = ("items", *(name for name in TABLE_NAMES if name != "items"), "events", "meta")
+    table_names = ("items", *(name for name in TABLE_NAMES if name != "items"), *FINDING_TABLE_NAMES, "events", "meta")
     snapshot = {table: _rows(connection, table) for table in table_names}
     output.parent.mkdir(parents=True, exist_ok=True)
     descriptor = os.open(output, os.O_CREAT | os.O_EXCL | os.O_WRONLY | getattr(os, "O_NOFOLLOW", 0), 0o600)

--- a/_project/scripts/todo_db_standalone_compat.py
+++ b/_project/scripts/todo_db_standalone_compat.py
@@ -30,6 +30,7 @@ COMMANDS = frozenset(
         "create",
         "show",
         "claim",
+        "renew",
         "release",
         "deps",
         "unblock",

--- a/_project/scripts/todo_findings.py
+++ b/_project/scripts/todo_findings.py
@@ -499,6 +499,7 @@ def parse_draft(path: Path) -> dict[str, Any]:
         "related_paths": _json_list_or_none(data.get("related_paths")),
         "suggested_sweep": _str_or_none(data.get("suggested_sweep")),
         "todo_id": _str_or_none(data.get("todo_id")),
+        "todo_id_declared": "todo_id" in data,
         # Legacy todo_id -> link kind, by status. A `promoted-to` edge asserts the
         # finding is `promoted`, so an `actioned` record must not use it.
         "todo_link_kind": ("promoted-to" if disposition == "promoted" else "resolved-by"),
@@ -1066,6 +1067,7 @@ def import_corpus(
     corpus_dir: str | Path,
     *,
     dry_run: bool = False,
+    existing_ids: set[str] | None = None,
 ) -> dict[str, Any]:
     """Import legacy records into the findings tables. Reads only; never writes files.
 
@@ -1097,7 +1099,7 @@ def import_corpus(
             resolved = conn.execute("SELECT 1 FROM items WHERE id = ?", (fields["todo_id"],)).fetchone() is not None
             if not resolved:
                 result["danglers"].append({"finding": finding_id, "todo_id": fields["todo_id"]})
-        if get_finding(conn, finding_id) is not None:
+        if (existing_ids is not None and finding_id in existing_ids) or get_finding(conn, finding_id) is not None:
             result["skipped"].append(finding_id)
             continue
         if dry_run:
@@ -1113,7 +1115,14 @@ def import_corpus(
     return result
 
 
-def stage_corpus_import(staging_path: Path, items_source: Path, corpus_dir: str | Path, actor: str) -> dict[str, Any]:
+def stage_corpus_import(
+    staging_path: Path,
+    items_source: Path,
+    corpus_dir: str | Path,
+    actor: str,
+    *,
+    existing_ids: set[str] | None = None,
+) -> dict[str, Any]:
     """Build a v4 staging database holding ONLY this import's findings rows.
 
     ``items_source`` seeds the items domain so legacy ``todo_id`` values resolve --
@@ -1131,7 +1140,7 @@ def stage_corpus_import(staging_path: Path, items_source: Path, corpus_dir: str 
         raw.close()
     conn = todo_db.connect(staging_path)
     try:
-        return import_corpus(conn, actor, corpus_dir)
+        return import_corpus(conn, actor, corpus_dir, existing_ids=existing_ids)
     finally:
         conn.close()
 
@@ -1184,6 +1193,11 @@ def target_findings_maxima(conn: Any) -> dict[str, int]:
     return maxima
 
 
+def target_finding_ids(conn: Any) -> set[str]:
+    """Return finding IDs already present on the hosted target."""
+    return {str(row[0]) for row in conn.execute("SELECT id FROM findings")}
+
+
 def parity_report(conn: Any, corpus_dir: str | Path, imported: dict[str, Any]) -> dict[str, Any]:
     """Machine-checkable parity of the corpus against what is stored.
 
@@ -1199,6 +1213,8 @@ def parity_report(conn: Any, corpus_dir: str | Path, imported: dict[str, Any]) -
         "frontmatter_diffs": [],
         "section_diffs": [],
         "triage_log_diffs": [],
+        "evidence_diffs": [],
+        "link_diffs": [],
         "danglers": imported.get("danglers", []),
         "failed_parses": imported.get("failed", []),
     }
@@ -1239,6 +1255,22 @@ def parity_report(conn: Any, corpus_dir: str | Path, imported: dict[str, Any]) -
             report["section_diffs"].append(
                 {"record": path.stem, "expected": len(want_sections), "stored": len(got_sections)}
             )
+        if fields.get("evidence_declared") and _normalize_evidence(fields.get("evidence")) != _normalize_evidence(
+            stored.get("evidence")
+        ):
+            report["evidence_diffs"].append({"record": path.stem})
+        if fields.get("todo_id_declared"):
+            todo_id = fields.get("todo_id")
+            expected_links = []
+            if todo_id:
+                resolved = conn.execute("SELECT 1 FROM items WHERE id = ?", (todo_id,)).fetchone() is not None
+                note = f"imported from todo_id: {todo_id}" + ("" if resolved else " (no such item at import time)")
+                expected_links.append((fields["todo_link_kind"], todo_id if resolved else None, note))
+            actual_links = [
+                (link.get("kind"), link.get("target_item"), link.get("note")) for link in stored.get("links") or []
+            ]
+            if actual_links != expected_links:
+                report["link_diffs"].append({"record": path.stem, "expected": expected_links, "stored": actual_links})
         # One imported_triage_log event per non-empty line.
         want_lines = _triage_log_lines(fields.get("triage_log") or "")
         got_lines = [e for e in stored.get("events") or [] if e.get("action") == IMPORTED_TRIAGE_ACTION]
@@ -1252,6 +1284,9 @@ def parity_report(conn: Any, corpus_dir: str | Path, imported: dict[str, Any]) -
         and not report["frontmatter_diffs"]
         and not report["section_diffs"]
         and not report["triage_log_diffs"]
+        and not report["evidence_diffs"]
+        and not report["link_diffs"]
+        and not report["danglers"]
         and not report["failed_parses"]
     )
     return report
@@ -1752,16 +1787,27 @@ def _cmd_import_bulk(conn: Any, actor: str, args: argparse.Namespace) -> int:
         )
 
     maxima = target_findings_maxima(conn)
+    existing_ids = target_finding_ids(conn)
     tmpdir = tempfile.mkdtemp(prefix="findings-import-")
     try:
         staging = Path(tmpdir) / "staging.sqlite"
-        staged = stage_corpus_import(staging, items_source, args.corpus, actor)
+        staged = stage_corpus_import(staging, items_source, args.corpus, actor, existing_ids=existing_ids)
         if staged["failed"]:
             for failure in staged["failed"]:
                 print(f"  FAILED {failure['file']}: {failure['error']}", file=todo_db.sys.stderr)
             raise todo_db.TodoError(f"{len(staged['failed'])} record(s) failed to parse; nothing was transferred")
         if not staged["imported"]:
             print("nothing to import: every record is already present")
+            sync = getattr(conn, "sync", None)
+            if callable(sync):
+                sync()
+            report = parity_report(conn, args.corpus, staged)
+            if args.report:
+                print(json.dumps(report, indent=2, sort_keys=True))
+            if not report["ok"]:
+                print("PARITY FAILED after no-op import", file=todo_db.sys.stderr)
+                return 1
+            print(f"parity OK: {report['stored_records']}/{report['corpus_records']} records, zero diffs")
             return 0
         # bulk_transfer copies primary keys verbatim, so staged ids must clear the
         # target's maxima or the first colliding row aborts the whole transfer.

--- a/benchbox/cli/commands/run.py
+++ b/benchbox/cli/commands/run.py
@@ -629,6 +629,23 @@ def _apply_dataframe_suffix_mode(s: types.SimpleNamespace) -> None:
         s.mode = "dataframe"
 
 
+_DUCKLAKE_DEPLOYMENT_MODES = frozenset({"local", "local_catalog_s3", "postgres_catalog", "postgres_catalog_s3"})
+
+
+def _apply_ducklake_deployment_suffix(s: types.SimpleNamespace) -> None:
+    """Turn ``ducklake:<mode>`` shorthand into an explicit platform option."""
+    if not s.platform or not s.platform.lower().startswith("ducklake:"):
+        return
+    platform, mode = s.platform.split(":", 1)
+    if mode not in _DUCKLAKE_DEPLOYMENT_MODES:
+        return
+    s.platform = platform
+    pairs = list(s.platform_option_pairs or ())
+    if not any(key.casefold() == "deployment_mode" for key, _value in pairs):
+        pairs.insert(0, ("deployment_mode", mode))
+    s.platform_option_pairs = tuple(pairs)
+
+
 def _parse_plat_bench_options(s: types.SimpleNamespace) -> None:
     """Parse --platform-option and --benchmark-option flags; set state fields."""
     s.logger, s.verbosity_settings = setup_verbose_logging(s.verbose, quiet=bool(s.quiet))
@@ -637,6 +654,7 @@ def _parse_plat_bench_options(s: types.SimpleNamespace) -> None:
     s.verbosity_payload = s.verbosity_settings.to_config()
 
     _apply_dataframe_suffix_mode(s)
+    _apply_ducklake_deployment_suffix(s)
     s.platform_key = normalize_platform_name(s.platform) if s.platform else None
     s.benchmark = normalize_benchmark_name(s.benchmark) if s.benchmark else None
     s.table_mode = (s.table_mode or "native").lower()

--- a/benchbox/cli/commands/run.py
+++ b/benchbox/cli/commands/run.py
@@ -629,15 +629,12 @@ def _apply_dataframe_suffix_mode(s: types.SimpleNamespace) -> None:
         s.mode = "dataframe"
 
 
-_DUCKLAKE_DEPLOYMENT_MODES = frozenset({"local", "local_catalog_s3", "postgres_catalog", "postgres_catalog_s3"})
-
-
 def _apply_ducklake_deployment_suffix(s: types.SimpleNamespace) -> None:
     """Turn ``ducklake:<mode>`` shorthand into an explicit platform option."""
     if not s.platform or not s.platform.lower().startswith("ducklake:"):
         return
     platform, mode = s.platform.split(":", 1)
-    if mode not in _DUCKLAKE_DEPLOYMENT_MODES:
+    if mode not in ("local", "local_catalog_s3", "postgres_catalog", "postgres_catalog_s3"):
         return
     s.platform = platform
     pairs = list(s.platform_option_pairs or ())

--- a/benchbox/core/results/anonymization.py
+++ b/benchbox/core/results/anonymization.py
@@ -21,7 +21,7 @@ from urllib.parse import urlparse
 
 import yaml
 
-from benchbox.core.results.platform_options import _SECRET_KEY_PARTS
+from benchbox.core.results.platform_options import _SECRET_KEY_PARTS, is_secret_option_key
 
 logger = logging.getLogger(__name__)
 
@@ -57,7 +57,7 @@ _MESSAGE_PATH_RE = re.compile(
 )
 _MESSAGE_URL_RE = re.compile(r"\b[a-z][a-z0-9+.-]*://[^\s'\",;)]*", flags=re.IGNORECASE)
 _MESSAGE_SECRET_ASSIGNMENT_RE = re.compile(
-    r"\b([a-z0-9_]*(?:token|password|secret|access_key|private_key)[a-z0-9_]*)=[^&\s,;)]*",
+    r"\b([a-z0-9][a-z0-9_.-]*)=[^&\s,;)]*",
     flags=re.IGNORECASE,
 )
 
@@ -411,17 +411,16 @@ class AnonymizationManager:
     def _looks_like_connection_string(value: str) -> bool:
         if re.search(r"://[^/@\s:]+:[^/@\s]+@", value):
             return True
-        return bool(
-            re.search(
-                r"\b[a-z0-9_]*(?:password|token|secret|access_key|private_key)[a-z0-9_]*=",
-                value,
-                flags=re.IGNORECASE,
-            )
-        )
+        return any(is_secret_option_key(match.group(1)) for match in _MESSAGE_SECRET_ASSIGNMENT_RE.finditer(value))
 
     def _sanitize_public_message(self, value: str) -> str:
         cleaned = self.remove_pii(value)
-        cleaned = _MESSAGE_SECRET_ASSIGNMENT_RE.sub(lambda match: f"{match.group(1)}={PUBLIC_REDACTED_VALUE}", cleaned)
+        cleaned = _MESSAGE_SECRET_ASSIGNMENT_RE.sub(
+            lambda match: (
+                f"{match.group(1)}={PUBLIC_REDACTED_VALUE}" if is_secret_option_key(match.group(1)) else match.group(0)
+            ),
+            cleaned,
+        )
         cleaned = _MESSAGE_URL_RE.sub(lambda match: self._hash_public_identifier(match.group(0), "endpoint"), cleaned)
         cleaned = _MESSAGE_PATH_RE.sub(lambda match: self._hash_public_identifier(match.group(0), "path"), cleaned)
         return cleaned

--- a/benchbox/core/results/exporter.py
+++ b/benchbox/core/results/exporter.py
@@ -40,6 +40,7 @@ from benchbox.core.results.anonymization import (
 from benchbox.core.results.canonical_json import canonical_json_text
 from benchbox.core.results.models import BenchmarkResults
 from benchbox.core.results.normalizer import get_query_map, normalize_result_dict
+from benchbox.core.results.platform_options import REDACTED_VALUE, _is_username_key
 from benchbox.core.results.schema import (
     SchemaV2ValidationError,
     SchemaV2Validator,
@@ -57,6 +58,18 @@ logger = logging.getLogger(__name__)
 
 ResultLike = BenchmarkResults
 QueryResultLike = "QueryResult | dict[str, Any]"
+
+
+def _redact_usernames(value: Any) -> Any:
+    """Redact connection-identity keys for a non-anonymized export."""
+    if isinstance(value, dict):
+        return {
+            str(key): REDACTED_VALUE if _is_username_key(str(key)) else _redact_usernames(child)
+            for key, child in value.items()
+        }
+    if isinstance(value, list):
+        return [_redact_usernames(item) for item in value]
+    return value
 
 
 class ResultExporter:
@@ -242,6 +255,10 @@ class ResultExporter:
             self._apply_anonymization(payload)
             anonymized = True
         else:
+            # Capture retains usernames until the public anonymizer can assign
+            # stable per-value pseudonyms. Private exports still must not carry
+            # connection identities verbatim, so redact them at this boundary.
+            payload = _redact_usernames(payload)
             anonymized = False
 
         # Add export metadata

--- a/benchbox/core/results/platform_options.py
+++ b/benchbox/core/results/platform_options.py
@@ -103,6 +103,7 @@ def sanitize_platform_options(
     options: Mapping[str, Any] | None,
     *,
     exclude_internal: bool = False,
+    redact_usernames: bool = True,
 ) -> dict[str, Any]:
     """Return a JSON-friendly platform-options dict with secret-like values redacted.
 
@@ -120,10 +121,14 @@ def sanitize_platform_options(
         key_str = str(key)
         if exclude_internal and (key_str.startswith("_") or key_str in _INTERNAL_OPTION_KEYS):
             continue
-        if is_secret_option_key(key_str) or _is_username_key(key_str):
+        if is_secret_option_key(key_str) or (redact_usernames and _is_username_key(key_str)):
             sanitized[key_str] = REDACTED_VALUE
         else:
-            sanitized[key_str] = _sanitize_option_value(value, exclude_internal=exclude_internal)
+            sanitized[key_str] = _sanitize_option_value(
+                value,
+                exclude_internal=exclude_internal,
+                redact_usernames=redact_usernames,
+            )
     return sanitized
 
 
@@ -159,7 +164,10 @@ def build_platform_options_capture(
         values[key] = value
         sources[key] = requested_source
 
-    sanitized_values = sanitize_platform_options(values, exclude_internal=True)
+    # Keep usernames available to the public anonymizer so distinct connection
+    # identities receive distinct stable pseudonyms. The non-anonymized exporter
+    # redacts these keys at the final internal-export boundary.
+    sanitized_values = sanitize_platform_options(values, exclude_internal=True, redact_usernames=False)
     return sanitized_values, {key: sources[key] for key in sanitized_values if key in sources}
 
 
@@ -173,13 +181,31 @@ def _iter_public_options(options: Mapping[str, Any] | None):
         yield key_str, value
 
 
-def _sanitize_option_value(value: Any, *, exclude_internal: bool = False) -> Any:
+def _sanitize_option_value(value: Any, *, exclude_internal: bool = False, redact_usernames: bool = True) -> Any:
     if isinstance(value, Mapping):
-        return sanitize_platform_options(value, exclude_internal=exclude_internal)
+        return sanitize_platform_options(
+            value,
+            exclude_internal=exclude_internal,
+            redact_usernames=redact_usernames,
+        )
     if isinstance(value, list):
-        return [_sanitize_option_value(item, exclude_internal=exclude_internal) for item in value]
+        return [
+            _sanitize_option_value(
+                item,
+                exclude_internal=exclude_internal,
+                redact_usernames=redact_usernames,
+            )
+            for item in value
+        ]
     if isinstance(value, tuple):
-        return [_sanitize_option_value(item, exclude_internal=exclude_internal) for item in value]
+        return [
+            _sanitize_option_value(
+                item,
+                exclude_internal=exclude_internal,
+                redact_usernames=redact_usernames,
+            )
+            for item in value
+        ]
     if isinstance(value, (str, int, float, bool)) or value is None:
         return value
     try:
@@ -192,8 +218,16 @@ def _sanitize_option_value(value: Any, *, exclude_internal: bool = False) -> Any
         except Exception:
             return f"<unserializable:{type(value).__name__}>"
         if isinstance(as_dict, Mapping):
-            return sanitize_platform_options(as_dict, exclude_internal=exclude_internal)
-        return _sanitize_option_value(as_dict, exclude_internal=exclude_internal)
+            return sanitize_platform_options(
+                as_dict,
+                exclude_internal=exclude_internal,
+                redact_usernames=redact_usernames,
+            )
+        return _sanitize_option_value(
+            as_dict,
+            exclude_internal=exclude_internal,
+            redact_usernames=redact_usernames,
+        )
     # No canonical serialization available. Never fall back to str()/repr()
     # here: that would silently publish opaque Python repr text into
     # exported bundles/payloads. Leave an explicit marker instead so gaps

--- a/benchbox/core/tuning/introspection.py
+++ b/benchbox/core/tuning/introspection.py
@@ -340,6 +340,9 @@ def _statement_table(statement: AppliedStatement) -> str | None:
     ct = _CREATE_TABLE_RE.match(text)
     if ct:
         return normalize_identifier(ct.group("table"))
+    alter = _ALTER_TABLE_RE.match(text)
+    if alter:
+        return normalize_identifier(alter.group("table"))
     if statement.table:
         return normalize_identifier(statement.table)
     return None

--- a/benchbox/platforms/__init__.py
+++ b/benchbox/platforms/__init__.py
@@ -698,6 +698,7 @@ pg-duckdb|postgres_scan_threads|Threads for parallel PostgreSQL table scanning (
 pg-duckdb|compare_native|Run native DuckDB comparison for matched queries|{'parser': 'parse_bool', 'default': False}
 ducklake|metadata_path|DuckLake catalog metadata file path (.ducklake)|{}
 ducklake|data_path|DuckLake Parquet data directory (local path or s3:// URI)|{}
+ducklake|deployment_mode|DuckLake deployment mode: local, local_catalog_s3, postgres_catalog, or postgres_catalog_s3|{'choices': ('local', 'local_catalog_s3', 'postgres_catalog', 'postgres_catalog_s3')}
 ducklake|catalog|DuckLake catalog backend: duckdb, sqlite, or postgres|{'choices': ('duckdb', 'sqlite', 'postgres'), 'default': 'duckdb'}
 ducklake|pg_host|PostgreSQL hostname for the postgres catalog backend|{'default': 'localhost'}
 ducklake|pg_port|PostgreSQL port for the postgres catalog backend|{'parser': 'int', 'default': 5432}

--- a/benchbox/platforms/ducklake.py
+++ b/benchbox/platforms/ducklake.py
@@ -813,7 +813,7 @@ class DuckLakeAdapter(DuckDBAdapter):
         identity = self._run_identity(benchmark)
         table = self._quote_identifier(_RUN_IDENTITY_TABLE)
         connection.execute(
-            f"CREATE TABLE IF NOT EXISTS lake.main.{table} (identity_key VARCHAR PRIMARY KEY, identity_value VARCHAR)"
+            f"CREATE TABLE IF NOT EXISTS lake.main.{table} (identity_key VARCHAR, identity_value VARCHAR)"
         )
         connection.execute(f"DELETE FROM lake.main.{table}")
         connection.executemany(

--- a/benchbox/platforms/ducklake.py
+++ b/benchbox/platforms/ducklake.py
@@ -25,6 +25,8 @@ Licensed under the MIT License. See LICENSE file in the project root for details
 from __future__ import annotations
 
 import argparse
+import hashlib
+import json
 import logging
 import re
 import shutil
@@ -47,6 +49,7 @@ _VALID_CATALOGS: tuple[str, ...] = ("duckdb", "sqlite", "postgres")
 # Stable, idempotent secret name so reconnects/CREATE OR REPLACE don't
 # accumulate anonymous secrets.
 _S3_SECRET_NAME = "benchbox_ducklake_s3"
+_RUN_IDENTITY_TABLE = "__benchbox_run_identity"
 
 # Connection credentials that must never reach exported result metadata.
 # get_platform_info() already omits these, but the normalized metadata is also
@@ -388,6 +391,9 @@ class DuckLakeAdapter(DuckDBAdapter):
 
         adapter_config["metadata_path"] = metadata_path
         adapter_config["data_path"] = data_path
+        for key in ("benchmark", "scale_factor"):
+            if key in config:
+                adapter_config[key] = config[key]
 
         # Pass through DuckDB-family configuration (base DuckDB connection
         # settings for the "shell" connection the DuckLake catalog attaches to).
@@ -439,8 +445,10 @@ class DuckLakeAdapter(DuckDBAdapter):
         # left unspecified. Explicit options stay authoritative - a
         # contradiction warns rather than being overridden, because whoever
         # typed `--platform-option catalog=...` said the more specific thing.
-        catalog = _resolve_catalog_with_deployment_mode(config.get("deployment_mode"), catalog)
-        _warn_if_deployment_mode_contradicts_storage(config.get("deployment_mode"), data_path)
+        deployment_mode = config.get("deployment_mode") or _resolve_option("deployment_mode")
+        catalog = _resolve_catalog_with_deployment_mode(deployment_mode, catalog)
+        _warn_if_deployment_mode_contradicts_storage(deployment_mode, data_path)
+        adapter_config["deployment_mode"] = deployment_mode
 
         if catalog is not None:
             adapter_config["catalog"] = catalog
@@ -459,6 +467,8 @@ class DuckLakeAdapter(DuckDBAdapter):
 
     def __init__(self, **config):
         super().__init__(**config)
+        self._expected_benchmark = config.get("benchmark")
+        self._expected_scale_factor = config.get("scale_factor")
 
         metadata_path = config.get("metadata_path")
         data_path = config.get("data_path")
@@ -757,17 +767,81 @@ class DuckLakeAdapter(DuckDBAdapter):
             "superseded Parquet from earlier runs remains and must be cleared manually."
         )
 
-    def _existing_lake_tables(self, setup_conn: Any) -> list[str]:
-        """Names of user tables already present in the ATTACHed ``lake`` catalog.
+    @staticmethod
+    def _quote_identifier(identifier: Any) -> str:
+        """Quote one DuckDB identifier for a generated maintenance statement."""
+        return '"' + str(identifier).replace('"', '""') + '"'
+
+    def _existing_lake_tables(self, setup_conn: Any) -> list[tuple[str, str]]:
+        """Schema/table pairs present in the attached ``lake`` catalog.
 
         ``duckdb_tables()`` reports every catalog the session can see, so the
         result is filtered to ``lake`` - the base memory/file catalog of the
         shell connection is not part of DuckLake's persistence unit.
         """
         rows = setup_conn.execute(
-            "SELECT table_name FROM duckdb_tables() WHERE database_name = 'lake' ORDER BY table_name"
+            "SELECT schema_name, table_name FROM duckdb_tables() "
+            "WHERE database_name = 'lake' ORDER BY schema_name, table_name"
         ).fetchall()
-        return [row[0] for row in rows]
+        return [(row[0], row[1]) for row in rows]
+
+    def _run_identity(self, benchmark: Any | None = None) -> dict[str, str]:
+        benchmark_name = self._expected_benchmark
+        if benchmark_name is None and benchmark is not None:
+            benchmark_name = getattr(benchmark, "_name", None) or benchmark.__class__.__name__
+        scale_factor = self._expected_scale_factor
+        if scale_factor is None and benchmark is not None:
+            scale_factor = getattr(benchmark, "scale_factor", None)
+        tuning = self.unified_tuning_configuration
+        try:
+            from dataclasses import asdict, is_dataclass
+
+            if is_dataclass(tuning):
+                tuning = asdict(tuning)
+            tuning_payload = json.dumps(tuning, sort_keys=True, default=str, separators=(",", ":"))
+        except (TypeError, ValueError):
+            tuning_payload = repr(tuning)
+        return {
+            "benchmark": str(benchmark_name or ""),
+            "scale_factor": str(scale_factor if scale_factor is not None else ""),
+            "tuning_sha256": hashlib.sha256(tuning_payload.encode("utf-8")).hexdigest(),
+        }
+
+    def _write_run_identity(self, connection: Any, benchmark: Any) -> None:
+        if self._expected_benchmark is None or self._expected_scale_factor is None:
+            return
+        identity = self._run_identity(benchmark)
+        table = self._quote_identifier(_RUN_IDENTITY_TABLE)
+        connection.execute(
+            f"CREATE TABLE IF NOT EXISTS lake.main.{table} (identity_key VARCHAR PRIMARY KEY, identity_value VARCHAR)"
+        )
+        connection.execute(f"DELETE FROM lake.main.{table}")
+        connection.executemany(
+            f"INSERT INTO lake.main.{table} (identity_key, identity_value) VALUES (?, ?)",
+            list(identity.items()),
+        )
+
+    def _verify_run_identity(self, setup_conn: Any) -> None:
+        if self._expected_benchmark is None or self._expected_scale_factor is None:
+            return
+        table = self._quote_identifier(_RUN_IDENTITY_TABLE)
+        rows = setup_conn.execute(
+            f"SELECT identity_key, identity_value FROM lake.main.{table} ORDER BY identity_key"
+        ).fetchall()
+        actual = {row[0]: row[1] for row in rows}
+        expected = self._run_identity()
+        if actual != expected:
+            raise RuntimeError(
+                "DuckLake catalog identity does not match this run "
+                f"(expected benchmark={expected['benchmark']!r}, scale_factor={expected['scale_factor']!r}, "
+                "and tuning configuration). Use --force or a fresh catalog."
+            )
+
+    def create_schema(self, benchmark: Any, connection: Any) -> float:
+        """Create benchmark tables and persist their benchmark/run identity."""
+        elapsed = super().create_schema(benchmark, connection)
+        self._write_run_identity(_unwrap_duckdb_connection(connection), benchmark)
+        return elapsed
 
     def _resolve_postgres_catalog_reuse(self, setup_conn: Any) -> None:
         """Apply reuse/force semantics to a server-side (postgres) catalog.
@@ -796,13 +870,35 @@ class DuckLakeAdapter(DuckDBAdapter):
             self.log_very_verbose("DuckLake postgres catalog holds no tables yet - treating as a fresh run")
             return
 
+        identity_name = _RUN_IDENTITY_TABLE.casefold()
+        user_tables = [
+            (schema, table) for schema, table in existing if str(table).strip('"').casefold() != identity_name
+        ]
+        if not user_tables and not self.force_recreate:
+            self.log_very_verbose("DuckLake catalog contains only its identity marker - treating as a fresh run")
+            return
+        if (
+            user_tables
+            and not self.force_recreate
+            and self._expected_benchmark is not None
+            and self._expected_scale_factor is not None
+        ):
+            if not any(str(table).strip('"').casefold() == identity_name for _schema, table in existing):
+                raise RuntimeError(
+                    "DuckLake catalog is populated but has no BenchBox run identity; "
+                    "refusing to reuse it. Use --force or a fresh catalog."
+                )
+            self._verify_run_identity(setup_conn)
+
         if self.force_recreate:
             self.log_verbose(
                 f"Force recreate enabled - dropping {len(existing)} table(s) from the DuckLake "
-                f"postgres catalog: {', '.join(existing)}"
+                f"postgres catalog: {', '.join(f'{schema}.{table}' for schema, table in existing)}"
             )
-            for table in existing:
-                setup_conn.execute(f'DROP TABLE IF EXISTS lake.main."{table}"')
+            for schema, table in existing:
+                setup_conn.execute(
+                    f"DROP TABLE IF EXISTS lake.{self._quote_identifier(schema)}.{self._quote_identifier(table)}"
+                )
             # Dropping the catalog entries is only half of --force: the Parquet
             # those tables were written from is still in DATA_PATH, and every
             # other backend clears it. Verified live against PostgreSQL 18 -

--- a/benchbox/platforms/snowflake_introspection.py
+++ b/benchbox/platforms/snowflake_introspection.py
@@ -90,19 +90,25 @@ class SnowflakeTuningIntrospector:
         ``error``, and corroboration then refuses the upgrade.
         """
         tables = ledger_tables(ledger)
+        table_params = tuple(sorted(table.upper() for table in tables))
+        table_filter = ""
+        if table_params:
+            placeholders = ", ".join("%s" for _table in table_params)
+            table_filter = f" AND UPPER(TABLE_NAME) IN ({placeholders})"
         try:
             query = (
                 "SELECT TABLE_NAME, CLUSTERING_KEY FROM INFORMATION_SCHEMA.TABLES "
-                f"WHERE CLUSTERING_KEY IS NOT NULL LIMIT {_MAX_TABLE_ROWS}"
+                f"WHERE CLUSTERING_KEY IS NOT NULL{table_filter} LIMIT {_MAX_TABLE_ROWS}"
             )
-            params: tuple[Any, ...] = ()
+            params: tuple[Any, ...] = table_params
             if self._schema:
                 query = (
                     "SELECT TABLE_NAME, CLUSTERING_KEY FROM INFORMATION_SCHEMA.TABLES "
-                    "WHERE TABLE_SCHEMA = %s AND CLUSTERING_KEY IS NOT NULL "
+                    "WHERE TABLE_SCHEMA = %s AND CLUSTERING_KEY IS NOT NULL"
+                    f"{table_filter} "
                     f"LIMIT {_MAX_TABLE_ROWS}"
                 )
-                params = (normalize_snowflake_schema(self._schema),)
+                params = (normalize_snowflake_schema(self._schema), *table_params)
             rows = _fetch(connection, query, params)
         except Exception as exc:  # introspection must never break a run
             logger.debug("snowflake clustering introspection degraded: %s", exc)

--- a/benchbox/utils/tpc_compilation.py
+++ b/benchbox/utils/tpc_compilation.py
@@ -172,8 +172,8 @@ class BinaryInfo:
     """Information about a TPC binary."""
 
     name: str
-    source_dir: Path
-    binary_path: Path
+    source_dir: Optional[Path]
+    binary_path: Optional[Path]
     precompiled_path: Optional[Path] = None
     makefile_path: Optional[Path] = None
     dependencies: list[str] = None
@@ -263,8 +263,8 @@ class TPCCompiler:
         if self.tpc_h_source or self.precompiled_base:
             self.binaries["dbgen"] = BinaryInfo(
                 name="dbgen",
-                source_dir=self.tpc_h_source or Path(),
-                binary_path=(self.tpc_h_source / f"dbgen{exe_suffix}") if self.tpc_h_source else Path(),
+                source_dir=self.tpc_h_source,
+                binary_path=(self.tpc_h_source / f"dbgen{exe_suffix}") if self.tpc_h_source else None,
                 precompiled_path=get_precompiled_path("tpc-h", "dbgen"),
                 makefile_path=(self.tpc_h_source / "makefile.suite") if self.tpc_h_source else None,
                 dependencies=["gcc", "make"],
@@ -272,8 +272,8 @@ class TPCCompiler:
 
             self.binaries["qgen"] = BinaryInfo(
                 name="qgen",
-                source_dir=self.tpc_h_source or Path(),
-                binary_path=(self.tpc_h_source / f"qgen{exe_suffix}") if self.tpc_h_source else Path(),
+                source_dir=self.tpc_h_source,
+                binary_path=(self.tpc_h_source / f"qgen{exe_suffix}") if self.tpc_h_source else None,
                 precompiled_path=get_precompiled_path("tpc-h", "qgen"),
                 makefile_path=(self.tpc_h_source / "makefile.suite") if self.tpc_h_source else None,
                 dependencies=["gcc", "make"],
@@ -283,8 +283,8 @@ class TPCCompiler:
         if self.tpc_ds_source or self.precompiled_base:
             self.binaries["dsdgen"] = BinaryInfo(
                 name="dsdgen",
-                source_dir=self.tpc_ds_source or Path(),
-                binary_path=(self.tpc_ds_source / f"dsdgen{exe_suffix}") if self.tpc_ds_source else Path(),
+                source_dir=self.tpc_ds_source,
+                binary_path=(self.tpc_ds_source / f"dsdgen{exe_suffix}") if self.tpc_ds_source else None,
                 precompiled_path=get_precompiled_path("tpc-ds", "dsdgen"),
                 makefile_path=(self.tpc_ds_source / "makefile") if self.tpc_ds_source else None,
                 dependencies=["gcc", "make", "yacc"],
@@ -292,8 +292,8 @@ class TPCCompiler:
 
             self.binaries["dsqgen"] = BinaryInfo(
                 name="dsqgen",
-                source_dir=self.tpc_ds_source or Path(),
-                binary_path=(self.tpc_ds_source / f"dsqgen{exe_suffix}") if self.tpc_ds_source else Path(),
+                source_dir=self.tpc_ds_source,
+                binary_path=(self.tpc_ds_source / f"dsqgen{exe_suffix}") if self.tpc_ds_source else None,
                 precompiled_path=get_precompiled_path("tpc-ds", "dsqgen"),
                 makefile_path=(self.tpc_ds_source / "makefile") if self.tpc_ds_source else None,
                 dependencies=["gcc", "make", "yacc"],
@@ -486,7 +486,7 @@ class TPCCompiler:
         binary_info = self.binaries[binary_name]
 
         # Check if source directory exists
-        if not binary_info.source_dir.exists():
+        if binary_info.source_dir is None or not binary_info.source_dir.exists():
             return False
 
         # Check if binary is already available

--- a/docs/development/adr/adr-ducklake-maturity-and-publishability.md
+++ b/docs/development/adr/adr-ducklake-maturity-and-publishability.md
@@ -74,7 +74,7 @@ DuckLake moves to `beta` when **all** of the following hold, and not before:
    a real S3 bucket.)*
 3. A full TPC-H SF>=1 run completes on each of the four deployment modes with
    results validated by the standard correctness gate - not just the SF=0.01
-   smoke coverage that exists today. **(Not met.)**
+   smoke coverage that exists today. *(Met as of 2026-07-30.)*
 4. Catalog reuse and `--force` are verified against a server-side catalog, not
    only a local file. *(Met 2026-07-30; that verification found and fixed a real
    defect where `--force` left orphaned Parquet.)*
@@ -82,9 +82,8 @@ DuckLake moves to `beta` when **all** of the following hold, and not before:
 
 **Basis.** Criteria 1-2 and 4 encode the failure modes this review actually
 found: coverage that existed but ran nowhere, and reuse/force semantics that
-were never exercised against the backend they were written for. Criterion 3 is
-the gap that remains - every DuckLake execution to date is SF=0.01 smoke, which
-exercises correctness but says nothing about behaviour at benchmark scale.
+were never exercised against the backend they were written for. Criterion 3
+was closed by the recorded SF=1 runs across all four deployment modes.
 
 **What would reverse this.** If `beta` acquires a repo-wide definition that
 conflicts with these, that definition wins and this section should be deleted
@@ -183,8 +182,8 @@ layout in results metadata.
 
 ## Consequences
 
-- w11's criterion 3 (scale runs on all four deployment modes) is now the single
-  blocker for `beta`; DuckLake stays `experimental` until it is met.
+- w11's criteria are met; DuckLake is now `beta`. Future demotion would require
+  new evidence against the reversal conditions above.
 - w12 requires that catalog backend and storage location reach result metadata.
   The registry already models these as independent axes (four deployment modes
   as of the w10 fix), so the vocabulary exists; wiring it into result metadata

--- a/docs/platforms/ducklake.md
+++ b/docs/platforms/ducklake.md
@@ -8,7 +8,7 @@
 DuckLake is an open lakehouse table format shipped as a DuckDB extension: table **data** is stored as Parquet files, while table **metadata** (the catalog) lives in a SQL database. BenchBox runs DuckLake through the same DuckDB engine used by the `duckdb` platform, inheriting DuckDB's SQL dialect and benchmark compatibility unchanged.
 
 ```{warning}
-The DuckLake platform is **beta** (promoted from experimental on 2026-07-30). All four combinations of catalog backend and storage location have been validated with a TPC-H SF=1 run through the correctness gate - see [Catalog Backends](#catalog-backends) below and the [maturity ADR](../development/adr/adr-ducklake-maturity-and-publishability.md) for what promotion required.
+The DuckLake platform is **beta** (promoted from experimental on 2026-07-30). The four registry deployment modes (catalog/storage pairings) have each been validated with a TPC-H SF=1 run through the correctness gate; this is not a claim that every one of the six possible backend-by-storage cross-product combinations was separately exercised - see [Catalog Backends](#catalog-backends) below and the [maturity ADR](../development/adr/adr-ducklake-maturity-and-publishability.md) for what promotion required.
 ```
 
 ## Features
@@ -263,7 +263,9 @@ RuntimeError: Failed to initialize the DuckLake catalog (INSTALL/LOAD/ATTACH 'du
 
 If a benchmark run is interrupted mid-load, a subsequent run without `--force` reuses the existing (partially loaded) catalog. Pass `--force` to wipe the catalog metadata file and Parquet data directory and rebuild from scratch.
 
-For `catalog=postgres`, `--force` only clears local artifacts and does **not** reach the remote catalog (see below) - use a fresh `pg_database` per run instead if you hit this with a PostgreSQL catalog.
+For `catalog=postgres`, the adapter inspects the attached catalog, verifies the
+benchmark/scale/tuning identity before reuse, and drops its tables when
+`--force` is passed.
 
 ### PostgreSQL Catalog: Database Does Not Exist
 

--- a/docs/platforms/support-status.md
+++ b/docs/platforms/support-status.md
@@ -20,8 +20,8 @@ Platform registry: **51** metadata entries; **46** SQL-capable; **19** DataFrame
 | Status | Entries | SQL-capable | DataFrame-capable | Dependency group | CLI exposure | MCP exposure | Docs exposure |
 | --- | ---: | ---: | ---: | --- | --- | --- | --- |
 | `stable` | 5 | 3 | 3 | Core or single local extra | Listed by registry; runnable when dependency is installed | Discovery/control-plane metadata via registry | Full platform docs |
-| `beta` | 27 | 26 | 3 | Optional extras, credentials, or local services | Listed by registry; may need SDK/credentials | Discovery/control-plane metadata via registry | Platform docs and setup notes |
-| `experimental` | 18 | 16 | 13 | Optional, GPU/native, or cloud Spark extras | Listed but labeled experimental in metadata/docs | Discovery metadata only unless tool support is documented | Experimental caveats required |
+| `beta` | 28 | 27 | 3 | Optional extras, credentials, or local services | Listed by registry; may need SDK/credentials | Discovery/control-plane metadata via registry | Platform docs and setup notes |
+| `experimental` | 17 | 15 | 13 | Optional, GPU/native, or cloud Spark extras | Listed but labeled experimental in metadata/docs | Discovery metadata only unless tool support is documented | Experimental caveats required |
 | `repo_only` | 0 | 0 | 0 | Source checkout only | Hidden from normal runtime | Not exposed | Developer docs only |
 | `deprecated` | 1 | 1 | 0 | Compatibility selector | Retained for migration | Existing-client exposure only | Migration docs required |
 | `document_only` | 0 | 0 | 0 | None | Not runnable | Not exposed | Docs must say not executable |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -114,7 +114,7 @@ all = [
     # Browser-generated results.duckdb files use the default v1.0.0 on-disk format,
     # readable by @duckdb/duckdb-wasm regardless of writer version; cap <2 to catch
     # the next-major API break in CI.
-    "duckdb>=1.0.0,<2.0.0",
+    "duckdb>=1.3.0,<2.0.0",
     "clickhouse-connect>=0.10.0",
     "clickhouse-driver>=0.2.0",
     "databricks-sql-connector>=2.0.0",

--- a/results-explorer/src/__tests__/snapshotReadiness.test.ts
+++ b/results-explorer/src/__tests__/snapshotReadiness.test.ts
@@ -8,6 +8,7 @@ vi.mock("@/lib/performanceMarks", () => ({
 }));
 
 import {
+  _COLD_EMPTY_READ_MAX_DELAY_MS_FOR_TEST,
   _waitForSnapshotRowsForTest,
   shouldRetryColdEmptyRead,
   shouldRetryTransientQueryError,
@@ -273,6 +274,10 @@ describe("shouldRetryColdEmptyRead", () => {
   it("retries exactly at the window boundary", () => {
     expect(shouldRetryColdEmptyRead(1, READY_AT + 15_000, READY_AT)).toBe(true);
     expect(shouldRetryColdEmptyRead(1, READY_AT + 15_001, READY_AT)).toBe(false);
+  });
+
+  it("bounds a genuinely empty query below the shortest browser recovery attempt", () => {
+    expect(_COLD_EMPTY_READ_MAX_DELAY_MS_FOR_TEST).toBeLessThan(8_000);
   });
 });
 

--- a/results-explorer/src/__tests__/snapshotReadiness.test.ts
+++ b/results-explorer/src/__tests__/snapshotReadiness.test.ts
@@ -7,7 +7,11 @@ vi.mock("@/lib/performanceMarks", () => ({
   markExplorerError: vi.fn(),
 }));
 
-import { _waitForSnapshotRowsForTest, shouldRetryColdEmptyRead } from "@/db";
+import {
+  _waitForSnapshotRowsForTest,
+  shouldRetryColdEmptyRead,
+  shouldRetryTransientQueryError,
+} from "@/db";
 
 interface FakeRow {
   result_id: string;
@@ -258,8 +262,8 @@ describe("shouldRetryColdEmptyRead", () => {
     expect(shouldRetryColdEmptyRead(1, READY_AT + 60_000, READY_AT)).toBe(false);
   });
 
-  it("stops at the final attempt so an empty result is returned, not looped", () => {
-    expect(shouldRetryColdEmptyRead(3, READY_AT + 1_000, READY_AT)).toBe(false);
+  it("stops at the size-budget attempt so an empty result is returned, not looped", () => {
+    expect(shouldRetryColdEmptyRead(100, READY_AT + 1_000, READY_AT)).toBe(false);
   });
 
   it("does not retry before the snapshot has ever been attached", () => {
@@ -269,5 +273,19 @@ describe("shouldRetryColdEmptyRead", () => {
   it("retries exactly at the window boundary", () => {
     expect(shouldRetryColdEmptyRead(1, READY_AT + 15_000, READY_AT)).toBe(true);
     expect(shouldRetryColdEmptyRead(1, READY_AT + 15_001, READY_AT)).toBe(false);
+  });
+});
+
+describe("shouldRetryTransientQueryError", () => {
+  const transient = new Error("offset is out of bounds");
+
+  it("keeps transient errors on the original three-attempt budget", () => {
+    expect(shouldRetryTransientQueryError(transient, 1)).toBe(true);
+    expect(shouldRetryTransientQueryError(transient, 2)).toBe(true);
+    expect(shouldRetryTransientQueryError(transient, 3)).toBe(false);
+  });
+
+  it("does not retry non-transient errors", () => {
+    expect(shouldRetryTransientQueryError(new Error("syntax error"), 1)).toBe(false);
   });
 });

--- a/results-explorer/src/db.ts
+++ b/results-explorer/src/db.ts
@@ -40,6 +40,12 @@ const SNAPSHOT_READY_DELAY_MS = 100;
 const QUERY_RETRY_ATTEMPTS = 100;
 const QUERY_ERROR_RETRY_ATTEMPTS = 3;
 const QUERY_RETRY_DELAY_MS = 100;
+// Keep a genuinely empty query bounded below the browser suite's shortest
+// data-wait attempt (8s). Linear backoff here previously held the page in its
+// loading skeleton for the full 15s cold window, so the recovery navigation
+// could never run. Frequent re-reads also do more useful work warming the
+// missing HTTP-backed row group than sleeping progressively longer.
+const QUERY_EMPTY_RETRY_DELAY_MS = 50;
 // How long after the snapshot is attached an EMPTY result is treated as a cold
 // read worth re-issuing rather than the truth. Cold init measures P95 ~1s, so
 // this is generous; outside it, empty returns immediately.
@@ -140,6 +146,8 @@ export async function _validateAttachedSnapshotForTest(
 }
 
 export const _EXPECTED_READ_MODEL_VERSION_FOR_TEST = EXPECTED_READ_MODEL_VERSION;
+export const _COLD_EMPTY_READ_MAX_DELAY_MS_FOR_TEST =
+  QUERY_RETRY_ATTEMPTS * QUERY_EMPTY_RETRY_DELAY_MS;
 
 async function verifyReadModelVersion(conn: DuckDBConnection): Promise<void> {
   const found = await readSnapshotReadModelVersion(conn);
@@ -414,7 +422,7 @@ export async function queryRows<T>(
       // Empty, and the snapshot is still warming: re-read rather than let a
       // cold zero-row answer reach the UI as "no such result". See
       // shouldRetryColdEmptyRead.
-      await sleep(QUERY_RETRY_DELAY_MS * attempt);
+      await sleep(QUERY_EMPTY_RETRY_DELAY_MS);
       continue;
     } catch (error: unknown) {
       lastError = error;

--- a/results-explorer/src/db.ts
+++ b/results-explorer/src/db.ts
@@ -35,7 +35,10 @@ let initFailures = 0;
 const INIT_FAILURE_LIMIT = 3;
 const SNAPSHOT_READY_ATTEMPTS = 8;
 const SNAPSHOT_READY_DELAY_MS = 100;
-const QUERY_RETRY_ATTEMPTS = 3;
+// Empty reads keep retrying for the warm-up window; this is a safety cap for
+// pathological clocks or zero-delay test timers rather than the normal stop.
+const QUERY_RETRY_ATTEMPTS = 100;
+const QUERY_ERROR_RETRY_ATTEMPTS = 3;
 const QUERY_RETRY_DELAY_MS = 100;
 // How long after the snapshot is attached an EMPTY result is treated as a cold
 // read worth re-issuing rather than the truth. Cold init measures P95 ~1s, so
@@ -415,7 +418,7 @@ export async function queryRows<T>(
       continue;
     } catch (error: unknown) {
       lastError = error;
-      if (!isTransientDuckDbSnapshotError(error) || attempt === QUERY_RETRY_ATTEMPTS) {
+      if (!shouldRetryTransientQueryError(error, attempt)) {
         throw error;
       }
       await sleep(QUERY_RETRY_DELAY_MS * attempt);
@@ -461,6 +464,10 @@ export function shouldRetryColdEmptyRead(
 
 function isColdEmptyRead(attempt: number): boolean {
   return shouldRetryColdEmptyRead(attempt, Date.now(), snapshotReadyAt);
+}
+
+export function shouldRetryTransientQueryError(error: unknown, attempt: number): boolean {
+  return isTransientDuckDbSnapshotError(error) && attempt < QUERY_ERROR_RETRY_ATTEMPTS;
 }
 
 async function queryRowsOnce<T>(

--- a/tests/integration/test_clickhouse_applied_ledger_live.py
+++ b/tests/integration/test_clickhouse_applied_ledger_live.py
@@ -53,10 +53,11 @@ def _tuned_adapter() -> ClickHouseAdapter:
     adapter.tuning_enabled = True
     adapter._applied_tuning_ledger = AppliedTuningLedger()
     adapter._applied_layout_operations = []
+    adapter.unified_tuning_configuration = _combined_tuning_config()
     return adapter
 
 
-def _combined_tunings() -> dict:
+def _combined_tuning_config() -> UnifiedTuningConfiguration:
     config = UnifiedTuningConfiguration()
     config.table_tunings["LINEITEM"] = TableTuning(
         table_name="LINEITEM",
@@ -66,7 +67,19 @@ def _combined_tunings() -> dict:
         ],
         partitioning=[TuningColumn(name="l_shipdate", type="DATE", order=1)],
     )
-    return config.table_tunings
+    return config
+
+
+def _combined_tunings() -> dict:
+    return _combined_tuning_config().table_tunings
+
+
+class _Benchmark:
+    def get_create_tables_sql(self, **_kwargs):
+        return SOURCE_DDL
+
+    def get_schema(self):
+        return {}
 
 
 @pytest.fixture
@@ -161,11 +174,7 @@ class TestAppliedLedgerAgainstLiveClickHouse:
 
     def test_ledger_orders_create_table_before_optimize(self, connection):
         adapter = _tuned_adapter()
-        tunings = _combined_tunings()
-        optimized = adapter._optimize_table_definition(SOURCE_DDL, tunings, nullable_columns=set())
-
-        connection.execute(optimized)
-        adapter._record_tuned_sort_key_op(SOURCE_DDL, optimized, "lineitem", tunings)
+        adapter.create_schema(_Benchmark(), connection)
         connection.execute("OPTIMIZE TABLE lineitem FINAL")
         adapter._applied_tuning_ledger.record("OPTIMIZE TABLE lineitem FINAL", PHASE_DDL)
         adapter._fold_layout_operations_into_ledger()

--- a/tests/unit/core/results/test_anonymization.py
+++ b/tests/unit/core/results/test_anonymization.py
@@ -855,3 +855,20 @@ class TestPublicPayloadPgUserAndTenantId:
         )["platform_metadata"]["platform_raw_config"]
         assert out["username"].startswith("user_")
         assert out["account"].startswith("account_")
+
+
+class TestPublicPayloadSecretMessages:
+    def test_message_values_use_the_shared_secret_key_classifier(self):
+        manager = AnonymizationManager()
+        out = manager.anonymize_result_payload(
+            {
+                "platform_metadata": {
+                    "error_message": "api_key=API-SENTINEL storage_account_key=AZ-SENTINEL",
+                    "stderr": "AccountKey=AZ-CONNECTION-SENTINEL",
+                }
+            }
+        )
+        serialized = json.dumps(out, default=str)
+        assert "API-SENTINEL" not in serialized
+        assert "AZ-SENTINEL" not in serialized
+        assert "AZ-CONNECTION-SENTINEL" not in serialized

--- a/tests/unit/core/results/test_environment_anonymization.py
+++ b/tests/unit/core/results/test_environment_anonymization.py
@@ -220,3 +220,4 @@ def test_private_export_preserves_raw_platform_metadata_behind_explicit_option(t
     assert "super-secret-password" in serialized
     assert "warehouse.internal.example.com" in serialized
     assert "raw-bucket" in serialized
+    assert payload["platform"]["raw_config"]["username"] == "<redacted>"

--- a/tests/unit/core/results/test_platform_options_capture.py
+++ b/tests/unit/core/results/test_platform_options_capture.py
@@ -89,6 +89,15 @@ def test_registered_default_recorded_when_no_saved_value() -> None:
     assert sources == {"foo": "registered_default"}
 
 
+def test_capture_retains_usernames_until_the_export_boundary() -> None:
+    values, _sources = build_platform_options_capture(
+        requested_options={"username": "alice-sentinel", "password": "secret-sentinel"}
+    )
+
+    assert values["username"] == "alice-sentinel"
+    assert values["password"] == REDACTED_VALUE
+
+
 @pytest.mark.parametrize(
     "key",
     [

--- a/tests/unit/platforms/test_ducklake_adapter.py
+++ b/tests/unit/platforms/test_ducklake_adapter.py
@@ -839,7 +839,7 @@ class TestDuckLakePostgresCatalogReuse:
     class _StubConn:
         """Minimal setup-connection stub recording the SQL it is given."""
 
-        def __init__(self, tables: list[str]):
+        def __init__(self, tables: list[str] | list[tuple[str, str]]):
             self._tables = tables
             self.executed: list[str] = []
 
@@ -848,7 +848,7 @@ class TestDuckLakePostgresCatalogReuse:
             return self
 
         def fetchall(self):
-            return [(name,) for name in self._tables]
+            return [table if isinstance(table, tuple) else ("main", table) for table in self._tables]
 
     def _adapter(self, tmp_path, **kwargs):
         return DuckLakeAdapter(
@@ -879,8 +879,8 @@ class TestDuckLakePostgresCatalogReuse:
         assert adapter.database_was_reused is False
         dropped = [sql for sql in conn.executed if sql.startswith("DROP TABLE")]
         assert dropped == [
-            'DROP TABLE IF EXISTS lake.main."lineitem"',
-            'DROP TABLE IF EXISTS lake.main."orders"',
+            'DROP TABLE IF EXISTS lake."main"."lineitem"',
+            'DROP TABLE IF EXISTS lake."main"."orders"',
         ]
 
     def test_force_also_clears_the_local_data_path(self, tmp_path):

--- a/tests/unit/platforms/test_ducklake_adapter.py
+++ b/tests/unit/platforms/test_ducklake_adapter.py
@@ -826,6 +826,40 @@ class TestDuckLakeFromConfigCatalogOptions:
         assert adapter.force_recreate is False
 
 
+class TestDuckLakeRunIdentity:
+    """The persistence marker must use DDL supported by DuckLake itself."""
+
+    class _StubConn:
+        def __init__(self):
+            self.executed: list[str] = []
+            self.inserted: list[tuple[str, str]] = []
+
+        def execute(self, sql):
+            self.executed.append(sql)
+            return self
+
+        def executemany(self, sql, rows):
+            self.executed.append(sql)
+            self.inserted.extend(rows)
+
+    def test_marker_table_omits_unsupported_primary_key_constraint(self, tmp_path):
+        adapter = DuckLakeAdapter(
+            metadata_path=str(tmp_path / "catalog.ducklake"),
+            data_path=str(tmp_path / "data"),
+            benchmark="tpch",
+            scale_factor=0.01,
+        )
+        conn = self._StubConn()
+
+        adapter._write_run_identity(conn, object())
+
+        create_sql = conn.executed[0]
+        assert create_sql.startswith('CREATE TABLE IF NOT EXISTS lake.main."__benchbox_run_identity"')
+        assert "PRIMARY KEY" not in create_sql
+        assert "UNIQUE" not in create_sql
+        assert {key for key, _value in conn.inserted} == {"benchmark", "scale_factor", "tuning_sha256"}
+
+
 class TestDuckLakePostgresCatalogReuse:
     """Reuse/force for a server-side catalog, resolved post-ATTACH (w6).
 

--- a/tests/unit/platforms/test_snowflake_introspection.py
+++ b/tests/unit/platforms/test_snowflake_introspection.py
@@ -117,7 +117,8 @@ class TestSnowflakeIntrospector:
         assert "INFORMATION_SCHEMA.TABLES" in query
         assert "SHOW CREATE" not in query
         assert "TABLE_SCHEMA = %s" in raw_query
-        assert conn.cursors[0].calls[0][1] == ("BENCH",)
+        assert "UPPER(TABLE_NAME) IN (%s)" in raw_query
+        assert conn.cursors[0].calls[0][1] == ("BENCH", "LINEITEM")
 
     def test_lowercase_schema_is_normalized_and_bound(self):
         conn = _FakeSnowflakeConnection([("LINEITEM", "LINEAR(A)")])
@@ -126,7 +127,7 @@ class TestSnowflakeIntrospector:
         assert state.error is None
         query, params = conn.cursors[0].calls[0]
         assert "TABLE_SCHEMA = %s" in query
-        assert params == ("BENCH",)
+        assert params == ("BENCH", "LINEITEM")
         assert "'bench'" not in query
 
     def test_unsafe_schema_degrades_without_interpolation(self):
@@ -143,6 +144,9 @@ class TestSnowflakeIntrospector:
         )
         state = SnowflakeTuningIntrospector().introspect(conn, _clustered_ledger())
         assert {obj.table for obj in state.objects} == {"LINEITEM"}
+        query, params = conn.cursors[0].calls[0]
+        assert "UPPER(TABLE_NAME) IN (%s)" in query
+        assert params == ("LINEITEM",)
 
     def test_non_fatal_on_query_failure(self):
         conn = _FakeSnowflakeConnection([], fail=True)

--- a/tests/unit/scripts/test_check_uv_lock_revision.py
+++ b/tests/unit/scripts/test_check_uv_lock_revision.py
@@ -65,3 +65,24 @@ class TestRevisionParsing:
     def test_repo_lock_has_parseable_revision(self):
         text = (REPO_ROOT / "uv.lock").read_text(encoding="utf-8")
         assert guard.parse_revision(text, "uv.lock") >= 3
+
+    def test_baseline_ref_is_used_for_git_lookup(self, monkeypatch, tmp_path):
+        calls = []
+
+        def fake_run(command, **kwargs):
+            calls.append(command)
+            return type("Result", (), {"returncode": 0, "stdout": "revision = 3\n"})()
+
+        monkeypatch.setattr(guard.subprocess, "run", fake_run)
+        assert guard._committed_lock_text(tmp_path, "origin/develop") == "revision = 3\n"
+        assert calls == [["git", "show", "origin/develop:uv.lock"]]
+
+    def test_explicit_missing_baseline_fails_closed(self, monkeypatch, capsys):
+        monkeypatch.setattr(guard, "_committed_lock_text", lambda _root, _ref: None)
+        assert guard.main(["--baseline-ref", "missing-base"]) == 1
+        assert "explicitly requested baseline" in capsys.readouterr().err
+
+    def test_default_missing_head_remains_valid_for_fresh_repo(self, monkeypatch, capsys):
+        monkeypatch.setattr(guard, "_committed_lock_text", lambda _root, _ref: None)
+        assert guard.main([]) == 0
+        assert "nothing to compare" in capsys.readouterr().out

--- a/tests/unit/scripts/test_todo_db.py
+++ b/tests/unit/scripts/test_todo_db.py
@@ -147,6 +147,7 @@ class TestWorkUnits:
                 {"id": "w2", "summary": "second unit", "needs": ["w1"]},
             ],
         )
+        todo_db.claim_item(conn, "tester", "sample-item")
         with pytest.raises(todo_db.TodoError, match="needs unfinished"):
             todo_db.done_unit(conn, "tester", "sample-item", "w2", "ran tests")
         todo_db.done_unit(conn, "tester", "sample-item", "w1", "ran tests")
@@ -317,6 +318,7 @@ class TestVerifyRun:
                 {"description": "always fails", "command": "false"},
             ],
         )
+        todo_db.claim_item(conn, "tester", "sample-item")
         result, _ = todo_db.run_verification(conn, "tester", "sample-item", 1)
         assert result == "pass"
         result, _ = todo_db.run_verification(conn, "tester", "sample-item", 2)
@@ -342,6 +344,7 @@ class TestVerifyRun:
                 {"description": "fails", "command": "false", "expected": "human-readable criterion"},
             ],
         )
+        todo_db.claim_item(conn, "tester", "sample-item")
         assert todo_db.run_verification(conn, "tester", "sample-item", 1)[0] == "pass"
         assert todo_db.run_verification(conn, "tester", "sample-item", 2)[0] == "fail"
 

--- a/tests/unit/scripts/test_todo_db_hardening.py
+++ b/tests/unit/scripts/test_todo_db_hardening.py
@@ -287,7 +287,8 @@ class TestClaimRenewal:
         todo_db.claim_item(conn, "agent-a", "long-work")
         todo_db.release_item(conn, "agent-a", "long-work")
 
-        todo_db.done_unit(conn, "agent-a", "long-work", "w1", "evidence")
+        with pytest.raises(todo_db.TodoError, match="lease"):
+            todo_db.done_unit(conn, "agent-a", "long-work", "w1", "evidence")
 
         row = conn.execute("SELECT claimed_by, claimed_at FROM items WHERE id = 'long-work'").fetchone()
         assert row["claimed_by"] is None

--- a/tests/unit/scripts/test_todo_db_shadow.py
+++ b/tests/unit/scripts/test_todo_db_shadow.py
@@ -289,7 +289,13 @@ def test_hosted_snapshot_is_bulk_complete_private_and_no_clobber(
     monkeypatch.setattr(shadow, "_rows", fake_rows)
     output = tmp_path / "snapshot.json"
     counts = shadow.write_hosted_legacy_snapshot(object(), output)
-    expected_tables = ["items", *[name for name in shadow.TABLE_NAMES if name != "items"], "events", "meta"]
+    expected_tables = [
+        "items",
+        *[name for name in shadow.TABLE_NAMES if name != "items"],
+        *shadow.FINDING_TABLE_NAMES,
+        "events",
+        "meta",
+    ]
     assert queried == expected_tables
     assert counts == dict.fromkeys(expected_tables, 1)
     assert output.stat().st_mode & 0o777 == 0o600

--- a/tests/unit/scripts/test_todo_db_v2.py
+++ b/tests/unit/scripts/test_todo_db_v2.py
@@ -180,7 +180,9 @@ class TestResumeLocation:
         todo_db.claim_item(conn, "alice", "resume-item")
         todo_db.start_unit(conn, "alice", "resume-item", "w1")
         monkeypatch.chdir(git_repo["main"])
-        todo_db.done_unit(conn, "bob", "resume-item", "w1", "finished elsewhere")
+        with pytest.raises(todo_db.TodoError, match="lease"):
+            todo_db.done_unit(conn, "bob", "resume-item", "w1", "finished elsewhere")
+        todo_db.done_unit(conn, "alice", "resume-item", "w1", "finished elsewhere")
         unit = todo_db.get_item(conn, "resume-item")["work"][0]
         assert unit["started_branch"] == "feat-resume"
 
@@ -384,6 +386,16 @@ class TestLintUnrunnableCommands:
         findings = todo_db.lint_item(conn, "parse-item")
         assert any("cannot execute" in f and "shell parse" in f for f in findings)
 
+    def test_shell_parse_rejects_a_malformed_pipeline(self, conn):
+        self._mk_with_command(conn, "pipeline-item", "printf ok |")
+        findings = todo_db.lint_item(conn, "pipeline-item")
+        assert any("cannot execute" in f and "shell parse" in f for f in findings)
+
+    def test_shell_parse_accepts_heredoc_body_quotes(self, conn):
+        command = "cat <<'EOF'\nthis body contains an unmatched apostrophe: '\nEOF"
+        self._mk_with_command(conn, "heredoc-item", command)
+        assert not any("cannot execute" in f for f in todo_db.lint_item(conn, "heredoc-item"))
+
     def test_runnable_command_is_not_flagged(self, conn):
         self._mk_with_command(conn, "ok-item", "uv run -- python -m pytest tests -q")
         assert not any("cannot execute" in f for f in todo_db.lint_item(conn, "ok-item"))
@@ -445,7 +457,25 @@ class TestLintUnresolvableScopeAndLadderPaths:
         findings = todo_db.lint_item(conn, "prospective-glob")
         assert not any("planned-out" in f for f in findings)
 
-    def test_settled_item_unresolvable_paths_are_flagged(self):
+    def test_open_item_prospective_glob_does_not_scan_the_tree(self, monkeypatch):
+        item = {
+            "state": "ready",
+            "scope": [{"kind": "only_modify", "path_glob": "_project/decisions/planned-out-*.md"}],
+            "verifications": [],
+        }
+        monkeypatch.setattr(todo_db, "_glob_resolves", lambda *_args: pytest.fail("prospective glob was scanned"))
+        assert todo_db._unresolvable_scope_findings(item) == []
+
+    def test_open_item_verification_glob_does_not_scan_the_tree(self, monkeypatch):
+        item = {
+            "state": "ready",
+            "scope": [],
+            "verifications": [{"seq": 1, "command": "uv run -- pytest tests/planned/test_*.py", "expected": "passes"}],
+        }
+        monkeypatch.setattr(todo_db, "_glob_resolves", lambda *_args: pytest.fail("prospective glob was scanned"))
+        assert todo_db._unresolvable_command_path_findings(item) == []
+
+    def test_settled_item_paths_are_not_reinterpreted_against_current_tree(self):
         item = {
             "state": "done",
             "scope": [
@@ -456,11 +486,8 @@ class TestLintUnresolvableScopeAndLadderPaths:
                 {"seq": 1, "command": "uv run -- python -m pytest tests/unit/scripts/test_never_materialized.py -q"}
             ],
         }
-        scope_findings = todo_db._unresolvable_scope_findings(item)
-        assert any("resolves to nothing" in f and "tests/no-such-dir/**" in f for f in scope_findings)
-        assert any("test_never_materialized" in f for f in scope_findings)
-        command_findings = todo_db._unresolvable_command_path_findings(item)
-        assert any("resolves to nothing" in f and "test_never_materialized" in f for f in command_findings)
+        assert todo_db._unresolvable_scope_findings(item) == []
+        assert todo_db._unresolvable_command_path_findings(item) == []
 
     def test_absolute_paths_are_skipped_even_when_settled(self):
         item = {
@@ -521,6 +548,15 @@ class TestLintUnresolvableScopeAndLadderPaths:
         findings = todo_db.lint_item(conn, "annotated-deny")
         assert any("do_not_modify" in f and "annotation" in f for f in findings)
 
+    def test_deny_rule_with_space_in_path_stays_legal(self, conn):
+        self._mk_scoped(
+            conn,
+            "spaced-deny",
+            scope=[("do_not_modify", "_sources/tpc-ds/tools/New Tool.rules")],
+        )
+        findings = todo_db.lint_item(conn, "spaced-deny")
+        assert not any("New Tool.rules" in f for f in findings)
+
     def test_inert_deny_rule_package_dir_shadow_is_flagged_on_open_item(self, conn):
         # benchbox/core/runner.py does not exist; the runner/ package does.
         # The deny intent (protect the runner) can never fire.
@@ -554,18 +590,6 @@ class TestLintUnresolvableScopeAndLadderPaths:
         self._mk_scoped(conn, "family-deny", scope=[("do_not_modify", "benchbox/core/zq_forbidden_*.py")])
         findings = todo_db.lint_item(conn, "family-deny")
         assert not any("zq_forbidden" in f for f in findings)
-
-    def test_inert_deny_rule_checks_do_not_apply_when_settled(self):
-        # Settled items keep the blanket resolves-to-nothing finding; the
-        # deny-specific classification is an open-item aid.
-        item = {
-            "state": "done",
-            "scope": [{"kind": "do_not_modify", "path_glob": "benchbox/core/runner.py"}],
-            "verifications": [],
-        }
-        findings = todo_db._unresolvable_scope_findings(item)
-        assert any("resolves to nothing" in f for f in findings)
-        assert not any("package directory" in f for f in findings)
 
 
 class TestLintFalsifiabilityAndScopeCompleteness:

--- a/tests/unit/scripts/test_todo_findings.py
+++ b/tests/unit/scripts/test_todo_findings.py
@@ -1538,6 +1538,7 @@ class TestBulkImportTargetGuard:
         monkeypatch.setattr(todo_db, "hosted_replica_path", lambda: replica)
         monkeypatch.setenv("TODO_DB_AUTH_TOKEN", "token")
         monkeypatch.setattr(todo_db, "bulk_transfer", fake_bulk_transfer)
+        monkeypatch.setattr(todo_db, "sync_hosted_replica", lambda _conn: None)
 
         assert (
             todo_findings._cmd_import(conn, "tester", self._args(corpus=str(corpus), confirm_target="benchbox-todo"))
@@ -1771,4 +1772,5 @@ class TestBulkImportSyncsBeforeParity:
             db=None,
         )
         assert todo_findings._cmd_import_bulk(_Conn(), "tester", args) == 0
-        assert calls == ["sync", "read"], "parity must not read before the replica sync"
+        assert calls == ["read", "sync", "read"]
+        assert calls[-2:] == ["sync", "read"], "post-transfer parity must not read before the replica sync"

--- a/tests/unit/scripts/test_todo_findings.py
+++ b/tests/unit/scripts/test_todo_findings.py
@@ -189,7 +189,10 @@ class TestFindingsNonClaimable:
         # a future stats key that wrongly reflects findings is still caught.
 
         def items_domain(snapshot):
-            return {k: v for k, v in snapshot.items() if k != "findings_by_disposition"}
+            result = {k: v for k, v in snapshot.items() if k != "findings_by_disposition"}
+            result["events"] = dict(result["events"])
+            result["events"].pop("findings", None)
+            return result
 
         assert items_domain(after) == items_domain(before)
         assert after["findings_by_disposition"] == {"open": 2}
@@ -1293,6 +1296,14 @@ class TestFindingImportParity:
         ]
         assert len(events) == 1
 
+    def test_import_skips_target_ids_when_staging_for_bulk_transfer(self, conn, tmp_path):
+        finding_id = "2026-01-02-030405-target-present"
+        self._record(tmp_path, finding_id)
+        result = todo_findings.import_corpus(conn, "importer", tmp_path, existing_ids={finding_id})
+        assert result["imported"] == []
+        assert result["skipped"] == [finding_id]
+        assert todo_findings.get_finding(conn, finding_id) is None
+
     def test_import_records_provenance(self, conn, tmp_path):
         path = self._record(tmp_path, "2026-01-02-030405-provenance-record")
         todo_findings.import_corpus(conn, "importer", tmp_path)
@@ -1343,6 +1354,20 @@ class TestFindingImportParity:
         report = todo_findings.parity_report(conn, tmp_path, result)
         assert report["ok"] is False
         assert report["triage_log_diffs"][0]["expected_lines"] == 3
+
+    def test_parity_report_fails_closed_when_evidence_is_lost(self, conn, tmp_path):
+        self._record(tmp_path, "2026-01-02-030405-lossy-evidence", extra_section=None)
+        path = tmp_path / "2026-01-02-030405-lossy-evidence.md"
+        text = path.read_text(encoding="utf-8").replace(
+            'review_context: "ultrareview X"', 'review_context: "ultrareview X"\nevidence:\n  - path: a.py'
+        )
+        path.write_text(text, encoding="utf-8")
+        result = todo_findings.import_corpus(conn, "importer", tmp_path)
+        with todo_db._write_txn(conn):
+            conn.execute("DELETE FROM finding_evidence WHERE finding_id = ?", (path.stem,))
+        report = todo_findings.parity_report(conn, tmp_path, result)
+        assert report["ok"] is False
+        assert report["evidence_diffs"] == [{"record": path.stem}]
 
     def test_dangling_todo_id_is_reported_not_silently_skipped(self, conn, tmp_path):
         self._record(tmp_path, "2026-01-02-030405-dangling-import", todo_id="no-such-item")
@@ -1483,6 +1508,44 @@ class TestBulkImportTargetGuard:
         monkeypatch.setattr(todo_findings, "_cmd_import_bulk", _boom)
         args = self._args(dry_run=True, corpus=str(tmp_path))
         assert todo_findings._cmd_import(conn, "tester", args) == 0
+
+    def test_import_command_drives_successful_bulk_orchestration(self, conn, tmp_path, monkeypatch, capsys):
+        """The CLI branch must stage, transfer the requested tables, and verify parity."""
+        finding_id = "2026-01-02-030405-bulk-command"
+        corpus = tmp_path / "corpus"
+        _draft(corpus / "draft.md", finding_id)
+
+        replica = tmp_path / "replica.sqlite"
+        replica_conn = todo_db.connect(replica)
+        replica_conn.close()
+        transfer_calls = []
+
+        def fake_bulk_transfer(staging, _url, _token, **kwargs):
+            transfer_calls.append(kwargs)
+            tables = kwargs["tables"]
+            row_count = 0
+            with todo_db._write_txn(conn):
+                for table in tables:
+                    columns = [row[1] for row in staging.execute(f"PRAGMA table_info({table})")]
+                    names = ", ".join(columns)
+                    placeholders = ", ".join("?" for _ in columns)
+                    for row in staging.execute(f"SELECT {names} FROM {table}"):
+                        conn.execute(f"INSERT INTO {table} ({names}) VALUES ({placeholders})", tuple(row))
+                        row_count += 1
+            return {"rows": row_count, "batches": 1}
+
+        monkeypatch.setattr(todo_db, "resolve_backend", lambda _db: self.HOSTED)
+        monkeypatch.setattr(todo_db, "hosted_replica_path", lambda: replica)
+        monkeypatch.setenv("TODO_DB_AUTH_TOKEN", "token")
+        monkeypatch.setattr(todo_db, "bulk_transfer", fake_bulk_transfer)
+
+        assert (
+            todo_findings._cmd_import(conn, "tester", self._args(corpus=str(corpus), confirm_target="benchbox-todo"))
+            == 0
+        )
+        assert transfer_calls == [{"require_empty": False, "tables": todo_findings.FINDINGS_TRANSFER_TABLES}]
+        assert conn.execute("SELECT count(*) FROM findings WHERE id = ?", (finding_id,)).fetchone()[0] == 1
+        assert "parity OK: 1/1 records" in capsys.readouterr().out
 
 
 class TestReconcileCoversV4Columns:

--- a/tests/unit/test_agent_write_preflight.py
+++ b/tests/unit/test_agent_write_preflight.py
@@ -22,6 +22,7 @@ def _run_preflight(*, primary_clone: Path, allow: bool = False) -> subprocess.Co
         **os.environ,
         "BENCHBOX_AGENT_PRIMARY_CLONE": str(primary_clone),
     }
+    env.pop("BENCHBOX_EPHEMERAL_CLONE", None)
     if allow:
         env["BENCHBOX_ALLOW_MAIN_CLONE_WRITE"] = "1"
     else:

--- a/tests/unit/test_marker_strategy.py
+++ b/tests/unit/test_marker_strategy.py
@@ -4,9 +4,11 @@ from __future__ import annotations
 
 import ast
 import re
+import shlex
 from pathlib import Path
 
 import pytest
+import yaml
 
 from tests import conftest as benchbox_conftest
 
@@ -36,7 +38,7 @@ _TREE_WIDE_LANES = (
     "medium and not (slow or stress or resource_heavy or live_integration)",
     "platform_smoke or (integration and fast)",
 )
-_WORKFLOW_TEST_PATH_RE = re.compile(r"tests/[\w/]+/test_\w+\.py")
+_WORKFLOW_TEST_PATH_RE = re.compile(r"tests/[A-Za-z0-9_./-]+/test_[A-Za-z0-9_-]+\.py")
 # Declaring one of these at MODULE level says "this whole module is opt-in and
 # runs outside the automatic lanes" (credentialed cloud suites, stress runs).
 _OPT_IN_LANE_MARKERS = {"live_integration", "stress"}
@@ -286,9 +288,31 @@ def _explicitly_invoked_test_paths() -> set[str]:
     covered, so scan for them rather than reporting a false positive.
     """
     paths: set[str] = set()
+
+    def run_blocks(value):
+        if isinstance(value, dict):
+            for key, child in value.items():
+                if key == "run" and isinstance(child, str):
+                    yield child
+                else:
+                    yield from run_blocks(child)
+        elif isinstance(value, list):
+            for child in value:
+                yield from run_blocks(child)
+
     for workflow in sorted((_REPO_ROOT / ".github" / "workflows").glob("*.yml")):
-        for match in _WORKFLOW_TEST_PATH_RE.finditer(workflow.read_text(encoding="utf-8")):
-            paths.add(match.group(0))
+        document = yaml.safe_load(workflow.read_text(encoding="utf-8")) or {}
+        for command in run_blocks(document):
+            try:
+                tokens = shlex.split(command, comments=True, posix=True)
+            except ValueError:
+                tokens = []
+            pytest_positions = [index for index, token in enumerate(tokens) if token == "pytest"]
+            for index in pytest_positions:
+                for token in tokens[index + 1 :]:
+                    path = token.split("::", 1)[0]
+                    if _WORKFLOW_TEST_PATH_RE.fullmatch(path):
+                        paths.add(path)
     return paths
 
 

--- a/tests/unit/utils/test_file_format.py
+++ b/tests/unit/utils/test_file_format.py
@@ -12,10 +12,12 @@ Copyright 2026 Joe Harris / BenchBox Project
 Licensed under the MIT License. See LICENSE file in the project root for details.
 """
 
+import gzip
 from pathlib import Path
 
 import pytest
 
+from benchbox.utils.compression import CompressionError
 from benchbox.utils.file_format import (
     COMPRESSION_EXTENSIONS,
     DATA_FORMAT_EXTENSIONS,
@@ -635,6 +637,15 @@ class TestHasTrailingDelimiterFraming:
         path.write_bytes(b"\r\n\r\n0|AFRICA|comment|\r\n")
         assert has_trailing_delimiter(path, "|", ["r_regionkey", "r_name", "r_comment"]) is True
 
+    @pytest.mark.parametrize("raw,expected", [(b"0|AFRICA|comment|\r\n", True), (b"0|AFRICA|comment\r\n", False)])
+    def test_gzip_framing_uses_the_compressed_read_path(self, tmp_path, raw, expected):
+        path = tmp_path / "region.tbl.gz"
+        with gzip.open(path, "wb") as handle:
+            handle.write(raw)
+
+        assert has_trailing_delimiter(path, "|", ["r_regionkey", "r_name", "r_comment"]) is expected
+        assert has_trailing_delimiter(path, "|") is expected
+
 
 class TestHasTrailingDelimiterSurfacesReadFailures:
     """A file we cannot read is not a file without a trailing delimiter.
@@ -651,21 +662,28 @@ class TestHasTrailingDelimiterSurfacesReadFailures:
         with pytest.raises(OSError):
             has_trailing_delimiter(tmp_path / "does-not-exist.tbl", "|", ["a", "b"])
 
-    def test_unreadable_file_raises_rather_than_reporting_clean(self, tmp_path):
+    def test_unreadable_file_raises_rather_than_reporting_clean(self, tmp_path, monkeypatch):
         path = tmp_path / "locked.tbl"
         path.write_bytes(b"1|x|\n")
-        path.chmod(0o000)
-        try:
-            with pytest.raises(OSError):
-                has_trailing_delimiter(path, "|", ["a", "b"])
-        finally:
-            path.chmod(0o644)
+
+        def deny_open(*args, **kwargs):
+            raise PermissionError("denied")
+
+        monkeypatch.setattr(Path, "open", deny_open)
+        with pytest.raises(OSError):
+            has_trailing_delimiter(path, "|", ["a", "b"])
 
     def test_a_directory_in_place_of_a_file_raises(self, tmp_path):
         target = tmp_path / "a_directory.tbl"
         target.mkdir()
         with pytest.raises(OSError):
             has_trailing_delimiter(target, "|", ["a", "b"])
+
+    def test_unsupported_compression_raises_rather_than_reporting_clean(self, tmp_path):
+        path = tmp_path / "region.tbl.bz2"
+        path.write_bytes(b"not-decoded")
+        with pytest.raises(CompressionError, match="Unsupported compression type 'bzip2'"):
+            has_trailing_delimiter(path, "|", ["a", "b"])
 
     def test_an_empty_file_still_answers_false(self, tmp_path):
         # The one legitimate False: nothing to classify, not a failure to read.

--- a/tests/unit/utils/test_tpc_compilation.py
+++ b/tests/unit/utils/test_tpc_compilation.py
@@ -192,6 +192,25 @@ class TestBinaryConfigSetup:
 
         assert len(compiler.binaries) == 0
 
+    def test_unrunnable_precompiled_without_source_never_falls_back_to_cwd(self, tmp_path):
+        """An installed bundle with no source must fail cleanly, not select ``Path('.')``."""
+        precompiled_base = tmp_path / "_binaries"
+        precompiled_base.mkdir()
+
+        with patch(
+            "benchbox.utils.tpc_compilation._discover_tpc_paths",
+            return_value={"tpc_h_source": None, "tpc_ds_source": None, "precompiled_base": precompiled_base},
+        ):
+            compiler = TPCCompiler()
+
+        info = compiler.binaries["dbgen"]
+        assert info.source_dir is None
+        assert info.binary_path is None
+        assert compiler.needs_compilation("dbgen") is False
+        result = compiler.compile_binary("dbgen")
+        assert result.status == CompilationStatus.FAILED
+        assert result.binary_path is None
+
 
 # ---------------------------------------------------------------------------
 # Checksum verification

--- a/uv.lock
+++ b/uv.lock
@@ -14,14 +14,14 @@ name = "ablog"
 version = "0.11.13"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "docutils", version = "0.22.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
-    { name = "feedgen", marker = "python_full_version >= '3.11'" },
-    { name = "invoke", marker = "python_full_version >= '3.11'" },
-    { name = "packaging", marker = "python_full_version >= '3.11'" },
-    { name = "python-dateutil", marker = "python_full_version >= '3.11'" },
-    { name = "sphinx", version = "9.0.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
+    { name = "docutils", version = "0.22.4", source = { registry = "https://pypi.org/simple" } },
+    { name = "feedgen" },
+    { name = "invoke" },
+    { name = "packaging" },
+    { name = "python-dateutil" },
+    { name = "sphinx", version = "9.0.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
     { name = "sphinx", version = "9.1.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
-    { name = "watchdog", marker = "python_full_version >= '3.11'" },
+    { name = "watchdog" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/ba/8c/bbe097fca7222bbb345e3102d99f773cad77a7871b65f3c476c9fef93e2d/ablog-0.11.13.tar.gz", hash = "sha256:ae990d2c5c495ced6a33e0ec47d34355b828b81b97b6ad3786f682252d1ad36a", size = 103676, upload-time = "2026-01-26T14:02:44.721Z" }
 wheels = [
@@ -749,7 +749,7 @@ requires-dist = [
     { name = "datafusion", marker = "extra == 'datafusion'", specifier = ">=50.1.0" },
     { name = "deltalake", marker = "extra == 'all'", specifier = ">=1.2.1" },
     { name = "deltalake", marker = "extra == 'table-formats'", specifier = ">=1.2.1" },
-    { name = "duckdb", marker = "extra == 'all'", specifier = ">=1.0.0,<2.0.0" },
+    { name = "duckdb", marker = "extra == 'all'", specifier = ">=1.3.0,<2.0.0" },
     { name = "duckdb", marker = "extra == 'dev'", specifier = ">=1.0.0,<2.0.0" },
     { name = "duckdb", marker = "extra == 'duckdb'", specifier = ">=1.0.0,<2.0.0" },
     { name = "duckdb", marker = "extra == 'ducklake'", specifier = ">=1.3.0,<2.0.0" },
@@ -1721,37 +1721,37 @@ wheels = [
 
 [package.optional-dependencies]
 cublas = [
-    { name = "nvidia-cublas", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "nvidia-cublas" },
 ]
 cudart = [
-    { name = "nvidia-cuda-runtime", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "nvidia-cuda-runtime" },
 ]
 cufft = [
-    { name = "nvidia-cufft", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "nvidia-cufft" },
 ]
 cufile = [
-    { name = "nvidia-cufile", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-cufile" },
 ]
 cupti = [
-    { name = "nvidia-cuda-cupti", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "nvidia-cuda-cupti" },
 ]
 curand = [
-    { name = "nvidia-curand", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "nvidia-curand" },
 ]
 cusolver = [
-    { name = "nvidia-cusolver", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "nvidia-cusolver" },
 ]
 cusparse = [
-    { name = "nvidia-cusparse", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "nvidia-cusparse" },
 ]
 nvjitlink = [
-    { name = "nvidia-nvjitlink", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "nvidia-nvjitlink" },
 ]
 nvrtc = [
-    { name = "nvidia-cuda-nvrtc", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "nvidia-cuda-nvrtc" },
 ]
 nvtx = [
-    { name = "nvidia-nvtx", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "nvidia-nvtx" },
 ]
 
 [[package]]
@@ -1862,17 +1862,17 @@ resolution-markers = [
     "python_full_version < '3.11'",
 ]
 dependencies = [
-    { name = "databricks-sdk", marker = "python_full_version < '3.12'" },
-    { name = "googleapis-common-protos", marker = "python_full_version < '3.12'" },
-    { name = "grpcio", marker = "python_full_version < '3.12'" },
-    { name = "grpcio-status", marker = "python_full_version < '3.12'" },
-    { name = "numpy", version = "1.26.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
-    { name = "packaging", marker = "python_full_version < '3.12'" },
-    { name = "pandas", marker = "python_full_version < '3.12'" },
-    { name = "py4j", version = "0.10.9.7", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
-    { name = "pyarrow", marker = "python_full_version < '3.12'" },
-    { name = "setuptools", marker = "python_full_version < '3.12'" },
-    { name = "six", marker = "python_full_version < '3.12'" },
+    { name = "databricks-sdk" },
+    { name = "googleapis-common-protos" },
+    { name = "grpcio" },
+    { name = "grpcio-status" },
+    { name = "numpy", version = "1.26.4", source = { registry = "https://pypi.org/simple" } },
+    { name = "packaging" },
+    { name = "pandas" },
+    { name = "py4j", version = "0.10.9.7", source = { registry = "https://pypi.org/simple" } },
+    { name = "pyarrow" },
+    { name = "setuptools" },
+    { name = "six" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d1/5d/ae8c59de242ca6ef1631e66fdf7fc413bc0d51d2521c4e1cb90104dd62d9/databricks_connect-16.1.7-py2.py3-none-any.whl", hash = "sha256:ddc7ddb8bcfb7910db67e8c4ef5ab2f938c55cf1a1b2e066ff56d2db68b13cb5", size = 2393078, upload-time = "2025-10-28T14:25:02.265Z" },
@@ -1888,18 +1888,18 @@ resolution-markers = [
     "python_full_version == '3.12.*'",
 ]
 dependencies = [
-    { name = "databricks-sdk", marker = "python_full_version >= '3.12'" },
-    { name = "googleapis-common-protos", marker = "python_full_version >= '3.12'" },
-    { name = "grpcio", marker = "python_full_version >= '3.12'" },
-    { name = "grpcio-status", marker = "python_full_version >= '3.12'" },
-    { name = "numpy", version = "2.4.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
-    { name = "packaging", marker = "python_full_version >= '3.12'" },
-    { name = "pandas", marker = "python_full_version >= '3.12'" },
-    { name = "py4j", version = "0.10.9.9", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
-    { name = "pyarrow", marker = "python_full_version >= '3.12'" },
-    { name = "setuptools", marker = "python_full_version >= '3.12'" },
-    { name = "six", marker = "python_full_version >= '3.12'" },
-    { name = "zstandard", marker = "python_full_version >= '3.12'" },
+    { name = "databricks-sdk" },
+    { name = "googleapis-common-protos" },
+    { name = "grpcio" },
+    { name = "grpcio-status" },
+    { name = "numpy", version = "2.4.4", source = { registry = "https://pypi.org/simple" } },
+    { name = "packaging" },
+    { name = "pandas" },
+    { name = "py4j", version = "0.10.9.9", source = { registry = "https://pypi.org/simple" } },
+    { name = "pyarrow" },
+    { name = "setuptools" },
+    { name = "six" },
+    { name = "zstandard" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a3/ab/0f51fda312fe10737e67edf18c1fb000a95e778ff19e59530aeb54b0f30c/databricks_connect-18.1.2-py2.py3-none-any.whl", hash = "sha256:b9133a113d111acd828d5fd8aad588a9f355b431d6926dbaeb3e28f4757cc8bb", size = 2842760, upload-time = "2026-03-19T08:17:26.274Z" },
@@ -2112,7 +2112,7 @@ name = "exceptiongroup"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+    { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
 wheels = [
@@ -2133,8 +2133,8 @@ name = "feedgen"
 version = "1.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "lxml", marker = "python_full_version >= '3.11'" },
-    { name = "python-dateutil", marker = "python_full_version >= '3.11'" },
+    { name = "lxml" },
+    { name = "python-dateutil" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/6b/59/be0a6f852b5dfbf19e6c8e962c8f41407697f9f52a7902250ed98683ae89/feedgen-1.0.0.tar.gz", hash = "sha256:d9bd51c3b5e956a2a52998c3708c4d2c729f2fcc311188e1e5d3b9726393546a", size = 258496, upload-time = "2023-12-25T18:04:08.421Z" }
 
@@ -2373,7 +2373,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/38/3f/9859f655d11901e7b2996c6e3d33e0caa9a1d4572c3bc61ed0faa64b2f4c/greenlet-3.3.2-cp310-cp310-macosx_11_0_universal2.whl", hash = "sha256:9bc885b89709d901859cf95179ec9f6bb67a3d2bb1f0e88456461bd4b7f8fd0d", size = 277747, upload-time = "2026-02-20T20:16:21.325Z" },
     { url = "https://files.pythonhosted.org/packages/fb/07/cb284a8b5c6498dbd7cba35d31380bb123d7dceaa7907f606c8ff5993cbf/greenlet-3.3.2-cp310-cp310-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b568183cf65b94919be4438dc28416b234b678c608cafac8874dfeeb2a9bbe13", size = 579202, upload-time = "2026-02-20T20:47:28.955Z" },
     { url = "https://files.pythonhosted.org/packages/ed/45/67922992b3a152f726163b19f890a85129a992f39607a2a53155de3448b8/greenlet-3.3.2-cp310-cp310-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:527fec58dc9f90efd594b9b700662ed3fb2493c2122067ac9c740d98080a620e", size = 590620, upload-time = "2026-02-20T20:55:55.581Z" },
-    { url = "https://files.pythonhosted.org/packages/03/5f/6e2a7d80c353587751ef3d44bb947f0565ec008a2e0927821c007e96d3a7/greenlet-3.3.2-cp310-cp310-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:508c7f01f1791fbc8e011bd508f6794cb95397fdb198a46cb6635eb5b78d85a7", size = 602132, upload-time = "2026-02-20T21:02:43.261Z" },
     { url = "https://files.pythonhosted.org/packages/ad/55/9f1ebb5a825215fadcc0f7d5073f6e79e3007e3282b14b22d6aba7ca6cb8/greenlet-3.3.2-cp310-cp310-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ad0c8917dd42a819fe77e6bdfcb84e3379c0de956469301d9fd36427a1ca501f", size = 591729, upload-time = "2026-02-20T20:20:58.395Z" },
     { url = "https://files.pythonhosted.org/packages/24/b4/21f5455773d37f94b866eb3cf5caed88d6cea6dd2c6e1f9c34f463cba3ec/greenlet-3.3.2-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:97245cc10e5515dbc8c3104b2928f7f02b6813002770cfaffaf9a6e0fc2b94ef", size = 1551946, upload-time = "2026-02-20T20:49:31.102Z" },
     { url = "https://files.pythonhosted.org/packages/00/68/91f061a926abead128fe1a87f0b453ccf07368666bd59ffa46016627a930/greenlet-3.3.2-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:8c1fdd7d1b309ff0da81d60a9688a8bd044ac4e18b250320a96fc68d31c209ca", size = 1618494, upload-time = "2026-02-20T20:21:06.541Z" },
@@ -2381,7 +2380,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/f3/47/16400cb42d18d7a6bb46f0626852c1718612e35dcb0dffa16bbaffdf5dd2/greenlet-3.3.2-cp311-cp311-macosx_11_0_universal2.whl", hash = "sha256:c56692189a7d1c7606cb794be0a8381470d95c57ce5be03fb3d0ef57c7853b86", size = 278890, upload-time = "2026-02-20T20:19:39.263Z" },
     { url = "https://files.pythonhosted.org/packages/a3/90/42762b77a5b6aa96cd8c0e80612663d39211e8ae8a6cd47c7f1249a66262/greenlet-3.3.2-cp311-cp311-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1ebd458fa8285960f382841da585e02201b53a5ec2bac6b156fc623b5ce4499f", size = 581120, upload-time = "2026-02-20T20:47:30.161Z" },
     { url = "https://files.pythonhosted.org/packages/bf/6f/f3d64f4fa0a9c7b5c5b3c810ff1df614540d5aa7d519261b53fba55d4df9/greenlet-3.3.2-cp311-cp311-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:a443358b33c4ec7b05b79a7c8b466f5d275025e750298be7340f8fc63dff2a55", size = 594363, upload-time = "2026-02-20T20:55:56.965Z" },
-    { url = "https://files.pythonhosted.org/packages/9c/8b/1430a04657735a3f23116c2e0d5eb10220928846e4537a938a41b350bed6/greenlet-3.3.2-cp311-cp311-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:4375a58e49522698d3e70cc0b801c19433021b5c37686f7ce9c65b0d5c8677d2", size = 605046, upload-time = "2026-02-20T21:02:45.234Z" },
     { url = "https://files.pythonhosted.org/packages/72/83/3e06a52aca8128bdd4dcd67e932b809e76a96ab8c232a8b025b2850264c5/greenlet-3.3.2-cp311-cp311-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8e2cd90d413acbf5e77ae41e5d3c9b3ac1d011a756d7284d7f3f2b806bbd6358", size = 594156, upload-time = "2026-02-20T20:20:59.955Z" },
     { url = "https://files.pythonhosted.org/packages/70/79/0de5e62b873e08fe3cef7dbe84e5c4bc0e8ed0c7ff131bccb8405cd107c8/greenlet-3.3.2-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:442b6057453c8cb29b4fb36a2ac689382fc71112273726e2423f7f17dc73bf99", size = 1554649, upload-time = "2026-02-20T20:49:32.293Z" },
     { url = "https://files.pythonhosted.org/packages/5a/00/32d30dee8389dc36d42170a9c66217757289e2afb0de59a3565260f38373/greenlet-3.3.2-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:45abe8eb6339518180d5a7fa47fa01945414d7cca5ecb745346fc6a87d2750be", size = 1619472, upload-time = "2026-02-20T20:21:07.966Z" },
@@ -2390,7 +2388,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/ea/ab/1608e5a7578e62113506740b88066bf09888322a311cff602105e619bd87/greenlet-3.3.2-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:ac8d61d4343b799d1e526db579833d72f23759c71e07181c2d2944e429eb09cd", size = 280358, upload-time = "2026-02-20T20:17:43.971Z" },
     { url = "https://files.pythonhosted.org/packages/a5/23/0eae412a4ade4e6623ff7626e38998cb9b11e9ff1ebacaa021e4e108ec15/greenlet-3.3.2-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3ceec72030dae6ac0c8ed7591b96b70410a8be370b6a477b1dbc072856ad02bd", size = 601217, upload-time = "2026-02-20T20:47:31.462Z" },
     { url = "https://files.pythonhosted.org/packages/f8/16/5b1678a9c07098ecb9ab2dd159fafaf12e963293e61ee8d10ecb55273e5e/greenlet-3.3.2-cp312-cp312-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:a2a5be83a45ce6188c045bcc44b0ee037d6a518978de9a5d97438548b953a1ac", size = 611792, upload-time = "2026-02-20T20:55:58.423Z" },
-    { url = "https://files.pythonhosted.org/packages/5c/c5/cc09412a29e43406eba18d61c70baa936e299bc27e074e2be3806ed29098/greenlet-3.3.2-cp312-cp312-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:ae9e21c84035c490506c17002f5c8ab25f980205c3e61ddb3a2a2a2e6c411fcb", size = 626250, upload-time = "2026-02-20T21:02:46.596Z" },
     { url = "https://files.pythonhosted.org/packages/50/1f/5155f55bd71cabd03765a4aac9ac446be129895271f73872c36ebd4b04b6/greenlet-3.3.2-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:43e99d1749147ac21dde49b99c9abffcbc1e2d55c67501465ef0930d6e78e070", size = 613875, upload-time = "2026-02-20T20:21:01.102Z" },
     { url = "https://files.pythonhosted.org/packages/fc/dd/845f249c3fcd69e32df80cdab059b4be8b766ef5830a3d0aa9d6cad55beb/greenlet-3.3.2-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:4c956a19350e2c37f2c48b336a3afb4bff120b36076d9d7fb68cb44e05d95b79", size = 1571467, upload-time = "2026-02-20T20:49:33.495Z" },
     { url = "https://files.pythonhosted.org/packages/2a/50/2649fe21fcc2b56659a452868e695634722a6655ba245d9f77f5656010bf/greenlet-3.3.2-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:6c6f8ba97d17a1e7d664151284cb3315fc5f8353e75221ed4324f84eb162b395", size = 1640001, upload-time = "2026-02-20T20:21:09.154Z" },
@@ -2399,7 +2396,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/ac/48/f8b875fa7dea7dd9b33245e37f065af59df6a25af2f9561efa8d822fde51/greenlet-3.3.2-cp313-cp313-macosx_11_0_universal2.whl", hash = "sha256:aa6ac98bdfd716a749b84d4034486863fd81c3abde9aa3cf8eff9127981a4ae4", size = 279120, upload-time = "2026-02-20T20:19:01.9Z" },
     { url = "https://files.pythonhosted.org/packages/49/8d/9771d03e7a8b1ee456511961e1b97a6d77ae1dea4a34a5b98eee706689d3/greenlet-3.3.2-cp313-cp313-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ab0c7e7901a00bc0a7284907273dc165b32e0d109a6713babd04471327ff7986", size = 603238, upload-time = "2026-02-20T20:47:32.873Z" },
     { url = "https://files.pythonhosted.org/packages/59/0e/4223c2bbb63cd5c97f28ffb2a8aee71bdfb30b323c35d409450f51b91e3e/greenlet-3.3.2-cp313-cp313-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:d248d8c23c67d2291ffd47af766e2a3aa9fa1c6703155c099feb11f526c63a92", size = 614219, upload-time = "2026-02-20T20:55:59.817Z" },
-    { url = "https://files.pythonhosted.org/packages/94/2b/4d012a69759ac9d77210b8bfb128bc621125f5b20fc398bce3940d036b1c/greenlet-3.3.2-cp313-cp313-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:ccd21bb86944ca9be6d967cf7691e658e43417782bce90b5d2faeda0ff78a7dd", size = 628268, upload-time = "2026-02-20T21:02:48.024Z" },
     { url = "https://files.pythonhosted.org/packages/7a/34/259b28ea7a2a0c904b11cd36c79b8cef8019b26ee5dbe24e73b469dea347/greenlet-3.3.2-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b6997d360a4e6a4e936c0f9625b1c20416b8a0ea18a8e19cabbefc712e7397ab", size = 616774, upload-time = "2026-02-20T20:21:02.454Z" },
     { url = "https://files.pythonhosted.org/packages/0a/03/996c2d1689d486a6e199cb0f1cf9e4aa940c500e01bdf201299d7d61fa69/greenlet-3.3.2-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:64970c33a50551c7c50491671265d8954046cb6e8e2999aacdd60e439b70418a", size = 1571277, upload-time = "2026-02-20T20:49:34.795Z" },
     { url = "https://files.pythonhosted.org/packages/d9/c4/2570fc07f34a39f2caf0bf9f24b0a1a0a47bc2e8e465b2c2424821389dfc/greenlet-3.3.2-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:1a9172f5bf6bd88e6ba5a84e0a68afeac9dc7b6b412b245dd64f52d83c81e55b", size = 1640455, upload-time = "2026-02-20T20:21:10.261Z" },
@@ -2408,7 +2404,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/3f/ae/8bffcbd373b57a5992cd077cbe8858fff39110480a9d50697091faea6f39/greenlet-3.3.2-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:8d1658d7291f9859beed69a776c10822a0a799bc4bfe1bd4272bb60e62507dab", size = 279650, upload-time = "2026-02-20T20:18:00.783Z" },
     { url = "https://files.pythonhosted.org/packages/d1/c0/45f93f348fa49abf32ac8439938726c480bd96b2a3c6f4d949ec0124b69f/greenlet-3.3.2-cp314-cp314-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:18cb1b7337bca281915b3c5d5ae19f4e76d35e1df80f4ad3c1a7be91fadf1082", size = 650295, upload-time = "2026-02-20T20:47:34.036Z" },
     { url = "https://files.pythonhosted.org/packages/b3/de/dd7589b3f2b8372069ab3e4763ea5329940fc7ad9dcd3e272a37516d7c9b/greenlet-3.3.2-cp314-cp314-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:c2e47408e8ce1c6f1ceea0dffcdf6ebb85cc09e55c7af407c99f1112016e45e9", size = 662163, upload-time = "2026-02-20T20:56:01.295Z" },
-    { url = "https://files.pythonhosted.org/packages/cd/ac/85804f74f1ccea31ba518dcc8ee6f14c79f73fe36fa1beba38930806df09/greenlet-3.3.2-cp314-cp314-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:e3cb43ce200f59483eb82949bf1835a99cf43d7571e900d7c8d5c62cdf25d2f9", size = 675371, upload-time = "2026-02-20T21:02:49.664Z" },
     { url = "https://files.pythonhosted.org/packages/d2/d8/09bfa816572a4d83bccd6750df1926f79158b1c36c5f73786e26dbe4ee38/greenlet-3.3.2-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:63d10328839d1973e5ba35e98cccbca71b232b14051fd957b6f8b6e8e80d0506", size = 664160, upload-time = "2026-02-20T20:21:04.015Z" },
     { url = "https://files.pythonhosted.org/packages/48/cf/56832f0c8255d27f6c35d41b5ec91168d74ec721d85f01a12131eec6b93c/greenlet-3.3.2-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:8e4ab3cfb02993c8cc248ea73d7dae6cec0253e9afa311c9b37e603ca9fad2ce", size = 1619181, upload-time = "2026-02-20T20:49:36.052Z" },
     { url = "https://files.pythonhosted.org/packages/0a/23/b90b60a4aabb4cec0796e55f25ffbfb579a907c3898cd2905c8918acaa16/greenlet-3.3.2-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:94ad81f0fd3c0c0681a018a976e5c2bd2ca2d9d94895f23e7bb1af4e8af4e2d5", size = 1687713, upload-time = "2026-02-20T20:21:11.684Z" },
@@ -2417,7 +2412,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/98/6d/8f2ef704e614bcf58ed43cfb8d87afa1c285e98194ab2cfad351bf04f81e/greenlet-3.3.2-cp314-cp314t-macosx_11_0_universal2.whl", hash = "sha256:e26e72bec7ab387ac80caa7496e0f908ff954f31065b0ffc1f8ecb1338b11b54", size = 286617, upload-time = "2026-02-20T20:19:29.856Z" },
     { url = "https://files.pythonhosted.org/packages/5e/0d/93894161d307c6ea237a43988f27eba0947b360b99ac5239ad3fe09f0b47/greenlet-3.3.2-cp314-cp314t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8b466dff7a4ffda6ca975979bab80bdadde979e29fc947ac3be4451428d8b0e4", size = 655189, upload-time = "2026-02-20T20:47:35.742Z" },
     { url = "https://files.pythonhosted.org/packages/f5/2c/d2d506ebd8abcb57386ec4f7ba20f4030cbe56eae541bc6fd6ef399c0b41/greenlet-3.3.2-cp314-cp314t-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:b8bddc5b73c9720bea487b3bffdb1840fe4e3656fba3bd40aa1489e9f37877ff", size = 658225, upload-time = "2026-02-20T20:56:02.527Z" },
-    { url = "https://files.pythonhosted.org/packages/d1/67/8197b7e7e602150938049d8e7f30de1660cfb87e4c8ee349b42b67bdb2e1/greenlet-3.3.2-cp314-cp314t-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:59b3e2c40f6706b05a9cd299c836c6aa2378cabe25d021acd80f13abf81181cf", size = 666581, upload-time = "2026-02-20T21:02:51.526Z" },
     { url = "https://files.pythonhosted.org/packages/8e/30/3a09155fbf728673a1dea713572d2d31159f824a37c22da82127056c44e4/greenlet-3.3.2-cp314-cp314t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b26b0f4428b871a751968285a1ac9648944cea09807177ac639b030bddebcea4", size = 657907, upload-time = "2026-02-20T20:21:05.259Z" },
     { url = "https://files.pythonhosted.org/packages/f3/fd/d05a4b7acd0154ed758797f0a43b4c0962a843bedfe980115e842c5b2d08/greenlet-3.3.2-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:1fb39a11ee2e4d94be9a76671482be9398560955c9e568550de0224e41104727", size = 1618857, upload-time = "2026-02-20T20:49:37.309Z" },
     { url = "https://files.pythonhosted.org/packages/6f/e1/50ee92a5db521de8f35075b5eff060dd43d39ebd46c2181a2042f7070385/greenlet-3.3.2-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:20154044d9085151bc309e7689d6f7ba10027f8f5a8c0676ad398b951913d89e", size = 1680010, upload-time = "2026-02-20T20:21:13.427Z" },
@@ -3240,7 +3234,7 @@ resolution-markers = [
     "python_full_version < '3.11'",
 ]
 dependencies = [
-    { name = "mdurl", marker = "python_full_version < '3.11'" },
+    { name = "mdurl" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/38/71/3b932df36c1a044d397a1f92d1cf91ee0a503d91e470cbd670aa66b07ed0/markdown-it-py-3.0.0.tar.gz", hash = "sha256:e3f60a94fa066dc52ec76661e37c851cb232d92f9886b15cb560aaada2df8feb", size = 74596, upload-time = "2023-06-03T06:41:14.443Z" }
 wheels = [
@@ -3249,7 +3243,7 @@ wheels = [
 
 [package.optional-dependencies]
 linkify = [
-    { name = "linkify-it-py", marker = "python_full_version < '3.11'" },
+    { name = "linkify-it-py" },
 ]
 
 [[package]]
@@ -3263,7 +3257,7 @@ resolution-markers = [
     "python_full_version == '3.11.*'",
 ]
 dependencies = [
-    { name = "mdurl", marker = "python_full_version >= '3.11'" },
+    { name = "mdurl" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/5b/f5/4ec618ed16cc4f8fb3b701563655a69816155e79e24a17b651541804721d/markdown_it_py-4.0.0.tar.gz", hash = "sha256:cb0a2b4aa34f932c007117b194e945bd74e0ec24133ceb5bac59009cda1cb9f3", size = 73070, upload-time = "2025-08-11T12:57:52.854Z" }
 wheels = [
@@ -3272,7 +3266,7 @@ wheels = [
 
 [package.optional-dependencies]
 linkify = [
-    { name = "linkify-it-py", marker = "python_full_version >= '3.11'" },
+    { name = "linkify-it-py" },
 ]
 
 [[package]]
@@ -3752,12 +3746,12 @@ resolution-markers = [
     "python_full_version < '3.11'",
 ]
 dependencies = [
-    { name = "docutils", version = "0.21.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "jinja2", marker = "python_full_version < '3.11'" },
-    { name = "markdown-it-py", version = "3.0.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "mdit-py-plugins", marker = "python_full_version < '3.11'" },
-    { name = "pyyaml", marker = "python_full_version < '3.11'" },
-    { name = "sphinx", version = "8.1.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "docutils", version = "0.21.2", source = { registry = "https://pypi.org/simple" } },
+    { name = "jinja2" },
+    { name = "markdown-it-py", version = "3.0.0", source = { registry = "https://pypi.org/simple" } },
+    { name = "mdit-py-plugins" },
+    { name = "pyyaml" },
+    { name = "sphinx", version = "8.1.3", source = { registry = "https://pypi.org/simple" } },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/66/a5/9626ba4f73555b3735ad86247a8077d4603aa8628537687c839ab08bfe44/myst_parser-4.0.1.tar.gz", hash = "sha256:5cfea715e4f3574138aecbf7d54132296bfd72bb614d31168f48c477a830a7c4", size = 93985, upload-time = "2025-02-12T10:53:03.833Z" }
 wheels = [
@@ -3775,12 +3769,12 @@ resolution-markers = [
     "python_full_version == '3.11.*'",
 ]
 dependencies = [
-    { name = "docutils", version = "0.22.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
-    { name = "jinja2", marker = "python_full_version >= '3.11'" },
-    { name = "markdown-it-py", version = "4.0.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
-    { name = "mdit-py-plugins", marker = "python_full_version >= '3.11'" },
-    { name = "pyyaml", marker = "python_full_version >= '3.11'" },
-    { name = "sphinx", version = "9.0.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
+    { name = "docutils", version = "0.22.4", source = { registry = "https://pypi.org/simple" } },
+    { name = "jinja2" },
+    { name = "markdown-it-py", version = "4.0.0", source = { registry = "https://pypi.org/simple" } },
+    { name = "mdit-py-plugins" },
+    { name = "pyyaml" },
+    { name = "sphinx", version = "9.0.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
     { name = "sphinx", version = "9.1.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/33/fa/7b45eef11b7971f0beb29d27b7bfe0d747d063aa29e170d9edd004733c8a/myst_parser-5.0.0.tar.gz", hash = "sha256:f6f231452c56e8baa662cc352c548158f6a16fcbd6e3800fc594978002b94f3a", size = 98535, upload-time = "2026-01-15T09:08:18.036Z" }
@@ -5947,10 +5941,10 @@ resolution-markers = [
     "python_full_version < '3.11'",
 ]
 dependencies = [
-    { name = "joblib", marker = "python_full_version < '3.11'" },
-    { name = "numpy", version = "1.26.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "scipy", version = "1.15.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "threadpoolctl", marker = "python_full_version < '3.11'" },
+    { name = "joblib" },
+    { name = "numpy", version = "1.26.4", source = { registry = "https://pypi.org/simple" } },
+    { name = "scipy", version = "1.15.3", source = { registry = "https://pypi.org/simple" } },
+    { name = "threadpoolctl" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/98/c2/a7855e41c9d285dfe86dc50b250978105dce513d6e459ea66a6aeb0e1e0c/scikit_learn-1.7.2.tar.gz", hash = "sha256:20e9e49ecd130598f1ca38a1d85090e1a600147b9c02fa6f15d69cb53d968fda", size = 7193136, upload-time = "2025-09-09T08:21:29.075Z" }
 wheels = [
@@ -5997,11 +5991,11 @@ resolution-markers = [
     "python_full_version == '3.11.*'",
 ]
 dependencies = [
-    { name = "joblib", marker = "python_full_version >= '3.11'" },
-    { name = "numpy", version = "1.26.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
+    { name = "joblib" },
+    { name = "numpy", version = "1.26.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
     { name = "numpy", version = "2.4.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
-    { name = "scipy", version = "1.17.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
-    { name = "threadpoolctl", marker = "python_full_version >= '3.11'" },
+    { name = "scipy", version = "1.17.1", source = { registry = "https://pypi.org/simple" } },
+    { name = "threadpoolctl" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/0e/d4/40988bf3b8e34feec1d0e6a051446b1f66225f8529b9309becaeef62b6c4/scikit_learn-1.8.0.tar.gz", hash = "sha256:9bccbb3b40e3de10351f8f5068e105d0f4083b1a65fa07b6634fbc401a6287fd", size = 7335585, upload-time = "2025-12-10T07:08:53.618Z" }
 wheels = [
@@ -6051,7 +6045,7 @@ resolution-markers = [
     "python_full_version < '3.11'",
 ]
 dependencies = [
-    { name = "numpy", version = "1.26.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "numpy", version = "1.26.4", source = { registry = "https://pypi.org/simple" } },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/0f/37/6964b830433e654ec7485e45a00fc9a27cf868d622838f6b6d9c5ec0d532/scipy-1.15.3.tar.gz", hash = "sha256:eae3cf522bc7df64b42cad3925c876e1b0b6c35c1337c93e12c0f366f55b0eaf", size = 59419214, upload-time = "2025-05-08T16:13:05.955Z" }
 wheels = [
@@ -6113,7 +6107,7 @@ resolution-markers = [
     "python_full_version == '3.11.*'",
 ]
 dependencies = [
-    { name = "numpy", version = "1.26.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
+    { name = "numpy", version = "1.26.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
     { name = "numpy", version = "2.4.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/7a/97/5a3609c4f8d58b039179648e62dd220f89864f56f7357f5d4f45c29eb2cc/scipy-1.17.1.tar.gz", hash = "sha256:95d8e012d8cb8816c226aef832200b1d45109ed4464303e997c5b13122b297c0", size = 30573822, upload-time = "2026-02-23T00:26:24.851Z" }
@@ -6560,23 +6554,23 @@ resolution-markers = [
     "python_full_version < '3.11'",
 ]
 dependencies = [
-    { name = "alabaster", marker = "python_full_version < '3.11'" },
-    { name = "babel", marker = "python_full_version < '3.11'" },
-    { name = "colorama", marker = "python_full_version < '3.11' and sys_platform == 'win32'" },
-    { name = "docutils", version = "0.21.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "imagesize", marker = "python_full_version < '3.11'" },
-    { name = "jinja2", marker = "python_full_version < '3.11'" },
-    { name = "packaging", marker = "python_full_version < '3.11'" },
-    { name = "pygments", marker = "python_full_version < '3.11'" },
-    { name = "requests", marker = "python_full_version < '3.11'" },
-    { name = "snowballstemmer", marker = "python_full_version < '3.11'" },
-    { name = "sphinxcontrib-applehelp", marker = "python_full_version < '3.11'" },
-    { name = "sphinxcontrib-devhelp", marker = "python_full_version < '3.11'" },
-    { name = "sphinxcontrib-htmlhelp", marker = "python_full_version < '3.11'" },
-    { name = "sphinxcontrib-jsmath", marker = "python_full_version < '3.11'" },
-    { name = "sphinxcontrib-qthelp", marker = "python_full_version < '3.11'" },
-    { name = "sphinxcontrib-serializinghtml", marker = "python_full_version < '3.11'" },
-    { name = "tomli", marker = "python_full_version < '3.11'" },
+    { name = "alabaster" },
+    { name = "babel" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "docutils", version = "0.21.2", source = { registry = "https://pypi.org/simple" } },
+    { name = "imagesize" },
+    { name = "jinja2" },
+    { name = "packaging" },
+    { name = "pygments" },
+    { name = "requests" },
+    { name = "snowballstemmer" },
+    { name = "sphinxcontrib-applehelp" },
+    { name = "sphinxcontrib-devhelp" },
+    { name = "sphinxcontrib-htmlhelp" },
+    { name = "sphinxcontrib-jsmath" },
+    { name = "sphinxcontrib-qthelp" },
+    { name = "sphinxcontrib-serializinghtml" },
+    { name = "tomli" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/6f/6d/be0b61178fe2cdcb67e2a92fc9ebb488e3c51c4f74a36a7824c0adf23425/sphinx-8.1.3.tar.gz", hash = "sha256:43c1911eecb0d3e161ad78611bc905d1ad0e523e4ddc202a58a821773dc4c927", size = 8184611, upload-time = "2024-10-13T20:27:13.93Z" }
 wheels = [
@@ -6591,23 +6585,23 @@ resolution-markers = [
     "python_full_version == '3.11.*'",
 ]
 dependencies = [
-    { name = "alabaster", marker = "python_full_version == '3.11.*'" },
-    { name = "babel", marker = "python_full_version == '3.11.*'" },
-    { name = "colorama", marker = "python_full_version == '3.11.*' and sys_platform == 'win32'" },
-    { name = "docutils", version = "0.22.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
-    { name = "imagesize", marker = "python_full_version == '3.11.*'" },
-    { name = "jinja2", marker = "python_full_version == '3.11.*'" },
-    { name = "packaging", marker = "python_full_version == '3.11.*'" },
-    { name = "pygments", marker = "python_full_version == '3.11.*'" },
-    { name = "requests", marker = "python_full_version == '3.11.*'" },
-    { name = "roman-numerals", marker = "python_full_version == '3.11.*'" },
-    { name = "snowballstemmer", marker = "python_full_version == '3.11.*'" },
-    { name = "sphinxcontrib-applehelp", marker = "python_full_version == '3.11.*'" },
-    { name = "sphinxcontrib-devhelp", marker = "python_full_version == '3.11.*'" },
-    { name = "sphinxcontrib-htmlhelp", marker = "python_full_version == '3.11.*'" },
-    { name = "sphinxcontrib-jsmath", marker = "python_full_version == '3.11.*'" },
-    { name = "sphinxcontrib-qthelp", marker = "python_full_version == '3.11.*'" },
-    { name = "sphinxcontrib-serializinghtml", marker = "python_full_version == '3.11.*'" },
+    { name = "alabaster" },
+    { name = "babel" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "docutils", version = "0.22.4", source = { registry = "https://pypi.org/simple" } },
+    { name = "imagesize" },
+    { name = "jinja2" },
+    { name = "packaging" },
+    { name = "pygments" },
+    { name = "requests" },
+    { name = "roman-numerals" },
+    { name = "snowballstemmer" },
+    { name = "sphinxcontrib-applehelp" },
+    { name = "sphinxcontrib-devhelp" },
+    { name = "sphinxcontrib-htmlhelp" },
+    { name = "sphinxcontrib-jsmath" },
+    { name = "sphinxcontrib-qthelp" },
+    { name = "sphinxcontrib-serializinghtml" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/42/50/a8c6ccc36d5eacdfd7913ddccd15a9cee03ecafc5ee2bc40e1f168d85022/sphinx-9.0.4.tar.gz", hash = "sha256:594ef59d042972abbc581d8baa577404abe4e6c3b04ef61bd7fc2acbd51f3fa3", size = 8710502, upload-time = "2025-12-04T07:45:27.343Z" }
 wheels = [
@@ -6624,23 +6618,23 @@ resolution-markers = [
     "python_full_version == '3.12.*'",
 ]
 dependencies = [
-    { name = "alabaster", marker = "python_full_version >= '3.12'" },
-    { name = "babel", marker = "python_full_version >= '3.12'" },
-    { name = "colorama", marker = "python_full_version >= '3.12' and sys_platform == 'win32'" },
-    { name = "docutils", version = "0.22.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
-    { name = "imagesize", marker = "python_full_version >= '3.12'" },
-    { name = "jinja2", marker = "python_full_version >= '3.12'" },
-    { name = "packaging", marker = "python_full_version >= '3.12'" },
-    { name = "pygments", marker = "python_full_version >= '3.12'" },
-    { name = "requests", marker = "python_full_version >= '3.12'" },
-    { name = "roman-numerals", marker = "python_full_version >= '3.12'" },
-    { name = "snowballstemmer", marker = "python_full_version >= '3.12'" },
-    { name = "sphinxcontrib-applehelp", marker = "python_full_version >= '3.12'" },
-    { name = "sphinxcontrib-devhelp", marker = "python_full_version >= '3.12'" },
-    { name = "sphinxcontrib-htmlhelp", marker = "python_full_version >= '3.12'" },
-    { name = "sphinxcontrib-jsmath", marker = "python_full_version >= '3.12'" },
-    { name = "sphinxcontrib-qthelp", marker = "python_full_version >= '3.12'" },
-    { name = "sphinxcontrib-serializinghtml", marker = "python_full_version >= '3.12'" },
+    { name = "alabaster" },
+    { name = "babel" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "docutils", version = "0.22.4", source = { registry = "https://pypi.org/simple" } },
+    { name = "imagesize" },
+    { name = "jinja2" },
+    { name = "packaging" },
+    { name = "pygments" },
+    { name = "requests" },
+    { name = "roman-numerals" },
+    { name = "snowballstemmer" },
+    { name = "sphinxcontrib-applehelp" },
+    { name = "sphinxcontrib-devhelp" },
+    { name = "sphinxcontrib-htmlhelp" },
+    { name = "sphinxcontrib-jsmath" },
+    { name = "sphinxcontrib-qthelp" },
+    { name = "sphinxcontrib-serializinghtml" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/cd/bd/f08eb0f4eed5c83f1ba2a3bd18f7745a2b1525fad70660a1c00224ec468a/sphinx-9.1.0.tar.gz", hash = "sha256:7741722357dd75f8190766926071fed3bdc211c74dd2d7d4df5404da95930ddb", size = 8718324, upload-time = "2025-12-31T15:09:27.646Z" }
 wheels = [
@@ -6669,7 +6663,7 @@ resolution-markers = [
     "python_full_version < '3.11'",
 ]
 dependencies = [
-    { name = "sphinx", version = "8.1.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "sphinx", version = "8.1.3", source = { registry = "https://pypi.org/simple" } },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/2b/69/b34e0cb5336f09c6866d53b4a19d76c227cdec1bbc7ac4de63ca7d58c9c7/sphinx_design-0.6.1.tar.gz", hash = "sha256:b44eea3719386d04d765c1a8257caca2b3e6f8421d7b3a5e742c0fd45f84e632", size = 2193689, upload-time = "2024-08-02T13:48:44.277Z" }
 wheels = [
@@ -6687,7 +6681,7 @@ resolution-markers = [
     "python_full_version == '3.11.*'",
 ]
 dependencies = [
-    { name = "sphinx", version = "9.0.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
+    { name = "sphinx", version = "9.0.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
     { name = "sphinx", version = "9.1.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/13/7b/804f311da4663a4aecc6cf7abd83443f3d4ded970826d0c958edc77d4527/sphinx_design-0.7.0.tar.gz", hash = "sha256:d2a3f5b19c24b916adb52f97c5f00efab4009ca337812001109084a740ec9b7a", size = 2203582, upload-time = "2026-01-19T13:12:53.297Z" }
@@ -7585,8 +7579,8 @@ resolution-markers = [
     "python_full_version < '3.11'",
 ]
 dependencies = [
-    { name = "pyarrow", marker = "python_full_version < '3.11'" },
-    { name = "substrait", marker = "python_full_version < '3.11'" },
+    { name = "pyarrow" },
+    { name = "substrait" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/fd/fd/cae1e4e56bc2f1149da8ceb8e41abf9e0e62ff173a38d65db0086320eb57/vortex_data-0.33.2-cp310-abi3-macosx_10_12_x86_64.whl", hash = "sha256:2cce3dbf5a6f94ed623afc3acd92942576bed5489efc6ea0d5bd3194224c7613", size = 10219485, upload-time = "2025-05-15T16:47:29.056Z" },
@@ -7606,9 +7600,9 @@ resolution-markers = [
     "python_full_version == '3.11.*'",
 ]
 dependencies = [
-    { name = "pyarrow", marker = "python_full_version >= '3.11'" },
-    { name = "substrait", marker = "python_full_version >= '3.11'" },
-    { name = "typing-extensions", marker = "python_full_version >= '3.11'" },
+    { name = "pyarrow" },
+    { name = "substrait" },
+    { name = "typing-extensions" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/cb/c6/76eb4f55d4a890436df3761163e0fbf0dd0966092f3d538dbc79e9140dcb/vortex_data-0.67.0-cp311-abi3-macosx_10_12_x86_64.whl", hash = "sha256:8110b600958f83cd8f32272bf32f03b44a927f5edb428da4a7e09af86852d54b", size = 36601988, upload-time = "2026-03-30T12:34:03.653Z" },


### PR DESCRIPTION
## Summary

- closes actionable findings from the asynchronous review sweep across recent merged PRs
- hardens TODO tracker freeze/lease/snapshot/finding-domain invariants and deny-rule linting
- fixes DuckLake reuse identity, deployment shorthand, schema-safe drops, and dependency floors
- fixes Snowflake ledger table discovery, compression probing, marker workflow scanning, explorer cold-read retries, and tracked-file spellcheck filtering
- preserves the required single-commit follow-up workflow
- re-triggered Codex reviews on 52 recent PRs that had no prior Codex review

## Verification

- `uv run -- python -m pytest tests/unit/ -x -q` — 26,018 passed, 13 skipped
- `uv run -- python -m pytest tests/unit/scripts/test_todo_db_v2.py -q` — 74 passed
- `THRESHOLD_BYTES=16000000 make pr-preflight` — passed (26,166 passed, 18 skipped)
- `make spellcheck` — passed
- `uv run -- ruff check .` and `uv run -- ruff format --check .` — passed
- review-thread rescan across 34 recent merged PRs — 0 unresolved threads