### PR TITLE
feat(mcp): secure remote HTTP access

### DIFF
--- a/benchbox/mcp/__init__.py
+++ b/benchbox/mcp/__init__.py
@@ -50,6 +50,10 @@ from __future__ import annotations
 
 from collections.abc import Mapping
 from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from benchbox.mcp.security import RemoteSecurityRuntime
 
 try:
     from mcp.server.mcpserver import MCPServer
@@ -87,6 +91,7 @@ def create_server(
     charts_dir: str | Path | None = None,
     log_level: str | int | None = None,
     env: Mapping[str, str] | None = None,
+    remote_security: RemoteSecurityRuntime | None = None,
 ) -> MCPServer:
     """Create and configure the BenchBox MCP server.
 
@@ -95,12 +100,15 @@ def create_server(
     """
     from benchbox.mcp.server import create_benchbox_server
 
-    return create_benchbox_server(
-        results_dir=results_dir,
-        charts_dir=charts_dir,
-        log_level=log_level,
-        env=env,
-    )
+    kwargs: dict[str, Any] = {
+        "results_dir": results_dir,
+        "charts_dir": charts_dir,
+        "log_level": log_level,
+        "env": env,
+    }
+    if remote_security is not None:
+        kwargs["remote_security"] = remote_security
+    return create_benchbox_server(**kwargs)
 
 
 def run_server(
@@ -113,6 +121,7 @@ def run_server(
     host: str = "127.0.0.1",
     port: int = 8000,
     streamable_http_path: str = "/mcp",
+    security_config: str | Path | None = None,
 ) -> None:
     """Run the BenchBox MCP server.
 
@@ -120,20 +129,27 @@ def run_server(
     - `benchbox-mcp` CLI command
     - `python -m benchbox.mcp`
     """
+    from benchbox.mcp.security import RemoteSecurityRuntime
     from benchbox.mcp.transport import MCPTransportSettings, run_transport
+
+    remote_security = RemoteSecurityRuntime.from_file(security_config) if security_config is not None else None
 
     transport_settings = MCPTransportSettings(
         transport=transport,
         host=host,
         port=port,
         streamable_http_path=streamable_http_path,
+        remote_security=remote_security,
     )
-    server = create_server(
-        results_dir=results_dir,
-        charts_dir=charts_dir,
-        log_level=log_level,
-        env=env,
-    )
+    server_kwargs: dict[str, Any] = {
+        "results_dir": results_dir,
+        "charts_dir": charts_dir,
+        "log_level": log_level,
+        "env": env,
+    }
+    if remote_security is not None:
+        server_kwargs["remote_security"] = remote_security
+    server = create_server(**server_kwargs)
     run_transport(server, transport_settings)
 
 

--- a/benchbox/mcp/cli.py
+++ b/benchbox/mcp/cli.py
@@ -66,6 +66,10 @@ def build_parser() -> argparse.ArgumentParser:
         default="/mcp",
         help="Streamable HTTP endpoint path (default: /mcp).",
     )
+    parser.add_argument(
+        "--security-config",
+        help="JSON policy enabling authenticated, tenant-scoped Streamable HTTP.",
+    )
     return parser
 
 
@@ -92,4 +96,5 @@ def main(argv: Sequence[str] | None = None) -> None:
         host=args.host,
         port=args.port,
         streamable_http_path=args.streamable_http_path,
+        security_config=args.security_config,
     )

--- a/benchbox/mcp/execution.py
+++ b/benchbox/mcp/execution.py
@@ -419,7 +419,7 @@ async def run_benchmark_async(
             )
 
     except Exception as e:
-        logger.exception(f"Async benchmark execution failed: {e}")
+        logger.error("Async benchmark execution failed (%s)", type(e).__name__)
         tracker.update_status(
             execution_id,
             ExecutionStatus.FAILED,

--- a/benchbox/mcp/resources/registry.py
+++ b/benchbox/mcp/resources/registry.py
@@ -25,6 +25,7 @@ from benchbox.core.benchmark_registry import (
     get_public_benchmark_class,
     list_public_benchmark_ids,
 )
+from benchbox.mcp.security import PathProvider, resolve_path_provider
 from benchbox.validation.bundle import COMPANION_SUFFIXES
 
 logger = logging.getLogger(__name__)
@@ -181,7 +182,7 @@ def _parse_result_file_metadata(file_path: Path) -> dict | None:
             "execution_id": data.get("run", {}).get("id", "unknown"),
         }
     except Exception as e:
-        logger.warning(f"Could not parse result file {file_path}: {e}")
+        logger.warning("Could not parse result file %s (%s)", file_path.name, type(e).__name__)
         return None
 
 
@@ -250,14 +251,12 @@ def _build_system_profile() -> str:
     )
 
 
-def register_all_resources(mcp: MCPServer, *, results_dir: Path) -> None:
+def register_all_resources(mcp: MCPServer, *, results_dir: PathProvider) -> None:
     """Register all MCP resources with the server.
 
     Args:
         mcp: The MCPServer instance to register resources with.
     """
-
-    resolved_results_dir = Path(results_dir).expanduser()
 
     @mcp.resource("benchbox://benchmarks")
     def list_benchmarks_resource() -> str:
@@ -282,7 +281,7 @@ def register_all_resources(mcp: MCPServer, *, results_dir: Path) -> None:
     @mcp.resource("benchbox://results/recent")
     def get_recent_results_resource() -> str:
         """Get list of recent benchmark results."""
-        return _build_recent_results(resolved_results_dir)
+        return _build_recent_results(resolve_path_provider(results_dir).expanduser())
 
     @mcp.resource("benchbox://system/profile")
     def get_system_profile_resource() -> str:

--- a/benchbox/mcp/security.py
+++ b/benchbox/mcp/security.py
@@ -1,0 +1,673 @@
+"""Authentication, tenancy, admission, and audit controls for remote MCP."""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import json
+import logging
+import math
+import sqlite3
+import uuid
+from collections.abc import Callable, Mapping
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import anyio
+from mcp.server.auth.middleware.auth_context import get_access_token
+from mcp.server.auth.provider import AccessToken, TokenVerifier, principal_components
+from mcp.server.auth.settings import AuthSettings
+from mcp.server.context import CallNext, HandlerResult, ServerRequestContext
+from mcp.shared.exceptions import MCPError
+from mcp.types import CallToolResult, TextContent
+from pydantic import AnyHttpUrl, BaseModel, ConfigDict, Field, field_validator, model_validator
+
+from benchbox.utils.clock import mono_time, utc_now
+
+AUTHORIZATION_ERROR = -32003
+ADMISSION_ERROR = -32004
+READ_SCOPE = "benchbox:read"
+EXECUTE_SCOPE = "benchbox:execute"
+WRITE_SCOPE = "benchbox:write"
+
+
+class TokenIdentity(BaseModel):
+    """Trusted identity and permissions for one pre-provisioned bearer digest."""
+
+    model_config = ConfigDict(frozen=True)
+
+    token_sha256: str
+    client_id: str = Field(min_length=1, max_length=200)
+    subject: str = Field(min_length=1, max_length=200)
+    scopes: tuple[str, ...] = (READ_SCOPE,)
+
+    @field_validator("token_sha256")
+    @classmethod
+    def validate_digest(cls, value: str) -> str:
+        """Require a lowercase SHA-256 digest, never a raw credential."""
+        normalized = value.strip().lower()
+        if len(normalized) != 64 or any(char not in "0123456789abcdef" for char in normalized):
+            raise ValueError("token_sha256 must be a 64-character hexadecimal SHA-256 digest")
+        return normalized
+
+
+class AdmissionLimits(BaseModel):
+    """Durable request limits shared by every HTTP worker."""
+
+    model_config = ConfigDict(frozen=True)
+
+    requests_per_minute: int = Field(default=120, ge=1, le=100_000)
+    global_concurrency: int = Field(default=8, ge=1, le=10_000)
+    principal_concurrency: int = Field(default=2, ge=1, le=10_000)
+    queue_limit: int = Field(default=32, ge=0, le=100_000)
+    queue_timeout_seconds: float = Field(default=5.0, ge=0.0, le=300.0)
+    lease_seconds: float = Field(default=3_600.0, gt=0.0, le=86_400.0)
+
+
+class RemoteSecurityConfig(BaseModel):
+    """Fail-closed remote MCP security configuration."""
+
+    model_config = ConfigDict(frozen=True)
+
+    issuer_url: AnyHttpUrl
+    resource_server_url: AnyHttpUrl
+    allowed_hosts: tuple[str, ...]
+    allowed_origins: tuple[str, ...]
+    workspace_root: Path
+    state_db: Path
+    tokens: tuple[TokenIdentity, ...]
+    allowed_platforms: tuple[str, ...] = ()
+    allowed_benchmarks: tuple[str, ...] = ()
+    max_scale_factor: float = Field(default=1.0, gt=0.0)
+    admission: AdmissionLimits = Field(default_factory=AdmissionLimits)
+
+    @field_validator("allowed_hosts", "allowed_origins", "tokens")
+    @classmethod
+    def require_nonempty(cls, value: tuple[Any, ...]) -> tuple[Any, ...]:
+        """Reject incomplete remote security configuration."""
+        if not value:
+            raise ValueError("remote security allowlists and tokens must not be empty")
+        return value
+
+    @field_validator("allowed_platforms", "allowed_benchmarks")
+    @classmethod
+    def normalize_policy_names(cls, value: tuple[str, ...]) -> tuple[str, ...]:
+        """Normalize policy identifiers to the tool's comparison form."""
+        return tuple(dict.fromkeys(item.strip().lower() for item in value if item.strip()))
+
+    @model_validator(mode="after")
+    def reject_ambiguous_token_digests(self) -> RemoteSecurityConfig:
+        """Ensure one bearer digest cannot resolve to multiple principals."""
+        digests = [identity.token_sha256 for identity in self.tokens]
+        if len(digests) != len(set(digests)):
+            raise ValueError("token_sha256 values must be unique")
+        return self
+
+    def require_remote_tls(self) -> None:
+        """Require externally visible OAuth endpoints to use HTTPS."""
+        if self.issuer_url.scheme != "https" or self.resource_server_url.scheme != "https":
+            raise ValueError("remote MCP requires HTTPS issuer_url and resource_server_url")
+
+
+def load_remote_security_config(path: str | Path) -> RemoteSecurityConfig:
+    """Load validated security policy, resolving owned paths beside the config."""
+    config_path = Path(path).expanduser().resolve(strict=True)
+    try:
+        raw = json.loads(config_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise ValueError(f"Could not load MCP security configuration ({type(exc).__name__})") from exc
+    if not isinstance(raw, dict):
+        raise ValueError("MCP security configuration must be a JSON object")
+    for key in ("workspace_root", "state_db"):
+        candidate = Path(str(raw.get(key, ""))).expanduser()
+        if not candidate.is_absolute():
+            candidate = config_path.parent / candidate
+        raw[key] = candidate.resolve()
+    config = RemoteSecurityConfig.model_validate(raw)
+    config.workspace_root.mkdir(parents=True, exist_ok=True)
+    config.state_db.parent.mkdir(parents=True, exist_ok=True)
+    return config
+
+
+class _TransportSecurityLogFilter(logging.Filter):
+    """Keep SDK rejection diagnostics without logging attacker headers."""
+
+    def filter(self, record: logging.LogRecord) -> bool:
+        message = record.getMessage()
+        if message.startswith("Invalid Host header:"):
+            record.msg = "Rejected invalid Host header"
+            record.args = ()
+        elif message.startswith("Invalid Origin header:"):
+            record.msg = "Rejected invalid Origin header"
+            record.args = ()
+        return True
+
+
+def configure_transport_security_logging() -> None:
+    """Install the idempotent SDK header-redaction filter."""
+    logger = logging.getLogger("mcp.server.transport_security")
+    if not any(isinstance(item, _TransportSecurityLogFilter) for item in logger.filters):
+        logger.addFilter(_TransportSecurityLogFilter())
+
+
+class DigestTokenVerifier(TokenVerifier):
+    """Verify opaque bearer tokens against trusted SHA-256 digests."""
+
+    def __init__(self, config: RemoteSecurityConfig):
+        self._config = config
+
+    async def verify_token(self, token: str) -> AccessToken | None:
+        """Return the configured identity without persisting or logging *token*."""
+        digest = hashlib.sha256(token.encode("utf-8")).hexdigest()
+        for identity in self._config.tokens:
+            if hmac.compare_digest(digest, identity.token_sha256):
+                return AccessToken(
+                    token=token,
+                    client_id=identity.client_id,
+                    subject=identity.subject,
+                    scopes=list(identity.scopes),
+                    resource=str(self._config.resource_server_url),
+                    claims={"iss": str(self._config.issuer_url)},
+                )
+        return None
+
+
+@dataclass(frozen=True, slots=True)
+class Principal:
+    """Opaque stable identity used for ownership, limits, and audit."""
+
+    principal_id: str
+    client_id: str
+    issuer: str | None
+    subject: str | None
+    scopes: frozenset[str]
+
+    @classmethod
+    def from_access_token(cls, token: AccessToken) -> Principal:
+        """Derive an opaque identifier from all SDK principal components."""
+        client_id, issuer, subject = principal_components(token)
+        material = json.dumps([client_id, issuer, subject], separators=(",", ":"), ensure_ascii=True)
+        principal_id = hashlib.sha256(material.encode("utf-8")).hexdigest()[:32]
+        return cls(principal_id, client_id, issuer, subject, frozenset(token.scopes))
+
+
+def authenticated_principal() -> Principal:
+    """Return the request principal or fail closed outside authenticated HTTP."""
+    token = get_access_token()
+    if token is None:
+        raise MCPError(AUTHORIZATION_ERROR, "Authenticated principal required")
+    return Principal.from_access_token(token)
+
+
+@dataclass(frozen=True, slots=True)
+class WorkspacePaths:
+    """Server-owned paths for one authenticated tenant."""
+
+    root: Path
+    results_dir: Path
+    charts_dir: Path
+
+
+class TenantWorkspaceProvider:
+    """Resolve request paths solely from the authenticated principal."""
+
+    def __init__(self, workspace_root: Path):
+        self._workspace_root = workspace_root.resolve()
+
+    def paths_for(self, principal: Principal) -> WorkspacePaths:
+        """Return contained, server-owned paths for *principal*."""
+        root = (self._workspace_root / principal.principal_id).resolve()
+        root.relative_to(self._workspace_root)
+        results_dir = root / "results"
+        charts_dir = root / "charts"
+        results_dir.mkdir(parents=True, exist_ok=True)
+        charts_dir.mkdir(parents=True, exist_ok=True)
+        return WorkspacePaths(root, results_dir, charts_dir)
+
+    def current_results_dir(self) -> Path:
+        """Resolve the current request's result directory."""
+        return self.paths_for(authenticated_principal()).results_dir
+
+    def current_charts_dir(self) -> Path:
+        """Resolve the current request's chart directory."""
+        return self.paths_for(authenticated_principal()).charts_dir
+
+
+@dataclass(frozen=True, slots=True)
+class AdmissionLease:
+    """A durable active admission ticket."""
+
+    ticket_id: str
+    principal_id: str
+
+
+class DurableSecurityStore:
+    """SQLite-backed rate, queue, lease, and redacted audit coordination."""
+
+    def __init__(self, path: Path, limits: AdmissionLimits):
+        self.path = path
+        self.limits = limits
+        self._initialize()
+
+    def _connect(self) -> sqlite3.Connection:
+        connection = sqlite3.connect(self.path, timeout=10.0, isolation_level=None)
+        connection.row_factory = sqlite3.Row
+        connection.execute("PRAGMA busy_timeout = 10000")
+        return connection
+
+    def _initialize(self) -> None:
+        with self._connect() as connection:
+            connection.execute("PRAGMA journal_mode = WAL")
+            connection.executescript(
+                """
+                CREATE TABLE IF NOT EXISTS mcp_rate_windows (
+                    principal_id TEXT NOT NULL,
+                    window_start INTEGER NOT NULL,
+                    request_count INTEGER NOT NULL,
+                    PRIMARY KEY (principal_id, window_start)
+                );
+                CREATE TABLE IF NOT EXISTS mcp_admission_tickets (
+                    ticket_id TEXT PRIMARY KEY,
+                    principal_id TEXT NOT NULL,
+                    state TEXT NOT NULL CHECK (state IN ('waiting', 'active')),
+                    created_at REAL NOT NULL,
+                    lease_expires_at REAL
+                );
+                CREATE INDEX IF NOT EXISTS mcp_admission_state_idx
+                    ON mcp_admission_tickets (state, created_at);
+                CREATE INDEX IF NOT EXISTS mcp_admission_principal_idx
+                    ON mcp_admission_tickets (principal_id, state);
+                CREATE TABLE IF NOT EXISTS mcp_audit_events (
+                    event_id TEXT PRIMARY KEY,
+                    recorded_at TEXT NOT NULL,
+                    principal_id TEXT NOT NULL,
+                    tool_name TEXT NOT NULL,
+                    decision TEXT NOT NULL,
+                    execution_id TEXT,
+                    artifact_ref TEXT
+                );
+                """
+            )
+
+    def _begin(self, connection: sqlite3.Connection) -> None:
+        connection.execute("BEGIN IMMEDIATE")
+
+    def _cleanup_expired(self, connection: sqlite3.Connection, now: float) -> None:
+        connection.execute("DELETE FROM mcp_admission_tickets WHERE state = 'active' AND lease_expires_at <= ?", (now,))
+
+    def _check_rate(self, connection: sqlite3.Connection, principal_id: str, now: float) -> None:
+        window_start = int(now // 60) * 60
+        row = connection.execute(
+            "SELECT request_count FROM mcp_rate_windows WHERE principal_id = ? AND window_start = ?",
+            (principal_id, window_start),
+        ).fetchone()
+        if row is not None and int(row["request_count"]) >= self.limits.requests_per_minute:
+            raise MCPError(ADMISSION_ERROR, "Request rate limit exceeded")
+        connection.execute(
+            """
+            INSERT INTO mcp_rate_windows (principal_id, window_start, request_count) VALUES (?, ?, 1)
+            ON CONFLICT (principal_id, window_start)
+            DO UPDATE SET request_count = request_count + 1
+            """,
+            (principal_id, window_start),
+        )
+        connection.execute("DELETE FROM mcp_rate_windows WHERE window_start < ?", (window_start - 120,))
+
+    def _capacity_available(self, connection: sqlite3.Connection, principal_id: str) -> bool:
+        global_active = connection.execute(
+            "SELECT COUNT(*) FROM mcp_admission_tickets WHERE state = 'active'"
+        ).fetchone()[0]
+        principal_active = connection.execute(
+            "SELECT COUNT(*) FROM mcp_admission_tickets WHERE state = 'active' AND principal_id = ?",
+            (principal_id,),
+        ).fetchone()[0]
+        return global_active < self.limits.global_concurrency and principal_active < self.limits.principal_concurrency
+
+    def _enqueue(self, principal_id: str) -> str:
+        ticket_id = uuid.uuid4().hex
+        now = utc_now().timestamp()
+        with self._connect() as connection:
+            self._begin(connection)
+            self._cleanup_expired(connection, now)
+            self._check_rate(connection, principal_id, now)
+            state = "active" if self._capacity_available(connection, principal_id) else "waiting"
+            if state == "waiting":
+                waiting = connection.execute(
+                    "SELECT COUNT(*) FROM mcp_admission_tickets WHERE state = 'waiting'"
+                ).fetchone()[0]
+                if waiting >= self.limits.queue_limit:
+                    connection.rollback()
+                    raise MCPError(ADMISSION_ERROR, "Admission queue is full")
+            expires_at = now + self.limits.lease_seconds if state == "active" else None
+            connection.execute(
+                """INSERT INTO mcp_admission_tickets
+                   (ticket_id, principal_id, state, created_at, lease_expires_at)
+                   VALUES (?, ?, ?, ?, ?)""",
+                (ticket_id, principal_id, state, now, expires_at),
+            )
+            connection.commit()
+        return ticket_id
+
+    def _try_promote(self, ticket_id: str, principal_id: str) -> bool:
+        now = utc_now().timestamp()
+        with self._connect() as connection:
+            self._begin(connection)
+            self._cleanup_expired(connection, now)
+            row = connection.execute(
+                "SELECT state FROM mcp_admission_tickets WHERE ticket_id = ? AND principal_id = ?",
+                (ticket_id, principal_id),
+            ).fetchone()
+            if row is None:
+                connection.rollback()
+                return False
+            if row["state"] == "active":
+                connection.commit()
+                return True
+            first_waiting = connection.execute(
+                "SELECT ticket_id FROM mcp_admission_tickets WHERE state = 'waiting' ORDER BY created_at, ticket_id LIMIT 1"
+            ).fetchone()
+            if (
+                first_waiting is not None
+                and first_waiting["ticket_id"] == ticket_id
+                and self._capacity_available(connection, principal_id)
+            ):
+                connection.execute(
+                    "UPDATE mcp_admission_tickets SET state = 'active', lease_expires_at = ? WHERE ticket_id = ?",
+                    (now + self.limits.lease_seconds, ticket_id),
+                )
+                connection.commit()
+                return True
+            connection.commit()
+        return False
+
+    async def admit(self, principal_id: str) -> AdmissionLease:
+        """Rate-limit, queue, and acquire a shared concurrency lease."""
+        ticket_id = await anyio.to_thread.run_sync(self._enqueue, principal_id)
+        deadline_start = mono_time()
+        while not await anyio.to_thread.run_sync(self._try_promote, ticket_id, principal_id):
+            if mono_time() - deadline_start >= self.limits.queue_timeout_seconds:
+                await anyio.to_thread.run_sync(self.release, AdmissionLease(ticket_id, principal_id))
+                raise MCPError(ADMISSION_ERROR, "Admission queue wait timed out")
+            await anyio.sleep(0.025)
+        return AdmissionLease(ticket_id, principal_id)
+
+    def release(self, lease: AdmissionLease) -> None:
+        """Release a ticket idempotently."""
+        with self._connect() as connection:
+            connection.execute(
+                "DELETE FROM mcp_admission_tickets WHERE ticket_id = ? AND principal_id = ?",
+                (lease.ticket_id, lease.principal_id),
+            )
+
+    def renew(self, lease: AdmissionLease) -> bool:
+        """Extend an active lease while its request is still running."""
+        with self._connect() as connection:
+            cursor = connection.execute(
+                """UPDATE mcp_admission_tickets SET lease_expires_at = ?
+                   WHERE ticket_id = ? AND principal_id = ? AND state = 'active'""",
+                (utc_now().timestamp() + self.limits.lease_seconds, lease.ticket_id, lease.principal_id),
+            )
+        return cursor.rowcount == 1
+
+    def audit(
+        self,
+        *,
+        principal_id: str,
+        tool_name: str,
+        decision: str,
+        execution_id: str | None = None,
+        artifact_ref: str | None = None,
+    ) -> None:
+        """Persist a bounded event without arguments, payloads, or credentials."""
+        with self._connect() as connection:
+            connection.execute(
+                """INSERT INTO mcp_audit_events
+                   (event_id, recorded_at, principal_id, tool_name, decision, execution_id, artifact_ref)
+                   VALUES (?, ?, ?, ?, ?, ?, ?)""",
+                (
+                    uuid.uuid4().hex,
+                    utc_now().isoformat(),
+                    principal_id[:64],
+                    tool_name[:120],
+                    decision[:32],
+                    execution_id[:120] if execution_id else None,
+                    Path(artifact_ref).name[:255] if artifact_ref else None,
+                ),
+            )
+
+    def audit_events(self) -> list[Mapping[str, Any]]:
+        """Return audit rows for verification and operator diagnostics."""
+        with self._connect() as connection:
+            rows = connection.execute("SELECT * FROM mcp_audit_events ORDER BY recorded_at, event_id").fetchall()
+        return [dict(row) for row in rows]
+
+
+READ_ONLY_TOOLS = frozenset(
+    {
+        "list_available",
+        "get_benchmark_info",
+        "system_profile",
+        "check_dependencies",
+        "get_query_details",
+        "get_results",
+        "analyze_results",
+        "get_query_plan",
+        "validate_results",
+        "suggest_charts",
+    }
+)
+READ_METHODS = frozenset(
+    {
+        "tools/list",
+        "resources/list",
+        "resources/templates/list",
+        "resources/read",
+        "prompts/list",
+        "prompts/get",
+    }
+)
+
+
+class RemoteSecurityMiddleware:
+    """Authorize and admit each remote tool call using durable shared state."""
+
+    def __init__(self, config: RemoteSecurityConfig, store: DurableSecurityStore):
+        self.config = config
+        self.store = store
+
+    def _authorize(self, principal: Principal, tool_name: str, arguments: Mapping[str, Any]) -> None:
+        required_scope = READ_SCOPE if tool_name in READ_ONLY_TOOLS else WRITE_SCOPE
+        if tool_name == "run_benchmark":
+            required_scope = EXECUTE_SCOPE
+        elif tool_name == "get_results" and arguments.get("output_path"):
+            required_scope = WRITE_SCOPE
+        if required_scope not in principal.scopes:
+            raise MCPError(AUTHORIZATION_ERROR, f"Scope required: {required_scope}")
+        if tool_name != "run_benchmark":
+            return
+        platform = str(arguments.get("platform", "")).lower()
+        benchmark = str(arguments.get("benchmark", "")).lower()
+        try:
+            scale_factor = float(arguments.get("scale_factor", 0.01))
+        except (TypeError, ValueError) as exc:
+            raise MCPError(AUTHORIZATION_ERROR, "Invalid benchmark scale factor") from exc
+        if self.config.allowed_platforms and platform not in self.config.allowed_platforms:
+            raise MCPError(AUTHORIZATION_ERROR, "Platform is not authorized")
+        if self.config.allowed_benchmarks and benchmark not in self.config.allowed_benchmarks:
+            raise MCPError(AUTHORIZATION_ERROR, "Benchmark is not authorized")
+        if not math.isfinite(scale_factor) or scale_factor <= 0:
+            raise MCPError(AUTHORIZATION_ERROR, "Benchmark scale factor must be finite and positive")
+        if scale_factor > self.config.max_scale_factor:
+            raise MCPError(AUTHORIZATION_ERROR, "Benchmark scale factor exceeds policy")
+
+    @staticmethod
+    def _tool_call(ctx: ServerRequestContext[Any, Any]) -> tuple[str, Mapping[str, Any]] | None:
+        if ctx.method != "tools/call" or not isinstance(ctx.params, Mapping):
+            return None
+        name = ctx.params.get("name")
+        arguments = ctx.params.get("arguments", {})
+        if not isinstance(name, str) or not isinstance(arguments, Mapping):
+            return None
+        return name, arguments
+
+    @staticmethod
+    def _result_refs(result: HandlerResult) -> tuple[str | None, str | None]:
+        """Extract only bounded identifiers from a tool result for audit."""
+        payload: Mapping[str, Any] | None = result if isinstance(result, Mapping) else None
+        if isinstance(result, CallToolResult):
+            text = next((part.text for part in result.content if isinstance(part, TextContent)), None)
+            if text is not None and len(text) <= 65_536:
+                try:
+                    decoded = json.loads(text)
+                except json.JSONDecodeError:
+                    decoded = None
+                if isinstance(decoded, Mapping):
+                    payload = decoded
+        if payload is None:
+            return None, None
+        metadata = payload.get("mcp_metadata")
+        metadata_map = metadata if isinstance(metadata, Mapping) else {}
+        execution = metadata_map.get("execution_id", payload.get("execution_id"))
+        artifact = metadata_map.get("result_file", payload.get("file"))
+        return (
+            str(execution) if isinstance(execution, str) else None,
+            str(artifact) if isinstance(artifact, str) else None,
+        )
+
+    async def __call__(self, ctx: ServerRequestContext[Any, Any], call_next: CallNext) -> HandlerResult:
+        """Enforce policy around SDK dispatch without exposing raw inputs."""
+        if ctx.request_id is None:
+            return await call_next(ctx)
+        principal = authenticated_principal()
+        tool_call = self._tool_call(ctx)
+        if tool_call is None:
+            if ctx.method in READ_METHODS:
+                if READ_SCOPE not in principal.scopes:
+                    await self._audit(
+                        principal_id=principal.principal_id,
+                        tool_name=ctx.method,
+                        decision="denied",
+                    )
+                    raise MCPError(AUTHORIZATION_ERROR, f"Scope required: {READ_SCOPE}")
+            return await self._call_admitted(principal, ctx.method, ctx, call_next)
+        tool_name, arguments = tool_call
+        try:
+            self._authorize(principal, tool_name, arguments)
+        except MCPError:
+            await self._audit(principal_id=principal.principal_id, tool_name=tool_name, decision="denied")
+            raise
+
+        return await self._call_admitted(principal, tool_name, ctx, call_next)
+
+    async def _call_admitted(
+        self,
+        principal: Principal,
+        operation: str,
+        ctx: ServerRequestContext[Any, Any],
+        call_next: CallNext,
+    ) -> HandlerResult:
+        """Coordinate, dispatch, and audit one authenticated request."""
+
+        lease: AdmissionLease | None = None
+        try:
+            lease = await self.store.admit(principal.principal_id)
+            async with anyio.create_task_group() as task_group:
+                task_group.start_soon(self._renew_lease, lease)
+                try:
+                    result = await call_next(ctx)
+                finally:
+                    task_group.cancel_scope.cancel()
+            execution_id, artifact_ref = self._result_refs(result)
+            await self._audit(
+                principal_id=principal.principal_id,
+                tool_name=operation,
+                decision="allowed",
+                execution_id=execution_id,
+                artifact_ref=artifact_ref,
+            )
+            return result
+        except MCPError:
+            await self._audit(principal_id=principal.principal_id, tool_name=operation, decision="failed")
+            raise
+        except Exception as exc:
+            await self._audit(principal_id=principal.principal_id, tool_name=operation, decision="failed")
+            raise MCPError(-32603, f"Tool execution failed ({type(exc).__name__})") from exc
+        finally:
+            if lease is not None:
+                await anyio.to_thread.run_sync(self.store.release, lease)
+
+    async def _renew_lease(self, lease: AdmissionLease) -> None:
+        """Heartbeat one active request without process-local authority."""
+        interval = max(0.05, min(self.store.limits.lease_seconds / 3, 30.0))
+        while True:
+            await anyio.sleep(interval)
+            if not await anyio.to_thread.run_sync(self.store.renew, lease):
+                return
+
+    async def _audit(
+        self,
+        *,
+        principal_id: str,
+        tool_name: str,
+        decision: str,
+        execution_id: str | None = None,
+        artifact_ref: str | None = None,
+    ) -> None:
+        """Persist audit off the event loop."""
+        await anyio.to_thread.run_sync(
+            lambda: self.store.audit(
+                principal_id=principal_id,
+                tool_name=tool_name,
+                decision=decision,
+                execution_id=execution_id,
+                artifact_ref=artifact_ref,
+            )
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class RemoteSecurityRuntime:
+    """Constructed remote security services shared by server and transport."""
+
+    config: RemoteSecurityConfig
+    verifier: DigestTokenVerifier
+    workspaces: TenantWorkspaceProvider
+    store: DurableSecurityStore
+    middleware: RemoteSecurityMiddleware
+
+    @classmethod
+    def from_file(cls, path: str | Path) -> RemoteSecurityRuntime:
+        """Construct the complete runtime from one validated config file."""
+        config = load_remote_security_config(path)
+        store = DurableSecurityStore(config.state_db, config.admission)
+        return cls(
+            config=config,
+            verifier=DigestTokenVerifier(config),
+            workspaces=TenantWorkspaceProvider(config.workspace_root),
+            store=store,
+            middleware=RemoteSecurityMiddleware(config, store),
+        )
+
+    def auth_settings(self) -> AuthSettings:
+        """Return SDK resource-server auth settings."""
+        return AuthSettings(
+            issuer_url=self.config.issuer_url,
+            resource_server_url=self.config.resource_server_url,
+            required_scopes=[],
+        )
+
+
+PathProvider = Path | Callable[[], Path]
+
+
+def resolve_path_provider(provider: PathProvider) -> Path:
+    """Resolve a static local path or request-scoped tenant path."""
+    if isinstance(provider, Path):
+        return provider
+    return Path(provider())
+
+
+def token_sha256(token: str) -> str:
+    """Return a provisioning digest without storing the token."""
+    return hashlib.sha256(token.encode("utf-8")).hexdigest()

--- a/benchbox/mcp/server.py
+++ b/benchbox/mcp/server.py
@@ -22,6 +22,7 @@ from mcp.server.mcpserver import MCPServer
 from benchbox.core.runtime_paths import resolve_runtime_paths
 from benchbox.mcp.prompts import register_all_prompts
 from benchbox.mcp.resources import register_all_resources
+from benchbox.mcp.security import RemoteSecurityRuntime, configure_transport_security_logging
 from benchbox.mcp.tools.analytics import register_analytics_tools
 from benchbox.mcp.tools.benchmark import register_benchmark_tools
 from benchbox.mcp.tools.discovery import register_discovery_tools
@@ -72,6 +73,7 @@ def create_benchbox_server(
     charts_dir: str | Path | None = None,
     log_level: str | int | None = None,
     env: Mapping[str, str] | None = None,
+    remote_security: RemoteSecurityRuntime | None = None,
 ) -> MCPServer:
     """Create and configure the BenchBox MCP server.
 
@@ -104,6 +106,18 @@ def create_benchbox_server(
         resolved_results_dir = runtime_paths.results_dir
         resolved_charts_dir = runtime_paths.charts_dir
 
+    server_kwargs: dict[str, object] = {}
+    if remote_security is not None:
+        # The SDK rejection warnings include the raw attacker-controlled Host
+        # or Origin value. Preserve the generic HTTP rejection without making
+        # those headers a log-egress channel.
+        configure_transport_security_logging()
+        server_kwargs.update(
+            auth=remote_security.auth_settings(),
+            token_verifier=remote_security.verifier,
+            middleware=[remote_security.middleware],
+        )
+
     mcp = MCPServer(
         "benchbox",
         version=version("benchbox"),
@@ -127,6 +141,14 @@ To capture query execution plans, use the capture_plans parameter:
   run_benchmark(platform="datafusion", benchmark="tpch", capture_plans=True)
 Then inspect plans: get_query_plan(result_file="...", query_id="19")
 """,
+        **server_kwargs,
+    )
+
+    results_provider = (
+        remote_security.workspaces.current_results_dir if remote_security is not None else resolved_results_dir
+    )
+    charts_provider = (
+        remote_security.workspaces.current_charts_dir if remote_security is not None else resolved_charts_dir
     )
 
     # Register all tools
@@ -134,23 +156,23 @@ Then inspect plans: get_query_plan(result_file="...", query_id="19")
     register_discovery_tools(mcp)
 
     logger.info("Registering benchmark execution tools...")
-    register_benchmark_tools(mcp, results_dir=resolved_results_dir)
+    register_benchmark_tools(mcp, results_dir=results_provider)
 
     logger.info("Registering results tools...")
-    register_results_tools(mcp, results_dir=resolved_results_dir)
+    register_results_tools(mcp, results_dir=results_provider)
 
     logger.info("Registering analytics tools...")
-    register_analytics_tools(mcp, results_dir=resolved_results_dir)
+    register_analytics_tools(mcp, results_dir=results_provider)
 
     logger.info("Registering visualization tools...")
     register_visualization_tools(
         mcp,
-        results_dir=resolved_results_dir,
-        charts_dir=resolved_charts_dir,
+        results_dir=results_provider,
+        charts_dir=charts_provider,
     )
 
     logger.info("Registering resources...")
-    register_all_resources(mcp, results_dir=resolved_results_dir)
+    register_all_resources(mcp, results_dir=results_provider)
 
     logger.info("Registering prompts...")
     register_all_prompts(mcp)
@@ -159,8 +181,8 @@ Then inspect plans: get_query_plan(result_file="...", query_id="19")
     # They are logged for startup visibility.
     logger.info(
         "MCP path configuration: results_dir=%s charts_dir=%s",
-        resolved_results_dir,
-        resolved_charts_dir,
+        "tenant-scoped" if remote_security is not None else resolved_results_dir,
+        "tenant-scoped" if remote_security is not None else resolved_charts_dir,
     )
     logger.info("BenchBox MCP server configured successfully")
 

--- a/benchbox/mcp/tools/analytics.py
+++ b/benchbox/mcp/tools/analytics.py
@@ -22,6 +22,7 @@ from mcp.types import ToolAnnotations
 from benchbox.core.results.exporter import ResultExporter
 from benchbox.core.results.query_normalizer import normalize_query_id
 from benchbox.mcp.errors import ErrorCode, make_error, make_not_found_error
+from benchbox.mcp.security import PathProvider, resolve_path_provider
 from benchbox.mcp.tools.path_utils import resolve_result_file_path
 from benchbox.utils.printing import get_quiet_console
 from benchbox.validation.bundle import COMPANION_SUFFIXES
@@ -38,9 +39,24 @@ ANALYTICS_READONLY_ANNOTATIONS = ToolAnnotations(
 )
 
 
-def register_analytics_tools(mcp: MCPServer, *, results_dir: Path) -> None:
+def _resolve_validation_directory(directory: str, results_dir: Path, *, tenant_scoped: bool) -> Path | dict[str, Any]:
+    """Resolve a validation directory while containing remote tenants."""
+    candidate = Path(directory)
+    if tenant_scoped and candidate.is_absolute():
+        return make_error(ErrorCode.VALIDATION_ERROR, "Absolute validation directories are not allowed")
+    if not candidate.is_absolute():
+        candidate = results_dir / candidate
+    if tenant_scoped:
+        try:
+            candidate.resolve().relative_to(results_dir.resolve())
+        except ValueError:
+            return make_error(ErrorCode.VALIDATION_ERROR, "Validation directory escapes tenant workspace")
+    return candidate
+
+
+def register_analytics_tools(mcp: MCPServer, *, results_dir: PathProvider) -> None:
     """Register analytics tools with the MCP server."""
-    configured_results_dir = Path(results_dir)
+    tenant_scoped = not isinstance(results_dir, Path)
 
     @mcp.tool(annotations=ANALYTICS_READONLY_ANNOTATIONS)
     def analyze_results(
@@ -70,6 +86,7 @@ def register_analytics_tools(mcp: MCPServer, *, results_dir: Path) -> None:
         Returns:
             Analysis results based on the selected type.
         """
+        configured_results_dir = resolve_path_provider(results_dir)
         analysis_lower = analysis.lower()
 
         if analysis_lower == "compare":
@@ -122,6 +139,7 @@ def register_analytics_tools(mcp: MCPServer, *, results_dir: Path) -> None:
                 details={"valid_formats": valid_formats},
             )
 
+        configured_results_dir = resolve_path_provider(results_dir)
         file_path = resolve_result_file_path(result_file, configured_results_dir)
         if file_path is None:
             return make_error(
@@ -139,7 +157,7 @@ def register_analytics_tools(mcp: MCPServer, *, results_dir: Path) -> None:
                 details={"file": result_file, "parse_error": str(e)},
             )
         except Exception as e:
-            logger.exception(f"Failed to get query plan: {e}")
+            logger.error("Failed to get query plan (%s)", type(e).__name__)
             return make_error(
                 ErrorCode.INTERNAL_ERROR,
                 f"Failed to get query plan: {e}",
@@ -170,9 +188,10 @@ def register_analytics_tools(mcp: MCPServer, *, results_dir: Path) -> None:
             validate_file as _validate_file,
         )
 
+        configured_results_dir = resolve_path_provider(results_dir)
         if result_file:
             file_path = resolve_result_file_path(result_file, configured_results_dir)
-            if not file_path.exists():
+            if file_path is None or not file_path.exists():
                 return make_not_found_error(result_file, configured_results_dir)
             report = _validate_file(file_path)
             checks = [
@@ -196,9 +215,14 @@ def register_analytics_tools(mcp: MCPServer, *, results_dir: Path) -> None:
                 "checks": checks,
             }
         elif directory:
-            dir_path = Path(directory)
-            if not dir_path.is_absolute():
-                dir_path = configured_results_dir / directory
+            resolved_directory = _resolve_validation_directory(
+                directory,
+                configured_results_dir,
+                tenant_scoped=tenant_scoped,
+            )
+            if isinstance(resolved_directory, dict):
+                return resolved_directory
+            dir_path = resolved_directory
             if not dir_path.is_dir():
                 return make_error(
                     ErrorCode.RESOURCE_NOT_FOUND,
@@ -439,7 +463,7 @@ def _load_regression_runs(
                 break
 
         except Exception as e:
-            logger.warning(f"Could not parse result file {file_path}: {e}")
+            logger.warning("Could not parse result file %s (%s)", file_path.name, type(e).__name__)
             continue
     return runs
 
@@ -620,7 +644,7 @@ def _load_trend_data_point(
         with open(file_path, encoding="utf-8") as f:
             data = json.load(f)
     except Exception as e:
-        logger.warning(f"Could not parse result file {file_path}: {e}")
+        logger.warning("Could not parse result file %s (%s)", file_path.name, type(e).__name__)
         return None
 
     run_platform = data.get("platform", {}).get("name", "unknown")
@@ -808,7 +832,7 @@ def _aggregate_results_impl(
             )
 
         except Exception as e:
-            logger.warning(f"Could not parse result file {file_path}: {e}")
+            logger.warning("Could not parse result file %s (%s)", file_path.name, type(e).__name__)
             continue
 
     if not groups:

--- a/benchbox/mcp/tools/benchmark.py
+++ b/benchbox/mcp/tools/benchmark.py
@@ -35,6 +35,7 @@ from benchbox.mcp.errors import (
     make_not_found_error,
     make_unsupported_mode_error,
 )
+from benchbox.mcp.security import PathProvider, resolve_path_provider
 from benchbox.utils.clock import elapsed_seconds, mono_time
 from benchbox.utils.path_utils import get_benchmark_runs_datagen_path
 from benchbox.utils.printing import get_quiet_console, silence_output
@@ -145,9 +146,8 @@ def _map_phases_to_test_execution_type(phases: list[str]) -> str:
         return "standard"
 
 
-def register_benchmark_tools(mcp: MCPServer, *, results_dir: Path) -> None:
+def register_benchmark_tools(mcp: MCPServer, *, results_dir: PathProvider) -> None:
     """Register benchmark execution tools with the MCP server."""
-    resolved_results_dir = Path(results_dir)
 
     @mcp.tool(annotations=RUN_BENCHMARK_ANNOTATIONS)
     def run_benchmark(
@@ -206,7 +206,7 @@ def register_benchmark_tools(mcp: MCPServer, *, results_dir: Path) -> None:
             phases,
             mode,
             capture_plans,
-            results_dir=resolved_results_dir,
+            results_dir=resolve_path_provider(results_dir),
         )
 
     @mcp.tool(annotations=QUERY_DETAILS_ANNOTATIONS)
@@ -302,11 +302,11 @@ def _export_and_build_payload(
             with open(result_file_path, encoding="utf-8") as handle:
                 result_payload = json.load(handle)
     except Exception as export_err:
-        logger.warning(f"Failed to export benchmark results: {export_err}")
+        logger.warning("Failed to export benchmark results (%s)", type(export_err).__name__)
         try:
             result_payload = build_result_payload(result)
         except Exception as payload_err:
-            logger.warning(f"Failed to build benchmark payload: {payload_err}")
+            logger.warning("Failed to build benchmark payload (%s)", type(payload_err).__name__)
     return result_file_path, result_payload
 
 
@@ -451,7 +451,7 @@ def _run_benchmark_impl(
         return response
 
     except Exception as e:
-        logger.exception(f"Benchmark execution failed: {e}")
+        logger.error("Benchmark execution failed (%s)", type(e).__name__)
         error_response = make_execution_error(
             f"Benchmark execution failed: {e}",
             execution_id=execution_id,
@@ -613,7 +613,7 @@ def _dry_run_impl(
         return response
 
     except Exception as e:
-        logger.exception(f"Dry run failed: {e}")
+        logger.error("Dry run failed (%s)", type(e).__name__)
         error_response = make_error(
             ErrorCode.INTERNAL_ERROR,
             f"Dry run failed: {e}",

--- a/benchbox/mcp/tools/results.py
+++ b/benchbox/mcp/tools/results.py
@@ -22,6 +22,7 @@ from mcp.types import ToolAnnotations
 
 from benchbox.core.results.loader import ResultLoadError, UnsupportedSchemaError, load_result_file
 from benchbox.mcp.errors import ErrorCode, make_error
+from benchbox.mcp.security import PathProvider, resolve_path_provider
 from benchbox.mcp.tools.path_utils import resolve_result_file_path
 from benchbox.validation.bundle import COMPANION_SUFFIXES
 
@@ -46,9 +47,8 @@ EXPORT_ANNOTATIONS = ToolAnnotations(
 )
 
 
-def register_results_tools(mcp: MCPServer, *, results_dir: Path) -> None:
+def register_results_tools(mcp: MCPServer, *, results_dir: PathProvider) -> None:
     """Register results tools with the MCP server."""
-    configured_results_dir = Path(results_dir)
 
     @mcp.tool(annotations=RESULTS_READONLY_ANNOTATIONS)
     def get_results(
@@ -76,9 +76,10 @@ def register_results_tools(mcp: MCPServer, *, results_dir: Path) -> None:
         """
         # If no result_file, list recent runs
         if result_file is None or format == "list":
-            return _list_recent_runs_impl(limit, platform, benchmark, configured_results_dir)
+            return _list_recent_runs_impl(limit, platform, benchmark, resolve_path_provider(results_dir))
 
         # Get results for specific file
+        configured_results_dir = resolve_path_provider(results_dir)
         results = _get_results_impl(result_file, include_queries, results_dir=configured_results_dir)
         if "error" in results:
             return results
@@ -153,7 +154,7 @@ def _list_recent_runs_impl(
                 break
 
         except Exception as e:
-            logger.warning(f"Could not parse result file {file_path}: {e}")
+            logger.warning("Could not parse result file %s (%s)", file_path.name, type(e).__name__)
             continue
 
     return {

--- a/benchbox/mcp/tools/visualization.py
+++ b/benchbox/mcp/tools/visualization.py
@@ -20,6 +20,7 @@ from benchbox.core.visualization.chart_types import CHART_TYPE_DESCRIPTIONS
 from benchbox.core.visualization.orchestration import render_chart_set
 from benchbox.core.visualization.suggestions import build_visualization_profile, recommend_charts, select_primary_chart
 from benchbox.mcp.errors import ErrorCode, make_error
+from benchbox.mcp.security import PathProvider, resolve_path_provider
 from benchbox.mcp.tools.path_utils import resolve_result_file_path
 
 logger = logging.getLogger(__name__)
@@ -201,7 +202,7 @@ def _generate_ascii_chart(
         }
 
     except Exception as e:
-        logger.exception(f"ASCII chart generation failed: {e}")
+        logger.error("ASCII chart generation failed (%s)", type(e).__name__)
         return make_error(
             ErrorCode.INTERNAL_ERROR,
             f"ASCII chart generation failed: {e}",
@@ -279,7 +280,7 @@ def _suggest_charts_impl(file_list: list[str], resolved_paths: list[Path]) -> di
             details={"result_files": file_list},
         )
     except Exception as e:
-        logger.exception(f"Chart suggestion failed: {e}")
+        logger.error("Chart suggestion failed (%s)", type(e).__name__)
         return make_error(
             ErrorCode.INTERNAL_ERROR,
             f"Chart suggestion failed: {e}",
@@ -322,12 +323,10 @@ def _generate_chart_impl(
 def register_visualization_tools(
     mcp: MCPServer,
     *,
-    results_dir: Path,
-    charts_dir: Path,
+    results_dir: PathProvider,
+    charts_dir: PathProvider,
 ) -> None:
     """Register visualization tools with the MCP server."""
-    configured_results_dir = Path(results_dir)
-    configured_charts_dir = Path(charts_dir)
 
     @mcp.tool(description=MCP_SUGGEST_CHARTS_DESCRIPTION, annotations=VIZ_READONLY_ANNOTATIONS)
     def suggest_charts(result_files: str) -> dict[str, Any]:
@@ -347,7 +346,7 @@ def register_visualization_tools(
                 suggestion="Provide comma-separated list of result filenames",
             )
 
-        result = _resolve_and_validate_result_files(file_list, configured_results_dir)
+        result = _resolve_and_validate_result_files(file_list, resolve_path_provider(results_dir))
         if isinstance(result, dict):
             return result
         resolved_paths, file_list = result
@@ -392,8 +391,8 @@ def register_visualization_tools(
                 suggestion="Provide comma-separated list of result filenames",
             )
 
-        _ = configured_charts_dir  # reserved for future chart file outputs
-        result = _resolve_and_validate_result_files(file_list, configured_results_dir)
+        _ = resolve_path_provider(charts_dir)  # reserved for future chart file outputs
+        result = _resolve_and_validate_result_files(file_list, resolve_path_provider(results_dir))
         if isinstance(result, dict):
             return result
         resolved_paths, file_list = result

--- a/benchbox/mcp/transport.py
+++ b/benchbox/mcp/transport.py
@@ -8,6 +8,8 @@ from typing import Literal
 from mcp.server.mcpserver import MCPServer
 from mcp.server.transport_security import TransportSecuritySettings
 
+from benchbox.mcp.security import RemoteSecurityRuntime
+
 MCPTransport = Literal["stdio", "streamable-http"]
 
 
@@ -24,6 +26,7 @@ class MCPTransportSettings:
     host: str = "127.0.0.1"
     port: int = 8000
     streamable_http_path: str = "/mcp"
+    remote_security: RemoteSecurityRuntime | None = None
 
     def __post_init__(self) -> None:
         if self.transport not in ("stdio", "streamable-http"):
@@ -32,13 +35,22 @@ class MCPTransportSettings:
             raise ValueError("MCP HTTP port must be between 1 and 65535")
         if not self.streamable_http_path.startswith("/"):
             raise ValueError("MCP Streamable HTTP path must start with '/'")
-        if self.transport == "streamable-http" and not is_supported_loopback_host(self.host):
+        if self.transport == "stdio" and self.remote_security is not None:
+            raise ValueError("Remote security configuration is only valid with Streamable HTTP")
+        if (
+            self.transport == "streamable-http"
+            and not is_supported_loopback_host(self.host)
+            and self.remote_security is None
+        ):
             raise ValueError(
                 "MCP Streamable HTTP currently supports loopback hosts only; "
                 "remote binding requires the authentication and tenancy controls"
             )
         if self.transport == "streamable-http":
             object.__setattr__(self, "host", self.host.strip().lower())
+        if self.transport == "streamable-http" and not is_supported_loopback_host(self.host):
+            assert self.remote_security is not None
+            self.remote_security.config.require_remote_tls()
 
 
 def run_transport(server: MCPServer, settings: MCPTransportSettings) -> None:
@@ -46,6 +58,20 @@ def run_transport(server: MCPServer, settings: MCPTransportSettings) -> None:
     if settings.transport == "stdio":
         server.run(transport="stdio")
         return
+
+    if settings.remote_security is None:
+        allowed_hosts = ["127.0.0.1", "127.0.0.1:*", "localhost", "localhost:*", "[::1]", "[::1]:*"]
+        allowed_origins = [
+            "http://127.0.0.1",
+            "http://127.0.0.1:*",
+            "http://localhost",
+            "http://localhost:*",
+            "http://[::1]",
+            "http://[::1]:*",
+        ]
+    else:
+        allowed_hosts = list(settings.remote_security.config.allowed_hosts)
+        allowed_origins = list(settings.remote_security.config.allowed_origins)
 
     server.run(
         transport="streamable-http",
@@ -62,14 +88,7 @@ def run_transport(server: MCPServer, settings: MCPTransportSettings) -> None:
         # automatic policy covers only its three canonical host spellings.
         transport_security=TransportSecuritySettings(
             enable_dns_rebinding_protection=True,
-            allowed_hosts=["127.0.0.1", "127.0.0.1:*", "localhost", "localhost:*", "[::1]", "[::1]:*"],
-            allowed_origins=[
-                "http://127.0.0.1",
-                "http://127.0.0.1:*",
-                "http://localhost",
-                "http://localhost:*",
-                "http://[::1]",
-                "http://[::1]:*",
-            ],
+            allowed_hosts=allowed_hosts,
+            allowed_origins=allowed_origins,
         ),
     )

--- a/docs/operations/mcp-remote-security.md
+++ b/docs/operations/mcp-remote-security.md
@@ -1,0 +1,98 @@
+# Remote MCP security and tenancy
+
+BenchBox Streamable HTTP is local-only unless an operator supplies a complete
+security policy. Stateless transport removes sticky protocol sessions; it does
+not authenticate callers, authorize tools, isolate files, or coordinate load.
+
+## Threat model
+
+| Asset | Trust boundary | Primary abuse cases | Control |
+|---|---|---|---|
+| Database credentials and bearer tokens | Client, OAuth issuer, reverse proxy, BenchBox | disclosure through errors, logs, traces, or audit | bearer values exist only during SDK verification; config stores SHA-256 digests; MCP logs and audit omit raw arguments and exception text |
+| Benchmark execution capacity | Untrusted authenticated caller to platform adapters | expensive platforms/scales, request floods, worker hopping | per-tool scopes and platform/benchmark/scale policy; transactional shared rate, queue, and concurrency limits |
+| Results, charts, exports, and jobs | One authenticated principal to another | guessed names, traversal, caller-selected workspace, cross-worker identity confusion | stable principal derived from SDK client ID, issuer, and subject; server-owned workspace root; existing path-containment checks run inside that tenant root |
+| HTTP endpoint | Browser/network to MCP process | public accidental bind, DNS rebinding, hostile Host/Origin, missing auth | loopback default; non-loopback startup requires the full policy and HTTPS public URLs; SDK bearer, Host, Origin, and content-type middleware validate every request |
+| Audit and coordination database | All MCP workers to durable storage | process-local quota bypass, restart reset, secret-rich audit | transactional shared SQLite store; bounded audit schema contains only opaque principal, tool, decision, execution ID, and artifact basename |
+
+The pre-provisioned token verifier is a resource-server integration seam, not
+an authorization server. Tokens must be issued out of band. For horizontally
+scaled deployments, every worker must mount the configured state database and
+workspace root from storage with shared locking and durability semantics. Do
+not use node-local files on multiple hosts. A later production-readiness gate
+must pass before publishing a shared endpoint.
+
+## Configuration
+
+The policy file is JSON. It must contain no raw token; provision each token as
+the lowercase SHA-256 digest of its exact bearer value.
+
+```json
+{
+  "issuer_url": "https://login.example.com",
+  "resource_server_url": "https://benchbox.example.com/mcp",
+  "allowed_hosts": ["benchbox.example.com"],
+  "allowed_origins": ["https://console.example.com"],
+  "workspace_root": "/srv/benchbox/mcp/workspaces",
+  "state_db": "/srv/benchbox/mcp/state/security.sqlite3",
+  "tokens": [
+    {
+      "token_sha256": "<64 lowercase hex characters>",
+      "client_id": "automation-client",
+      "subject": "team-a",
+      "scopes": ["benchbox:read", "benchbox:write", "benchbox:execute"]
+    }
+  ],
+  "allowed_platforms": ["duckdb"],
+  "allowed_benchmarks": ["tpch"],
+  "max_scale_factor": 1.0,
+  "admission": {
+    "requests_per_minute": 120,
+    "global_concurrency": 8,
+    "principal_concurrency": 2,
+    "queue_limit": 32,
+    "queue_timeout_seconds": 5,
+    "lease_seconds": 3600
+  }
+}
+```
+
+The scope contract is:
+
+- `benchbox:read`: discovery, system profile, result reads, analytics, and chart suggestions;
+- `benchbox:write`: chart generation and other non-benchmark artifact writes;
+- `benchbox:execute`: `run_benchmark`, still constrained by platform,
+  benchmark, and maximum-scale policy.
+
+## Fail-closed deployment
+
+Run the process behind a TLS-terminating reverse proxy. The externally visible
+issuer and resource-server URLs must use HTTPS. The proxy must preserve the
+validated `Host`, `Origin`, `Content-Type`, and `Authorization` headers and must
+not log bearer values.
+
+```bash
+benchbox-mcp \
+  --transport streamable-http \
+  --host 10.0.0.12 \
+  --port 8000 \
+  --security-config /etc/benchbox/mcp-security.json
+```
+
+Startup is rejected if a non-loopback host has no policy, if its public URLs
+are not HTTPS, or if Host/Origin/token allowlists are empty. Stdio keeps its
+existing local behavior and rejects the remote-only policy option.
+
+The SQLite file is a durable shared backend only for workers on storage that
+provides correct cross-process locking. Before multi-host use, replace or mount
+it on an explicitly supported shared storage service and pass the production
+readiness acceptance matrix. Statelessness must never substitute for this
+coordination.
+
+## Audit contract
+
+Each protected tool decision records an opaque principal ID, tool name,
+decision, and optional bounded execution/artifact identifiers. Audit records do
+not contain token digests, bearer values, OAuth claims, tool arguments,
+database URLs, result payloads, or exception messages. Operators should apply
+normal access control, retention, backup, and integrity monitoring to the state
+database.

--- a/docs/reference/mcp.md
+++ b/docs/reference/mcp.md
@@ -48,10 +48,13 @@ localhost-only option at `http://127.0.0.1:8000/mcp`.
 }
 ```
 
-Do not expose this endpoint through a public bind, port forward, or reverse
-proxy. Until the remote-security work lands, BenchBox rejects non-loopback
-hosts because stateless transport does not provide authentication,
-authorization, tenant isolation, quotas, or admission control.
+Do not expose the unauthenticated localhost endpoint through a public bind,
+port forward, or reverse proxy. Non-loopback binding requires a complete
+`--security-config` policy. See [Remote MCP security and tenancy](../operations/mcp-remote-security.md)
+for its threat model, token-digest provisioning, scopes, tenant workspaces,
+shared admission store, and fail-closed proxy requirements. This capability is
+not a production-readiness claim; keep shared endpoint publication disabled
+until the separate conformance and operations gate has current evidence.
 
 ### SDK Compatibility
 
@@ -107,9 +110,10 @@ The inspector provides a web UI to browse tools, test calls, and view responses.
 | `--charts-dir` | Charts root used by MCP visualization paths |
 | `--log-level` | Logging level (DEBUG, INFO, WARNING, ERROR) |
 | `--transport` | `stdio` (default) or opt-in `streamable-http` |
-| `--host` | Streamable HTTP bind host; loopback interfaces only (default `127.0.0.1`) |
+| `--host` | Streamable HTTP bind host; non-loopback requires `--security-config` (default `127.0.0.1`) |
 | `--port` | Streamable HTTP bind port (default `8000`) |
 | `--streamable-http-path` | Streamable HTTP endpoint path (default `/mcp`) |
+| `--security-config` | Remote-only JSON policy for SDK auth, tenancy, authorization, admission, and audit |
 
 **Environment variables**
 

--- a/tests/integration/mcp/_security.py
+++ b/tests/integration/mcp/_security.py
@@ -1,0 +1,83 @@
+"""Shared authenticated HTTP fixtures for MCP security integration tests."""
+
+from __future__ import annotations
+
+import json
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
+from pathlib import Path
+
+import httpx2
+from mcp.client import Client
+from mcp.client.streamable_http import streamable_http_client
+from mcp.server.transport_security import TransportSecuritySettings
+
+from benchbox.mcp import create_server
+from benchbox.mcp.security import RemoteSecurityRuntime, token_sha256
+
+
+def write_security_config(
+    tmp_path: Path,
+    *,
+    tokens: dict[str, tuple[str, tuple[str, ...]]],
+    admission: dict[str, object] | None = None,
+) -> Path:
+    """Write a digest-only test policy and return its path."""
+    policy = {
+        "issuer_url": "https://auth.example.test",
+        "resource_server_url": "https://mcp.example.test/mcp",
+        "allowed_hosts": ["127.0.0.1", "127.0.0.1:*"],
+        "allowed_origins": ["https://client.example.test"],
+        "workspace_root": str(tmp_path / "workspaces"),
+        "state_db": str(tmp_path / "security.sqlite3"),
+        "tokens": [
+            {
+                "token_sha256": token_sha256(token),
+                "client_id": f"client-{subject}",
+                "subject": subject,
+                "scopes": list(scopes),
+            }
+            for token, (subject, scopes) in tokens.items()
+        ],
+        "allowed_platforms": ["duckdb"],
+        "allowed_benchmarks": ["tpch"],
+        "max_scale_factor": 1.0,
+    }
+    if admission is not None:
+        policy["admission"] = admission
+    path = tmp_path / "security.json"
+    path.write_text(json.dumps(policy), encoding="utf-8")
+    return path
+
+
+@asynccontextmanager
+async def authenticated_http_client(
+    config_path: Path, token: str
+) -> AsyncIterator[tuple[Client, RemoteSecurityRuntime]]:
+    """Yield an SDK client authenticated to an in-process server."""
+    runtime = RemoteSecurityRuntime.from_file(config_path)
+    server = create_server(remote_security=runtime)
+    app = server.streamable_http_app(
+        host="127.0.0.1",
+        streamable_http_path="/mcp",
+        stateless_http=True,
+        json_response=False,
+        transport_security=TransportSecuritySettings(
+            enable_dns_rebinding_protection=True,
+            allowed_hosts=list(runtime.config.allowed_hosts),
+            allowed_origins=list(runtime.config.allowed_origins),
+        ),
+    )
+    transport = httpx2.ASGITransport(app=app)
+    async with app.router.lifespan_context(app):
+        async with httpx2.AsyncClient(
+            transport=transport,
+            base_url="http://127.0.0.1:8000",
+            headers={"Authorization": f"Bearer {token}"},
+        ) as sdk_http_client:
+            mcp_transport = streamable_http_client(
+                "http://127.0.0.1:8000/mcp",
+                http_client=sdk_http_client,
+            )
+            async with Client(mcp_transport, mode="auto") as client:
+                yield client, runtime

--- a/tests/integration/mcp/test_admission_control.py
+++ b/tests/integration/mcp/test_admission_control.py
@@ -1,0 +1,60 @@
+"""Multi-worker durable MCP admission-control coverage."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import anyio
+import pytest
+from mcp.shared.exceptions import MCPError
+
+from benchbox.mcp.security import AdmissionLimits, DurableSecurityStore
+
+pytestmark = [pytest.mark.integration, pytest.mark.fast]
+
+
+def test_two_workers_share_global_concurrency_and_bounded_queue(tmp_path: Path) -> None:
+    limits = AdmissionLimits(
+        requests_per_minute=100,
+        global_concurrency=1,
+        principal_concurrency=1,
+        queue_limit=1,
+        queue_timeout_seconds=2,
+    )
+    worker_a = DurableSecurityStore(tmp_path / "shared.sqlite3", limits)
+    worker_b = DurableSecurityStore(tmp_path / "shared.sqlite3", limits)
+
+    async def exercise() -> None:
+        first = await worker_a.admit("principal-a")
+        acquired: list[object] = []
+
+        async def wait_on_other_worker() -> None:
+            acquired.append(await worker_b.admit("principal-b"))
+
+        async with anyio.create_task_group() as group:
+            group.start_soon(wait_on_other_worker)
+            await anyio.sleep(0.1)
+            with pytest.raises(MCPError, match="queue is full"):
+                await worker_a.admit("principal-c")
+            worker_a.release(first)
+
+        assert len(acquired) == 1
+        worker_b.release(acquired[0])
+
+    anyio.run(exercise)
+
+
+def test_rate_limit_cannot_be_bypassed_by_alternating_workers(tmp_path: Path) -> None:
+    limits = AdmissionLimits(requests_per_minute=2, global_concurrency=4, principal_concurrency=4)
+    worker_a = DurableSecurityStore(tmp_path / "shared.sqlite3", limits)
+    worker_b = DurableSecurityStore(tmp_path / "shared.sqlite3", limits)
+
+    async def exercise() -> None:
+        first = await worker_a.admit("principal-a")
+        worker_a.release(first)
+        second = await worker_b.admit("principal-a")
+        worker_b.release(second)
+        with pytest.raises(MCPError, match="rate limit"):
+            await worker_a.admit("principal-a")
+
+    anyio.run(exercise)

--- a/tests/integration/mcp/test_secret_egress.py
+++ b/tests/integration/mcp/test_secret_egress.py
@@ -1,0 +1,126 @@
+"""Credential sentinels never leave remote MCP observability surfaces."""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+import anyio
+import httpx2
+import pytest
+from mcp.server.transport_security import TransportSecuritySettings
+
+from tests.integration.mcp._security import authenticated_http_client, write_security_config
+
+pytestmark = [pytest.mark.integration, pytest.mark.fast]
+SENTINEL = "MCP_SECRET_SENTINEL"
+
+
+def test_invalid_bearer_and_failing_driver_do_not_egress_secret(
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    config = write_security_config(
+        tmp_path,
+        tokens={SENTINEL: ("tenant-a", ("benchbox:read", "benchbox:execute"))},
+    )
+
+    async def exercise() -> list[str]:
+        observed: list[str] = []
+        async with authenticated_http_client(config, SENTINEL) as (client, runtime):
+            from benchbox.mcp.tools import benchmark as benchmark_tools
+
+            def fail_adapter(*args: object, **kwargs: object) -> object:
+                raise RuntimeError(f"password={SENTINEL}")
+
+            monkeypatch.setattr(benchmark_tools, "_get_platform_adapter", fail_adapter)
+            result = await client.call_tool(
+                "run_benchmark",
+                {"platform": "duckdb", "benchmark": "tpch", "scale_factor": 0.01},
+            )
+            observed.append(str(result))
+            observed.append(repr(runtime.store.audit_events()))
+        return observed
+
+    caplog.set_level(logging.DEBUG)
+    observed = anyio.run(exercise)
+    assert SENTINEL not in "\n".join(observed)
+    assert SENTINEL not in caplog.text
+
+
+def test_unauthorized_http_response_does_not_echo_bearer(tmp_path: Path) -> None:
+    config = write_security_config(
+        tmp_path,
+        tokens={"valid-token": ("tenant-a", ("benchbox:read",))},
+    )
+
+    async def exercise() -> str:
+        from benchbox.mcp import create_server
+        from benchbox.mcp.security import RemoteSecurityRuntime
+
+        runtime = RemoteSecurityRuntime.from_file(config)
+        app = create_server(remote_security=runtime).streamable_http_app(stateless_http=True)
+        async with httpx2.AsyncClient(
+            transport=httpx2.ASGITransport(app=app),
+            base_url="http://127.0.0.1:8000",
+        ) as client:
+            response = await client.post(
+                "/mcp",
+                headers={"Authorization": f"Bearer {SENTINEL}", "Content-Type": "application/json"},
+                json={"jsonrpc": "2.0", "id": 1, "method": "tools/list"},
+            )
+            assert response.status_code == 401
+            return response.text
+
+    assert SENTINEL not in anyio.run(exercise)
+
+
+def test_hostile_host_and_origin_are_rejected_without_log_egress(
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    config = write_security_config(
+        tmp_path,
+        tokens={"valid-token": ("tenant-a", ("benchbox:read",))},
+    )
+
+    async def exercise() -> list[str]:
+        from benchbox.mcp import create_server
+        from benchbox.mcp.security import RemoteSecurityRuntime
+
+        runtime = RemoteSecurityRuntime.from_file(config)
+        app = create_server(remote_security=runtime).streamable_http_app(
+            stateless_http=True,
+            transport_security=TransportSecuritySettings(
+                enable_dns_rebinding_protection=True,
+                allowed_hosts=list(runtime.config.allowed_hosts),
+                allowed_origins=list(runtime.config.allowed_origins),
+            ),
+        )
+        async with app.router.lifespan_context(app):
+            async with httpx2.AsyncClient(
+                transport=httpx2.ASGITransport(app=app),
+                base_url="http://127.0.0.1:8000",
+            ) as client:
+                common = {
+                    "Authorization": "Bearer valid-token",
+                    "Content-Type": "application/json",
+                }
+                hostile_host = await client.post(
+                    "/mcp",
+                    headers={**common, "Host": f"{SENTINEL}.invalid"},
+                    json={"jsonrpc": "2.0", "id": 1, "method": "tools/list"},
+                )
+                hostile_origin = await client.post(
+                    "/mcp",
+                    headers={**common, "Origin": f"https://{SENTINEL}.invalid"},
+                    json={"jsonrpc": "2.0", "id": 2, "method": "tools/list"},
+                )
+                assert hostile_host.status_code == 421
+                assert hostile_origin.status_code == 403
+                return [hostile_host.text, hostile_origin.text]
+
+    caplog.set_level(logging.DEBUG)
+    assert SENTINEL not in "\n".join(anyio.run(exercise))
+    assert SENTINEL not in caplog.text

--- a/tests/integration/mcp/test_tenant_isolation.py
+++ b/tests/integration/mcp/test_tenant_isolation.py
@@ -1,0 +1,76 @@
+"""Cross-principal artifact isolation over stateless HTTP."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import anyio
+import pytest
+from mcp.types import CallToolResult, TextContent
+
+from benchbox.mcp.security import Principal
+from tests.integration.mcp._security import authenticated_http_client, write_security_config
+
+pytestmark = [pytest.mark.integration, pytest.mark.fast]
+
+
+def _text(result: CallToolResult) -> str:
+    assert isinstance(result.content[0], TextContent)
+    return result.content[0].text
+
+
+def test_principal_cannot_list_read_or_export_another_workspace(tmp_path: Path) -> None:
+    token_a = "tenant-a-token"
+    token_b = "tenant-b-token"
+    config = write_security_config(
+        tmp_path,
+        tokens={
+            token_a: ("tenant-a", ("benchbox:read", "benchbox:write")),
+            token_b: ("tenant-b", ("benchbox:read", "benchbox:write")),
+        },
+    )
+
+    async def exercise() -> None:
+        async with authenticated_http_client(config, token_a) as (client_a, runtime_a):
+            access = await runtime_a.verifier.verify_token(token_a)
+            assert access is not None
+            workspace = runtime_a.workspaces.paths_for(Principal.from_access_token(access))
+            artifact = workspace.results_dir / "tenant-a-result.json"
+            artifact.write_text(
+                json.dumps(
+                    {
+                        "schema_version": "1.0",
+                        "platform": {"name": "duckdb"},
+                        "benchmark": {"id": "tpch", "scale_factor": 0.01},
+                        "run": {"id": "execution-a", "timestamp": "2026-08-01T00:00:00Z"},
+                    }
+                ),
+                encoding="utf-8",
+            )
+            own_listing = await client_a.call_tool("get_results", {"format": "list"})
+            assert "tenant-a-result.json" in _text(own_listing)
+
+        async with authenticated_http_client(config, token_b) as (client_b, _):
+            listing = await client_b.call_tool("get_results", {"format": "list"})
+            assert "tenant-a-result.json" not in _text(listing)
+            read = await client_b.call_tool("get_results", {"result_file": "tenant-a-result.json"})
+            assert "RESOURCE_NOT_FOUND" in _text(read)
+            exported = await client_b.call_tool(
+                "get_results",
+                {"result_file": "tenant-a-result.json", "format": "csv", "output_path": "stolen.csv"},
+            )
+            assert "RESOURCE_NOT_FOUND" in _text(exported)
+            validation = await client_b.call_tool(
+                "validate_results",
+                {"directory": str(artifact.parent)},
+            )
+            assert "Absolute validation directories are not allowed" in _text(validation)
+            traversal = await client_b.call_tool(
+                "validate_results",
+                {"directory": "../"},
+            )
+            assert "Validation directory escapes tenant workspace" in _text(traversal)
+
+    anyio.run(exercise)
+    assert not list((tmp_path / "workspaces").rglob("stolen.csv"))

--- a/tests/unit/mcp/test_cli.py
+++ b/tests/unit/mcp/test_cli.py
@@ -2,13 +2,16 @@
 
 from __future__ import annotations
 
+from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
 from mcp.server.transport_security import TransportSecuritySettings
 
 from benchbox.mcp.cli import parse_args
+from benchbox.mcp.security import RemoteSecurityRuntime
 from benchbox.mcp.transport import MCPTransportSettings, is_supported_loopback_host, run_transport
+from tests.integration.mcp._security import write_security_config
 
 pytestmark = [pytest.mark.unit, pytest.mark.fast]
 
@@ -20,6 +23,7 @@ def test_transport_defaults_preserve_stdio() -> None:
     assert args.host == "127.0.0.1"
     assert args.port == 8000
     assert args.streamable_http_path == "/mcp"
+    assert args.security_config is None
 
 
 def test_streamable_http_cli_options_are_forwarded(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -102,7 +106,7 @@ def test_streamable_http_uses_streaming_capable_stateless_sdk_route() -> None:
     )
 
 
-def test_run_server_rejects_public_http_host_before_creating_server() -> None:
+def test_remote_binding_fail_closed_without_security_config() -> None:
     with patch("benchbox.mcp.create_server") as create_server:
         from benchbox.mcp import run_server
 
@@ -110,6 +114,26 @@ def test_run_server_rejects_public_http_host_before_creating_server() -> None:
             run_server(transport="streamable-http", host="0.0.0.0")
 
     create_server.assert_not_called()
+
+
+def test_remote_binding_accepts_complete_https_security_config(tmp_path: Path) -> None:
+    policy = write_security_config(
+        tmp_path,
+        tokens={"token": ("tenant-a", ("benchbox:read",))},
+    )
+    runtime = RemoteSecurityRuntime.from_file(policy)
+    settings = MCPTransportSettings(transport="streamable-http", host="10.0.0.12", remote_security=runtime)
+    assert settings.host == "10.0.0.12"
+
+
+def test_stdio_rejects_remote_security_config(tmp_path: Path) -> None:
+    policy = write_security_config(
+        tmp_path,
+        tokens={"token": ("tenant-a", ("benchbox:read",))},
+    )
+    runtime = RemoteSecurityRuntime.from_file(policy)
+    with pytest.raises(ValueError, match="only valid with Streamable HTTP"):
+        MCPTransportSettings(remote_security=runtime)
 
 
 @pytest.mark.parametrize("port", ["0", "65536"])

--- a/tests/unit/mcp/test_security.py
+++ b/tests/unit/mcp/test_security.py
@@ -1,0 +1,122 @@
+"""Unit coverage for remote MCP security policy and durable coordination."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import anyio
+import pytest
+from mcp.shared.exceptions import MCPError
+from mcp.types import CallToolResult, TextContent
+
+from benchbox.mcp.security import (
+    AdmissionLimits,
+    DurableSecurityStore,
+    Principal,
+    RemoteSecurityMiddleware,
+    TenantWorkspaceProvider,
+    load_remote_security_config,
+)
+from tests.integration.mcp._security import write_security_config
+
+pytestmark = [pytest.mark.unit, pytest.mark.fast]
+
+
+def test_auth_config_contains_only_digests_and_verifies_identity(tmp_path: Path) -> None:
+    token = "unit-secret-token"
+    path = write_security_config(tmp_path, tokens={token: ("tenant-a", ("benchbox:read",))})
+    assert token not in path.read_text(encoding="utf-8")
+    config = load_remote_security_config(path)
+
+    async def exercise() -> None:
+        from benchbox.mcp.security import DigestTokenVerifier
+
+        verifier = DigestTokenVerifier(config)
+        access = await verifier.verify_token(token)
+        assert access is not None
+        assert access.subject == "tenant-a"
+        assert await verifier.verify_token("wrong") is None
+
+    anyio.run(exercise)
+
+
+def test_tenant_workspace_is_server_owned_and_distinct(tmp_path: Path) -> None:
+    provider = TenantWorkspaceProvider(tmp_path / "owned")
+    first = Principal("a" * 32, "client", "issuer", "a", frozenset())
+    second = Principal("b" * 32, "client", "issuer", "b", frozenset())
+    first_paths = provider.paths_for(first)
+    second_paths = provider.paths_for(second)
+    assert first_paths.results_dir != second_paths.results_dir
+    assert first_paths.results_dir.is_relative_to(tmp_path / "owned")
+    assert second_paths.charts_dir.is_relative_to(tmp_path / "owned")
+
+
+def test_authorization_rejects_platform_benchmark_and_scale_outside_policy(tmp_path: Path) -> None:
+    path = write_security_config(
+        tmp_path,
+        tokens={"token": ("tenant-a", ("benchbox:read", "benchbox:execute"))},
+    )
+    config = load_remote_security_config(path)
+    middleware = RemoteSecurityMiddleware(config, DurableSecurityStore(config.state_db, config.admission))
+    principal = Principal("a" * 32, "client", "issuer", "a", frozenset({"benchbox:execute"}))
+    middleware._authorize(principal, "run_benchmark", {"platform": "duckdb", "benchmark": "tpch", "scale_factor": 1})
+    with pytest.raises(MCPError, match="Platform"):
+        middleware._authorize(
+            principal, "run_benchmark", {"platform": "snowflake", "benchmark": "tpch", "scale_factor": 1}
+        )
+    with pytest.raises(MCPError, match="Benchmark"):
+        middleware._authorize(
+            principal, "run_benchmark", {"platform": "duckdb", "benchmark": "tpcds", "scale_factor": 1}
+        )
+    with pytest.raises(MCPError, match="scale"):
+        middleware._authorize(
+            principal, "run_benchmark", {"platform": "duckdb", "benchmark": "tpch", "scale_factor": 2}
+        )
+    with pytest.raises(MCPError, match="finite"):
+        middleware._authorize(
+            principal, "run_benchmark", {"platform": "duckdb", "benchmark": "tpch", "scale_factor": "nan"}
+        )
+
+
+def test_durable_admission_is_shared_between_store_instances(tmp_path: Path) -> None:
+    limits = AdmissionLimits(global_concurrency=1, principal_concurrency=1, queue_limit=0)
+    first = DurableSecurityStore(tmp_path / "state.sqlite3", limits)
+    second = DurableSecurityStore(tmp_path / "state.sqlite3", limits)
+
+    async def exercise() -> None:
+        lease = await first.admit("principal-a")
+        with pytest.raises(MCPError, match="queue"):
+            await second.admit("principal-b")
+        first.release(lease)
+        second_lease = await second.admit("principal-b")
+        second.release(second_lease)
+
+    anyio.run(exercise)
+
+
+def test_audit_schema_excludes_secrets_arguments_and_database_urls(tmp_path: Path) -> None:
+    store = DurableSecurityStore(tmp_path / "state.sqlite3", AdmissionLimits())
+    store.audit(
+        principal_id="opaque-principal",
+        tool_name="run_benchmark",
+        decision="allowed",
+        execution_id="execution-1",
+        artifact_ref="/server/owned/result.json",
+    )
+    serialized = repr(store.audit_events())
+    assert "opaque-principal" in serialized
+    assert "result.json" in serialized
+    assert "server/owned" not in serialized
+    assert "token" not in serialized.lower()
+
+
+def test_audit_reference_extraction_is_bounded_to_execution_and_basename() -> None:
+    result = CallToolResult(
+        content=[
+            TextContent(
+                type="text",
+                text='{"mcp_metadata":{"execution_id":"execution-1","result_file":"/owned/result.json"}}',
+            )
+        ]
+    )
+    assert RemoteSecurityMiddleware._result_refs(result) == ("execution-1", "/owned/result.json")


### PR DESCRIPTION
## Summary

- integrate MCP SDK bearer authentication with digest-only token provisioning and explicit Host/Origin allowlists
- derive server-owned tenant workspaces from authenticated SDK principal components and authorize tool scopes, platforms, benchmarks, scales, resources, and artifact writes
- coordinate request rate, bounded queueing, global/principal concurrency, lease heartbeats, and redacted audit records through a transactional shared SQLite store
- keep stdio unchanged and reject non-loopback HTTP unless remote HTTPS security configuration is complete
- document the remote threat model, TLS proxy boundary, storage topology, scope contract, and production-readiness limitation

## Verification

- tracker verification rungs 1-5: pass
- `uv run -- python -m pytest tests/unit/mcp tests/integration/mcp -q -n 0` — 539 passed
- focused Ruff, format, and ty checks — pass
- strict TODO scope check — 19 authorized files
- self-review fixes: tenant directory containment, finite positive scale policy, off-loop SQLite coordination, renewable leases, request-wide admission, and redacted SDK header-rejection logs
- `make pr-preflight` found the missing unit marker; targeted marker strategy plus security tests pass after the fix, and all commit hooks pass

## Deployment boundary

Remote binding still is not a production-readiness claim. Public endpoint publication remains blocked on the separate conformance, multi-worker acceptance, observability, cache-policy, and operations gate TODO.
