### PR TITLE
test(cli): make invalid-output-dir tests root-proof

### DIFF
--- a/tests/unit/cli/test_cli_dryrun.py
+++ b/tests/unit/cli/test_cli_dryrun.py
@@ -773,13 +773,15 @@ class TestDryRunErrorHandling:
             assert "Unknown benchmark: invalid" in str(result.warnings)
 
     @pytest.mark.skipif(sys.platform == "win32", reason="Path handling differs on Windows")
-    def test_dry_run_with_missing_output_dir(self):
+    def test_dry_run_with_missing_output_dir(self, tmp_path):
         """Test dry run when output directory cannot be created."""
-        # Should handle missing directory gracefully - but our current implementation fails fast
-        # This is expected behavior, so we expect an exception
+        # Fail-fast is the expected behavior. The invalid path sits under a
+        # regular FILE so creation fails for every uid - root can mkdir
+        # /invalid, which made the old absolute-path probe root-sensitive.
+        blocker = tmp_path / "blocker"
+        blocker.write_text("")
         with pytest.raises(OSError):
-            # Try to create executor with invalid path - should raise OSError
-            DryRunExecutor(output_dir="/invalid")
+            DryRunExecutor(output_dir=str(blocker / "sub"))
 
     @patch("benchbox.cli.dryrun.console")
     def test_dry_run_with_empty_query_list(self, mock_console):

--- a/tests/unit/cli/test_cli_output.py
+++ b/tests/unit/cli/test_cli_output.py
@@ -972,9 +972,15 @@ class TestResultExporterErrorHandling:
 
     @pytest.mark.skipif(sys.platform == "win32", reason="Path handling differs on Windows")
     def test_export_with_invalid_output_dir(self):
-        """Test export with invalid output directory."""
+        """Test export with invalid output directory.
+
+        A path under a regular file is uncreatable for every uid,
+        including root (mkdir raises NotADirectoryError, converted to
+        FileNotFoundError by the exporter)."""
+        blocker = Path(self.temp_dir) / "blocker"
+        blocker.write_text("")
         with pytest.raises(FileNotFoundError):
-            ResultExporter(output_dir=Path("/invalid/path/that/cannot/be/created"))
+            ResultExporter(output_dir=blocker / "sub")
 
     def test_list_results_with_corrupted_json(self):
         """Test listing results with corrupted JSON files."""

--- a/tests/unit/cli/test_exceptions.py
+++ b/tests/unit/cli/test_exceptions.py
@@ -295,13 +295,20 @@ class TestValidationRules:
         # Should not raise exception
         ValidationRules.validate_output_directory(str(tmp_path))
 
-    def test_validate_output_directory_local_invalid(self):
-        """Test output directory validation with invalid local path."""
+    def test_validate_output_directory_local_invalid(self, tmp_path):
+        """Test output directory validation with invalid local path.
+
+        The invalid path sits under a regular FILE so creation fails for
+        every uid - root can mkdir /invalid, which made an absolute-path
+        probe pass vacuously as non-root and fail as root."""
+        blocker = tmp_path / "blocker"
+        blocker.write_text("")
+        invalid = str(blocker / "sub")
         with pytest.raises(ValidationError) as exc_info:
-            ValidationRules.validate_output_directory("/invalid/path/that/cannot/be/created")
+            ValidationRules.validate_output_directory(invalid)
 
         assert "Cannot create output directory" in str(exc_info.value)
-        assert exc_info.value.details["path"] == "/invalid/path/that/cannot/be/created"
+        assert exc_info.value.details["path"] == invalid
 
     def test_validate_output_directory_cloud_invalid_credentials(self):
         """Test output directory validation with cloud path and invalid credentials."""


### PR DESCRIPTION
The three tests probed /invalid/... absolute paths, which root can
create - they passed vacuously as non-root and failed in root
containers (the remote-session CI case). Block creation with a path
under a regular file instead: uncreatable for every uid (mkdir raises
NotADirectoryError, which each production path already converts to the
asserted exception type). Mechanism driven in a root container: uid 0
creates /invalid successfully but fails under a file.

TODO: cli-invalid-output-dir-tests-assume-non-root
