### PR TITLE
fix/pr1437 canonical tuning mode review

### DIFF
--- a/benchbox/cli/commands/run.py
+++ b/benchbox/cli/commands/run.py
@@ -358,7 +358,7 @@ def _build_execution_context(
         capture_plans=capture_plans,
         strict_plan_capture=strict_plan_capture,
         non_interactive=non_interactive,
-        tuning_mode=tuning if tuning and tuning != "notuning" else None,
+        tuning_mode=tuning_modes.NOTUNING if tuning == tuning_modes.NOTUNING else tuning,
     )
 
 

--- a/benchbox/core/schemas.py
+++ b/benchbox/core/schemas.py
@@ -494,7 +494,7 @@ class ExecutionContext(BaseModel):
     non_interactive: bool = False
 
     # Tuning
-    tuning_mode: Optional[str] = None  # "tuned", "notuning", "auto", or path
+    tuning_mode: Optional[str] = None  # Canonical value from benchbox.core.tuning.modes, or absent.
 
     def to_cli_args(self) -> list[str]:
         """Reconstruct CLI arguments from non-default values.
@@ -547,7 +547,7 @@ class ExecutionContext(BaseModel):
             args.extend(["--queries", ",".join(self.query_subset)])
         if self.strict_plan_capture:
             args.extend(["--plan-config", "strict:true"])
-        if self.tuning_mode and self.tuning_mode != "notuning":
+        if self.tuning_mode:
             args.extend(["--tuning", self.tuning_mode])
 
         return args

--- a/tests/unit/cli/test_run_command_branches.py
+++ b/tests/unit/cli/test_run_command_branches.py
@@ -171,9 +171,30 @@ class TestBuildExecutionContext:
         assert ctx.mode == "sql"
         assert ctx.seed is None
         assert ctx.query_subset is None
-        assert ctx.tuning_mode is None  # "notuning" produces None
+        assert ctx.tuning_mode == "notuning"
         assert ctx.validation_mode == "loose"
         assert ctx.force_datagen is True
+
+    def test_absent_tuning_stays_not_recorded(self):
+        from benchbox.cli.commands.run import _build_execution_context
+        from benchbox.cli.composite_params import CompressionConfig, ForceConfig, ValidationConfig
+
+        ctx = _build_execution_context(
+            phases_to_run=["power"],
+            seed=None,
+            compression=CompressionConfig(enabled=False, type="none", level=None),
+            mode=None,
+            official=False,
+            validation=ValidationConfig(mode="exact"),
+            force=ForceConfig(datagen=False, upload=False),
+            queries_to_run=None,
+            capture_plans=False,
+            strict_plan_capture=False,
+            non_interactive=False,
+            tuning=None,
+        )
+
+        assert ctx.tuning_mode is None
 
     def test_official_mode(self):
         from benchbox.cli.commands.run import _build_execution_context

--- a/tests/unit/core/test_execution_context.py
+++ b/tests/unit/core/test_execution_context.py
@@ -238,11 +238,19 @@ class TestToCliArgs:
         assert "--tuning" in args
         assert "tuned" in args
 
-    def test_tuning_mode_notuning_not_included(self):
-        """Notuning should not be included (it's the default)."""
+    def test_tuning_mode_notuning_round_trips_explicit_request(self):
+        """Explicit notuning must remain distinct from an absent tuning flag."""
         ctx = ExecutionContext(tuning_mode="notuning")
         args = ctx.to_cli_args()
-        assert "--tuning" not in args
+        assert args[-2:] == ["--tuning", "notuning"]
+
+        absent = ExecutionContext()
+        assert "--tuning" not in absent.to_cli_args()
+
+    def test_tuning_path_round_trips_byte_for_byte(self):
+        tuning_path = "/tmp/custom tuning/profile.yaml"
+
+        assert ExecutionContext(tuning_mode=tuning_path).to_cli_args()[-2:] == ["--tuning", tuning_path]
 
 
 class TestToCliString:

--- a/tests/unit/core/test_execution_context.py
+++ b/tests/unit/core/test_execution_context.py
@@ -247,10 +247,10 @@ class TestToCliArgs:
         absent = ExecutionContext()
         assert "--tuning" not in absent.to_cli_args()
 
-    def test_tuning_path_round_trips_byte_for_byte(self):
-        tuning_path = "/tmp/custom tuning/profile.yaml"
+    def test_tuning_mode_custom_round_trips_canonical_value(self):
+        ctx = ExecutionContext(tuning_mode="custom")
 
-        assert ExecutionContext(tuning_mode=tuning_path).to_cli_args()[-2:] == ["--tuning", tuning_path]
+        assert ctx.to_cli_args()[-2:] == ["--tuning", "custom"]
 
 
 class TestToCliString:


### PR DESCRIPTION
- **fix(cli): preserve explicit notuning in receipts**
- **test(tuning): keep execution context modes canonical**
