### PR TITLE
fix(mcp): keep chart output inline-only

### DIFF
--- a/benchbox/mcp/tools/visualization.py
+++ b/benchbox/mcp/tools/visualization.py
@@ -77,7 +77,8 @@ MCP_GENERATE_CHART_DESCRIPTION = (
     "Generate ASCII chart output from BenchBox result files using semantic chart IDs or chart templates. "
     f"{BENCHBOX_CHART_NAMESPACE_NOTE} "
     f"Current semantic chart IDs: {_semantic_chart_id_help()}. "
-    f"Current templates: {_template_name_help()}."
+    f"Current templates: {_template_name_help()}. "
+    "MCP output is inline-only: file output and non-ASCII formats are rejected."
 )
 
 # Tool annotations for read-only visualization info tools
@@ -391,7 +392,20 @@ def register_visualization_tools(
                 suggestion="Provide comma-separated list of result filenames",
             )
 
-        _ = resolve_path_provider(charts_dir)  # reserved for future chart file outputs
+        if format != "ascii":
+            return make_error(
+                ErrorCode.VALIDATION_INVALID_FORMAT,
+                "MCP chart output supports only the inline 'ascii' format",
+                details={"format": format, "supported_formats": ["ascii"]},
+            )
+        if output_dir is not None:
+            return make_error(
+                ErrorCode.VALIDATION_ERROR,
+                "MCP chart output is inline-only; file output is not supported",
+                details={"output_mode": "inline", "supported_formats": ["ascii"]},
+            )
+
+        resolve_path_provider(charts_dir)  # Validate the configured provider without accepting a caller path.
         result = _resolve_and_validate_result_files(file_list, resolve_path_provider(results_dir))
         if isinstance(result, dict):
             return result

--- a/docs/reference/mcp.md
+++ b/docs/reference/mcp.md
@@ -387,8 +387,15 @@ its tools remain a separate raw rendering namespace.
 | `result_files` | string | Yes | - | Comma-separated result filenames. |
 | `chart_type` | string | No | `performance_bar` | Chart type for single-chart output. |
 | `template` | string or null | No | `null` | Template name for multi-chart output. |
-| `output_dir` | string or null | No | `null` | Output directory relative to charts dir. |
-| `format` | string | No | `ascii` | Output format; current MCP output is ASCII. |
+| `output_dir` | string or null | No | `null` | Must remain `null`; MCP chart output is intentionally inline-only and caller-selected file paths are rejected. |
+| `format` | string | No | `ascii` | Must be `ascii`; other formats are rejected until a tenant-scoped artifact contract is approved. |
+
+Chart generation is intentionally inline-only. `generate_chart` returns the
+ASCII content in the MCP response and does not create a caller-selected file.
+This keeps chart output inside the response boundary while a future artifact
+contract is designed for tenant ownership, path containment, overwrite and
+retention semantics. Requests that set `output_dir` or choose another format
+fail closed with a structured validation error.
 
 Available `chart_type` values and template names are derived from the
 visualization registries and are discoverable with `list_available(category="charts")`.

--- a/tests/unit/mcp/test_visualization_tools.py
+++ b/tests/unit/mcp/test_visualization_tools.py
@@ -527,6 +527,23 @@ class TestGenerateChartIntegration:
         assert result["format"] == "ascii"
         assert "content" in result
 
+    def test_file_output_is_explicitly_rejected(self, tmp_path):
+        tools = _get_viz_tool_functions(results_dir=tmp_path / "results")
+        result = tools["generate_chart"](result_files="missing.json", output_dir="../escape")
+
+        assert result["error"] is True
+        assert result["error_code"] == "VALIDATION_ERROR"
+        assert result["details"]["output_mode"] == "inline"
+        assert "escape" not in str(result)
+
+    def test_non_ascii_formats_are_explicitly_rejected(self, tmp_path):
+        tools = _get_viz_tool_functions(results_dir=tmp_path / "results")
+        result = tools["generate_chart"](result_files="missing.json", format="png")
+
+        assert result["error"] is True
+        assert result["error_code"] == "VALIDATION_INVALID_FORMAT"
+        assert result["details"]["supported_formats"] == ["ascii"]
+
     def test_rejects_invalid_chart_type(self, tmp_path):
         """Test that invalid chart type is rejected."""
         results_dir = tmp_path / "benchmark_runs" / "results"


### PR DESCRIPTION
Implements add-file-output-support-to-mcp-chart-generation-v2-2.\n\n- Makes the inline ASCII-only contract explicit.\n- Rejects caller-selected output paths and non-ASCII formats before result resolution.\n- Adds regression coverage and documents the deferred tenant artifact contract.\n\nVerification: 43 visualization unit tests; 19 MCP integration tests; Ruff check/format.