### PR TITLE
ci(explorer): run the browser lane on develop and pin the gate contract

### DIFF
--- a/.github/workflows/results-explorer-browser.yml
+++ b/.github/workflows/results-explorer-browser.yml
@@ -2,7 +2,11 @@ name: Results Explorer browser tests
 
 on:
   push:
-    branches: [ release ]
+    # `develop` is included so the lane runs on the integration branch itself,
+    # not only on PRs into it. Without it a squash-merge could land a
+    # combination no PR ever exercised and develop would stay silently red
+    # until the next explorer PR happened to rebuild.
+    branches: [ release, develop ]
     paths:
       - 'results-explorer/**'
       - '_project/scripts/explorer_pipeline/**'

--- a/tests/unit/workflows/test_results_explorer_browser_gate.py
+++ b/tests/unit/workflows/test_results_explorer_browser_gate.py
@@ -1,0 +1,108 @@
+"""Contract tests for the Results Explorer browser lane wiring.
+
+The browser workflow calls its Chromium job "blocking". That word is only true
+if two separate things hold: the job must actually run on the branches we care
+about, and it must not be `continue-on-error`. Neither is visible from the job
+name, and both have been wrong at some point.
+
+These tests pin the workflow-local half of the contract. Whether Chromium is a
+*required status check* lives in the repository ruleset, which no unit test can
+reach; that half is verified by the tracked item's `gh api` rung.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+import yaml
+
+pytestmark = [pytest.mark.unit, pytest.mark.fast]
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+WORKFLOW_PATH = REPO_ROOT / ".github" / "workflows" / "results-explorer-browser.yml"
+
+CHROMIUM_JOB = "chromium"
+ADVISORY_JOBS = ("firefox-smoke", "webkit-smoke")
+
+
+@pytest.fixture(scope="module")
+def workflow() -> dict[str, Any]:
+    return yaml.safe_load(WORKFLOW_PATH.read_text(encoding="utf-8"))
+
+
+def _triggers(workflow: dict[str, Any]) -> dict[str, Any]:
+    """Return the `on:` block.
+
+    PyYAML resolves an unquoted ``on`` key to the boolean ``True`` (YAML 1.1),
+    so accept either spelling rather than silently reading an empty trigger set
+    and passing.
+    """
+    triggers = workflow.get("on", workflow.get(True))
+    assert triggers is not None, "workflow has no `on:` block"
+    return triggers
+
+
+def test_lane_runs_on_develop_pushes(workflow: dict[str, Any]) -> None:
+    """develop pushes must rebuild the browser lane.
+
+    PRs into develop are not sufficient: a squash merge produces a commit no PR
+    ever ran, so a bad interaction between two independently green PRs would
+    only surface whenever the next explorer PR happened to rebuild.
+    """
+    push_branches = _triggers(workflow)["push"]["branches"]
+    assert "develop" in push_branches, f"browser lane does not run on develop pushes: {push_branches}"
+
+
+def test_lane_still_runs_on_pull_requests_into_develop(workflow: dict[str, Any]) -> None:
+    """The push trigger is an addition, not a replacement for PR coverage."""
+    pr_branches = _triggers(workflow)["pull_request"]["branches"]
+    assert "develop" in pr_branches, f"browser lane no longer runs on develop PRs: {pr_branches}"
+
+
+def test_chromium_job_is_not_continue_on_error(workflow: dict[str, Any]) -> None:
+    """A `continue-on-error` job reports success no matter what it found.
+
+    The Chromium job's name asserts that it blocks. If this ever flips to true
+    the name becomes a lie and every downstream reader - human or ruleset - is
+    misled.
+    """
+    chromium = workflow["jobs"][CHROMIUM_JOB]
+    assert chromium.get("continue-on-error", False) is False, "Chromium job is continue-on-error but claims to block"
+
+
+def test_chromium_job_name_claims_blocking_only_while_it_can_block(workflow: dict[str, Any]) -> None:
+    """Keep the job name and the job's actual semantics in sync."""
+    chromium = workflow["jobs"][CHROMIUM_JOB]
+    if "blocking" in chromium["name"].lower() and "non-blocking" not in chromium["name"].lower():
+        assert chromium.get("continue-on-error", False) is False, (
+            "job name says 'blocking' while continue-on-error suppresses its result"
+        )
+
+
+def test_advisory_browsers_are_not_silently_promoted(workflow: dict[str, Any]) -> None:
+    """Firefox and WebKit graduate individually, by explicit decision.
+
+    They are advisory until each independently clears the graduation criterion
+    in `docs/operations/browser-ci.md`. Making Chromium genuinely blocking must
+    not drag them along as a side effect.
+    """
+    for job_id in ADVISORY_JOBS:
+        job = workflow["jobs"][job_id]
+        assert job.get("continue-on-error") is True, f"{job_id} was promoted to blocking without an explicit decision"
+        assert "non-blocking" in job["name"].lower(), f"{job_id} name no longer marks it advisory"
+
+
+def test_chromium_runs_the_full_suite_entrypoint(workflow: dict[str, Any]) -> None:
+    """The gate must run the deterministic full-suite entrypoint.
+
+    `test:e2e:chromium` regenerates fixtures, rebuilds dist, and runs the
+    failures specs at `--retries=0` in a separate invocation. Swapping it for a
+    bare `playwright test` would quietly drop the cold-load regression guard.
+    """
+    steps = workflow["jobs"][CHROMIUM_JOB]["steps"]
+    run_commands = [step.get("run", "") for step in steps]
+    assert any("test:e2e:chromium" in command for command in run_commands), (
+        "Chromium job no longer runs the npm test:e2e:chromium entrypoint"
+    )


### PR DESCRIPTION
## Problem

Two things were true at once, and neither was visible from the job name:

1. **The browser lane never ran on `develop`.** The push trigger listed only `release`; `develop` appeared only under `pull_request`. A squash merge produces a commit no PR ever exercised, so a bad interaction between two independently green PRs sat undetected until the next explorer PR happened to rebuild.
2. **Nothing checked the wiring.** The job is named `Chromium (full suite, blocking)`, but "blocking" depends on it running, not being `continue-on-error`, and being a required context — none of which any test asserted.

## Change

- Add `develop` to the browser workflow's push trigger.
- Add `tests/unit/workflows/test_results_explorer_browser_gate.py` pinning the workflow-local contract:
  - lane runs on develop pushes **and** develop PRs (the trigger is an addition, not a swap)
  - Chromium is not `continue-on-error` while its name claims to block
  - Firefox and WebKit stay advisory — making Chromium blocking must not promote them as a side effect
  - the job still runs the `test:e2e:chromium` entrypoint, not a bare `playwright test` that would silently drop the `--retries=0` cold-load regression guard

## Falsification

The develop-trigger assertion fails against the pre-change workflow:

```
AssertionError: browser lane does not run on develop pushes: ['release']
```

6 tests pass on the changed tree.

## Gotcha worth knowing

PyYAML resolves an unquoted `on:` key to boolean `True` under YAML 1.1. A naive `workflow["on"]` returns nothing and every trigger assertion passes vacuously. The helper accepts either spelling.

## Not in this PR

**Chromium is still not a required status check.** develop's ruleset (`develop-squash-only`, id 15611785) requires only `ci-required-result`, so this job cannot block a merge no matter what it reports. That is a repository settings change and needs an explicit decision — see the tracked item `explorer-chromium-gate-actually-blocking-20260803-v3`, rung 1.

All three browser jobs are currently green on develop, so the suite is ready for that promotion whenever you want it.