### PR TITLE
fix: address follow-up review comments

### DIFF
--- a/benchbox/mcp/tools/benchmark.py
+++ b/benchbox/mcp/tools/benchmark.py
@@ -114,10 +114,11 @@ def _prepare_adapter_platform_options(platform: str, options: Mapping[str, objec
             platform_optimizations.physical_rendering_id = None
         columns = normalized.pop("liquid_clustering_columns", None)
         if columns is not None:
-            platform_optimizations.liquid_clustering_columns = [
-                column.strip() for column in str(columns).split(",") if column.strip()
-            ]
-            platform_optimizations.liquid_clustering_enabled = bool(platform_optimizations.liquid_clustering_columns)
+            parsed_columns = [column.strip() for column in str(columns).split(",") if column.strip()]
+            platform_optimizations.liquid_clustering_columns = parsed_columns
+            platform_optimizations.liquid_clustering_enabled = bool(parsed_columns)
+            if parsed_columns and strategy is None:
+                platform_optimizations.databricks_clustering_strategy = "liquid_clustering"
         platform_optimizations.__post_init__()
         normalized["tuning_config"] = tuning_config
         normalized["tuning_enabled"] = True

--- a/benchbox/platforms/datafusion.py
+++ b/benchbox/platforms/datafusion.py
@@ -290,6 +290,8 @@ class DataFusionAdapter(NoConstraintEnforcementMixin, PlatformAdapter):
             "tuning_source_file",
             "verbose_enabled",
             "very_verbose",
+            "parquet_pushdown",
+            "repartition_joins",
         ]:
             if key in config:
                 adapter_config[key] = config[key]

--- a/tests/unit/mcp/test_benchmark_tools.py
+++ b/tests/unit/mcp/test_benchmark_tools.py
@@ -182,6 +182,16 @@ class TestRunBenchmarkTool:
         assert tuning.platform_optimizations.databricks_clustering_strategy == "liquid_clustering"
         assert tuning.platform_optimizations.liquid_clustering_columns == ["event_time", "id"]
 
+    def test_databricks_columns_infer_liquid_clustering_strategy(self):
+        from benchbox.mcp.tools.benchmark import _prepare_adapter_platform_options
+
+        options = _prepare_adapter_platform_options("databricks", {"liquid_clustering_columns": "customer_id,order_id"})
+
+        tuning = options["tuning_config"]
+        assert options["tuning_enabled"] is True
+        assert tuning.platform_optimizations.databricks_clustering_strategy == "liquid_clustering"
+        assert tuning.platform_optimizations.liquid_clustering_columns == ["customer_id", "order_id"]
+
 
 class TestGetQueryDetailsTool:
     """Tests for get_query_details tool functionality."""

--- a/tests/unit/platforms/test_datafusion_adapter.py
+++ b/tests/unit/platforms/test_datafusion_adapter.py
@@ -172,6 +172,20 @@ class TestDataFusionAdapter:
             mock_config.with_parquet_pruning.assert_called_once_with(False)
             mock_config.with_repartition_joins.assert_called_once_with(False)
 
+    def test_from_config_forwards_optimization_flags(self, tmp_path):
+        """Unified configuration must preserve DataFusion optimization flags."""
+        with patch.object(DataFusionAdapter, "__init__", return_value=None) as init:
+            DataFusionAdapter.from_config(
+                {
+                    "working_dir": str(tmp_path),
+                    "parquet_pushdown": False,
+                    "repartition_joins": False,
+                }
+            )
+
+        assert init.call_args.kwargs["parquet_pushdown"] is False
+        assert init.call_args.kwargs["repartition_joins"] is False
+
     def test_parse_memory_limit(self):
         """Test memory limit parsing."""
         with patch("benchbox.platforms.datafusion.SessionContext"), tempfile.TemporaryDirectory() as tmpdir:


### PR DESCRIPTION
## Summary
- forward DataFusion parquet_pushdown and repartition_joins options through from_config
- infer liquid_clustering for standalone Databricks clustering columns
- add regression coverage for both review findings

## Verification
- `BENCHBOX_MAX_XDIST_WORKERS=1 uv run -- python -m pytest tests/unit/ -x -q`
- `uv run -- ruff check ...`
- `uv run -- ruff format --check ...`
- pre-push fast preflight passed