### PR TITLE
test: cover MCP prompt transport parity

### DIFF
--- a/docs/reference/mcp.md
+++ b/docs/reference/mcp.md
@@ -398,6 +398,14 @@ visualization registries and are discoverable with `list_available(category="cha
 ## Prompts
 
 Prompts are reusable templates for AI analysis. Invoke via slash commands in Claude Code.
+The same prompt catalog is available through both supported transports: use
+`prompts/list` to discover the seven names and argument schemas, then
+`prompts/get` with a prompt name and string-valued arguments to render one
+prompt. Stdio and sessionless Streamable HTTP return the same prompt metadata
+and rendered text; HTTP requests do not require or receive an `Mcp-Session-Id`.
+The landing quickstart catalog references three of these prompts for guided
+benchmark flows; the four remaining prompts are still first-class MCP prompts
+and are discoverable at runtime.
 
 ### `analyze_results`
 

--- a/tests/integration/mcp/test_stateless_http.py
+++ b/tests/integration/mcp/test_stateless_http.py
@@ -12,6 +12,24 @@ from tests.integration.mcp._transport import http_client
 
 pytestmark = [pytest.mark.integration, pytest.mark.fast]
 
+EXPECTED_PROMPTS = {
+    "analyze_results",
+    "benchmark_planning",
+    "benchmark_run",
+    "compare_platforms",
+    "identify_regressions",
+    "platform_tuning",
+    "troubleshoot_failure",
+}
+
+
+async def _prompt_text(client, name: str, arguments: dict[str, str]) -> str:
+    result = await client.get_prompt(name, arguments)
+    assert len(result.messages) == 1
+    content = result.messages[0].content
+    assert isinstance(content, TextContent)
+    return content.text
+
 
 def test_modern_discovery_and_tool_call_are_sessionless(tmp_path: Path) -> None:
     request_headers: list[dict[str, str]] = []
@@ -36,6 +54,36 @@ def test_modern_discovery_and_tool_call_are_sessionless(tmp_path: Path) -> None:
     anyio.run(exercise)
 
     assert len(request_headers) >= 3  # discover, tools/list, and tools/call
+    assert all("mcp-session-id" not in headers for headers in request_headers)
+    assert all("mcp-session-id" not in headers for headers in response_headers)
+
+
+def test_modern_prompt_list_and_get_are_sessionless(tmp_path: Path) -> None:
+    request_headers: list[dict[str, str]] = []
+    response_headers: list[dict[str, str]] = []
+
+    async def exercise() -> None:
+        async with http_client(
+            tmp_path,
+            mode="auto",
+            request_headers=request_headers,
+            response_headers=response_headers,
+        ) as client:
+            prompts = await client.list_prompts()
+            assert {prompt.name for prompt in prompts.prompts} == EXPECTED_PROMPTS
+
+            rendered = await _prompt_text(
+                client,
+                "benchmark_run",
+                {"platform": "duckdb", "benchmark": "tpch", "scale_factor": "0.01", "queries": "Q1,Q6"},
+            )
+            assert "Platform: duckdb" in rendered
+            assert "Benchmark: TPCH" in rendered
+            assert "Query subset: Q1,Q6" in rendered
+
+    anyio.run(exercise)
+
+    assert len(request_headers) >= 3  # discover, prompts/list, and prompts/get
     assert all("mcp-session-id" not in headers for headers in request_headers)
     assert all("mcp-session-id" not in headers for headers in response_headers)
 

--- a/tests/integration/mcp/test_transport_contract_parity.py
+++ b/tests/integration/mcp/test_transport_contract_parity.py
@@ -16,6 +16,24 @@ from tests.integration.mcp._transport import http_client
 
 pytestmark = [pytest.mark.integration, pytest.mark.fast]
 
+PROMPT_ARGUMENTS: dict[str, dict[str, str]] = {
+    "analyze_results": {"benchmark": "tpch", "platform": "duckdb", "focus": "slowest_queries"},
+    "benchmark_planning": {"use_case": "comparison", "platforms": "duckdb,snowflake", "time_budget_minutes": "60"},
+    "benchmark_run": {"platform": "duckdb", "benchmark": "tpch", "scale_factor": "0.01", "queries": "Q1,Q6"},
+    "compare_platforms": {"benchmark": "tpch", "platforms": "duckdb,polars-df", "scale_factor": "0.1"},
+    "identify_regressions": {
+        "baseline_run": "run1.json",
+        "comparison_run": "run2.json",
+        "threshold_percent": "15",
+    },
+    "platform_tuning": {"platform": "duckdb", "workload": "OLAP heavy joins"},
+    "troubleshoot_failure": {
+        "error_message": "Connection refused",
+        "platform": "snowflake",
+        "benchmark": "tpch",
+    },
+}
+
 
 async def _inventory(client: Client) -> dict[str, list[dict[str, Any]]]:
     """Return the public discovery contract in a transport-neutral shape."""
@@ -38,8 +56,22 @@ async def _inventory(client: Client) -> dict[str, list[dict[str, Any]]]:
     }
 
 
+async def _prompt_payloads(client: Client) -> dict[str, list[str]]:
+    """Render every prompt through the public client API."""
+    rendered: dict[str, list[str]] = {}
+    for name, arguments in PROMPT_ARGUMENTS.items():
+        result = await client.get_prompt(name, arguments)
+        rendered[name] = [message.content.text for message in result.messages]
+    return rendered
+
+
 def test_stdio_and_streamable_http_publish_identical_contracts(tmp_path: Path) -> None:
-    async def exercise() -> tuple[dict[str, list[dict[str, Any]]], dict[str, list[dict[str, Any]]]]:
+    async def exercise() -> tuple[
+        dict[str, list[dict[str, Any]]],
+        dict[str, list[dict[str, Any]]],
+        dict[str, list[str]],
+        dict[str, list[str]],
+    ]:
         results_dir = tmp_path / "results"
         charts_dir = tmp_path / "charts"
         params = StdioServerParameters(
@@ -57,6 +89,7 @@ def test_stdio_and_streamable_http_publish_identical_contracts(tmp_path: Path) -
         with open(os.devnull, "w", encoding="utf-8") as errlog:
             async with Client(stdio_client(params, errlog=errlog), mode="legacy") as stdio:
                 stdio_inventory = await _inventory(stdio)
+                stdio_prompts = await _prompt_payloads(stdio)
 
         async with http_client(
             tmp_path,
@@ -65,12 +98,16 @@ def test_stdio_and_streamable_http_publish_identical_contracts(tmp_path: Path) -
             response_headers=[],
         ) as http:
             http_inventory = await _inventory(http)
+            http_prompts = await _prompt_payloads(http)
 
-        return stdio_inventory, http_inventory
+        return stdio_inventory, http_inventory, stdio_prompts, http_prompts
 
-    stdio_inventory, http_inventory = anyio.run(exercise)
+    stdio_inventory, http_inventory, stdio_prompts, http_prompts = anyio.run(exercise)
 
     assert stdio_inventory == http_inventory
+    assert stdio_prompts == http_prompts
+    assert set(http_prompts) == {prompt["name"] for prompt in http_inventory["prompts"]}
+    assert all(payload and all(text.strip() for text in payload) for payload in http_prompts.values())
     assert len(http_inventory["tools"]) == 12
     assert len(http_inventory["resources"]) == 4
     assert len(http_inventory["resource_templates"]) == 2

--- a/tests/unit/landing/test_landing_quickstarts.py
+++ b/tests/unit/landing/test_landing_quickstarts.py
@@ -290,6 +290,15 @@ def test_unknown_mcp_prompt_is_rejected(gen, catalog):
     assert any("prompt_that_does_not_exist" in e for e in errors)
 
 
+def test_mcp_prompt_catalog_matches_registered_prompt_surface(catalog):
+    from benchbox.mcp import create_server
+    from tests.unit.mcp.public_api import list_prompt_names
+
+    configured = catalog["mcp"]["prompts"]
+    assert set(configured) == {"analyze_results", "benchmark_run", "compare_platforms"}
+    assert set(configured.values()) <= list_prompt_names(create_server())
+
+
 def test_credential_platforms_declare_safety_terms(browser_catalog):
     for platform in browser_catalog["platforms"]:
         if platform.get("credential_deployments"):


### PR DESCRIPTION
Implements mcp-live-prompt-integration-coverage-v2-2.

- exercises prompts/list and prompts/get over stdio and stateless Streamable HTTP
- compares all seven rendered prompt payloads across transports
- pins landing prompt mapping to registered names
- documents intentional landing subset and sessionless parity

Verification: focused MCP/landing suites (80 passed), generator validate-only, Ruff check/format.