### PR TITLE
fix(explorer): make cold-read regressions deterministic

### DIFF
--- a/docs/operations/browser-ci.md
+++ b/docs/operations/browser-ci.md
@@ -112,6 +112,17 @@ cold-load regression guard (the pass-1 bug it pins surfaced as *partial* rows,
 1 of 5, which a `count > 0` check would have passed). Leave its single-shot
 waits and exact row counts alone — if it flakes, that is signal, not noise.
 
+The blocking Chromium command therefore runs every spec under `e2e/failures/`
+in a separate `--retries=0` invocation. The ordinary CI retry policy must not
+turn a probabilistic cold-load regression into a flaky-but-green gate.
+
+`queryRows` deliberately retries only zero-row answers during the bounded cold
+window. A generic non-empty result carries no trustworthy completeness signal:
+retrying every non-empty query would penalize legitimate `LIMIT`, filtered, and
+streaming reads, while guessing expected row counts from SQL would be brittle.
+Partial non-empty reads are therefore an accepted residual risk at this layer,
+pinned by the dedicated cold-load spec's fixture-derived exact row counts.
+
 The root cause is in `results-explorer/src/**` (gate the first keyed query on a
 queryable snapshot, or re-query when it returns zero rows), tracked as
 `explorer-cold-snapshot-zero-row-race-20260729`; the e2e suite is not permitted

--- a/results-explorer/e2e/smoke/harness.spec.ts
+++ b/results-explorer/e2e/smoke/harness.spec.ts
@@ -1,6 +1,6 @@
 import { expect, test } from "@playwright/test";
 
-import { waitForDataLoaded } from "../support/fixtures";
+import { dataWaitNavigationAction, waitForDataLoaded } from "../support/fixtures";
 
 /**
  * Harness sanity check - proves that the Playwright webServer boots the
@@ -37,4 +37,13 @@ test("@smoke loads DuckDB-WASM from same-origin bundled assets, not jsDelivr", a
   await waitForDataLoaded(page, /Recent Results/i);
 
   expect(jsDelivrRequests).toEqual([]);
+});
+
+test("data waits re-wait after same-route query canonicalization", () => {
+  expect(
+    dataWaitNavigationAction(
+      "http://127.0.0.1:4319/results/query/?sql=SELECT%20*%20FROM%20bench.results",
+      "http://127.0.0.1:4319/results/query/?sql=SELECT+*+FROM+bench.results",
+    ),
+  ).toBe("rewait");
 });

--- a/results-explorer/e2e/support/fixtures.ts
+++ b/results-explorer/e2e/support/fixtures.ts
@@ -55,6 +55,13 @@ function navigationKey(url: string): string {
   return parsed.toString();
 }
 
+export function dataWaitNavigationAction(
+  entryUrl: string,
+  currentUrl: string,
+): "renavigate" | "rewait" {
+  return navigationKey(currentUrl) === navigationKey(entryUrl) ? "renavigate" : "rewait";
+}
+
 /**
  * Wait for the DuckDB-WASM attach to complete and the page to render real
  * data, re-navigating between attempts to defeat the zero-row cold-snapshot
@@ -86,10 +93,11 @@ export async function waitForDataElement(page: Page, target: Locator) {
 
   for (const [attempt, budget] of DATA_ATTEMPT_BUDGETS_MS.entries()) {
     if (attempt > 0) {
-      if (navigationKey(page.url()) !== entryKey) break;
-      // Drop the fragment: navigating to a URL identical including its hash is
-      // a same-document scroll, which would not re-initialize the snapshot.
-      await page.goto(entryKey, { timeout: RENAVIGATE_TIMEOUT_MS });
+      if (dataWaitNavigationAction(entryUrl, page.url()) === "renavigate") {
+        // Drop the fragment: navigating to a URL identical including its hash is
+        // a same-document scroll, which would not re-initialize the snapshot.
+        await page.goto(entryKey, { timeout: RENAVIGATE_TIMEOUT_MS });
+      }
     }
     try {
       await expect(target).toBeVisible({ timeout: budget });
@@ -103,7 +111,8 @@ export async function waitForDataElement(page: Page, target: Locator) {
   throw new Error(
     `Data-bound wait failed after ${DATA_ATTEMPT_BUDGETS_MS.length} attempts ` +
       `(budgets ${DATA_ATTEMPT_BUDGETS_MS.map((ms) => `${ms / 1000}s`).join(" + ")}, ` +
-      `${elapsed}s elapsed) on ${entryUrl}. Re-navigating between attempts did not help, so this is ` +
+      `${elapsed}s elapsed) on ${entryUrl}. Re-navigation, or re-waiting after intervening navigation, ` +
+      `did not help, so this is ` +
       `NOT the cold-snapshot zero-row race that budget is sized for -- do not "fix" it by widening ` +
       `the budget. See docs/operations/browser-ci.md.\n\nLast attempt: ${lastError.message}`,
     { cause: lastError },

--- a/results-explorer/package.json
+++ b/results-explorer/package.json
@@ -14,7 +14,7 @@
     "test:watch": "vitest",
     "test:e2e": "playwright test",
     "test:e2e:chromium": "npm run test:e2e:fixtures && npm run build && npm run test:e2e:chromium:run",
-    "test:e2e:chromium:run": "playwright test --project=chromium --workers=1 --grep-invert @performance && playwright test --project=chromium --workers=1 --retries=0 e2e/performance.spec.ts",
+    "test:e2e:chromium:run": "E2E_EXCLUDE_FAILURES=1 playwright test --project=chromium --workers=1 --grep-invert @performance && playwright test --project=chromium --workers=1 --retries=0 e2e/failures/ && playwright test --project=chromium --workers=1 --retries=0 e2e/performance.spec.ts",
     "test:e2e:chromium:setup": "npm run test:e2e:install:chromium && npm run test:e2e:chromium",
     "test:e2e:full": "npm run test:e2e:fixtures && npm run build && npm run test:e2e:chromium:run && playwright test --project=firefox && playwright test --project=webkit --workers=1",
     "test:e2e:firefox": "npm run test:e2e:fixtures && npm run build && playwright test --project=firefox",

--- a/results-explorer/package.json
+++ b/results-explorer/package.json
@@ -14,7 +14,7 @@
     "test:watch": "vitest",
     "test:e2e": "playwright test",
     "test:e2e:chromium": "npm run test:e2e:fixtures && npm run build && npm run test:e2e:chromium:run",
-    "test:e2e:chromium:run": "E2E_EXCLUDE_FAILURES=1 playwright test --project=chromium --workers=1 --grep-invert @performance && playwright test --project=chromium --workers=1 --retries=0 e2e/failures/ && playwright test --project=chromium --workers=1 --retries=0 e2e/performance.spec.ts",
+    "test:e2e:chromium:run": "E2E_EXCLUDE_FAILURES=1 playwright test --project=chromium --workers=1 --grep-invert @performance && E2E_CAPTURE_FIRST_FAILURE=1 playwright test --project=chromium --workers=1 --retries=0 e2e/failures/ && playwright test --project=chromium --workers=1 --retries=0 e2e/performance.spec.ts",
     "test:e2e:chromium:setup": "npm run test:e2e:install:chromium && npm run test:e2e:chromium",
     "test:e2e:full": "npm run test:e2e:fixtures && npm run build && npm run test:e2e:chromium:run && playwright test --project=firefox && playwright test --project=webkit --workers=1",
     "test:e2e:firefox": "npm run test:e2e:fixtures && npm run build && playwright test --project=firefox",

--- a/results-explorer/playwright.config.ts
+++ b/results-explorer/playwright.config.ts
@@ -27,6 +27,9 @@ const BASE_URL = `http://${HOST}:${PORT}`;
 
 export default defineConfig({
   testDir: "./e2e",
+  // The blocking Chromium script runs failure-regression specs separately
+  // with retries disabled, so a probabilistic regression cannot pass as flaky.
+  testIgnore: process.env.E2E_EXCLUDE_FAILURES ? /failures\// : undefined,
   outputDir: "./test-results",
   fullyParallel: true,
   forbidOnly: Boolean(process.env.CI),

--- a/results-explorer/playwright.config.ts
+++ b/results-explorer/playwright.config.ts
@@ -24,6 +24,7 @@ import { defineConfig, devices } from "@playwright/test";
 const PORT = Number(process.env.E2E_PORT ?? 4319);
 const HOST = process.env.E2E_HOST ?? "127.0.0.1";
 const BASE_URL = `http://${HOST}:${PORT}`;
+const CAPTURE_FIRST_FAILURE = Boolean(process.env.E2E_CAPTURE_FIRST_FAILURE);
 
 export default defineConfig({
   testDir: "./e2e",
@@ -53,9 +54,9 @@ export default defineConfig({
 
   use: {
     baseURL: BASE_URL,
-    trace: "on-first-retry",
+    trace: CAPTURE_FIRST_FAILURE ? "retain-on-failure" : "on-first-retry",
     screenshot: "only-on-failure",
-    video: "on-first-retry",
+    video: CAPTURE_FIRST_FAILURE ? "retain-on-failure" : "on-first-retry",
   },
 
   projects: [

--- a/results-explorer/src/db.ts
+++ b/results-explorer/src/db.ts
@@ -414,8 +414,7 @@ export async function queryRows<T>(
   sql: string,
   params: unknown[] = [],
 ): Promise<T[]> {
-  let lastError: unknown = null;
-  for (let attempt = 1; attempt <= QUERY_RETRY_ATTEMPTS; attempt += 1) {
+  for (let attempt = 1; ; attempt += 1) {
     try {
       const rows = await queryRowsOnce<T>(sql, params);
       if (rows.length > 0 || !isColdEmptyRead(attempt)) return rows;
@@ -425,19 +424,12 @@ export async function queryRows<T>(
       await sleep(QUERY_EMPTY_RETRY_DELAY_MS);
       continue;
     } catch (error: unknown) {
-      lastError = error;
       if (!shouldRetryTransientQueryError(error, attempt)) {
         throw error;
       }
       await sleep(QUERY_RETRY_DELAY_MS * attempt);
     }
   }
-  if (lastError !== null) {
-    throw lastError instanceof Error ? lastError : new Error("DuckDB query failed");
-  }
-  // Every attempt returned empty inside the warm-up window: the result really
-  // is empty (a filtered query, or an id that does not exist).
-  return [];
 }
 
 /**


### PR DESCRIPTION
## Summary
- run `e2e/failures/` in a dedicated Chromium invocation with `--retries=0` so probabilistic regressions cannot pass as flaky
- preserve the documented `waitForDataElement` contract by re-waiting after URL canonicalization and cover it with a harness self-test
- document the accepted partial-row policy and remove unreachable `queryRows` post-loop code

## Verification
- `cd results-explorer && npm run typecheck && npm test` (844 passed)
- tracker verification sequences 1-3 (all passed)
- `cd results-explorer && npx playwright test --project=chromium` (113 passed, 10 skipped)
- `git push` fast-lane `pr-preflight` passed

## Preflight note
The standalone `make pr-preflight` reached 95% of the fast suite and stalled in the known Ray shutdown path; it was bounded with SIGINT after the item-specific gates were green. The push-hook fast preflight then passed.