### PR TITLE
docs: retain textcharts runtime dependency

### DIFF
--- a/docs/development/adr/adr-textcharts-extraction.md
+++ b/docs/development/adr/adr-textcharts-extraction.md
@@ -51,3 +51,30 @@ Extract the ASCII charting package into a standalone library called `textcharts`
 - The charting code becomes independently usable, testable, and releasable
 - Migration requires a compatibility shim period (one release cycle minimum)
 - Internal BenchBox callers must go through `ascii_api.py` facade (no direct submodule imports)
+
+## Follow-up dependency decision (2026-08-02)
+
+**Status**: Accepted — retain the direct `textcharts>=0.1.0` core dependency.
+
+The extraction is complete, but it did not make `textcharts` optional. The
+runtime still imports the package from the ASCII compatibility shims and from
+`benchbox.monitoring.report`; the dependency audit records 20 production
+import sites. Removing the declaration would make a normal BenchBox install
+fail while importing supported visualization or monitoring paths, and would
+also break the documented legacy shim imports.
+
+Replacement, vendoring, and deprecation were compared:
+
+- **Replacement** would require reimplementing or adopting another renderer and
+  re-establishing byte-for-byte output and shim compatibility.
+- **Vendoring** would duplicate the standalone package, create two ownership
+  and security-update paths, and still require a migration for existing imports.
+- **Deprecating the shims** would be a public API break without a release and
+  migration window; it would not remove the monitoring import path by itself.
+
+Retention is therefore the lowest-risk supported choice for this release. The
+manifest, lockfile, generated dependency audit, ASCII shims, and MCP semantic
+chart boundary remain coupled and must move together in any future migration.
+Revisit after a replacement renderer and a separately approved compatibility
+and package-install plan exist; no MCP server registration is implied by this
+Python dependency.

--- a/docs/development/dependency-inventory.md
+++ b/docs/development/dependency-inventory.md
@@ -132,7 +132,7 @@ or declaration appears unused.
 | `pyyaml` | C | `benchbox/cli/**`, `benchbox/core/**`, `scripts/`, `benchbox/security/**`, tests | 23 | KEEP |
 | `rich` | CL | `benchbox/cli/**`, `benchbox/core/**`, `benchbox/platforms/**`, `benchbox/utils/**` | 146 | KEEP |
 | `sqlglot` | C | `benchbox/base.py`, `benchbox/core/**`, `benchbox/platforms/**`, `benchbox/utils/**`, tests | 16 | KEEP |
-| `textcharts` | C | `benchbox/core/visualization/ascii/**`, `benchbox/monitoring/**` | 20 | KEEP |
+| `textcharts` | C | `benchbox/core/visualization/ascii/**`, `benchbox/monitoring/**` | 20 | KEEP — retained by ADR follow-up; removing it would break supported ASCII shims and monitoring imports |
 | `tomli` | C | `benchbox/utils/dependency_validation.py`, `benchbox/utils/version.py`, `scripts/`, tests | 9 | KEEP - guarded by `python_version < '3.11'`; stdlib `tomllib` covers 3.11+ |
 | `zstandard` | C | `benchbox/core/primitives/**`, `benchbox/utils/**`, tests | 9 | KEEP |
 | `azure-identity` | CSP | `benchbox/platforms/azure/**` | 9 | KEEP |

--- a/tests/unit/core/visualization/test_textcharts_dependency_contract.py
+++ b/tests/unit/core/visualization/test_textcharts_dependency_contract.py
@@ -1,0 +1,24 @@
+"""Package-install and compatibility contract for the retained textcharts dependency."""
+
+from __future__ import annotations
+
+import importlib
+from importlib.metadata import version
+from pathlib import Path
+
+import pytest
+
+pytestmark = [pytest.mark.unit, pytest.mark.fast]
+
+
+def test_textcharts_is_installed_and_legacy_shim_delegates() -> None:
+    package = importlib.import_module("textcharts")
+    from benchbox.core.visualization.ascii.bar_chart import BarChart
+
+    assert version("textcharts")
+    assert BarChart is package.BarChart
+
+
+def test_textcharts_remains_a_core_manifest_dependency() -> None:
+    manifest = (Path(__file__).resolve().parents[4] / "pyproject.toml").read_text(encoding="utf-8")
+    assert '"textcharts>=0.1.0"' in manifest


### PR DESCRIPTION
Implements remove-textcharts-as-a-dependency-v2 by recording the retention decision.

- compares replacement, vendoring, and shim deprecation options
- documents why textcharts remains a direct core dependency for 20 runtime import sites
- adds package-install and legacy-shim identity regression checks
- keeps pyproject.toml, uv.lock, generated audit, renderer, and MCP contracts consistent

Verification: 125 focused visualization/MCP tests passed; uv lock --check, generated dependency audit, and dependency audit passed; Ruff clean.