### PR TITLE
fix: close merged PR review follow-up findings

### DIFF
--- a/_project/audits/todo-db-hosted-acceptance-2026-07-18.md
+++ b/_project/audits/todo-db-hosted-acceptance-2026-07-18.md
@@ -76,10 +76,10 @@ inside the transfer's `BEGIN IMMEDIATE` transaction).
 Recorded result (drifts as TODO/DONE files land):
 `imported: 1364  skipped: 0  warnings: 18`,
 `deps_resolved 539, deps_dangling 1`, stats `open` deferrals 629 — these
-reproduce exactly at this file's pinned SHA. The live run's row total,
-32,595 in 82 data batches / 44s wall via the Hrana bulk path (vs 4s
-local-SQLite control, vs ~2.5h projected for row-by-row delegation), came
-from the PR #1219 head tree; a replay at the pinned SHA yields 32,621
+reproduce exactly at this file's pinned SHA. The historical PR #1219 live
+measurement is separately bound to that exact head tree in
+[`todo-db-hosted-live-measurement-2026-07-18.md`](todo-db-hosted-live-measurement-2026-07-18.md).
+A replay at the pinned SHA yields 32,621
 rows (intervening TODO/DONE edits), and the hardened CLI reports pipeline
 requests (data batches + guard + commit), so a replay prints 84. Verify hosted == local by
 running the same import into a scratch local file

--- a/_project/audits/todo-db-hosted-live-measurement-2026-07-18.md
+++ b/_project/audits/todo-db-hosted-live-measurement-2026-07-18.md
@@ -1,0 +1,19 @@
+---
+develop_sha: 542590b66a0cec74280d863f4e9d5ea6e48a9f50
+measured_at_sha: 542590b66a0cec74280d863f4e9d5ea6e48a9f50
+measurement_scope: "PR #1219 head tree"
+---
+# Historical hosted TODO tracker measurement (2026-07-18)
+
+This record binds the live hosted-backend import totals to the exact PR #1219
+head tree that produced them. The later acceptance audit is based on a newer
+tree and therefore links here instead of attributing these counters to its
+own `measured_at_sha`.
+
+- Hosted import: **32,595 rows**, **82 data batches**, **44s wall** through the
+  Hrana bulk path.
+- The same run used a 4s local-SQLite control and compared the resulting
+  report and statistics.
+
+The live credentialed run is historical evidence only; this file does not
+claim that the hosted primary was re-run during the later audit replay.

--- a/_project/scripts/pr_review_followups.py
+++ b/_project/scripts/pr_review_followups.py
@@ -18,6 +18,7 @@ import datetime as dt
 import json
 import os
 import re
+import shutil
 import subprocess
 import sys
 import textwrap
@@ -718,6 +719,16 @@ def build_executor_prompt(
     return rendered.strip()
 
 
+def _executor_command() -> str:
+    """Return an executable command, including the Windows launcher suffix."""
+    if os.name != "nt":
+        return "codex"
+    resolved = shutil.which("codex")
+    if resolved is None:
+        raise FileNotFoundError("codex")
+    return resolved
+
+
 def check_executor_version(
     runner: CommandRunner, *, minimum: tuple[int, int, int] = MIN_EXECUTOR_VERSION
 ) -> tuple[int, int, int]:
@@ -729,14 +740,15 @@ def check_executor_version(
     fast instead of mid-loop with an opaque flag-not-recognized error.
     """
     try:
-        result = runner.run(["codex", "--version"])
+        command = _executor_command()
+        result = runner.run([command, "--version"])
     except FileNotFoundError as exc:
         raise RuntimeError(
             "Executor binary `codex` not found on PATH. Install codex-cli "
             f">= {'.'.join(str(p) for p in minimum)} (https://github.com/openai/codex)."
         ) from exc
     if result.returncode != 0:
-        raise CommandError(["codex", "--version"], result)
+        raise CommandError([command, "--version"], result)
     text = (result.stdout or result.stderr or "").strip()
     match = re.search(r"(\d+)\.(\d+)\.(\d+)", text)
     if not match:
@@ -766,7 +778,7 @@ def run_executor_for_comment(
     # syntax (`-c approval_policy=<mode>`) works across the supported version
     # range and is forward-stable.
     cmd = [
-        "codex",
+        _executor_command(),
         "exec",
         "--cd",
         str(runner.cwd),

--- a/_project/scripts/todo_db.py
+++ b/_project/scripts/todo_db.py
@@ -97,6 +97,14 @@ MIGRATIONS: dict[int, list[str]] = {
     4: todo_findings.finding_migration_v4_statements(),
 }
 
+# The migration builders are intentionally callable so the findings schema can
+# remain the single DDL source. Keep an explicit statement-count contract next
+# to the runtime map: a future helper cannot silently return an empty or
+# truncated migration without failing immediately at import time.
+MIGRATION_STATEMENT_COUNTS: dict[int, int] = {2: 3, 3: 6, 4: 8}
+if {revision: len(statements) for revision, statements in MIGRATIONS.items()} != MIGRATION_STATEMENT_COUNTS:
+    raise RuntimeError("MIGRATIONS do not match MIGRATION_STATEMENT_COUNTS")
+
 PRIORITIES = ("critical", "high", "medium-high", "medium", "low")
 STATES = ("planning", "active", "done", "dropped")
 # Legal item-state transitions; everything else is rejected.
@@ -2877,12 +2885,12 @@ def _export_substring_scan_verifications(item: dict) -> list[int]:
     return [ver["seq"] for ver in item["verifications"] if _EXPORT_SUBSTRING_SCAN_RE.search(ver.get("command") or "")]
 
 
-def lint_item_notes(conn: sqlite3.Connection, item_id: str) -> list[str]:
+def lint_item_notes(conn: sqlite3.Connection, item_id: str, *, item: dict[str, Any] | None = None) -> list[str]:
     """Advisory notes, not defects: policy skips that would otherwise be
     silent. A category exemption from the falsifiability check is author-
     selectable free text, so lint says when it applied - an exemption you
     can see is auditable, one you cannot is a hole."""
-    item = get_item(conn, item_id)
+    item = item if item is not None else get_item(conn, item_id)
     notes = []
     if (
         get_config(conn, "lint.require_falsifiable_rung") == "on"
@@ -2897,8 +2905,8 @@ def lint_item_notes(conn: sqlite3.Connection, item_id: str) -> list[str]:
     return notes
 
 
-def lint_item(conn: sqlite3.Connection, item_id: str) -> list[str]:
-    item = get_item(conn, item_id)
+def lint_item(conn: sqlite3.Connection, item_id: str, *, item: dict[str, Any] | None = None) -> list[str]:
+    item = item if item is not None else get_item(conn, item_id)
     findings = []
     if not item["verifications"]:
         findings.append("no verification steps recorded")
@@ -4224,13 +4232,14 @@ def _cmd_lint(conn, actor, args):
         raise TodoError("lint requires an item id or --all")
     total = 0
     for target in targets:
-        findings = lint_item(conn, target)
+        item = get_item(conn, target)
+        findings = lint_item(conn, target, item=item)
         total += len(findings)
         for finding in findings:
             print(f"{target}: {finding}")
         # Notes are advisory visibility, not defects: they neither count nor
         # affect the exit code.
-        for note in lint_item_notes(conn, target):
+        for note in lint_item_notes(conn, target, item=item):
             print(f"{target}: {note}")
     print(f"{total} finding(s) across {len(targets)} item(s)")
     return 1 if total else 0

--- a/_project/scripts/todo_schema_migration_check.py
+++ b/_project/scripts/todo_schema_migration_check.py
@@ -55,14 +55,43 @@ def _migration_revisions(module: ast.Module, source: Path) -> list[int]:
     raise SchemaMigrationError(f"{source}: missing MIGRATIONS assignment")
 
 
+def _migration_statement_counts(module: ast.Module, source: Path) -> dict[int, int]:
+    for node in module.body:
+        targets: list[ast.expr]
+        if isinstance(node, ast.Assign):
+            targets, value = node.targets, node.value
+        elif isinstance(node, ast.AnnAssign):
+            targets, value = [node.target], node.value
+        else:
+            continue
+        if not any(isinstance(target, ast.Name) and target.id == "MIGRATION_STATEMENT_COUNTS" for target in targets):
+            continue
+        if not isinstance(value, ast.Dict):
+            raise SchemaMigrationError(f"{source}: MIGRATION_STATEMENT_COUNTS must be a dict literal")
+        counts: dict[int, int] = {}
+        for key, count in zip(value.keys, value.values, strict=True):
+            if not isinstance(key, ast.Constant) or not isinstance(key.value, int):
+                raise SchemaMigrationError(f"{source}: every migration-count key must be an integer literal")
+            if not isinstance(count, ast.Constant) or not isinstance(count.value, int) or count.value <= 0:
+                raise SchemaMigrationError(f"{source}: migration {key.value} needs a positive statement count")
+            counts[key.value] = count.value
+        return counts
+    raise SchemaMigrationError(f"{source}: missing MIGRATION_STATEMENT_COUNTS assignment")
+
+
 def validate_contract(*, tracker: Path, wrapper: Path, inventory: Path) -> None:
     module = ast.parse(tracker.read_text(encoding="utf-8"), filename=str(tracker))
     schema_version = _integer_assignment(module, "SCHEMA_VERSION", tracker)
     revisions = _migration_revisions(module, tracker)
+    statement_counts = _migration_statement_counts(module, tracker)
     expected_revisions = list(range(2, schema_version + 1))
     if revisions != expected_revisions:
         raise SchemaMigrationError(
             f"{tracker}: migration revisions {revisions!r} must be ordered and contiguous {expected_revisions!r}"
+        )
+    if list(statement_counts) != revisions:
+        raise SchemaMigrationError(
+            f"{tracker}: migration statement counts {list(statement_counts)!r} must match revisions {revisions!r}"
         )
 
     wrapper_text = wrapper.read_text(encoding="utf-8")
@@ -99,6 +128,12 @@ def validate_contract(*, tracker: Path, wrapper: Path, inventory: Path) -> None:
         for field in ("summary", "deployment_order"):
             if not isinstance(entry.get(field), str) or not entry[field].strip():
                 raise SchemaMigrationError(f"{inventory}: revision {revision} needs non-empty {field}")
+        expected_count = statement_counts[revision]
+        if entry.get("statement_count") != expected_count:
+            raise SchemaMigrationError(
+                f"{inventory}: revision {revision} statement_count={entry.get('statement_count')!r} "
+                f"does not match runtime contract {expected_count}"
+            )
     current = entries[-1]
     evidence = current.get("deployment_evidence")
     if not isinstance(evidence, str) or not evidence.strip():

--- a/_project/todo-schema-migrations.json
+++ b/_project/todo-schema-migrations.json
@@ -3,16 +3,19 @@
   "migrations": [
     {
       "revision": 2,
+      "statement_count": 3,
       "summary": "Add work-unit execution provenance columns",
       "deployment_order": "Migration code shipped before or with the schema-revision consumer."
     },
     {
       "revision": 3,
+      "statement_count": 6,
       "summary": "Add the findings domain",
       "deployment_order": "Migration code shipped before or with the schema-revision consumer."
     },
     {
       "revision": 4,
+      "statement_count": 8,
       "summary": "Preserve legacy finding capture fields and deferrable item links",
       "deployment_order": "The hosted primary was migrated to revision 4 before revision-4-only tracker writes resumed.",
       "deployment_evidence": "_project/decisions/todo-db-cutover-write-freeze-2026-08-01.md"

--- a/benchbox/core/results/anonymization.py
+++ b/benchbox/core/results/anonymization.py
@@ -325,6 +325,60 @@ class AnonymizationManager:
         """
         return self._anonymize_public_value(payload, ())
 
+    def anonymize_tuning_payload(self, payload: dict[str, Any]) -> dict[str, Any]:
+        """Anonymize a tuning companion while preserving its safe provenance.
+
+        Tuning payloads use table names as mapping keys and column names under
+        a generic ``name`` key, so the generic payload walker cannot identify
+        those identifiers. ``source_file`` is already normalized to a
+        repository-relative/template reference by the capture path and is a
+        public provenance field, so it must not be path-hashed here.
+        """
+        source_file = payload.get("source_file")
+        working = dict(payload)
+        working.pop("source_file", None)
+
+        requested = working.get("requested")
+        table_tunings = None
+        if isinstance(requested, dict):
+            requested = dict(requested)
+            table_tunings = requested.pop("table_tunings", None)
+            working["requested"] = requested
+
+        anonymized = self.anonymize_result_payload(working)
+        if source_file is not None:
+            anonymized["source_file"] = source_file
+        if table_tunings is not None:
+            anonymized_requested = anonymized.setdefault("requested", {})
+            if isinstance(anonymized_requested, dict):
+                anonymized_requested["table_tunings"] = self._anonymize_tuning_table_tunings(table_tunings)
+        return anonymized
+
+    def _anonymize_tuning_table_tunings(self, value: Any) -> Any:
+        if isinstance(value, dict):
+            return {
+                self._hash_public_identifier(str(key), "table"): self._anonymize_tuning_value(child)
+                for key, child in value.items()
+            }
+        return self._anonymize_tuning_value(value)
+
+    def _anonymize_tuning_value(self, value: Any) -> Any:
+        if isinstance(value, dict):
+            anonymized: dict[str, Any] = {}
+            for key, child in value.items():
+                if key in {"table", "table_name"}:
+                    anonymized[key] = self._hash_public_identifier(str(child), "table")
+                elif key in {"column", "column_name", "name"}:
+                    anonymized[key] = self._hash_public_identifier(str(child), "column")
+                else:
+                    anonymized[key] = self._anonymize_tuning_value(child)
+            return anonymized
+        if isinstance(value, list):
+            return [self._anonymize_tuning_value(item) for item in value]
+        if isinstance(value, tuple):
+            return [self._anonymize_tuning_value(item) for item in value]
+        return value
+
     def _anonymize_public_value(self, value: Any, key_path: tuple[str, ...]) -> Any:
         if isinstance(value, dict):
             anonymized: dict[str, Any] = {}
@@ -335,6 +389,12 @@ class AnonymizationManager:
                 else:
                     anonymized[key] = self._anonymize_public_value(child, child_path)
             return anonymized
+
+        if isinstance(value, (set, frozenset)):
+            # Set iteration depends on PYTHONHASHSEED. Sort by the stable
+            # scalar representation before recursing so canonical JSON is
+            # reproducible across processes.
+            value = sorted(value, key=repr)
 
         if isinstance(value, (list, tuple, set, frozenset)):
             # Tuples/sets serialize as JSON arrays; recursing as a list keeps

--- a/benchbox/core/results/environment.py
+++ b/benchbox/core/results/environment.py
@@ -7,6 +7,8 @@ from dataclasses import asdict, dataclass, field, is_dataclass
 from typing import Any, Literal, TypeAlias
 from urllib.parse import urlparse
 
+from benchbox.core.results.platform_options import sanitize_platform_options
+
 MetadataSource: TypeAlias = Literal[
     "registered_default",
     "saved_config",
@@ -265,6 +267,7 @@ def build_platform_metadata_payload(
     storage: PlatformStorageMetadata | Mapping[str, Any] | None,
     raw_config: Mapping[str, Any] | None,
     raw_metadata: Mapping[str, Any] | None,
+    sanitize_raw_config: bool = True,
 ) -> dict[str, Any]:
     """Build normalized ``platform`` metadata blocks with conservative defaults."""
     default_deployment = _default_deployment_metadata(platform_info or {}, platform_config or {})
@@ -274,7 +277,12 @@ def build_platform_metadata_payload(
         "compute": _metadata_dict(compute) or PlatformComputeMetadata().to_dict(),
         "storage": _metadata_dict(storage) or PlatformStorageMetadata().to_dict(),
     }
+    # ``raw_config`` may come from an adapter-specific hook rather than the
+    # normalized platform config fallback. Keep this as the public export
+    # boundary so every selected source receives the same structural filtering.
     raw_config_payload = _metadata_dict(raw_config)
+    if sanitize_raw_config:
+        raw_config_payload = sanitize_platform_options(raw_config_payload)
     if raw_config_payload:
         payload["raw_config"] = raw_config_payload
     raw_metadata_payload = _metadata_dict(raw_metadata)

--- a/benchbox/core/results/exporter.py
+++ b/benchbox/core/results/exporter.py
@@ -248,7 +248,7 @@ class ResultExporter:
     def _export_json_v2(self, result: ResultLike, filename_base: str) -> Path:
         """Export result to JSON using schema v2.0 with companion files."""
         # Build primary payload
-        payload = build_result_payload(result)
+        payload = build_result_payload(result, sanitize_platform_secrets=self.anonymize)
 
         # Apply anonymization if enabled
         if self.anonymize and self.anonymization_manager:
@@ -301,7 +301,7 @@ class ResultExporter:
         # Tuning companion file
         tuning_payload = build_tuning_payload(result)
         if tuning_payload and self.anonymize and self.anonymization_manager:
-            tuning_payload = self.anonymization_manager.anonymize_result_payload(tuning_payload)
+            tuning_payload = self.anonymization_manager.anonymize_tuning_payload(tuning_payload)
         if tuning_payload:
             tuning_path = self._create_file_path(f"{filename_base}.tuning.json")
             self._write_file(tuning_path, canonical_json_text(tuning_payload))

--- a/benchbox/core/results/schema.py
+++ b/benchbox/core/results/schema.py
@@ -210,7 +210,7 @@ class SchemaV2Validator:
             raise SchemaV2ValidationError(f"schema v2.0 payload contains unexpected keys: {sorted(unexpected)}")
 
 
-def build_result_payload(result: BenchmarkResults) -> dict[str, Any]:
+def build_result_payload(result: BenchmarkResults, *, sanitize_platform_secrets: bool = True) -> dict[str, Any]:
     """Build v2.0 result payload from BenchmarkResults.
 
     Args:
@@ -240,7 +240,7 @@ def build_result_payload(result: BenchmarkResults) -> dict[str, Any]:
     run = _build_run_section(result, query_times_ms, iterations_set, streams_set)
     benchmark = _build_benchmark_section(result)
     driver_metadata = _collect_driver_metadata(result)
-    platform = _build_platform_section(result, driver_metadata)
+    platform = _build_platform_section(result, driver_metadata, sanitize_platform_secrets=sanitize_platform_secrets)
 
     # Build environment block
     environment = _build_environment_block(result)
@@ -509,7 +509,12 @@ def _dataset_identity_fields(result: BenchmarkResults) -> dict[str, str]:
     }
 
 
-def _build_platform_section(result: BenchmarkResults, driver_metadata: dict[str, Any]) -> dict[str, Any]:
+def _build_platform_section(
+    result: BenchmarkResults,
+    driver_metadata: dict[str, Any],
+    *,
+    sanitize_platform_secrets: bool = True,
+) -> dict[str, Any]:
     """Build the platform block of the payload."""
     platform_name = str(result.platform).replace(" (DataFrame)", "")
     platform: dict[str, Any] = {"name": platform_name}
@@ -542,6 +547,7 @@ def _build_platform_section(result: BenchmarkResults, driver_metadata: dict[str,
                 if getattr(result, "platform_raw_metadata", None) is not None
                 else getattr(result, "platform_metadata", None)
             ),
+            sanitize_raw_config=sanitize_platform_secrets,
         )
     )
 

--- a/benchbox/platforms/snowflake.py
+++ b/benchbox/platforms/snowflake.py
@@ -1722,7 +1722,7 @@ class SnowflakeAdapter(PlatformAdapter):
                 # Check current clustering key
                 cursor.execute(
                     """
-                        SELECT CLUSTERING_KEY
+                        SELECT CLUSTERING_KEY, AUTO_CLUSTERING_ON
                         FROM INFORMATION_SCHEMA.TABLES
                         WHERE TABLE_SCHEMA = %s
                         AND TABLE_NAME = %s
@@ -1731,11 +1731,22 @@ class SnowflakeAdapter(PlatformAdapter):
                 )
                 result = cursor.fetchone()
                 current_clustering = result[0] if result and result[0] else None
+                automatic_clustering_value = result[1] if result and len(result) > 1 else None
+                automatic_clustering_on = automatic_clustering_value is True or str(
+                    automatic_clustering_value
+                ).strip().upper() in {
+                    "ON",
+                    "TRUE",
+                    "1",
+                }
 
                 desired_clustering = f"({', '.join(clustering_columns)})"
                 cluster_sql = f"ALTER TABLE {table_name} CLUSTER BY ({', '.join(clustering_columns)})"
 
-                if parse_clustering_key(current_clustering) != parse_clustering_key(desired_clustering):
+                clustering_matches = parse_clustering_key(current_clustering) == parse_clustering_key(
+                    desired_clustering
+                )
+                if not clustering_matches:
                     # Apply clustering key
                     try:
                         cursor.execute(cluster_sql)
@@ -1756,6 +1767,16 @@ class SnowflakeAdapter(PlatformAdapter):
                     ledger = getattr(self, "_applied_tuning_ledger", None)
                     if ledger is not None:
                         ledger.record_dropped(cluster_sql, "already present in Snowflake catalog; ALTER skipped")
+
+                    # A reused table can have the right key while Automatic
+                    # Clustering is suspended. The key check and maintenance
+                    # state are independent catalog facts.
+                    if len(clustering_columns) <= 4 and not automatic_clustering_on:
+                        try:
+                            cursor.execute(f"ALTER TABLE {table_name} RESUME RECLUSTER")
+                            self.logger.info(f"Enabled automatic clustering for {table_name}")
+                        except Exception as e:
+                            self.logger.debug(f"Could not enable automatic clustering for {table_name}: {e}")
 
             # Handle sorting - in Snowflake, this is achieved through clustering
             sort_columns = table_tuning.get_columns_by_type(TuningType.SORTING)

--- a/docs/development/tuning-introspection-receipts.md
+++ b/docs/development/tuning-introspection-receipts.md
@@ -145,8 +145,10 @@ that itself reaches the cap remains explicitly truncated.
   DuckDB sorting is verification-eligible end to end. The initial tuned
   `CREATE INDEX` is dropped by the loader's
   `CREATE OR REPLACE TABLE ... ORDER BY` CTAS, so
-  `DuckDBAdapter.apply_ctas_sort` re-creates that same generator-rendered
-  index after CTAS. `_record_sort_index_layout_op` records the successful or
+  `DuckDBAdapter.apply_ctas_sort` re-creates that same index after CTAS using
+  the shared `_duckdb_sort_index_sql` helper (the generator renders the CTAS
+  `ORDER BY`, not this index statement). `_record_sort_index_layout_op` records
+  the successful or
   failed re-creation as a `post_load` layout operation, and
   `PlatformAdapter._fold_layout_operations_into_ledger` folds it into the
   ledger before corroboration. The live full-flow test
@@ -168,9 +170,9 @@ that itself reaches the cap remains explicitly truncated.
   non-blocking maintenance statement. This is intentionally weaker than the
   ClickHouse receipt, whose CREATE-time sorting and partition keys describe the
   physical MergeTree layout. When a reused Snowflake table already has the
-  requested key, the adapter skips both ALTER and RESUME and records the intent
-  as dropped/already-present; that current run therefore stays fail-closed
-  rather than claiming it physically applied the pre-existing layout.
+  requested key, the adapter skips ALTER, records the intent as
+  dropped/already-present, and separately reads `AUTO_CLUSTERING_ON` to resume
+  maintenance when it is suspended.
 
 - **ClickHouse** (`benchbox/platforms/clickhouse/introspection.py`): reads
   `system.tables` (`name` / `sorting_key` / `partition_key` -- structured

--- a/tests/unit/core/results/test_anonymization.py
+++ b/tests/unit/core/results/test_anonymization.py
@@ -843,6 +843,38 @@ class TestPublicPayloadTupleRecursion:
         )["platform_metadata"]["platform_raw_config"]
         assert out[0]["username"].startswith("user_")
 
+    def test_unordered_collections_are_sorted_before_export(self):
+        out = AnonymizationManager().anonymize_result_payload(
+            {"platform_metadata": {"values": frozenset({"zeta", "alpha"})}}
+        )
+
+        assert out["platform_metadata"]["values"] == ["alpha", "zeta"]
+
+
+class TestTuningPayloadAnonymization:
+    def test_table_and_column_identifiers_are_pseudonymized_but_source_is_preserved(self):
+        manager = AnonymizationManager()
+        out = manager.anonymize_tuning_payload(
+            {
+                "source_file": "examples/tunings/custom.yaml:0123456789abcdef",
+                "requested": {
+                    "table_tunings": {
+                        "lineitem": {
+                            "table_name": "lineitem",
+                            "sorting": [{"name": "l_orderkey", "order": 1}],
+                        }
+                    }
+                },
+            }
+        )
+
+        tuning = out["requested"]["table_tunings"]
+        table_key = next(iter(tuning))
+        assert table_key.startswith("table_")
+        assert tuning[table_key]["table_name"].startswith("table_")
+        assert tuning[table_key]["sorting"][0]["name"].startswith("column_")
+        assert out["source_file"] == "examples/tunings/custom.yaml:0123456789abcdef"
+
 
 class TestPublicPayloadWorkspaceRoleAndApplicationIds:
     """Near-miss variants of covered identifier keys are the recurring leak

--- a/tests/unit/core/results/test_platform_config_secret_filtering.py
+++ b/tests/unit/core/results/test_platform_config_secret_filtering.py
@@ -12,6 +12,7 @@ import json
 
 import pytest
 
+from benchbox.core.results.environment import build_platform_metadata_payload
 from benchbox.core.results.platform_options import REDACTED_VALUE
 from benchbox.core.results.schema import _extract_platform_config
 
@@ -38,6 +39,21 @@ class TestExtractPlatformConfigFiltering:
 
 
 class TestResultsDbMetadataFiltering:
+    def test_explicit_raw_config_is_filtered_at_metadata_boundary(self):
+        payload = build_platform_metadata_payload(
+            platform_info=None,
+            platform_config=None,
+            deployment=None,
+            cloud=None,
+            compute=None,
+            storage=None,
+            raw_config={"password": "RAW-PASSWORD-SENTINEL", "threads": 4},
+            raw_metadata=None,
+        )
+
+        assert payload["raw_config"]["password"] == REDACTED_VALUE
+        assert payload["raw_config"]["threads"] == 4
+
     def test_platform_info_secret_never_reaches_metadata_json(self, tmp_path):
         from datetime import datetime
 

--- a/tests/unit/core/results/test_tuning_provenance_export.py
+++ b/tests/unit/core/results/test_tuning_provenance_export.py
@@ -16,6 +16,7 @@ from datetime import datetime
 
 import pytest
 
+from benchbox.core.results.exporter import ResultExporter
 from benchbox.core.results.models import BenchmarkResults
 from benchbox.core.results.schema import (
     build_applied_ledger_payload,
@@ -244,6 +245,27 @@ def test_no_absolute_paths_anywhere_in_emitted_bundle_or_companion():
         assert "/Users/" not in text
         assert "/root/" not in text
         assert "C:\\\\" not in text
+
+
+def test_anonymized_tuning_companion_hides_identifiers_and_preserves_source(tmp_path):
+    config = _tuned_config()
+    result = _make_result(
+        tunings_applied=config.to_dict(),
+        tuning_source="explicit_file",
+        tuning_source_file="examples/tunings/custom.yaml:0123456789abcdef",
+        tuning_config_hash=config.get_configuration_hash(),
+    )
+
+    exporter = ResultExporter(output_dir=tmp_path, anonymize=True)
+    exporter._write_companion_files(result, "run-1")
+    payload = json.loads((tmp_path / "run-1.tuning.json").read_text(encoding="utf-8"))
+
+    table_tunings = payload["requested"]["table_tunings"]
+    table_key = next(iter(table_tunings))
+    assert table_key.startswith("table_")
+    assert table_tunings[table_key]["table_name"].startswith("table_")
+    assert table_tunings[table_key]["sorting"][0]["name"].startswith("column_")
+    assert payload["source_file"] == "examples/tunings/custom.yaml:0123456789abcdef"
 
 
 def test_requested_block_reports_platform_optimizations_non_defaults_only():

--- a/tests/unit/platforms/test_snowflake_adapter_coverage.py
+++ b/tests/unit/platforms/test_snowflake_adapter_coverage.py
@@ -1050,6 +1050,19 @@ class TestApplyTableTunings:
         alter_sqls = [s for s in all_sqls if "ALTER TABLE" in s.upper() and "CLUSTER BY" in s.upper()]
         assert len(alter_sqls) == 0
 
+    def test_resumes_reclustering_when_matching_key_is_suspended(self):
+        adapter = _make_adapter()
+        mock_conn = Mock()
+        mock_cursor = Mock()
+        mock_conn.cursor.return_value = mock_cursor
+        mock_cursor.fetchone.return_value = ("(o_orderdate)", "OFF")
+
+        tuning = self._make_tuning(table_name="ORDERS", cluster_cols=[self._make_col("o_orderdate")])
+        adapter.apply_table_tunings(tuning, mock_conn)
+
+        all_sqls = [call.args[0] for call in mock_cursor.execute.call_args_list]
+        assert "ALTER TABLE ORDERS RESUME RECLUSTER" in all_sqls
+
     def test_linear_catalog_form_skips_alter_and_records_dropped_intent(self):
         adapter = _make_adapter()
         adapter._applied_tuning_ledger = AppliedTuningLedger()

--- a/tests/unit/scripts/test_pr_review_followups.py
+++ b/tests/unit/scripts/test_pr_review_followups.py
@@ -150,7 +150,7 @@ def test_fake_codex_launcher_resolves_from_path_and_reports_version(monkeypatch,
 
     assert resolved is not None
     assert Path(resolved).resolve() == launcher.resolve()
-    completed = subprocess.run(["codex", "--version"], check=False, capture_output=True, text=True)
+    completed = subprocess.run([str(resolved), "--version"], check=False, capture_output=True, text=True)
     assert completed.returncode == 0
     assert completed.stdout.strip() == "codex-cli 0.128.0"
 

--- a/tests/unit/scripts/test_todo_db_v2.py
+++ b/tests/unit/scripts/test_todo_db_v2.py
@@ -698,12 +698,22 @@ class TestLintExemptionVisibility:
         assert any("falsifiability" in f for f in todo_db.lint_item(conn, "normal-cat"))
         assert todo_db.lint_item_notes(conn, "normal-cat") == []
 
-    def test_exemption_note_does_not_affect_exit_code(self, conn, capsys):
+    def test_exemption_note_does_not_affect_exit_code(self, conn, capsys, monkeypatch):
         self._mk_exempt(conn, "flake-exit", "flake")
+        original_get_item = todo_db.get_item
+        calls = 0
+
+        def counted_get_item(connection, item_id):
+            nonlocal calls
+            calls += 1
+            return original_get_item(connection, item_id)
+
+        monkeypatch.setattr(todo_db, "get_item", counted_get_item)
         rc = todo_db._cmd_lint(conn, "tester", SimpleNamespace(id="flake-exit", all=False))
         out = capsys.readouterr().out
         assert "exempt" in out
         assert rc == 0
+        assert calls == 1
 
 
 class TestLintFalsifiabilityAndScopeCompleteness:

--- a/tests/unit/scripts/test_todo_schema_migration_check.py
+++ b/tests/unit/scripts/test_todo_schema_migration_check.py
@@ -38,7 +38,11 @@ def test_todo_schema_migration_contract_is_current() -> None:
 
 def test_todo_schema_migration_contract_rejects_cli_bump_without_migration(tmp_path: Path) -> None:
     tracker = tmp_path / "todo_db.py"
-    tracker.write_text("SCHEMA_VERSION = 5\nMIGRATIONS = {2: ['a'], 3: ['b'], 4: ['c']}\n", encoding="utf-8")
+    tracker.write_text(
+        "SCHEMA_VERSION = 5\nMIGRATIONS = {2: ['a'], 3: ['b'], 4: ['c']}\n"
+        "MIGRATION_STATEMENT_COUNTS = {2: 1, 3: 1, 4: 1}\n",
+        encoding="utf-8",
+    )
     paths = _contract_paths()
     with pytest.raises(todo_schema_migration_check.SchemaMigrationError, match="contiguous"):
         todo_schema_migration_check.validate_contract(
@@ -65,6 +69,33 @@ def test_todo_schema_migration_contract_requires_current_deployment_evidence(tmp
     with pytest.raises(todo_schema_migration_check.SchemaMigrationError, match="deployment_evidence"):
         todo_schema_migration_check.validate_contract(
             tracker=paths["tracker"], wrapper=paths["wrapper"], inventory=inventory
+        )
+
+
+def test_todo_schema_migration_contract_requires_statement_count_inventory(tmp_path: Path) -> None:
+    inventory = tmp_path / "migrations.json"
+    record = json.loads(_contract_paths()["inventory"].read_text(encoding="utf-8"))
+    record["migrations"][-1].pop("statement_count")
+    inventory.write_text(json.dumps(record), encoding="utf-8")
+    paths = _contract_paths()
+
+    with pytest.raises(todo_schema_migration_check.SchemaMigrationError, match="statement_count"):
+        todo_schema_migration_check.validate_contract(
+            tracker=paths["tracker"], wrapper=paths["wrapper"], inventory=inventory
+        )
+
+
+def test_todo_schema_migration_contract_requires_static_count_contract(tmp_path: Path) -> None:
+    tracker = tmp_path / "todo_db.py"
+    tracker.write_text(
+        "SCHEMA_VERSION = 2\nMIGRATIONS = {2: build_migration()}\n",
+        encoding="utf-8",
+    )
+    paths = _contract_paths()
+
+    with pytest.raises(todo_schema_migration_check.SchemaMigrationError, match="MIGRATION_STATEMENT_COUNTS"):
+        todo_schema_migration_check.validate_contract(
+            tracker=tracker, wrapper=paths["wrapper"], inventory=paths["inventory"]
         )
 
 


### PR DESCRIPTION
## Summary

Closes actionable findings from the merged-PR review sweep across the latest 30 merged PRs.

### Included fixes

- Sanitize selected raw platform configuration at the public export boundary while preserving the explicit private-export contract.
- Anonymize tuning table/column identifiers, preserve normalized tuning source references, and make unordered payload collections deterministic.
- Reuse the fetched TODO item during lint and add a runtime/static migration statement-count contract.
- Resume Snowflake automatic clustering independently when the requested clustering key already matches but maintenance is suspended.
- Correct the DuckDB renderer documentation and resolve the Windows Codex launcher before subprocess execution.
- Bind the historical hosted measurement counters to the PR #1219 head tree.

### Out of scope

- The historical TODO evaluation arm-tree provenance finding requires reconstruction of ephemeral worktrees that are no longer available.
- The migration deployment-evidence finding requires separate live hosted-primary evidence; no deployment claim is fabricated.
- The two #1418 findings are already addressed by open PR #1434.

### Verification

- `uv run -- python -m pytest tests/unit/ -x -q`: 26204 passed, 13 skipped, 4 subtests passed.
- Focused regression suite: 330 passed.
- `uv run -- ruff check .` and `uv run -- ruff format --check .`: passed.
- Migration contract, audit SHA, commit hooks, marker guard, and push-time preflight: passed.