### PR TITLE
test: pin MCP conformance baseline rationale

### DIFF
--- a/docs/operations/mcp-conformance-baseline.md
+++ b/docs/operations/mcp-conformance-baseline.md
@@ -1,0 +1,41 @@
+# MCP conformance baseline
+
+The automated conformance gate is pinned to protocol `2026-07-28` and
+conformance revision `81eb1c3edaed87d7fd585d7b80186da7a2960660` (short SHA
+`81eb1c3`). The Inspector package and integrity pins live in
+`benchbox.mcp.readiness`. The verifier allows exactly four server-stateless
+entries; every other conformance result is unexpected and blocks the gate.
+
+| Baseline entry | Classification | Why it is bounded and non-waiving |
+| --- | --- | --- |
+| `server-stateless:sep-2575-server-rejects-undeclared-capability` | Fixture non-applicability | The upstream scenario requires a diagnostic `test_missing_capability` tool. BenchBox intentionally publishes no diagnostic or sampling tool, so the MUST cannot be exercised. The compatibility test asserts that this tool is absent. |
+| `server-stateless:sep-2575-missing-capability-http-400` | Fixture non-applicability | This HTTP status check is conditional on the same missing-capability error. Without the diagnostic fixture there is no status claim to waive; an actual BenchBox capability error remains gate-blocking. |
+| `server-stateless:sep-2575-server-sends-prompts-list-changed-on-subscription` | Static-registry limitation | BenchBox's prompt registry is assembled at startup and has no supported runtime mutation or diagnostic trigger. The server's subscription transport is retained for the stateless protocol, but no prompt-list change is promised. |
+| `server-stateless:sep-2575-server-sends-tools-list-changed-on-subscription` | Static-registry limitation | BenchBox's tool registry is assembled at startup and has no supported runtime mutation or diagnostic trigger. The server's subscription transport is retained for the stateless protocol, but no tool-list change is promised. |
+
+The two capability entries are not a security exception: BenchBox does not
+claim to implement the absent diagnostic capability. The two list-change
+entries are not permission to mutate registries silently: any future dynamic
+registration path must add its own notification behavior, tests, and a new
+revision-bound baseline review. The guard in
+`tests/integration/mcp/test_protocol_compatibility.py` checks the absence of
+the diagnostic tool and the stability of tool and prompt listings across
+requests for both supported handshake modes. The upstream notification
+requirements are named `promptsListChanged` and `toolsListChanged`; those
+capabilities have no supported BenchBox mutation trigger today.
+
+## Rerun and retirement policy
+
+Run:
+
+```bash
+uv run -- python scripts/verify_mcp_conformance.py --protocol-version 2026-07-28
+```
+
+The exact four IDs are declared individually in
+`scripts/verify_mcp_conformance.py`. Do not broaden the baseline to a prefix,
+scenario, or “known failures” bucket. When upstream removes a fixture gap or
+BenchBox adds a dynamic mutation path, rerun the pinned gate, remove the
+resolved entry, and update this document in the same change. A stale or
+unexpected result remains fail-closed and keeps the production-readiness gate
+closed.

--- a/docs/operations/mcp-production-readiness.md
+++ b/docs/operations/mcp-production-readiness.md
@@ -47,3 +47,7 @@ diagnostic evidence but never satisfy the gate.
 The publication gate validates evidence freshness, source revision, exact tool
 pins, the evidence-file digest supplied out of band, and every required row.
 Do not weaken or bypass the gate to publish an endpoint.
+
+The exact conformance baseline and its fixture-bound rationale are maintained
+in [MCP conformance baseline](mcp-conformance-baseline.md). A baseline entry
+does not waive a real protocol, security, or tenancy defect.

--- a/scripts/verify_mcp_conformance.py
+++ b/scripts/verify_mcp_conformance.py
@@ -35,6 +35,16 @@ SCENARIOS = (
     "server-sse-multiple-streams",
     "server-stateless",
 )
+# This is an exact, revision-bound fixture baseline.  Keep every entry
+# individually named: the conformance runner must fail closed for any result
+# not listed here, and a baseline entry never waives a real BenchBox defect.
+EXPECTED_FAILURE_IDS = (
+    "server-stateless:sep-2575-server-rejects-undeclared-capability",
+    "server-stateless:sep-2575-missing-capability-http-400",
+    "server-stateless:sep-2575-server-sends-prompts-list-changed-on-subscription",
+    "server-stateless:sep-2575-server-sends-tools-list-changed-on-subscription",
+)
+EXPECTED_FAILURES = "server:\n" + "".join(f"  - {failure}\n" for failure in EXPECTED_FAILURE_IDS)
 
 
 def _run(command: list[str], *, cwd: Path | None = None, timeout: int = 600) -> None:

--- a/tests/integration/mcp/test_protocol_compatibility.py
+++ b/tests/integration/mcp/test_protocol_compatibility.py
@@ -35,3 +35,22 @@ def test_supported_protocol_is_sessionless(tmp_path: Path, mode: str, expected_v
     assert request_headers
     assert all("mcp-session-id" not in headers for headers in request_headers)
     assert all("mcp-session-id" not in headers for headers in response_headers)
+
+
+@pytest.mark.parametrize("mode", ["auto", "legacy"])
+def test_conformance_baseline_assumptions_are_guarded(tmp_path: Path, mode: str) -> None:
+    """Keep the pinned fixture gaps separate from BenchBox's supported surface."""
+
+    async def exercise() -> None:
+        async with http_client(tmp_path, mode=mode, request_headers=[], response_headers=[]) as client:
+            tool_names = {tool.name for tool in (await client.list_tools()).tools}
+            first_tools = [tool.model_dump(mode="json") for tool in (await client.list_tools()).tools]
+            second_tools = [tool.model_dump(mode="json") for tool in (await client.list_tools()).tools]
+            first_prompts = [prompt.model_dump(mode="json") for prompt in (await client.list_prompts()).prompts]
+            second_prompts = [prompt.model_dump(mode="json") for prompt in (await client.list_prompts()).prompts]
+
+            assert "test_missing_capability" not in tool_names
+            assert first_tools == second_tools
+            assert first_prompts == second_prompts
+
+    anyio.run(exercise)


### PR DESCRIPTION
Implements mcp-conformance-baseline-followup-v2-2.

- records the exact four baseline entries against conformance revision 81eb1c3
- keeps verifier allowances individually named and fail-closed for new failures
- guards absent diagnostic fixture and static tool/prompt registries for both handshakes
- links the baseline to production-readiness documentation

Verification: pinned conformance/Inspector gate exit 0 (26/28 passed plus exactly four baseline entries), compatibility/stateless tests pass, Ruff clean.