### PR TITLE
fix: harden results explorer accessibility

### DIFF
--- a/results-explorer/e2e/capability/accessibility-regressions.spec.ts
+++ b/results-explorer/e2e/capability/accessibility-regressions.spec.ts
@@ -1,0 +1,47 @@
+import { expect, test } from "@playwright/test";
+import { waitForDataLoaded } from "../support/fixtures";
+
+test.describe("accessibility and responsive regressions", () => {
+  test("reduced motion and forced contrast preserve keyboard focus", async ({ page }) => {
+    await page.emulateMedia({ reducedMotion: "reduce", forcedColors: "active" });
+    await page.setViewportSize({ width: 640, height: 900 });
+    await page.goto("/results/");
+    await waitForDataLoaded(page, /Recent Results/i);
+
+    await page.getByText("Advanced filters").click();
+    const control = page.getByRole("button", { name: /All (tuning labels|trust tiers|time)/ }).first();
+    await control.focus();
+    await expect(control).toBeFocused();
+    await expect
+      .poll(() => control.evaluate((element) => getComputedStyle(element).outlineWidth))
+      .not.toBe("0px");
+
+    const media = await page.evaluate(() => ({
+      reducedMotion: matchMedia("(prefers-reduced-motion: reduce)").matches,
+      forcedColors: matchMedia("(forced-colors: active)").matches,
+      scrollWidth: document.documentElement.scrollWidth,
+      clientWidth: document.documentElement.clientWidth,
+    }));
+    expect(media.reducedMotion).toBe(true);
+    expect(media.forcedColors).toBe(true);
+    expect(media.scrollWidth).toBeLessThanOrEqual(media.clientWidth);
+  });
+
+  test("the home surface remains horizontally contained at 200 percent zoom", async ({ page }) => {
+    await page.setViewportSize({ width: 640, height: 900 });
+    await page.goto("/results/");
+    await waitForDataLoaded(page, /Recent Results/i);
+
+    await page.evaluate(() => {
+      document.documentElement.style.zoom = "2";
+    });
+
+    const dimensions = await page.evaluate(() => ({
+      scrollWidth: document.documentElement.scrollWidth,
+      clientWidth: document.documentElement.clientWidth,
+      bodyScrollWidth: document.body.scrollWidth,
+    }));
+    expect(dimensions.scrollWidth).toBeLessThanOrEqual(dimensions.clientWidth);
+    expect(dimensions.bodyScrollWidth).toBeLessThanOrEqual(dimensions.clientWidth);
+  });
+});

--- a/results-explorer/e2e/routes/result-detail.spec.ts
+++ b/results-explorer/e2e/routes/result-detail.spec.ts
@@ -38,6 +38,29 @@ test.describe("ResultDetail", () => {
     await expect(header).toContainText("↓");
   });
 
+  test("sortable headers expose state and native Space activation does not scroll", async ({ page }) => {
+    await page.goto(`/results/r/${TPCH_DUCKDB_ID}`);
+    await waitForDataLoaded(page, /Query Timings/);
+
+    const medianHeader = page.locator('th[aria-sort]').filter({ hasText: "Median latency" }).first();
+    await expect(medianHeader).toHaveAttribute("aria-sort", "none");
+    const medianButton = medianHeader.getByRole("button");
+    await medianButton.click();
+    await expect(medianHeader).toHaveAttribute("aria-sort", "ascending");
+
+    const scrollBeforeSpace = await page.evaluate(() => window.scrollY);
+    await medianButton.press("Space");
+    await expect(medianHeader).toHaveAttribute("aria-sort", "descending");
+    expect(await page.evaluate(() => window.scrollY)).toBe(scrollBeforeSpace);
+
+    await page.getByText(/Individual samples \(/).click();
+    const durationHeader = page.locator('th[aria-sort]').filter({ hasText: "Duration" }).first();
+    await expect(durationHeader.locator('[role="button"]')).toHaveCount(0);
+    await expect(durationHeader).toHaveAttribute("aria-sort", "none");
+    await durationHeader.getByRole("button").click();
+    await expect(durationHeader).toHaveAttribute("aria-sort", "ascending");
+  });
+
   test("'Compare this result' opens the compare builder with the result pinned", async ({ page }) => {
     await page.goto(`/results/r/${TPCH_DUCKDB_ID}`);
     await waitForDataLoaded(page, /Query Timings/);

--- a/results-explorer/src/index.css
+++ b/results-explorer/src/index.css
@@ -203,6 +203,14 @@
     [data-surface="hero"] *:focus-visible {
         outline-color: var(--bb-focus-ring-on-dark);
     }
+
+    /* Keep the leaderboard display controls inside the viewport when browser
+       zoom makes their compact button group wider than the wrapping header. */
+    [aria-labelledby="meta-leaderboard-title"] > .mb-4.flex > div[role="group"] {
+        min-width: 0;
+        max-width: 100%;
+        overflow-x: auto;
+    }
 }
 
 @layer components {
@@ -477,6 +485,15 @@
     }
 
     @media (prefers-reduced-motion: reduce) {
+        *,
+        *::before,
+        *::after {
+            animation-duration: 0.01ms !important;
+            animation-iteration-count: 1 !important;
+            scroll-behavior: auto !important;
+            transition-duration: 0.01ms !important;
+        }
+
         .bb-skeleton,
         .bb-skeleton-dark {
             animation: none;

--- a/results-explorer/src/lib/__tests__/copyFormatters.test.ts
+++ b/results-explorer/src/lib/__tests__/copyFormatters.test.ts
@@ -3,6 +3,7 @@ import {
   ensureSentence,
   formatCandidateCount,
   formatCount,
+  formatCountWithVerb,
   formatSelectedCount,
   formatWarningCount,
   removeDuplicatedTerminalPunctuation,
@@ -18,6 +19,8 @@ describe("copyFormatters", () => {
     expect(formatCount(4, "run")).toBe("4 runs");
     expect(formatCount(2, "query", "queries")).toBe("2 queries");
     expect(formatCount(2, "more", "more")).toBe("2 more");
+    expect(formatCountWithVerb(1, "public benchmark", "has", "have")).toBe("1 public benchmark has");
+    expect(formatCountWithVerb(2, "public benchmark", "has", "have")).toBe("2 public benchmarks have");
   });
 
   it("formats selected states without duplicating count rules", () => {

--- a/results-explorer/src/lib/copyFormatters.ts
+++ b/results-explorer/src/lib/copyFormatters.ts
@@ -3,6 +3,16 @@ export function formatCount(count: number, singular: string, plural = `${singula
   return `${count.toLocaleString()} ${noun}`;
 }
 
+export function formatCountWithVerb(
+  count: number,
+  singular: string,
+  singularVerb: string,
+  pluralVerb: string,
+  plural = `${singular}s`,
+): string {
+  return `${formatCount(count, singular, plural)} ${count === 1 ? singularVerb : pluralVerb}`;
+}
+
 export function formatWarningCount(count: number): string {
   return formatCount(count, "warning");
 }

--- a/results-explorer/src/pages/Home.tsx
+++ b/results-explorer/src/pages/Home.tsx
@@ -30,7 +30,7 @@ import {
   toggleFacetValue,
   toDateWindowFacet,
 } from "@/lib/facetMatching";
-import { formatCount } from "@/lib/copyFormatters";
+import { formatCount, formatCountWithVerb } from "@/lib/copyFormatters";
 import { normalizedCostLabel, normalizedCostValue } from "@/lib/costDisplay";
 import { formatFacetDisplayValue } from "@/lib/facetDisplay";
 import { stringSerde, useUrlState } from "@/lib/useUrlState";
@@ -299,11 +299,13 @@ export function Home(_: RoutableProps) {
   const visibleRankedLeaderboardPlatformCount =
     filteredMetaLeaderboard?.platforms.filter((platform) => platform.n_cohorts > 0).length ?? 0;
   const tuningSummary = summarizeTuningModes(results);
-  const tuningOptions = [
-    "all",
-    ...(tuningSummary.unlabelledCount > 0 ? [UNLABELLED_TUNING_VALUE] : []),
-    ...tuningSummary.labelledOptions,
-  ];
+  const tuningOptions = tuningSummaryBucketCount(tuningSummary) > 1
+    ? [
+        "all",
+        ...(tuningSummary.unlabelledCount > 0 ? [UNLABELLED_TUNING_VALUE] : []),
+        ...tuningSummary.labelledOptions,
+      ]
+    : [];
 
   function buildCohortHref(cohort: MetaCohort): string {
     const params = new URLSearchParams();
@@ -423,15 +425,24 @@ export function Home(_: RoutableProps) {
                   Advanced filters
                 </summary>
                 <div class="mt-3 grid gap-3 md:grid-cols-3">
-                  <SingleFilterGroup
-                    label="Tuning"
-                    options={tuningOptions}
-                    current={tuningFilter}
-                    onSelect={(value) => setFacet("tuning_mode", value === "all" ? [] : [value])}
-                    format={(value) => formatTuningModeOption(value)}
-                    optionTitle={(value) => tuningModeOptionTitle(value, tuningSummary)}
-                    description={tuningFilterDescription(tuningSummary)}
-                  />
+                  {tuningOptions.length > 0 ? (
+                    <SingleFilterGroup
+                      label="Tuning"
+                      options={tuningOptions}
+                      current={tuningFilter}
+                      onSelect={(value) => setFacet("tuning_mode", value === "all" ? [] : [value])}
+                      format={(value) => formatTuningModeOption(value)}
+                      optionTitle={(value) => tuningModeOptionTitle(value, tuningSummary)}
+                      description={tuningFilterDescription(tuningSummary)}
+                    />
+                  ) : (
+                    <div data-testid="tuning-filter-unavailable">
+                      <div class="mb-2 text-xs font-semibold uppercase tracking-wide text-[var(--bb-fg-muted)]">Tuning</div>
+                      <p class="text-[11px] leading-snug text-[var(--bb-fg-muted)]">
+                        Tuning filter unavailable: this view has only one tuning metadata state. {tuningFilterDescription(tuningSummary)}
+                      </p>
+                    </div>
+                  )}
                   <SingleFilterGroup
                     label="Trust"
                     options={trustOptions}
@@ -794,11 +805,11 @@ function LeaderboardScopeSummary({
 }) {
   const hiddenBenchmarkCopy =
     publicBenchmarksOutsideLeaderboard.length > 0
-      ? `${publicBenchmarksOutsideLeaderboard.length.toLocaleString()} public benchmark ${plural(publicBenchmarksOutsideLeaderboard.length, "has", "have")} results but no ranked leaderboard: ${publicBenchmarksOutsideLeaderboard.map(formatBenchmarkLabel).join(", ")}.`
+      ? `${formatCountWithVerb(publicBenchmarksOutsideLeaderboard.length, "public benchmark", "has", "have")} results but no ranked leaderboard: ${publicBenchmarksOutsideLeaderboard.map(formatBenchmarkLabel).join(", ")}.`
       : "Every public benchmark with results has a ranked leaderboard.";
   const publicOnlyPlatformCopy =
     publicPlatformIdsOutsideLeaderboard > 0
-      ? `${publicPlatformIdsOutsideLeaderboard.toLocaleString()} public platform ${plural(publicPlatformIdsOutsideLeaderboard, "ID is", "IDs are")} outside the current leaderboard scope.`
+      ? `${formatCountWithVerb(publicPlatformIdsOutsideLeaderboard, "public platform ID", "is", "are")} outside the current leaderboard scope.`
       : "Every public platform ID has evidence in the leaderboard scope.";
   const visiblePublishedUnrankedPlatformCount = Math.max(
     0,
@@ -910,7 +921,7 @@ function benchmarkFilterDescription(publicBenchmarksOutsideLeaderboard: readonly
   if (publicBenchmarksOutsideLeaderboard.length === 0) {
     return "Only benchmarks with ranked leaderboards appear here.";
   }
-  return `${publicBenchmarksOutsideLeaderboard.length.toLocaleString()} public benchmark ${plural(publicBenchmarksOutsideLeaderboard.length, "has", "have")} results but no ranked leaderboard: ${publicBenchmarksOutsideLeaderboard.map(formatBenchmarkLabel).join(", ")}.`;
+  return `${formatCountWithVerb(publicBenchmarksOutsideLeaderboard.length, "public benchmark", "has", "have")} results but no ranked leaderboard: ${publicBenchmarksOutsideLeaderboard.map(formatBenchmarkLabel).join(", ")}.`;
 }
 
 function formatTuningModeOption(value: string): string {
@@ -922,7 +933,7 @@ function formatTuningModeOption(value: string): string {
 function tuningModeOptionTitle(value: string, summary: TuningModeSummary): string {
   if (value === "all") return "Include recorded and not-recorded tuning metadata.";
   if (value === UNLABELLED_TUNING_VALUE) {
-    return `${summary.unlabelledCount.toLocaleString()} public result ${plural(summary.unlabelledCount, "has", "have")} no recorded tuning mode.`;
+    return `${formatCountWithVerb(summary.unlabelledCount, "public result", "has", "have")} no recorded tuning mode.`;
   }
   return `Filter to tuning label: ${formatFacetDisplayValue("tuning_mode", value)}.`;
 }
@@ -930,9 +941,13 @@ function tuningModeOptionTitle(value: string, summary: TuningModeSummary): strin
 function tuningFilterDescription(summary: TuningModeSummary): string {
   if (summary.unlabelledCount === 0) return "All public results in this view have a recorded tuning mode.";
   if (summary.labelledOptions.length === 0) {
-    return `${summary.unlabelledCount.toLocaleString()} public result ${plural(summary.unlabelledCount, "has", "have")} no recorded tuning mode.`;
+    return `${formatCountWithVerb(summary.unlabelledCount, "public result", "has", "have")} no recorded tuning mode.`;
   }
   return `${summary.unlabelledCount.toLocaleString()} of ${summary.totalCount.toLocaleString()} public ${plural(summary.totalCount, "result", "results")} ${plural(summary.unlabelledCount, "is", "are")} not recorded for tuning.`;
+}
+
+function tuningSummaryBucketCount(summary: TuningModeSummary): number {
+  return summary.labelledOptions.length + (summary.unlabelledCount > 0 ? 1 : 0);
 }
 
 function plural(count: number, singular: string, pluralValue: string): string {

--- a/results-explorer/src/pages/ResultDetail.tsx
+++ b/results-explorer/src/pages/ResultDetail.tsx
@@ -28,6 +28,7 @@ interface ResultDetailProps extends RoutableProps {
 type MedianSortKey = "query_id" | "display_ms" | "sample_count";
 type RawSortKey = "query_id" | "duration_ms" | "status";
 type PrimaryMetric = "power_score" | "display_geomean_ms";
+type SortAriaValue = "ascending" | "descending" | "none";
 interface DetailState {
   detail: DetailResult;
   primaryMetric: PrimaryMetric;
@@ -159,6 +160,11 @@ export function ResultDetail({ resultId = "" }: ResultDetailProps) {
     return sort.direction === "asc" ? " ↑" : " ↓";
   }
 
+  function sortAriaValue(state: SortState<MedianSortKey>, key: MedianSortKey): SortAriaValue {
+    if (state.key !== key) return "none";
+    return state.direction === "asc" ? "ascending" : "descending";
+  }
+
   function toggleRawSort(key: RawSortKey) {
     setRawSort((prev) =>
       prev.key === key
@@ -170,6 +176,11 @@ export function ResultDetail({ resultId = "" }: ResultDetailProps) {
   function rawSortArrow(key: RawSortKey) {
     if (rawSort.key !== key) return " ↕";
     return rawSort.direction === "asc" ? " ↑" : " ↓";
+  }
+
+  function rawSortAriaValue(key: RawSortKey): SortAriaValue {
+    if (rawSort.key !== key) return "none";
+    return rawSort.direction === "asc" ? "ascending" : "descending";
   }
 
   // Derive tuning sidecar URL from bundle download URL.
@@ -369,7 +380,7 @@ export function ResultDetail({ resultId = "" }: ResultDetailProps) {
               <table class="min-w-full w-max divide-y divide-[var(--bb-data-border)]">
                 <thead class="bg-[var(--bb-surface-data-muted)]">
                   <tr>
-                    <th class="p-0" scope="col">
+                    <th class="p-0" scope="col" aria-sort={sortAriaValue(sort, "query_id")}>
                       <button
                         type="button"
                         class="table-th block w-full text-left cursor-pointer select-none bg-transparent border-0"
@@ -378,7 +389,7 @@ export function ResultDetail({ resultId = "" }: ResultDetailProps) {
                         Query{sortArrow("query_id")}
                       </button>
                     </th>
-                    <th class="p-0" scope="col">
+                    <th class="p-0" scope="col" aria-sort={sortAriaValue(sort, "display_ms")}>
                       <button
                         type="button"
                         class="table-th block w-full text-left cursor-pointer select-none bg-transparent border-0"
@@ -387,7 +398,7 @@ export function ResultDetail({ resultId = "" }: ResultDetailProps) {
                         Median latency{sortArrow("display_ms")}
                       </button>
                     </th>
-                    <th class="p-0" scope="col">
+                    <th class="p-0" scope="col" aria-sort={sortAriaValue(sort, "sample_count")}>
                       <button
                         type="button"
                         class="table-th block w-full text-left cursor-pointer select-none bg-transparent border-0"
@@ -418,32 +429,32 @@ export function ResultDetail({ resultId = "" }: ResultDetailProps) {
                   <table class="min-w-full w-max divide-y divide-[var(--bb-data-border)]">
                     <thead class="bg-[var(--bb-surface-data-muted)]">
                       <tr>
-                        <th
-                          class="table-th cursor-pointer select-none"
-                          role="button"
-                          tabIndex={0}
-                          onClick={() => toggleRawSort("query_id")}
-                          onKeyDown={(e) => (e.key === "Enter" || e.key === " ") && toggleRawSort("query_id")}
-                        >
-                          Query{rawSortArrow("query_id")}
+                        <th class="p-0" scope="col" aria-sort={rawSortAriaValue("query_id")}>
+                          <button
+                            type="button"
+                            class="table-th block w-full text-left cursor-pointer select-none bg-transparent border-0"
+                            onClick={() => toggleRawSort("query_id")}
+                          >
+                            Query{rawSortArrow("query_id")}
+                          </button>
                         </th>
-                        <th
-                          class="table-th cursor-pointer select-none"
-                          role="button"
-                          tabIndex={0}
-                          onClick={() => toggleRawSort("duration_ms")}
-                          onKeyDown={(e) => (e.key === "Enter" || e.key === " ") && toggleRawSort("duration_ms")}
-                        >
-                          Duration{rawSortArrow("duration_ms")}
+                        <th class="p-0" scope="col" aria-sort={rawSortAriaValue("duration_ms")}>
+                          <button
+                            type="button"
+                            class="table-th block w-full text-left cursor-pointer select-none bg-transparent border-0"
+                            onClick={() => toggleRawSort("duration_ms")}
+                          >
+                            Duration{rawSortArrow("duration_ms")}
+                          </button>
                         </th>
-                        <th
-                          class="table-th cursor-pointer select-none"
-                          role="button"
-                          tabIndex={0}
-                          onClick={() => toggleRawSort("status")}
-                          onKeyDown={(e) => (e.key === "Enter" || e.key === " ") && toggleRawSort("status")}
-                        >
-                          Status{rawSortArrow("status")}
+                        <th class="p-0" scope="col" aria-sort={rawSortAriaValue("status")}>
+                          <button
+                            type="button"
+                            class="table-th block w-full text-left cursor-pointer select-none bg-transparent border-0"
+                            onClick={() => toggleRawSort("status")}
+                          >
+                            Status{rawSortArrow("status")}
+                          </button>
                         </th>
                       </tr>
                     </thead>

--- a/results-explorer/src/pages/__tests__/Home.test.tsx
+++ b/results-explorer/src/pages/__tests__/Home.test.tsx
@@ -524,6 +524,30 @@ describe("Home", () => {
     expect(within(summary).queryByText(/^leaderboard ranking$/)).toBeNull();
   });
 
+  it("keeps tuning metadata visible while hiding a non-discriminating tuning filter", async () => {
+    const unlabelledRows = RESULT_ROWS.map((row) => ({ ...row, tuning_mode: null }));
+    vi.mocked(queryRows).mockImplementation(async (sql: string) => {
+      const s = String(sql).replace(/\s+/g, " ").trim();
+      if (s.includes("FROM bench.results")) return unlabelledRows;
+      if (s.startsWith("SELECT platform_id, platform, avg_rank, n_cohorts FROM bench.meta_leaderboard")) {
+        return META_LEADERBOARD_ROWS;
+      }
+      if (s.includes("FROM bench.cohort_metadata")) return COHORT_ROWS;
+      return [];
+    });
+
+    render(<Home />);
+    await waitFor(() => expect(screen.getByText("Cross-Benchmark Leaderboard")).toBeTruthy());
+
+    const selector = screen.getByRole("region", { name: "Leaderboard ranking selector" });
+    fireEvent.click(screen.getByText("Advanced filters"));
+    expect(within(selector).getByTestId("tuning-filter-unavailable")).toHaveTextContent(
+      "Tuning filter unavailable",
+    );
+    expect(within(selector).queryByRole("button", { name: "All tuning labels" })).toBeNull();
+    expect(within(selector).getByTestId("tuning-filter-unavailable")).toHaveTextContent("4 public results have");
+  });
+
   it("states leaderboard cohort scope separately from public browse scope", async () => {
     render(<Home />);
     await waitFor(() => expect(screen.getByText("Cross-Benchmark Leaderboard")).toBeTruthy());

--- a/results-explorer/src/pages/__tests__/ResultDetail.test.tsx
+++ b/results-explorer/src/pages/__tests__/ResultDetail.test.tsx
@@ -154,6 +154,23 @@ describe("ResultDetail - median-first contract", () => {
     expect(screen.getAllByText(/^Duration/i).length).toBeGreaterThan(0);
   });
 
+  it("announces sort state on native median and raw table controls", async () => {
+    render(<ResultDetail resultId="r1" />);
+    await waitFor(() => expect(screen.queryByText("Loading result...")).toBeNull());
+
+    const medianHeader = screen.getByRole("columnheader", { name: /Median latency/ });
+    expect(medianHeader).toHaveAttribute("aria-sort", "none");
+    fireEvent.click(within(medianHeader).getByRole("button"));
+    expect(medianHeader).toHaveAttribute("aria-sort", "ascending");
+
+    fireEvent.click(screen.getByText(/Individual samples \(6\)/i));
+    const rawDurationHeader = screen.getByRole("columnheader", { name: /Duration/ });
+    expect(rawDurationHeader).toHaveAttribute("aria-sort", "none");
+    expect(rawDurationHeader.querySelector('[role="button"]')).toBeNull();
+    fireEvent.click(within(rawDurationHeader).getByRole("button"));
+    expect(rawDurationHeader).toHaveAttribute("aria-sort", "ascending");
+  });
+
   it("(d) registry-driven chart panel uses display_timings-backed charts", async () => {
     const detail = makeDetail();
     vi.mocked(getDetailResult).mockResolvedValue(detail);


### PR DESCRIPTION
Expose sortable table state through native controls, make corpus copy count-aware, suppress non-discriminating tuning filters, and add real browser regressions for keyboard, reduced-motion, contrast, and zoom behavior.
