### PR TITLE
fix(results): harden route recovery and docs navigation

### DIFF
--- a/results-explorer/e2e/routes/direct-route.spec.ts
+++ b/results-explorer/e2e/routes/direct-route.spec.ts
@@ -1,5 +1,5 @@
 import { expect, test, type Page } from "@playwright/test";
-import { waitForDataElement, waitForShell } from "../support/fixtures";
+import { waitForDataElement, waitForDataLoaded, waitForShell } from "../support/fixtures";
 
 const SHORT_DUCKDB = "ba6a8c83";
 const SHORT_DATAFUSION = "5e6c5eba";
@@ -60,6 +60,28 @@ test.describe("direct route parity", () => {
 
     await page.goto("/results/compare");
     await waitForDataElement(page, page.getByRole("heading", { name: /^Pick runs to compare$/ }));
+  });
+
+  test("flywheel documentation CTAs use real native navigation", async ({ page }) => {
+    await page.route("**/docs/**", async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: "text/html",
+        body: "<!doctype html><title>BenchBox docs</title><h1>Documentation route</h1>",
+      });
+    });
+    await page.goto("/results/");
+    await waitForDataLoaded(page, /Recent Results/i);
+
+    await page.getByRole("link", { name: "Run a benchmark" }).click();
+    await expect(page).toHaveURL(/\/docs\/usage\/installation\.html$/);
+    await expect(page.getByRole("heading", { name: "Documentation route" })).toBeVisible();
+
+    await page.goto("/results/");
+    await waitForDataLoaded(page, /Recent Results/i);
+    await page.getByRole("link", { name: "Submit a bundle" }).click();
+    await expect(page).toHaveURL(/\/docs\/contributing-results\.html$/);
+    await expect(page.getByRole("heading", { name: "Documentation route" })).toBeVisible();
   });
 
   test("direct route compare warning copy uses singular and plural labels", async ({ page }) => {

--- a/results-explorer/src/pages/Home.tsx
+++ b/results-explorer/src/pages/Home.tsx
@@ -1083,6 +1083,7 @@ function FlywheelStrip() {
             <a
               key={step.href}
               href={step.href}
+              data-native={step.href.startsWith("/docs/") ? "true" : undefined}
               aria-label={step.label}
               class="inline-flex h-9 items-center gap-2 rounded-md border border-[var(--bb-data-border)] bg-[var(--bb-surface-data)] px-3 text-sm font-medium text-[var(--bb-data-fg-primary)] no-underline hover:border-[var(--bb-accent)] hover:bg-[var(--bb-tone-info-bg)] hover:text-[var(--bb-accent-hover)]"
             >

--- a/results-explorer/src/pages/PlatformIndex.tsx
+++ b/results-explorer/src/pages/PlatformIndex.tsx
@@ -47,6 +47,12 @@ type TrendMetric = "power_score" | "display_geomean_ms";
 const TABLE_RENDER_LIMIT = 200;
 const TABLE_RENDER_INCREMENT = 200;
 const MIN_TREND_OBSERVATIONS = 3;
+const PLATFORM_ROUTE_ALIASES: Readonly<Record<string, string>> = {
+  // Historical links used underscores, while the registry's canonical ID is
+  // hyphenated. Keep this explicit: arbitrary underscore rewriting would
+  // corrupt legitimate platform or benchmark identifiers.
+  clickhouse_local: "clickhouse-local",
+};
 const PLATFORM_RESULT_FACET_KEYS: FacetKey[] = [
   "benchmark",
   "scale_factor",
@@ -77,8 +83,13 @@ function normalizePlatformKey(value: string): string {
   return value.trim().toLowerCase();
 }
 
+function canonicalPlatformRouteKey(value: string): string {
+  const normalized = normalizePlatformKey(value);
+  return PLATFORM_ROUTE_ALIASES[normalized] ?? normalized;
+}
+
 function platformRowsForRequest(rows: PlatformIndexRowRow[], platform: string): PlatformIndexRowRow[] {
-  const requested = normalizePlatformKey(platform);
+  const requested = canonicalPlatformRouteKey(platform);
   // platform_id is the canonical URL identity. Only fall back to display
   // labels when no canonical id matches, otherwise same-name sibling tracks
   // such as datafusion/datafusion-44 would collapse into one page.
@@ -204,6 +215,16 @@ export function PlatformIndex({ platform = "" }: PlatformIndexProps) {
   }, []);
 
   useEffect(() => {
+    if (!rows) return;
+    const requested = normalizePlatformKey(platform);
+    const canonical = canonicalPlatformRouteKey(platform);
+    if (requested === canonical) return;
+    if (rows.some((row) => normalizePlatformKey(row.platform_id) === canonical)) {
+      route(`/results/p/${canonical}/`, true);
+    }
+  }, [platform, rows]);
+
+  useEffect(() => {
     setVisibleLimit(TABLE_RENDER_LIMIT);
   }, [
     platform,
@@ -242,7 +263,7 @@ export function PlatformIndex({ platform = "" }: PlatformIndexProps) {
   // Fall back to matching by display name for backward compatibility with any
   // old links constructed from the display name.
   const allPlatformResults = platformRowsForRequest(rows, platform);
-  const canonicalPlatformId = normalizePlatformKey(allPlatformResults[0]?.platform_id ?? platform);
+  const canonicalPlatformId = normalizePlatformKey(allPlatformResults[0]?.platform_id ?? canonicalPlatformRouteKey(platform));
 
   // Distinct platform options for the in-page sibling pivot, sorted by
   // display name. Platform ids can arrive with mixed casing from older

--- a/results-explorer/src/pages/ResultDetail.tsx
+++ b/results-explorer/src/pages/ResultDetail.tsx
@@ -129,7 +129,19 @@ export function ResultDetail({ resultId = "" }: ResultDetailProps) {
     [detail, rawSort],
   );
 
-  if (error) return <ErrorMessage message={error} />;
+  if (error) {
+    return (
+      <div class="mx-auto max-w-7xl px-4 py-8 sm:px-6 lg:px-8">
+        <Breadcrumb crumbs={[{ label: "Results", href: "/results/" }, { label: "Result detail" }]} />
+        <div class="mt-8">
+          <ErrorMessage message={error} />
+          <a href="/results/" class="mt-4 inline-block btn btn-secondary no-underline">
+            Back to Results
+          </a>
+        </div>
+      </div>
+    );
+  }
   if (!detail || !chartContext) return <LoadingSpinner message="Loading result..." />;
 
   const benchmarkLabel = humanizeBenchmark(detail.benchmark);

--- a/results-explorer/src/pages/__tests__/Home.test.tsx
+++ b/results-explorer/src/pages/__tests__/Home.test.tsx
@@ -682,18 +682,16 @@ describe("Home", () => {
 
     expect(screen.getByText("Run -> Compare -> Submit")).toBeTruthy();
     const workflow = screen.getByRole("navigation", { name: "Result contribution workflow" });
-    expect(within(workflow).getByRole("link", { name: "Run a benchmark" })).toHaveAttribute(
-      "href",
-      "/docs/usage/installation.html",
-    );
+    const runLink = within(workflow).getByRole("link", { name: "Run a benchmark" });
+    expect(runLink).toHaveAttribute("href", "/docs/usage/installation.html");
+    expect(runLink).toHaveAttribute("data-native", "true");
     expect(within(workflow).getByRole("link", { name: "Compare your result" })).toHaveAttribute(
       "href",
       "/results/compare",
     );
-    expect(within(workflow).getByRole("link", { name: "Submit a bundle" })).toHaveAttribute(
-      "href",
-      "/docs/contributing-results.html",
-    );
+    const submitLink = within(workflow).getByRole("link", { name: "Submit a bundle" });
+    expect(submitLink).toHaveAttribute("href", "/docs/contributing-results.html");
+    expect(submitLink).toHaveAttribute("data-native", "true");
     expect(screen.queryByText("Run BenchBox on your platform and submit your results")).toBeNull();
   });
 

--- a/results-explorer/src/pages/__tests__/PlatformIndex.test.tsx
+++ b/results-explorer/src/pages/__tests__/PlatformIndex.test.tsx
@@ -144,6 +144,23 @@ describe("PlatformIndex - sortable table headers", () => {
     expect(getRowOrder(container)).toEqual(["r-tpch-fast", "r-ssb-mid", "r-tpch-slow", "r-null-geo"]);
   });
 
+  it("canonicalizes the explicit clickhouse_local route alias", async () => {
+    const preactRouter = await import("preact-router");
+    const routeMock = vi.mocked(preactRouter.route);
+    vi.mocked(getPlatformIndexRows).mockResolvedValue([
+      ...ROWS,
+      makeRow({ result_id: "r-clickhouse", platform_id: "clickhouse-local", platform: "ClickHouse Local" }),
+    ]);
+
+    render(<PlatformIndex platform="clickhouse_local" />);
+    await waitFor(() => expect(screen.getByText("ClickHouse Local Results")).toBeTruthy());
+
+    await waitFor(() => expect(routeMock).toHaveBeenCalledWith("/results/p/clickhouse-local/", true));
+    const switcher = screen.getByTestId("platform-switcher") as HTMLSelectElement;
+    expect(switcher.value).toBe("clickhouse-local");
+    expect(within(switcher).queryByRole("option", { name: "clickhouse_local" })).toBeNull();
+  });
+
   it("retries a transient empty platform index before rendering a terminal empty state", async () => {
     vi.mocked(getPlatformIndexRows).mockResolvedValueOnce([]).mockResolvedValueOnce(ROWS);
 

--- a/results-explorer/src/pages/__tests__/ResultDetail.test.tsx
+++ b/results-explorer/src/pages/__tests__/ResultDetail.test.tsx
@@ -90,6 +90,16 @@ describe("ResultDetail - median-first contract", () => {
     vi.mocked(getPrimaryMetricForBenchmark).mockResolvedValue("power_score");
   });
 
+  it("gives an invalid result ID a recovery link", async () => {
+    vi.mocked(getDetailResult).mockResolvedValue(null);
+
+    render(<ResultDetail resultId="stale-result" />);
+    await waitFor(() => expect(screen.getByRole("alert")).toBeTruthy());
+
+    expect(screen.getByRole("alert")).toHaveTextContent('No result found for "stale-result".');
+    expect(screen.getByRole("link", { name: "Back to Results" })).toHaveAttribute("href", "/results/");
+  });
+
   it("(a) default table shows one row per display_timing, not per raw query", async () => {
     render(<ResultDetail resultId="r1" />);
     await waitFor(() => expect(screen.queryByText("Loading result...")).toBeNull());


### PR DESCRIPTION
## Summary
- mark Home documentation CTAs as native links so preact-router cannot render the SPA 404
- canonicalize the explicit clickhouse_local legacy alias without rewriting arbitrary identifiers
- add invalid-result recovery controls and real-click/direct-route browser coverage

## Verification
- typecheck passed
- focused Home/PlatformIndex/ResultDetail/NotFound tests: 73 passed
- isolated Pages-shaped Chromium direct-route matrix: 5 passed, including real locator.click docs navigation

The browser run used an isolated generated fixture directory and port to avoid reusing a stale server.