### PR TITLE
fix(results-explorer): recover partial compare URLs

### DIFF
--- a/results-explorer/e2e/failures/compare-hard-block.spec.ts
+++ b/results-explorer/e2e/failures/compare-hard-block.spec.ts
@@ -43,12 +43,40 @@ test.describe("Compare guardrails", () => {
     await expect(main.getByRole("heading", { name: /Cannot compare/i })).toHaveCount(0);
   });
 
-  test("a Compare URL that references an unknown result_id surfaces a removal-hint error", async ({
+  test("a Compare URL that references one stale ID retains the resolvable result", async ({
     page,
   }) => {
     await page.goto(`/results/compare?ids=${TPCH_ID},tpch-unknown-does-not-exist`);
     await waitForShell(page);
 
+    await waitForDataLoaded(page, /TPC-H Comparison/);
+    await expect(page.getByTestId("compare-url-notice")).toContainText("Ignored unavailable result ID");
+    await expect(page.getByRole("heading", { name: "Decision Summary" })).toBeVisible();
+    await expect(page.getByRole("heading", { name: /Cannot compare/i })).toHaveCount(0);
+
+    expect(page.url()).toContain("tpch-unknown-does-not-exist");
+    await page.reload();
+    await waitForDataLoaded(page, /TPC-H Comparison/);
+    await expect(page.getByRole("heading", { name: "Decision Summary" })).toBeVisible();
+  });
+
+  test("all-unavailable compare IDs retain the removal-hint error", async ({ page }) => {
+    await page.goto("/results/compare?ids=tpch-unknown-one,tpch-unknown-two");
+    await waitForShell(page);
     await expect(page.getByText(/No result found for/i)).toBeVisible({ timeout: 20_000 });
+  });
+
+  test("duplicate and excess IDs are disclosed while the first four unique entries are retained", async ({ page }) => {
+    const ids = [TPCH_SHORT, TPCH_SHORT, STAR_SCHEMA_SHORT, TPCH_SF01_SHORT, "stale-one", "stale-two"].join(",");
+    await page.goto(`/results/compare?ids=${ids}`);
+    await waitForShell(page);
+    await waitForDataLoaded(page, /Comparison/);
+
+    const notice = page.getByTestId("compare-url-notice");
+    await expect(notice).toContainText("Ignored duplicate result ID");
+    await expect(notice).toContainText("comparisons are limited to 4 unique results");
+    await expect(notice).toContainText("Ignored unavailable result ID");
+    await expect(page.getByRole("heading", { name: "Decision Summary" })).toBeVisible();
+    await expect(page.getByRole("heading", { name: /Cannot compare/i })).toHaveCount(0);
   });
 });

--- a/results-explorer/src/pages/Compare.tsx
+++ b/results-explorer/src/pages/Compare.tsx
@@ -85,6 +85,41 @@ function searchParamsFromUrl(url: string): URLSearchParams {
   return new URL(url, "https://benchbox.dev").searchParams;
 }
 
+interface CompareIdPlan {
+  retained: string[];
+  duplicates: string[];
+  overflow: string[];
+}
+
+function planCompareIds(rawIds: string[], limit: number): CompareIdPlan {
+  const unique: string[] = [];
+  const duplicates: string[] = [];
+  const seen = new Set<string>();
+  for (const rawId of rawIds) {
+    const id = rawId.trim();
+    if (!id) continue;
+    if (seen.has(id)) {
+      duplicates.push(id);
+      continue;
+    }
+    seen.add(id);
+    unique.push(id);
+  }
+  return {
+    retained: unique.slice(0, limit),
+    duplicates,
+    overflow: unique.slice(limit),
+  };
+}
+
+function formatIdList(ids: string[]): string {
+  return ids.map((id) => `“${id}”`).join(", ");
+}
+
+function appendCompareNotice(current: string | null, next: string): string {
+  return current ? `${current} ${next}` : next;
+}
+
 export function Compare({ url }: CompareProps) {
   const activeUrl = currentCompareUrl(url);
   const [compareState, setCompareState] = useState<CompareState | null>(null);
@@ -99,6 +134,7 @@ export function Compare({ url }: CompareProps) {
   // dead-ended the user on the page they came from.
   const [builderPinnedId, setBuilderPinnedId] = useState<string | null>(null);
   const [showBuilder, setShowBuilder] = useState(false);
+  const [compareNotice, setCompareNotice] = useState<string | null>(null);
   const copyTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const results = compareState?.results ?? EMPTY_RESULTS;
   const primaryMetric = compareState?.primaryMetric ?? "display_geomean_ms";
@@ -114,14 +150,23 @@ export function Compare({ url }: CompareProps) {
     setLoading(true);
     setBuilderPinnedId(null);
     setShowBuilder(false);
+    setCompareNotice(null);
 
     const params = searchParamsFromUrl(activeUrl);
     const idsParam = params.get("ids") ?? "";
-    const ids = idsParam
-      .split(",")
-      .map((s) => s.trim())
-      .filter(Boolean)
-      .slice(0, 4);
+    const plan = planCompareIds(idsParam.split(","), MAX_COMPARE_SELECTIONS);
+    let initialNotice: string | null = null;
+    if (plan.duplicates.length > 0) {
+      initialNotice = `Ignored duplicate result ID${plan.duplicates.length === 1 ? "" : "s"}: ${formatIdList(plan.duplicates)}.`;
+    }
+    if (plan.overflow.length > 0) {
+      initialNotice = appendCompareNotice(
+        initialNotice,
+        `Ignored ${plan.overflow.length} additional result ID${plan.overflow.length === 1 ? "" : "s"} (${formatIdList(plan.overflow)}); comparisons are limited to ${MAX_COMPARE_SELECTIONS} unique results.`,
+      );
+    }
+    if (initialNotice) setCompareNotice(initialNotice);
+    const ids = plan.retained;
 
     if (ids.length === 0) {
       setShowBuilder(true);
@@ -165,23 +210,78 @@ export function Compare({ url }: CompareProps) {
       };
     }
 
-    Promise.all(ids.map((id) => resolveShortId(id)))
-      .then(async (resolvedIds) => {
+    Promise.all(
+      ids.map(async (requestedId) => {
+        try {
+          return { requestedId, resolvedId: await resolveShortId(requestedId), error: null };
+        } catch (error) {
+          return { requestedId, resolvedId: null, error };
+        }
+      }),
+    )
+      .then(async (resolved) => {
         if (cancelled) return;
 
-        const loaded = await Promise.all(resolvedIds.map((id) => getDetailResult(id)));
+        const resolvedSeen = new Set<string>();
+        const aliases = resolved.filter(
+          (entry): entry is { requestedId: string; resolvedId: string; error: null } => {
+            if (entry.resolvedId === null || !resolvedSeen.has(entry.resolvedId)) {
+              if (entry.resolvedId !== null) resolvedSeen.add(entry.resolvedId);
+              return false;
+            }
+            return true;
+          },
+        );
+        if (aliases.length > 0) {
+          const aliasNotice = `Ignored duplicate result ID${aliases.length === 1 ? "" : "s"} after alias resolution: ${formatIdList(aliases.map((entry) => entry.requestedId))}.`;
+          initialNotice = appendCompareNotice(initialNotice, aliasNotice);
+          setCompareNotice(initialNotice);
+        }
+
+        const candidates = resolved.filter(
+          (entry): entry is { requestedId: string; resolvedId: string; error: null } =>
+            entry.resolvedId !== null && !aliases.some((alias) => alias.requestedId === entry.requestedId),
+        );
+        const loaded = await Promise.all(
+          candidates.map(async (entry) => {
+            try {
+              return { ...entry, detail: await getDetailResult(entry.resolvedId), loadError: null };
+            } catch (error) {
+              return { ...entry, detail: null, loadError: error };
+            }
+          }),
+        );
         if (cancelled) return;
 
-        const missing = resolvedIds.filter((_, i) => loaded[i] === null);
-        if (missing.length > 0) {
-          setError(
-            `No result found for: ${missing.join(", ")}. ` +
-              "These results may have been removed from the published dataset.",
-          );
+        const missing = loaded.filter((entry) => entry.detail === null && entry.loadError === null);
+        const failed = [
+          ...resolved.filter((entry) => entry.error !== null),
+          ...loaded.filter((entry) => entry.loadError !== null),
+        ];
+        const details = loaded.flatMap((entry) => (entry.detail ? [entry.detail] : []));
+        if (details.length === 0) {
+          if (failed.length > 0) {
+            const firstFailure = failed[0]!;
+            const failureError = firstFailure.error ?? ("loadError" in firstFailure ? firstFailure.loadError : null);
+            setError(errMsg(failureError));
+          } else {
+            const missingIds = missing.map((entry) => entry.requestedId);
+            setError(
+              `No result found for: ${missingIds.join(", ")}. ` +
+                "These results may have been removed from the published dataset.",
+            );
+          }
           setLoading(false);
           return;
         }
-        const details = loaded as DetailResult[];
+        if (missing.length > 0 || failed.length > 0) {
+          const unavailable = [...missing, ...failed].map((entry) => entry.requestedId);
+          initialNotice = appendCompareNotice(
+            initialNotice,
+            `Ignored unavailable result ID${unavailable.length === 1 ? "" : "s"}: ${formatIdList(unavailable)}.`,
+          );
+          setCompareNotice(initialNotice);
+        }
 
         const metric = await getPrimaryMetricForBenchmark(details[0]!.benchmark);
         if (cancelled) return;
@@ -203,21 +303,50 @@ export function Compare({ url }: CompareProps) {
     };
   }, [activeUrl]);
 
-  // Canonicalize URL to short IDs once data is loaded and URL has long-form IDs.
+  // Canonicalize URL to the retained short IDs once data is loaded. This also
+  // removes stale, duplicate, or excess entries so a copied URL reproduces
+  // the same visible comparison state after refresh.
   useEffect(() => {
     const ids = results.map((r) => r.result_id);
-    if (ids.length === 0) return;
-    const raw = new URLSearchParams(window.location.search).get("ids") ?? "";
-    const hasLongForm = raw.split(",").some((id) => id.trim().includes("-"));
-    if (!hasLongForm) return;
+    if (ids.length === 0 || typeof window === "undefined") return;
+    const currentParams = new URLSearchParams(window.location.search);
+    const currentRawIds = currentParams.get("ids") ?? "";
+    // A URL that started as a multi-selection must remain a multi-selection
+    // after stale-ID recovery. Keeping its explicit membership is the only
+    // way for a one-result recovery to reload into the same comparison surface
+    // instead of being reinterpreted as the single-result builder entrypoint.
+    if (ids.length < 2 && planCompareIds(currentRawIds.split(","), MAX_COMPARE_SELECTIONS).retained.length > 1) {
+      setCompareNotice((current) =>
+        appendCompareNotice(current, "The original comparison URL is kept so refresh preserves this recovery state."),
+      );
+      return;
+    }
     toShortIds(ids)
       .then((shortIds) => {
+        if (shortIds.length !== ids.length || new Set(shortIds).size !== ids.length) {
+          setCompareNotice((current) =>
+            appendCompareNotice(
+              current,
+              "The comparison URL could not be canonicalized; retained result order is unchanged.",
+            ),
+          );
+          return;
+        }
         const params = new URLSearchParams(window.location.search);
-        params.set("ids", shortIds.join(","));
-        history.replaceState(null, "", `/results/compare?${params.toString()}`);
+        const currentIds = params.get("ids") ?? "";
+        const canonicalIds = shortIds.join(",");
+        if (currentIds === canonicalIds) return;
+        params.set("ids", canonicalIds);
+        const search = params.toString();
+        history.replaceState(null, "", `${window.location.pathname}${search ? `?${search}` : ""}${window.location.hash}`);
       })
       .catch(() => {
-        /* silently skip - non-critical */
+        setCompareNotice((current) =>
+          appendCompareNotice(
+            current,
+            "The comparison URL could not be canonicalized; sharing it will retry when the dataset is available.",
+          ),
+        );
       });
   }, [results]);
 
@@ -233,7 +362,7 @@ export function Compare({ url }: CompareProps) {
     );
 
   if (showBuilder) {
-    return <CompareBuilder pinnedId={builderPinnedId} />;
+    return <CompareBuilder pinnedId={builderPinnedId} notice={compareNotice} />;
   }
 
   if (results.length === 0) return null;
@@ -354,6 +483,16 @@ export function Compare({ url }: CompareProps) {
               ]
         }
       />
+
+      {compareNotice && (
+        <div
+          class="mt-4 rounded-md border border-[var(--bb-data-border-strong)] bg-[var(--bb-surface-data)] px-4 py-3 text-sm text-[var(--bb-data-fg-muted)]"
+          role="status"
+          data-testid="compare-url-notice"
+        >
+          {compareNotice}
+        </div>
+      )}
 
       <section class="mt-6 mb-8 panel-elevated p-5" aria-label="Comparison summary">
         <div class="flex flex-wrap items-start justify-between gap-3">
@@ -604,7 +743,7 @@ function severeCohortMismatchReason(results: DetailResult[]) {
   return reasons.length > 0 ? reasons.join(" and ") : null;
 }
 
-function CompareBuilder({ pinnedId }: { pinnedId: string | null }) {
+function CompareBuilder({ pinnedId, notice }: { pinnedId: string | null; notice: string | null }) {
   const [candidates, setCandidates] = useState<ResultRow[] | null>(null);
   const [loadError, setLoadError] = useState<string | null>(null);
   const [selectedIds, setSelectedIds] = useState<Set<string>>(
@@ -785,6 +924,16 @@ function CompareBuilder({ pinnedId }: { pinnedId: string | null }) {
   return (
     <div class="mx-auto max-w-7xl px-4 py-8 sm:px-6 lg:px-8" data-testid="compare-builder">
       <Breadcrumb crumbs={[{ label: "Results", href: "/results/" }, { label: "Compare" }]} />
+
+      {notice && (
+        <div
+          class="mt-4 rounded-md border border-[var(--bb-data-border-strong)] bg-[var(--bb-surface-data)] px-4 py-3 text-sm text-[var(--bb-data-fg-muted)]"
+          role="status"
+          data-testid="compare-url-notice"
+        >
+          {notice}
+        </div>
+      )}
 
       <section class="mt-6 mb-6 panel-elevated p-5" aria-label="Compare builder intro">
         <p class="text-xs font-semibold uppercase tracking-wide text-[var(--bb-data-fg-subtle)]">Compare</p>

--- a/results-explorer/src/pages/__tests__/Compare.test.tsx
+++ b/results-explorer/src/pages/__tests__/Compare.test.tsx
@@ -236,6 +236,67 @@ describe("Compare", () => {
     expect(route).not.toHaveBeenCalled();
   });
 
+  it("retains resolvable IDs when a shared compare URL contains a stale ID", async () => {
+    setupUrl(["r1", "stale-result", "r2"]);
+    vi.mocked(getDetailResult).mockImplementation((id) => {
+      if (id === "r1") return Promise.resolve(DUCKDB);
+      if (id === "r2") return Promise.resolve(SQLITE);
+      return Promise.resolve(null);
+    });
+
+    render(<Compare />);
+
+    await waitFor(() => expect(screen.getByRole("heading", { name: "Decision Summary" })).toBeTruthy());
+    const notice = screen.getByTestId("compare-url-notice");
+    expect(notice).toHaveTextContent("Ignored unavailable result ID: “stale-result”.");
+    expect(screen.getByRole("heading", { name: "Decision Summary" })).toBeTruthy();
+    expect(screen.queryByText(/Cannot compare/i)).toBeNull();
+    await waitFor(() => {
+      expect(new URL(window.location.href).searchParams.get("ids")).toBe("r1,r2");
+    });
+  });
+
+  it("deduplicates IDs and discloses the four-result comparison limit", async () => {
+    setupUrl(["r1", "r1", "r2", "r3", "r4", "r5"]);
+    const r4 = makeResult({ result_id: "r4", platform: "Trino", platform_id: "trino", power_score: 800 });
+    const r5 = makeResult({ result_id: "r5", platform: "Polars", platform_id: "polars", power_score: 700 });
+    const byId: Record<string, DetailResult> = { r1: DUCKDB, r2: SQLITE, r3: POSTGRES, r4, r5 };
+    vi.mocked(getDetailResult).mockImplementation((id) => Promise.resolve(byId[id] ?? null));
+
+    render(<Compare />);
+
+    await waitFor(() => expect(document.title).toBe("Compare (4) · BenchBox Results"));
+    const notice = screen.getByTestId("compare-url-notice");
+    expect(notice).toHaveTextContent("Ignored duplicate result ID: “r1”.");
+    expect(notice).toHaveTextContent("Ignored 1 additional result ID (“r5”); comparisons are limited to 4 unique results.");
+    expect(screen.getAllByText("Trino").length).toBeGreaterThan(0);
+    expect(screen.queryByText("Polars")).toBeNull();
+    await waitFor(() => {
+      expect(new URL(window.location.href).searchParams.get("ids")).toBe("r1,r2,r3,r4");
+    });
+  });
+
+  it("deduplicates short-ID aliases without changing retained order", async () => {
+    setupUrl(["r1", "alias-r1", "r2"]);
+    vi.mocked(resolveShortId).mockImplementation((id) => Promise.resolve(id === "alias-r1" ? "r1" : id));
+    vi.mocked(getDetailResult).mockImplementation((id) => {
+      if (id === "r1") return Promise.resolve(DUCKDB);
+      if (id === "r2") return Promise.resolve(SQLITE);
+      return Promise.resolve(null);
+    });
+
+    render(<Compare />);
+
+    await waitFor(() => expect(document.title).toBe("Compare (2) · BenchBox Results"));
+    expect(screen.getByTestId("compare-url-notice")).toHaveTextContent(
+      "Ignored duplicate result ID after alias resolution: “alias-r1”.",
+    );
+    await waitFor(() => {
+      expect(new URL(window.location.href).searchParams.get("ids")).toBe("r1,r2");
+    });
+    expect(screen.getByRole("heading", { name: "Decision Summary" })).toBeTruthy();
+  });
+
   it("renders the in-page compare builder when no ids are provided (no URL editing required)", async () => {
     setupUrl([]);
 


### PR DESCRIPTION
## Summary
- recover valid compare IDs when another requested ID is stale or unavailable
- deduplicate exact and resolved aliases before enforcing the four-result limit
- disclose discarded IDs and canonicalize retained URLs while preserving one-result recovery reload parity

## Verification
- `uv run -- python -c 'from pathlib import Path; t=Path("results-explorer/src/pages/Compare.tsx").read_text(); assert ".slice(0, 4)" not in t'`\n- `npm test -- --run` (70 files, 852 tests)\n- `npm run typecheck`\n- `npx playwright test --project=chromium --workers=1 e2e/failures/compare-hard-block.spec.ts` (5 passed)\n- pre-commit token scan, YAML, formatting, and `pr-preflight` passed\n\n## Scope\nNo changes to corpus, pipeline, database, or cohort-safety claim suppression.