### PR TITLE
fix(results): recurse into tuples in the public anonymizer

### DIFF
--- a/benchbox/core/results/anonymization.py
+++ b/benchbox/core/results/anonymization.py
@@ -336,7 +336,10 @@ class AnonymizationManager:
                     anonymized[key] = self._anonymize_public_value(child, child_path)
             return anonymized
 
-        if isinstance(value, list):
+        if isinstance(value, (list, tuple, set, frozenset)):
+            # Tuples/sets serialize as JSON arrays; recursing as a list keeps
+            # their contents inside the anonymization boundary instead of
+            # falling through to the scalar branch untouched.
             return [self._anonymize_public_value(item, key_path) for item in value]
 
         return self._anonymize_public_scalar(value, key_path)

--- a/tests/unit/core/results/test_anonymization.py
+++ b/tests/unit/core/results/test_anonymization.py
@@ -792,6 +792,35 @@ class TestPublicPayloadApiKeyAndAccountKey:
         assert "AZKEY-SENTINEL" not in out
 
 
+class TestPublicPayloadTupleRecursion:
+    """A tuple fell through to the scalar branch untouched, so any payload
+    branch not pre-flattened by internal capture leaked tuple contents."""
+
+    def test_tuple_nested_identifier_is_anonymized(self):
+        out = json.dumps(
+            AnonymizationManager().anonymize_result_payload(
+                {"platform_metadata": {"nested": ({"userid": "TUP-SENTINEL"},)}}
+            ),
+            default=str,
+        )
+        assert "TUP-SENTINEL" not in out
+
+    def test_tuple_secret_key_is_redacted(self):
+        out = json.dumps(
+            AnonymizationManager().anonymize_result_payload(
+                {"platform_metadata": {"configs": ({"password": "TUPPW-SENTINEL"},)}}
+            ),
+            default=str,
+        )
+        assert "TUPPW-SENTINEL" not in out
+
+    def test_list_and_dict_recursion_unchanged(self):
+        out = AnonymizationManager().anonymize_result_payload(
+            {"platform_metadata": {"platform_raw_config": [{"username": "alice-sentinel"}]}}
+        )["platform_metadata"]["platform_raw_config"]
+        assert out[0]["username"].startswith("user_")
+
+
 class TestPublicPayloadWorkspaceRoleAndApplicationIds:
     """Near-miss variants of covered identifier keys are the recurring leak
     pattern: workspace_name, job_role and application_id all exported


### PR DESCRIPTION
_anonymize_public_value handled dict and list; a tuple fell through to
the scalar branch untouched, so any payload branch not pre-flattened by
internal capture (which converts tuples to lists) leaked tuple contents
verbatim. Treat tuples and sets like lists - they serialize as JSON
arrays anyway.

TODO: public-anonymizer-tuple-values-pass-verbatim
