### PR TITLE
fix(results): redact service_account on both export layers

### DIFF
--- a/benchbox/core/results/anonymization_specs.yaml
+++ b/benchbox/core/results/anonymization_specs.yaml
@@ -54,6 +54,7 @@ identifier_keys:
   clientid: client
   machineid: machine
   applicationid: application
+  serviceaccount: serviceaccount
 endpoint_keys:
 - apiendpoint
 - endpoint

--- a/benchbox/core/results/platform_options.py
+++ b/benchbox/core/results/platform_options.py
@@ -57,7 +57,10 @@ _SECRET_KEY_PARTS = tuple(
 # username rode into every internal bundle verbatim. Exact normalized match
 # only - a substring rule on "user" would nuke user_agent/num_users-class
 # options.
-_USERNAME_KEYS = frozenset({"user", "username", "userid", "pguser", "dbuser"})
+# serviceaccount: an IAM principal email (dataproc) - identity, not a secret,
+# but it names the project and operator, so internal export redacts it like
+# every other username spelling.
+_USERNAME_KEYS = frozenset({"user", "username", "userid", "pguser", "dbuser", "serviceaccount"})
 
 
 def _is_username_key(key: str) -> bool:

--- a/tests/unit/core/results/test_platform_options_capture.py
+++ b/tests/unit/core/results/test_platform_options_capture.py
@@ -445,6 +445,35 @@ class TestUsernameRedactionInternalPath:
         assert result["connection"]["host"] == "db.internal"
 
 
+class TestServiceAccountRedaction:
+    """service_account carries an IAM principal email (dataproc); the public
+    layer caught it only when the VALUE was email-shaped, and the internal
+    layer exported it verbatim."""
+
+    def test_service_account_is_redacted_internally(self):
+        from benchbox.core.results.platform_options import sanitize_platform_options
+
+        out = sanitize_platform_options({"service_account": "svc-bench@proj.iam.gserviceaccount.com"})
+        assert out["service_account"] != "svc-bench@proj.iam.gserviceaccount.com"
+
+    def test_non_email_service_account_is_pseudonymized_publicly(self):
+        import json
+
+        from benchbox.core.results.anonymization import AnonymizationManager
+
+        out = AnonymizationManager().anonymize_result_payload(
+            {"platform_metadata": {"platform_raw_config": {"service_account": "SA-SENTINEL-NOT-AN-EMAIL"}}}
+        )["platform_metadata"]["platform_raw_config"]
+        assert "SA-SENTINEL-NOT-AN-EMAIL" not in json.dumps(out, default=str)
+
+    def test_auth_method_lookalikes_keep_real_values(self):
+        from benchbox.core.results.platform_options import sanitize_platform_options
+
+        out = sanitize_platform_options({"auth_method": "service_principal", "runtime_version": "1.2"})
+        assert out["auth_method"] == "service_principal"
+        assert out["runtime_version"] == "1.2"
+
+
 class TestApiKeyAndAccountKeyRedaction:
     """api_key and *_account_key are credentials and must never export
     verbatim (2026-07-31 sentinel-sweep finding: they leaked through both


### PR DESCRIPTION
The dataproc service_account option carries an IAM principal email that
names the project and operator. Internally it exported verbatim; the
public layer caught it only when the VALUE was email-shaped. Treat it
as a username spelling internally and give it key-level public
pseudonymization so a non-email value is covered too.

TODO: internal-export-service-account-email-verbatim
