### PR TITLE
fix(results-explorer): align Home skeleton headline with loaded hero

### DIFF
--- a/results-explorer/src/pages/Home.tsx
+++ b/results-explorer/src/pages/Home.tsx
@@ -595,7 +595,7 @@ function HomeLoadingSkeleton() {
       <section class="surface-hero border-b border-[var(--bb-border-default)]">
         <div class="mx-auto max-w-7xl px-4 py-7 sm:px-6 lg:px-8">
           <div class="max-w-4xl">
-            <h1 class="text-3xl font-bold sm:text-4xl">BenchBox Database Leaderboards</h1>
+            <h1 class="text-3xl font-bold sm:text-4xl">BenchBox Curated Results Preview</h1>
             <p class="mt-3 max-w-3xl text-base text-[var(--bb-fg-muted)] sm:text-lg">
               Reproducible OLAP benchmark rankings, with public corpus browse below.
             </p>

--- a/results-explorer/src/pages/__tests__/Home.test.tsx
+++ b/results-explorer/src/pages/__tests__/Home.test.tsx
@@ -387,7 +387,11 @@ describe("Home", () => {
 
     await waitFor(() => expect(resultCalls).toBe(1));
     await waitFor(() => expect(screen.getByText("Initializing static DuckDB snapshot...")).toBeTruthy());
-    expect(screen.getByRole("heading", { level: 1, name: "BenchBox Database Leaderboards" })).toBeTruthy();
+    // The skeleton and the loaded hero deliberately share one headline, so this
+    // assertion is time-invariant. Loading state is still pinned by the
+    // snapshot-init text above, the aria-busy region below, and the absence of
+    // "Recent Results" - none of which survive into the loaded page.
+    expect(screen.getByRole("heading", { level: 1, name: "BenchBox Curated Results Preview" })).toBeTruthy();
     expect(screen.getByRole("region", { name: "Cross-benchmark leaderboard loading" })).toHaveAttribute(
       "aria-busy",
       "true",


### PR DESCRIPTION
## Problem

PR #1482 renamed the loaded Home `h1` to `BenchBox Curated Results Preview`
(`Home.tsx:352`) but left `HomeLoadingSkeleton`'s `h1` as
`BenchBox Database Leaderboards` (`Home.tsx:598`, reached from the early return
at `:257`). The retired string therefore existed **only in the loading
skeleton**.

That made every e2e heading assertion timing-dependent:

- asserting before the data wait matched the skeleton and passed;
- asserting after the data wait failed deterministically.

Proven locally against `develop@3af42e29b` with a three-case Playwright probe:

| Probe | Result |
|---|---|
| assert retired heading **before** data load | passed in 152 ms |
| same assertion **after** data load | **failed** |
| assert `Curated Results Preview` after data load | passed |

This is the root cause behind the red Chromium lane
(`responsive.spec.ts:51`, which waits for data first and so fails outright)
and behind `home.spec.ts` being a false-green `@smoke` test that has never
asserted anything about the loaded Home page.

## Change

Set the skeleton headline to the canonical loaded copy so the `h1` is stable
across loading and loaded states, and update the Vitest loading-state
assertion that pinned the retired string.

The loading-state test still discriminates loading from loaded via the
snapshot-init text, the `aria-busy` region, and the absence of `Recent
Results` — none of which survive into the loaded page.

## Verification

| Rung | Result |
|---|---|
| Skeleton and loaded hero share one canonical headline | pass |
| Retired headline absent from `Home.tsx` | pass |
| Home Vitest suite | pass |

Both source rungs were confirmed to **fail** on the unfixed tree before the
change, so the ladder discriminates rather than passing vacuously.

Additionally: full Vitest suite **70 files / 860 tests pass**, `tsc --noEmit`
clean, `todo check-scope` OK (2 files).

## Follow-ups recorded (not in this PR)

Deliberately kept out of scope to hold this PR to the tracked headline unit:

- `explorer-pr246-capture-headline-refresh-20260803` —
  `e2e/captures/pr246-home-remediation.spec.ts` still pins the retired string.
  It is opt-in behind `PR246_HOME_CAPTURE=1` so CI is unaffected, but it was
  orphaned by every existing item.
- `explorer-home-skeleton-subtitle-parity-20260803` — the skeleton subtitle
  still diverges from the loaded subtitle, leaving the same class of trap one
  level down.

This PR does **not** fix the desktop/wide above-the-fold regression that this
change makes visible; that is tracked separately in
`explorer-home-abovefold-desktop-wide-20260803-v2`.

Refs: `explorer-home-skeleton-h1-parity-20260803-v2`
