### PR TITLE
feat(tracker): lint stale references to deleted files

### DIFF
--- a/_project/scripts/todo_db.py
+++ b/_project/scripts/todo_db.py
@@ -2381,6 +2381,31 @@ def _glob_resolves(root: Path, pattern: str) -> bool:
         return False
 
 
+_HISTORY_CACHE: dict[tuple[str, str], bool] = {}
+
+
+def _existed_then_deleted(root: Path, path: str) -> bool:
+    """Whether ``path`` once existed in git history (it does not resolve now).
+
+    Ratios cannot separate a stale reference to a deleted file from a planned
+    new file - todo_cli.py (deleted in the G5 cutover) and a genuinely new
+    test sit at the same difflib distance from their nearest siblings. Git
+    history separates them exactly. Cached per (root, path) so a lint --all
+    pass pays one subprocess per distinct stale path, not per item.
+    """
+    key = (str(root), path)
+    if key not in _HISTORY_CACHE:
+        result = subprocess.run(
+            ["git", "log", "--all", "-1", "--format=%h", "--", path],
+            cwd=root,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        _HISTORY_CACHE[key] = result.returncode == 0 and bool(result.stdout.strip())
+    return _HISTORY_CACHE[key]
+
+
 def _near_miss(root: Path, literal: str, cutoff: float = _NEAR_MISS_CUTOFF) -> str | None:
     """An existing sibling whose name closely matches ``literal``'s, if any."""
     target = root / literal
@@ -2404,6 +2429,8 @@ def _unresolved_path_finding(root: Path, path: str, *, settled: bool) -> str | N
     close = _near_miss(root, path)
     if close:
         return f"names a nonexistent path suspiciously close to existing '{close}'"
+    if _existed_then_deleted(root, path):
+        return "references a file that was deleted from the tree"
     return None
 
 

--- a/_project/scripts/todo_db.py
+++ b/_project/scripts/todo_db.py
@@ -2396,7 +2396,7 @@ def _existed_then_deleted(root: Path, path: str) -> bool:
     key = (str(root), path)
     if key not in _HISTORY_CACHE:
         result = subprocess.run(
-            ["git", "log", "--all", "-1", "--format=%h", "--", path],
+            ["git", "log", "-1", "--format=%h", "--", path],
             cwd=root,
             capture_output=True,
             text=True,

--- a/tests/unit/scripts/test_todo_db_v2.py
+++ b/tests/unit/scripts/test_todo_db_v2.py
@@ -537,6 +537,35 @@ class TestLintUnresolvableScopeAndLadderPaths:
         findings = todo_db.lint_item(conn, "node-id-cmd")
         assert not any("test_todo_db_v2" in f for f in findings)
 
+    def test_stale_reference_to_deleted_path_is_flagged_on_open_item(self, conn):
+        # _project/scripts/todo_cli.py existed and was deleted in the G5
+        # cutover (#1232); six open items still referenced it below the
+        # near-miss cutoff.
+        self._mk_scoped(conn, "stale-ref", scope=[("only_modify", "_project/scripts/todo_cli.py")])
+        findings = todo_db.lint_item(conn, "stale-ref")
+        assert any("deleted from the tree" in f for f in findings)
+
+    def test_deleted_path_in_command_is_flagged(self, conn):
+        self._mk_scoped(
+            conn,
+            "stale-cmd-ref",
+            verifications=[
+                {
+                    "description": "rung",
+                    "command": "uv run -- python _project/scripts/todo_cli.py list",
+                    "expected": "whatever",
+                }
+            ],
+        )
+        findings = todo_db.lint_item(conn, "stale-cmd-ref")
+        assert any("deleted from the tree" in f for f in findings)
+
+    def test_deleted_path_never_existed_stays_legal(self, conn):
+        # A planned new file has no git history - it must stay creatable.
+        self._mk_scoped(conn, "planned-new", scope=[("only_modify", "tests/unit/scripts/test_zq_never_existed.py")])
+        findings = todo_db.lint_item(conn, "planned-new")
+        assert not any("test_zq_never_existed" in f for f in findings)
+
     def test_inert_deny_rule_annotated_glob_is_flagged_on_open_item(self, conn):
         # "path (prose)" can never fnmatch a changed file, so the deny rule
         # silently protects nothing — exactly the enforcement hole to surface.

--- a/tests/unit/scripts/test_todo_db_v2.py
+++ b/tests/unit/scripts/test_todo_db_v2.py
@@ -76,6 +76,34 @@ def conn(tmp_path):
     connection.close()
 
 
+@pytest.fixture()
+def deleted_path_repo(tmp_path):
+    """Repository with deleted paths on the current and an unrelated lineage."""
+    root = tmp_path / "history"
+    root.mkdir()
+    _git(root, "init", "-q", "-b", "trunk")
+    _git(root, "commit", "--allow-empty", "-q", "-m", "root")
+
+    sibling_path = root / "tests" / "planned_only_on_sibling.py"
+    _git(root, "switch", "-q", "-c", "sibling")
+    sibling_path.parent.mkdir(parents=True)
+    sibling_path.write_text("planned = True\n")
+    _git(root, "add", sibling_path.relative_to(root).as_posix())
+    _git(root, "commit", "-q", "-m", "add sibling path")
+    _git(root, "rm", "-q", sibling_path.relative_to(root).as_posix())
+    _git(root, "commit", "-q", "-m", "delete sibling path")
+
+    deleted_path = root / "_project" / "scripts" / "deleted_in_lineage.py"
+    _git(root, "switch", "-q", "trunk")
+    deleted_path.parent.mkdir(parents=True)
+    deleted_path.write_text("deleted = True\n")
+    _git(root, "add", deleted_path.relative_to(root).as_posix())
+    _git(root, "commit", "-q", "-m", "add current path")
+    _git(root, "rm", "-q", deleted_path.relative_to(root).as_posix())
+    _git(root, "commit", "-q", "-m", "delete current path")
+    return root
+
+
 def _mk(conn, item_id="resume-item", **overrides):
     kwargs = {
         "item_id": item_id,
@@ -537,22 +565,21 @@ class TestLintUnresolvableScopeAndLadderPaths:
         findings = todo_db.lint_item(conn, "node-id-cmd")
         assert not any("test_todo_db_v2" in f for f in findings)
 
-    def test_stale_reference_to_deleted_path_is_flagged_on_open_item(self, conn):
-        # _project/scripts/todo_cli.py existed and was deleted in the G5
-        # cutover (#1232); six open items still referenced it below the
-        # near-miss cutoff.
-        self._mk_scoped(conn, "stale-ref", scope=[("only_modify", "_project/scripts/todo_cli.py")])
+    def test_stale_reference_to_deleted_path_is_flagged_on_open_item(self, conn, deleted_path_repo, monkeypatch):
+        monkeypatch.setattr(todo_db, "_lint_repo_root", lambda: deleted_path_repo)
+        self._mk_scoped(conn, "stale-ref", scope=[("only_modify", "_project/scripts/deleted_in_lineage.py")])
         findings = todo_db.lint_item(conn, "stale-ref")
         assert any("deleted from the tree" in f for f in findings)
 
-    def test_deleted_path_in_command_is_flagged(self, conn):
+    def test_deleted_path_in_command_is_flagged(self, conn, deleted_path_repo, monkeypatch):
+        monkeypatch.setattr(todo_db, "_lint_repo_root", lambda: deleted_path_repo)
         self._mk_scoped(
             conn,
             "stale-cmd-ref",
             verifications=[
                 {
                     "description": "rung",
-                    "command": "uv run -- python _project/scripts/todo_cli.py list",
+                    "command": "uv run -- python _project/scripts/deleted_in_lineage.py list",
                     "expected": "whatever",
                 }
             ],
@@ -565,6 +592,12 @@ class TestLintUnresolvableScopeAndLadderPaths:
         self._mk_scoped(conn, "planned-new", scope=[("only_modify", "tests/unit/scripts/test_zq_never_existed.py")])
         findings = todo_db.lint_item(conn, "planned-new")
         assert not any("test_zq_never_existed" in f for f in findings)
+
+    def test_path_deleted_only_on_unrelated_branch_stays_legal(self, conn, deleted_path_repo, monkeypatch):
+        monkeypatch.setattr(todo_db, "_lint_repo_root", lambda: deleted_path_repo)
+        self._mk_scoped(conn, "sibling-only", scope=[("only_modify", "tests/planned_only_on_sibling.py")])
+        findings = todo_db.lint_item(conn, "sibling-only")
+        assert not any("planned_only_on_sibling" in f for f in findings)
 
     def test_inert_deny_rule_annotated_glob_is_flagged_on_open_item(self, conn):
         # "path (prose)" can never fnmatch a changed file, so the deny rule


### PR DESCRIPTION
todo_cli.py and validate_todo.py were deleted in the G5 cutover; eleven
open items still reference them, at difflib ratios (0.74-0.76)
indistinguishable from genuinely planned new files - no cutoff separates
the populations, git history does exactly. An unresolved open-item
literal with no near-miss now gets one cached 'git log --all -1' probe:
existed-then-deleted is a finding, never-existed stays a legal plan.

TODO: todo-lint-misses-deleted-file-stale-references
