### PR TITLE
fix(ci): validate paired bundle on plans/tuning companion-only PRs

### DIFF
--- a/.github/workflows/validate-submission.yml
+++ b/.github/workflows/validate-submission.yml
@@ -177,6 +177,44 @@ jobs:
             done <<< "$CHANGED_APPLIED"
           fi
 
+          # Detect changed plans/tuning companions separately. These two
+          # suffixes are filtered out of CHANGED above, so without this block a
+          # companion-only PR leaves CHANGED empty and skips bundle validation,
+          # public path scanning, companion hash validation, and corpus
+          # inventory validation. That is the opposite of what is wanted: the
+          # public privacy scanner in scripts/validate_submission.py explicitly
+          # targets .plans.json and .tuning.json, so those are exactly the files
+          # that must not reach a public branch unscanned. Derive the paired
+          # primary bundle so the existing validation step covers them, matching
+          # the manifest and applied handling above. Include deletions (D): a
+          # removed companion is still a contract change while its bundle
+          # exists.
+          CHANGED_COMPANIONS=$(git diff --no-renames --name-only --diff-filter=ACMRD \
+            ${{ github.event.pull_request.base.sha }}...HEAD -- \
+            ':(icase,glob)results-data/bundles/*.json' ':(icase,glob)results-data/bundles/**/*.json' \
+            | grep -iE '\.(plans|tuning)\.json$' \
+            || true)
+          if [ -n "$CHANGED_COMPANIONS" ]; then
+            while IFS= read -r companion; do
+              # Suffix length varies, so pick it from the lowercased name to stay
+              # case-insensitive the way bundle discovery is.
+              lower=$(printf '%s' "$companion" | tr '[:upper:]' '[:lower:]')
+              case "$lower" in
+                *.plans.json) strip=11 ;;
+                *.tuning.json) strip=12 ;;
+                *) continue ;;
+              esac
+              stem="${companion:0:$(( ${#companion} - strip ))}"
+              bundle=$(git ls-tree -r --name-only HEAD -- results-data/bundles \
+                | awk -v stem="$stem" 'substr($0, 1, length($0) - 5) == stem && tolower(substr($0, length($0) - 4)) == ".json" { print; exit }')
+              # Only add if the paired bundle exists and is not already in CHANGED.
+              if git cat-file -e "HEAD:${bundle}" 2>/dev/null \
+                  && ! printf '%s\n' "$CHANGED" | grep -qxF "$bundle"; then
+                CHANGED="${CHANGED:+${CHANGED}$'\n'}${bundle}"
+              fi
+            done <<< "$CHANGED_COMPANIONS"
+          fi
+
           if [ -z "$CHANGED" ]; then
             echo "No bundle files changed."
             echo "has_bundles=false" >> "$GITHUB_OUTPUT"

--- a/tests/unit/workflows/test_validate_submission_changed_bundles.py
+++ b/tests/unit/workflows/test_validate_submission_changed_bundles.py
@@ -194,3 +194,46 @@ def test_companion_pairing_preserves_stem_case(tmp_path: Path) -> None:
 
     assert result.returncode == 0, result.stderr
     assert result.stdout.strip().splitlines() == ["results-data/bundles/foo.json"]
+
+
+@pytest.mark.parametrize("companion_suffix", [".plans.json", ".tuning.json"])
+def test_plans_or_tuning_only_change_discovers_paired_primary_bundle(tmp_path: Path, companion_suffix: str) -> None:
+    """A plans- or tuning-only edit must still invoke primary-bundle validation.
+
+    ``.manifest.json`` and ``.applied.json`` each have an explicit back-mapping
+    block, but ``.plans.json`` and ``.tuning.json`` are filtered out of CHANGED
+    with no equivalent. A companion-only PR would therefore skip bundle
+    validation, public path scanning, companion hash validation, and corpus
+    inventory validation - and the public privacy scanner explicitly targets
+    exactly these two suffixes.
+    """
+    _git(tmp_path, "init", "--quiet")
+    _git(tmp_path, "config", "user.name", "Test")
+    _git(tmp_path, "config", "user.email", "test@example.invalid")
+
+    primary = tmp_path / "results-data" / "bundles" / "result.json"
+    primary.parent.mkdir(parents=True)
+    primary.write_text("{}\n", encoding="utf-8")
+    _git(tmp_path, "add", str(primary.relative_to(tmp_path)))
+    _git(tmp_path, "commit", "--quiet", "-m", "base")
+    base_sha = _git(tmp_path, "rev-parse", "HEAD")
+
+    companion = primary.with_name(f"result{companion_suffix}")
+    companion.write_text('{"note": "companion only"}\n', encoding="utf-8")
+    _git(tmp_path, "add", str(companion.relative_to(tmp_path)))
+    _git(tmp_path, "commit", "--quiet", "-m", "companion only")
+
+    skip_without_posix_shell()
+    env = os.environ.copy()
+    env["BASE_SHA"] = base_sha
+    result = run_posix_shell(
+        _changed_bundle_discovery_script(),
+        cwd=tmp_path,
+        check=False,
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.strip().splitlines() == ["results-data/bundles/result.json"]


### PR DESCRIPTION
## Problem

`validate-submission.yml` filters `.plans.json` and `.tuning.json` out of
`CHANGED`, then sets `has_bundles=false` when no primary bundle changed.

`.manifest.json` and `.applied.json` each have an explicit back-mapping block
that re-adds the paired primary bundle. These two suffixes had none.

A companion-only PR therefore skipped:

- bundle validation
- **public path scanning**
- companion hash validation
- corpus inventory validation

That is the wrong way round: the public privacy scanner in
`scripts/validate_submission.py` explicitly targets `.plans.json` and
`.tuning.json` (`_PUBLIC_COMPANION_SUFFIXES`), so these are precisely the files
that must not reach a public branch unscanned. Commit `ef0df3685` ("anonymize
tuning constraint identifiers") shows tuning companions do carry sensitive
material.

## Reachability

Checked on `develop@3af42e29b`: the corpus currently contains **zero**
`.plans.json` and **zero** `.tuning.json` files, so this hole is **latent and
unexercised**, not actively exploited. It is worth closing before the corpus
starts carrying companions — the Explorer pipeline already emits `.plans.json`
into its published output.

## Change

Adds a `CHANGED_COMPANIONS` block mirroring the existing manifest/applied
handling:

- case-insensitive suffix detection (`grep -iE`, lowercased `case`), matching
  how bundle discovery already behaves;
- per-suffix stem length (`.plans.json` 11, `.tuning.json` 12);
- `--diff-filter=ACMRD` so a companion **deletion** still trips validation
  while its bundle exists;
- only appends when the paired bundle exists at HEAD and is not already in
  `CHANGED`.

## Verification

Test-first. The parametrized test was added and confirmed **failing** before
the workflow change:

```
AssertionError: assert [] == ['results-data/bundles/result.json']
FAILED ...[.plans.json]
FAILED ...[.tuning.json]
```

After the fix:

| Check | Result |
|---|---|
| New plans/tuning cases | 2 passed |
| `test_validate_submission_changed_bundles.py` (manifest/applied unaffected) | 7 passed |
| `tests/unit/workflows/` | 115 passed |
| `tests/unit/scripts/test_validate_submission.py` | 86 passed |
| Workflow YAML parses | ok |
| Fast-lane collect | 26,556 / 27,050 cap, 0 violations |

`todo check-scope`: OK (2 files).

Refs: `submission-validator-plans-tuning-backmap-20260803-v3`
