### PR TITLE
fix(tracker): make doctor truly read only

### DIFF
--- a/_project/scripts/todo_db.py
+++ b/_project/scripts/todo_db.py
@@ -569,9 +569,12 @@ def _ensure_schema(conn: sqlite3.Connection) -> None:
         raise TodoError(f"database schema_version={version} is newer than this CLI ({SCHEMA_VERSION}); use a newer CLI")
 
 
-def connect(db_path: Path) -> sqlite3.Connection:
-    db_path.parent.mkdir(parents=True, exist_ok=True)
-    conn = sqlite3.connect(db_path)
+def connect(db_path: Path, *, read_only: bool = False) -> sqlite3.Connection:
+    if read_only:
+        conn = sqlite3.connect(f"{db_path.resolve().as_uri()}?mode=ro", uri=True)
+    else:
+        db_path.parent.mkdir(parents=True, exist_ok=True)
+        conn = sqlite3.connect(db_path)
     conn.row_factory = sqlite3.Row
     # Autocommit mode: every multi-statement write goes through _write_txn,
     # which takes the write lock up front (BEGIN IMMEDIATE) so check-then-act
@@ -579,7 +582,8 @@ def connect(db_path: Path) -> sqlite3.Connection:
     conn.isolation_level = None
     conn.execute("PRAGMA foreign_keys = ON")
     conn.execute("PRAGMA busy_timeout = 5000")
-    _ensure_schema(conn)
+    if not read_only:
+        _ensure_schema(conn)
     return conn
 
 
@@ -1213,7 +1217,7 @@ def _report_backend(backend: Path | str, *, implicit_default_local: bool) -> Non
 
 def connect_backend(backend: Path | str, *, read_only: bool = False) -> sqlite3.Connection | _HostedConnection:
     if isinstance(backend, Path):
-        return connect(backend)
+        return connect(backend, read_only=read_only)
     return connect_hosted(backend, read_only=read_only)
 
 
@@ -1235,11 +1239,12 @@ _DOCTOR_AUTH_MARKERS = (
     "authentication",
     "401",
     "403",
-    "expired",
     "invalid token",
     "invalidtoken",
     "jwt",
 )
+
+_DOCTOR_TOKEN_EXPIRY_MARKERS = ("token", "jwt", "bearer")
 
 
 def _doctor_is_auth_failure(exc: BaseException) -> bool:
@@ -1251,7 +1256,9 @@ def _doctor_is_auth_failure(exc: BaseException) -> bool:
     is down, so anything unrecognized stays a generic FAIL.
     """
     text = str(exc).lower()
-    return any(marker in text for marker in _DOCTOR_AUTH_MARKERS)
+    return any(marker in text for marker in _DOCTOR_AUTH_MARKERS) or (
+        "expired" in text and any(marker in text for marker in _DOCTOR_TOKEN_EXPIRY_MARKERS)
+    )
 
 
 def run_doctor(backend: Path | str, *, implicit_default_local: bool, as_json: bool = False) -> int:

--- a/_project/scripts/todo_db.py
+++ b/_project/scripts/todo_db.py
@@ -569,7 +569,12 @@ def _ensure_schema(conn: sqlite3.Connection) -> None:
         raise TodoError(f"database schema_version={version} is newer than this CLI ({SCHEMA_VERSION}); use a newer CLI")
 
 
-def connect(db_path: Path, *, read_only: bool = False) -> sqlite3.Connection:
+def connect(
+    db_path: Path,
+    *,
+    read_only: bool = False,
+    validate_schema: bool = True,
+) -> sqlite3.Connection:
     if read_only:
         conn = sqlite3.connect(f"{db_path.resolve().as_uri()}?mode=ro", uri=True)
     else:
@@ -582,7 +587,22 @@ def connect(db_path: Path, *, read_only: bool = False) -> sqlite3.Connection:
     conn.isolation_level = None
     conn.execute("PRAGMA foreign_keys = ON")
     conn.execute("PRAGMA busy_timeout = 5000")
-    if not read_only:
+    if read_only and validate_schema:
+        version = _schema_version(conn)
+        if version is None:
+            conn.close()
+            raise TodoError("local tracker: no schema found; run `todo init`")
+        if version < SCHEMA_VERSION:
+            conn.close()
+            raise TodoError(
+                f"database schema_version={version}, CLI expects {SCHEMA_VERSION}; run `todo migrate` to upgrade it"
+            )
+        if version > SCHEMA_VERSION:
+            conn.close()
+            raise TodoError(
+                f"database schema_version={version} is newer than this CLI ({SCHEMA_VERSION}); use a newer CLI"
+            )
+    elif not read_only:
         _ensure_schema(conn)
     return conn
 
@@ -824,9 +844,11 @@ def _hosted_read_connect(url: str) -> _HostedConnection:
     return _HostedConnection(libsql.connect(url, auth_token=token))
 
 
-def connect_hosted(url: str, *, read_only: bool = False) -> _HostedConnection:
+def connect_hosted(url: str, *, read_only: bool = False, validate_schema: bool = True) -> _HostedConnection:
     if read_only:
         conn = _hosted_read_connect(url)
+        if not validate_schema:
+            return conn
         version = _schema_version(conn)
         if version is None:
             conn.close()
@@ -1215,10 +1237,17 @@ def _report_backend(backend: Path | str, *, implicit_default_local: bool) -> Non
     print("todo backend: hosted", file=sys.stderr)
 
 
-def connect_backend(backend: Path | str, *, read_only: bool = False) -> sqlite3.Connection | _HostedConnection:
+def connect_backend(
+    backend: Path | str,
+    *,
+    read_only: bool = False,
+    validate_schema: bool = True,
+) -> sqlite3.Connection | _HostedConnection:
     if isinstance(backend, Path):
-        return connect(backend, read_only=read_only)
-    return connect_hosted(backend, read_only=read_only)
+        return connect(backend, read_only=read_only, validate_schema=validate_schema)
+    if validate_schema:
+        return connect_hosted(backend, read_only=read_only)
+    return connect_hosted(backend, read_only=read_only, validate_schema=False)
 
 
 # `doctor` exit contract. 0 = every check OK (warnings allowed), 4 = auth
@@ -1259,6 +1288,12 @@ def _doctor_is_auth_failure(exc: BaseException) -> bool:
     return any(marker in text for marker in _DOCTOR_AUTH_MARKERS) or (
         "expired" in text and any(marker in text for marker in _DOCTOR_TOKEN_EXPIRY_MARKERS)
     )
+
+
+def _doctor_incompatible_schema_detail(version: int) -> str:
+    if version < SCHEMA_VERSION:
+        return f"v{version}, expected v{SCHEMA_VERSION}; run `todo migrate`"
+    return f"v{version} is newer than this CLI (v{SCHEMA_VERSION}); use a newer CLI"
 
 
 def run_doctor(backend: Path | str, *, implicit_default_local: bool, as_json: bool = False) -> int:
@@ -1314,17 +1349,19 @@ def run_doctor(backend: Path | str, *, implicit_default_local: bool, as_json: bo
     else:
         conn = None
         try:
-            conn = connect_backend(backend, read_only=True)
-            count = list(conn.execute("SELECT count(*) AS n FROM items"))[0]["n"]
-            record("reachable", "OK", f"read {count} item(s)")
+            conn = connect_backend(backend, read_only=True, validate_schema=False)
             version = _schema_version(conn)
             if version == SCHEMA_VERSION:
+                count = list(conn.execute("SELECT count(*) AS n FROM items"))[0]["n"]
+                record("reachable", "OK", f"read {count} item(s)")
                 record("schema", "OK", f"v{version}")
             elif version is None:
+                record("reachable", "OK", "connected")
                 record("schema", "FAIL", "no schema found; run `todo init`")
                 exit_code = DOCTOR_EXIT_FAIL
             else:
-                record("schema", "FAIL", f"v{version}, expected v{SCHEMA_VERSION}; run `todo migrate`")
+                record("reachable", "OK", "connected")
+                record("schema", "FAIL", _doctor_incompatible_schema_detail(version))
                 exit_code = DOCTOR_EXIT_FAIL
         # `Exception`, not `BaseException`: doctor turns failures into check results,
         # but a Ctrl-C during a slow hosted connect must still interrupt rather than

--- a/tests/unit/scripts/test_todo_db_doctor.py
+++ b/tests/unit/scripts/test_todo_db_doctor.py
@@ -77,6 +77,34 @@ def test_doctor_does_not_create_a_missing_local_database(tmp_path, capsys):
     assert "FAIL reachable" in capsys.readouterr().out
 
 
+def test_doctor_reports_an_existing_schemaless_database_as_a_schema_failure(tmp_path, capsys):
+    db = tmp_path / "empty.sqlite"
+    db.touch()
+
+    assert todo_db.main(["--db", str(db), "doctor"]) == todo_db.DOCTOR_EXIT_FAIL
+
+    out = capsys.readouterr().out
+    assert "OK   reachable" in out
+    assert "FAIL schema" in out
+    assert "no schema found" in out
+
+
+@pytest.mark.parametrize(
+    ("version", "guidance"),
+    [(todo_db.SCHEMA_VERSION - 1, "migrate"), (todo_db.SCHEMA_VERSION + 1, "newer CLI")],
+)
+def test_read_only_local_connect_rejects_incompatible_schema(local_db, version, guidance):
+    conn = sqlite3.connect(local_db)
+    try:
+        conn.execute("UPDATE meta SET value = ? WHERE key = 'schema_version'", (str(version),))
+        conn.commit()
+    finally:
+        conn.close()
+
+    with pytest.raises(todo_db.TodoError, match=rf"schema_version={version}.*{guidance}"):
+        todo_db.connect_backend(local_db, read_only=True)
+
+
 def test_doctor_json_is_machine_readable(local_db, capsys):
     assert todo_db.main(["--db", str(local_db), "doctor", "--json"]) == todo_db.DOCTOR_EXIT_OK
     payload = json.loads(capsys.readouterr().out)

--- a/tests/unit/scripts/test_todo_db_doctor.py
+++ b/tests/unit/scripts/test_todo_db_doctor.py
@@ -67,6 +67,16 @@ def test_doctor_reports_healthy_local_backend(local_db, capsys):
     assert f"v{todo_db.SCHEMA_VERSION}" in out
 
 
+def test_doctor_does_not_create_a_missing_local_database(tmp_path, capsys):
+    db = tmp_path / "missing" / "todo.sqlite"
+
+    assert todo_db.main(["--db", str(db), "doctor"]) == todo_db.DOCTOR_EXIT_FAIL
+
+    assert not db.exists()
+    assert not db.parent.exists()
+    assert "FAIL reachable" in capsys.readouterr().out
+
+
 def test_doctor_json_is_machine_readable(local_db, capsys):
     assert todo_db.main(["--db", str(local_db), "doctor", "--json"]) == todo_db.DOCTOR_EXIT_OK
     payload = json.loads(capsys.readouterr().out)
@@ -101,6 +111,30 @@ def test_rejected_token_is_classified_as_auth_not_a_plain_outage(monkeypatch, ca
     monkeypatch.setattr(todo_db, "connect_backend", boom)
     assert todo_db.main(["--db", _HOSTED_URL, "doctor"]) == todo_db.DOCTOR_EXIT_AUTH
     assert "auth failure" in capsys.readouterr().out
+
+
+def test_expired_token_is_classified_as_auth(monkeypatch, capsys):
+    monkeypatch.setenv("TODO_DB_AUTH_TOKEN", _SECRET)
+
+    def boom(*_args, **_kwargs):
+        raise RuntimeError("JWT token has expired")
+
+    monkeypatch.setattr(todo_db, "connect_backend", boom)
+    assert todo_db.main(["--db", _HOSTED_URL, "doctor"]) == todo_db.DOCTOR_EXIT_AUTH
+    assert "auth failure" in capsys.readouterr().out
+
+
+def test_expired_tls_certificate_is_a_plain_outage(monkeypatch, capsys):
+    monkeypatch.setenv("TODO_DB_AUTH_TOKEN", _SECRET)
+
+    def boom(*_args, **_kwargs):
+        raise RuntimeError("TLS certificate has expired")
+
+    monkeypatch.setattr(todo_db, "connect_backend", boom)
+    assert todo_db.main(["--db", _HOSTED_URL, "doctor"]) == todo_db.DOCTOR_EXIT_FAIL
+    out = capsys.readouterr().out
+    assert "FAIL reachable" in out
+    assert "auth failure" not in out
 
 
 def test_plain_outage_is_exit_2_not_auth(monkeypatch, capsys):


### PR DESCRIPTION
## Summary

- make local `read_only=True` connections use SQLite `mode=ro` without creating parent directories, databases, or schemas
- classify expiry as authentication failure only in token, JWT, or bearer contexts
- add regressions for nonexistent local doctor targets, expired tokens, and expired TLS certificates

Post-merge follow-up for the two actionable review findings on #1418.

## Verification

- `uv run -- python -m pytest tests/unit/scripts/test_todo_db_doctor.py -q` (13 passed)
- focused hosted/read-only test selection passed
- Ruff check and format passed
- `make pr-preflight` completed all non-pytest lint/type/architecture guards; its initial marker collection was blocked by the legitimate shared pytest holder
- `make lint-markers` passed after that holder exited (29,278 collected; marker strategy 10 passed)
