### PR TITLE
chore: enforce results explorer dependency audit

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -393,6 +393,11 @@ jobs:
         run: npm ci
         working-directory: results-explorer
 
+      - name: Audit frontend dependencies
+        if: steps.explorer.outputs.present == 'true'
+        run: npm run audit:high
+        working-directory: results-explorer
+
       - name: Verify parity fixtures match Python source
         if: steps.explorer.outputs.present == 'true'
         run: make parity-check

--- a/.github/workflows/results-explorer-browser.yml
+++ b/.github/workflows/results-explorer-browser.yml
@@ -60,6 +60,10 @@ jobs:
         run: npm ci
         working-directory: results-explorer
 
+      - name: Audit frontend dependencies
+        run: npm run audit:high
+        working-directory: results-explorer
+
       - name: Cache Playwright browsers
         uses: actions/cache@v4
         with:

--- a/docs/operations/browser-ci.md
+++ b/docs/operations/browser-ci.md
@@ -7,6 +7,18 @@ and anyone triaging a red or advisory browser-lane check on a PR.
 [`docs/development/results-explorer-browser-testing.md`](../development/results-explorer-browser-testing.md)
 (how to run the suite locally, what's covered, how to add tests).
 
+## Frontend dependency audit
+
+The blocking Chromium job and the nightly parity job run
+`npm run audit:high` immediately after `npm ci`. The command fails on any
+high or critical advisory; low-severity build-tool advisories remain visible
+in the audit output and are not silently allowlisted. Dependency updates must
+use the narrowest patched range and retain deterministic `npm ci` behavior;
+`npm audit fix --force` is not an accepted remediation. The only transitive
+override currently present is `undici >=7.28.0`, constrained to remove the
+Playwright tooling advisory range; remove it when the upstream graph no longer
+needs it.
+
 ## Current lane status
 
 | Browser  | Job name                          | Scope                | Gate       | Status as of 2026-07-23 |

--- a/results-explorer/package-lock.json
+++ b/results-explorer/package-lock.json
@@ -13,7 +13,7 @@
         "preact-router": "^4.1.2"
       },
       "devDependencies": {
-        "@playwright/test": "^1.49.0",
+        "@playwright/test": "^1.62.1",
         "@preact/preset-vite": "^2.9.1",
         "@testing-library/jest-dom": "^6.9.1",
         "@testing-library/preact": "^3.2.4",
@@ -25,10 +25,10 @@
         "autoprefixer": "^10.4.20",
         "jest-axe": "^9.0.0",
         "jsdom": "^29.0.2",
-        "postcss": "^8.5.1",
+        "postcss": "^8.5.25",
         "tailwindcss": "^3.4.17",
         "typescript": "^5.7.3",
-        "vite": "^6.1.0",
+        "vite": "^6.4.3",
         "vitest": "^4.1.4"
       }
     },
@@ -1206,19 +1206,19 @@
       }
     },
     "node_modules/@playwright/test": {
-      "version": "1.59.1",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.59.1.tgz",
-      "integrity": "sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==",
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.62.1.tgz",
+      "integrity": "sha512-DTcUc8qii+cpHvtOwggMtBRMjKZHXYWdw8syRYu2vtzuq4Wxphqq4NfCs5Zt44L6mA8rfDfj+PHnxFc/FeK6mQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright": "1.59.1"
+        "playwright": "1.62.1"
       },
       "bin": {
         "playwright": "cli.js"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=20"
       }
     },
     "node_modules/@preact/preset-vite": {
@@ -4434,9 +4434,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.11",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
-      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "version": "3.3.16",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
       "dev": true,
       "funding": [
         {
@@ -4666,35 +4666,35 @@
       }
     },
     "node_modules/playwright": {
-      "version": "1.59.1",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.59.1.tgz",
-      "integrity": "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==",
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.62.1.tgz",
+      "integrity": "sha512-0M+L3LAD8/nm554LOla9Ayx0j0tmFZ0FBcoQ7F1VuVHpM/XpiC8RcDzBQB8W5+hA8L22THxELzeF+2WcUzvcLg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright-core": "1.59.1"
+        "playwright-core": "1.62.1"
       },
       "bin": {
         "playwright": "cli.js"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=20"
       },
       "optionalDependencies": {
         "fsevents": "2.3.2"
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.59.1",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.1.tgz",
-      "integrity": "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==",
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.62.1.tgz",
+      "integrity": "sha512-wPYSwEBJY9GHraISXqyqtx0na0LpO3XEX7jNDhntbex7tzUS7kLnZsOlFruFJB4Hi/rhDMjXGqHewDZ68nYZVw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
         "playwright-core": "cli.js"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=20"
       }
     },
     "node_modules/playwright/node_modules/fsevents": {
@@ -4723,9 +4723,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.13",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.13.tgz",
-      "integrity": "sha512-qif0+jGGZoLWdHey3UFHHWP0H7Gbmsk8T5VEqyYFbWqPr1XqvLGBbk/sl8V5exGmcYJklJOhOQq1pV9IcsiFag==",
+      "version": "8.5.25",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.25.tgz",
+      "integrity": "sha512-DTPx3RWSSnWyzLxQnlH0rJP+EW5ekl16ZU4/psbIhA0e53kJfdgaN5vKM+xP7yJtXVu+nfdVFmlgFDEKAe4Pyw==",
       "dev": true,
       "funding": [
         {
@@ -4743,7 +4743,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.11",
+        "nanoid": "^3.3.16",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
@@ -5692,9 +5692,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "7.25.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.25.0.tgz",
-      "integrity": "sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==",
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.29.0.tgz",
+      "integrity": "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -5746,9 +5746,9 @@
       "license": "MIT"
     },
     "node_modules/vite": {
-      "version": "6.4.2",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.2.tgz",
-      "integrity": "sha512-2N/55r4JDJ4gdrCvGgINMy+HH3iRpNIz8K6SFwVsA+JbQScLiC+clmAxBgwiSPgcG9U15QmvqCGWzMbqda5zGQ==",
+      "version": "6.4.3",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.3.tgz",
+      "integrity": "sha512-NTKlcQjlAK7MlQoyb6LgaqHc8sso/pVyUJYWMws3jg21uTJw/LddqIFPcPqP6PzpgbIcZyKI85sFE4HBrQDA8A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/results-explorer/package.json
+++ b/results-explorer/package.json
@@ -13,6 +13,7 @@
     "test": "vitest run",
     "test:watch": "vitest",
     "test:e2e": "playwright test",
+    "audit:high": "npm audit --audit-level=high",
     "test:e2e:chromium": "npm run test:e2e:fixtures && npm run build && npm run test:e2e:chromium:run",
     "test:e2e:chromium:run": "E2E_EXCLUDE_FAILURES=1 playwright test --project=chromium --workers=1 --grep-invert @performance && E2E_CAPTURE_FIRST_FAILURE=1 playwright test --project=chromium --workers=1 --retries=0 e2e/failures/ && playwright test --project=chromium --workers=1 --retries=0 e2e/performance.spec.ts",
     "test:e2e:chromium:setup": "npm run test:e2e:install:chromium && npm run test:e2e:chromium",
@@ -31,7 +32,7 @@
     "preact-router": "^4.1.2"
   },
   "devDependencies": {
-    "@playwright/test": "^1.49.0",
+    "@playwright/test": "^1.62.1",
     "@preact/preset-vite": "^2.9.1",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/preact": "^3.2.4",
@@ -43,10 +44,13 @@
     "autoprefixer": "^10.4.20",
     "jest-axe": "^9.0.0",
     "jsdom": "^29.0.2",
-    "postcss": "^8.5.1",
+    "postcss": "^8.5.25",
     "tailwindcss": "^3.4.17",
     "typescript": "^5.7.3",
-    "vite": "^6.1.0",
+    "vite": "^6.4.3",
     "vitest": "^4.1.4"
+  },
+  "overrides": {
+    "undici": "^7.28.0"
   }
 }

--- a/tests/unit/workflows/test_results_explorer_dependency_audit.py
+++ b/tests/unit/workflows/test_results_explorer_dependency_audit.py
@@ -1,0 +1,24 @@
+"""Regression checks for the blocking Results Explorer dependency audit."""
+
+from pathlib import Path
+
+import pytest
+
+pytestmark = [pytest.mark.unit, pytest.mark.fast]
+
+ROOT = Path(__file__).parents[3]
+
+
+def test_browser_and_nightly_lanes_run_the_high_severity_audit() -> None:
+    browser = (ROOT / ".github/workflows/results-explorer-browser.yml").read_text(encoding="utf-8")
+    nightly = (ROOT / ".github/workflows/nightly.yml").read_text(encoding="utf-8")
+
+    assert browser.count("npm run audit:high") >= 1
+    assert nightly.count("npm run audit:high") >= 1
+
+
+def test_audit_script_is_not_force_fix_or_unbounded() -> None:
+    package_text = (ROOT / "results-explorer/package.json").read_text(encoding="utf-8")
+
+    assert '"audit:high": "npm audit --audit-level=high"' in package_text
+    assert "audit fix --force" not in package_text


### PR DESCRIPTION
Add a high-severity npm audit gate to blocking and nightly explorer lanes, patch the audited frontend toolchain, and document the policy with workflow regression tests.
