### PR TITLE
fix(results): pseudonymize workspace_name, job_role and application_id

### DIFF
--- a/benchbox/core/results/anonymization_specs.yaml
+++ b/benchbox/core/results/anonymization_specs.yaml
@@ -16,6 +16,7 @@ identifier_keys:
   projectid: project
   workspace: workspace
   workspaceid: workspace
+  workspacename: workspace
   warehouse: warehouse
   warehousename: warehouse
   workgroup: workgroup
@@ -46,11 +47,13 @@ identifier_keys:
   rolearn: role
   iamrole: role
   iamrolearn: role
+  jobrole: role
   arn: arn
   engine: engine
   enginename: engine
   clientid: client
   machineid: machine
+  applicationid: application
 endpoint_keys:
 - apiendpoint
 - endpoint

--- a/tests/unit/core/results/test_anonymization.py
+++ b/tests/unit/core/results/test_anonymization.py
@@ -792,6 +792,37 @@ class TestPublicPayloadApiKeyAndAccountKey:
         assert "AZKEY-SENTINEL" not in out
 
 
+class TestPublicPayloadWorkspaceRoleAndApplicationIds:
+    """Near-miss variants of covered identifier keys are the recurring leak
+    pattern: workspace_name, job_role and application_id all exported
+    verbatim while workspace/workspaceid and role/iamrole were covered."""
+
+    @staticmethod
+    def _payload(config):
+        return {"platform_metadata": {"platform_raw_config": config}}
+
+    def test_workspace_name_pseudonymizes_like_workspace(self):
+        out = AnonymizationManager().anonymize_result_payload(self._payload({"workspace_name": "WSN-SENTINEL"}))[
+            "platform_metadata"
+        ]["platform_raw_config"]
+        assert out["workspace_name"] != "WSN-SENTINEL"
+        assert out["workspace_name"].startswith("workspace_")
+
+    def test_job_role_pseudonymizes_like_role(self):
+        out = AnonymizationManager().anonymize_result_payload(self._payload({"job_role": "JR-SENTINEL"}))[
+            "platform_metadata"
+        ]["platform_raw_config"]
+        assert out["job_role"] != "JR-SENTINEL"
+        assert out["job_role"].startswith("role_")
+
+    def test_application_id_is_hashed(self):
+        out = AnonymizationManager().anonymize_result_payload(self._payload({"application_id": "APP-SENTINEL"}))[
+            "platform_metadata"
+        ]["platform_raw_config"]
+        assert out["application_id"] != "APP-SENTINEL"
+        assert out["application_id"].startswith("application_")
+
+
 class TestPublicPayloadPgUserAndTenantId:
     """pg_user must pseudonymize like every other username spelling, and a
     tenant id (an org-identifying GUID) must hash — both escaped the public


### PR DESCRIPTION
Near-miss spellings of covered identifier keys are the recurring leak
pattern: workspace/workspaceid were pseudonymized but workspace_name
exported verbatim, role/iamrole were covered but job_role (an IAM role,
often a full ARN carrying the account id) was not, and application_id
(an account-scoped EMR resource id) matched nothing. Map all three into
the existing pseudonym families.

TODO: public-export-misses-workspace-and-role-identity-keys
