### PR TITLE
feat(tracker): surface falsifiability exemptions in lint output

### DIFF
--- a/_project/scripts/todo_db.py
+++ b/_project/scripts/todo_db.py
@@ -2568,6 +2568,26 @@ def _unsatisfiable_verifications(item: dict) -> list[int]:
     return offenders
 
 
+def lint_item_notes(conn: sqlite3.Connection, item_id: str) -> list[str]:
+    """Advisory notes, not defects: policy skips that would otherwise be
+    silent. A category exemption from the falsifiability check is author-
+    selectable free text, so lint says when it applied - an exemption you
+    can see is auditable, one you cannot is a hole."""
+    item = get_item(conn, item_id)
+    notes = []
+    if (
+        get_config(conn, "lint.require_falsifiable_rung") == "on"
+        and item["state"] in ("planning", "active")
+        and (item.get("category") or "") in _FALSIFIABILITY_EXEMPT_CATEGORIES
+        and any((v.get("command") or "").strip() for v in item["verifications"])
+    ):
+        notes.append(
+            f"note: falsifiability check skipped - category '{item['category']}' is exempt "
+            "(tripwires/acceptance runs legitimately pass on the current tree)"
+        )
+    return notes
+
+
 def lint_item(conn: sqlite3.Connection, item_id: str) -> list[str]:
     item = get_item(conn, item_id)
     findings = []
@@ -3909,6 +3929,10 @@ def _cmd_lint(conn, actor, args):
         total += len(findings)
         for finding in findings:
             print(f"{target}: {finding}")
+        # Notes are advisory visibility, not defects: they neither count nor
+        # affect the exit code.
+        for note in lint_item_notes(conn, target):
+            print(f"{target}: {note}")
     print(f"{total} finding(s) across {len(targets)} item(s)")
     return 1 if total else 0
 

--- a/tests/unit/scripts/test_todo_db_v2.py
+++ b/tests/unit/scripts/test_todo_db_v2.py
@@ -592,6 +592,45 @@ class TestLintUnresolvableScopeAndLadderPaths:
         assert not any("zq_forbidden" in f for f in findings)
 
 
+class TestLintExemptionVisibility:
+    """A category-based falsifiability exemption must be visible in lint
+    output - silent, author-selectable skips are unauditable."""
+
+    def _mk_exempt(self, conn, item_id, category):
+        todo_db.set_config(conn, "tester", "lint.require_falsifiable_rung", "on")
+        todo_db.create_item(
+            conn,
+            "tester",
+            item_id=item_id,
+            title="Item exercising exemption visibility",
+            worktree="spike",
+            priority="medium",
+            description="A description longer than ten characters.",
+            category=category,
+            work=[{"id": "w1", "summary": "one unit of work"}],
+            scope=[("only_modify", "tests/conftest.py")],
+            verifications=[{"description": "tripwire", "command": "true", "expected": "always passes"}],
+        )
+
+    def test_exempt_category_gets_note_not_finding(self, conn):
+        self._mk_exempt(conn, "flake-exempt", "flake")
+        assert not any("falsifiability" in f for f in todo_db.lint_item(conn, "flake-exempt"))
+        notes = todo_db.lint_item_notes(conn, "flake-exempt")
+        assert any("exempt" in n for n in notes)
+
+    def test_normal_category_gets_finding_not_note(self, conn):
+        self._mk_exempt(conn, "normal-cat", "security")
+        assert any("falsifiability" in f for f in todo_db.lint_item(conn, "normal-cat"))
+        assert todo_db.lint_item_notes(conn, "normal-cat") == []
+
+    def test_exemption_note_does_not_affect_exit_code(self, conn, capsys):
+        self._mk_exempt(conn, "flake-exit", "flake")
+        rc = todo_db._cmd_lint(conn, "tester", SimpleNamespace(id="flake-exit", all=False))
+        out = capsys.readouterr().out
+        assert "exempt" in out
+        assert rc == 0
+
+
 class TestLintFalsifiabilityAndScopeCompleteness:
     """A ladder must contain at least one rung that FAILS on the unfixed tree
     (declared in its expected text), and only_modify must not orphan a source


### PR DESCRIPTION
The flake/validation category exemption is semantically right for
tripwires and acceptance runs, but category is unvalidated free text
(the corpus has 170+ distinct values, so an enum would break import
losslessness) - a wrongly-categorized item skipped the falsifiability
check silently. Lint now prints an advisory note when the exemption
applies; notes do not count as findings or affect the exit code, so
exempt items stay lint-clean while the skip becomes auditable.

TODO: todo-lint-falsifiability-exemption-invisible
