### PR TITLE
fix: close recent review follow-up findings

### DIFF
--- a/.github/path-filters.yml
+++ b/.github/path-filters.yml
@@ -137,4 +137,6 @@ explorer-vitest:
   - "_project/scripts/explorer_publish.py"
   - "results-data/**"
   - "scripts/generate_corpus_inventory.py"
+  - "tests/parity/fixtures/**"
+  - "tests/unit/core/tuning/fixtures/**"
   - ".github/workflows/results-explorer-browser.yml"

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1044,6 +1044,17 @@ jobs:
           cache: npm
           cache-dependency-path: results-explorer/package-lock.json
 
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v4
+
+      - name: Install Python dependencies
+        run: uv sync --group dev
+
       - name: Install explorer dependencies
         run: npm ci
         working-directory: results-explorer

--- a/_project/scripts/explorer_pipeline/pipeline.py
+++ b/_project/scripts/explorer_pipeline/pipeline.py
@@ -33,6 +33,7 @@ from _project.scripts.explorer_pipeline.models import (
 from _project.scripts.explorer_pipeline.ranking import RankedCohort, rank_platforms
 from _project.scripts.explorer_pipeline.transformer import (
     BundleTransformer,
+    _applied_receipt,
     _platform_percentile_stats,
 )
 from benchbox.core.results.anonymization import AnonymizationManager, find_public_path_leaks
@@ -79,6 +80,34 @@ def _find_submission_manifest(bundle_path: Path) -> Path | None:
     if legacy.is_file():
         return legacy
     return None
+
+
+def _public_applied_receipt(bundle_path: Path, anonymizer: AnonymizationManager) -> str | None:
+    """Return the bounded applied receipt after public-path sanitization."""
+    receipt_json = _applied_receipt(bundle_path)
+    if receipt_json is None:
+        return None
+    try:
+        public_receipt = anonymizer.anonymize_result_payload(json.loads(receipt_json))
+    except (TypeError, ValueError, json.JSONDecodeError) as exc:
+        raise ValueError(f"could not sanitize applied receipt {bundle_path.name}: {exc}") from exc
+    leaks = find_public_path_leaks(public_receipt)
+    if leaks:
+        raise ValueError("public applied receipt privacy check failed for fields: " + ", ".join(sorted(set(leaks))))
+    return canonical_json_bytes(public_receipt).decode("utf-8")
+
+
+def _public_bundle_data(
+    bundle_path: Path,
+    bundle_data: dict[str, Any],
+    anonymizer: AnonymizationManager,
+) -> tuple[dict[str, Any], str | None]:
+    """Sanitize a bundle and its companion before creating public read-model rows."""
+    public_bundle = anonymizer.anonymize_result_payload(bundle_data)
+    public_leaks = find_public_path_leaks(public_bundle)
+    if public_leaks:
+        raise ValueError("public bundle privacy check failed for fields: " + ", ".join(sorted(set(public_leaks))))
+    return public_bundle, _public_applied_receipt(bundle_path, anonymizer)
 
 
 # Type alias for the summary accumulator: (benchmark, scale_factor, phase) → rows
@@ -491,13 +520,16 @@ class ExplorerPipeline:
                         effective_trust,
                     )
 
+                public_bundle, public_receipt = _public_bundle_data(bundle_path, bundle_data, public_anonymizer)
+
                 entry = self._transformer.to_manifest_entry(
                     bundle_path,
                     trust_label=effective_trust,
                     visibility=effective_visibility,
                     result_id=result_id,
-                    data=bundle_data,
+                    data=public_bundle,
                 )
+                entry = entry.model_copy(update={"applied_receipt": public_receipt})
 
                 detail = self._transformer.to_detail_result(
                     bundle_path,
@@ -505,8 +537,9 @@ class ExplorerPipeline:
                     trust_label=effective_trust,
                     visibility=effective_visibility,
                     bundle_download_url=bundle_download_url,
-                    data=bundle_data,
+                    data=public_bundle,
                 )
+                detail = detail.model_copy(update={"applied_receipt": public_receipt})
 
                 dest_bundle = (out_bundles_dir / f"{result_id}.json").resolve()
                 if not dest_bundle.is_relative_to(out_bundles_dir.resolve()):
@@ -517,12 +550,6 @@ class ExplorerPipeline:
                         result_id,
                     )
                     continue
-                public_bundle = public_anonymizer.anonymize_result_payload(bundle_data)
-                public_leaks = find_public_path_leaks(public_bundle)
-                if public_leaks:
-                    raise ValueError(
-                        "public bundle privacy check failed for fields: " + ", ".join(sorted(set(public_leaks)))
-                    )
                 dest_bundle.write_bytes(canonical_json_bytes(public_bundle))
 
                 # Publish the plans sidecar alongside the bundle when present

--- a/benchbox/core/results/anonymization.py
+++ b/benchbox/core/results/anonymization.py
@@ -55,7 +55,7 @@ _MESSAGE_KEYS = set(_ANONYMIZATION_SPECS["message_keys"])
 
 _MESSAGE_PATH_RE = re.compile(
     r"(?<![A-Za-z0-9_])("
-    r"(?:~|/Users|/home|/private/var|/var/folders|/var/run|/Volumes)/[^\s'\",;)]*"
+    r"(?:~|/Users|/home|/root|/private/var|/var/folders|/var/run|/Volumes)/[^\s'\",;)]*"
     r"|[A-Za-z]:\\Users\\[^\s'\",;)]*"
     r")"
 )
@@ -74,7 +74,7 @@ _MESSAGE_SECRET_ASSIGNMENT_RE = re.compile(
 # SQL literals, and repository-relative tuning references must remain intact.
 _PRIVATE_LOCAL_PATH_RE = re.compile(
     r"(?<![A-Za-z0-9_])(?:"
-    r"(?:~|/Users|/home|/private/var|/var/folders|/var/run|/Volumes)/[^\s'\",;)]*"
+    r"(?:~|/Users|/home|/root|/private/var|/var/folders|/var/run|/Volumes)/[^\s'\",;)]*"
     r"|[A-Za-z]:\\Users\\[^\s'\",;)]*"
     r")",
     flags=re.IGNORECASE,
@@ -411,7 +411,11 @@ class AnonymizationManager:
                 elif key in {"columns", "column_names", "referenced_columns", "referenced_column_names"}:
                     anonymized[key] = self._anonymize_constraint_identifier_collection(child, "column")
                 else:
-                    anonymized[key] = self._anonymize_tuning_constraints(child)
+                    anonymized[key] = (
+                        self._anonymize_tuning_constraints(child)
+                        if isinstance(child, (dict, list, tuple))
+                        else self._anonymize_public_value({str(key): child}, ())[str(key)]
+                    )
             return anonymized
         if isinstance(value, list):
             return [self._anonymize_tuning_constraints(item) for item in value]

--- a/benchbox/mcp/errors.py
+++ b/benchbox/mcp/errors.py
@@ -37,7 +37,12 @@ _SECRET_QUOTED_ASSIGNMENT_RE = re.compile(
     flags=re.IGNORECASE,
 )
 _SECRET_COLON_ASSIGNMENT_RE = re.compile(
-    rf"(?P<prefix>{_SECRET_KEY_PATTERN}\s*:\s*)(?P<value>[^&\s,;'\")]+)",
+    rf"(?P<prefix>{_SECRET_KEY_PATTERN}\s*:\s*)(?P<value>'[^']*'|\"[^\"]*\"|[^&\s,;]+)",
+    flags=re.IGNORECASE,
+)
+_SECRET_PROSE_CONNECTOR_RE = re.compile(
+    rf"(?P<prefix>\b{_SECRET_KEY_PATTERN}\s+(?:is|was|equals?|set\s+to|configured\s+as)\s+)"
+    r"(?P<value>[^\s,;:()]+)",
     flags=re.IGNORECASE,
 )
 _SECRET_PROSE_RE = re.compile(
@@ -96,6 +101,7 @@ def scrub_secret_material(text: str) -> str:
     scrubbed = _SECRET_QUOTED_ASSIGNMENT_RE.sub(replace_quoted, text)
     scrubbed = _SECRET_ASSIGNMENT_RE.sub(r"\1****", scrubbed)
     scrubbed = _SECRET_COLON_ASSIGNMENT_RE.sub(replace_colon, scrubbed)
+    scrubbed = _SECRET_PROSE_CONNECTOR_RE.sub(replace_prose, scrubbed)
     scrubbed = _SECRET_PROSE_RE.sub(replace_prose, scrubbed)
     return _URL_USERINFO_RE.sub(r"\1****@", scrubbed)
 

--- a/benchbox/mcp/schemas.py
+++ b/benchbox/mcp/schemas.py
@@ -134,7 +134,7 @@ MCP_PLATFORM_OPTION_ALLOWLIST: dict[str, dict[str, MCPPlatformOptionSpec]] = {
         ),
         "liquid_clustering_columns": _MCP_OPTION("string"),
     },
-    "modin": {"engine": _MCP_OPTION("string", choices=("pandas", "ray", "dask"))},
+    "modin": {"engine": _MCP_OPTION("string", choices=("ray", "dask"))},
     "pandas": {"dtype_backend": _MCP_OPTION("string", choices=("numpy_nullable", "pyarrow"))},
     "polars": {
         "n_rows": _MCP_OPTION("int", minimum=1, maximum=10_000_000),
@@ -148,7 +148,7 @@ MCP_PLATFORM_OPTION_ALLOWLIST: dict[str, dict[str, MCPPlatformOptionSpec]] = {
     },
     "velox": {
         "adaptive_enabled": _MCP_OPTION("bool"),
-        "deployment": _MCP_OPTION("string", choices=("local", "docker")),
+        "deployment": _MCP_OPTION("string", choices=("local", "remote")),
         "driver_memory": _MCP_OPTION("string"),
         "offheap_size": _MCP_OPTION("string"),
         "shuffle_partitions": _MCP_OPTION("int", minimum=1, maximum=1_024),

--- a/benchbox/mcp/security.py
+++ b/benchbox/mcp/security.py
@@ -512,6 +512,7 @@ READ_ONLY_TOOLS = frozenset(
         "get_query_plan",
         "validate_results",
         "suggest_charts",
+        "generate_chart",
         "get_benchmark_status",
         "get_benchmark_result",
     }

--- a/benchbox/mcp/tools/benchmark.py
+++ b/benchbox/mcp/tools/benchmark.py
@@ -88,6 +88,43 @@ def _get_platform_adapter(platform: str, mode: str | None = None, **config):
         return get_platform_adapter(platform_lower, **config)
 
 
+def _prepare_adapter_platform_options(platform: str, options: Mapping[str, object]) -> dict[str, object]:
+    """Translate MCP option names to the adapter and tuning contracts."""
+    normalized = dict(options)
+    platform_name = platform.lower().removesuffix("-df")
+
+    if platform_name == "duckdb" and "threads" in normalized:
+        normalized["thread_limit"] = normalized.pop("threads")
+
+    if platform_name == "databricks" and (
+        "databricks_clustering_strategy" in normalized or "liquid_clustering_columns" in normalized
+    ):
+        from benchbox.core.tuning.interface import UnifiedTuningConfiguration
+
+        tuning_config = UnifiedTuningConfiguration()
+        platform_optimizations = tuning_config.platform_optimizations
+        strategy = normalized.pop("databricks_clustering_strategy", None)
+        if strategy is not None:
+            strategy = str(strategy).lower()
+            platform_optimizations.databricks_clustering_strategy = strategy
+            platform_optimizations.liquid_clustering_enabled = strategy in {
+                "liquid_clustering",
+                "liquid_clustering_auto",
+            }
+            platform_optimizations.physical_rendering_id = None
+        columns = normalized.pop("liquid_clustering_columns", None)
+        if columns is not None:
+            platform_optimizations.liquid_clustering_columns = [
+                column.strip() for column in str(columns).split(",") if column.strip()
+            ]
+            platform_optimizations.liquid_clustering_enabled = bool(platform_optimizations.liquid_clustering_columns)
+        platform_optimizations.__post_init__()
+        normalized["tuning_config"] = tuning_config
+        normalized["tuning_enabled"] = True
+
+    return normalized
+
+
 def _validate_and_resolve_mode(platform: str, mode: str | None) -> tuple[str, dict | None]:
     """Validate mode against platform capabilities, resolve default if not specified."""
     from benchbox.core.platform_registry import PlatformRegistry
@@ -410,7 +447,7 @@ def _run_benchmark_impl(
                 mode=resolved_mode,
                 benchmark=benchmark_lower,
                 scale_factor=scale_factor,
-                **normalized_platform_options,
+                **_prepare_adapter_platform_options(platform, normalized_platform_options),
             )
         except (ValueError, ImportError) as e:
             return _make_failed_response(

--- a/benchbox/mcp/tools/visualization.py
+++ b/benchbox/mcp/tools/visualization.py
@@ -90,10 +90,10 @@ VIZ_READONLY_ANNOTATIONS = ToolAnnotations(
     open_world_hint=False,
 )
 
-# Tool annotations for chart generation (creates files)
+# Tool annotations for inline chart generation
 VIZ_GENERATE_ANNOTATIONS = ToolAnnotations(
-    title="Generate visualization",
-    read_only_hint=False,
+    title="Generate inline visualization",
+    read_only_hint=True,
     destructive_hint=False,
     idempotent_hint=True,
     open_world_hint=False,

--- a/benchbox/platforms/datafusion.py
+++ b/benchbox/platforms/datafusion.py
@@ -308,6 +308,8 @@ class DataFusionAdapter(NoConstraintEnforcementMixin, PlatformAdapter):
         self.data_format = config.get("data_format", "parquet")
         self.temp_dir = config.get("temp_dir")
         self.batch_size = config.get("batch_size", 8192)
+        self.parquet_pushdown = bool(config.get("parquet_pushdown", True))
+        self.repartition_joins = bool(config.get("repartition_joins", True))
 
         # Schema tracking (populated during create_schema)
         self._table_schemas = {}
@@ -413,8 +415,8 @@ class DataFusionAdapter(NoConstraintEnforcementMixin, PlatformAdapter):
         config = config.with_target_partitions(self.target_partitions)
 
         # Enable optimizations
-        config = config.with_parquet_pruning(True)
-        config = config.with_repartition_joins(True)
+        config = config.with_parquet_pruning(self.parquet_pushdown)
+        config = config.with_repartition_joins(self.repartition_joins)
         config = config.with_repartition_aggregations(True)
         config = config.with_repartition_windows(True)
         config = config.with_information_schema(True)
@@ -426,8 +428,8 @@ class DataFusionAdapter(NoConstraintEnforcementMixin, PlatformAdapter):
         config_applied = [
             f"target_partitions={self.target_partitions}",
             f"batch_size={self.batch_size}",
-            "parquet_pruning=enabled",
-            "repartitioning=enabled",
+            f"parquet_pruning={'enabled' if self.parquet_pushdown else 'disabled'}",
+            f"repartition_joins={'enabled' if self.repartition_joins else 'disabled'}",
         ]
 
         # Add runtime configuration to tracking

--- a/docs/reference/mcp.md
+++ b/docs/reference/mcp.md
@@ -192,7 +192,7 @@ CLI result bundles, but MCP does not claim option parity with `benchbox run`.
 | `get_query_plan` | analytics | No | Read captured query plans from a result bundle. |
 | `validate_results` | analytics | No | Validate result JSON integrity, completeness, and believability. |
 | `suggest_charts` | visualization | No | Suggest useful chart types for one or more result files. |
-| `generate_chart` | visualization | Yes | Generate ASCII chart output from result files. |
+| `generate_chart` | visualization | No | Generate ASCII chart output from result files. |
 
 Authenticated remote mode additionally registers:
 

--- a/results-explorer/src/pages/Compare.tsx
+++ b/results-explorer/src/pages/Compare.tsx
@@ -135,6 +135,7 @@ export function Compare({ url }: CompareProps) {
   const [builderPinnedId, setBuilderPinnedId] = useState<string | null>(null);
   const [showBuilder, setShowBuilder] = useState(false);
   const [compareNotice, setCompareNotice] = useState<string | null>(null);
+  const [preserveRequestedIds, setPreserveRequestedIds] = useState(false);
   const copyTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const results = compareState?.results ?? EMPTY_RESULTS;
   const primaryMetric = compareState?.primaryMetric ?? "display_geomean_ms";
@@ -151,10 +152,14 @@ export function Compare({ url }: CompareProps) {
     setBuilderPinnedId(null);
     setShowBuilder(false);
     setCompareNotice(null);
+    setPreserveRequestedIds(false);
 
     const params = searchParamsFromUrl(activeUrl);
     const idsParam = params.get("ids") ?? "";
-    const plan = planCompareIds(idsParam.split(","), MAX_COMPARE_SELECTIONS);
+    const rawIds = idsParam.split(",");
+    // Resolve every requested ID before applying the comparison limit so a
+    // short ID and its long-form alias consume one slot, not two.
+    const plan = planCompareIds(rawIds, rawIds.length);
     let initialNotice: string | null = null;
     if (plan.duplicates.length > 0) {
       initialNotice = `Ignored duplicate result ID${plan.duplicates.length === 1 ? "" : "s"}: ${formatIdList(plan.duplicates)}.`;
@@ -238,9 +243,21 @@ export function Compare({ url }: CompareProps) {
           setCompareNotice(initialNotice);
         }
 
-        const candidates = resolved.filter(
-          (entry): entry is { requestedId: string; resolvedId: string; error: null } =>
-            entry.resolvedId !== null && !aliases.some((alias) => alias.requestedId === entry.requestedId),
+        const deduplicated = resolved.filter(
+          (entry) => !aliases.some((alias) => alias.requestedId === entry.requestedId),
+        );
+        const retained = deduplicated.slice(0, MAX_COMPARE_SELECTIONS);
+        const overflow = deduplicated.slice(MAX_COMPARE_SELECTIONS);
+        if (overflow.length > 0) {
+          const aliasResolutionNote = aliases.length > 0 ? " after alias resolution" : "";
+          initialNotice = appendCompareNotice(
+            initialNotice,
+            `Ignored ${overflow.length} additional result ID${overflow.length === 1 ? "" : "s"}${aliasResolutionNote} (${formatIdList(overflow.map((entry) => entry.requestedId))}); comparisons are limited to ${MAX_COMPARE_SELECTIONS} unique results.`,
+          );
+          setCompareNotice(initialNotice);
+        }
+        const candidates = retained.filter(
+          (entry): entry is { requestedId: string; resolvedId: string; error: null } => entry.resolvedId !== null,
         );
         const loaded = await Promise.all(
           candidates.map(async (entry) => {
@@ -255,10 +272,12 @@ export function Compare({ url }: CompareProps) {
 
         const missing = loaded.filter((entry) => entry.detail === null && entry.loadError === null);
         const failed = [
-          ...resolved.filter((entry) => entry.error !== null),
+          ...retained.filter((entry) => entry.error !== null),
           ...loaded.filter((entry) => entry.loadError !== null),
         ];
-        const details = loaded.flatMap((entry) => (entry.detail ? [entry.detail] : []));
+        const retainedLoaded = loaded;
+        const details = retainedLoaded.flatMap((entry) => (entry.detail ? [entry.detail] : []));
+        if (failed.length > 0) setPreserveRequestedIds(true);
         if (details.length === 0) {
           if (failed.length > 0) {
             const firstFailure = failed[0]!;
@@ -274,8 +293,13 @@ export function Compare({ url }: CompareProps) {
           setLoading(false);
           return;
         }
-        if (missing.length > 0 || failed.length > 0) {
-          const unavailable = [...missing, ...failed].map((entry) => entry.requestedId);
+        const retainedMissing = retainedLoaded.filter((entry) => entry.detail === null && entry.loadError === null);
+        const retainedFailed = [
+          ...retained.filter((entry) => entry.error !== null),
+          ...retainedLoaded.filter((entry) => entry.loadError !== null),
+        ];
+        if (retainedMissing.length > 0 || retainedFailed.length > 0) {
+          const unavailable = [...retainedMissing, ...retainedFailed].map((entry) => entry.requestedId);
           initialNotice = appendCompareNotice(
             initialNotice,
             `Ignored unavailable result ID${unavailable.length === 1 ? "" : "s"}: ${formatIdList(unavailable)}.`,
@@ -309,6 +333,7 @@ export function Compare({ url }: CompareProps) {
   useEffect(() => {
     const ids = results.map((r) => r.result_id);
     if (ids.length === 0 || typeof window === "undefined") return;
+    if (preserveRequestedIds) return;
     const currentParams = new URLSearchParams(window.location.search);
     const currentRawIds = currentParams.get("ids") ?? "";
     // A URL that started as a multi-selection must remain a multi-selection
@@ -348,7 +373,7 @@ export function Compare({ url }: CompareProps) {
           ),
         );
       });
-  }, [results]);
+  }, [preserveRequestedIds, results]);
 
   if (loading) return <CompareSummarySkeleton message="Loading results for comparison..." />;
   if (error)

--- a/results-explorer/src/pages/PlatformIndex.tsx
+++ b/results-explorer/src/pages/PlatformIndex.tsx
@@ -220,7 +220,7 @@ export function PlatformIndex({ platform = "" }: PlatformIndexProps) {
     const canonical = canonicalPlatformRouteKey(platform);
     if (requested === canonical) return;
     if (rows.some((row) => normalizePlatformKey(row.platform_id) === canonical)) {
-      route(`/results/p/${canonical}/`, true);
+      route(`/results/p/${canonical}/${window.location.search}`, true);
     }
   }, [platform, rows]);
 

--- a/results-explorer/src/pages/__tests__/Compare.test.tsx
+++ b/results-explorer/src/pages/__tests__/Compare.test.tsx
@@ -297,6 +297,37 @@ describe("Compare", () => {
     expect(screen.getByRole("heading", { name: "Decision Summary" })).toBeTruthy();
   });
 
+  it("resolves aliases before applying the four-result comparison limit", async () => {
+    setupUrl(["r1", "alias-r1", "r2", "r3", "r4"]);
+    vi.mocked(resolveShortId).mockImplementation((id) =>
+      Promise.resolve(id === "alias-r1" ? "r1" : id),
+    );
+    const r4 = makeResult({ result_id: "r4", platform: "Trino", platform_id: "trino" });
+    const byId: Record<string, DetailResult> = { r1: DUCKDB, r2: SQLITE, r3: POSTGRES, r4 };
+    vi.mocked(getDetailResult).mockImplementation((id) => Promise.resolve(byId[id] ?? null));
+
+    render(<Compare />);
+
+    await waitFor(() => expect(document.title).toBe("Compare (4) · BenchBox Results"));
+    expect(screen.getAllByText("Trino").length).toBeGreaterThan(0);
+    expect(screen.getByTestId("compare-url-notice")).toHaveTextContent(
+      "Ignored duplicate result ID after alias resolution: “alias-r1”.",
+    );
+  });
+
+  it("preserves requested IDs when a detail lookup rejects", async () => {
+    setupUrl(["r1", "r2", "r3"]);
+    vi.mocked(getDetailResult).mockImplementation((id) => {
+      if (id === "r2") return Promise.reject(new Error("transient detail failure"));
+      return Promise.resolve(id === "r1" ? DUCKDB : POSTGRES);
+    });
+
+    render(<Compare />);
+
+    await waitFor(() => expect(screen.getByRole("heading", { name: "Decision Summary" })).toBeTruthy());
+    expect(new URL(window.location.href).searchParams.get("ids")).toBe("r1,r2,r3");
+  });
+
   it("renders the in-page compare builder when no ids are provided (no URL editing required)", async () => {
     setupUrl([]);
 

--- a/results-explorer/src/pages/__tests__/PlatformIndex.test.tsx
+++ b/results-explorer/src/pages/__tests__/PlatformIndex.test.tsx
@@ -161,6 +161,21 @@ describe("PlatformIndex - sortable table headers", () => {
     expect(within(switcher).queryByRole("option", { name: "clickhouse_local" })).toBeNull();
   });
 
+  it("preserves query parameters while canonicalizing platform aliases", async () => {
+    const preactRouter = await import("preact-router");
+    const routeMock = vi.mocked(preactRouter.route);
+    window.history.replaceState(null, "", "/results/p/clickhouse_local/?tuning=notuning");
+    vi.mocked(getPlatformIndexRows).mockResolvedValue([
+      ...ROWS,
+      makeRow({ result_id: "r-clickhouse", platform_id: "clickhouse-local", platform: "ClickHouse Local" }),
+    ]);
+
+    render(<PlatformIndex platform="clickhouse_local" />);
+    await waitFor(() => expect(screen.getByText("ClickHouse Local Results")).toBeTruthy());
+
+    await waitFor(() => expect(routeMock).toHaveBeenCalledWith("/results/p/clickhouse-local/?tuning=notuning", true));
+  });
+
   it("retries a transient empty platform index before rendering a terminal empty state", async () => {
     vi.mocked(getPlatformIndexRows).mockResolvedValueOnce([]).mockResolvedValueOnce(ROWS);
 

--- a/scripts/validate_submission.py
+++ b/scripts/validate_submission.py
@@ -49,7 +49,7 @@ try:
 except ImportError:  # pragma: no cover - published-results keeps a slim package mirror.
     _PRIVATE_LOCAL_PATH_RE = re.compile(
         r"(?<![A-Za-z0-9_])(?:"
-        r"(?:~|/Users|/home|/private/var|/var/folders|/var/run|/Volumes)/[^\s'\",;)]*"
+        r"(?:~|/Users|/home|/root|/private/var|/var/folders|/var/run|/Volumes)/[^\s'\",;)]*"
         r"|[A-Za-z]:\\Users\\[^\s'\",;)]*"
         r")",
         flags=re.IGNORECASE,
@@ -88,9 +88,13 @@ _PUBLIC_COMPANION_SUFFIXES = (".plans.json", ".tuning.json", ".applied.json", ".
 def _public_json_surfaces(bundle_path: Path) -> list[Path]:
     """Return a primary bundle plus its JSON companions for privacy scanning."""
     candidates = [bundle_path]
+    try:
+        siblings = {path.name.lower(): path for path in bundle_path.parent.iterdir() if path.is_file()}
+    except OSError:
+        siblings = {}
     for suffix in _PUBLIC_COMPANION_SUFFIXES:
-        candidate = bundle_path.with_name(f"{bundle_path.stem}{suffix}")
-        if candidate.is_file():
+        candidate = siblings.get(f"{bundle_path.stem}{suffix}".lower())
+        if candidate is not None:
             candidates.append(candidate)
     legacy_manifest = bundle_path.parent / "submission-manifest.json"
     if legacy_manifest.is_file():
@@ -107,10 +111,18 @@ def _append_public_privacy_errors(paths: list[Path], results: list[ValidationRes
             continue
         for surface in _public_json_surfaces(bundle_path):
             try:
-                payload = json.loads(surface.read_text(encoding="utf-8"))
-            except (OSError, json.JSONDecodeError):
-                # The schema/manifest validators own malformed JSON reporting;
-                # do not duplicate or alter those diagnostics here.
+                raw_text = surface.read_text(encoding="utf-8")
+            except OSError as exc:
+                result.error(f"Cannot read public JSON surface {surface.name}: {exc}")
+                continue
+            try:
+                payload = json.loads(raw_text)
+            except json.JSONDecodeError:
+                if surface != bundle_path:
+                    result.error(f"Malformed public companion JSON: {surface.name}")
+                raw_leaks = sorted(set(find_public_path_leaks(raw_text)))
+                if raw_leaks:
+                    result.error(f"Public privacy contract rejects private absolute paths in malformed {surface.name}")
                 continue
             leaks = sorted(set(find_public_path_leaks(payload)))
             if leaks:

--- a/tests/unit/core/results/test_anonymization.py
+++ b/tests/unit/core/results/test_anonymization.py
@@ -882,6 +882,28 @@ class TestPublicPayloadTupleRecursion:
 
 
 class TestTuningPayloadAnonymization:
+    def test_unknown_constraint_fields_use_generic_public_sanitization(self):
+        out = AnonymizationManager().anonymize_tuning_payload(
+            {
+                "requested": {
+                    "constraints": {
+                        "foreign_keys": {
+                            "password": "CONSTRAINT-PASSWORD",
+                            "owner_email": "owner@example.com",
+                            "endpoint": "https://warehouse.example.com",
+                            "path": "/Users/alice/private-run",
+                        }
+                    }
+                }
+            }
+        )
+
+        serialized = json.dumps(out)
+        assert "CONSTRAINT-PASSWORD" not in serialized
+        assert "owner@example.com" not in serialized
+        assert "warehouse.example.com" not in serialized
+        assert "/Users/alice" not in serialized
+
     def test_constraint_table_and_column_identifiers_are_pseudonymized(self):
         out = AnonymizationManager().anonymize_tuning_payload(
             {
@@ -1065,3 +1087,10 @@ class TestPublicPayloadPathPrivacy:
     def test_detector_reports_field_paths_without_echoing_values(self):
         leaks = find_public_path_leaks({"nested": [{"working_dir": "/Users/alice/private"}]})
         assert leaks == ["nested.0.working_dir"]
+
+    def test_root_owned_home_paths_are_private_even_under_generic_keys(self):
+        payload = {"raw_config": {"location": "/root/private-run"}}
+
+        assert find_public_path_leaks(payload)
+        out = AnonymizationManager().anonymize_result_payload(payload)
+        assert "/root/private-run" not in json.dumps(out, default=str)

--- a/tests/unit/core/visualization/test_textcharts_dependency_contract.py
+++ b/tests/unit/core/visualization/test_textcharts_dependency_contract.py
@@ -7,6 +7,12 @@ from importlib.metadata import version
 from pathlib import Path
 
 import pytest
+from packaging.requirements import Requirement
+
+try:
+    import tomllib
+except ModuleNotFoundError:  # pragma: no cover - Python 3.10 compatibility.
+    import tomli as tomllib
 
 pytestmark = [pytest.mark.unit, pytest.mark.fast]
 
@@ -20,5 +26,9 @@ def test_textcharts_is_installed_and_legacy_shim_delegates() -> None:
 
 
 def test_textcharts_remains_a_core_manifest_dependency() -> None:
-    manifest = (Path(__file__).resolve().parents[4] / "pyproject.toml").read_text(encoding="utf-8")
-    assert '"textcharts>=0.1.0"' in manifest
+    manifest_path = Path(__file__).resolve().parents[4] / "pyproject.toml"
+    with manifest_path.open("rb") as handle:
+        manifest = tomllib.load(handle)
+
+    dependencies = manifest["project"]["dependencies"]
+    assert any(Requirement(str(requirement)).name.lower() == "textcharts" for requirement in dependencies)

--- a/tests/unit/mcp/test_benchmark_tools.py
+++ b/tests/unit/mcp/test_benchmark_tools.py
@@ -166,7 +166,21 @@ class TestRunBenchmarkTool:
             )
 
         assert response["mcp_metadata"]["status"] == "no_results"
-        assert get_adapter.call_args.kwargs["threads"] == 4
+        assert get_adapter.call_args.kwargs["thread_limit"] == 4
+
+    def test_databricks_layout_options_build_unified_tuning_config(self):
+        from benchbox.mcp.tools.benchmark import _prepare_adapter_platform_options
+
+        options = _prepare_adapter_platform_options(
+            "databricks",
+            {"databricks_clustering_strategy": "liquid_clustering", "liquid_clustering_columns": "event_time,id"},
+        )
+
+        tuning = options["tuning_config"]
+        assert options["tuning_enabled"] is True
+        assert "databricks_clustering_strategy" not in options
+        assert tuning.platform_optimizations.databricks_clustering_strategy == "liquid_clustering"
+        assert tuning.platform_optimizations.liquid_clustering_columns == ["event_time", "id"]
 
 
 class TestGetQueryDetailsTool:

--- a/tests/unit/mcp/test_errors.py
+++ b/tests/unit/mcp/test_errors.py
@@ -17,6 +17,7 @@ from benchbox.mcp.errors import (
     make_not_found_error,
     make_platform_error,
     make_validation_error,
+    scrub_secret_material,
 )
 
 pytestmark = [
@@ -56,6 +57,19 @@ class TestErrorCode:
         """Test that internal error codes are defined."""
         assert ErrorCode.INTERNAL_ERROR.value == "INTERNAL_ERROR"
         assert ErrorCode.INTERNAL_TIMEOUT.value == "INTERNAL_TIMEOUT"
+
+
+@pytest.mark.parametrize(
+    ("text", "expected"),
+    [
+        ("password: 'hunter2'", "password: ****"),
+        ('token: "secret-value"', "token: ****"),
+        ("password is hunter2", "password is ****"),
+        ("token was abc123", "token was ****"),
+    ],
+)
+def test_scrub_secret_material_covers_quoted_colon_and_prose_values(text: str, expected: str) -> None:
+    assert scrub_secret_material(text) == expected
 
 
 class TestErrorCategory:

--- a/tests/unit/mcp/test_schemas.py
+++ b/tests/unit/mcp/test_schemas.py
@@ -284,6 +284,13 @@ class TestRunBenchmarkInput:
         with pytest.raises(MCPValidationError):
             validate_platform_options("databricks", {"liquid_clustering_columns": "event_time;DROP"})
 
+    def test_mcp_platform_choices_match_adapter_contracts(self):
+        with pytest.raises(MCPValidationError):
+            validate_platform_options("velox", {"deployment": "docker"})
+        assert validate_platform_options("velox", {"deployment": "remote"}) == {"deployment": "remote"}
+        with pytest.raises(MCPValidationError):
+            validate_platform_options("modin", {"engine": "pandas"})
+
 
 class TestDryRunInput:
     """Tests for DryRunInput Pydantic model."""

--- a/tests/unit/mcp/test_security.py
+++ b/tests/unit/mcp/test_security.py
@@ -11,6 +11,7 @@ from mcp.shared.exceptions import MCPError
 from mcp.types import CallToolResult, TextContent
 
 from benchbox.mcp.security import (
+    READ_ONLY_TOOLS,
     AdmissionLease,
     AdmissionLimits,
     DurableSecurityStore,
@@ -22,6 +23,10 @@ from benchbox.mcp.security import (
 from tests.integration.mcp._security import write_security_config
 
 pytestmark = [pytest.mark.unit, pytest.mark.fast]
+
+
+def test_inline_chart_generation_is_read_only() -> None:
+    assert "generate_chart" in READ_ONLY_TOOLS
 
 
 def test_auth_config_contains_only_digests_and_verifies_identity(tmp_path: Path) -> None:

--- a/tests/unit/platforms/test_datafusion_adapter.py
+++ b/tests/unit/platforms/test_datafusion_adapter.py
@@ -141,6 +141,37 @@ class TestDataFusionAdapter:
                         mock_config.with_repartition_joins.assert_called_once_with(True)
                         mock_config.with_batch_size.assert_called_once_with(16384)
 
+    def test_create_connection_honors_optimization_flags(self):
+        """MCP-supplied DataFusion optimization flags must reach SessionConfig."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            mock_config = Mock()
+            mock_config.with_target_partitions.return_value = mock_config
+            mock_config.with_parquet_pruning.return_value = mock_config
+            mock_config.with_repartition_joins.return_value = mock_config
+            mock_config.with_repartition_aggregations.return_value = mock_config
+            mock_config.with_repartition_windows.return_value = mock_config
+            mock_config.with_information_schema.return_value = mock_config
+            mock_config.with_batch_size.return_value = mock_config
+            mock_config.set.side_effect = Exception("Config not supported")
+
+            mock_runtime_builder = Mock()
+            mock_runtime_builder.build.return_value = Mock()
+
+            with patch("benchbox.platforms.datafusion.SessionConfig", return_value=mock_config):
+                with patch("benchbox.platforms.datafusion.SessionContext"):
+                    with patch("benchbox.platforms.datafusion.RuntimeEnv", return_value=mock_runtime_builder):
+                        adapter = DataFusionAdapter(
+                            working_dir=tmpdir,
+                            parquet_pushdown=False,
+                            repartition_joins=False,
+                        )
+
+                        with patch.object(adapter, "handle_existing_database"):
+                            adapter.create_connection()
+
+            mock_config.with_parquet_pruning.assert_called_once_with(False)
+            mock_config.with_repartition_joins.assert_called_once_with(False)
+
     def test_parse_memory_limit(self):
         """Test memory limit parsing."""
         with patch("benchbox.platforms.datafusion.SessionContext"), tempfile.TemporaryDirectory() as tmpdir:

--- a/tests/unit/scripts/explorer_pipeline/test_pipeline.py
+++ b/tests/unit/scripts/explorer_pipeline/test_pipeline.py
@@ -185,6 +185,23 @@ class TestExplorerPipelineRun:
         assert "/Users/alice" not in published
         assert "path_" in published
 
+    def test_applied_receipt_is_sanitized_before_duckdb_publication(self, tmp_path: Path) -> None:
+        bundles_dir = tmp_path / "data" / "bundles"
+        bundles_dir.mkdir(parents=True)
+        source = bundles_dir / "with_receipt.json"
+        source.write_text(json.dumps(MINIMAL_BUNDLE), encoding="utf-8")
+        source.with_name("with_receipt.applied.json").write_text(
+            json.dumps({"receipt": {"entries": [{"statement": "SET path=/Users/alice/private"}]}}),
+            encoding="utf-8",
+        )
+
+        output = tmp_path / "out"
+        ExplorerPipeline().run(tmp_path / "data", output)
+
+        row = _duckdb_results(output)[0]
+        assert row["applied_receipt"] is not None
+        assert "/Users/alice" not in row["applied_receipt"]
+
     def test_publishes_plans_sidecar_when_present(self, tmp_path: Path) -> None:
         """w1 wire-up: when a ``*.plans.json`` sidecar exists alongside a
         bundle, the pipeline must copy it to ``out/bundles/<result_id>.plans.json``

--- a/tests/unit/scripts/test_validate_submission.py
+++ b/tests/unit/scripts/test_validate_submission.py
@@ -850,3 +850,29 @@ class TestMain:
         bad = tmp_path / "bad.json"
         bad.write_text(json.dumps({"version": "1.0"}), encoding="utf-8")
         assert main([str(bad)]) == 1
+
+    def test_malformed_public_companion_fails_closed(self, tmp_path: Path, capsys: pytest.CaptureFixture[str]):
+        bundle = tmp_path / "tpch_result.json"
+        bundle.write_text(json.dumps(_minimal_bundle()), encoding="utf-8")
+        bundle.with_name("tpch_result.plans.json").write_text(
+            '{"plan": "/Users/alice/private" not-json',
+            encoding="utf-8",
+        )
+
+        assert main([str(bundle)]) == 1
+        assert "Malformed public companion JSON" in capsys.readouterr().out
+
+    def test_case_insensitive_companion_name_is_privacy_scanned(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ):
+        bundle = tmp_path / "tpch_result.json"
+        bundle.write_text(json.dumps(_minimal_bundle()), encoding="utf-8")
+        bundle.with_name("tpch_result.PLANS.JSON").write_text(
+            json.dumps({"path": "/Users/alice/private"}),
+            encoding="utf-8",
+        )
+
+        assert main([str(bundle)]) == 1
+        output = capsys.readouterr().out
+        assert "PLANS.JSON" in output
+        assert "private absolute paths" in output


### PR DESCRIPTION
## Summary
- close 16 actionable findings from the latest merged-PR review sweep
- harden MCP secret scrubbing, adapter option translation, and read-only chart metadata
- sanitize public Explorer payloads/receipts and fail closed on malformed companions
- preserve Explorer alias query parameters and expand the CI/path-filter contracts

## Verification
- `BENCHBOX_MAX_XDIST_WORKERS=1 uv run -- python -m pytest tests/unit/ -x -q` — 26,358 passed, 13 skipped
- Explorer Vitest PlatformIndex suite — 33 passed
- Explorer TypeScript check — passed
- commit hooks and push preflight — passed

Three historical commit-identity findings were intentionally not rewritten because their PRs are already merged; those threads will be acknowledged as separate follow-ups.