### PR TITLE
fix(tuning): harden corroboration shape matching

### DIFF
--- a/benchbox/core/tuning/introspection.py
+++ b/benchbox/core/tuning/introspection.py
@@ -275,6 +275,64 @@ _TRANSIENT_PREFIXES = ("set ", "pragma ", "set\t", "pragma\t", "reset ", "use ")
 _MAINTENANCE_PREFIXES = ("optimize ", "vacuum", "analyze", "compact ")
 
 
+def _strip_sql_literals_and_comments(statement: str) -> str:
+    """Blank quoted/comment text while preserving offsets and SQL shape.
+
+    This is deliberately a small lexical guard, not a SQL parser. Existing
+    clause regexes must never classify ``ORDER BY`` / ``PARTITION BY`` text
+    embedded in defaults or comments. Quoted identifiers also blank out and
+    therefore fail closed rather than being guessed into corroboration.
+    """
+    chars = list(statement)
+    index = 0
+    quote_end: str | None = None
+    while index < len(chars):
+        char = chars[index]
+        following = chars[index + 1] if index + 1 < len(chars) else ""
+        if quote_end is not None:
+            if char == quote_end:
+                chars[index] = " "
+                if following == quote_end and quote_end != "]":
+                    chars[index + 1] = " "
+                    index += 2
+                    continue
+                quote_end = None
+            elif char != "\n":
+                chars[index] = " "
+            index += 1
+            continue
+        if char == "-" and following == "-":
+            while index < len(chars) and chars[index] != "\n":
+                chars[index] = " "
+                index += 1
+            continue
+        if char == "/" and following == "*":
+            chars[index] = chars[index + 1] = " "
+            index += 2
+            while index < len(chars):
+                if chars[index] == "*" and index + 1 < len(chars) and chars[index + 1] == "/":
+                    chars[index] = chars[index + 1] = " "
+                    index += 2
+                    break
+                if chars[index] != "\n":
+                    chars[index] = " "
+                index += 1
+            continue
+        if char in "'\"`":
+            quote_end = char
+            chars[index] = " "
+        elif char == "[":
+            quote_end = "]"
+            chars[index] = " "
+        index += 1
+    return "".join(chars)
+
+
+def has_order_by_clause(statement: str) -> bool:
+    """Whether statement shape contains ORDER BY outside literals/comments."""
+    return _ORDER_BY_KEYWORD_RE.search(_strip_sql_literals_and_comments(statement)) is not None
+
+
 def normalize_identifier(value: Any) -> str:
     """Case-fold and strip quoting from a single SQL identifier."""
     text = str(value).strip()
@@ -388,7 +446,7 @@ def _classify(statement: AppliedStatement) -> tuple[str, list[_Intent]]:
     MergeTree does exactly this), and corroborating only the first would let a
     run reach ``applied_verified`` while the other key silently never applied.
     """
-    text = str(statement.statement or "").strip()
+    text = _strip_sql_literals_and_comments(str(statement.statement or "")).strip()
     lowered = text.lower()
 
     if statement.phase == PHASE_SESSION or lowered.startswith(_TRANSIENT_PREFIXES):
@@ -472,6 +530,10 @@ def _match_object(intent: _Intent, state: IntrospectedState) -> tuple[str, Intro
     ]
     if not same_table:
         return ABSENT, None
+    if not intent.columns:
+        # Empty == empty is not evidence of a realized physical key. Treat a
+        # present table/key row as a fail-closed mismatch, never corroboration.
+        return MISMATCH, same_table[0]
     # Exact column match (order-sensitive) is corroboration. Prefer a
     # name-matched fact when the intent carries an index name.
     for obj in same_table:

--- a/benchbox/platforms/clickhouse/workload.py
+++ b/benchbox/platforms/clickhouse/workload.py
@@ -6,6 +6,7 @@ import logging
 from pathlib import Path
 from typing import Any
 
+from benchbox.core.tuning.introspection import has_order_by_clause
 from benchbox.utils.clock import elapsed_seconds, mono_time
 from benchbox.utils.cloud_storage import get_cloud_path_info, is_cloud_path
 from benchbox.utils.printing import emit
@@ -220,7 +221,7 @@ class ClickHouseWorkloadMixin:
         try:
             if not (getattr(self, "tuning_enabled", False) and table_tunings):
                 return
-            if "ORDER BY" in original_statement.upper():
+            if has_order_by_clause(original_statement):
                 return  # pre-existing ORDER BY was not overridden by tuning
             tuning_clauses = self._resolve_tuned_ddl_clauses(original_statement, table_tunings)
             if tuning_clauses is None:

--- a/docs/development/tuning-introspection-receipts.md
+++ b/docs/development/tuning-introspection-receipts.md
@@ -98,6 +98,13 @@ Example summary/entry shape (the ledger's statement order is preserved):
 }
 ```
 
+Clause matching first blanks string literals, quoted identifiers, line
+comments, and block comments with a small lexical scanner, then applies the
+auditable regex shapes above. Clause-looking text in a `DEFAULT` literal or
+comment therefore cannot create an intent or suppress ClickHouse's tuned-key
+recording. Empty parsed column tuples never corroborate: even an empty catalog
+tuple is treated as a fail-closed mismatch, not trivial equality.
+
 ### Session SETs are corroboration-eligible? No (default).
 
 Session `SET`/`PRAGMA` statements are transient: they configure the
@@ -182,6 +189,14 @@ that itself reaches the cap remains explicitly truncated.
   `INTERVAL 1 DAY` to `toIntervalDay(1)` remain an honest fail-closed mismatch.
   Reimplementing ClickHouse's version-dependent expression canonicalizer here
   could over-certify a different expression.
+
+  Table identity also stays conservative. Generic corroboration compares the
+  normalized table strings exactly; it does not suffix-match a
+  schema-qualified intent such as `analytics.t` to a bare catalog fact `t`.
+  Current introspectors are scoped to a database/schema and emit the names their
+  structured catalogs provide. Until the contract carries qualification on
+  both sides, an ambiguous qualified-vs-bare pair remains `absent` rather than
+  widening matching and risking certification of the wrong table.
 
   ClickHouse applies `ORDER BY` / `PARTITION BY` at `CREATE TABLE` time in the
   *schema* phase, which is not wrapped by the tuning recording connection, so

--- a/tests/unit/core/tuning/test_introspection.py
+++ b/tests/unit/core/tuning/test_introspection.py
@@ -23,6 +23,7 @@ from benchbox.core.tuning.applied_ledger import (
     PHASE_POST_LOAD,
     PHASE_SESSION,
     STATEMENT_FAILED,
+    AppliedStatement,
     AppliedTuningLedger,
 )
 from benchbox.core.tuning.introspection import (
@@ -40,6 +41,9 @@ from benchbox.core.tuning.introspection import (
     IntrospectedState,
     IntrospectionReceipt,
     Introspector,
+    _classify,
+    _Intent,
+    _match_object,
     corroborate,
     ledger_tables,
     normalize_columns,
@@ -99,6 +103,20 @@ class TestNormalization:
     def test_normalize_columns_preserves_single_expression_verbatim(self):
         assert normalize_columns("toYYYYMM(event_ts)") == ("toyyyymm(event_ts)",)
 
+    def test_classifier_ignores_clause_decoys_in_literals_and_comments(self):
+        statement = AppliedStatement(
+            statement=(
+                "CREATE TABLE t (c String DEFAULT 'order by (decoy)') "
+                "ENGINE=MergeTree /* PARTITION BY (also_decoy) */ ORDER BY (real_col)"
+            ),
+            phase=PHASE_DDL,
+        )
+
+        klass, intents = _classify(statement)
+
+        assert klass == "verifiable"
+        assert [(intent.kind, intent.columns) for intent in intents] == [(KIND_SORT_KEY, ("real_col",))]
+
     def test_normalize_columns_from_iterable_and_empty(self):
         assert normalize_columns(["A", " B "]) == ("a", "b")
         assert normalize_columns("") == ()
@@ -125,6 +143,28 @@ class TestCorroborate:
         receipt = corroborate(_index_ledger(), _index_state(columns=("l_linenumber", "l_orderkey")))
         assert receipt.corroborated is False
         assert receipt.entries[0].verdict == MISMATCH
+
+    def test_empty_columns_cannot_corroborate_trivially(self):
+        verdict, _ = _match_object(
+            _Intent(kind=KIND_SORT_KEY, table="t", columns=()),
+            IntrospectedState(
+                platform="x",
+                objects=[IntrospectedObject(kind=KIND_SORT_KEY, table="t", columns=())],
+            ),
+        )
+
+        assert verdict != CORROBORATED
+
+    def test_schema_qualified_intent_does_not_suffix_match_bare_catalog_fact(self):
+        verdict, _ = _match_object(
+            _Intent(kind=KIND_SORT_KEY, table="analytics.t", columns=("a",)),
+            IntrospectedState(
+                platform="x",
+                objects=[IntrospectedObject(kind=KIND_SORT_KEY, table="t", columns=("a",))],
+            ),
+        )
+
+        assert verdict == ABSENT
 
     def test_mismatch_has_diff_and_no_upgrade(self):
         # Catalog index over (a) only, ledger says (a, b).

--- a/tests/unit/platforms/test_clickhouse_introspection.py
+++ b/tests/unit/platforms/test_clickhouse_introspection.py
@@ -290,6 +290,20 @@ class TestCombinedPartitionAndSortKey:
         recorded = adapter._applied_tuning_ledger.executed_statements
         assert len(recorded) == 1 and recorded[0].mechanism == "partition_key"
 
+    def test_partition_only_table_with_order_by_literal_decoy_is_recorded(self):
+        adapter = self._tuned_adapter()
+        tunings = _partitioned_only_tuning_config().table_tunings
+        original = (
+            "CREATE TABLE orders (o_orderkey INTEGER PRIMARY KEY, "
+            "note VARCHAR DEFAULT 'ORDER BY (decoy)', o_orderdate DATE)"
+        )
+        optimized = adapter._optimize_table_definition(original, tunings, nullable_columns=set())
+
+        adapter._record_tuned_sort_key_op(original, optimized, "orders", tunings)
+
+        recorded = adapter._applied_tuning_ledger.executed_statements
+        assert len(recorded) == 1 and recorded[0].mechanism == "partition_key"
+
     def test_partition_only_table_with_unapplied_partition_blocks_run(self):
         adapter = self._tuned_adapter()
         # One sort-tuned table whose key DID apply...


### PR DESCRIPTION
## Summary
- blank SQL literals, quoted identifiers, and comments before applying the existing corroboration shape regexes
- prevent empty intent columns from corroborating trivially
- make ClickHouse ORDER BY recording guard clause-aware and pin exact qualified-vs-bare table matching as fail-closed

## Verification
- tracker seq 1 and 2 probes passed
- tracker seq 3: 706 tuning/ClickHouse tests passed
- Ruff, Ruff format, pre-commit hooks, and push-hook fast preflight passed

## Landing order
Land PR #1422 first, then refresh this branch from `develop` and re-enable auto-merge. Both PRs intentionally update `docs/development/tuning-introspection-receipts.md`; auto-merge is disabled here until that overlap is reconciled.