### PR TITLE
ci(results): require Explorer Vitest on develop

### DIFF
--- a/.github/path-filters.yml
+++ b/.github/path-filters.yml
@@ -127,3 +127,14 @@ viz:
   - "results-explorer/**"
   - "tests/parity/**"
   - "_project/scripts/explorer_pipeline/**"
+
+# Results Explorer unit-test contract. Keep this broader than the frontend
+# source tree: read-model/build-contract, curated data, fixture generators,
+# and publication workflow changes can all invalidate Vitest expectations.
+explorer-vitest:
+  - "results-explorer/**"
+  - "_project/scripts/explorer_pipeline/**"
+  - "_project/scripts/explorer_publish.py"
+  - "results-data/**"
+  - "scripts/generate_corpus_inventory.py"
+  - ".github/workflows/results-explorer-browser.yml"

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -26,6 +26,7 @@ jobs:
       estimated-runner-minutes-saved: ${{ steps.classify.outputs.estimated-runner-minutes-saved }}
       packaging-needed: ${{ steps.classify.outputs.packaging-needed }}
       viz-needed: ${{ steps.classify.outputs.viz-needed }}
+      explorer-vitest-needed: ${{ steps.classify.outputs.explorer-vitest-needed }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -1022,6 +1023,35 @@ jobs:
             uv run --with pip-audit -- pip-audit
           fi
 
+  explorer-vitest:
+    name: explorer-vitest
+    needs: ci-paths
+    # The Explorer contract includes frontend source/tests, package metadata,
+    # read-model/build-contract code, curated inputs, and the fixture/publish
+    # scripts. The path-filter group keeps unrelated Python-only PRs from
+    # installing Node while ensuring every input Vitest can exercise is gated.
+    if: ${{ needs.ci-paths.outputs.explorer-vitest-needed == 'true' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: npm
+          cache-dependency-path: results-explorer/package-lock.json
+
+      - name: Install explorer dependencies
+        run: npm ci
+        working-directory: results-explorer
+
+      - name: Run Explorer Vitest suite
+        run: npm test -- --run
+        working-directory: results-explorer
+
   parity-check:
     name: parity-check
     needs: ci-paths
@@ -1096,7 +1126,7 @@ jobs:
 
   ci-required-result:
     name: ci-required-result
-    needs: [ci-paths, content-guard, code-lint, code-test, correctness-gate, plan-capture-gate, medium-test, explorer-tokens, audit-sha, package-smoke, dependency-audit, parity-check]
+    needs: [ci-paths, content-guard, code-lint, code-test, correctness-gate, plan-capture-gate, medium-test, explorer-tokens, explorer-vitest, audit-sha, package-smoke, dependency-audit, parity-check]
     if: always()
     runs-on: ubuntu-latest
     steps:
@@ -1110,6 +1140,7 @@ jobs:
           PLAN_CAPTURE_RESULT: ${{ needs.plan-capture-gate.result }}
           MEDIUM_TEST_RESULT: ${{ needs.medium-test.result }}
           EXPLORER_TOKENS_RESULT: ${{ needs.explorer-tokens.result }}
+          EXPLORER_VITEST_RESULT: ${{ needs.explorer-vitest.result }}
           AUDIT_SHA_RESULT: ${{ needs.audit-sha.result }}
           PACKAGE_SMOKE_RESULT: ${{ needs.package-smoke.result }}
           DEPENDENCY_AUDIT_RESULT: ${{ needs.dependency-audit.result }}
@@ -1178,6 +1209,15 @@ jobs:
           if [ "$EXPLORER_TOKENS_RESULT" != "success" ] \
               && [ "$EXPLORER_TOKENS_RESULT" != "skipped" ]; then
             echo "explorer-tokens=$EXPLORER_TOKENS_RESULT"
+            exit 1
+          fi
+
+          # Explorer Vitest is path-filtered on the complete frontend/read-model
+          # contract. A skipped result is intentional only when the contract
+          # group did not match; a real failure must block the required context.
+          if [ "$EXPLORER_VITEST_RESULT" != "success" ] \
+              && [ "$EXPLORER_VITEST_RESULT" != "skipped" ]; then
+            echo "explorer-vitest=$EXPLORER_VITEST_RESULT"
             exit 1
           fi
 

--- a/tests/unit/scripts/test_path_filter_decision.py
+++ b/tests/unit/scripts/test_path_filter_decision.py
@@ -69,6 +69,36 @@ def test_empty_diff_routes_to_full_ci(rules: dict[str, list[str]]) -> None:
     assert decision["needs_code_ci"] is True
 
 
+def test_explorer_vitest_group_covers_the_full_contract(rules: dict[str, list[str]]) -> None:
+    decision = classify_paths(
+        [
+            "results-explorer/src/pages/Home.tsx",
+            "results-explorer/package-lock.json",
+            "_project/scripts/explorer_pipeline/contract.py",
+            "results-data/corpus-inventory.json",
+            "scripts/generate_corpus_inventory.py",
+            ".github/workflows/results-explorer-browser.yml",
+        ],
+        rules,
+    )
+
+    assert decision["explorer_vitest_needed"] is True
+    assert set(decision["explorer_vitest_paths"]) == {
+        "results-explorer/src/pages/Home.tsx",
+        "results-explorer/package-lock.json",
+        "_project/scripts/explorer_pipeline/contract.py",
+        "results-data/corpus-inventory.json",
+        "scripts/generate_corpus_inventory.py",
+        ".github/workflows/results-explorer-browser.yml",
+    }
+
+
+def test_unrelated_python_change_skips_explorer_vitest(rules: dict[str, list[str]]) -> None:
+    decision = classify_paths(["benchbox/cli/run.py"], rules)
+    assert decision["explorer_vitest_needed"] is False
+    assert decision["explorer_vitest_paths"] == []
+
+
 # F2 regression: docs/** glob originally treated all of docs/ as safe-content,
 # bypassing lint/test for Sphinx Python and config files. The narrowed rules
 # must keep prose safe but route Sphinx code through full CI.

--- a/tests/unit/workflows/test_pr_workflow_path_classifier.py
+++ b/tests/unit/workflows/test_pr_workflow_path_classifier.py
@@ -76,6 +76,7 @@ def _run_ci_required_result(**env_overrides: str) -> subprocess.CompletedProcess
         "PACKAGE_SMOKE_RESULT": "skipped",
         "DEPENDENCY_AUDIT_RESULT": "skipped",
         "PARITY_CHECK_RESULT": "skipped",
+        "EXPLORER_VITEST_RESULT": "skipped",
         "CONTENT_GUARD_NEEDED": "false",
         "NEEDS_CODE_CI": "false",
         "SAFE_CONTENT_ONLY": "true",
@@ -133,6 +134,39 @@ def test_ci_required_result_fails_on_explorer_tokens_failure() -> None:
 
     assert result.returncode == 1
     assert "explorer-tokens=failure" in result.stdout
+
+
+def test_ci_required_result_fails_on_explorer_vitest_failure() -> None:
+    result = _run_ci_required_result(
+        NEEDS_CODE_CI="true",
+        SAFE_CONTENT_ONLY="false",
+        LINT_RESULT="success",
+        TEST_RESULT="success",
+        CORRECTNESS_RESULT="success",
+        PLAN_CAPTURE_RESULT="success",
+        MEDIUM_TEST_RESULT="success",
+        EXPLORER_TOKENS_RESULT="success",
+        EXPLORER_VITEST_RESULT="failure",
+    )
+
+    assert result.returncode == 1
+    assert "explorer-vitest=failure" in result.stdout
+
+
+def test_ci_required_result_treats_explorer_vitest_skipped_as_success() -> None:
+    result = _run_ci_required_result(
+        NEEDS_CODE_CI="true",
+        SAFE_CONTENT_ONLY="false",
+        LINT_RESULT="success",
+        TEST_RESULT="success",
+        CORRECTNESS_RESULT="success",
+        PLAN_CAPTURE_RESULT="success",
+        MEDIUM_TEST_RESULT="success",
+        EXPLORER_TOKENS_RESULT="success",
+        EXPLORER_VITEST_RESULT="skipped",
+    )
+
+    assert result.returncode == 0
 
 
 def test_ci_required_result_treats_explorer_tokens_skipped_as_success() -> None:
@@ -231,6 +265,23 @@ def test_ci_required_result_required_jobs_in_needs() -> None:
     # result silently disappears from the gate.
     assert "package-smoke" in needs
     assert "dependency-audit" in needs
+    assert "explorer-vitest" in needs
+
+
+def test_explorer_vitest_job_uses_contract_filter_and_exact_command() -> None:
+    workflow_yaml = yaml.safe_load((REPO_ROOT / ".github" / "workflows" / "pr.yml").read_text(encoding="utf-8"))
+    job = workflow_yaml["jobs"]["explorer-vitest"]
+    assert job["if"] == "${{ needs.ci-paths.outputs.explorer-vitest-needed == 'true' }}"
+    run_steps = [step for step in job["steps"] if step.get("name") == "Run Explorer Vitest suite"]
+    assert len(run_steps) == 1
+    assert run_steps[0]["run"] == "npm test -- --run"
+    assert run_steps[0]["working-directory"] == "results-explorer"
+    aggregate = next(
+        step
+        for step in workflow_yaml["jobs"]["ci-required-result"]["steps"]
+        if step.get("name") == "Aggregate required result"
+    )
+    assert aggregate["env"]["EXPLORER_VITEST_RESULT"] == "${{ needs.explorer-vitest.result }}"
 
 
 def test_ci_paths_job_outputs_declare_every_path_filter_group() -> None:


### PR DESCRIPTION
## Summary
- add an Explorer contract path-filter group covering frontend, read-model, curated data, fixture, and publish inputs
- run the exact npm Vitest command in a distinct path-aware PR job
- feed success/failure/intentional-skip into ci-required-result so Vitest failures block develop merges

## Verification
- 131 Python workflow/path tests passed
- npm ci && npm test -- --run: 70 files, 849 tests passed
- YAML parsing and pre-commit check-yaml passed
- failure and unrelated-path skip behavior are pinned by shell contract tests