### PR TITLE
docs(tuning): align receipts and ADRs with landed behavior

### DIFF
--- a/benchbox/core/tuning/introspection.py
+++ b/benchbox/core/tuning/introspection.py
@@ -189,7 +189,10 @@ class IntrospectionReceipt:
         counts: dict[str, int] = {}
         for entry in self.entries:
             counts[entry.verdict] = counts.get(entry.verdict, 0) + 1
-        counts["verifiable_total"] = sum(1 for e in self.entries if e.verdict in _VERIFIABLE_VERDICTS)
+        # Includes corroborated catalog facts and every fail-closed verdict
+        # that participates in the upgrade decision. "verifiable" was
+        # misleading because UNVERIFIABLE is intentionally included.
+        counts["gate_relevant_total"] = sum(1 for e in self.entries if e.verdict in _VERIFIABLE_VERDICTS)
         return counts
 
     def to_payload(self) -> dict[str, Any]:

--- a/docs/development/tuning-adr-001-trust-and-hash-semantics.md
+++ b/docs/development/tuning-adr-001-trust-and-hash-semantics.md
@@ -272,6 +272,28 @@ Scope and honesty constraints:
   dropped under the same policy as the statement/receipt text, leaving the
   structural `is_valid` + `drifted_sections` and a `drift_redacted` marker.
 
+## Addendum (2026-08-01): introspection and fail-closed gating landed
+
+The original Decision section recorded post-load introspection as a future
+direction. It has since landed in `benchbox.core.tuning.introspection` and
+`PlatformAdapter._corroborate_applied_ledger`; this addendum updates current
+state without rewriting that historical decision.
+
+`applied_verified` now requires at least one gate-relevant physical intent,
+every such intent corroborated against structured catalog facts, and no failed
+ddl/post_load statement or dropped tuning intent. Failures receive blocking
+`unverifiable` receipt entries, while dropped intents are copied into the
+receipt. The summary key is `gate_relevant_total` because it counts all verdicts
+that participate in the decision, including fail-closed `unverifiable`; the
+former `verifiable_total` name had no production consumer and was misleading.
+
+The applied-ledger hash continues to preserve statement chronology: JSON object
+keys are sorted for canonical serialization, but the executed-statement list is
+never reordered. Post-load layout operations that do not pass through the
+recording connection are folded into that list at their actual execution phase
+before session statements, via
+`PlatformAdapter._fold_layout_operations_into_ledger`.
+
 ## References
 
 - `benchbox/platforms/base/adapter.py:743-747`

--- a/docs/development/tuning-adr-003-baseline-and-single-renderer.md
+++ b/docs/development/tuning-adr-003-baseline-and-single-renderer.md
@@ -154,3 +154,20 @@ block a run outright, versus warn and proceed? See Consequences.
    interface than against ~20 adapter classes with mixed constructor
    requirements. Generators additionally already cover more platforms
    (17 modules) than adapters currently delegate to.
+
+## Addendum (2026-08-01): landed policy seam and current consolidation state
+
+The baseline inversion identified above has landed: ClickHouse's curated OLAP
+pack runs only on the tuned path, while harness-operational and SQL-correctness
+settings apply in every mode and are recorded as session statements. StarRocks
+keeps only its engine-mandatory distribution fallback in baseline; tuned layout
+is rendered by `core.tuning.generators.starrocks`. DuckDB and ClickHouse also
+consume their core generators on their execution paths.
+
+The consolidation is explicit rather than inferred from a package version.
+`benchbox.core.tuning.policy_generation.TUNING_POLICY_GENERATION` stamps
+`adr-003` into tuned bundle summaries and tuning companions, and the Explorer
+warns on comparisons across that seam. The capability registry is the current
+inventory of migrated and remaining adapter-renderer parity: entries that still
+have a distinct execution renderer remain documented gaps, not evidence that
+the repository-wide migration is complete.

--- a/docs/development/tuning-introspection-receipts.md
+++ b/docs/development/tuning-introspection-receipts.md
@@ -39,6 +39,14 @@ An all-physical-failed ledger derives `failed` before corroboration, and an
 empty ledger cannot earn the upgrade. The introspection step must never fail or
 materially slow a run.
 
+The receipt summary calls the count participating in this decision
+`gate_relevant_total`. It includes `corroborated`, `absent`, `mismatch`, and
+blocking `unverifiable` entries; `transient` and `maintenance` are excluded.
+The earlier name `verifiable_total` was removed because a count that includes
+`unverifiable` entries was internally contradictory. There are no production
+consumers of this additive receipt-summary key; the upgrade decision continues
+to use the entry verdicts directly.
+
 ## Statement classes (per phase x mechanism)
 
 `corroborate()` gates every ledger statement by recorded status and phase,
@@ -61,6 +69,12 @@ platform-agnostic; the per-platform catalog *reads* live in the
 | failed statement                             | session        | `transient`   | transient session failure is noted but has no persistent catalog footprint -- **non-blocking** | no          |
 | anything else                                | ddl/post_load  | `unverifiable`| no corroboration rule -- **blocks** the upgrade (conservative: stay unverified)    | n/a (blocks)         |
 
+The generic classifier's non-blocking prefix sets are intentionally narrow and
+are documentation, not an invitation to expand the gate: transient prefixes
+are exactly `set `, `pragma `, `set\t`, `pragma\t`, `reset `, and `use `;
+maintenance prefixes are exactly `optimize `, `vacuum`, `analyze`, and
+`compact `. Any other ddl/post_load shape remains blocking `unverifiable`.
+
 A `CREATE TABLE` carrying **both** an `ORDER BY` and a `PARTITION BY` (the
 ClickHouse MergeTree shape) classifies as both `sort_key` and `partition_key`
 and emits one receipt entry per clause, so each key must corroborate on its
@@ -72,6 +86,18 @@ in catalog), `mismatch` (object present, columns differ -- carries a short
 diff), plus the non-blocking notes `transient` / `maintenance` and the
 blocking `unverifiable`.
 
+Example summary/entry shape (the ledger's statement order is preserved):
+
+```json
+{
+  "summary": {"corroborated": 1, "transient": 1, "gate_relevant_total": 1},
+  "entries": [
+    {"statement": "CREATE INDEX i ON t (a)", "phase": "post_load", "verdict": "corroborated"},
+    {"statement": "SET threads=4", "phase": "session", "verdict": "transient"}
+  ]
+}
+```
+
 ### Session SETs are corroboration-eligible? No (default).
 
 Session `SET`/`PRAGMA` statements are transient: they configure the
@@ -79,8 +105,9 @@ connection, leave no catalog trace, and vanish when the session closes.
 They are **noted** in the receipt (so the reader sees they ran) but do
 **not** block verification and cannot, on their own, earn it. A run whose
 only tuning is session SETs stays `applied_unverified` -- there is nothing
-physical to corroborate. This matches the ledger's own physical-hash
-intent (chronology of *layout* ops).
+physical to corroborate. The applied-ledger hash still includes those executed
+session records in their true chronology; exclusion here is specific to the
+catalog-corroboration gate, not to ledger identity.
 
 A failed session statement follows the same transient gate rule: it is
 visible in the receipt but does not block a sibling physical statement that
@@ -108,23 +135,17 @@ that itself reaches the cap remains explicitly truncated.
   bounded query, filtered to the ledger's tables. Corroborates each
   `CREATE INDEX` ledger entry against its `index` row.
 
-  Caveat (verified 2026-07-22, follow-up for the orchestrator): a DuckDB
-  **SORTING** tuning renders to `CREATE INDEX idx_<t>_sort` *before* data
-  load, but the loader's CTAS sorted ingestion then runs
-  `CREATE OR REPLACE TABLE <t> AS SELECT * FROM <t> ORDER BY ...`, which
-  **drops that index**. So at introspection time the sort index is absent
-  and a sorting-only run honestly stays `applied_unverified` (the receipt
-  records `absent`) -- a live demonstration of the "never verified without
-  corroboration" invariant, not a bug in this module. The `CLUSTERING`
-  branch of DuckDB's `apply_table_tunings` would produce a persisting index
-  (CTAS only consumes SORTING columns), but DuckDB's config validation
-  rejects the `clustering` tuning type, so that branch is currently
-  unreachable. Corroboration -> `applied_verified` is exercised against a
-  live DuckDB catalog where a recorded index persists (see
-  `tests/unit/platforms/test_duckdb_introspection.py`). Making a full
-  DuckDB *sorting* CLI run verification-eligible needs the sort layout
-  recorded as a corroboratable footprint (e.g. recording the CTAS
-  `ORDER BY`, or re-creating the index post-load) -- out of scope here.
+  DuckDB sorting is verification-eligible end to end. The initial tuned
+  `CREATE INDEX` is dropped by the loader's
+  `CREATE OR REPLACE TABLE ... ORDER BY` CTAS, so
+  `DuckDBAdapter.apply_ctas_sort` re-creates that same generator-rendered
+  index after CTAS. `_record_sort_index_layout_op` records the successful or
+  failed re-creation as a `post_load` layout operation, and
+  `PlatformAdapter._fold_layout_operations_into_ledger` folds it into the
+  ledger before corroboration. The live full-flow test
+  `tests/unit/platforms/test_duckdb_introspection.py::TestDuckDBCtasIndexRecreation::test_full_flow_reaches_applied_verified`
+  pins the surviving catalog index and verified outcome. Dry runs capture SQL
+  but neither execute nor record the re-creation.
 
 - **Snowflake** (`benchbox/platforms/snowflake_introspection.py`): reads
   `INFORMATION_SCHEMA.TABLES.CLUSTERING_KEY` with bound, normalized schema
@@ -177,9 +198,10 @@ that itself reaches the cap remains explicitly truncated.
 
 ## Wiring
 
-`run_enhanced_benchmark` (`benchbox/platforms/base/adapter.py`, after the
-`overall_status` derivation ~line 984, connection still open): when the
-derived status is `applied_unverified` and the adapter exposes an
+`PlatformAdapter.run_enhanced_benchmark` folds post-load layout operations
+before session configuration, then derives `overall_status` after execution
+while the connection remains open. When that status is `applied_unverified`
+and the adapter exposes an
 introspector (`get_tuning_introspector()`), run introspection guarded,
 corroborate, and upgrade to `applied_verified` iff the receipt corroborates.
 The receipt rides inside the existing `.applied.json` companion

--- a/tests/unit/core/tuning/test_introspection.py
+++ b/tests/unit/core/tuning/test_introspection.py
@@ -113,7 +113,7 @@ class TestCorroborate:
         receipt = corroborate(_index_ledger(), _index_state())
         assert receipt.corroborated is True
         assert receipt.summary["corroborated"] == 1
-        assert receipt.summary["verifiable_total"] == 1
+        assert receipt.summary["gate_relevant_total"] == 1
         entry = receipt.entries[0]
         assert entry.verdict == CORROBORATED
         assert entry.kind == KIND_INDEX
@@ -152,7 +152,7 @@ class TestCorroborate:
     def test_empty_ledger_no_upgrade(self):
         receipt = corroborate(AppliedTuningLedger(), _index_state())
         assert receipt.corroborated is False
-        assert receipt.summary["verifiable_total"] == 0
+        assert receipt.summary["gate_relevant_total"] == 0
 
     def test_failed_physical_statement_gets_blocking_receipt_entry(self):
         ledger = AppliedTuningLedger()
@@ -200,7 +200,7 @@ class TestSessionAndMaintenance:
         assert receipt.corroborated is True
         verdicts = [e.verdict for e in receipt.entries]
         assert TRANSIENT in verdicts
-        assert receipt.summary["verifiable_total"] == 1  # SET excluded from the gate
+        assert receipt.summary["gate_relevant_total"] == 1  # SET excluded from the gate
 
     def test_failed_session_statement_is_transient_and_non_blocking(self):
         ledger = _index_ledger()
@@ -218,7 +218,7 @@ class TestSessionAndMaintenance:
         ledger.record("PRAGMA memory_limit='1GB'", PHASE_SESSION)
         receipt = corroborate(ledger, IntrospectedState(platform="duckdb", objects=[]))
         assert receipt.corroborated is False
-        assert receipt.summary["verifiable_total"] == 0
+        assert receipt.summary["gate_relevant_total"] == 0
         assert all(e.verdict == TRANSIENT for e in receipt.entries)
 
     def test_pragma_in_ddl_phase_is_transient(self):
@@ -346,7 +346,7 @@ class TestMultiClauseCreateTable:
         receipt = corroborate(self._ledger(), self._state())
         kinds = [e.kind for e in receipt.entries]
         assert kinds == [KIND_SORT_KEY, KIND_PARTITION_KEY]
-        assert receipt.summary["verifiable_total"] == 2
+        assert receipt.summary["gate_relevant_total"] == 2
         assert receipt.corroborated is True
 
     def test_uncorroborated_partition_blocks_upgrade(self):
@@ -453,7 +453,7 @@ class TestClusterKeyClassification:
         # these neither earn nor block verification (same class as OPTIMIZE).
         receipt = corroborate(self._ledger(statement), self._state())
         assert receipt.entries[0].verdict == MAINTENANCE
-        assert receipt.summary["verifiable_total"] == 0
+        assert receipt.summary["gate_relevant_total"] == 0
 
     def test_unparsable_cluster_clause_fails_closed(self):
         # Visible CLUSTER BY we cannot parse must keep blocking, never vanish.

--- a/tests/unit/platforms/test_clickhouse_introspection.py
+++ b/tests/unit/platforms/test_clickhouse_introspection.py
@@ -112,7 +112,7 @@ class TestClickHouseIntrospector:
         ledger = _optimize_ledger()
         receipt = corroborate(ledger, ClickHouseTuningIntrospector().introspect(_FakeCHConnection(rows), ledger))
         assert receipt.corroborated is False
-        assert receipt.summary["verifiable_total"] == 0
+        assert receipt.summary["gate_relevant_total"] == 0
         assert any(o.kind == KIND_SORT_KEY for o in receipt.observed)
 
 

--- a/tests/unit/platforms/test_snowflake_introspection.py
+++ b/tests/unit/platforms/test_snowflake_introspection.py
@@ -186,7 +186,7 @@ class TestSnowflakeCorroboration:
         assert (KIND_CLUSTER_KEY, "corroborated") in verdicts
         # RESUME RECLUSTER is maintenance and the session SET is transient:
         # noted, but neither earns nor blocks.
-        assert receipt.summary["verifiable_total"] == 1
+        assert receipt.summary["gate_relevant_total"] == 1
         assert receipt.corroborated is True
 
     def test_different_cluster_key_blocks_verification(self):


### PR DESCRIPTION
## Summary
- replace the stale DuckDB caveat with the landed post-CTAS index re-creation and fold path
- rename the misleading receipt summary key from `verifiable_total` to `gate_relevant_total` without changing upgrade logic
- document exact classifier prefixes, receipt shape, wiring, and append dated ADR-001/ADR-003 landed-state addenda

## Verification
- tracker seq 1: 683 tuning tests passed
- tracker seq 2: stale caveat grep passed
- direct summary-shape probe, Ruff, Ruff format, pre-commit markdownlint/codespell passed
- push-hook fast-lane `pr-preflight` passed

## Broad-suite note
The optional tracker seq 3 reached the known sleeping-xdist/Ray tail and was bounded after about four minutes; the focused ladder and publication fast-lane gate are green.