### PR TITLE
fix(results): filter secrets structurally at platform.config boundaries

### DIFF
--- a/benchbox/core/results/builder.py
+++ b/benchbox/core/results/builder.py
@@ -58,6 +58,7 @@ from benchbox.core.results.platform_info import (
     PlatformInfoInput,
     format_platform_display_name,
 )
+from benchbox.core.results.platform_options import sanitize_platform_options
 from benchbox.core.results.query_normalizer import (
     QueryResultInput,
     format_query_id,
@@ -1090,7 +1091,9 @@ class ResultBuilder:
             cloud=self._platform_cloud,
             compute=self._platform_compute,
             storage=self._platform_storage,
-            raw_config=self._platform_raw_config if self._platform_raw_config is not None else platform_config,
+            raw_config=self._platform_raw_config
+            if self._platform_raw_config is not None
+            else sanitize_platform_options(platform_config),
             raw_metadata=self._platform_raw_metadata,
         )
 

--- a/benchbox/core/results/database.py
+++ b/benchbox/core/results/database.py
@@ -25,6 +25,7 @@ from pathlib import Path
 from typing import Any
 
 from benchbox.core.results.models import BenchmarkResults
+from benchbox.core.results.platform_options import sanitize_platform_options
 
 logger = logging.getLogger(__name__)
 
@@ -353,7 +354,10 @@ class ResultDatabase:
         # Build metadata
         metadata = {
             "system_profile": result.system_profile,
-            "platform_info": result.platform_info,
+            # ~/.benchbox/results.db outlives the run; sanitize so a
+            # convention slip in an adapter's platform_info never persists a
+            # secret to the local sink.
+            "platform_info": sanitize_platform_options(result.platform_info or {}),
             "tunings_applied": result.tunings_applied,
             "test_execution_type": result.test_execution_type,
         }

--- a/benchbox/core/results/schema.py
+++ b/benchbox/core/results/schema.py
@@ -30,6 +30,7 @@ from benchbox.core.results.environment import (
     build_environment_payload,
     build_platform_metadata_payload,
 )
+from benchbox.core.results.platform_options import sanitize_platform_options
 from benchbox.core.results.query_normalizer import normalize_query_id
 from benchbox.core.results.schema_policy import CURRENT_SCHEMA_VERSION, RUNTIME_SCHEMA_POLICY
 from benchbox.validation.bundle import REQUIRED_TOP_KEYS
@@ -535,7 +536,7 @@ def _build_platform_section(result: BenchmarkResults, driver_metadata: dict[str,
             cloud=getattr(result, "platform_cloud", None),
             compute=getattr(result, "platform_compute", None),
             storage=getattr(result, "platform_storage", None),
-            raw_config=getattr(result, "platform_raw_config", None) or config,
+            raw_config=getattr(result, "platform_raw_config", None) or sanitize_platform_options(config),
             raw_metadata=(
                 getattr(result, "platform_raw_metadata", None)
                 if getattr(result, "platform_raw_metadata", None) is not None
@@ -1684,4 +1685,7 @@ def _extract_platform_config(platform_info: dict[str, Any]) -> dict[str, Any]:
                 config[key] = value
 
     extract_recursive(platform_info)
-    return config
+    # Adapters keep secrets out of platform_info by convention, but nothing
+    # enforced it - a convention slip would ride into platform.config and the
+    # raw_config fallback verbatim. Filter structurally at the boundary.
+    return sanitize_platform_options(config)

--- a/tests/unit/core/results/test_platform_config_secret_filtering.py
+++ b/tests/unit/core/results/test_platform_config_secret_filtering.py
@@ -1,0 +1,62 @@
+"""platform.config extraction, the raw_config fallbacks, and the results.db
+metadata sink must filter secrets structurally.
+
+Adapters keep secrets out of platform_info by convention; these boundaries
+previously trusted that convention with no enforcement.
+
+Copyright 2026 Joe Harris / BenchBox Project
+Licensed under the MIT License. See LICENSE file in the project root for details.
+"""
+
+import json
+
+import pytest
+
+from benchbox.core.results.platform_options import REDACTED_VALUE
+from benchbox.core.results.schema import _extract_platform_config
+
+pytestmark = [
+    pytest.mark.unit,
+    pytest.mark.fast,
+]
+
+
+class TestExtractPlatformConfigFiltering:
+    def test_password_sentinel_is_filtered(self):
+        out = _extract_platform_config({"configuration": {"password": "PW-SENTINEL"}})
+        assert "PW-SENTINEL" not in json.dumps(out)
+        assert out["password"] == REDACTED_VALUE
+
+    def test_nested_secret_is_filtered(self):
+        out = _extract_platform_config({"configuration": {"s3": {"secret_key": "SK-SENTINEL"}}})
+        assert "SK-SENTINEL" not in json.dumps(out)
+
+    def test_non_secret_config_keeps_real_values(self):
+        out = _extract_platform_config({"configuration": {"memory_limit": "8GB", "threads": 4}})
+        assert out["memory_limit"] == "8GB"
+        assert out["threads"] == 4
+
+
+class TestResultsDbMetadataFiltering:
+    def test_platform_info_secret_never_reaches_metadata_json(self, tmp_path):
+        from datetime import datetime
+
+        from benchbox.core.results.database import ResultDatabase
+        from benchbox.core.results.models import BenchmarkResults
+
+        result = BenchmarkResults(
+            benchmark_name="tpch",
+            platform="duckdb",
+            scale_factor=0.01,
+            execution_id="exec-filter-test",
+            timestamp=datetime.now(),
+            duration_seconds=1.0,
+            total_queries=1,
+            successful_queries=1,
+            failed_queries=0,
+            platform_info={"name": "duckdb", "api_key": "DBKEY-SENTINEL"},
+        )
+        db = ResultDatabase(db_path=tmp_path / "results.db")
+        db.store_result(result)
+        raw = (tmp_path / "results.db").read_bytes()
+        assert b"DBKEY-SENTINEL" not in raw


### PR DESCRIPTION
platform.config extraction, the raw_config fallbacks, and the
~/.benchbox/results.db metadata sink all trusted the convention that
adapters keep secrets out of platform_info - nothing enforced it, so a
single convention slip would export or persist a credential verbatim.
Route all four boundaries through sanitize_platform_options; non-secret
config keys keep their real values.

TODO: platform-config-extraction-lacks-secret-filtering
