### PR TITLE
test(dataframe): cover production memory policy

### DIFF
--- a/tests/unit/platforms/dataframe/test_benchmark_mixin_memory_policy.py
+++ b/tests/unit/platforms/dataframe/test_benchmark_mixin_memory_policy.py
@@ -1,0 +1,74 @@
+"""Production memory-policy coverage for ``BenchmarkExecutionMixin``."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from benchbox.core.schemas import BenchmarkConfig
+from benchbox.platforms.dataframe.benchmark_mixin import (
+    BenchmarkExecutionMixin,
+    DataFramePhases,
+    DataFrameRunOptions,
+)
+
+pytestmark = [pytest.mark.unit, pytest.mark.fast]
+
+
+class MemoryPolicyAdapter(BenchmarkExecutionMixin):
+    """Minimal adapter that records whether execution passed the memory gate."""
+
+    platform_name = "Polars"
+    family = "expression"
+
+    def __init__(self) -> None:
+        self.context_created = False
+
+    def create_context(self) -> SimpleNamespace:
+        self.context_created = True
+        return SimpleNamespace()
+
+    def get_platform_info(self) -> dict[str, str]:
+        return {"platform": self.platform_name, "family": self.family}
+
+
+def _benchmark_config() -> BenchmarkConfig:
+    return BenchmarkConfig(name="tpch", display_name="TPC-H", scale_factor=1.0)
+
+
+def _benchmark() -> SimpleNamespace:
+    return SimpleNamespace(name="tpch", display_name="TPC-H", scale_factor=1.0, tables={})
+
+
+def test_run_benchmark_rejects_unsafe_memory(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The production capacity check aborts before an execution context is created."""
+    monkeypatch.setattr("benchbox.core.dataframe.capabilities.get_available_memory_gb", lambda: 0.01)
+    adapter = MemoryPolicyAdapter()
+
+    result = adapter.run_benchmark(
+        _benchmark(),
+        benchmark_config=_benchmark_config(),
+        phases=DataFramePhases(load=False, execute=False),
+    )
+
+    assert result.validation_status == "FAILED"
+    assert result.validation_details["error_type"] == "InsufficientMemoryError"
+    assert "Insufficient memory" in result.validation_details["error"]
+    assert adapter.context_created is False
+
+
+def test_run_benchmark_ignore_memory_warning_reaches_execution(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The explicit override bypasses the same unsafe host-memory condition."""
+    monkeypatch.setattr("benchbox.core.dataframe.capabilities.get_available_memory_gb", lambda: 0.01)
+    adapter = MemoryPolicyAdapter()
+
+    result = adapter.run_benchmark(
+        _benchmark(),
+        benchmark_config=_benchmark_config(),
+        phases=DataFramePhases(load=False, execute=False),
+        options=DataFrameRunOptions(ignore_memory_warnings=True),
+    )
+
+    assert result.validation_status != "FAILED"
+    assert adapter.context_created is True


### PR DESCRIPTION
## Summary

- add production `BenchmarkExecutionMixin.run_benchmark()` coverage for insufficient-memory rejection
- verify `ignore_memory_warnings=True` bypasses the same deterministic low-memory condition
- keep the tests outside the ambient-memory isolation fixture so they exercise the real capacity check

Follow-up to #1415 and its unresolved memory-policy review finding.

## Verification

- `uv run -- python -m pytest tests/unit/platforms/dataframe/test_benchmark_mixin_behavioral.py tests/unit/platforms/dataframe/test_benchmark_mixin_memory_policy.py -q` (35 passed)
- `uv run -- ruff check tests/unit/platforms/dataframe/test_benchmark_mixin_memory_policy.py`
- `uv run -- ruff format --check tests/unit/platforms/dataframe/test_benchmark_mixin_memory_policy.py`
- `make pr-preflight` (26,301 passed, 18 skipped; stopped only at report-only hygiene for preserved `benchmark_runs/datagen` artifact)
