### PR TITLE
fix(results): hash the libpq sslrootcert path on the public layer

### DIFF
--- a/benchbox/core/results/anonymization_specs.yaml
+++ b/benchbox/core/results/anonymization_specs.yaml
@@ -68,6 +68,9 @@ endpoint_keys:
 path_keys:
 - credentialfile
 - databasepath
+# libpq spelling (redshift.py): no underscore, so the *path/*file suffix
+# rules never fire and the raw local path (home-dir username) leaked.
+- sslrootcert
 - datadirectory
 - datapath
 - filepath

--- a/tests/unit/core/results/test_anonymization.py
+++ b/tests/unit/core/results/test_anonymization.py
@@ -792,6 +792,29 @@ class TestPublicPayloadApiKeyAndAccountKey:
         assert "AZKEY-SENTINEL" not in out
 
 
+class TestPublicPayloadSslRootCert:
+    """The libpq sslrootcert spelling ends in neither path nor file, so the
+    raw local path (leaking the home-dir username) passed through."""
+
+    def test_sslrootcert_path_is_hashed(self):
+        out = json.dumps(
+            AnonymizationManager().anonymize_result_payload(
+                {"platform_metadata": {"platform_raw_config": {"sslrootcert": "/Users/joe/certs/root.pem"}}}
+            ),
+            default=str,
+        )
+        assert "/Users/joe" not in out
+
+    def test_underscore_cert_paths_still_hashed(self):
+        out = json.dumps(
+            AnonymizationManager().anonymize_result_payload(
+                {"platform_metadata": {"platform_raw_config": {"ca_cert_path": "/Users/joe/certs/ca.pem"}}}
+            ),
+            default=str,
+        )
+        assert "/Users/joe" not in out
+
+
 class TestPublicPayloadTupleRecursion:
     """A tuple fell through to the scalar branch untouched, so any payload
     branch not pre-flattened by internal capture leaked tuple contents."""


### PR DESCRIPTION
sslrootcert (redshift.py's libpq spelling) ends in neither 'path' nor
'file', so no identifier rule fired and the raw local path - leaking
the home-directory username - exported verbatim publicly. Add it to
path_keys; ca_cert_path/ssl_cert_path behavior is unchanged.

TODO: public-export-sslrootcert-path-unhashed
