### PR TITLE
feat(mcp): add stateless HTTP transport

### DIFF
--- a/benchbox/mcp/__init__.py
+++ b/benchbox/mcp/__init__.py
@@ -60,6 +60,8 @@ except ImportError as e:
         "  uv add benchbox --extra mcp  # uv project"
     ) from e
 
+from benchbox.mcp.transport import MCPTransport
+
 # Lazy imports to avoid circular dependencies
 __all__ = [
     "create_server",
@@ -107,6 +109,10 @@ def run_server(
     charts_dir: str | Path | None = None,
     log_level: str | int | None = None,
     env: Mapping[str, str] | None = None,
+    transport: MCPTransport = "stdio",
+    host: str = "127.0.0.1",
+    port: int = 8000,
+    streamable_http_path: str = "/mcp",
 ) -> None:
     """Run the BenchBox MCP server.
 
@@ -114,13 +120,21 @@ def run_server(
     - `benchbox-mcp` CLI command
     - `python -m benchbox.mcp`
     """
+    from benchbox.mcp.transport import MCPTransportSettings, run_transport
+
+    transport_settings = MCPTransportSettings(
+        transport=transport,
+        host=host,
+        port=port,
+        streamable_http_path=streamable_http_path,
+    )
     server = create_server(
         results_dir=results_dir,
         charts_dir=charts_dir,
         log_level=log_level,
         env=env,
     )
-    server.run()
+    run_transport(server, transport_settings)
 
 
 # Lazy-loaded exports for error handling

--- a/benchbox/mcp/cli.py
+++ b/benchbox/mcp/cli.py
@@ -10,6 +10,14 @@ from benchbox.core.runtime_paths import resolve_runtime_paths
 from benchbox.mcp import run_server
 
 
+def _http_port(value: str) -> int:
+    """Parse an HTTP port with an argparse-friendly error."""
+    port = int(value)
+    if not 1 <= port <= 65535:
+        raise argparse.ArgumentTypeError("port must be between 1 and 65535")
+    return port
+
+
 def build_parser() -> argparse.ArgumentParser:
     """Build parser for MCP server startup options."""
     parser = argparse.ArgumentParser(
@@ -36,6 +44,28 @@ def build_parser() -> argparse.ArgumentParser:
         "--log-level",
         help="Logging level (e.g., DEBUG, INFO, WARNING). Falls back to BENCHBOX_LOG_LEVEL.",
     )
+    parser.add_argument(
+        "--transport",
+        choices=("stdio", "streamable-http"),
+        default="stdio",
+        help="MCP transport (default: stdio; Streamable HTTP is localhost-only).",
+    )
+    parser.add_argument(
+        "--host",
+        default="127.0.0.1",
+        help="Streamable HTTP bind host (loopback interfaces only; default: 127.0.0.1).",
+    )
+    parser.add_argument(
+        "--port",
+        type=_http_port,
+        default=8000,
+        help="Streamable HTTP bind port (default: 8000).",
+    )
+    parser.add_argument(
+        "--streamable-http-path",
+        default="/mcp",
+        help="Streamable HTTP endpoint path (default: /mcp).",
+    )
     return parser
 
 
@@ -58,4 +88,8 @@ def main(argv: Sequence[str] | None = None) -> None:
         charts_dir=runtime_paths.charts_dir,
         log_level=args.log_level,
         env=os.environ,
+        transport=args.transport,
+        host=args.host,
+        port=args.port,
+        streamable_http_path=args.streamable_http_path,
     )

--- a/benchbox/mcp/transport.py
+++ b/benchbox/mcp/transport.py
@@ -1,0 +1,68 @@
+"""Transport configuration for the BenchBox MCP server."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Literal
+
+from mcp.server.mcpserver import MCPServer
+from mcp.server.transport_security import TransportSecuritySettings
+
+MCPTransport = Literal["stdio", "streamable-http"]
+
+
+def is_supported_loopback_host(host: str) -> bool:
+    """Return whether *host* is a loopback spelling protected by the SDK policy."""
+    return host.strip().lower() in {"127.0.0.1", "localhost", "::1"}
+
+
+@dataclass(frozen=True, slots=True)
+class MCPTransportSettings:
+    """Validated startup settings for stdio or localhost Streamable HTTP."""
+
+    transport: MCPTransport = "stdio"
+    host: str = "127.0.0.1"
+    port: int = 8000
+    streamable_http_path: str = "/mcp"
+
+    def __post_init__(self) -> None:
+        if self.transport not in ("stdio", "streamable-http"):
+            raise ValueError(f"Unsupported MCP transport: {self.transport}")
+        if not 1 <= self.port <= 65535:
+            raise ValueError("MCP HTTP port must be between 1 and 65535")
+        if not self.streamable_http_path.startswith("/"):
+            raise ValueError("MCP Streamable HTTP path must start with '/'")
+        if self.transport == "streamable-http" and not is_supported_loopback_host(self.host):
+            raise ValueError(
+                "MCP Streamable HTTP currently supports loopback hosts only; "
+                "remote binding requires the authentication and tenancy controls"
+            )
+        if self.transport == "streamable-http":
+            object.__setattr__(self, "host", self.host.strip().lower())
+
+
+def run_transport(server: MCPServer, settings: MCPTransportSettings) -> None:
+    """Run *server* through the SDK-owned transport implementation."""
+    if settings.transport == "stdio":
+        server.run(transport="stdio")
+        return
+
+    server.run(
+        transport="streamable-http",
+        host=settings.host,
+        port=settings.port,
+        streamable_http_path=settings.streamable_http_path,
+        # Modern MCP is sessionless by construction. This flag also keeps the
+        # supported handshake-era HTTP leg stateless between requests.
+        stateless_http=True,
+        # Keep the SDK's streaming-capable response mode for progress and
+        # future request-scoped notifications.
+        json_response=False,
+        # Pass this explicitly for every accepted loopback address. The SDK's
+        # automatic policy covers only its three canonical host spellings.
+        transport_security=TransportSecuritySettings(
+            enable_dns_rebinding_protection=True,
+            allowed_hosts=["127.0.0.1:*", "localhost:*", "[::1]:*"],
+            allowed_origins=["http://127.0.0.1:*", "http://localhost:*", "http://[::1]:*"],
+        ),
+    )

--- a/docs/reference/mcp.md
+++ b/docs/reference/mcp.md
@@ -28,9 +28,30 @@ benchbox-mcp
 
 # With explicit MCP path overrides
 benchbox-mcp --results-dir /tmp/benchbox-results --charts-dir /tmp/benchbox-charts
+
+# Opt in to localhost Streamable HTTP
+benchbox-mcp --transport streamable-http
 ```
 
-The server communicates via stdio using JSON-RPC, compatible with Claude Code and other MCP clients.
+The default server communicates via stdio using JSON-RPC, compatible with
+Claude Code and other local MCP clients. Streamable HTTP is an explicit
+localhost-only option at `http://127.0.0.1:8000/mcp`.
+
+```json
+{
+  "mcpServers": {
+    "benchbox": {
+      "type": "streamable-http",
+      "url": "http://127.0.0.1:8000/mcp"
+    }
+  }
+}
+```
+
+Do not expose this endpoint through a public bind, port forward, or reverse
+proxy. Until the remote-security work lands, BenchBox rejects non-loopback
+hosts because stateless transport does not provide authentication,
+authorization, tenant isolation, quotas, or admission control.
 
 ### SDK Compatibility
 
@@ -40,6 +61,14 @@ The v2 migration preserves the public stdio contract: 12 tools, 4 static
 resources, 2 resource templates, and 7 prompts. Tool names, input schemas,
 annotations, resource URIs, prompt schemas, and handler behavior are unchanged;
 only Python-side SDK model attributes use the v2 snake-case names.
+
+Streamable HTTP supports modern MCP `2026-07-28` as a sessionless protocol:
+each request can reach any server process and no `Mcp-Session-Id` is issued.
+The same endpoint retains the SDK's stateless compatibility path for supported
+handshake-era clients. Protocol discovery, version negotiation, headers, and
+DNS-rebinding checks are provided by the MCP SDK rather than reimplemented by
+BenchBox. Responses remain streaming-capable; JSON-only mode is intentionally
+disabled so progress and future request-scoped notifications remain possible.
 
 ### Testing Locally
 
@@ -77,6 +106,10 @@ The inspector provides a web UI to browse tools, test calls, and view responses.
 | `--results-dir` | Results root used by MCP result reads/writes |
 | `--charts-dir` | Charts root used by MCP visualization paths |
 | `--log-level` | Logging level (DEBUG, INFO, WARNING, ERROR) |
+| `--transport` | `stdio` (default) or opt-in `streamable-http` |
+| `--host` | Streamable HTTP bind host; loopback interfaces only (default `127.0.0.1`) |
+| `--port` | Streamable HTTP bind port (default `8000`) |
+| `--streamable-http-path` | Streamable HTTP endpoint path (default `/mcp`) |
 
 **Environment variables**
 
@@ -98,6 +131,16 @@ Example:
 
 ```bash
 BENCHBOX_RESULTS_DIR=/tmp/results BENCHBOX_LOG_LEVEL=DEBUG benchbox-mcp
+```
+
+Additional localhost examples:
+
+```bash
+# IPv4 loopback with a custom port and path
+benchbox-mcp --transport streamable-http --port 8765 --streamable-http-path /benchbox-mcp
+
+# IPv6 loopback
+benchbox-mcp --transport streamable-http --host ::1
 ```
 
 ## Tools

--- a/tests/integration/mcp/__init__.py
+++ b/tests/integration/mcp/__init__.py
@@ -1,0 +1,1 @@
+"""MCP transport integration tests."""

--- a/tests/integration/mcp/_transport.py
+++ b/tests/integration/mcp/_transport.py
@@ -1,0 +1,51 @@
+"""Shared supported-API transport fixtures for MCP integration tests."""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
+from pathlib import Path
+
+import httpx2
+from mcp.client import Client
+from mcp.client.streamable_http import streamable_http_client
+
+from benchbox.mcp import create_server
+
+
+@asynccontextmanager
+async def http_client(
+    tmp_path: Path,
+    *,
+    mode: str,
+    request_headers: list[dict[str, str]],
+    response_headers: list[dict[str, str]],
+) -> AsyncIterator[Client]:
+    """Yield an SDK client connected to the in-process HTTP transport."""
+    server = create_server(results_dir=tmp_path / "results", charts_dir=tmp_path / "charts")
+    app = server.streamable_http_app(
+        host="127.0.0.1",
+        streamable_http_path="/mcp",
+        stateless_http=True,
+        json_response=False,
+    )
+
+    async def record_request(request: httpx2.Request) -> None:
+        request_headers.append(dict(request.headers))
+
+    async def record_response(response: httpx2.Response) -> None:
+        response_headers.append(dict(response.headers))
+
+    transport = httpx2.ASGITransport(app=app)
+    async with app.router.lifespan_context(app):
+        async with httpx2.AsyncClient(
+            transport=transport,
+            base_url="http://127.0.0.1:8000",
+            event_hooks={"request": [record_request], "response": [record_response]},
+        ) as sdk_http_client:
+            mcp_transport = streamable_http_client(
+                "http://127.0.0.1:8000/mcp",
+                http_client=sdk_http_client,
+            )
+            async with Client(mcp_transport, mode=mode) as client:
+                yield client

--- a/tests/integration/mcp/test_stateless_http.py
+++ b/tests/integration/mcp/test_stateless_http.py
@@ -1,0 +1,61 @@
+"""Protocol-level coverage for localhost stateless Streamable HTTP."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import anyio
+import pytest
+from mcp.types import TextContent
+
+from tests.integration.mcp._transport import http_client
+
+pytestmark = [pytest.mark.integration, pytest.mark.fast]
+
+
+def test_modern_discovery_and_tool_call_are_sessionless(tmp_path: Path) -> None:
+    request_headers: list[dict[str, str]] = []
+    response_headers: list[dict[str, str]] = []
+
+    async def exercise() -> None:
+        async with http_client(
+            tmp_path,
+            mode="auto",
+            request_headers=request_headers,
+            response_headers=response_headers,
+        ) as client:
+            assert client.session.discover_result is not None
+            tools = await client.list_tools()
+            assert {tool.name for tool in tools.tools} >= {"list_available", "run_benchmark", "get_results"}
+
+            result = await client.call_tool("list_available", {"category": "charts"})
+            assert not result.is_error
+            assert isinstance(result.content[0], TextContent)
+            assert "charts" in result.content[0].text
+
+    anyio.run(exercise)
+
+    assert len(request_headers) >= 3  # discover, tools/list, and tools/call
+    assert all("mcp-session-id" not in headers for headers in request_headers)
+    assert all("mcp-session-id" not in headers for headers in response_headers)
+
+
+def test_supported_legacy_http_client_does_not_require_sticky_session(tmp_path: Path) -> None:
+    request_headers: list[dict[str, str]] = []
+    response_headers: list[dict[str, str]] = []
+
+    async def exercise() -> None:
+        async with http_client(
+            tmp_path,
+            mode="legacy",
+            request_headers=request_headers,
+            response_headers=response_headers,
+        ) as client:
+            tools = await client.list_tools()
+            assert len(tools.tools) == 12
+
+    anyio.run(exercise)
+
+    assert request_headers
+    assert all("mcp-session-id" not in headers for headers in request_headers)
+    assert all("mcp-session-id" not in headers for headers in response_headers)

--- a/tests/integration/mcp/test_transport_contract_parity.py
+++ b/tests/integration/mcp/test_transport_contract_parity.py
@@ -1,0 +1,77 @@
+"""Contract parity between the stdio and Streamable HTTP MCP transports."""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+from typing import Any
+
+import anyio
+import pytest
+from mcp.client import Client
+from mcp.client.stdio import StdioServerParameters, stdio_client
+
+from tests.integration.mcp._transport import http_client
+
+pytestmark = [pytest.mark.integration, pytest.mark.fast]
+
+
+async def _inventory(client: Client) -> dict[str, list[dict[str, Any]]]:
+    """Return the public discovery contract in a transport-neutral shape."""
+
+    def normalize(items: list[Any]) -> list[dict[str, Any]]:
+        return sorted(
+            (item.model_dump(mode="json", by_alias=True, exclude_none=True) for item in items),
+            key=lambda item: str(item.get("name", item.get("uri", item.get("uriTemplate", "")))),
+        )
+
+    tools = await client.list_tools()
+    resources = await client.list_resources()
+    templates = await client.list_resource_templates()
+    prompts = await client.list_prompts()
+    return {
+        "tools": normalize(tools.tools),
+        "resources": normalize(resources.resources),
+        "resource_templates": normalize(templates.resource_templates),
+        "prompts": normalize(prompts.prompts),
+    }
+
+
+def test_stdio_and_streamable_http_publish_identical_contracts(tmp_path: Path) -> None:
+    async def exercise() -> tuple[dict[str, list[dict[str, Any]]], dict[str, list[dict[str, Any]]]]:
+        results_dir = tmp_path / "results"
+        charts_dir = tmp_path / "charts"
+        params = StdioServerParameters(
+            command=sys.executable,
+            args=[
+                "-m",
+                "benchbox.mcp",
+                "--results-dir",
+                str(results_dir),
+                "--charts-dir",
+                str(charts_dir),
+            ],
+            env=dict(os.environ),
+        )
+        with open(os.devnull, "w", encoding="utf-8") as errlog:
+            async with Client(stdio_client(params, errlog=errlog), mode="legacy") as stdio:
+                stdio_inventory = await _inventory(stdio)
+
+        async with http_client(
+            tmp_path,
+            mode="auto",
+            request_headers=[],
+            response_headers=[],
+        ) as http:
+            http_inventory = await _inventory(http)
+
+        return stdio_inventory, http_inventory
+
+    stdio_inventory, http_inventory = anyio.run(exercise)
+
+    assert stdio_inventory == http_inventory
+    assert len(http_inventory["tools"]) == 12
+    assert len(http_inventory["resources"]) == 4
+    assert len(http_inventory["resource_templates"]) == 2
+    assert len(http_inventory["prompts"]) == 7

--- a/tests/unit/mcp/test_cli.py
+++ b/tests/unit/mcp/test_cli.py
@@ -1,0 +1,111 @@
+"""Transport configuration tests for the BenchBox MCP CLI."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from mcp.server.transport_security import TransportSecuritySettings
+
+from benchbox.mcp.cli import parse_args
+from benchbox.mcp.transport import MCPTransportSettings, is_supported_loopback_host, run_transport
+
+pytestmark = [pytest.mark.unit, pytest.mark.fast]
+
+
+def test_transport_defaults_preserve_stdio() -> None:
+    args = parse_args([])
+
+    assert args.transport == "stdio"
+    assert args.host == "127.0.0.1"
+    assert args.port == 8000
+    assert args.streamable_http_path == "/mcp"
+
+
+def test_streamable_http_cli_options_are_forwarded(monkeypatch: pytest.MonkeyPatch) -> None:
+    from benchbox.mcp import cli
+
+    captured: dict[str, object] = {}
+    monkeypatch.setattr(cli, "run_server", lambda **kwargs: captured.update(kwargs))
+
+    cli.main(
+        [
+            "--transport",
+            "streamable-http",
+            "--host",
+            "::1",
+            "--port",
+            "8765",
+            "--streamable-http-path",
+            "/benchbox-mcp",
+        ]
+    )
+
+    assert captured["transport"] == "streamable-http"
+    assert captured["host"] == "::1"
+    assert captured["port"] == 8765
+    assert captured["streamable_http_path"] == "/benchbox-mcp"
+
+
+@pytest.mark.parametrize("host", ["127.0.0.1", "localhost", "::1"])
+def test_loopback_hosts_are_accepted(host: str) -> None:
+    assert is_supported_loopback_host(host)
+    MCPTransportSettings(transport="streamable-http", host=host)
+
+
+@pytest.mark.parametrize("host", ["0.0.0.0", "::", "192.0.2.1", "mcp.example.com"])
+def test_non_loopback_http_host_is_rejected(host: str) -> None:
+    with pytest.raises(ValueError, match="loopback hosts only"):
+        MCPTransportSettings(transport="streamable-http", host=host)
+
+
+def test_stdio_uses_explicit_sdk_transport() -> None:
+    server = MagicMock()
+
+    run_transport(server, MCPTransportSettings())
+
+    server.run.assert_called_once_with(transport="stdio")
+
+
+def test_streamable_http_uses_streaming_capable_stateless_sdk_route() -> None:
+    server = MagicMock()
+
+    run_transport(
+        server,
+        MCPTransportSettings(
+            transport="streamable-http",
+            host="localhost",
+            port=8765,
+            streamable_http_path="/benchbox-mcp",
+        ),
+    )
+
+    server.run.assert_called_once_with(
+        transport="streamable-http",
+        host="localhost",
+        port=8765,
+        streamable_http_path="/benchbox-mcp",
+        stateless_http=True,
+        json_response=False,
+        transport_security=TransportSecuritySettings(
+            enable_dns_rebinding_protection=True,
+            allowed_hosts=["127.0.0.1:*", "localhost:*", "[::1]:*"],
+            allowed_origins=["http://127.0.0.1:*", "http://localhost:*", "http://[::1]:*"],
+        ),
+    )
+
+
+def test_run_server_rejects_public_http_host_before_creating_server() -> None:
+    with patch("benchbox.mcp.create_server") as create_server:
+        from benchbox.mcp import run_server
+
+        with pytest.raises(ValueError, match="loopback hosts only"):
+            run_server(transport="streamable-http", host="0.0.0.0")
+
+    create_server.assert_not_called()
+
+
+@pytest.mark.parametrize("port", ["0", "65536"])
+def test_cli_rejects_invalid_http_port(port: str) -> None:
+    with pytest.raises(SystemExit):
+        parse_args(["--port", port])

--- a/tests/unit/mcp/test_mcp_main_module.py
+++ b/tests/unit/mcp/test_mcp_main_module.py
@@ -8,6 +8,7 @@ from unittest.mock import MagicMock
 import pytest
 
 import benchbox.mcp
+import benchbox.mcp.cli
 
 pytestmark = [
     pytest.mark.unit,
@@ -17,7 +18,7 @@ pytestmark = [
 
 def test_module_main_invokes_run_server(monkeypatch):
     run_server = MagicMock()
-    monkeypatch.setattr(benchbox.mcp, "run_server", run_server)
+    monkeypatch.setattr(benchbox.mcp.cli, "run_server", run_server)
     monkeypatch.setattr(sys, "argv", ["benchbox-mcp"])
 
     runpy.run_module("benchbox.mcp.__main__", run_name="__main__")


### PR DESCRIPTION
## Summary

- preserve stdio as the zero-configuration default and add opt-in localhost Streamable HTTP
- route both transports through MCP SDK 2 APIs with modern sessionless HTTP and stateless legacy compatibility
- enforce canonical loopback-only binding plus SDK DNS-rebinding protection while retaining streaming-capable responses
- prove real stdio and HTTP tool/resource/prompt/schema inventories are identical
- document startup, client configuration, compatibility, and the public-bind prohibition

## Verification

- `todo verify mcp-dual-transport-stateless-http-v2 --run 1..5`
- `uv run -- python -m pytest tests/unit/mcp tests/integration/mcp -q` (525 passed)
- `uv run -- ruff check benchbox/mcp tests/unit/mcp tests/integration/mcp`
- `uv run -- ty check` (exit 0; existing repository warnings only)
- `make pr-preflight` completed all guards except `lint-markers`, which was prevented from starting by an active shared pytest lock in another pool worktree
- equivalent failed guard rerun without the shared parallel lock: `uv run -- python -m pytest -n 0 tests/unit/test_marker_strategy.py -q` (10 passed)
- `make -s uat-artifact-hygiene`

## Design decisions

- JSON-only HTTP responses remain disabled so progress and future request-scoped streaming stay possible.
- Protocol headers, discovery, version negotiation, and DNS-rebinding middleware remain SDK-owned.
- Public binding is rejected here; authentication, tenancy, quotas, and admission control are a separate dependent TODO.

## Tracker

- `mcp-dual-transport-stateless-http-v2`
