### PR TITLE
fix/explorer home abovefold desktop wide 20260803

### DIFF
--- a/results-explorer/e2e/responsive.spec.ts
+++ b/results-explorer/e2e/responsive.spec.ts
@@ -56,7 +56,7 @@ test.describe("responsive explorer assertions", () => {
       await waitForDataLoaded(page, /Recent Results/i);
 
       await expectTopWithin(
-        page.getByRole("heading", { name: "BenchBox Database Leaderboards" }),
+        page.getByRole("heading", { name: "BenchBox Curated Results Preview" }),
         viewport.maxY,
         "home headline",
       );

--- a/results-explorer/e2e/routes/home.spec.ts
+++ b/results-explorer/e2e/routes/home.spec.ts
@@ -6,11 +6,16 @@ test.describe("Home", () => {
     await page.goto("/results/");
     await waitForShell(page);
 
-    await expect(page.getByRole("heading", { name: "BenchBox Database Leaderboards" })).toBeVisible();
-
     // Recent Results table header - a stable landmark that only renders
     // once the DuckDB snapshot has attached and listResults() resolves.
     await waitForDataLoaded(page, /Recent Results/i);
+
+    // Assert the headline only AFTER the data wait. The loading skeleton and
+    // the loaded hero deliberately share one headline, so asserting before the
+    // wait would resolve against the skeleton and prove nothing about the
+    // loaded page - which is exactly how this test passed while never once
+    // exercising loaded Home content.
+    await expect(page.getByRole("heading", { name: "BenchBox Curated Results Preview" })).toBeVisible();
 
     const summary = page.getByRole("region", { name: "Corpus summary" });
     // Corpus Summary labels are count-aware: when the fixture corpus has

--- a/results-explorer/src/pages/Home.tsx
+++ b/results-explorer/src/pages/Home.tsx
@@ -347,7 +347,11 @@ export function Home(_: RoutableProps) {
         data-testid="home-hero-filter-band"
         data-surface="hero"
       >
-        <div class="mx-auto max-w-7xl px-4 py-4 sm:px-6 sm:py-7 lg:px-8">
+        {/* lg:py-4 trims hero vertical cost at desktop and wide only. Those two
+            viewports budget the fold at 900px, and the taller hero pushed the
+            second leaderboard row past it (see responsive.spec.ts). Tablet and
+            mobile keep the roomier padding; their fold budget is 1200px. */}
+        <div class="mx-auto max-w-7xl px-4 py-4 sm:px-6 sm:py-7 lg:px-8 lg:py-4">
           <div class="max-w-4xl">
             <h1 class="text-2xl font-bold sm:text-4xl">BenchBox Curated Results Preview</h1>
             <p class="mt-2 max-w-3xl text-sm text-[var(--bb-fg-muted)] sm:mt-3 sm:text-lg">

--- a/results-explorer/src/pages/Home.tsx
+++ b/results-explorer/src/pages/Home.tsx
@@ -597,7 +597,10 @@ function HomeLoadingSkeleton() {
   return (
     <div>
       <section class="surface-hero border-b border-[var(--bb-border-default)]">
-        <div class="mx-auto max-w-7xl px-4 py-7 sm:px-6 lg:px-8">
+        {/* Mirrors the loaded hero's lg:py-4 exactly. If these diverge the hero
+            visibly jumps when data arrives, which is the same skeleton-vs-loaded
+            drift that made heading assertions timing-dependent. */}
+        <div class="mx-auto max-w-7xl px-4 py-7 sm:px-6 lg:px-8 lg:py-4">
           <div class="max-w-4xl">
             <h1 class="text-3xl font-bold sm:text-4xl">BenchBox Curated Results Preview</h1>
             <p class="mt-3 max-w-3xl text-base text-[var(--bb-fg-muted)] sm:text-lg">

--- a/results-explorer/src/pages/Home.tsx
+++ b/results-explorer/src/pages/Home.tsx
@@ -595,7 +595,7 @@ function HomeLoadingSkeleton() {
       <section class="surface-hero border-b border-[var(--bb-border-default)]">
         <div class="mx-auto max-w-7xl px-4 py-7 sm:px-6 lg:px-8">
           <div class="max-w-4xl">
-            <h1 class="text-3xl font-bold sm:text-4xl">BenchBox Database Leaderboards</h1>
+            <h1 class="text-3xl font-bold sm:text-4xl">BenchBox Curated Results Preview</h1>
             <p class="mt-3 max-w-3xl text-base text-[var(--bb-fg-muted)] sm:text-lg">
               Reproducible OLAP benchmark rankings, with public corpus browse below.
             </p>

--- a/results-explorer/src/pages/__tests__/Home.test.tsx
+++ b/results-explorer/src/pages/__tests__/Home.test.tsx
@@ -387,7 +387,11 @@ describe("Home", () => {
 
     await waitFor(() => expect(resultCalls).toBe(1));
     await waitFor(() => expect(screen.getByText("Initializing static DuckDB snapshot...")).toBeTruthy());
-    expect(screen.getByRole("heading", { level: 1, name: "BenchBox Database Leaderboards" })).toBeTruthy();
+    // The skeleton and the loaded hero deliberately share one headline, so this
+    // assertion is time-invariant. Loading state is still pinned by the
+    // snapshot-init text above, the aria-busy region below, and the absence of
+    // "Recent Results" - none of which survive into the loaded page.
+    expect(screen.getByRole("heading", { level: 1, name: "BenchBox Curated Results Preview" })).toBeTruthy();
     expect(screen.getByRole("region", { name: "Cross-benchmark leaderboard loading" })).toHaveAttribute(
       "aria-busy",
       "true",


### PR DESCRIPTION
> **Stacked on #1496 and #1497.** Review only `4ed0c4440`.

## Problem — a regression that was invisible

`responsive.spec.ts` sets `test.describe.configure({ mode: "serial" })`, so the
first failure aborts the block. On `develop@3af42e29b` the stale-headline
failure suppressed **23 downstream tests**, reported only as
`1 failed ... 23 did not run`.

Behind that mask sat a genuine regression: at **desktop and wide**, only one
leaderboard row cleared the fold against a budget of two. Mobile and tablet
pass.

Measured in-browser at 1280x900:

| | before |
|---|---|
| grid top | 792 |
| row height | 61 |
| row tops | 842, **903**, 964 |
| fold | 900 |

Row 2 missed by **4px**. The cause is the taller hero from #1482, which added
`ActiveLeaderboardSummary` above the rows.

## Change

`lg:py-4` on the hero container, so the trim lands only at desktop and wide
(>=1024px) where the fold budget is 900px. Tablet and mobile keep `sm:py-7`
and their roomier 1200px budget.

| | after |
|---|---|
| row tops | 818, **879**, 940 |
| headroom on row 2 | **21px** |

21px of margin rather than a 4px squeak, so ordinary content drift will not
silently re-break it.

**The budget constant is unchanged at 2.** The layout was fixed, not the
assertion weakened — rung 2 is an explicit guard against exactly that.

Also retargets the spec's headline assertion to the canonical copy: the retired
string no longer exists anywhere after #1496.

## Verification

| Rung | Result |
|---|---|
| Home viewport test at every viewport incl. desktop and wide | pass |
| Desktop above-fold budget not silently lowered | pass |
| Full responsive spec, no silently skipped tests | pass |

Full responsive spec: **25 passed**, zero failures, zero did-not-run
(previously 1 failed with 23 suppressed).

Regression: full Vitest **70 files / 860 tests pass**, `tsc --noEmit` clean,
`todo check-scope` OK.

## Scope note

This item's scope was amended via `todo scope-update` to include
`responsive.spec.ts`. The two items were mutually unverifiable: this item's
rungs run that spec, but the stale assertion aborted the block before the
layout could be checked, while the item owning the spec
(`results-explorer-responsive-headline-contract-20260802`) had a rung requiring
all responsive tests to pass — impossible without this layout fix. Granting
this item the spec file breaks the deadlock; that sibling item is currently
blocked and is now largely redundant.

Refs: `explorer-home-abovefold-desktop-wide-20260803-v2`
