### PR TITLE
fix(dataframe): skip a headered CSV's header row instead of ingesting it as data

### DIFF
--- a/benchbox/core/dataframe/data_loader.py
+++ b/benchbox/core/dataframe/data_loader.py
@@ -78,7 +78,11 @@ DEFAULT_CACHE_DIR = Path("benchmark_runs") / "datagen"
 # inference; and empty fields in declared string columns load as '' instead of
 # null when the SQL dialect keeps '' (null_marker is None). Pre-v4 caches must be
 # regenerated to pick up the declared dtypes and the empty-string contract.
-DATAFRAME_CACHE_VERSION = "v4"
+# v5: headered CSVs are read with skip_rows=1 when explicit column names are
+# supplied. Pre-v5 caches for such benchmarks either failed conversion (and
+# silently fell back to an untyped read of the source file) or embedded the header
+# row as data, so they must be regenerated.
+DATAFRAME_CACHE_VERSION = "v5"
 
 # Format subdirectory names that belong to the DataFrame cache layer.
 # Used by clear_cache() to selectively remove cached conversions without
@@ -365,6 +369,7 @@ class FormatConverter:
         write_config: DataFrameWriteConfiguration | None = None,
         column_types: dict[str, str] | None = None,
         null_marker: str | None = "",
+        has_header: bool = False,
     ) -> tuple[ConversionStatus, int]:
         """Convert CSV/TBL file to Parquet format.
 
@@ -411,8 +416,15 @@ class FormatConverter:
             if is_tbl_file and column_names and has_trailing:
                 actual_column_names = column_names + [TRAILING_DUMMY_COLUMN]
 
+            # PyArrow's `column_names` REPLACES the header names but does NOT skip
+            # the header LINE, so a headered CSV read with explicit column names
+            # parses its own header as a data row. With declared numeric/date types
+            # that conversion FAILS, and the caller then silently falls back to the
+            # raw source file -- an UNTYPED read where dates stay strings and every
+            # date filter matches nothing. Headerless TPC `.tbl` is unaffected.
             read_options = pv.ReadOptions(
                 column_names=actual_column_names if actual_column_names else None,
+                skip_rows=1 if (has_header and actual_column_names) else 0,
             )
             parse_options = pv.ParseOptions(delimiter=delimiter)
             arrow_column_types = FormatConverter._resolve_arrow_types(column_types)
@@ -1270,6 +1282,7 @@ class DataFrameDataLoader:
         table_metadata: dict[str, dict[str, Any]] = {}
 
         benchmark_delimiter = getattr(benchmark, "csv_delimiter", None)
+        benchmark_has_header = bool(getattr(benchmark, "csv_has_header", False))
 
         for table_name, source_path in source_files.items():
             source_list = source_path if isinstance(source_path, list) else [source_path]
@@ -1286,6 +1299,7 @@ class DataFrameDataLoader:
                 benchmark_delimiter,
                 cache_path,
                 null_marker=null_markers.get(table_name, ""),
+                has_header=benchmark_has_header,
             )
 
             if len(converted_list) == 1:
@@ -1332,6 +1346,7 @@ class DataFrameDataLoader:
         cache_path: Path,
         *,
         null_marker: str | None = "",
+        has_header: bool = False,
     ) -> tuple[list[Path], list[dict[str, Any]]]:
         """Convert a single table's source files to Parquet."""
         converted_list: list[Path] = []
@@ -1359,6 +1374,7 @@ class DataFrameDataLoader:
                 write_config=table_write_config,
                 column_types=column_types,
                 null_marker=null_marker,
+                has_header=has_header and format_type == "csv",
             )
 
             if status == ConversionStatus.SUCCESS:

--- a/tests/unit/core/dataframe/test_data_loader_behavioral.py
+++ b/tests/unit/core/dataframe/test_data_loader_behavioral.py
@@ -682,3 +682,77 @@ class TestGetTPCHColumnNamesCompleteness:
         """TPC-H region table has exactly 3 columns."""
         columns = get_tpch_column_names()
         assert len(columns["region"]) == 3
+
+
+class TestHeaderedCsvConversion:
+    """A headered CSV converted with explicit column names must skip its header.
+
+    PyArrow's ``column_names`` REPLACES the header names but does not skip the
+    header LINE, so a headered CSV read with explicit names parses its own header
+    as a data row. With declared numeric/date column types that conversion FAILS,
+    and the loader then silently falls back to the raw source file -- an untyped
+    read where date columns stay strings and every date filter matches nothing.
+    Headerless TPC ``.tbl`` must be unaffected.
+    """
+
+    def _column_types(self):
+        return {"id": "int64", "event_date": "date32", "label": "string"}
+
+    def test_headered_csv_converts_with_typed_columns(self, tmp_path: Path):
+        pytest.importorskip("pyarrow")
+        source = tmp_path / "events.csv"
+        source.write_text("id,event_date,label\n1,2024-12-01,alpha\n2,2024-12-02,beta\n")
+
+        status, rows = FormatConverter.convert_csv_to_parquet(
+            source_path=source,
+            target_path=tmp_path / "events.parquet",
+            column_names=["id", "event_date", "label"],
+            delimiter=",",
+            column_types=self._column_types(),
+            has_header=True,
+        )
+
+        assert status == ConversionStatus.SUCCESS, "typed conversion of a headered CSV must not fail"
+        assert rows == 2, f"header row must not be counted as data; got {rows} rows"
+
+    def test_header_row_is_not_ingested_as_data(self, tmp_path: Path):
+        """The literal header text must not survive into the converted table."""
+        pyarrow = pytest.importorskip("pyarrow")
+        pq = pytest.importorskip("pyarrow.parquet")
+        source = tmp_path / "events.csv"
+        source.write_text("id,event_date,label\n1,2024-12-01,alpha\n")
+        target = tmp_path / "events.parquet"
+
+        status, _ = FormatConverter.convert_csv_to_parquet(
+            source_path=source,
+            target_path=target,
+            column_names=["id", "event_date", "label"],
+            delimiter=",",
+            column_types=self._column_types(),
+            has_header=True,
+        )
+        assert status == ConversionStatus.SUCCESS
+
+        table = pq.read_table(target)
+        assert "label" not in table.column("label").to_pylist(), "header row leaked in as data"
+        assert pyarrow.types.is_date(table.schema.field("event_date").type), (
+            "event_date must keep its declared date type, not fall back to string"
+        )
+
+    def test_headerless_source_is_unchanged(self, tmp_path: Path):
+        """has_header=False (TPC .tbl and friends) must keep every row."""
+        pytest.importorskip("pyarrow")
+        source = tmp_path / "events.csv"
+        source.write_text("1,2024-12-01,alpha\n2,2024-12-02,beta\n")
+
+        status, rows = FormatConverter.convert_csv_to_parquet(
+            source_path=source,
+            target_path=tmp_path / "events.parquet",
+            column_names=["id", "event_date", "label"],
+            delimiter=",",
+            column_types=self._column_types(),
+            has_header=False,
+        )
+
+        assert status == ConversionStatus.SUCCESS
+        assert rows == 2, "a headerless source must not lose its first row"


### PR DESCRIPTION
`FormatConverter.convert_csv_to_parquet` passes the schema's column names to
`pyarrow.csv.ReadOptions(column_names=...)`. That REPLACES the header names but
does NOT skip the header LINE, so a headered CSV is parsed with its own header as
the first data row. With declared numeric/date column types the conversion then
fails outright:

    CSV conversion error to int64: invalid value 'day_of_week'
    Failed to convert flights, using source file

and the caller silently falls back to the RAW CSV — an untyped read where date
columns stay strings. Every downstream date filter then matches nothing, so the
DataFrame surface returns zero rows rather than erroring. The failure is invisible
without a second surface to compare against.

Headerless TPC `.tbl` is unaffected — it has no header — which is why this
survived: every benchmark gated so far is `.tbl` or headerless. It surfaced while
probing a FlightData cross-surface gate, whose CSVs carry headers: all 20 queries
diverged on both DataFrame backends. FlightData already declared
`csv_has_header = True`; the converter simply never received it.

`has_header` is now resolved from the benchmark beside the existing
`csv_delimiter` and threaded through `_convert_table_files`, setting
`skip_rows=1` only when a header is declared AND explicit column names are
supplied. The pass-through is gated on `format_type == "csv"` so `.tbl` stays
headerless regardless of the attribute. `DATAFRAME_CACHE_VERSION` goes v4 to v5:
caches built from the broken path are either a failed conversion or a Parquet
with the header embedded as data, so they must not be reused.

Pinned by three tests. Reverting only the `skip_rows` line fails the two headered
cases and leaves the headerless case passing, so the guard is provably
header-specific. Full DataFrame loader suite: 849 passed.
