### PR TITLE
test(results): gate corpus path privacy across the whole corpus

### DIFF
--- a/docs/operations/results-phase-2-runbook.md
+++ b/docs/operations/results-phase-2-runbook.md
@@ -96,6 +96,35 @@ git commit -m "chore: refresh corpus inventory"
 
 If you are fixing the contributor branch yourself, explain that in the PR before pushing.
 
+## 4b. Corpus Path Privacy
+
+Every JSON file under `results-data/` must be free of private absolute paths.
+`tests/unit/scripts/test_corpus_privacy_invariant.py` scans the whole corpus on
+every code CI run, not just the files a PR touched. #1467 cleaned the corpus;
+this gate is what stops it regressing. A changed-files scan cannot do that job:
+a bundle merged before the scan existed is invisible to it permanently.
+
+The gate is marked `fast`, so it runs inside `code-test`, which
+`ci-required-result` gates on. A corpus-only diff still routes to `code-test`;
+the same test file pins both facts so the gate cannot become decorative.
+
+To re-migrate after importing legacy bundles:
+
+```bash
+uv run -- python _project/scripts/results_explorer_corpus_migrate.py
+```
+
+Dry run by default; add `--write` to apply. It reuses the canonical
+`AnonymizationManager` and preserves values that are already public hashes, so
+re-running it on the current corpus is a verified no-op (207 unchanged). It
+writes an audit trail to
+`results-data/bundles/path-privacy-migration.manifest.json` recording old/new
+hashes and result IDs — never a private value.
+
+Migrating rewrites `result_id` for every changed bundle. The Explorer derives
+result IDs from the *published* bytes, so regenerate the inventory afterwards
+(§4) and expect detail URLs to move.
+
 ## 5. Rolling Back a Bad Merge
 
 Use a fresh branch off the affected target branch. Set `REMOTE` to the repo you are

--- a/tests/unit/scripts/test_corpus_privacy_invariant.py
+++ b/tests/unit/scripts/test_corpus_privacy_invariant.py
@@ -1,0 +1,118 @@
+"""Whole-corpus privacy invariant for the curated results corpus.
+
+The submission workflow only scans the files a PR touched, so a bundle that
+was already committed with a private path stays invisible to it forever. This
+module closes that hole: it walks *every* JSON file under ``results-data/``
+on every run, using the same canonical detector that guards the submission
+boundary and the Explorer publication boundary.
+
+Fail-closed is deliberate. A file that cannot be read or parsed is reported as
+a failure rather than skipped, because "unparseable" is exactly the state an
+unreviewed or truncated bundle would be in, and skipping it would let the
+corpus regress while the gate stayed green.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from benchbox.core.results.anonymization import find_public_path_leaks
+
+pytestmark = [
+    pytest.mark.unit,
+    pytest.mark.fast,
+]
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+RESULTS_DATA = REPO_ROOT / "results-data"
+
+
+def _corpus_json_files() -> list[Path]:
+    """Every JSON file in the corpus - bundles, companions, manifests, inventory."""
+    return sorted(RESULTS_DATA.rglob("*.json"))
+
+
+def test_corpus_directory_is_present() -> None:
+    """Guard against the invariant silently passing on an empty scan.
+
+    Without this, a rename or a partial checkout would make ``rglob`` return
+    nothing and every assertion below would vacuously pass.
+    """
+    assert RESULTS_DATA.is_dir(), f"missing corpus directory: {RESULTS_DATA}"
+    assert _corpus_json_files(), "corpus scan found no JSON files - the invariant would be vacuous"
+
+
+def test_no_corpus_file_exposes_a_private_path() -> None:
+    """Every corpus JSON file is free of private absolute paths.
+
+    Reports the offending *field paths* only. ``find_public_path_leaks`` is
+    value-redacting by design, so a failure message never echoes the home
+    directory or machine-local material it detected.
+    """
+    offenders: list[str] = []
+    unreadable: list[str] = []
+
+    for path in _corpus_json_files():
+        rel = path.relative_to(REPO_ROOT)
+        try:
+            payload = json.loads(path.read_text(encoding="utf-8"))
+        except (OSError, UnicodeDecodeError, json.JSONDecodeError) as exc:
+            # Fail closed: an unreadable file is a gate failure, never a skip.
+            unreadable.append(f"{rel}: {type(exc).__name__}")
+            continue
+        leaks = find_public_path_leaks(payload)
+        if leaks:
+            offenders.append(f"{rel}: {', '.join(sorted(set(leaks))[:5])}")
+
+    assert not unreadable, "corpus files could not be parsed (failing closed):\n" + "\n".join(unreadable)
+    assert not offenders, f"{len(offenders)} corpus file(s) expose private paths:\n" + "\n".join(offenders[:20])
+
+
+def test_corpus_only_change_routes_to_required_code_ci() -> None:
+    """A results-data-only PR must still run the lane this invariant lives in.
+
+    The gate above is marked ``fast``, so it runs inside the ``code-test`` job
+    rather than a bespoke workflow. That is only sufficient while a corpus-only
+    diff actually reaches ``code-test``. If ``results-data/**`` were ever added
+    to the safe-content allowlist, this whole-corpus gate would stop running on
+    exactly the PRs it exists to police, and every one of them would go green.
+    """
+    # scripts/ is importable here via the tests/unit/scripts/ conftest shim.
+    from path_filter_decision import DEFAULT_RULES, classify_paths, load_rules
+
+    rules = load_rules(REPO_ROOT / DEFAULT_RULES)
+    for changed in (
+        ["results-data/bundles/example.json"],
+        ["results-data/bundles/example.manifest.json"],
+        ["results-data/corpus-inventory.json"],
+    ):
+        decision = classify_paths(changed, rules)
+        assert decision["needs_code_ci"] is True, f"{changed[0]} would skip the required code-test lane"
+
+
+def test_code_test_is_gated_by_ci_required_result() -> None:
+    """``code-test`` must remain a dependency of the one required check.
+
+    develop's ruleset requires only ``ci-required-result``. A job that is not
+    in its ``needs`` list cannot block a merge no matter what it reports, so
+    this invariant's required-ness rests entirely on that edge.
+    """
+    import yaml
+
+    workflow = yaml.safe_load((REPO_ROOT / ".github/workflows/pr.yml").read_text(encoding="utf-8"))
+    needs = workflow["jobs"]["ci-required-result"]["needs"]
+    assert "code-test" in needs, "ci-required-result no longer gates on code-test"
+
+
+def test_detector_still_flags_a_planted_leak() -> None:
+    """The invariant above is only meaningful if the detector still fires.
+
+    A clean corpus and a broken detector produce identical output, so pin the
+    detector's behaviour here. Without this, silently neutering
+    ``find_public_path_leaks`` would turn the whole-corpus gate green.
+    """
+    planted = {"metadata": {"working_dir": "/Users/someone/benchbox"}}
+    assert find_public_path_leaks(planted), "detector no longer flags a private home path"


### PR DESCRIPTION
> **Rescoped.** This PR originally also migrated the corpus. [#1467](https://github.com/joeharris76/BenchBox/pull/1467) landed the same migration first, so that work is dropped rather than re-applied. What remains is the part develop still lacks: the gate.

## Problem

#1467 cleaned the corpus. Nothing stops it regressing.

The submission workflow only scans files a PR touches, so a bundle merged before that scan existed is invisible to it permanently, and a re-import of legacy bundles would land unnoticed. A changed-files scan structurally cannot police an already-committed corpus.

## Change

`tests/unit/scripts/test_corpus_privacy_invariant.py` — scans **every** `results-data` JSON file on every code CI run with the canonical `find_public_path_leaks`, so submission validation and the Explorer boundary keep one detector.

It also:

- **fails closed** — an unreadable or unparseable file is a failure, not a skip
- **guards against a vacuous scan** — a rename or partial checkout that returns zero files would otherwise pass silently
- **pins that the detector still fires** on a planted leak, because a clean corpus and a neutered detector produce identical output

## No new workflow job

The gate is marked `fast`, so it runs inside `code-test`, which `ci-required-result` gates on — and a corpus-only diff still routes to `code-test` (verified against the real `.github/path-filters.yml`; the classifier fails closed). A bespoke job would be redundant. **Both facts are pinned by tests in the same file**, so the gate cannot quietly become decorative if the path filters or the required-check graph change.

## Falsification

Restoring one pre-#1467 bundle onto current develop makes it fail, reporting field paths only and never echoing a private value:

```
1 corpus file(s) expose private paths:
  amplab_sf001_datafusion_df_...json: execution.driver_runtime_python_executable,
  platform.config.working_dir, platform.raw_config.working_dir, ...
```

Passes on develop as-is: 0 leaks across all 400 corpus JSON files.