### PR TITLE
fix(agents): enforce human commit authorship at claim, commit and merge time

### DIFF
--- a/.claude/skills/SHARED/commit-framework/SKILL.md
+++ b/.claude/skills/SHARED/commit-framework/SKILL.md
@@ -28,13 +28,16 @@ Use only when a calling skill authorizes a write-shaped commit.
 - **[COMMIT-IDENTITY-001] Resolve and validate human identity.** Inspect the
   effective `user.name` and `user.email` with their config origins before the
   first commit. A repository-local value overrides the user's global identity;
-  do not assume that makes it intentional. Reject known agent/service identities
-  (for example Claude, Codex, Gemini, ChatGPT, or their vendor noreply addresses)
+  do not assume that makes it intentional, and every linked worktree inherits
+  it. This binds authorship: reject known agent/service identities (for example
+  Claude, Codex, Gemini, ChatGPT, or their vendor noreply addresses) as author
   unless the current authorized task explicitly names that exact identity.
-  Otherwise use the user's effective human author and committer identity. Do not
-  pass `--author` or set `GIT_AUTHOR_*` / `GIT_COMMITTER_*` merely to work around
-  a stale config. A task-local override applies only to that task; never convert
-  it into standing repository or skill policy.
+  Otherwise use the user's effective human author identity. A commit-signing
+  service may hold the committer slot behind a human author, so signatures stay
+  verifiable without misattributing the work. Do not pass `--author` or set
+  `GIT_AUTHOR_*` / `GIT_COMMITTER_*` merely to work around a stale config; an
+  explicitly authorized task-local override applies only to that task and never
+  becomes standing repository or skill policy.
 - Do not add an agent/service `Co-Authored-By` trailer or any equivalent
   attribution unless the current task explicitly requests that exact trailer.
   A stale author request, tool convention, or claim that an agent contributed

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -317,6 +317,15 @@ jobs:
       - name: Validate Git identity is not an agent/service
         id: guard-agent-identity
         continue-on-error: true
+        # GitHub's ephemeral checkout has no user.* config. Inject a
+        # non-agent identity only for this read-only resolution check; the
+        # commit-range guard below remains authoritative for PR authorship.
+        env:
+          GIT_CONFIG_COUNT: '2'
+          GIT_CONFIG_KEY_0: user.name
+          GIT_CONFIG_VALUE_0: BenchBox CI
+          GIT_CONFIG_KEY_1: user.email
+          GIT_CONFIG_VALUE_1: ci@benchbox.invalid
         run: make agent-identity-check
 
       # Merge-time guard. The step above reads the resolved config, which here

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -314,6 +314,20 @@ jobs:
         continue-on-error: true
         run: make agent-instructions-check
 
+      - name: Validate Git identity is not an agent/service
+        id: guard-agent-identity
+        continue-on-error: true
+        run: make agent-identity-check
+
+      # Merge-time guard. The step above reads the resolved config, which here
+      # is the runner's own identity; this one inspects the commits the PR
+      # actually carries, which is the only check that can keep agent
+      # authorship off develop.
+      - name: Validate no agent authorship or attribution in PR commits
+        id: guard-agent-commit-range
+        continue-on-error: true
+        run: make agent-commit-range-check
+
       - name: Timing policy (wall-clock allowlist)
         id: guard-timing-policy
         continue-on-error: true

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,7 +3,7 @@
 #                               via default_install_hook_types below)
 # Run manually: pre-commit run --all-files
 
-default_install_hook_types: [pre-commit, pre-push]
+default_install_hook_types: [pre-commit, pre-push, commit-msg]
 default_stages: [pre-commit]
 
 repos:
@@ -140,6 +140,15 @@ repos:
         pass_filenames: false
         always_run: true
         stages: [pre-commit]
+
+      # commit-msg stage: the trailer only exists once a message has been
+      # written, so this cannot ride along with the pre-commit hook above.
+      - id: agent-attribution-trailers
+        name: reject agent Co-Authored-By/session trailers
+        entry: sh scripts/check_agent_trailers.sh
+        language: system
+        always_run: true
+        stages: [commit-msg]
 
   # Code formatting with ruff
   - repo: https://github.com/astral-sh/ruff-pre-commit

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,11 +21,16 @@ turn a recommendation or earlier task instruction into a standing requirement.
 
 `[COMMIT-IDENTITY-001]` Resolve Git identity and inspect its config origin
 before committing. Repository-local values override the user's global identity
-but are not automatically intentional. Reject known agent/service identities
-unless the user explicitly requests that exact identity for the current task.
+but are not automatically intentional, and every linked worktree inherits them.
+This binds authorship: reject known agent/service identities as author unless
+the user explicitly requests that exact identity for the current task. A
+commit-signing service may hold the committer slot behind a human author, so
+signatures stay verifiable without misattributing the work.
 Do not add an agent/service `Co-Authored-By` trailer or equivalent attribution
 unless the current task explicitly requests that exact trailer; a stale request,
 tool convention, or claim of agent contribution is not authorization.
+`make agent-write-preflight` asserts this at claim time, and `ci-lint` rejects
+agent authorship both in config and across `origin/develop..HEAD`.
 
 ## Authorization boundary
 

--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,7 @@ POOL_CLAIM_MARKER_STALE_SECONDS ?= 600
 # truth instead of repeating the four-deep nested expansion.
 POOL_REPO_CMD = basename "$$(dirname "$$(realpath "$$(git rev-parse --git-common-dir)")")"
 
-.PHONY: test test-unit test-integration test-tpch test-all test-fast test-unlock test-medium test-slow test-stress test-pytest clean lint lint-markers lint-imports lint-explorer-tokens lint-site-theme-tokens artifact-hygiene agent-instructions-check agent-identity-check audit-sha-check agent-write-preflight install develop coverage coverage-fast coverage-all coverage-html coverage-report coverage-check test-duckdb test-sqlite test-read-primitives test-benchmarks test-ci typecheck validate-imports catalog-schema-check format dependency-check docs-build docs-serve docs-clean docs-linkcheck docs-validate docs-check docs-images test-pyspark ci-lint ci-test ci-docs ci-local security-audit spellcheck docstring-coverage test-package test-integration-smoke test-correctness-gate plan-capture-gate correctness-gate-digests-regen test-local-matrix joinorder-verify-reference-results complexity-check complexity-report duplicate-check duplicate-check-verbose duplicate-check-json skill-sync skill-sync-check skill-sync-verify skill-sync-lock-audit mutation-test tpchavoc-equivalence-report tpchavoc-equivalence-report-postgres tpchavoc-equivalence-report-datafusion tpchavoc-equivalence-report-clickhouse tpchavoc-dataframe-equivalence-report ssb-cross-surface-equivalence-report amplab-cross-surface-equivalence-report coffeeshop-cross-surface-equivalence-report clickbench-cross-surface-equivalence-report joinorder-synthetic-cross-surface-equivalence-report h2odb-cross-surface-equivalence-report read-primitives-cross-surface-equivalence-report cross-surface-update-baseline cross-surface-baseline-autodetect oracle-coverage-map oracle-coverage-map-check cross-surface-applicability-report compile-tpcds-binaries parity-fixtures parity-check compat-docs compat-docs-check pr-preflight pr-preflight-fast-tests pr-content-guard pr-open pr-status pr-review-followups pr-review-followups-list dev-loop-metrics shrink-rollup worktree-pool-init worktree-pool-status worktree-pool-check worktree-claim worktree-claim-locked worktree-claim-attempt worktree-release worktree-pool-reset worktree-pool-sweep-stale worktree-pool-disk-clean worktree-list worktree-prune
+.PHONY: test test-unit test-integration test-tpch test-all test-fast test-unlock test-medium test-slow test-stress test-pytest clean lint lint-markers lint-imports lint-explorer-tokens lint-site-theme-tokens artifact-hygiene agent-instructions-check agent-identity-check agent-commit-range-check audit-sha-check agent-write-preflight install develop coverage coverage-fast coverage-all coverage-html coverage-report coverage-check test-duckdb test-sqlite test-read-primitives test-benchmarks test-ci typecheck validate-imports catalog-schema-check format dependency-check docs-build docs-serve docs-clean docs-linkcheck docs-validate docs-check docs-images test-pyspark ci-lint ci-test ci-docs ci-local security-audit spellcheck docstring-coverage test-package test-integration-smoke test-correctness-gate plan-capture-gate correctness-gate-digests-regen test-local-matrix joinorder-verify-reference-results complexity-check complexity-report duplicate-check duplicate-check-verbose duplicate-check-json skill-sync skill-sync-check skill-sync-verify skill-sync-lock-audit mutation-test tpchavoc-equivalence-report tpchavoc-equivalence-report-postgres tpchavoc-equivalence-report-datafusion tpchavoc-equivalence-report-clickhouse tpchavoc-dataframe-equivalence-report ssb-cross-surface-equivalence-report amplab-cross-surface-equivalence-report coffeeshop-cross-surface-equivalence-report clickbench-cross-surface-equivalence-report joinorder-synthetic-cross-surface-equivalence-report h2odb-cross-surface-equivalence-report read-primitives-cross-surface-equivalence-report cross-surface-update-baseline cross-surface-baseline-autodetect oracle-coverage-map oracle-coverage-map-check cross-surface-applicability-report compile-tpcds-binaries parity-fixtures parity-check compat-docs compat-docs-check pr-preflight pr-preflight-fast-tests pr-content-guard pr-open pr-status pr-review-followups pr-review-followups-list dev-loop-metrics shrink-rollup worktree-pool-init worktree-pool-status worktree-pool-check worktree-claim worktree-claim-locked worktree-claim-attempt worktree-release worktree-pool-reset worktree-pool-sweep-stale worktree-pool-disk-clean worktree-list worktree-prune
 
 # Primary test commands using pytest marker system
 test: test-fast
@@ -730,6 +730,14 @@ agent-instructions-check:
 agent-identity-check:
 	uv run -- python _project/scripts/agent_instruction_audit.py --check-git-identity
 
+# Merge-time guard. agent-identity-check reads the resolved config, which on a
+# CI runner is the runner's own identity and reveals nothing about the branch;
+# this inspects the commits themselves so agent authorship cannot reach develop.
+AGENT_IDENTITY_BASE_REF ?= origin/develop
+agent-commit-range-check:
+	@git fetch origin $(patsubst origin/%,%,$(AGENT_IDENTITY_BASE_REF)) --quiet 2>/dev/null || true
+	uv run -- python _project/scripts/agent_instruction_audit.py --check-commit-range $(AGENT_IDENTITY_BASE_REF)
+
 # skill-sync — materialize project-local skills from ~/.skill-sync/skills.
 # Manifest is tracked (skill-sync.yaml/skill-sync.lock). The `claude` target
 # (.claude/skills) is a TRACKED snapshot committed for cloud/CI parity — verify
@@ -909,6 +917,10 @@ ci-lint:
 	[ $$? -eq 0 ] || failed="$$failed artifact-hygiene"; \
 	$(MAKE) agent-instructions-check; \
 	[ $$? -eq 0 ] || failed="$$failed agent-instructions"; \
+	$(MAKE) agent-identity-check; \
+	[ $$? -eq 0 ] || failed="$$failed agent-identity"; \
+	$(MAKE) agent-commit-range-check; \
+	[ $$? -eq 0 ] || failed="$$failed agent-commit-range"; \
 	$(MAKE) skill-sync-check; \
 	[ $$? -eq 0 ] || failed="$$failed skill-sync-check"; \
 	uv run -- python _project/scripts/timing_policy_check.py --strict; \

--- a/_project/scripts/agent_instruction_audit.py
+++ b/_project/scripts/agent_instruction_audit.py
@@ -43,19 +43,31 @@ CANONICAL_REVIEW_ANCHORS = {
     "REVIEW-CAPTURE-001": ("Projects provide storage locations/specs", "protocol governs behavior"),
     "REVIEW-PARITY-001": ("Missing IDs or contradictory semantics", "canonical skill wins"),
 }
+# The author/committer anchors are load-bearing: the audit previously pinned
+# only the trailer semantics, so the canonical skill could require a human
+# *committer* while the shipped gate allowed a signing service there, and
+# `agent-instructions-check` would still report the surface as valid.
 CANONICAL_COMMIT_ANCHORS = {
     "COMMIT-IDENTITY-001": (
         "Co-Authored-By",
         "explicitly requests that exact trailer",
         "stale author request",
         "is not authorization",
+        "human author identity",
+        "committer slot behind a human author",
     )
 }
-PROJECT_COMMIT_ANCHORS = {"COMMIT-IDENTITY-001": ("Co-Authored-By", "exact trailer", "not authorization")}
-PROJECT_REVIEW_ANCHORS = {"REVIEW-AUTH-001": ("later user turn", "bundling review and remediation")}
-AGENT_REVIEW_ANCHORS = {
-    "REVIEW-AUTH-001": ("zero tracked worktree-content changes", "do not review and then edit")
+PROJECT_COMMIT_ANCHORS = {
+    "COMMIT-IDENTITY-001": (
+        "Co-Authored-By",
+        "exact trailer",
+        "not authorization",
+        "identities as author",
+        "committer slot behind a human author",
+    )
 }
+PROJECT_REVIEW_ANCHORS = {"REVIEW-AUTH-001": ("later user turn", "bundling review and remediation")}
+AGENT_REVIEW_ANCHORS = {"REVIEW-AUTH-001": ("zero tracked worktree-content changes", "do not review and then edit")}
 AUTHORITY_CLASSES = {"task", "repository", "mechanical", "recommendation"}
 EVALUATION_ACTIONS = {
     "commit_with_human_identity",
@@ -83,10 +95,18 @@ AGENT_EMAILS = {"noreply@anthropic.com", "noreply@openai.com"}
 # address, and a committer email that does not match it makes the signature
 # unverifiable -- but only behind a human author, so attribution stays honest.
 SIGNING_SERVICE_EMAILS = {"noreply@anthropic.com"}
-# Trailers that attribute authorship to an agent. Matched on the vendor address
-# rather than the display name, which is the reliable signal.
+# Trailers that attribute authorship to an agent. The trailer identity is parsed
+# and run through the same name-or-email predicate used for authors: matching on
+# the vendor address alone let `Co-Authored-By: Claude <claude@example.com>`
+# through both this guard and the commit-msg hook, which is precisely the
+# attribution [COMMIT-IDENTITY-001] exists to reject.
 AGENT_TRAILER_RE = re.compile(r"^[ \t]*co-authored-by:[ \t]*(.+)$", re.IGNORECASE | re.MULTILINE)
-AGENT_SESSION_TRAILER_RE = re.compile(r"^[ \t]*(claude|codex|gemini|chatgpt)-session:[ \t]*(.+)$", re.IGNORECASE | re.MULTILINE)
+# `Display Name <address>`; the address is optional so a malformed trailer still
+# resolves to a name rather than silently parsing as neither.
+TRAILER_IDENTITY_RE = re.compile(r"^(?P<name>[^<]*?)\s*(?:<(?P<email>[^>]*)>)?\s*$")
+AGENT_SESSION_TRAILER_RE = re.compile(
+    r"^[ \t]*(claude|codex|gemini|chatgpt)-session:[ \t]*(.+)$", re.IGNORECASE | re.MULTILINE
+)
 
 
 @dataclass(frozen=True)
@@ -206,6 +226,18 @@ def _is_agent_identity(name: str, email: str) -> bool:
     return name.strip().casefold() in AGENT_NAMES or email.strip().casefold() in AGENT_EMAILS
 
 
+def _trailer_is_agent(trailer: str) -> bool:
+    """Apply the author name-or-email predicate to a `Co-Authored-By` value.
+
+    An agent that signs with a non-vendor address (`Claude <claude@example.com>`)
+    is recognised by name, exactly as it would be in the author slot.
+    """
+    match = TRAILER_IDENTITY_RE.match(trailer.strip())
+    if match is None:
+        return False
+    return _is_agent_identity(match.group("name") or "", match.group("email") or "")
+
+
 def _identity_origins(project: Path) -> str:
     return subprocess.run(
         ["git", "-C", str(project), "config", "--show-origin", "--get-regexp", r"^user\.(name|email)$"],
@@ -278,7 +310,7 @@ def audit_commit_range(project: Path, base_ref: str) -> list[str]:
             )
         for match in AGENT_TRAILER_RE.finditer(body):
             trailer = match.group(1).strip()
-            if any(agent in trailer.casefold() for agent in AGENT_EMAILS):
+            if _trailer_is_agent(trailer):
                 errors.append(
                     f"commit {sha[:12]} carries agent Co-Authored-By trailer '{trailer}'; "
                     f"[COMMIT-IDENTITY-001] forbids it unless the task requested that exact trailer"

--- a/_project/scripts/agent_instruction_audit.py
+++ b/_project/scripts/agent_instruction_audit.py
@@ -78,6 +78,15 @@ LEGACY_REVIEW_DOC = "docs/development/review-protocol.md"
 AUTHORITY_CONFLICT_MARKERS = ("this file wins", "canonical, unabridged", "conflicts resolve in favor of this")
 AGENT_NAMES = {"chatgpt", "claude", "codex", "gemini", "openai"}
 AGENT_EMAILS = {"noreply@anthropic.com", "noreply@openai.com"}
+# [COMMIT-IDENTITY-001] binds authorship. A commit-signing service may hold the
+# committer slot -- cloud agent sessions SSH-sign with a key registered to this
+# address, and a committer email that does not match it makes the signature
+# unverifiable -- but only behind a human author, so attribution stays honest.
+SIGNING_SERVICE_EMAILS = {"noreply@anthropic.com"}
+# Trailers that attribute authorship to an agent. Matched on the vendor address
+# rather than the display name, which is the reliable signal.
+AGENT_TRAILER_RE = re.compile(r"^[ \t]*co-authored-by:[ \t]*(.+)$", re.IGNORECASE | re.MULTILINE)
+AGENT_SESSION_TRAILER_RE = re.compile(r"^[ \t]*(claude|codex|gemini|chatgpt)-session:[ \t]*(.+)$", re.IGNORECASE | re.MULTILINE)
 
 
 @dataclass(frozen=True)
@@ -193,26 +202,91 @@ def _resolved_git_identity(project: Path, role: str) -> tuple[str, str]:
     return match.groups() if match else ("", "")
 
 
+def _is_agent_identity(name: str, email: str) -> bool:
+    return name.strip().casefold() in AGENT_NAMES or email.strip().casefold() in AGENT_EMAILS
+
+
+def _identity_origins(project: Path) -> str:
+    return subprocess.run(
+        ["git", "-C", str(project), "config", "--show-origin", "--get-regexp", r"^user\.(name|email)$"],
+        check=False,
+        capture_output=True,
+        text=True,
+    ).stdout.strip()
+
+
 def audit_git_identity(project: Path) -> list[str]:
     if os.environ.get("BENCHBOX_ALLOW_AGENT_GIT_IDENTITY") == "1":
         return []
 
+    identities = {role: _resolved_git_identity(project, role) for role in ("author", "committer")}
+    author_name, author_email = identities["author"]
+    author_is_human = bool(author_name and author_email) and not _is_agent_identity(author_name, author_email)
+
     errors: list[str] = []
-    for role in ("author", "committer"):
-        name, email = _resolved_git_identity(project, role)
+    for role, (name, email) in identities.items():
         if not name or not email:
             errors.append(f"unable to resolve Git {role} identity")
             continue
-        if name.strip().casefold() in AGENT_NAMES or email.strip().casefold() in AGENT_EMAILS:
-            origins = subprocess.run(
-                ["git", "-C", str(project), "config", "--show-origin", "--get-regexp", r"^user\.(name|email)$"],
-                check=False,
-                capture_output=True,
-                text=True,
-            ).stdout.strip()
+        if not _is_agent_identity(name, email):
+            continue
+        # A signing service behind a human author keeps signatures verifiable
+        # without misattributing the work; an agent author is never acceptable.
+        if role == "committer" and author_is_human and email.strip().casefold() in SIGNING_SERVICE_EMAILS:
+            continue
+        errors.append(
+            f"Git {role} identity resolves to known agent/service {name} <{email}>; "
+            f"inspect config origins and use the human identity. "
+            f"Origins: {_identity_origins(project) or '<none>'}"
+        )
+    return errors
+
+
+def audit_commit_range(project: Path, base_ref: str) -> list[str]:
+    """Merge-time guard over the commits a branch actually carries.
+
+    `audit_git_identity` reads the resolved config, which on a CI runner is the
+    runner's own identity and says nothing about what the branch contains. This
+    walks `base_ref..HEAD` instead, so an agent-authored commit produced in some
+    other session cannot reach a protected branch unnoticed.
+    """
+    if os.environ.get("BENCHBOX_ALLOW_AGENT_GIT_IDENTITY") == "1":
+        return []
+
+    # Separators are written as git's own %xNN escapes: a literal NUL cannot be
+    # passed through argv, and commit messages may contain anything else.
+    unit, record = "\x1f", "\x00"
+    result = subprocess.run(
+        ["git", "-C", str(project), "log", "--format=%H%x1f%an%x1f%ae%x1f%B%x00", f"{base_ref}..HEAD"],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        return [f"unable to inspect commit range {base_ref}..HEAD: {result.stderr.strip() or '<no detail>'}"]
+
+    errors: list[str] = []
+    for raw in result.stdout.split(record):
+        fields = raw.strip("\n").split(unit)
+        if len(fields) < 4:
+            continue
+        sha, name, email, body = fields[0], fields[1], fields[2], fields[3]
+        if _is_agent_identity(name, email):
             errors.append(
-                f"Git {role} identity resolves to known agent/service {name} <{email}>; "
-                f"inspect config origins and use the human identity. Origins: {origins or '<none>'}"
+                f"commit {sha[:12]} is authored by known agent/service {name} <{email}>; "
+                f"reauthor it with the human identity before merging"
+            )
+        for match in AGENT_TRAILER_RE.finditer(body):
+            trailer = match.group(1).strip()
+            if any(agent in trailer.casefold() for agent in AGENT_EMAILS):
+                errors.append(
+                    f"commit {sha[:12]} carries agent Co-Authored-By trailer '{trailer}'; "
+                    f"[COMMIT-IDENTITY-001] forbids it unless the task requested that exact trailer"
+                )
+        for match in AGENT_SESSION_TRAILER_RE.finditer(body):
+            errors.append(
+                f"commit {sha[:12]} carries agent session trailer '{match.group(0).strip()}'; "
+                f"[COMMIT-IDENTITY-001] treats it as equivalent agent attribution"
             )
     return errors
 
@@ -325,11 +399,18 @@ def main() -> int:
     parser.add_argument("--corpus", type=Path, default=DEFAULT_CORPUS)
     parser.add_argument("--json", action="store_true", dest="as_json")
     parser.add_argument("--check-git-identity", action="store_true")
+    parser.add_argument(
+        "--check-commit-range",
+        metavar="BASE_REF",
+        help="reject agent authorship/attribution on commits in BASE_REF..HEAD (merge-time guard)",
+    )
     args = parser.parse_args()
     corpus = json.loads(args.corpus.read_text(encoding="utf-8"))
     metrics, errors = audit(args.project.resolve(), corpus)
     if args.check_git_identity:
         errors.extend(audit_git_identity(args.project.resolve()))
+    if args.check_commit_range:
+        errors.extend(audit_commit_range(args.project.resolve(), args.check_commit_range))
     result = {"ok": not errors, "metrics": asdict(metrics), "errors": errors}
     if args.as_json:
         print(json.dumps(result, indent=2, sort_keys=True))

--- a/scripts/agent_write_preflight.sh
+++ b/scripts/agent_write_preflight.sh
@@ -58,6 +58,61 @@ EOF
   exit 1
 fi
 
+# [COMMIT-IDENTITY-001] Claim-time identity assertion.
+#
+# Linked worktrees share the primary clone's config, so a single stray [user]
+# block there silently reauthors every pool worktree at once. Catching it at
+# claim time -- the moment a session acquires write rights -- is the only point
+# where one check covers every worktree before any commit exists. Keep the agent
+# name/address lists in sync with AGENT_NAMES / AGENT_EMAILS and
+# SIGNING_SERVICE_EMAILS in _project/scripts/agent_instruction_audit.py.
+if [ "${BENCHBOX_ALLOW_AGENT_GIT_IDENTITY:-}" != "1" ]; then
+  author_ident=$(git -C "$top_abs" var GIT_AUTHOR_IDENT 2>/dev/null || true)
+  author_email=$(printf '%s' "$author_ident" | sed -n 's/^.*<\([^>]*\)>.*$/\1/p' | tr 'A-Z' 'a-z')
+  author_name=$(printf '%s' "$author_ident" | sed -n 's/^\(.*\) <[^>]*>.*$/\1/p' | tr 'A-Z' 'a-z')
+
+  agent_identity=no
+  case "$author_email" in
+    noreply@anthropic.com | noreply@openai.com) agent_identity=yes ;;
+  esac
+  case "$author_name" in
+    chatgpt | claude | codex | gemini | openai) agent_identity=yes ;;
+  esac
+
+  if [ "$agent_identity" = yes ]; then
+    origins=$(git -C "$top_abs" config --show-origin --get-regexp '^user\.(name|email)$' 2>/dev/null || true)
+    cat >&2 <<EOF
+Refusing BenchBox write preflight: Git author identity resolves to a known
+agent/service identity.
+
+  author:  $author_ident
+  origins:
+$(printf '%s\n' "${origins:-  <none>}" | sed 's/^/    /')
+
+A repository-local value overrides the global identity but is not automatically
+intentional, and every linked worktree inherits it. Set the human identity, or
+-- if this task explicitly authorized the agent identity -- declare it:
+  BENCHBOX_ALLOW_AGENT_GIT_IDENTITY=1 make agent-write-preflight
+
+A commit-signing service may still hold the committer slot behind a human
+author; only authorship is refused here.
+EOF
+    exit 1
+  fi
+fi
+
+# An ephemeral clone never runs worktree-claim, which is where pool worktrees
+# get their hooks, so the repo's commit-time gates would silently never fire
+# here. Installing is best-effort: CI re-runs the same guards, so a failure to
+# install is a warning rather than a refusal.
+if [ "$ephemeral" = "yes" ] && [ ! -e "$common_abs/hooks/pre-commit" ]; then
+  if (cd "$top_abs" && uv run -- pre-commit install --hook-type pre-commit --hook-type commit-msg >/dev/null 2>&1); then
+    printf 'Installed pre-commit hooks (ephemeral clone had none).\n'
+  else
+    echo "note: pre-commit install failed/unavailable; commit-time guards will not run here (CI still enforces them)" >&2
+  fi
+fi
+
 if [ "$ephemeral" = "yes" ]; then
   printf 'BenchBox write preflight OK (ephemeral clone, no worktree pool present): %s\n' "$top_abs"
 else

--- a/scripts/check_agent_trailers.sh
+++ b/scripts/check_agent_trailers.sh
@@ -28,8 +28,13 @@ fi
 # template mentioning the trailer must not fail the commit.
 body=$(grep -v '^[ \t]*#' "$message_file" || true)
 
+# Name-or-email, mirroring _is_agent_identity() in agent_instruction_audit.py.
+# Matching the vendor address alone let `Co-Authored-By: Claude <claude@example.com>`
+# through. The name arm anchors on the display-name slot (trailer start, up to
+# the address) and requires a whole-word match, so a human called
+# "Claudia Gemini-Lopez" is not caught.
 coauthor=$(printf '%s\n' "$body" |
-  grep -inE '^[ \t]*co-authored-by:.*(noreply@anthropic\.com|noreply@openai\.com)' || true)
+  grep -inE '^[ \t]*co-authored-by:(.*(noreply@anthropic\.com|noreply@openai\.com)|[ \t]*(chatgpt|claude|codex|gemini|openai)[ \t]*<)' || true)
 session=$(printf '%s\n' "$body" |
   grep -inE '^[ \t]*(claude|codex|gemini|chatgpt)-session:' || true)
 

--- a/scripts/check_agent_trailers.sh
+++ b/scripts/check_agent_trailers.sh
@@ -1,0 +1,54 @@
+#!/bin/sh
+set -eu
+
+# [COMMIT-IDENTITY-001] commit-msg gate: reject agent/service attribution
+# trailers.
+#
+# This rejects rather than rewrites. CLAUDE.md requires that project hooks not
+# silently mutate files, and a hook that quietly edited the commit message would
+# also hide the fact that something upstream keeps adding the trailer. Failing
+# loudly keeps the cause visible.
+#
+# Agent harnesses commonly append these trailers by default, so the offending
+# text is usually a message convention rather than a deliberate act. AGENTS.md
+# allows the trailer only when the current task explicitly requested that exact
+# trailer; that case declares itself with BENCHBOX_ALLOW_AGENT_COAUTHOR=1.
+
+message_file=${1:-}
+if [ -z "$message_file" ] || [ ! -f "$message_file" ]; then
+  echo "check_agent_trailers: expected a commit message file argument" >&2
+  exit 2
+fi
+
+if [ "${BENCHBOX_ALLOW_AGENT_COAUTHOR:-}" = "1" ]; then
+  exit 0
+fi
+
+# Comment lines never survive into the stored message, so ignore them; a commit
+# template mentioning the trailer must not fail the commit.
+body=$(grep -v '^[ \t]*#' "$message_file" || true)
+
+coauthor=$(printf '%s\n' "$body" |
+  grep -inE '^[ \t]*co-authored-by:.*(noreply@anthropic\.com|noreply@openai\.com)' || true)
+session=$(printf '%s\n' "$body" |
+  grep -inE '^[ \t]*(claude|codex|gemini|chatgpt)-session:' || true)
+
+if [ -z "$coauthor" ] && [ -z "$session" ]; then
+  exit 0
+fi
+
+{
+  echo "Refusing commit: message carries agent/service attribution."
+  echo
+  [ -n "$coauthor" ] && printf '%s\n' "$coauthor" | sed 's/^/  /'
+  [ -n "$session" ] && printf '%s\n' "$session" | sed 's/^/  /'
+  echo
+  echo "[COMMIT-IDENTITY-001] forbids an agent Co-Authored-By trailer, or any"
+  echo "equivalent attribution, unless the current task explicitly requested that"
+  echo "exact trailer. A tool convention is not authorization."
+  echo
+  echo "Remove the trailer, or -- if the task did request it -- declare that:"
+  echo "  BENCHBOX_ALLOW_AGENT_COAUTHOR=1 git commit ..."
+} >&2
+
+exit 1

--- a/skill-sync.lock
+++ b/skill-sync.lock
@@ -253,8 +253,8 @@
       "installMode": "mirror",
       "files": {
         "SKILL.md": {
-          "sha256": "2ab8e7e92eb18cf3b6860beaab9339352ee1a3895c6cba0849795ff203cadadc",
-          "size": 2402
+          "sha256": "ab93a2f3396df6dc7f51615930944a66d25ff1b5da20fe39cf35fdd8d4e3a8e2",
+          "size": 2623
         },
         "skill.yaml": {
           "sha256": "39b007a53d9126d3fe4e8938a67d616a52be210a82ba211753afa92a073d06bd",

--- a/tests/unit/scripts/test_agent_instruction_audit.py
+++ b/tests/unit/scripts/test_agent_instruction_audit.py
@@ -334,6 +334,36 @@ def test_commit_range_rejects_agent_coauthor_trailer(tmp_path: Path) -> None:
     assert any("carries agent Co-Authored-By trailer" in error for error in errors)
 
 
+def test_commit_range_rejects_agent_coauthor_by_name_with_non_vendor_address(tmp_path: Path) -> None:
+    """An agent that signs with its own address is still an agent.
+
+    Matching only the vendor address let this exact trailer through both the
+    merge-time guard and the commit-msg hook, which is the attribution
+    [COMMIT-IDENTITY-001] exists to reject.
+    """
+    project = _git_range_repo(tmp_path)
+    _git_commit(
+        project,
+        "feat: work\n\nCo-Authored-By: Claude <claude@example.com>",
+        "Joe Harris",
+        "joeharris76@gmail.com",
+    )
+    errors = audit_commit_range(project, "base-ref")
+    assert any("carries agent Co-Authored-By trailer" in error for error in errors)
+
+
+def test_commit_range_accepts_human_coauthor_named_like_a_vendor(tmp_path: Path) -> None:
+    """The name arm matches the whole display name, not a substring of it."""
+    project = _git_range_repo(tmp_path)
+    _git_commit(
+        project,
+        "feat: work\n\nCo-Authored-By: Claudia Gemini-Lopez <claudia@example.com>",
+        "Joe Harris",
+        "joeharris76@gmail.com",
+    )
+    assert audit_commit_range(project, "base-ref") == []
+
+
 def test_commit_range_rejects_agent_session_trailer(tmp_path: Path) -> None:
     project = _git_range_repo(tmp_path)
     _git_commit(

--- a/tests/unit/scripts/test_agent_instruction_audit.py
+++ b/tests/unit/scripts/test_agent_instruction_audit.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import importlib.util
 import json
+import os
 import shutil
 import subprocess
 import sys
@@ -35,6 +36,7 @@ CANONICAL_REVIEW_SKILL = agent_instruction_audit.CANONICAL_REVIEW_SKILL
 CANONICAL_COMMIT_SKILL = agent_instruction_audit.CANONICAL_COMMIT_SKILL
 audit = agent_instruction_audit.audit
 audit_git_identity = agent_instruction_audit.audit_git_identity
+audit_commit_range = agent_instruction_audit.audit_commit_range
 
 
 def _candidate(tmp_path: Path) -> Path:
@@ -251,3 +253,85 @@ def test_explicit_task_local_agent_identity_override_passes(tmp_path: Path, monk
     project = _git_configured_repo(tmp_path, "Claude", "noreply@anthropic.com")
     monkeypatch.setenv("BENCHBOX_ALLOW_AGENT_GIT_IDENTITY", "1")
     assert audit_git_identity(project) == []
+
+
+def test_signing_service_committer_behind_human_author_passes(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """A signing service may hold the committer slot when the author is human."""
+    project = _git_configured_repo(tmp_path, "Claude", "noreply@anthropic.com")
+    monkeypatch.setenv("GIT_AUTHOR_NAME", "Joe Harris")
+    monkeypatch.setenv("GIT_AUTHOR_EMAIL", "joeharris76@gmail.com")
+    assert audit_git_identity(project) == []
+
+
+def test_signing_service_committer_without_human_author_fails(tmp_path: Path) -> None:
+    """The allowance is conditional: an agent author is never acceptable."""
+    project = _git_configured_repo(tmp_path, "Claude", "noreply@anthropic.com")
+    errors = audit_git_identity(project)
+    assert any("author identity resolves to known agent/service" in error for error in errors)
+
+
+def _git_commit(project: Path, message: str, name: str, email: str) -> None:
+    (project / "file.txt").write_text(message, encoding="utf-8")
+    subprocess.run(["git", "-C", str(project), "add", "file.txt"], check=True)
+    subprocess.run(
+        ["git", "-C", str(project), "commit", "-q", "-m", message],
+        check=True,
+        env={
+            **os.environ,
+            "GIT_AUTHOR_NAME": name,
+            "GIT_AUTHOR_EMAIL": email,
+            "GIT_COMMITTER_NAME": name,
+            "GIT_COMMITTER_EMAIL": email,
+        },
+    )
+
+
+def _git_range_repo(tmp_path: Path) -> Path:
+    project = _git_configured_repo(tmp_path, "Joe Harris", "joeharris76@gmail.com")
+    _git_commit(project, "base", "Joe Harris", "joeharris76@gmail.com")
+    subprocess.run(["git", "-C", str(project), "branch", "-q", "base-ref"], check=True)
+    return project
+
+
+def test_commit_range_accepts_human_authorship(tmp_path: Path) -> None:
+    project = _git_range_repo(tmp_path)
+    _git_commit(project, "feat: human work", "Joe Harris", "joeharris76@gmail.com")
+    assert audit_commit_range(project, "base-ref") == []
+
+
+def test_commit_range_rejects_agent_authorship(tmp_path: Path) -> None:
+    project = _git_range_repo(tmp_path)
+    _git_commit(project, "feat: agent work", "Claude", "noreply@anthropic.com")
+    errors = audit_commit_range(project, "base-ref")
+    assert any("authored by known agent/service Claude <noreply@anthropic.com>" in error for error in errors)
+
+
+def test_commit_range_rejects_agent_coauthor_trailer(tmp_path: Path) -> None:
+    project = _git_range_repo(tmp_path)
+    _git_commit(
+        project,
+        "feat: work\n\nCo-Authored-By: Claude Fable 5 <noreply@anthropic.com>",
+        "Joe Harris",
+        "joeharris76@gmail.com",
+    )
+    errors = audit_commit_range(project, "base-ref")
+    assert any("carries agent Co-Authored-By trailer" in error for error in errors)
+
+
+def test_commit_range_rejects_agent_session_trailer(tmp_path: Path) -> None:
+    project = _git_range_repo(tmp_path)
+    _git_commit(
+        project,
+        "feat: work\n\nClaude-Session: https://claude.ai/code/session_abc",
+        "Joe Harris",
+        "joeharris76@gmail.com",
+    )
+    errors = audit_commit_range(project, "base-ref")
+    assert any("carries agent session trailer" in error for error in errors)
+
+
+def test_commit_range_reports_unresolvable_base_ref(tmp_path: Path) -> None:
+    """A missing base ref must surface, never silently pass as 'no findings'."""
+    project = _git_range_repo(tmp_path)
+    errors = audit_commit_range(project, "origin/does-not-exist")
+    assert any("unable to inspect commit range" in error for error in errors)

--- a/tests/unit/scripts/test_agent_instruction_audit.py
+++ b/tests/unit/scripts/test_agent_instruction_audit.py
@@ -15,6 +15,22 @@ from path_filter_decision import classify_paths, load_rules
 
 pytestmark = [pytest.mark.unit, pytest.mark.fast]
 
+
+@pytest.fixture(autouse=True)
+def _isolate_git_identity_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Force identity to resolve from config alone.
+
+    `git var` prefers GIT_AUTHOR_* / GIT_COMMITTER_* / EMAIL over any config
+    file, so an ambient value in the invoking shell decides these assertions
+    instead of the fixture repo. A cloud session that exports GIT_AUTHOR_* to
+    satisfy [COMMIT-IDENTITY-001] does exactly that, and it turned the
+    negative identity tests green against a repo configured as an agent.
+    Tests that want an ambient identity set it themselves, after this runs.
+    """
+    for name in ("GIT_AUTHOR_NAME", "GIT_AUTHOR_EMAIL", "GIT_COMMITTER_NAME", "GIT_COMMITTER_EMAIL", "EMAIL"):
+        monkeypatch.delenv(name, raising=False)
+
+
 ROOT = Path(__file__).resolve().parents[3]
 CORPUS = json.loads((ROOT / "_project/evals/agent-instructions/scenarios.json").read_text())
 

--- a/tests/unit/test_agent_write_preflight.py
+++ b/tests/unit/test_agent_write_preflight.py
@@ -16,10 +16,24 @@ pytestmark = [
 
 SCRIPT = Path("scripts/agent_write_preflight.sh")
 
+# These exercise the clone-location guard, so pin a human identity: otherwise
+# the preflight's [COMMIT-IDENTITY-001] assertion decides the result instead,
+# and every "allows" case fails wherever the ambient identity is an agent --
+# which is precisely the case in a cloud agent session.
+HUMAN_IDENTITY = {
+    "GIT_AUTHOR_NAME": "Joe Harris",
+    "GIT_AUTHOR_EMAIL": "joeharris76@gmail.com",
+}
+AGENT_IDENTITY = {
+    "GIT_AUTHOR_NAME": "Claude",
+    "GIT_AUTHOR_EMAIL": "noreply@anthropic.com",
+}
+
 
 def _run_preflight(*, primary_clone: Path, allow: bool = False) -> subprocess.CompletedProcess[str]:
     env = {
         **os.environ,
+        **HUMAN_IDENTITY,
         "BENCHBOX_AGENT_PRIMARY_CLONE": str(primary_clone),
     }
     env.pop("BENCHBOX_EPHEMERAL_CLONE", None)
@@ -90,7 +104,7 @@ def _run_in_clone(
     ephemeral: bool = False,
     extra_env: dict[str, str] | None = None,
 ) -> subprocess.CompletedProcess[str]:
-    env = {**os.environ}
+    env = {**os.environ, **HUMAN_IDENTITY}
     # Let the script derive the primary clone naturally from this repo.
     env.pop("BENCHBOX_AGENT_PRIMARY_CLONE", None)
     env.pop("BENCHBOX_ALLOW_MAIN_CLONE_WRITE", None)
@@ -165,6 +179,47 @@ def test_ephemeral_declaration_is_ignored_when_a_worktree_pool_is_present(tmp_pa
 
     assert result.returncode == 1
     assert "Refusing BenchBox write preflight in the primary clone" in result.stderr
+
+
+def test_preflight_refuses_an_agent_author_identity(tmp_path: Path) -> None:
+    """[COMMIT-IDENTITY-001] at claim time.
+
+    Linked worktrees share the primary clone's config, so one stray [user]
+    block reauthors every pool worktree at once. The claim is the only point
+    where a single check covers them all before any commit exists.
+    """
+    result = _run_in_clone(_init_clone(tmp_path / "BenchBox"), ephemeral=True, extra_env=AGENT_IDENTITY)
+
+    assert result.returncode == 1
+    assert "Git author identity resolves to a known" in result.stderr
+    assert "agent/service identity" in result.stderr
+    # The refusal has to show WHERE the value came from -- a repository-local
+    # override is invisible otherwise, and that is the case being caught.
+    assert "origins:" in result.stderr
+
+
+def test_preflight_agent_identity_refusal_is_declarable(tmp_path: Path) -> None:
+    """A task that explicitly authorized the agent identity can say so."""
+    result = _run_in_clone(
+        _init_clone(tmp_path / "BenchBox"),
+        ephemeral=True,
+        extra_env={**AGENT_IDENTITY, "BENCHBOX_ALLOW_AGENT_GIT_IDENTITY": "1"},
+    )
+
+    assert result.returncode == 0
+    assert "ephemeral clone" in result.stdout
+
+
+def test_preflight_identity_check_is_not_confused_by_a_human_named_like_a_vendor(tmp_path: Path) -> None:
+    """Match on the vendor address, not a substring of the display name."""
+    result = _run_in_clone(
+        _init_clone(tmp_path / "BenchBox"),
+        ephemeral=True,
+        extra_env={"GIT_AUTHOR_NAME": "Claudia Gemini-Lopez", "GIT_AUTHOR_EMAIL": "claudia@example.com"},
+    )
+
+    assert result.returncode == 0
+    assert "ephemeral clone" in result.stdout
 
 
 def test_refusal_names_the_ephemeral_escape_not_only_the_broad_override(tmp_path: Path) -> None:

--- a/tests/unit/test_check_agent_trailers.py
+++ b/tests/unit/test_check_agent_trailers.py
@@ -1,0 +1,93 @@
+"""Commit-msg gate for agent attribution trailers.
+
+`scripts/check_agent_trailers.sh` is the commit-time half of
+`[COMMIT-IDENTITY-001]`; `audit_commit_range` is the merge-time half. The two
+must agree, so the cases here mirror the trailer tests in
+`tests/unit/scripts/test_agent_instruction_audit.py`.
+
+The name arm matters as much as the address arm: matching only the vendor
+address let `Co-Authored-By: Claude <claude@example.com>` through both gates.
+It has to stay a whole-display-name match, though, or a human called
+"Claudia Gemini-Lopez" would be refused.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import pytest
+
+pytestmark = [pytest.mark.unit, pytest.mark.fast]
+
+SCRIPT = Path(__file__).resolve().parents[2] / "scripts/check_agent_trailers.sh"
+
+
+def _run(tmp_path: Path, message: str, env: dict[str, str] | None = None) -> subprocess.CompletedProcess[str]:
+    message_file = tmp_path / "COMMIT_EDITMSG"
+    message_file.write_text(message, encoding="utf-8")
+    return subprocess.run(
+        ["sh", str(SCRIPT), str(message_file)],
+        check=False,
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+
+
+REJECTED = pytest.mark.parametrize(
+    ("label", "message"),
+    [
+        ("vendor address", "feat: x\n\nCo-Authored-By: Claude Fable 5 <noreply@anthropic.com>"),
+        ("openai vendor address", "feat: x\n\nCo-Authored-By: Codex <noreply@openai.com>"),
+        ("agent name with its own address", "feat: x\n\nCo-Authored-By: Claude <claude@example.com>"),
+        ("agent name, unrelated address", "feat: x\n\nCo-Authored-By: Codex <codex@somewhere.org>"),
+        ("session trailer", "feat: x\n\nClaude-Session: https://claude.ai/code/session_abc"),
+    ],
+)
+
+ACCEPTED = pytest.mark.parametrize(
+    ("label", "message"),
+    [
+        ("plain human", "feat: x\n\nCo-Authored-By: Joe Harris <joeharris76@gmail.com>"),
+        ("human named like a vendor", "feat: x\n\nCo-Authored-By: Claudia Gemini-Lopez <claudia@example.com>"),
+        ("no trailer at all", "feat: x"),
+        # A commit template that documents the forbidden trailer must not fail
+        # the commit: comment lines never survive into the stored message.
+        ("commented-out trailer", "feat: x\n\n# Co-Authored-By: Claude <noreply@anthropic.com>"),
+    ],
+)
+
+
+@REJECTED
+def test_rejects_agent_attribution(tmp_path: Path, label: str, message: str) -> None:
+    result = _run(tmp_path, message)
+    assert result.returncode == 1, f"{label} should have been refused"
+    assert "agent/service attribution" in result.stderr
+
+
+@ACCEPTED
+def test_accepts_human_attribution(tmp_path: Path, label: str, message: str) -> None:
+    result = _run(tmp_path, message)
+    assert result.returncode == 0, f"{label} should have been accepted: {result.stderr}"
+
+
+def test_authorized_trailer_is_declarable(tmp_path: Path) -> None:
+    """A task that explicitly requested the trailer can say so."""
+    result = _run(
+        tmp_path,
+        "feat: x\n\nCo-Authored-By: Claude <noreply@anthropic.com>",
+        env={"PATH": "/usr/bin:/bin", "BENCHBOX_ALLOW_AGENT_COAUTHOR": "1"},
+    )
+    assert result.returncode == 0, result.stderr
+
+
+def test_missing_message_file_is_a_usage_error(tmp_path: Path) -> None:
+    """Fail loudly rather than passing vacuously when wired up wrong."""
+    result = subprocess.run(
+        ["sh", str(SCRIPT), str(tmp_path / "absent")],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 2


### PR DESCRIPTION
# Pull Request

## Description

Cloud agent sessions commit as `Claude <noreply@anthropic.com>`, because a harness `SessionStart` hook re-asserts that identity into the session's global git config on every session start.

The repo already had a gate for exactly this — `[COMMIT-IDENTITY-001]`, `agent_instruction_audit.py --check-git-identity` — but it was wired only into `.pre-commit-config.yaml`, and cloud clones never install pre-commit hooks. So it fired **nowhere**: not at commit, not in `ci-lint`, not in CI. A sweep of all 30 remote branches found **67 agent-authored commits across 5 unmerged `claude/*` branches**. `develop`, `release` and `published-results` are clean, so nothing protected is contaminated — but only by luck, not by a control.

This binds the policy to **authorship** and enforces it at three points:

- **Claim time** — `agent_write_preflight.sh` refuses when the resolved author is a known agent/service, printing config origins. Linked worktrees share the primary clone's config, so one stray `[user]` block reauthors every pool worktree at once; the claim is the only point where a single check covers them all before any commit exists.
- **Commit time** — the preflight installs `pre-commit` + `commit-msg` hooks in ephemeral clones, which otherwise never get them. A new `commit-msg` gate rejects agent `Co-Authored-By` and `*-Session` trailers. It **rejects rather than rewrites**: `CLAUDE.md` forbids hooks that silently mutate files, and a quiet rewrite would also hide whatever keeps adding the trailer.
- **Merge time** — `agent-commit-range-check` walks `origin/develop..HEAD`. The config check cannot do this job in CI, where the resolved identity is the runner's own and says nothing about what the branch carries.

A commit-signing service may now hold the **committer** slot behind a human **author**. Requiring a human committer too is unsatisfiable in a cloud session — the signing key is registered to the agent address, so any other committer email makes the signature unverifiable — and it bought nothing: authorship is what attribution turns on.

Escape hatches stay explicit and task-local: `BENCHBOX_ALLOW_AGENT_GIT_IDENTITY`, `BENCHBOX_ALLOW_AGENT_COAUTHOR`.

### Matching trailers by name, not address alone (`d9555d45`)

Both trailer gates originally tested only the vendor addresses, so `Co-Authored-By: Claude <claude@example.com>` — an agent signing with a non-vendor address — passed the commit-msg hook *and* the merge-time guard. The trailer identity is now parsed and run through `_is_agent_identity`, the same name-or-email predicate used for authors, and `check_agent_trailers.sh` mirrors it. The name arm is a whole-display-name match, so a contributor called "Claudia Gemini-Lopez" is still accepted.

The instruction-parity anchors now also pin the author/committer split. They previously covered only trailer semantics, so the canonical skill could have required a human *committer* while the shipped gate allowed a signing service there, and `agent-instructions-check` would still have reported the surface as valid.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactor / chore

## Testing

- `make pr-preflight` — `ci-lint` clean, including both new guards.
- Fast suite: **26,424 passed, 4 failed**. All 4 failures are pre-existing/environmental and unrelated to this diff:
  - 2× pyspark CSV — `Unable to determine Java version. PySpark SQL mode requires Java 17 or 21`
  - 1× delta scan — `HTTP 403` fetching `delta.duckdb_extension.gz`
  - 1× changelog guard — `CHANGELOG.md claims untagged version(s): ['0.1.0']`; `git diff origin/develop...HEAD -- CHANGELOG.md` is empty, so it fails on `develop` identically.
- `tests/unit/scripts/test_agent_instruction_audit.py` — **39 passed** (was 35; +2 trailer cases, both directions). `tests/unit/test_agent_write_preflight.py` — 13 passed. Both verified green **with and without** an ambient `GIT_AUTHOR_*` in the shell.
- `tests/unit/test_check_agent_trailers.py` — **11 passed** (new). The commit-msg hook had no test coverage at all; it now has both arms pinned, including the negative "human named like a vendor" case and the commented-out-trailer case.
- `tests/system/test_ci_lint_parity.py` — 7 passed; both new CI guards mirror `ci-lint` at the command level.
- Detection verified against a real contaminated commit (`6b2c7d904`), which trips all three signals: agent author, agent `Co-Authored-By`, and `Claude-Session:`.
- Anchor drift verified **in both directions**: `agent-instructions-check` passes on the current text, and fails with `canonical COMMIT-IDENTITY-001 semantics drifted; missing anchors: committer slot behind a human author` when that sentence is removed.

## Public Contract Check

- [x] I updated `docs/reference/public-contracts.md`, or this PR does not change public, beta-public, deprecated, generated, experimental, or repo-only contract surfaces.
- [x] I checked result schema fields, MCP tool parameters, platform support status, wrapper facades, adapter subclassing hooks, and generated docs for contract-map impact.
- [x] Any platform/benchmark count claim in docs is generated/checked from registry metadata, or explicitly marked editorial/non-authoritative.

No runtime/library surface is touched — the diff is governance tooling, CI wiring, and tests.

## Documentation

- [x] I updated the relevant user-facing docs — `AGENTS.md` `[COMMIT-IDENTITY-001]` now states the author/committer split and names the enforcing gates.
- [x] I added regression notes for behavior changes.
- [x] I confirmed API contract wording remains accurate.

## Code Quality

- [x] I ran formatting and lint/type checks — `ruff check`, `ruff format --check`, `ty check` all clean.
- [x] I reviewed impacted modules for backwards compatibility and migration impact.
- [x] I added/updated tests for behavior changes and error paths.
- [x] I confirmed public contracts and release checklists are still valid.

## Artifact Hygiene

- [x] I did not commit raw screenshots, browser reports, generated logs, benchmark outputs, or temporary binary artifacts.
- [x] Any committed binary/raw evidence file has durable repo value and is justified here with its consumer and size — none added.

## Notes

**The policy-drift blocker is resolved.** An earlier revision of this description said the canonical `[COMMIT-IDENTITY-001]` text could not be updated from a cloud session and that `.claude/skills/` was left untouched. That is no longer accurate: `a6c83582` updated `.claude/skills/SHARED/commit-framework/SKILL.md` and its `skill-sync.lock` hash together, so the mirror and `AGENTS.md` now agree that a signing service may hold the committer slot behind a human author. `skill-sync-check` is green in `ci-lint`. `develop` will therefore *not* be left in the drift state that kept auto-merge off.

**One genuine follow-up remains, and it is local-only.** The mirror's skill-sync **source** (`~/.skill-sync/skills`, absent from any cloud clone) still carries the old "author **and** committer" wording. The next local `make skill-sync` will revert the mirror unless the source is updated first. @joeharris76 — this needs the source edit applied locally and `make skill-sync` re-run. `make skill-sync-verify` **skips** (not passes) in a cloud environment because the CLI is absent, so it is worth re-running locally too.

**Auto-merge is still off.** The `enable` job fails on this PR by design — `auto_merge_soundness_paths.py` returns `false` and auto-merge was deliberately not enabled. That job's config is a CODEOWNERS soundness path, so it has been left untouched. Merging is a maintainer decision.

**Reviewer focus.** Three defects were found and fixed during verification. Two shared a root cause — ambient environment deciding a result that should come from fixtures:
1. The new audit identity tests read ambient `GIT_AUTHOR_*`, so `git var` returned the shell's human identity and the *negative* tests passed against a repo configured as an agent (`assert len(errors) == 2` saw `0`).
2. Adding the assertion to `agent_write_preflight.sh` broke three pre-existing tests that exercise the clone-location guard and inherit `os.environ`.
3. The trailer gates matched on vendor address only (see above) — found in review, fixed in `d9555d45`.

All three are now pinned in both directions.

**Known residual, accepted.** `Co-Authored-By: Claude Fable 5 <claude@example.com>` — agent *product* name plus a non-vendor address — still passes, because `AGENT_NAMES` matches the whole display name. Broadening to per-token matching would reject a contributor actually named Claude, a common given name; the false-positive cost is worse than the gap, and the vendor-address arm covers the harness default that actually occurs.

**Existing agent-authored commits are left alone.** They sit on unmerged branches; the merge-time guard is what keeps them off `develop`. Rewriting 67 commits would drop their signatures for no benefit.