### PR TITLE
fix(tuning): bound introspection to altered tables

### DIFF
--- a/benchbox/core/tuning/introspection.py
+++ b/benchbox/core/tuning/introspection.py
@@ -333,6 +333,9 @@ def _statement_table(statement: AppliedStatement) -> str | None:
     om = _OPTIMIZE_RE.match(text)
     if om:
         return normalize_identifier(om.group("table"))
+    at = _ALTER_TABLE_RE.match(text)
+    if at:
+        return normalize_identifier(at.group("table"))
     ct = _CREATE_TABLE_RE.match(text)
     if ct:
         return normalize_identifier(ct.group("table"))
@@ -345,7 +348,7 @@ def ledger_tables(ledger: AppliedTuningLedger) -> set[str]:
     """Normalized table names the executed ledger statements reference.
 
     Introspectors use this to BOUND their catalog reads to the tables actually
-    touched (CREATE INDEX / CREATE TABLE / OPTIMIZE targets), so introspection
+    touched (CREATE INDEX / CREATE TABLE / ALTER TABLE / OPTIMIZE targets), so introspection
     cannot scan an unbounded catalog.
     """
     tables: set[str] = set()

--- a/benchbox/platforms/clickhouse/introspection.py
+++ b/benchbox/platforms/clickhouse/introspection.py
@@ -77,14 +77,13 @@ class ClickHouseTuningIntrospector:
             logger.debug("clickhouse table introspection degraded: %s", exc)
             return IntrospectedState(platform=self.platform, error=f"system.tables read failed: {exc}")
 
-        truncated = len(rows) >= _MAX_TABLE_ROWS
+        relevant_rows = [row for row in rows if not tables or (row and normalize_identifier(row[0] or "") in tables)]
+        truncated = len(relevant_rows) >= _MAX_TABLE_ROWS
         objects: list[IntrospectedObject] = []
-        for row in rows:
+        for row in relevant_rows:
             try:
                 name, sorting_key, partition_key = row[0], row[1], row[2]
             except Exception:  # pragma: no cover - defensive on row shape
-                continue
-            if tables and normalize_identifier(name or "") not in tables:
                 continue
             if sorting_key:
                 objects.append(

--- a/benchbox/platforms/snowflake_introspection.py
+++ b/benchbox/platforms/snowflake_introspection.py
@@ -98,14 +98,13 @@ class SnowflakeTuningIntrospector:
             logger.debug("snowflake clustering introspection degraded: %s", exc)
             return IntrospectedState(platform=self.platform, error=f"INFORMATION_SCHEMA read failed: {exc}")
 
-        truncated = len(rows) >= _MAX_TABLE_ROWS
+        relevant_rows = [row for row in rows if not tables or (row and normalize_identifier(row[0] or "") in tables)]
+        truncated = len(relevant_rows) >= _MAX_TABLE_ROWS
         objects: list[IntrospectedObject] = []
-        for row in rows:
+        for row in relevant_rows:
             try:
                 name, clustering_key = row[0], row[1]
             except Exception:  # pragma: no cover - defensive on row shape
-                continue
-            if tables and normalize_identifier(name or "") not in tables:
                 continue
             columns = parse_clustering_key(clustering_key)
             if not columns:

--- a/docs/development/tuning-introspection-receipts.md
+++ b/docs/development/tuning-introspection-receipts.md
@@ -78,7 +78,13 @@ Each platform's `Introspector.introspect(connection, ledger) -> IntrospectedStat
 returns structured catalog facts (`kind`, `table`, `columns`, `name`,
 `evidence`), bounded to the tables the ledger touched and wrapped
 non-fatal. **No screen-scraping of engine DDL text** where a structured
-catalog exists.
+catalog exists. ClickHouse and Snowflake keep a hard catalog-row limit,
+then filter the bounded result to table names extracted from every supported
+ledger statement shape, including `ALTER TABLE`. Their `truncated` flag measures
+the relevant rows after filtering, so an at-cap catalog full of unrelated tables
+does not reject a complete target snapshot. A target omitted by the hard limit
+still yields an `absent` verdict (and therefore cannot verify); a relevant result
+that itself reaches the cap remains explicitly truncated.
 
 - **DuckDB** (`benchbox/platforms/duckdb_introspection.py`): reads
   `duckdb_indexes()` -- the `table_name` / `index_name` / `expressions`

--- a/tests/unit/core/tuning/test_introspection.py
+++ b/tests/unit/core/tuning/test_introspection.py
@@ -264,6 +264,12 @@ class TestPayloadAndProtocol:
         ledger.record("OPTIMIZE TABLE ORDERS FINAL", PHASE_POST_LOAD)
         assert ledger_tables(ledger) == {"lineitem", "orders"}
 
+    def test_ledger_tables_covers_alter_and_optimize_targets(self):
+        ledger = AppliedTuningLedger()
+        ledger.record("ALTER TABLE LINEITEM CLUSTER BY (a)", PHASE_POST_LOAD)
+        ledger.record("OPTIMIZE TABLE ORDERS FINAL", PHASE_POST_LOAD)
+        assert ledger_tables(ledger) == {"lineitem", "orders"}
+
     def test_introspector_protocol_is_runtime_checkable(self):
         class _Impl:
             platform = "x"

--- a/tests/unit/platforms/test_clickhouse_introspection.py
+++ b/tests/unit/platforms/test_clickhouse_introspection.py
@@ -88,6 +88,15 @@ class TestClickHouseIntrospector:
         tables = {obj.table for obj in state.objects}
         assert tables == {"lineitem"}
 
+    def test_unrelated_rows_at_catalog_cap_do_not_mark_relevant_snapshot_truncated(self):
+        rows = [(f"other_{index}", "id", "") for index in range(999)]
+        rows.append(("lineitem", "l_orderkey", ""))
+
+        state = ClickHouseTuningIntrospector().introspect(_FakeCHConnection(rows), _optimize_ledger())
+
+        assert state.truncated is False
+        assert {obj.table for obj in state.objects} == {"lineitem"}
+
     def test_non_fatal_on_query_failure(self):
         state = ClickHouseTuningIntrospector().introspect(_FakeCHConnection([], fail=True), _optimize_ledger())
         assert state.error is not None

--- a/tests/unit/platforms/test_snowflake_introspection.py
+++ b/tests/unit/platforms/test_snowflake_introspection.py
@@ -20,6 +20,7 @@ import pytest
 
 from benchbox.core.tuning.applied_ledger import (
     PHASE_DDL,
+    PHASE_POST_LOAD,
     PHASE_SESSION,
     AppliedTuningLedger,
 )
@@ -120,6 +121,25 @@ class TestSnowflakeIntrospector:
             [("LINEITEM", "LINEAR(A)"), ("ORDERS", "LINEAR(B)")],  # ORDERS not in ledger
         )
         state = SnowflakeTuningIntrospector().introspect(conn, _clustered_ledger())
+        assert {obj.table for obj in state.objects} == {"LINEITEM"}
+
+    def test_alter_target_is_not_filtered_when_another_statement_activates_bounding(self):
+        ledger = AppliedTuningLedger()
+        ledger.record("ALTER TABLE LINEITEM CLUSTER BY (A)", PHASE_POST_LOAD)
+        ledger.record("OPTIMIZE TABLE ORDERS", PHASE_POST_LOAD)
+        conn = _FakeSnowflakeConnection([("LINEITEM", "LINEAR(A)"), ("NATION", "LINEAR(N)")])
+
+        state = SnowflakeTuningIntrospector().introspect(conn, ledger)
+
+        assert {obj.table for obj in state.objects} == {"LINEITEM"}
+
+    def test_unrelated_rows_at_catalog_cap_do_not_mark_relevant_snapshot_truncated(self):
+        rows = [(f"OTHER_{index}", "LINEAR(ID)") for index in range(999)]
+        rows.append(("LINEITEM", "LINEAR(A)"))
+
+        state = SnowflakeTuningIntrospector().introspect(_FakeSnowflakeConnection(rows), _clustered_ledger())
+
+        assert state.truncated is False
         assert {obj.table for obj in state.objects} == {"LINEITEM"}
 
     def test_non_fatal_on_query_failure(self):


### PR DESCRIPTION
## Summary

- include `ALTER TABLE` targets in ledger table extraction using the existing strict parser and identifier normalization
- retain hard ClickHouse and Snowflake catalog caps while measuring truncation only across ledger-relevant rows
- document clipped-target and relevant-row fail-closed behavior

Tracker: `ledger-tables-alter-targets-and-truncation-bound-20260801`

## Verification

- tracker ALTER-target probe passed
- tracker introspection ladder: 721 passed
- focused post-fix suite: 84 passed
- adversarial probes proved a clipped target yields `absent` and a relevant at-cap snapshot remains `truncated`; neither can verify
- Ruff, format, diff check, pre-commit hooks, and seven-file tracker scope passed

`make pr-preflight` reached 95% before an unrelated Ray low-disk stall and was bounded-stopped at 10 minutes. A recovery fast-suite attempt did not execute because another live BenchBox worktree held the shared pytest lock; the lock was not bypassed. CI remains required.

## Review

No Critical, Required, Consideration, or Nit findings remain.
