### PR TITLE
docs(credentials): pin the singlestore persist-on-failure contract

### DIFF
--- a/benchbox/platforms/credentials/singlestore.py
+++ b/benchbox/platforms/credentials/singlestore.py
@@ -1,5 +1,12 @@
 """SingleStore credentials setup and validation.
 
+Persistence contract (deliberate, shared with athena/redshift/snowflake):
+credentials are saved to the 0600-permission store even when validation
+FAILS, marked CredentialStatus.INVALID, so the user can fix the reported
+problem and re-run ``--validate-only`` without re-entering every field.
+The password prompt never displays a stored value (``****SET****``).
+MotherDuck is the intentional exception: its token is never persisted.
+
 Copyright 2026 Joe Harris / BenchBox Project
 
 Licensed under the MIT License. See LICENSE file in the project root for details.

--- a/tests/unit/platforms/credentials/test_singlestore_credentials.py
+++ b/tests/unit/platforms/credentials/test_singlestore_credentials.py
@@ -1,0 +1,54 @@
+"""Pin the SingleStore credential-persistence contract.
+
+Persist-on-failure is deliberate retry UX shared with athena/redshift/
+snowflake: a failed validation still saves the entered credentials to the
+0600-permission store, marked INVALID, so ``--validate-only`` can be re-run
+without re-entering every field. These tests pin that decision; a change to
+it must update the module docstring contract too.
+
+Copyright 2026 Joe Harris / BenchBox Project
+Licensed under the MIT License. See LICENSE file in the project root for details.
+"""
+
+from unittest.mock import patch
+
+import pytest
+from rich.console import Console
+
+from benchbox.platforms.credentials import singlestore as ss
+from benchbox.security.credentials import CredentialManager, CredentialStatus
+
+pytestmark = [pytest.mark.unit, pytest.mark.fast]
+
+
+def _run_setup(tmp_path, validation_result):
+    manager = CredentialManager(credentials_path=tmp_path / "credentials.yaml")
+    console = Console(file=open(tmp_path / "console.log", "w", encoding="utf-8"), force_terminal=False)
+    with (
+        patch.object(ss, "_auto_detect_singlestore", return_value=None),
+        patch("rich.prompt.Confirm.ask", return_value=False),
+        patch.object(ss, "prompt_with_default", side_effect=["db.example.com", "3306", "joe", "benchbox"]),
+        patch.object(ss, "prompt_secure_field", return_value="PW-SENTINEL"),
+        patch.object(ss, "validate_singlestore_credentials", return_value=validation_result),
+    ):
+        ss.setup_singlestore_credentials(manager, console)
+    return manager
+
+
+class TestSingleStorePersistence:
+    def test_singlestore_persistence_on_failed_validation_saves_invalid(self, tmp_path):
+        _run_setup(tmp_path, (False, "connection refused"))
+        reloaded = CredentialManager(credentials_path=tmp_path / "credentials.yaml")
+        saved = reloaded.get_platform_credentials("singlestore")
+        assert saved is not None, "failed validation still persists credentials for retry UX"
+        assert saved["password"] == "PW-SENTINEL"
+        assert reloaded.get_credential_status("singlestore") == CredentialStatus.INVALID
+
+    def test_singlestore_persistence_on_success_saves_valid(self, tmp_path):
+        _run_setup(tmp_path, (True, None))
+        reloaded = CredentialManager(credentials_path=tmp_path / "credentials.yaml")
+        assert reloaded.get_platform_credentials("singlestore")["host"] == "db.example.com"
+        assert reloaded.get_credential_status("singlestore") == CredentialStatus.VALID
+
+    def test_singlestore_persistence_contract_is_documented(self):
+        assert "even when validation" in (ss.__doc__ or ""), "the persistence contract must stay documented"


### PR DESCRIPTION
Saving credentials with INVALID status on failed validation is the
deliberate retry UX shared by athena/redshift/snowflake/singlestore
(0600-permission store; the secure prompt never displays stored
values; motherduck's never-persisted token is the intentional
exception). Document the contract in the module docstring and pin it
with tests so a future change is a decision, not an accident.

TODO: singlestore-setup-persists-password-on-failed-validation
