### PR TITLE
test(tracker): cover the freeze on both bulk write paths, asserting the reason

### DIFF
--- a/tests/unit/scripts/test_todo_db_freeze.py
+++ b/tests/unit/scripts/test_todo_db_freeze.py
@@ -444,3 +444,58 @@ class TestMigrateIsGatedByTheFreeze:
         raw.close()
         assert _run(db, "migrate", actor="bob") == 0
         assert self._version(db) == todo_db.SCHEMA_VERSION
+
+
+class TestFreezeCoversBulkWritePaths:
+    """The two paths that stage through a temp local database before copying to
+    the primary. Both are gated at the command level in main(), before dispatch,
+    so neither can reach `bulk_transfer` under a foreign freeze -- but that was
+    reasoned rather than executed until these tests existed.
+    """
+
+    @pytest.fixture()
+    def frozen_db(self, tmp_path):
+        db = tmp_path / "todo.sqlite"
+        connection = todo_db.connect(db)
+        todo_db.set_freeze(connection, "alice", "cutover", ttl_hours=1)
+        connection.commit()
+        connection.close()
+        return db
+
+    def test_import_yaml_replace_is_refused(self, frozen_db, capsys):
+        # Assert on the REASON, not the exit code. `--replace` exits 2 on a local
+        # backend regardless, so an exit-code-only assertion passes even with the
+        # gate deleted -- verified by mutation, which is how this test was fixed.
+        assert _run(frozen_db, "import-yaml", "--replace", actor="bob") == 2
+        assert "frozen for maintenance" in capsys.readouterr().err
+
+    def test_import_yaml_dry_run_is_a_read(self, frozen_db, capsys):
+        # --dry-run writes nothing, so a freeze must not block it.
+        _run(frozen_db, "import-yaml", "--dry-run", actor="bob")
+        assert "frozen for maintenance" not in capsys.readouterr().err
+
+    def test_finding_import_bulk_is_refused(self, frozen_db, tmp_path, capsys):
+        corpus = tmp_path / "corpus"
+        corpus.mkdir()
+        assert (
+            _run(
+                frozen_db,
+                "finding",
+                "import",
+                "--corpus",
+                str(corpus),
+                "--bulk",
+                "--confirm-target",
+                "benchbox-todo",
+                actor="bob",
+            )
+            == 2
+        )
+        assert "frozen for maintenance" in capsys.readouterr().err
+
+    def test_the_refusal_is_the_freeze_not_an_incidental_error(self, tmp_path, capsys):
+        """Control: with no freeze the same command fails for a DIFFERENT reason."""
+        db = tmp_path / "todo.sqlite"
+        todo_db.connect(db).close()
+        _run(db, "import-yaml", "--replace", actor="bob")
+        assert "frozen for maintenance" not in capsys.readouterr().err


### PR DESCRIPTION
Closes the two remaining "reasoned but not executed" gaps in the freeze gate's coverage, plus records the §8.4.1 and §8.4.3 assessments.

## The tests

`import-yaml --replace` and `finding import --bulk` both stage through a temp local database before copying to the primary. Both were only ever verified by reading the code — which is the wrong standard here, since every defect found in this domain was found by *running* something.

**My first version of these tests was wrong**, and mutation-testing caught it. All four passed with the freeze gate deleted, because both commands exit 2 on a local backend anyway:

```
error: --replace only applies to a live import into the hosted backend
error: --bulk applies to a hosted backend; a local database imports directly
```

An exit-code-only assertion is a false positive. They now assert on the refusal *reason*, and re-running the mutation correctly fails two of them. There's a control test so the suite can't drift back.

## §8.4.3 — `replace_evidence` guard: verified

Mutation-tested (`replace_evidence = True`, the original unconditional wipe). Caught by `TestReconcileNeverWipesUndeclaredEvidence::test_related_paths_change_does_not_delete_undeclared_evidence`. The guard is at the **write** (gating the `DELETE` directly), not at the decision — which is the property that matters, since the original defect was a guard bypassed by a second route to the same write.

## §8.4.1 — `bulk_transfer` PK collision: assessed, not a cutover blocker

Only two items-domain tables have rowid-alias PKs that can collide: **`deferrals.id`** and **`events.seq`**. Every other `TRANSFER_TABLE` has a natural composite/text key.

The items-domain caller is:

```python
bulk_transfer(staging, backend, token,
              replace=args.replace,
              require_empty=not args.replace)
```

`require_empty` is the **negation** of `replace`, so the two modes are exhaustive and both safe — `--replace` deletes first and frees every id; without it the guard refuses a non-empty target inside the same `BEGIN IMMEDIATE`. There is no reachable additive-into-non-empty transfer for items. That is immunity **by construction**, not "by accident", and the earlier characterization of the cutover restore as "exactly the kind of additive non-`--replace` transfer that reopens this" does not hold for this path (the cutover uses todo-db's `restore-legacy --replace`, a different codebase).

The latent hazard is narrower: a *future* caller passing `replace=False, require_empty=False` — which is exactly what the findings caller does, and it is safe only because `offset_staging_pks` runs first. Worth fixing in `bulk-transfer-pk-collision-safety`, but it does not gate the cutover.

## Verification

- 1384 unit tests pass; ruff clean; timing policy exit 0 (26492/26550 — headroom is down to 58)
- Mutation-tested in both directions: gate intact → 4 pass; gate neutered → 2 fail