### PR TITLE
fix(mcp): scrub secret material from error text, justify export exemption

### DIFF
--- a/benchbox/mcp/errors.py
+++ b/benchbox/mcp/errors.py
@@ -10,9 +10,28 @@ Licensed under the MIT License. See LICENSE file in the project root for details
 
 from __future__ import annotations
 
+import re
 from dataclasses import dataclass, field
 from enum import Enum
 from typing import Any
+
+# Driver/adapter exceptions echo back the strings they were built from -
+# a DSN, an ATTACH statement, a config assignment - so exception text is a
+# credential materialisation channel (the #1333/#1345 family). Scrub
+# secret-assignment patterns and URL userinfo before the text leaves the
+# server; key-list redaction cannot help here because the secret is already
+# embedded in a value.
+_SECRET_ASSIGNMENT_RE = re.compile(
+    r"((?:password|passwd|pwd|token|secret|api[_-]?key|access[_-]?key|account[_-]?key|"
+    r"key[_-]?id|credential)[a-z0-9_-]*\s*[=:]\s*)[^&\s,;'\")]+",
+    flags=re.IGNORECASE,
+)
+_URL_USERINFO_RE = re.compile(r"(://)[^/@\s]+@")
+
+
+def scrub_secret_material(text: str) -> str:
+    """Mask secret-assignment values and URL userinfo in free text."""
+    return _URL_USERINFO_RE.sub(r"\1****@", _SECRET_ASSIGNMENT_RE.sub(r"\1****", text))
 
 
 class ErrorCode(str, Enum):
@@ -335,7 +354,7 @@ def make_execution_error(
         details["execution_id"] = execution_id
     if exception:
         details["exception_type"] = type(exception).__name__
-        details["exception_message"] = str(exception)
+        details["exception_message"] = scrub_secret_material(str(exception))
 
     return make_error(
         ErrorCode.BENCHMARK_EXECUTION_FAILED,

--- a/benchbox/mcp/tools/analytics.py
+++ b/benchbox/mcp/tools/analytics.py
@@ -343,7 +343,15 @@ def _get_query_plan_impl(file_path: Path, result_file: str, query_id: str, forma
 
 def _compare_results_impl(file1: str, file2: str, threshold_percent: float, results_dir: Path) -> dict[str, Any]:
     """Compare two benchmark runs."""
-    exporter = ResultExporter(anonymize=False, console=get_quiet_console())
+    # egress-reviewed: MCP serves a local, same-trust-boundary agent that
+    # needs real paths/hostnames to act on results; secrets are already
+    # redacted at capture time by sanitize_platform_options, and exception
+    # text is scrubbed in mcp/errors.py. Full anonymization would break
+    # path-based workflows without closing a live channel.
+    exporter = ResultExporter(
+        anonymize=False,  # egress-reviewed: local consumer, see comment above
+        console=get_quiet_console(),
+    )
     path1 = resolve_result_file_path(file1, results_dir)
     path2 = resolve_result_file_path(file2, results_dir)
 

--- a/benchbox/mcp/tools/benchmark.py
+++ b/benchbox/mcp/tools/benchmark.py
@@ -286,7 +286,16 @@ def _export_and_build_payload(
     result_payload: dict[str, Any] | None = None
     try:
         result.execution_id = execution_id
-        exporter = ResultExporter(output_dir=results_dir, anonymize=False, console=get_quiet_console())
+        # egress-reviewed: MCP serves a local, same-trust-boundary agent that
+        # needs real paths/hostnames to act on results; secrets are already
+        # redacted at capture time by sanitize_platform_options, and exception
+        # text is scrubbed in mcp/errors.py. Full anonymization would break
+        # path-based workflows without closing a live channel.
+        exporter = ResultExporter(
+            output_dir=results_dir,
+            anonymize=False,  # egress-reviewed: local consumer, see comment above
+            console=get_quiet_console(),
+        )
         exported_files = exporter.export_result(result, formats=["json"])
         if "json" in exported_files:
             result_file_path = str(exported_files["json"])

--- a/tests/unit/mcp/test_errors.py
+++ b/tests/unit/mcp/test_errors.py
@@ -278,6 +278,34 @@ class TestMakePlatformError:
         assert result["suggestion"] == "pip install clickhouse-driver"
 
 
+class TestExceptionSecretScrubbing:
+    """Exception text is a credential materialisation channel (a DSN or SQL
+    text echoed back by a driver); the response must scrub it."""
+
+    def test_secret_assignment_is_scrubbed(self):
+        result = make_execution_error("failed", exception=Exception("motherduck_token=SENT-123 during ATTACH"))
+        msg = result["details"]["exception_message"]
+        assert "SENT-123" not in msg
+        assert "motherduck_token=****" in msg
+
+    def test_url_userinfo_is_scrubbed(self):
+        result = make_execution_error(
+            "failed", exception=Exception("connect databend://joe:PW-SENT@db.example.com:8000 refused")
+        )
+        msg = result["details"]["exception_message"]
+        assert "PW-SENT" not in msg
+        assert "joe" not in msg
+        assert "://****@db.example.com" in msg
+
+    def test_password_colon_assignment_is_scrubbed(self):
+        result = make_execution_error("failed", exception=Exception("bad config: password: hunter2"))
+        assert "hunter2" not in result["details"]["exception_message"]
+
+    def test_plain_text_is_untouched(self):
+        result = make_execution_error("failed", exception=Exception("table lineitem not found"))
+        assert result["details"]["exception_message"] == "table lineitem not found"
+
+
 class TestMakeExecutionError:
     """Tests for make_execution_error helper function."""
 


### PR DESCRIPTION
MCP error responses echoed str(exception) verbatim - driver errors
carry the DSNs and assignments they were built from, so exception text
is a credential materialisation channel no key list can catch. Scrub
secret-assignment patterns and URL userinfo in make_execution_error.

The two anonymize=False export sites stay, now as a documented
decision: MCP serves a local, same-trust-boundary agent that needs
real paths to act on results, and capture-time sanitization already
redacts secrets from metadata. Both sites carry egress-reviewed
markers so the exemption is greppable.

TODO: mcp-output-bypasses-anonymization-and-echoes-raw-exceptions
