### PR TITLE
fix: close merged-PR review follow-ups across explorer pipeline and UI

### DIFF
--- a/_project/scripts/explorer_pipeline/pipeline.py
+++ b/_project/scripts/explorer_pipeline/pipeline.py
@@ -68,6 +68,13 @@ def _promote_staged_output(staged_dir: Path, output_dir: Path) -> None:
     """
     output_dir.mkdir(parents=True, exist_ok=True)
     target_bundles = output_dir / "bundles"
+    # `mkdir(exist_ok=True)` accepts a symlink that resolves to a directory, and
+    # every copy below - plus the stale-file sweep after promotion - would then
+    # follow the link, overwriting matching files and unlinking unrelated
+    # `*.json` outside `output_dir`. The pre-staging `shutil.rmtree` path refused
+    # to operate on a directory symlink; keep that guarantee explicit here.
+    if target_bundles.is_symlink():
+        raise ValueError(f"published bundles path must be a real directory, not a symlink: {target_bundles}")
     target_bundles.mkdir(parents=True, exist_ok=True)
     staged_bundles = staged_dir / "bundles"
     candidate_names = {path.name for path in staged_bundles.iterdir() if path.is_file()}
@@ -104,6 +111,11 @@ def _promote_staged_output(staged_dir: Path, output_dir: Path) -> None:
             (output_dir / legacy_file).unlink()
         except FileNotFoundError:
             pass
+        except OSError:
+            # The new DB is already live at this point, so a stubborn legacy
+            # path (a directory, a deletion-denying ACL) must not turn a
+            # successful publish into a reported failure and an ambiguous retry.
+            logger.warning("Could not remove legacy artifact %s", output_dir / legacy_file)
 
 
 def _is_vendor_subtree(bundle_path: Path, bundles_dir: Path) -> bool:
@@ -514,162 +526,169 @@ class ExplorerPipeline:
         output_dir = output_dir.resolve()
         output_dir.parent.mkdir(parents=True, exist_ok=True)
         staging_dir = Path(tempfile.mkdtemp(prefix=f".{output_dir.name}.", dir=output_dir.parent))
+        # The staging directory is populated from here through bundle processing,
+        # so the cleanup guard must start now: an uncaught I/O error before the DB
+        # build would otherwise strand a hidden `.out.*` tree next to the output,
+        # and repeated retries would accumulate stale copies of it.
+        try:
+            # All copied public JSON passes through one manager so the same stable
+            # pseudonyms are used across a primary bundle and its companions.
+            public_anonymizer = AnonymizationManager()
 
-        # All copied public JSON passes through one manager so the same stable
-        # pseudonyms are used across a primary bundle and its companions.
-        public_anonymizer = AnonymizationManager()
+            out_bundles_dir = staging_dir / "bundles"
+            out_bundles_dir.mkdir(parents=True)
 
-        out_bundles_dir = staging_dir / "bundles"
-        out_bundles_dir.mkdir(parents=True)
+            # Drop derived directories and files from earlier pipeline versions
+            # that emitted per-cohort / per-result / manifest JSON artifacts. The
+            # DuckDB browser store replaces them; leaving them behind would mask
+            # stale data.
+            manifest_entries: list[ManifestEntry] = []
+            # Accumulator for benchmark summary artifacts (zero extra I/O - reuses
+            # already-loaded bundle data from the single pass).
+            summary_accum: _SummaryAccum = defaultdict(list)
+            # Keyed by result_id; populated alongside manifest_entries so build_full()
+            # has per-result detail data without a second I/O pass.
+            details_map: dict[str, DetailResult] = {}
+            skipped_bundles = 0
 
-        # Drop derived directories and files from earlier pipeline versions
-        # that emitted per-cohort / per-result / manifest JSON artifacts. The
-        # DuckDB browser store replaces them; leaving them behind would mask
-        # stale data.
-        manifest_entries: list[ManifestEntry] = []
-        # Accumulator for benchmark summary artifacts (zero extra I/O - reuses
-        # already-loaded bundle data from the single pass).
-        summary_accum: _SummaryAccum = defaultdict(list)
-        # Keyed by result_id; populated alongside manifest_entries so build_full()
-        # has per-result detail data without a second I/O pass.
-        details_map: dict[str, DetailResult] = {}
-        skipped_bundles = 0
+            for bundle_path in bundle_files:
+                try:
+                    bundle_data, bundle_raw = self._transformer.load_bundle_full(bundle_path)
+                    result_id = self._transformer.result_id_from_bundle(bundle_path, data=bundle_data, raw=bundle_raw)
+                    prefix = bundle_url_prefix.rstrip("/")
+                    bundle_download_url = f"{prefix}/{result_id}.json"
 
-        for bundle_path in bundle_files:
-            try:
-                bundle_data, bundle_raw = self._transformer.load_bundle_full(bundle_path)
-                result_id = self._transformer.result_id_from_bundle(bundle_path, data=bundle_data, raw=bundle_raw)
-                prefix = bundle_url_prefix.rstrip("/")
-                bundle_download_url = f"{prefix}/{result_id}.json"
+                    # Per-bundle trust label. Precedence: a bundle under the
+                    # maintainer-controlled top-level vendor/ subtree is
+                    # vendor-supplied; else a submission-manifest sidecar marks it
+                    # community-submitted; else the pipeline default.
+                    effective_trust = trust_label
+                    effective_visibility = visibility
+                    if _is_vendor_subtree(bundle_path, bundles_dir):
+                        effective_trust = VENDOR_TRUST_LABEL
+                        effective_visibility = VENDOR_VISIBILITY
+                        logger.debug(
+                            "Vendor subtree bundle %s - using trust_label=%r", bundle_path.name, effective_trust
+                        )
+                    elif _find_submission_manifest(bundle_path) is not None:
+                        effective_trust = COMMUNITY_TRUST_LABEL
+                        logger.debug(
+                            "Found submission manifest for %s - using trust_label=%r",
+                            bundle_path.name,
+                            effective_trust,
+                        )
 
-                # Per-bundle trust label. Precedence: a bundle under the
-                # maintainer-controlled top-level vendor/ subtree is
-                # vendor-supplied; else a submission-manifest sidecar marks it
-                # community-submitted; else the pipeline default.
-                effective_trust = trust_label
-                effective_visibility = visibility
-                if _is_vendor_subtree(bundle_path, bundles_dir):
-                    effective_trust = VENDOR_TRUST_LABEL
-                    effective_visibility = VENDOR_VISIBILITY
-                    logger.debug("Vendor subtree bundle %s - using trust_label=%r", bundle_path.name, effective_trust)
-                elif _find_submission_manifest(bundle_path) is not None:
-                    effective_trust = COMMUNITY_TRUST_LABEL
-                    logger.debug(
-                        "Found submission manifest for %s - using trust_label=%r",
-                        bundle_path.name,
-                        effective_trust,
+                    public_bundle, public_receipt = _public_bundle_data(bundle_path, bundle_data, public_anonymizer)
+
+                    entry = self._transformer.to_manifest_entry(
+                        bundle_path,
+                        trust_label=effective_trust,
+                        visibility=effective_visibility,
+                        result_id=result_id,
+                        data=public_bundle,
                     )
+                    entry = entry.model_copy(update={"applied_receipt": public_receipt})
 
-                public_bundle, public_receipt = _public_bundle_data(bundle_path, bundle_data, public_anonymizer)
-
-                entry = self._transformer.to_manifest_entry(
-                    bundle_path,
-                    trust_label=effective_trust,
-                    visibility=effective_visibility,
-                    result_id=result_id,
-                    data=public_bundle,
-                )
-                entry = entry.model_copy(update={"applied_receipt": public_receipt})
-
-                detail = self._transformer.to_detail_result(
-                    bundle_path,
-                    result_id,
-                    trust_label=effective_trust,
-                    visibility=effective_visibility,
-                    bundle_download_url=bundle_download_url,
-                    data=public_bundle,
-                )
-                detail = detail.model_copy(update={"applied_receipt": public_receipt})
-
-                dest_bundle = (out_bundles_dir / f"{result_id}.json").resolve()
-                if not dest_bundle.is_relative_to(out_bundles_dir.resolve()):
-                    skipped_bundles += 1
-                    logger.warning(
-                        "Skipping bundle copy for %s - result_id %r escapes bundles directory",
+                    detail = self._transformer.to_detail_result(
                         bundle_path,
                         result_id,
+                        trust_label=effective_trust,
+                        visibility=effective_visibility,
+                        bundle_download_url=bundle_download_url,
+                        data=public_bundle,
                     )
-                    continue
-                dest_bundle.write_bytes(canonical_json_bytes(public_bundle))
+                    detail = detail.model_copy(update={"applied_receipt": public_receipt})
 
-                # Publish the plans sidecar alongside the bundle when present
-                # and set ``plans_published`` on the detail so the explorer UI
-                # only renders a download link for plans that actually exist
-                # at the published URL. Without this wire-up, the consumer-side
-                # gate (results-explorer/src/components/RunReceipt.tsx) sees
-                # ``plans_published=undefined`` and never renders a link, so
-                # the feature stays dark even when plans are available.
-                plans_src = bundle_path.with_name(f"{bundle_path.stem}.plans.json")
-                if plans_src.exists():
-                    plans_dest = (out_bundles_dir / f"{result_id}.plans.json").resolve()
-                    if plans_dest.is_relative_to(out_bundles_dir.resolve()):
-                        try:
-                            plans_payload = json.loads(plans_src.read_text(encoding="utf-8"))
-                            public_plans = public_anonymizer.anonymize_result_payload(plans_payload)
-                            plans_leaks = find_public_path_leaks(public_plans)
-                            if plans_leaks:
-                                raise ValueError(
-                                    "public plans privacy check failed for fields: "
-                                    + ", ".join(sorted(set(plans_leaks)))
+                    dest_bundle = (out_bundles_dir / f"{result_id}.json").resolve()
+                    if not dest_bundle.is_relative_to(out_bundles_dir.resolve()):
+                        skipped_bundles += 1
+                        logger.warning(
+                            "Skipping bundle copy for %s - result_id %r escapes bundles directory",
+                            bundle_path,
+                            result_id,
+                        )
+                        continue
+                    dest_bundle.write_bytes(canonical_json_bytes(public_bundle))
+
+                    # Publish the plans sidecar alongside the bundle when present
+                    # and set ``plans_published`` on the detail so the explorer UI
+                    # only renders a download link for plans that actually exist
+                    # at the published URL. Without this wire-up, the consumer-side
+                    # gate (results-explorer/src/components/RunReceipt.tsx) sees
+                    # ``plans_published=undefined`` and never renders a link, so
+                    # the feature stays dark even when plans are available.
+                    plans_src = bundle_path.with_name(f"{bundle_path.stem}.plans.json")
+                    if plans_src.exists():
+                        plans_dest = (out_bundles_dir / f"{result_id}.plans.json").resolve()
+                        if plans_dest.is_relative_to(out_bundles_dir.resolve()):
+                            try:
+                                plans_payload = json.loads(plans_src.read_text(encoding="utf-8"))
+                                public_plans = public_anonymizer.anonymize_result_payload(plans_payload)
+                                plans_leaks = find_public_path_leaks(public_plans)
+                                if plans_leaks:
+                                    raise ValueError(
+                                        "public plans privacy check failed for fields: "
+                                        + ", ".join(sorted(set(plans_leaks)))
+                                    )
+                                plans_dest.write_bytes(canonical_json_bytes(public_plans))
+                                detail.plans_published = True
+                            except (OSError, json.JSONDecodeError, TypeError, ValueError) as exc:
+                                logger.warning(
+                                    "Skipping plans companion %s - %s: %s", plans_src, type(exc).__name__, exc
                                 )
-                            plans_dest.write_bytes(canonical_json_bytes(public_plans))
-                            detail.plans_published = True
-                        except (OSError, json.JSONDecodeError, TypeError, ValueError) as exc:
-                            logger.warning("Skipping plans companion %s - %s: %s", plans_src, type(exc).__name__, exc)
 
-                # Add the entry only after the public bundle has been copied
-                # successfully.  A privacy rejection must not leave a
-                # manifest row without its corresponding detail record.
-                manifest_entries.append(entry)
+                    # Add the entry only after the public bundle has been copied
+                    # successfully.  A privacy rejection must not leave a
+                    # manifest row without its corresponding detail record.
+                    manifest_entries.append(entry)
 
-                # Accumulate for benchmark summary artifacts. Raw benchmark
-                # slug and test_type stay on the result/detail rows; only the
-                # derived cohort key uses the explicit canonical identity.
-                phase = canonical_phase(detail.test_type)
-                summary_key: _SummaryKey = (canonical_benchmark_slug(entry.benchmark), entry.scale_factor, phase)
-                summary_accum[summary_key].append((entry, detail))
-                details_map[entry.result_id] = detail
+                    # Accumulate for benchmark summary artifacts. Raw benchmark
+                    # slug and test_type stay on the result/detail rows; only the
+                    # derived cohort key uses the explicit canonical identity.
+                    phase = canonical_phase(detail.test_type)
+                    summary_key: _SummaryKey = (canonical_benchmark_slug(entry.benchmark), entry.scale_factor, phase)
+                    summary_accum[summary_key].append((entry, detail))
+                    details_map[entry.result_id] = detail
 
-                logger.debug("Processed bundle %s → %s", bundle_path.name, result_id)
+                    logger.debug("Processed bundle %s → %s", bundle_path.name, result_id)
 
-            except (json.JSONDecodeError, KeyError, ValueError, TypeError) as exc:
-                skipped_bundles += 1
-                logger.warning("Skipping bundle %s - %s: %s", bundle_path, type(exc).__name__, exc)
+                except (json.JSONDecodeError, KeyError, ValueError, TypeError) as exc:
+                    skipped_bundles += 1
+                    logger.warning("Skipping bundle %s - %s: %s", bundle_path, type(exc).__name__, exc)
 
-        generated_at = datetime.now(tz=timezone.utc).isoformat()
-        logger.info("Processed %d bundle(s)", len(manifest_entries))
-        if skipped_bundles:
-            logger.warning("Skipped %d bundle(s) due to processing errors", skipped_bundles)
+            generated_at = datetime.now(tz=timezone.utc).isoformat()
+            logger.info("Processed %d bundle(s)", len(manifest_entries))
+            if skipped_bundles:
+                logger.warning("Skipped %d bundle(s) due to processing errors", skipped_bundles)
 
-        # Build short ID lookup table (short → full result_id).
-        all_result_ids = [e.result_id for e in manifest_entries]
-        short_id_map = _build_short_ids(all_result_ids)  # short → full
-        full_to_short = {v: k for k, v in short_id_map.items()}  # full → short
+            # Build short ID lookup table (short → full result_id).
+            all_result_ids = [e.result_id for e in manifest_entries]
+            short_id_map = _build_short_ids(all_result_ids)  # short → full
+            full_to_short = {v: k for k, v in short_id_map.items()}  # full → short
 
-        # Build per-(benchmark, scale, phase) summaries for DuckDB population.
-        # The JSON emission was removed when BenchmarkIndex migrated to DuckDB
-        # (W4 slice 3); `_build_benchmark_summaries` still seeds the
-        # `benchmark_matrix_cells` and `benchmark_rankings` DuckDB tables via
-        # `_DuckDBBuilder`.
-        summaries = _build_benchmark_summaries(summary_accum, full_to_short)
-        logger.info(
-            "Built %d benchmark summary(ies) for DuckDB population",
-            len(summaries),
-        )
+            # Build per-(benchmark, scale, phase) summaries for DuckDB population.
+            # The JSON emission was removed when BenchmarkIndex migrated to DuckDB
+            # (W4 slice 3); `_build_benchmark_summaries` still seeds the
+            # `benchmark_matrix_cells` and `benchmark_rankings` DuckDB tables via
+            # `_DuckDBBuilder`.
+            summaries = _build_benchmark_summaries(summary_accum, full_to_short)
+            logger.info(
+                "Built %d benchmark summary(ies) for DuckDB population",
+                len(summaries),
+            )
 
-        # Build the cross-benchmark meta-leaderboard for DuckDB population.
-        # The JSON emission was removed when Home migrated to DuckDB (W4 slice 1);
-        # the `meta` dict below still seeds the `cohort_metadata` and
-        # `meta_leaderboard` DuckDB tables via `_DuckDBBuilder`.
-        meta = _build_meta_leaderboard(summaries, generated_at, full_to_short)
-        logger.info(
-            "Built meta-leaderboard (%d cohorts, %d platforms) for DuckDB population",
-            len(meta["cohorts"]),
-            len(meta["platforms"]),
-        )
+            # Build the cross-benchmark meta-leaderboard for DuckDB population.
+            # The JSON emission was removed when Home migrated to DuckDB (W4 slice 1);
+            # the `meta` dict below still seeds the `cohort_metadata` and
+            # `meta_leaderboard` DuckDB tables via `_DuckDBBuilder`.
+            meta = _build_meta_leaderboard(summaries, generated_at, full_to_short)
+            logger.info(
+                "Built meta-leaderboard (%d cohorts, %d platforms) for DuckDB population",
+                len(meta["cohorts"]),
+                len(meta["platforms"]),
+            )
 
-        duckdb_path = staging_dir / "results.duckdb"
-        try:
+            duckdb_path = staging_dir / "results.duckdb"
             self._duckdb_builder.build_full(
                 entries=manifest_entries,
                 details_map=details_map,

--- a/results-explorer/src/lib/__tests__/facetModel.test.ts
+++ b/results-explorer/src/lib/__tests__/facetModel.test.ts
@@ -6,11 +6,13 @@ import {
   FACET_URL_KEYS,
   FACET_URL_SERDES,
   facetsToWhereClause,
+  normalizeFacetState,
   readFacetParam,
   useFacetField,
   type FacetKey,
   type FacetState,
 } from "@/lib/facetModel";
+import { matchesFacetRow } from "@/lib/facetMatching";
 import { useUrlState, type UrlSerde } from "@/lib/useUrlState";
 
 const SAMPLE_VALUES: { [K in FacetKey]: FacetState[K] } = {
@@ -168,7 +170,7 @@ describe("facetsToWhereClause", () => {
 
     expect(sql).toContain("CASE WHEN benchmark = 'star_schema' THEN 'ssb'");
     expect(sql).toContain("scale_factor IN (?)");
-    expect(sql).toContain("test_type IN (?)");
+    expect(sql).toContain("THEN 'unknown' ELSE trim(lower(test_type)) END IN (?)");
     expect(sql).toContain("(platform IN (?) OR platform_id IN (?))");
     expect(sql).toContain("deployment_class IN (?, ?)");
     expect(sql).toContain("instance_or_warehouse IN (?)");
@@ -203,5 +205,35 @@ describe("facetsToWhereClause", () => {
 
     expect(sql).toContain("(tuning_mode IN (?) OR tuning_mode IS NULL)");
     expect(params).toEqual(["auto"]);
+  });
+
+  // The `unknown` phase cohort is user-selectable, and `matchesFacetRow` folds a
+  // null/blank `test_type` into it. A raw `test_type IN ('unknown')` predicate
+  // matched no null-phase row, so the cohort that produced the facet returned an
+  // empty leaderboard.
+  it("folds null and blank test_type into the unknown phase cohort", () => {
+    const { sql, params } = facetsToWhereClause({ phase: ["unknown"] });
+
+    expect(sql).toContain("coalesce(test_type, '')");
+    expect(sql).toContain("THEN 'unknown'");
+    expect(params).toEqual(["unknown"]);
+
+    const rowMatches = matchesFacetRow({ test_type: null }, normalizeFacetState({ phase: ["unknown"] }), {
+      keys: ["phase"],
+    });
+    expect(rowMatches).toBe(true);
+  });
+
+  it("canonicalizes phase casing on both the SQL and in-memory sides", () => {
+    const { params } = facetsToWhereClause({ phase: ["POWER", "power", " Power "] });
+
+    // canonicalPhase() trims and lowercases, so the three spellings collapse to
+    // one bound parameter rather than three literals that miss stored casing.
+    expect(params).toEqual(["power"]);
+
+    const rowMatches = matchesFacetRow({ test_type: "POWER" }, normalizeFacetState({ phase: ["power"] }), {
+      keys: ["phase"],
+    });
+    expect(rowMatches).toBe(true);
   });
 });

--- a/results-explorer/src/lib/facetModel.ts
+++ b/results-explorer/src/lib/facetModel.ts
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useMemo, useState } from "preact/hooks";
 import type { UrlSerde } from "@/lib/useUrlState";
-import { canonicalBenchmarkSlug } from "@/lib/displayLabels";
+import { canonicalBenchmarkSlug, canonicalPhase } from "@/lib/displayLabels";
 
 export const FACET_KEYS = [
   "benchmark",
@@ -361,7 +361,7 @@ export function facetsToWhereClause(
 
   addCanonicalBenchmarkClause(facets.benchmark, clauses, params);
   addNumericListClause("scale_factor", facets.scale_factor, clauses, params);
-  addListClause("test_type", facets.phase, clauses, params);
+  addCanonicalPhaseClause(facets.phase, clauses, params);
   addPlatformClause(facets.platform, clauses, params);
   addListClause("execution_mode", facets.execution_mode, clauses, params);
   addNullableSentinelClause("tuning_mode", facets.tuning_mode, NULL_TUNING_MODE_SENTINELS, clauses, params);
@@ -394,6 +394,24 @@ function addCanonicalBenchmarkClause(values: readonly string[], clauses: string[
       canonicalValues.map(() => "?").join(", ") +
       ")",
   );
+  params.push(...canonicalValues);
+}
+
+/**
+ * SQL mirror of `canonicalPhase()`: trim + lowercase, with null/blank folded
+ * into the `unknown` token. `matchesFacetKey` canonicalizes `test_type` in
+ * memory, so a raw `test_type IN (?)` predicate here would silently disagree -
+ * selecting the exposed `unknown` cohort would match no null-phase row, and a
+ * `POWER`/`power` casing difference would drop rows the matcher accepts,
+ * leaving the leaderboard empty or inconsistent with its own facet counts.
+ */
+const CANONICAL_PHASE_SQL =
+  "CASE WHEN trim(lower(coalesce(test_type, ''))) = '' THEN 'unknown' ELSE trim(lower(test_type)) END";
+
+function addCanonicalPhaseClause(values: readonly string[], clauses: string[], params: unknown[]) {
+  if (values.length === 0) return;
+  const canonicalValues = [...new Set(values.map(canonicalPhase))];
+  clauses.push(`${CANONICAL_PHASE_SQL} IN (${canonicalValues.map(() => "?").join(", ")})`);
   params.push(...canonicalValues);
 }
 

--- a/results-explorer/src/pages/Compare.tsx
+++ b/results-explorer/src/pages/Compare.tsx
@@ -762,7 +762,11 @@ function severeCohortMismatchReason(results: DetailResult[]) {
   if (new Set(results.map((result) => result.scale_factor)).size > 1) {
     reasons.push("scale factors differ");
   }
-  if (new Set(results.map((result) => result.test_type ?? "")).size > 1) {
+  // Canonicalize exactly as the cohort builder and selection lock do. Comparing
+  // raw values would flag `POWER` against `power` as a severe mismatch and
+  // suppress winner/ranking claims for results the builder admitted into one
+  // canonical cohort.
+  if (new Set(results.map((result) => canonicalPhase(result.test_type))).size > 1) {
     reasons.push("phases differ");
   }
   return reasons.length > 0 ? reasons.join(" and ") : null;

--- a/results-explorer/src/pages/Home.tsx
+++ b/results-explorer/src/pages/Home.tsx
@@ -302,7 +302,12 @@ export function Home(_: RoutableProps) {
   const visibleRankedLeaderboardPlatformCount =
     filteredMetaLeaderboard?.platforms.filter((platform) => platform.n_cohorts > 0).length ?? 0;
   const tuningSummary = summarizeTuningModes(results);
-  const tuningOptions = tuningSummaryBucketCount(tuningSummary) > 1
+  // An active tuning filter means `results` was already loaded with that
+  // predicate applied, so the summary necessarily collapses to one bucket.
+  // Dropping the selector then would strand the user on the filtered view with
+  // no control to return to "All tuning labels", so keep it whenever a filter
+  // is active regardless of the narrowed cardinality.
+  const tuningOptions = tuningSummaryBucketCount(tuningSummary) > 1 || tuningFilter !== "all"
     ? [
         "all",
         ...(tuningSummary.unlabelledCount > 0 ? [UNLABELLED_TUNING_VALUE] : []),

--- a/results-explorer/src/pages/__tests__/Home.test.tsx
+++ b/results-explorer/src/pages/__tests__/Home.test.tsx
@@ -781,7 +781,7 @@ describe("Home", () => {
       .mock.calls.find(([sql]) => String(sql).replace(/\s+/g, " ").trim().includes("FROM bench.results WHERE"));
     expect(String(resultCall?.[0])).toContain("CASE WHEN benchmark = 'star_schema' THEN 'ssb'");
     expect(String(resultCall?.[0])).toContain("scale_factor IN (?)");
-    expect(String(resultCall?.[0])).toContain("test_type IN (?)");
+    expect(String(resultCall?.[0])).toContain("THEN 'unknown' ELSE trim(lower(test_type)) END IN (?)");
     expect(String(resultCall?.[0])).toContain("(platform IN (?) OR platform_id IN (?))");
     expect(String(resultCall?.[0])).toContain("deployment_class IN (?)");
     expect(String(resultCall?.[0])).toContain("cost_status IN (?)");

--- a/tests/unit/scripts/explorer_pipeline/test_pipeline.py
+++ b/tests/unit/scripts/explorer_pipeline/test_pipeline.py
@@ -10,6 +10,7 @@ from pathlib import Path
 import duckdb
 import pytest
 
+from _project.scripts.explorer_pipeline import pipeline as pipeline_module
 from _project.scripts.explorer_pipeline.pipeline import (
     COMMUNITY_TRUST_LABEL,
     SUBMISSION_MANIFEST_FILENAME,
@@ -739,3 +740,47 @@ class TestExplorerPipelineRun:
                 assert resolved == result_id, (
                     f"short_id {short_id!r} in benchmark_rankings must resolve to {result_id!r}"
                 )
+
+
+# ---------------------------------------------------------------------------
+# Staged-output publication guards (PR #1483 review follow-ups)
+# ---------------------------------------------------------------------------
+
+
+class TestStagedOutputGuards:
+    def test_symlinked_bundles_destination_is_rejected(self, data_dir: Path, tmp_path: Path) -> None:
+        """A symlinked `bundles/` must not be published into.
+
+        `mkdir(exist_ok=True)` accepts a symlink to a directory, so without an
+        explicit check every copy and the post-promotion stale sweep would
+        follow the link and delete unrelated `*.json` in the target.
+        """
+        output = tmp_path / "out"
+        output.mkdir()
+        unrelated = tmp_path / "unrelated"
+        unrelated.mkdir()
+        bystander = unrelated / "keep-me.json"
+        bystander.write_text('{"keep": true}', encoding="utf-8")
+        (output / "bundles").symlink_to(unrelated, target_is_directory=True)
+
+        with pytest.raises(ValueError, match="must be a real directory"):
+            ExplorerPipeline().run(data_dir, output)
+
+        assert bystander.exists(), "A build must never sweep files inside a symlink target"
+
+    def test_staging_dir_is_removed_when_a_pre_build_step_fails(
+        self, data_dir: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """An uncaught error before the DB build must not strand the staging tree."""
+        output = tmp_path / "out"
+
+        def _boom(*_args: object, **_kwargs: object) -> None:
+            raise OSError("input vanished mid-build")
+
+        monkeypatch.setattr(pipeline_module, "_build_short_ids", _boom)
+
+        with pytest.raises(OSError, match="input vanished"):
+            ExplorerPipeline().run(data_dir, output)
+
+        leftovers = [p.name for p in output.parent.iterdir() if p.name.startswith(f".{output.name}.")]
+        assert leftovers == [], f"Staging directory leaked after a pre-build failure: {leftovers}"

--- a/tests/unit/workflows/test_pr_workflow_path_classifier.py
+++ b/tests/unit/workflows/test_pr_workflow_path_classifier.py
@@ -300,11 +300,22 @@ def test_explorer_vitest_job_declares_clean_runner_python_and_uv_setup() -> None
     assert install_python["run"] == "uv sync --group dev"
 
     npm_install_index = next(i for i, step in enumerate(steps) if step.get("name") == "Install explorer dependencies")
-    assert all(
-        i < npm_install_index
+    vitest_index = next(i for i, step in enumerate(steps) if step.get("name") == "Run Explorer Vitest suite")
+    prerequisite_indexes = [
+        i
         for i, step in enumerate(steps)
         if step.get("name") in {"Set up Python", "Install uv", "Install Python dependencies"}
-    )
+    ]
+    assert len(prerequisite_indexes) == 3
+
+    # Anchor the ordering to the Vitest step, not just to `npm ci`. Specs such as
+    # db-remediation-pin.test.ts and tuningModeVocabulary.test.ts spawn `uv`, so
+    # moving the suite ahead of the Python/uv setup group breaks a clean runner
+    # even while `npm ci` still trails it - which the npm-only guard below, and
+    # the exact-command test above, would both still wave through.
+    assert all(i < vitest_index for i in prerequisite_indexes)
+    assert all(i < npm_install_index for i in prerequisite_indexes)
+    assert npm_install_index < vitest_index
     assert all("continue-on-error" not in step for step in steps)
 
 


### PR DESCRIPTION
Sweep of unresolved `chatgpt-codex-connector` review threads left open on recently merged PRs. Scanned the last 30 merged PRs (#1446-#1493) and found 9 unresolved threads; this PR actions the 7 that are fixable in code.

## Explorer build pipeline (#1483)

- **P1 — reject a symlinked `bundles/` publication target.** `mkdir(exist_ok=True)` accepts a symlink that resolves to a directory, so every copy *and* the post-promotion stale sweep would follow the link, overwriting matching files and unlinking unrelated `*.json` outside `output_dir`.
- **P2 — widen the staging cleanup guard.** The `finally` began at the DB build, but the staging directory is created and populated well before that. An uncaught I/O error during bundle processing stranded a hidden `.out.*` tree beside the output, accumulating across retries.
- **P2 — keep post-promotion legacy cleanup best-effort.** Only `FileNotFoundError` was caught. Because `results.duckdb` is already replaced at that point, a stubborn legacy path turned a successful publish into a reported failure and an ambiguous retry.

## Results explorer (#1482, #1485)

- **P2 — canonicalize phase in `facetsToWhereClause`.** The in-memory matcher folds a null/blank `test_type` into `unknown` and lowercases, but the SQL side emitted a raw `test_type IN (?)`. Selecting the exposed `unknown` cohort therefore matched no null-phase row (empty leaderboard), and a `POWER`/`power` casing difference dropped rows the matcher accepts.
- **P2 — normalize phases in Compare's post-load guard.** It compared raw `test_type`, so results the cohort builder admitted under one canonical phase were flagged as a severe mismatch, suppressing winner/ranking claims.
- **P2 — keep the Home tuning selector removable.** Selecting a tuning option reloads `results` with that predicate applied, collapsing the summary to one bucket and replacing the selector with the "unavailable" message — leaving no control to return to "All tuning labels".

## CI guard (#1489)

- **P2 — anchor the prerequisite ordering assertion to the Vitest step.** It only compared the Python/uv setup steps against `Install explorer dependencies`. Moving the suite ahead of both groups while `npm ci` trailed them kept this guard *and* the exact-command test green while breaking a clean runner, since specs such as `db-remediation-pin.test.ts` spawn `uv`.

## Not actioned here

- **#1446** (uppercase bundle extensions) was already fixed by #1449, which switched the workflow to `:(icase,glob)` pathspecs and `grep -vi`. Thread resolved, no code change.
- **#1484** (re-author a commit recorded as `Codex <codex@openai.com>`) cannot be actioned in a follow-up PR — the commit is already merged, and re-authoring it would require rewriting published history. Flagged for a maintainer decision.

## Verification

- `uv run -- python -m pytest tests/unit/ -x -q` — 26410 passed, 24 skipped
- `npm test -- --run` (results-explorer) — 862 passed across 70 files
- `npm run typecheck` — clean
- `timing_policy_check.py --strict` — 0 violations, fast lane 26554/27050

New regression tests cover the symlink rejection, the staging-dir cleanup on a pre-build failure, and both phase-canonicalization paths. Both new pipeline tests were confirmed to fail without the fix. Two existing tests that pinned the previous raw `test_type IN (?)` SQL shape were updated.