### PR TITLE
feat(mcp): add platform option contract matrix

### DIFF
--- a/benchbox/mcp/schemas.py
+++ b/benchbox/mcp/schemas.py
@@ -90,6 +90,24 @@ class MCPPlatformOptionSpec:
 
 _MCP_OPTION = MCPPlatformOptionSpec
 
+
+@dataclass(frozen=True, slots=True)
+class MCPPlatformOptionContract:
+    """Review metadata for one accepted MCP option.
+
+    The contract is deliberately separate from the Pydantic-like value spec:
+    bounds validate syntax, while this record documents the effective consumer,
+    security class, compatibility aliases, and rejected alternatives.  The
+    validator requires both records to agree so a new allow-listed option
+    cannot bypass the review matrix accidentally.
+    """
+
+    consumer: str
+    security_class: Literal["execution", "resource", "device", "layout", "connection"]
+    aliases: tuple[str, ...] = ()
+    rejected_alternatives: tuple[str, ...] = ()
+
+
 # This is deliberately narrower than the CLI registry.  MCP callers cannot
 # change credentials, destinations, filesystem locations, package installation,
 # or other tenant-owned connection state through request arguments.
@@ -156,6 +174,109 @@ MCP_PLATFORM_OPTION_ALLOWLIST: dict[str, dict[str, MCPPlatformOptionSpec]] = {
 }
 
 
+def _contract(
+    consumer: str,
+    security_class: Literal["execution", "resource", "device", "layout", "connection"],
+    *,
+    aliases: tuple[str, ...] = (),
+    rejected_alternatives: tuple[str, ...] = (),
+) -> MCPPlatformOptionContract:
+    return MCPPlatformOptionContract(
+        consumer=consumer,
+        security_class=security_class,
+        aliases=aliases,
+        rejected_alternatives=rejected_alternatives,
+    )
+
+
+# Canonical option-to-consumer matrix.  Keep this map explicit instead of
+# deriving it from the allow-list: an accepted option must have a reviewed
+# consumer and security classification before it can cross the MCP boundary.
+MCP_PLATFORM_OPTION_CONTRACT: dict[str, dict[str, MCPPlatformOptionContract]] = {
+    "clickhouse": {
+        "deployment_mode": _contract("ClickHouseAdapter.from_config(deployment_mode)", "execution"),
+        "port": _contract(
+            "ClickHouseAdapter.from_config(port)",
+            "connection",
+            rejected_alternatives=("server-owned port", "arbitrary destination selection"),
+        ),
+        "secure": _contract(
+            "ClickHouseAdapter.from_config(secure)",
+            "connection",
+            rejected_alternatives=("server-owned TLS policy", "transport downgrade"),
+        ),
+    },
+    "clickhouse-server": {
+        "port": _contract(
+            "ClickHouseAdapter.from_config(port)",
+            "connection",
+            rejected_alternatives=("server-owned port", "arbitrary destination selection"),
+        ),
+        "secure": _contract(
+            "ClickHouseAdapter.from_config(secure)",
+            "connection",
+            rejected_alternatives=("server-owned TLS policy", "transport downgrade"),
+        ),
+    },
+    "cudf": {
+        "device_id": _contract("cuDF runtime device selection", "device"),
+        "spill_to_host": _contract("cuDF memory policy", "resource"),
+    },
+    "dask": {
+        "memory_limit": _contract("Dask worker resource envelope", "resource"),
+        "n_workers": _contract("Dask LocalCluster worker count", "resource"),
+        "threads_per_worker": _contract("Dask LocalCluster thread count", "resource"),
+        "use_distributed": _contract("Dask execution-mode selector", "execution"),
+    },
+    "datafusion": {
+        "batch_size": _contract("DataFusion execution configuration", "resource"),
+        "memory_limit": _contract("DataFusion memory policy", "resource"),
+        "parquet_pushdown": _contract("DataFusion parquet execution options", "execution"),
+        "repartition_joins": _contract("DataFusion join execution options", "execution"),
+        "target_partitions": _contract("DataFusion partition configuration", "resource"),
+    },
+    "duckdb": {
+        "memory_limit": _contract("DuckDB thread/memory adapter settings", "resource"),
+        "threads": _contract(
+            "DuckDBAdapter.thread_limit",
+            "resource",
+            aliases=("thread_limit",),
+        ),
+    },
+    "firebolt": {
+        "disable_result_cache": _contract("Firebolt query execution options", "execution"),
+        "strict_validation": _contract("Firebolt validation options", "execution"),
+    },
+    "databricks": {
+        "databricks_clustering_strategy": _contract(
+            "Databricks PlatformOptimizationConfiguration clustering strategy", "layout"
+        ),
+        "liquid_clustering_columns": _contract(
+            "Databricks PlatformOptimizationConfiguration clustering columns", "layout"
+        ),
+    },
+    "modin": {"engine": _contract("Modin dataframe backend selector", "execution")},
+    "pandas": {"dtype_backend": _contract("pandas dataframe dtype backend", "execution")},
+    "polars": {
+        "n_rows": _contract("Polars input row limit", "resource"),
+        "rechunk": _contract("Polars dataframe memory layout", "resource"),
+        "streaming": _contract("Polars dataframe execution mode", "execution"),
+    },
+    "spark": {"adaptive_enabled": _contract("Spark adaptive execution setting", "execution")},
+    "sqlite": {
+        "check_same_thread": _contract("SQLite connection safety setting", "execution"),
+        "timeout": _contract("SQLite connection timeout", "resource"),
+    },
+    "velox": {
+        "adaptive_enabled": _contract("Velox execution options", "execution"),
+        "deployment": _contract("Velox local/remote deployment selector", "connection"),
+        "driver_memory": _contract("Velox driver resource envelope", "resource"),
+        "offheap_size": _contract("Velox off-heap resource envelope", "resource"),
+        "shuffle_partitions": _contract("Velox shuffle resource envelope", "resource"),
+    },
+}
+
+
 def _validate_memory_limit(name: str, value: str) -> str:
     """Validate a bounded memory-size option without accepting paths or expressions."""
     if not MEMORY_LIMIT_PATTERN.fullmatch(value):
@@ -181,13 +302,18 @@ def validate_platform_options(platform: str, options: Mapping[str, object] | Non
     if specs is None and platform_name.endswith("-df"):
         specs = MCP_PLATFORM_OPTION_ALLOWLIST.get(platform_name[:-3])
     specs = specs or {}
+    contracts = MCP_PLATFORM_OPTION_CONTRACT.get(platform_name)
+    if contracts is None and platform_name.endswith("-df"):
+        contracts = MCP_PLATFORM_OPTION_CONTRACT.get(platform_name[:-3])
+    contracts = contracts or {}
     normalized: dict[str, object] = {}
     for raw_name, raw_value in options.items():
         if not isinstance(raw_name, str) or not PLATFORM_OPTION_NAME_PATTERN.fullmatch(raw_name):
             raise MCPValidationError("Platform option names must use lowercase snake_case")
         name = raw_name.lower()
         spec = specs.get(name)
-        if spec is None:
+        contract = contracts.get(name)
+        if spec is None or contract is None:
             raise MCPValidationError(f"Platform option '{name}' is not authorized for MCP")
         parsed = spec.parse(name, raw_value)
         if spec.kind == "string" and name in {"memory_limit", "driver_memory", "offheap_size"}:

--- a/docs/development/mcp-platform-option-contract.md
+++ b/docs/development/mcp-platform-option-contract.md
@@ -1,0 +1,49 @@
+# MCP platform-option contract
+
+This matrix is the review boundary for `platform_options` on the MCP run and
+durable-job surfaces. The value specs and the matrix in
+`benchbox/mcp/schemas.py` must have identical platform and option keys. A
+request is rejected when either record is missing, before an adapter is built
+or a durable job is persisted.
+
+The matrix is intentionally narrower than the CLI option registry. `consumer`
+identifies the code path that must consume the normalized value; it is not
+permission to expose the underlying adapter's full configuration surface.
+
+| Platform | Option(s) | Consumer | Security class | Compatibility alias / rejected alternatives |
+|---|---|---|---|---|
+| ClickHouse | `deployment_mode` | `ClickHouseAdapter.from_config` | execution | Connection destinations and transport policy remain server-owned. |
+| ClickHouse | `port`, `secure` | Current adapter fields; removal tracked separately | connection | Reject arbitrary ports, destinations, and TLS downgrade controls. |
+| cuDF | `device_id`, `spill_to_host` | cuDF runtime and memory policy | device/resource | Reject device paths, scheduler endpoints, and package controls. |
+| Dask | `memory_limit`, `n_workers`, `threads_per_worker` | LocalCluster resource envelope | resource | Enforce aggregate limits; reject scheduler endpoints and spill paths. |
+| Dask | `use_distributed` | Dask execution-mode selector | execution | Reject external scheduler selection. |
+| DataFusion | `batch_size`, `memory_limit`, `target_partitions` | DataFusion execution configuration | resource | Reject filesystem paths and unbounded worker controls. |
+| DataFusion | `parquet_pushdown`, `repartition_joins` | DataFusion execution options | execution | Reject arbitrary SQL or datasource configuration. |
+| DuckDB | `memory_limit`, `threads` | DuckDB adapter settings | resource | Public `threads` maps to adapter `thread_limit`; reject raw SQL settings. |
+| Firebolt | `disable_result_cache`, `strict_validation` | Firebolt execution/validation options | execution | Reject credentials, account, database, and endpoint fields. |
+| Databricks | `databricks_clustering_strategy`, `liquid_clustering_columns` | `PlatformOptimizationConfiguration` | layout | Reject raw connection settings and contradictory layout combinations. |
+| Modin | `engine` | Modin dataframe backend selector | execution | Only reviewed `ray`/`dask`; reject unsupported backend names. |
+| pandas | `dtype_backend` | pandas dataframe dtype backend | execution | Reject package installation and arbitrary dtype expressions. |
+| Polars | `n_rows`, `rechunk` | Polars input and memory layout | resource | Reject filesystem paths and unbounded row counts. |
+| Polars | `streaming` | Polars dataframe execution mode | execution | Reject arbitrary engine/plugin configuration. |
+| Spark | `adaptive_enabled` | Spark adaptive execution setting | execution | Reject cluster, master, and filesystem controls. |
+| SQLite | `check_same_thread` | SQLite connection safety setting | execution | Reject database paths and URI query controls. |
+| SQLite | `timeout` | SQLite connection timeout | resource | Reject arbitrary connection strings. |
+| Velox | `adaptive_enabled` | Velox execution options | execution | Reject unreviewed execution flags. |
+| Velox | `deployment` | Velox local/remote deployment selector | connection | Only `local`/`remote`; reject implicit Docker or arbitrary endpoint routing. |
+| Velox | `driver_memory`, `offheap_size`, `shuffle_partitions` | Velox resource envelope | resource | Reject paths, scheduler endpoints, and unbounded values. |
+
+## Change protocol
+
+Adding an option requires all of the following in one change:
+
+1. Add a bounded value spec and a matching matrix entry.
+2. Name the effective consumer and classify the security boundary.
+3. Record aliases and rejected alternatives, if any.
+4. Add a negative validation test and an effective-consumer test. Durable
+   requests must prove that normalized options survive persistence and replay.
+5. Update the public reference only after the focused tests and lint pass.
+
+Removing an option is fail-closed: delete it from both records, add a
+regression test for rejection, and document the compatibility impact. The
+matrix must never be widened merely to mirror the CLI registry.

--- a/docs/reference/mcp.md
+++ b/docs/reference/mcp.md
@@ -247,6 +247,11 @@ modes remain available because they do not hold the request for execution.
   filesystem paths, unbounded values, and driver auto-install/version controls
   fail closed. Authenticated durable jobs persist only this normalized object,
   so retries and worker restarts cannot reintroduce raw request mappings.
+- The authoritative option-to-consumer, security-class, alias, and rejection
+  matrix is maintained in
+  `docs/development/mcp-platform-option-contract.md`. Every allow-listed key
+  must have a matching matrix entry; a missing entry fails closed before
+  adapter construction or durable-job persistence.
 - Normal execution uses `BaseBenchmark.run_with_platform()` through public
   benchmark and adapter APIs.
 - MCP execution intentionally suppresses console output and returns structured

--- a/tests/integration/mcp/test_durable_jobs.py
+++ b/tests/integration/mcp/test_durable_jobs.py
@@ -11,6 +11,7 @@ from mcp.shared.exceptions import MCPError
 from mcp.types import TextContent
 
 from benchbox.mcp.jobs import DurableJobRepository, DurableJobWorker
+from benchbox.mcp.schemas import validate_platform_options
 from benchbox.mcp.security import JobLimits, TenantWorkspaceProvider
 from tests.integration.mcp._security import authenticated_http_client, write_security_config
 
@@ -77,6 +78,18 @@ def test_tenant_cannot_observe_or_cancel_another_job(tmp_path: Path) -> None:
     assert repository.get_owned(submitted.execution_id, "tenant-b") is None
     assert repository.cancel(submitted.execution_id, "tenant-b") is None
     assert repository.get_owned(submitted.execution_id, "tenant-a") is not None
+
+
+def test_normalized_platform_options_survive_repository_round_trip(tmp_path: Path) -> None:
+    repository = DurableJobRepository(tmp_path / "state.sqlite3", JobLimits())
+    options = validate_platform_options("duckdb", {"threads": 4})
+
+    submitted, created = repository.submit("tenant-a", {**_request(), "platform_options": options})
+
+    assert created is True
+    persisted = repository.get_owned(submitted.execution_id, "tenant-a")
+    assert persisted is not None
+    assert persisted.request["platform_options"] == {"threads": 4}
 
 
 def test_tenant_job_tools_are_remote_only_and_cross_tenant_fail_closed(tmp_path: Path, monkeypatch) -> None:

--- a/tests/integration/mcp/test_run_surface_contract.py
+++ b/tests/integration/mcp/test_run_surface_contract.py
@@ -1,0 +1,22 @@
+"""Cross-surface checks for the shared MCP platform-option contract."""
+
+from __future__ import annotations
+
+import pytest
+
+from benchbox.mcp.schemas import MCPValidationError, validate_platform_options
+from benchbox.mcp.tools.benchmark import _prepare_adapter_platform_options
+
+pytestmark = [pytest.mark.integration, pytest.mark.fast]
+
+
+def test_run_surface_normalizes_public_option_names_before_adapter_use() -> None:
+    normalized = validate_platform_options("duckdb", {"threads": 4})
+
+    assert normalized == {"threads": 4}
+    assert _prepare_adapter_platform_options("duckdb", normalized) == {"thread_limit": 4}
+
+
+def test_run_surface_rejects_an_option_without_a_contract() -> None:
+    with pytest.raises(MCPValidationError, match="not authorized"):
+        validate_platform_options("duckdb", {"thread_limit": 4})

--- a/tests/unit/mcp/test_benchmark_tools.py
+++ b/tests/unit/mcp/test_benchmark_tools.py
@@ -192,6 +192,35 @@ class TestRunBenchmarkTool:
         assert tuning.platform_optimizations.databricks_clustering_strategy == "liquid_clustering"
         assert tuning.platform_optimizations.liquid_clustering_columns == ["customer_id", "order_id"]
 
+    def test_every_matrix_option_reaches_effective_preparation(self):
+        """Each reviewed option reaches a concrete adapter-facing setting."""
+        from benchbox.mcp.schemas import MCP_PLATFORM_OPTION_ALLOWLIST, validate_platform_options
+        from benchbox.mcp.tools.benchmark import _prepare_adapter_platform_options
+
+        for platform, specs in MCP_PLATFORM_OPTION_ALLOWLIST.items():
+            for option_name, spec in specs.items():
+                if spec.kind == "bool":
+                    value: object = False
+                elif spec.kind == "int":
+                    value = spec.minimum if spec.minimum is not None else 1
+                elif spec.kind == "float":
+                    value = spec.minimum if spec.minimum is not None else 1.0
+                elif spec.choices:
+                    value = spec.choices[0]
+                elif option_name == "liquid_clustering_columns":
+                    value = "id"
+                else:
+                    value = "1GB"
+
+                normalized = validate_platform_options(platform, {option_name: value})
+                prepared = _prepare_adapter_platform_options(platform, normalized)
+                if platform == "duckdb" and option_name == "threads":
+                    assert prepared == {"thread_limit": value}
+                elif platform == "databricks":
+                    assert "tuning_config" in prepared
+                else:
+                    assert prepared[option_name] == value
+
 
 class TestGetQueryDetailsTool:
     """Tests for get_query_details tool functionality."""

--- a/tests/unit/mcp/test_schemas.py
+++ b/tests/unit/mcp/test_schemas.py
@@ -11,6 +11,8 @@ from pydantic import ValidationError as PydanticValidationError
 from benchbox.mcp.schemas import (
     MAX_QUERY_ID_LENGTH,
     MAX_QUERY_IDS,
+    MCP_PLATFORM_OPTION_ALLOWLIST,
+    MCP_PLATFORM_OPTION_CONTRACT,
     CompareResultsInput,
     DryRunInput,
     ExportSummaryInput,
@@ -259,6 +261,22 @@ class TestRunBenchmarkInput:
             platform_options={"threads": 4, "memory_limit": "2GB"},
         )
         assert inp.platform_options == {"threads": 4, "memory_limit": "2GB"}
+
+    def test_every_allowlisted_option_has_an_explicit_contract(self):
+        """The value allow-list cannot grow without a reviewed consumer matrix."""
+        assert set(MCP_PLATFORM_OPTION_ALLOWLIST) == set(MCP_PLATFORM_OPTION_CONTRACT)
+        for platform, specs in MCP_PLATFORM_OPTION_ALLOWLIST.items():
+            contracts = MCP_PLATFORM_OPTION_CONTRACT[platform]
+            assert set(specs) == set(contracts)
+            for option_name, contract in contracts.items():
+                assert contract.consumer
+                assert contract.security_class in {"execution", "resource", "device", "layout", "connection"}
+                assert all(alias != option_name for alias in contract.aliases)
+
+    def test_option_without_contract_is_rejected_fail_closed(self, monkeypatch):
+        monkeypatch.delitem(MCP_PLATFORM_OPTION_CONTRACT["duckdb"], "threads")
+        with pytest.raises(MCPValidationError, match="not authorized"):
+            validate_platform_options("duckdb", {"threads": 2})
 
     def test_secret_and_unknown_platform_options_are_rejected(self):
         with pytest.raises(PydanticValidationError):


### PR DESCRIPTION
## Summary

- implement TODO `mcp-v2-platform-option-contract-matrix-v3`
- add an explicit MCP platform-option consumer/security contract matrix
- fail closed when an allow-listed option lacks a reviewed contract entry
- cover effective preparation and durable normalized-option persistence

## Verification

- hosted TODO verification ladder: all three rungs passed
- focused MCP tests: 97 passed
- Ruff and format checks passed
- pre-push fast-test gate passed

`make pr-preflight` reached 26,509 tests; two unrelated UAT guard tests stopped
because the shared benchmark volume had 0.88 GiB free versus its 5 GiB safety
floor. No benchmark artifacts were removed.

## Batch

This is the first PR in the dependency sequence for the MCP v2 adversarial
remediation batch. Dependent platform TODOs remain blocked until this PR is
merged.
