### PR TITLE
fix: register SingleStore credential retry setup

### DIFF
--- a/benchbox/cli/commands/run.py
+++ b/benchbox/cli/commands/run.py
@@ -81,7 +81,9 @@ from benchbox.utils.verbosity import VerbositySettings
 
 logger = logging.getLogger(__name__)
 DATA_ORGANIZATION_ENV = "BENCHBOX_DATA_ORGANIZATION_CONFIG_JSON"
-_GUIDED_CREDENTIAL_PLATFORMS = frozenset({"athena", "bigquery", "databricks", "motherduck", "redshift", "snowflake"})
+_GUIDED_CREDENTIAL_PLATFORMS = frozenset(
+    {"athena", "bigquery", "databricks", "motherduck", "redshift", "singlestore", "snowflake"}
+)
 
 # Benchmark name aliases - maps common variations to canonical names
 BENCHMARK_ALIASES: dict[str, str] = {

--- a/benchbox/cli/commands/setup.py
+++ b/benchbox/cli/commands/setup.py
@@ -14,7 +14,15 @@ from rich.table import Table
 from benchbox.cli.shared import console
 from benchbox.security.credentials import CredentialManager, CredentialStatus
 
-SUPPORTED_SETUP_PLATFORMS = ("databricks", "snowflake", "bigquery", "redshift", "athena", "motherduck")
+SUPPORTED_SETUP_PLATFORMS = (
+    "databricks",
+    "snowflake",
+    "bigquery",
+    "redshift",
+    "athena",
+    "motherduck",
+    "singlestore",
+)
 
 PLATFORM_DISPLAY_NAMES = {
     "athena": "Athena",
@@ -22,6 +30,7 @@ PLATFORM_DISPLAY_NAMES = {
     "databricks": "Databricks",
     "motherduck": "MotherDuck",
     "redshift": "Redshift",
+    "singlestore": "SingleStore",
     "snowflake": "Snowflake",
 }
 
@@ -42,7 +51,7 @@ def setup_credentials(ctx, platform, validate_only, list_platforms_flag, show_st
     """Interactive setup for cloud platform credentials.
 
     Guides you through setting up authentication for Databricks, Snowflake,
-    BigQuery, Redshift, Athena, and MotherDuck platforms. Most platforms use
+    BigQuery, Redshift, Athena, MotherDuck, and SingleStore platforms. Most platforms use
     secure local credential storage; MotherDuck validates MOTHERDUCK_TOKEN
     without storing the token.
 
@@ -152,6 +161,12 @@ def _list_platforms(cred_manager: CredentialManager):
             "key": "motherduck",
             "description": "Serverless DuckDB cloud",
             "required": ["MOTHERDUCK_TOKEN", "database"],
+        },
+        {
+            "name": "SingleStore",
+            "key": "singlestore",
+            "description": "Distributed SQL database",
+            "required": ["host", "port", "database", "username", "password"],
         },
     ]
 
@@ -333,6 +348,10 @@ def _validate_credentials(cred_manager: CredentialManager, platform: str):
             from benchbox.platforms.credentials.motherduck import validate_motherduck_credentials
 
             success, error = validate_motherduck_credentials(cred_manager)
+        elif platform == "singlestore":
+            from benchbox.platforms.credentials.singlestore import validate_singlestore_credentials
+
+            success, error = validate_singlestore_credentials(cred_manager)
         else:
             console.print(f"[red]❌ Validation not implemented for {platform}[/red]")
             return
@@ -372,7 +391,7 @@ def run_platform_credential_setup(platform: str, console_obj, show_welcome: bool
     """Run interactive credential setup for a platform.
 
     Args:
-        platform: Platform name (snowflake, bigquery, databricks, redshift)
+        platform: Platform name (snowflake, bigquery, databricks, redshift, singlestore)
         console_obj: Console object for output
         show_welcome: Whether to show welcome panel (False when called from run command)
 
@@ -420,6 +439,11 @@ def run_platform_credential_setup(platform: str, console_obj, show_welcome: bool
             from benchbox.platforms.credentials.motherduck import setup_motherduck_credentials
 
             return setup_motherduck_credentials(cred_manager, console_obj)
+        elif platform == "singlestore":
+            from benchbox.platforms.credentials.singlestore import setup_singlestore_credentials
+
+            setup_singlestore_credentials(cred_manager, console_obj)
+            return cred_manager.has_credentials(platform)
         else:
             console_obj.print(f"[red]❌ Setup not implemented for {platform}[/red]")
             return False

--- a/benchbox/cli/orchestrator.py
+++ b/benchbox/cli/orchestrator.py
@@ -548,7 +548,7 @@ class BenchmarkOrchestrator:
         platform = database_config.type.lower()
 
         # Only offer for cloud platforms that support credential setup
-        cloud_platforms = ["snowflake", "bigquery", "databricks", "redshift"]
+        cloud_platforms = ["snowflake", "bigquery", "databricks", "redshift", "singlestore"]
         if platform not in cloud_platforms:
             return False
 
@@ -571,7 +571,7 @@ class BenchmarkOrchestrator:
         """Offer and run interactive credential setup when credentials are missing.
 
         Args:
-            platform: Platform name (snowflake, bigquery, databricks, redshift)
+            platform: Platform name (snowflake, bigquery, databricks, redshift, singlestore)
 
         Returns:
             True if credentials were successfully set up, False otherwise

--- a/benchbox/mcp/errors.py
+++ b/benchbox/mcp/errors.py
@@ -23,7 +23,8 @@ from typing import Any
 # embedded in a value.
 _SECRET_ASSIGNMENT_RE = re.compile(
     r"((?:password|passwd|pwd|token|secret|api[_-]?key|access[_-]?key|account[_-]?key|"
-    r"key[_-]?id|credential)[a-z0-9_-]*\s*[=:]\s*)[^&\s,;'\")]+",
+    r"key[_-]?id|credential)[a-z0-9_-]*\s*[=:]\s*)"
+    r"(?:'[^']*'|\"[^\"]*\"|[^&\s,;'\")]+)",
     flags=re.IGNORECASE,
 )
 _URL_USERINFO_RE = re.compile(r"(://)[^/@\s]+@")
@@ -358,7 +359,7 @@ def make_execution_error(
 
     return make_error(
         ErrorCode.BENCHMARK_EXECUTION_FAILED,
-        message,
+        scrub_secret_material(message),
         details=details,
         retry_hint=retry_hint,
     )

--- a/tests/uat/test_no_cli_surface_drift.py
+++ b/tests/uat/test_no_cli_surface_drift.py
@@ -80,6 +80,10 @@ ALLOWED_INTERNAL_CLI_FILES = {
     "benchbox/cli/platform.py",
 }
 ALLOWED_HIDDEN_COMPAT_CLI_FILES = {
+    # pr-review-followup-1394: SingleStore credential setup is intentionally
+    # added to the public setup platform choice and dispatch paths; the CLI
+    # tests pin the choice, interactive handler, and validate-only handler.
+    "benchbox/cli/commands/setup.py",
     "benchbox/cli/commands/calculate_qphh.py",
     "benchbox/cli/commands/compare_dataframes.py",
     "benchbox/cli/commands/compare_plans.py",

--- a/tests/unit/cli/test_cli_orchestrator.py
+++ b/tests/unit/cli/test_cli_orchestrator.py
@@ -595,6 +595,13 @@ class TestBenchmarkOrchestratorErrorHandling:
         """Clean up test fixtures."""
         shutil.rmtree(self.temp_dir, ignore_errors=True)
 
+    def test_singlestore_missing_credentials_offers_guided_setup(self):
+        database_config = Mock(type="singlestore")
+
+        assert self.orchestrator._should_offer_credential_setup(
+            database_config, RuntimeError("configuration requires username and password")
+        )
+
     def test_platform_config_without_system_profile(self):
         """Test platform config generation without system profile."""
         database_config = Mock()

--- a/tests/unit/cli/test_cli_setup.py
+++ b/tests/unit/cli/test_cli_setup.py
@@ -74,6 +74,7 @@ class TestSetupCommand:
         assert "BigQuery" in result.output
         assert "Redshift" in result.output
         assert "MotherDuck" in result.output
+        assert "SingleStore" in result.output
         assert "✅ Configured" in result.output
         assert "○ Not configured" in result.output
 
@@ -304,6 +305,23 @@ class TestSetupCommand:
 
     @patch("benchbox.cli.commands.setup.CredentialManager")
     @patch("benchbox.utils.dependencies.check_platform_dependencies")
+    @patch("benchbox.platforms.credentials.singlestore.setup_singlestore_credentials")
+    def test_setup_interactive_singlestore(self, mock_setup_singlestore, mock_check_deps, mock_cred_manager_class):
+        """Test interactive setup for SingleStore."""
+        mock_manager = MagicMock()
+        mock_cred_manager_class.return_value = mock_manager
+        mock_check_deps.return_value = (True, [])
+
+        runner = CliRunner()
+        result = runner.invoke(cli, ["setup", "--platform", "singlestore"])
+
+        assert result.exit_code == 0
+        assert "SingleStore Credentials Setup" in result.output
+        mock_setup_singlestore.assert_called_once()
+        assert mock_setup_singlestore.call_args[0][0] == mock_manager
+
+    @patch("benchbox.cli.commands.setup.CredentialManager")
+    @patch("benchbox.utils.dependencies.check_platform_dependencies")
     @patch("benchbox.platforms.credentials.bigquery.setup_bigquery_credentials")
     def test_setup_interactive_bigquery(self, mock_setup_bigquery, mock_check_deps, mock_cred_manager_class):
         """Test interactive setup for BigQuery."""
@@ -406,6 +424,22 @@ class TestSetupValidation:
             "database": "benchbox",
             "token_env_var": "MOTHERDUCK_TOKEN",
         }
+
+    @patch("benchbox.cli.commands.setup.CredentialManager")
+    @patch("benchbox.platforms.credentials.singlestore.validate_singlestore_credentials")
+    def test_validate_singlestore(self, mock_validate, mock_cred_manager_class):
+        """Test validate-only dispatch for SingleStore."""
+        mock_manager = MagicMock()
+        mock_manager.has_credentials.return_value = True
+        mock_cred_manager_class.return_value = mock_manager
+        mock_validate.return_value = (True, None)
+
+        runner = CliRunner()
+        result = runner.invoke(cli, ["setup", "--platform", "singlestore", "--validate-only"])
+
+        assert result.exit_code == 0
+        assert "SingleStore credentials are valid" in result.output
+        mock_validate.assert_called_once_with(mock_manager)
 
 
 class TestSetupIntegration:

--- a/tests/unit/cli/test_run_command_interactive_paths.py
+++ b/tests/unit/cli/test_run_command_interactive_paths.py
@@ -121,6 +121,25 @@ def test_interactive_cloud_setup_leaves_server_credentials_to_adapter():
     state.ctx.exit.assert_not_called()
 
 
+def test_interactive_cloud_setup_guides_singlestore_credentials():
+    state = SimpleNamespace(
+        database_config=SimpleNamespace(type="singlestore"),
+        non_interactive=False,
+        output=None,
+        ctx=Mock(),
+    )
+
+    with (
+        patch.object(_run_module, "_run_stages_through_cloud_storage", return_value=False),
+        patch.object(_run_module, "_run_requires_platform_credentials", return_value=True),
+        patch.object(_run_module, "check_and_setup_platform_credentials", return_value=True) as check_credentials,
+    ):
+        _run_module._interactive_cloud_setup_if_needed(state)
+
+    check_credentials.assert_called_once_with(platform="singlestore", console_obj=_run_module.console, interactive=True)
+    state.ctx.exit.assert_not_called()
+
+
 def test_interactive_guided_flow_uses_prompted_values_and_saves_preferences(tmp_path: Path):
     runner = CliRunner()
 

--- a/tests/unit/mcp/test_errors.py
+++ b/tests/unit/mcp/test_errors.py
@@ -301,6 +301,16 @@ class TestExceptionSecretScrubbing:
         result = make_execution_error("failed", exception=Exception("bad config: password: hunter2"))
         assert "hunter2" not in result["details"]["exception_message"]
 
+    def test_quoted_secret_assignments_are_scrubbed(self):
+        result = make_execution_error("failed", exception=Exception("PASSWORD = 'hunter2'; SECRET = \"token\""))
+        msg = result["details"]["exception_message"]
+        assert "hunter2" not in msg
+        assert "token" not in msg
+
+    def test_top_level_message_is_scrubbed(self):
+        result = make_execution_error("Benchmark execution failed: password=hunter2")
+        assert result["message"] == "Benchmark execution failed: password=****"
+
     def test_plain_text_is_untouched(self):
         result = make_execution_error("failed", exception=Exception("table lineitem not found"))
         assert result["details"]["exception_message"] == "table lineitem not found"


### PR DESCRIPTION
## Summary
- register SingleStore with `benchbox setup`
- wire interactive and `--validate-only` credential flows
- pin CLI surface and retry dispatch coverage

## Verification
- `uv run -- python -m pytest tests/unit/ -x -q` — 26033 passed, 13 skipped
- targeted CLI and credential tests — 37 passed
- `THRESHOLD_BYTES=16000000 make pr-preflight` — passed (26187 passed, 18 skipped)
- `uv run -- ruff check .` and `uv run -- ruff format --check .` — passed