### PR TITLE
fix/explorer e2e serial mask removal 20260803

### DIFF
--- a/results-explorer/e2e/responsive.spec.ts
+++ b/results-explorer/e2e/responsive.spec.ts
@@ -32,7 +32,14 @@ const AUDITED_ROUTES = [
   { path: "/results/query", ready: /matching result bundle/ },
 ] as const;
 
-test.describe.configure({ mode: "serial" });
+// Deliberately NOT serial. Every test here takes its own `page` fixture and
+// shares no state, so serial mode bought nothing - but it made the first
+// failure abort the whole block. On develop@3af42e29b a single stale-headline
+// assertion suppressed 23 downstream tests, reported only as
+// "1 failed ... 23 did not run", and it hid a real desktop/wide above-the-fold
+// regression for the entire time it was red. Independent viewport assertions
+// must fail independently.
+test.describe.configure({ mode: "parallel" });
 
 test.describe("responsive explorer assertions", () => {
   for (const viewport of VIEWPORTS) {

--- a/results-explorer/e2e/responsive.spec.ts
+++ b/results-explorer/e2e/responsive.spec.ts
@@ -56,7 +56,7 @@ test.describe("responsive explorer assertions", () => {
       await waitForDataLoaded(page, /Recent Results/i);
 
       await expectTopWithin(
-        page.getByRole("heading", { name: "BenchBox Database Leaderboards" }),
+        page.getByRole("heading", { name: "BenchBox Curated Results Preview" }),
         viewport.maxY,
         "home headline",
       );

--- a/results-explorer/e2e/routes/home.spec.ts
+++ b/results-explorer/e2e/routes/home.spec.ts
@@ -6,11 +6,16 @@ test.describe("Home", () => {
     await page.goto("/results/");
     await waitForShell(page);
 
-    await expect(page.getByRole("heading", { name: "BenchBox Database Leaderboards" })).toBeVisible();
-
     // Recent Results table header - a stable landmark that only renders
     // once the DuckDB snapshot has attached and listResults() resolves.
     await waitForDataLoaded(page, /Recent Results/i);
+
+    // Assert the headline only AFTER the data wait. The loading skeleton and
+    // the loaded hero deliberately share one headline, so asserting before the
+    // wait would resolve against the skeleton and prove nothing about the
+    // loaded page - which is exactly how this test passed while never once
+    // exercising loaded Home content.
+    await expect(page.getByRole("heading", { name: "BenchBox Curated Results Preview" })).toBeVisible();
 
     const summary = page.getByRole("region", { name: "Corpus summary" });
     // Corpus Summary labels are count-aware: when the fixture corpus has

--- a/results-explorer/src/pages/Home.tsx
+++ b/results-explorer/src/pages/Home.tsx
@@ -347,7 +347,11 @@ export function Home(_: RoutableProps) {
         data-testid="home-hero-filter-band"
         data-surface="hero"
       >
-        <div class="mx-auto max-w-7xl px-4 py-4 sm:px-6 sm:py-7 lg:px-8">
+        {/* lg:py-4 trims hero vertical cost at desktop and wide only. Those two
+            viewports budget the fold at 900px, and the taller hero pushed the
+            second leaderboard row past it (see responsive.spec.ts). Tablet and
+            mobile keep the roomier padding; their fold budget is 1200px. */}
+        <div class="mx-auto max-w-7xl px-4 py-4 sm:px-6 sm:py-7 lg:px-8 lg:py-4">
           <div class="max-w-4xl">
             <h1 class="text-2xl font-bold sm:text-4xl">BenchBox Curated Results Preview</h1>
             <p class="mt-2 max-w-3xl text-sm text-[var(--bb-fg-muted)] sm:mt-3 sm:text-lg">

--- a/results-explorer/src/pages/Home.tsx
+++ b/results-explorer/src/pages/Home.tsx
@@ -595,7 +595,7 @@ function HomeLoadingSkeleton() {
       <section class="surface-hero border-b border-[var(--bb-border-default)]">
         <div class="mx-auto max-w-7xl px-4 py-7 sm:px-6 lg:px-8">
           <div class="max-w-4xl">
-            <h1 class="text-3xl font-bold sm:text-4xl">BenchBox Database Leaderboards</h1>
+            <h1 class="text-3xl font-bold sm:text-4xl">BenchBox Curated Results Preview</h1>
             <p class="mt-3 max-w-3xl text-base text-[var(--bb-fg-muted)] sm:text-lg">
               Reproducible OLAP benchmark rankings, with public corpus browse below.
             </p>

--- a/results-explorer/src/pages/__tests__/Home.test.tsx
+++ b/results-explorer/src/pages/__tests__/Home.test.tsx
@@ -387,7 +387,11 @@ describe("Home", () => {
 
     await waitFor(() => expect(resultCalls).toBe(1));
     await waitFor(() => expect(screen.getByText("Initializing static DuckDB snapshot...")).toBeTruthy());
-    expect(screen.getByRole("heading", { level: 1, name: "BenchBox Database Leaderboards" })).toBeTruthy();
+    // The skeleton and the loaded hero deliberately share one headline, so this
+    // assertion is time-invariant. Loading state is still pinned by the
+    // snapshot-init text above, the aria-busy region below, and the absence of
+    // "Recent Results" - none of which survive into the loaded page.
+    expect(screen.getByRole("heading", { level: 1, name: "BenchBox Curated Results Preview" })).toBeTruthy();
     expect(screen.getByRole("region", { name: "Cross-benchmark leaderboard loading" })).toHaveAttribute(
       "aria-busy",
       "true",


### PR DESCRIPTION
> **Stacked on #1496, #1497, #1499.** Review only `d75d30f0a`.

## Problem

`responsive.spec.ts` ran its block in `mode: "serial"`, so the first failure
aborted every remaining test. On `develop@3af42e29b` a single stale-headline
assertion suppressed **23 downstream tests**, surfaced only as:

```
1 failed
23 did not run
```

That is not a loud failure — it reads like one small problem. In fact it
concealed a genuine desktop/wide above-the-fold regression (fixed in #1499)
for as long as the lane stayed red. A masking mechanism that hides real
regressions behind an unrelated failure is worse than the failure itself.

## Why parallel is safe here

The block shares no state:

- no `beforeAll`, no `beforeEach`
- no module-level mutable state
- every test takes its own `page` fixture and sets its own viewport

Serial mode bought nothing and only propagated aborts.

## Verification — behavioural, not just green

Rungs pass, but a green run does not prove the mask is gone. So the mask was
tested directly: a deliberate failure was injected into the first viewport
test.

| | serial (before) | parallel (after) |
|---|---|---|
| injected failures | — | 4 failed |
| downstream tests | suppressed | **21 passed** |
| did-not-run | 23 | **0** |

Independent viewport assertions now fail independently. The probe was
reverted; only the mode change and its explanatory comment remain.

| Rung | Result |
|---|---|
| Blanket serial mode gone from the responsive block | pass |
| Every responsive test executes and passes | pass |

`todo check-scope`: OK (1 file).

Refs: `explorer-e2e-serial-mask-removal-20260803-v2`
