### PR TITLE
fix(snowflake): harden clustering precheck

### DIFF
--- a/benchbox/platforms/snowflake.py
+++ b/benchbox/platforms/snowflake.py
@@ -1550,7 +1550,10 @@ class SnowflakeAdapter(PlatformAdapter):
                 }
 
             # Get table information
-            cursor.execute(f"""
+            from benchbox.platforms.snowflake_introspection import normalize_snowflake_schema
+
+            cursor.execute(
+                """
                 SELECT
                     TABLE_NAME,
                     ROW_COUNT,
@@ -1560,9 +1563,11 @@ class SnowflakeAdapter(PlatformAdapter):
                     LAST_ALTERED,
                     CLUSTERING_KEY
                 FROM INFORMATION_SCHEMA.TABLES
-                WHERE TABLE_SCHEMA = '{self.schema}'
+                WHERE TABLE_SCHEMA = %s
                 AND TABLE_TYPE = 'BASE TABLE'
-            """)
+                """,
+                (normalize_snowflake_schema(self.schema),),
+            )
             tables = cursor.fetchall()
             metadata["tables"] = [
                 {
@@ -1697,6 +1702,7 @@ class SnowflakeAdapter(PlatformAdapter):
         try:
             # Import here to avoid circular imports
             from benchbox.core.tuning.interface import TuningType
+            from benchbox.platforms.snowflake_introspection import normalize_snowflake_schema, parse_clustering_key
 
             # Handle clustering keys
             cluster_columns = table_tuning.get_columns_by_type(TuningType.CLUSTERING)
@@ -1714,20 +1720,23 @@ class SnowflakeAdapter(PlatformAdapter):
 
             if clustering_columns:
                 # Check current clustering key
-                cursor.execute(f"""
-                    SELECT CLUSTERING_KEY
-                    FROM INFORMATION_SCHEMA.TABLES
-                    WHERE TABLE_SCHEMA = '{self.schema}'
-                    AND TABLE_NAME = '{table_name}'
-                """)
+                cursor.execute(
+                    """
+                        SELECT CLUSTERING_KEY
+                        FROM INFORMATION_SCHEMA.TABLES
+                        WHERE TABLE_SCHEMA = %s
+                        AND TABLE_NAME = %s
+                    """,
+                    (normalize_snowflake_schema(self.schema), table_name),
+                )
                 result = cursor.fetchone()
                 current_clustering = result[0] if result and result[0] else None
 
                 desired_clustering = f"({', '.join(clustering_columns)})"
+                cluster_sql = f"ALTER TABLE {table_name} CLUSTER BY ({', '.join(clustering_columns)})"
 
-                if current_clustering != desired_clustering:
+                if parse_clustering_key(current_clustering) != parse_clustering_key(desired_clustering):
                     # Apply clustering key
-                    cluster_sql = f"ALTER TABLE {table_name} CLUSTER BY ({', '.join(clustering_columns)})"
                     try:
                         cursor.execute(cluster_sql)
                         self.logger.info(f"Applied clustering key to {table_name}: {', '.join(clustering_columns)}")
@@ -1744,6 +1753,9 @@ class SnowflakeAdapter(PlatformAdapter):
                         self.logger.warning(f"Failed to apply clustering key to {table_name}: {e}")
                 else:
                     self.logger.info(f"Table {table_name} already has desired clustering key: {current_clustering}")
+                    ledger = getattr(self, "_applied_tuning_ledger", None)
+                    if ledger is not None:
+                        ledger.record_dropped(cluster_sql, "already present in Snowflake catalog; ALTER skipped")
 
             # Handle sorting - in Snowflake, this is achieved through clustering
             sort_columns = table_tuning.get_columns_by_type(TuningType.SORTING)

--- a/benchbox/platforms/snowflake_introspection.py
+++ b/benchbox/platforms/snowflake_introspection.py
@@ -47,6 +47,7 @@ _MAX_TABLE_ROWS = 1000
 #: guessing wrong here would mismatch every clustered table against its own
 #: catalog fact, which fails CLOSED and would be invisible.
 _CLUSTERING_KEY_RE = re.compile(r"^\s*(?:linear\s*)?\((?P<cols>.*)\)\s*$", re.IGNORECASE | re.DOTALL)
+_UNQUOTED_IDENTIFIER_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_$]*$")
 
 
 def parse_clustering_key(raw: Any) -> tuple[str, ...]:
@@ -66,6 +67,14 @@ def parse_clustering_key(raw: Any) -> tuple[str, ...]:
     return normalize_columns(text)
 
 
+def normalize_snowflake_schema(raw: Any) -> str:
+    """Validate and normalize an unquoted Snowflake schema identifier."""
+    text = str(raw).strip()
+    if not _UNQUOTED_IDENTIFIER_RE.fullmatch(text):
+        raise ValueError("Snowflake schema must be a valid unquoted identifier")
+    return text.upper()
+
+
 class SnowflakeTuningIntrospector:
     """Introspect Snowflake ``INFORMATION_SCHEMA`` clustering keys."""
 
@@ -81,19 +90,20 @@ class SnowflakeTuningIntrospector:
         ``error``, and corroboration then refuses the upgrade.
         """
         tables = ledger_tables(ledger)
-        query = (
-            "SELECT TABLE_NAME, CLUSTERING_KEY FROM INFORMATION_SCHEMA.TABLES "
-            f"WHERE CLUSTERING_KEY IS NOT NULL LIMIT {_MAX_TABLE_ROWS}"
-        )
-        if self._schema:
+        try:
             query = (
                 "SELECT TABLE_NAME, CLUSTERING_KEY FROM INFORMATION_SCHEMA.TABLES "
-                f"WHERE TABLE_SCHEMA = '{self._schema}' AND CLUSTERING_KEY IS NOT NULL "
-                f"LIMIT {_MAX_TABLE_ROWS}"
+                f"WHERE CLUSTERING_KEY IS NOT NULL LIMIT {_MAX_TABLE_ROWS}"
             )
-
-        try:
-            rows = _fetch(connection, query)
+            params: tuple[Any, ...] = ()
+            if self._schema:
+                query = (
+                    "SELECT TABLE_NAME, CLUSTERING_KEY FROM INFORMATION_SCHEMA.TABLES "
+                    "WHERE TABLE_SCHEMA = %s AND CLUSTERING_KEY IS NOT NULL "
+                    f"LIMIT {_MAX_TABLE_ROWS}"
+                )
+                params = (normalize_snowflake_schema(self._schema),)
+            rows = _fetch(connection, query, params)
         except Exception as exc:  # introspection must never break a run
             logger.debug("snowflake clustering introspection degraded: %s", exc)
             return IntrospectedState(platform=self.platform, error=f"INFORMATION_SCHEMA read failed: {exc}")
@@ -121,20 +131,23 @@ class SnowflakeTuningIntrospector:
         return IntrospectedState(platform=self.platform, objects=objects, truncated=truncated)
 
 
-def _fetch(connection: Any, query: str) -> list[Any]:
+def _fetch(connection: Any, query: str, params: tuple[Any, ...] = ()) -> list[Any]:
     """Run a read through either a cursor-style or execute-style connection."""
     cursor_factory = getattr(connection, "cursor", None)
     if callable(cursor_factory):
         cursor = cursor_factory()
         try:
-            cursor.execute(query)
+            if params:
+                cursor.execute(query, params)
+            else:
+                cursor.execute(query)
             return list(cursor.fetchall() or [])
         finally:
             close = getattr(cursor, "close", None)
             if callable(close):
                 close()
-    result = connection.execute(query)
+    result = connection.execute(query, params) if params else connection.execute(query)
     return list(result) if result is not None else []
 
 
-__all__ = ["SnowflakeTuningIntrospector", "parse_clustering_key"]
+__all__ = ["SnowflakeTuningIntrospector", "normalize_snowflake_schema", "parse_clustering_key"]

--- a/docs/development/tuning-introspection-receipts.md
+++ b/docs/development/tuning-introspection-receipts.md
@@ -104,6 +104,24 @@ catalog exists.
   recorded as a corroboratable footprint (e.g. recording the CTAS
   `ORDER BY`, or re-creating the index post-load) -- out of scope here.
 
+- **Snowflake** (`benchbox/platforms/snowflake_introspection.py`): reads
+  `INFORMATION_SCHEMA.TABLES.CLUSTERING_KEY` with bound, normalized schema
+  parameters, then filters the structured rows to ledger tables. Both
+  `LINEAR(A, B)` and `(A, B)` catalog forms normalize to the same exact,
+  order-sensitive column tuple while the live catalog spelling remains
+  unconfirmed.
+
+  A matching catalog key certifies only that Snowflake accepted the clustering
+  **key metadata**. It does not certify that existing micro-partitions have
+  finished reclustering: `ALTER TABLE ... CLUSTER BY` updates metadata before
+  asynchronous maintenance completes, and `RESUME RECLUSTER` remains a
+  non-blocking maintenance statement. This is intentionally weaker than the
+  ClickHouse receipt, whose CREATE-time sorting and partition keys describe the
+  physical MergeTree layout. When a reused Snowflake table already has the
+  requested key, the adapter skips both ALTER and RESUME and records the intent
+  as dropped/already-present; that current run therefore stays fail-closed
+  rather than claiming it physically applied the pre-existing layout.
+
 - **ClickHouse** (`benchbox/platforms/clickhouse/introspection.py`): reads
   `system.tables` (`name` / `sorting_key` / `partition_key` -- structured
   comma-separated key expressions), filtered to `currentDatabase()` and the

--- a/tests/unit/platforms/test_snowflake_adapter_coverage.py
+++ b/tests/unit/platforms/test_snowflake_adapter_coverage.py
@@ -18,6 +18,8 @@ from unittest.mock import MagicMock, Mock, patch
 
 import pytest
 
+from benchbox.core.tuning.applied_ledger import PHASE_DDL, AppliedTuningLedger, recording_connection
+
 pytestmark = [
     pytest.mark.unit,
     pytest.mark.fast,
@@ -867,7 +869,7 @@ class TestGetPlatformMetadata:
 
         call_count = [0]
 
-        def _execute(sql):
+        def _execute(sql, params=None):
             call_count[0] += 1
             if "CURRENT_VERSION" in sql.upper():
                 mock_cursor.fetchone.return_value = (version,)
@@ -917,15 +919,21 @@ class TestGetPlatformMetadata:
         assert result["warehouse_info"]["size"] == "LARGE"
 
     def test_tables_list_populated(self):
-        adapter = _make_adapter()
+        adapter = _make_adapter(schema="bench")
         mock_conn = Mock()
         tables = [("LINEITEM", 6000000, 102400, 1, None, None, None)]
-        mock_conn.cursor.return_value = self._make_cursor(tables=tables)
+        mock_cursor = self._make_cursor(tables=tables)
+        mock_conn.cursor.return_value = mock_cursor
 
         result = adapter._get_platform_metadata(mock_conn)
 
         assert "tables" in result
         assert result["tables"][0]["table_name"] == "LINEITEM"
+        table_query = next(
+            call for call in mock_cursor.execute.call_args_list if "INFORMATION_SCHEMA.TABLES" in call.args[0]
+        )
+        assert "TABLE_SCHEMA = %s" in table_query.args[0]
+        assert table_query.args[1] == ("BENCH",)
 
     def test_metadata_error_key_on_exception(self):
         adapter = _make_adapter()
@@ -1041,6 +1049,61 @@ class TestApplyTableTunings:
         all_sqls = [call[0][0] for call in mock_cursor.execute.call_args_list]
         alter_sqls = [s for s in all_sqls if "ALTER TABLE" in s.upper() and "CLUSTER BY" in s.upper()]
         assert len(alter_sqls) == 0
+
+    def test_linear_catalog_form_skips_alter_and_records_dropped_intent(self):
+        adapter = _make_adapter()
+        adapter._applied_tuning_ledger = AppliedTuningLedger()
+        mock_conn = Mock()
+        mock_cursor = Mock()
+        mock_conn.cursor.return_value = mock_cursor
+        mock_cursor.fetchone.return_value = ("LINEAR(O_ORDERDATE, O_CUSTKEY)",)
+
+        tuning = self._make_tuning(
+            table_name="ORDERS",
+            cluster_cols=[self._make_col("o_orderdate", 0), self._make_col("o_custkey", 1)],
+        )
+        adapter.apply_table_tunings(tuning, mock_conn)
+
+        all_sqls = [call.args[0] for call in mock_cursor.execute.call_args_list]
+        assert not any("ALTER TABLE" in sql.upper() and "CLUSTER BY" in sql.upper() for sql in all_sqls)
+        assert [d.intent for d in adapter._applied_tuning_ledger.dropped] == [
+            "ALTER TABLE ORDERS CLUSTER BY (o_orderdate, o_custkey)"
+        ]
+        assert "already present" in adapter._applied_tuning_ledger.dropped[0].reason
+
+    def test_clustering_precheck_binds_normalized_schema_and_table(self):
+        adapter = _make_adapter(schema="bench")
+        mock_conn = Mock()
+        mock_cursor = Mock()
+        mock_conn.cursor.return_value = mock_cursor
+        mock_cursor.fetchone.return_value = (None,)
+
+        tuning = self._make_tuning(table_name="orders", cluster_cols=[self._make_col("o_orderdate")])
+        adapter.apply_table_tunings(tuning, mock_conn)
+
+        query_call = mock_cursor.execute.call_args_list[0]
+        assert "TABLE_SCHEMA = %s" in query_call.args[0]
+        assert "TABLE_NAME = %s" in query_call.args[0]
+        assert query_call.args[1] == ("BENCH", "ORDERS")
+
+    def test_fresh_table_records_executed_clustering_statements(self):
+        adapter = _make_adapter()
+        ledger = AppliedTuningLedger()
+        adapter._applied_tuning_ledger = ledger
+        mock_conn = Mock()
+        mock_cursor = Mock()
+        mock_conn.cursor.return_value = mock_cursor
+        mock_cursor.fetchone.return_value = (None,)
+        recording = recording_connection(mock_conn, ledger, PHASE_DDL)
+
+        tuning = self._make_tuning(table_name="ORDERS", cluster_cols=[self._make_col("o_orderdate")])
+        adapter.apply_table_tunings(tuning, recording)
+
+        assert [statement.statement for statement in ledger.executed_statements] == [
+            "ALTER TABLE ORDERS CLUSTER BY (o_orderdate)",
+            "ALTER TABLE ORDERS RESUME RECLUSTER",
+        ]
+        assert ledger.dropped == []
 
     def test_partition_cols_used_as_clustering_fallback(self):
         adapter = _make_adapter()

--- a/tests/unit/platforms/test_snowflake_introspection.py
+++ b/tests/unit/platforms/test_snowflake_introspection.py
@@ -38,9 +38,11 @@ class _FakeCursor:
         self._fail = fail
         self.closed = False
         self.queries: list[str] = []
+        self.calls: list[tuple[str, object]] = []
 
-    def execute(self, query):
+    def execute(self, query, params=None):
         self.queries.append(str(query))
+        self.calls.append((str(query), params))
         if self._fail:
             raise RuntimeError("INFORMATION_SCHEMA unavailable")
 
@@ -110,10 +112,30 @@ class TestSnowflakeIntrospector:
     def test_query_reads_information_schema_not_show_create(self):
         conn = _FakeSnowflakeConnection([("LINEITEM", "LINEAR(A)")])
         SnowflakeTuningIntrospector(schema="BENCH").introspect(conn, _clustered_ledger())
-        query = conn.cursors[0].queries[0].upper()
+        raw_query = conn.cursors[0].queries[0]
+        query = raw_query.upper()
         assert "INFORMATION_SCHEMA.TABLES" in query
         assert "SHOW CREATE" not in query
-        assert "BENCH" in query
+        assert "TABLE_SCHEMA = %s" in raw_query
+        assert conn.cursors[0].calls[0][1] == ("BENCH",)
+
+    def test_lowercase_schema_is_normalized_and_bound(self):
+        conn = _FakeSnowflakeConnection([("LINEITEM", "LINEAR(A)")])
+        state = SnowflakeTuningIntrospector(schema="bench").introspect(conn, _clustered_ledger())
+
+        assert state.error is None
+        query, params = conn.cursors[0].calls[0]
+        assert "TABLE_SCHEMA = %s" in query
+        assert params == ("BENCH",)
+        assert "'bench'" not in query
+
+    def test_unsafe_schema_degrades_without_interpolation(self):
+        conn = _FakeSnowflakeConnection([("LINEITEM", "LINEAR(A)")])
+        state = SnowflakeTuningIntrospector(schema="bench' OR TRUE --").introspect(conn, _clustered_ledger())
+
+        assert state.error is not None
+        assert state.objects == []
+        assert conn.cursors == []
 
     def test_bounded_to_ledger_tables(self):
         conn = _FakeSnowflakeConnection(


### PR DESCRIPTION
## Summary

- normalize and validate unquoted Snowflake schemas before metadata access, then bind them as query parameters
- compare desired and existing clustering keys through the catalog parser so `LINEAR(A, B)` and `(A, B)` remain equivalent
- make the already-clustered reuse path explicit: skip redundant `ALTER`/`RESUME RECLUSTER` and record a dropped intent that cannot over-certify the receipt
- document that Snowflake corroboration proves catalog key metadata, not completion of asynchronous physical reclustering

Tracker: `snowflake-clustering-precheck-schema-filter-20260801`

## Verification

- `uv run -- python -m pytest tests/unit/platforms/test_snowflake_introspection.py tests/unit/platforms -k snowflake -q` (323 passed)
- catalog-form normalization guard passed
- tracker fast-suite rung: 26,234 passed, 19 skipped
- post-commit `make pr-preflight`: 26,219 passed, 19 skipped
- Ruff check/format, diff check, strict scope check, and adversarial review passed

No live Snowflake calls were made. Live catalog-shape confirmation remains tracked separately.

## Follow-ups

- Deferral #676 was logged when the local tracker wrapper lacked standalone `todo update`, then dismissed because the requested live-verification TODO already exists and promotion would duplicate it.
