### PR TITLE
fix/explorer home smoke loaded assertions 20260803

### DIFF
--- a/results-explorer/e2e/routes/home.spec.ts
+++ b/results-explorer/e2e/routes/home.spec.ts
@@ -6,11 +6,16 @@ test.describe("Home", () => {
     await page.goto("/results/");
     await waitForShell(page);
 
-    await expect(page.getByRole("heading", { name: "BenchBox Database Leaderboards" })).toBeVisible();
-
     // Recent Results table header - a stable landmark that only renders
     // once the DuckDB snapshot has attached and listResults() resolves.
     await waitForDataLoaded(page, /Recent Results/i);
+
+    // Assert the headline only AFTER the data wait. The loading skeleton and
+    // the loaded hero deliberately share one headline, so asserting before the
+    // wait would resolve against the skeleton and prove nothing about the
+    // loaded page - which is exactly how this test passed while never once
+    // exercising loaded Home content.
+    await expect(page.getByRole("heading", { name: "BenchBox Curated Results Preview" })).toBeVisible();
 
     const summary = page.getByRole("region", { name: "Corpus summary" });
     // Corpus Summary labels are count-aware: when the fixture corpus has

--- a/results-explorer/src/pages/Home.tsx
+++ b/results-explorer/src/pages/Home.tsx
@@ -595,7 +595,7 @@ function HomeLoadingSkeleton() {
       <section class="surface-hero border-b border-[var(--bb-border-default)]">
         <div class="mx-auto max-w-7xl px-4 py-7 sm:px-6 lg:px-8">
           <div class="max-w-4xl">
-            <h1 class="text-3xl font-bold sm:text-4xl">BenchBox Database Leaderboards</h1>
+            <h1 class="text-3xl font-bold sm:text-4xl">BenchBox Curated Results Preview</h1>
             <p class="mt-3 max-w-3xl text-base text-[var(--bb-fg-muted)] sm:text-lg">
               Reproducible OLAP benchmark rankings, with public corpus browse below.
             </p>

--- a/results-explorer/src/pages/__tests__/Home.test.tsx
+++ b/results-explorer/src/pages/__tests__/Home.test.tsx
@@ -387,7 +387,11 @@ describe("Home", () => {
 
     await waitFor(() => expect(resultCalls).toBe(1));
     await waitFor(() => expect(screen.getByText("Initializing static DuckDB snapshot...")).toBeTruthy());
-    expect(screen.getByRole("heading", { level: 1, name: "BenchBox Database Leaderboards" })).toBeTruthy();
+    // The skeleton and the loaded hero deliberately share one headline, so this
+    // assertion is time-invariant. Loading state is still pinned by the
+    // snapshot-init text above, the aria-busy region below, and the absence of
+    // "Recent Results" - none of which survive into the loaded page.
+    expect(screen.getByRole("heading", { level: 1, name: "BenchBox Curated Results Preview" })).toBeTruthy();
     expect(screen.getByRole("region", { name: "Cross-benchmark leaderboard loading" })).toHaveAttribute(
       "aria-busy",
       "true",


### PR DESCRIPTION
> **Stacked on #1496.** This branch contains #1496's commit until that PR
> merges; review only `00788904c`. The two are intentionally coupled — see
> "Why this must land with #1496" below.

## Problem

`e2e/routes/home.spec.ts` asserted its headline on line 9, four lines **before**
the data wait on line 13. Because the retired headline existed only in
`HomeLoadingSkeleton`, that assertion resolved against the **loading state**.

This `@smoke` test — one of the tests gating the Firefox and WebKit lanes —
has therefore never once exercised loaded Home content.

A three-case Playwright probe on `develop@3af42e29b` isolated it:

| Probe | Result |
|---|---|
| assert retired heading **before** data load | passed in 152 ms |
| same assertion **after** data load | **failed** |
| assert `Curated Results Preview` after data load | passed |

## Why this must land with #1496

#1496 removes the retired string from the skeleton, which is correct — but it
also collapses this false-green into an honest failure. Verified locally on
#1496's branch alone:

```
✘ [firefox] home.spec.ts:5 @smoke ...
  Locator: getByRole('heading', { name: 'BenchBox Database Leaderboards' })
```

So #1496 on its own turns Firefox and WebKit red. This PR restores them. They
should land together or back to back.

## Change

Move the headline assertion after `waitForDataLoaded` and switch it to the
canonical copy, so the `Recent Results` landmark — which only renders once the
DuckDB snapshot has attached and `listResults()` resolves — gates every content
assertion.

Audited the file's other two tests (`w0`): both already call
`waitForDataLoaded` first, so no other assertion was skeleton-ambiguous.

## Verification

| Rung | Result |
|---|---|
| Data wait precedes the first heading assertion | pass |
| Home route spec on Chromium against a fresh build | pass |
| Home smoke on WebKit | pass |

Rung 1 is an ordering guard, not a string grep: it fails if any heading
assertion precedes the first `await waitForDataLoaded`. It was confirmed to
**fail** on the unfixed spec and **pass** on a correctly ordered one before
being adopted.

Local browser lanes with this fix: **Chromium `home.spec.ts` 3/3**,
**Firefox @smoke 16/16**, **WebKit @smoke 16/16** — all three were red or
false-green beforehand.

Refs: `explorer-home-smoke-loaded-assertions-20260803-v2`
