### PR TITLE
fix(results): reject uppercase primary bundles

### DIFF
--- a/benchbox/validation/bundle.py
+++ b/benchbox/validation/bundle.py
@@ -781,12 +781,12 @@ def discover_bundles(path: Path) -> list[Path]:
 
 
 def is_primary_bundle_file(path: Path) -> bool:
-    """Return whether *path* is a regular primary bundle, case-insensitively."""
+    """Return whether *path* is a regular, workflow-detectable primary bundle."""
     if not path.is_file():
         return False
-    name = path.name.lower()
-    if not name.endswith(".json"):
+    if not path.name.endswith(".json"):
         return False
+    name = path.name.lower()
     if any(name.endswith(suffix) for suffix in COMPANION_SUFFIXES):
         return False
     if name == "corpus-inventory.json":

--- a/tests/unit/scripts/explorer_pipeline/test_pipeline.py
+++ b/tests/unit/scripts/explorer_pipeline/test_pipeline.py
@@ -427,12 +427,15 @@ class TestExplorerPipelineRun:
         # Only the real bundle, not the applied-ledger companion.
         assert len(_duckdb_results(output)) == 1
 
-    def test_discovery_ignores_json_named_directories_and_mixed_case_companions(self, tmp_path: Path) -> None:
+    def test_discovery_ignores_json_named_directories_uppercase_primaries_and_mixed_case_companions(
+        self, tmp_path: Path
+    ) -> None:
         bundles_dir = tmp_path / "data" / "bundles"
         bundles_dir.mkdir(parents=True)
         (bundles_dir / "directory.json").mkdir()
-        (bundles_dir / "real_bundle.JSON").write_text(json.dumps(MINIMAL_BUNDLE), encoding="utf-8")
-        (bundles_dir / "real_bundle.APPLIED.JSON").write_text("{}", encoding="utf-8")
+        (bundles_dir / "real_bundle.json").write_text(json.dumps(MINIMAL_BUNDLE), encoding="utf-8")
+        (bundles_dir / "bypass.JSON").write_text(json.dumps(MINIMAL_BUNDLE), encoding="utf-8")
+        (bundles_dir / "real_bundle.APPLIED.json").write_text("{}", encoding="utf-8")
 
         output = tmp_path / "out"
         ExplorerPipeline().run(tmp_path / "data", output)

--- a/tests/unit/scripts/test_generate_corpus_inventory.py
+++ b/tests/unit/scripts/test_generate_corpus_inventory.py
@@ -152,14 +152,17 @@ class TestGenerateInventory:
         assert [entry["file"] for entry in inventory["bundles"]] == ["a.json", "b.json"]
         assert inventory["summary"]["total_bundles"] == 2
 
-    def test_discovery_ignores_json_named_directories_and_mixed_case_companions(self, tmp_path: Path) -> None:
+    def test_discovery_ignores_json_named_directories_uppercase_primaries_and_mixed_case_companions(
+        self, tmp_path: Path
+    ) -> None:
         (tmp_path / "directory.json").mkdir()
-        _write_bundle(tmp_path / "result.JSON")
-        (tmp_path / "result.APPLIED.JSON").write_text("{}", encoding="utf-8")
+        _write_bundle(tmp_path / "result.json")
+        _write_bundle(tmp_path / "bypass.JSON")
+        (tmp_path / "result.APPLIED.json").write_text("{}", encoding="utf-8")
 
         inventory = script.generate_inventory(tmp_path)
 
-        assert [entry["file"] for entry in inventory["bundles"]] == ["result.JSON"]
+        assert [entry["file"] for entry in inventory["bundles"]] == ["result.json"]
 
     def test_cohort_summary_groups_platforms(self, tmp_path: Path) -> None:
         _write_bundle(tmp_path / "duckdb.json", benchmark_id="tpch", scale_factor=0.1, platform="DuckDB")

--- a/tests/unit/scripts/test_validate_submission.py
+++ b/tests/unit/scripts/test_validate_submission.py
@@ -660,12 +660,13 @@ class TestDiscoverBundles:
         assert len(found) == 1
         assert found[0].name == "result.json"
 
-    def test_ignores_json_named_directories_and_companions_case_insensitively(self, tmp_path: Path):
+    def test_ignores_json_named_directories_uppercase_primaries_and_mixed_case_companions(self, tmp_path: Path):
         (tmp_path / "directory.json").mkdir()
-        (tmp_path / "result.JSON").write_text("{}", encoding="utf-8")
-        (tmp_path / "result.APPLIED.JSON").write_text("{}", encoding="utf-8")
+        (tmp_path / "result.json").write_text("{}", encoding="utf-8")
+        (tmp_path / "bypass.JSON").write_text("{}", encoding="utf-8")
+        (tmp_path / "result.APPLIED.json").write_text("{}", encoding="utf-8")
 
-        assert discover_bundles(tmp_path) == [tmp_path / "result.JSON"]
+        assert discover_bundles(tmp_path) == [tmp_path / "result.json"]
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- require primary result bundles to use the lowercase `.json` extension recognized by the submission-validation workflow
- preserve case-insensitive rejection of companion bundles and manifest files
- cover validation, corpus inventory generation, and Results Explorer ingestion against uppercase-primary bypasses

## Context

Follow-up to the unresolved P1 review finding on #1444: an uppercase primary such as `result.JSON` could bypass the workflow's lowercase `*.json` validation pathspec while still being ingested downstream.

## Verification

- `uv run -- python -m pytest -n 0 tests/unit/scripts/test_validate_submission.py tests/unit/scripts/test_generate_corpus_inventory.py tests/unit/scripts/explorer_pipeline/test_pipeline.py -k "uppercase_primaries" -q`
- `uv run -- python -m pytest -n 0 tests -k "bundle or submission or inventory" -q`
- `cd results-explorer && npm run typecheck && npm test`
- `uv run -- python -m pytest -n 0 -m fast -q`
- `PYTEST_ADDOPTS='-n 0' make pr-preflight`

Closes the post-merge review follow-up tracked by `pr1444-uppercase-primary-validation-bypass-20260801-2`.
