### PR TITLE
docs: define MCP textcharts namespace boundary

### DIFF
--- a/docs/reference/mcp.md
+++ b/docs/reference/mcp.md
@@ -387,6 +387,12 @@ from `benchbox.core.visualization.chart_types`, such as `performance_bar`,
 `textcharts_*` primitive MCP tools. BenchBox does not register or proxy the
 external `textcharts-mcp` server; if a client configures that server separately,
 its tools remain a separate raw rendering namespace.
+The `textcharts` Python package is an implementation dependency of BenchBox's
+ASCII compatibility layer, not an MCP server registration. Running only
+`benchbox-mcp` therefore publishes the result-aware tools listed below; a
+client that intentionally configures a separate `textcharts-mcp` process sees
+that server under its own namespace and must apply its own support and security
+review.
 
 #### `suggest_charts`
 

--- a/docs/reference/public-contracts.md
+++ b/docs/reference/public-contracts.md
@@ -207,6 +207,10 @@ When a user configures both servers, `textcharts_*` tools are a separate raw
 primitive rendering namespace; BenchBox MCP `chart_type` values remain semantic
 IDs from the registry above, and template names come from
 `benchbox.core.visualization.templates`.
+Installing the `textcharts` Python dependency does not change this MCP
+registration boundary. Any future bundle or proxy proposal requires a separate
+product, security, and support decision with its own contract and acceptance
+tests; no client should infer one from the dependency alone.
 
 ## SQL Compatibility Governance Decision
 

--- a/tests/integration/mcp/test_transport_contract_parity.py
+++ b/tests/integration/mcp/test_transport_contract_parity.py
@@ -33,6 +33,7 @@ PROMPT_ARGUMENTS: dict[str, dict[str, str]] = {
         "benchmark": "tpch",
     },
 }
+RAW_TEXTCHARTS_PREFIX = "textcharts_"
 
 
 async def _inventory(client: Client) -> dict[str, list[dict[str, Any]]]:
@@ -108,6 +109,10 @@ def test_stdio_and_streamable_http_publish_identical_contracts(tmp_path: Path) -
     assert stdio_prompts == http_prompts
     assert set(http_prompts) == {prompt["name"] for prompt in http_inventory["prompts"]}
     assert all(payload and all(text.strip() for text in payload) for payload in http_prompts.values())
+    for inventory in (stdio_inventory, http_inventory):
+        tool_names = {tool["name"] for tool in inventory["tools"]}
+        assert {"suggest_charts", "generate_chart"} <= tool_names
+        assert not any(name.startswith(RAW_TEXTCHARTS_PREFIX) for name in tool_names)
     assert len(http_inventory["tools"]) == 12
     assert len(http_inventory["resources"]) == 4
     assert len(http_inventory["resource_templates"]) == 2


### PR DESCRIPTION
Implements mcp-textcharts-surface-boundary-v2-2.

- documents result-aware BenchBox chart tools versus separately configured raw textcharts MCP tools
- states that the Python dependency does not imply MCP registration
- adds stdio/HTTP parity assertions forbidding implicit textcharts_ tools
- logs separate product/security decision follow-up before any future bundle/proxy work

Verification: 59 focused MCP tests passed; boundary checks and Ruff passed.