### PR TITLE
ci(explorer): add the required browser gate job

### DIFF
--- a/.github/workflows/results-explorer-browser.yml
+++ b/.github/workflows/results-explorer-browser.yml
@@ -14,13 +14,15 @@ on:
       - 'results-data/**'
       - '.github/workflows/results-explorer-browser.yml'
   pull_request:
+    # Deliberately NO `paths:` filter. `Results Explorer browser gate` is a
+    # required status check, and GitHub keeps a PR unmergeable forever waiting
+    # on a required check that never reports. A path-filtered workflow simply
+    # does not run, so it never reports, so every PR that touched nothing under
+    # results-explorer/ would deadlock. The filtering moved into the
+    # `explorer-changes` job below: the workflow always starts, the expensive
+    # browser jobs skip when nothing relevant changed, and the gate job always
+    # reports.
     branches: [ release, develop ]
-    paths:
-      - 'results-explorer/**'
-      - '_project/scripts/explorer_pipeline/**'
-      - '_project/scripts/explorer_publish.py'
-      - 'results-data/**'
-      - '.github/workflows/results-explorer-browser.yml'
   workflow_dispatch:
 
 permissions:
@@ -32,10 +34,52 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  # Replaces the `on.pull_request.paths` filter this workflow used to carry.
+  # Same allowlist, evaluated as a job so the workflow always starts and the
+  # required gate job below can always report a conclusion.
+  explorer-changes:
+    name: explorer-changes
+    runs-on: ubuntu-latest
+    outputs:
+      needed: ${{ steps.detect.outputs.needed }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Detect explorer-relevant changes
+        id: detect
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        run: |
+          set -euo pipefail
+          # Anything that is not a pull_request (push, workflow_dispatch)
+          # already passed the `on.push.paths` filter or was requested by hand,
+          # so it always runs the suite.
+          if [ "${{ github.event_name }}" != "pull_request" ]; then
+            echo "needed=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          changed=$(git diff --name-only "$BASE_SHA"...HEAD -- \
+            'results-explorer/**' \
+            '_project/scripts/explorer_pipeline/**' \
+            '_project/scripts/explorer_publish.py' \
+            'results-data/**' \
+            '.github/workflows/results-explorer-browser.yml')
+          if [ -n "$changed" ]; then
+            echo "needed=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "needed=false" >> "$GITHUB_OUTPUT"
+          fi
+          echo "explorer-relevant changed paths:"
+          echo "${changed:-<none>}"
+
   # Blocking gate: Chromium runs the full suite. Every acceptance path
   # asserted in `results-explorer/e2e/` must stay green for the PR to merge.
   chromium:
     name: Chromium (full suite, blocking)
+    needs: explorer-changes
+    if: needs.explorer-changes.outputs.needed == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 25
 
@@ -99,6 +143,8 @@ jobs:
   # once flake data supports it (tracked by w9 of the parent TODO).
   firefox-smoke:
     name: Firefox (@smoke, non-blocking)
+    needs: explorer-changes
+    if: needs.explorer-changes.outputs.needed == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 20
     continue-on-error: true
@@ -159,6 +205,8 @@ jobs:
   # once flake data supports it (tracked by w9 of the parent TODO).
   webkit-smoke:
     name: WebKit (@smoke, non-blocking)
+    needs: explorer-changes
+    if: needs.explorer-changes.outputs.needed == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 20
     continue-on-error: true
@@ -214,3 +262,55 @@ jobs:
             results-explorer/test-results
           if-no-files-found: ignore
           retention-days: 3
+
+  # The single required status check for this workflow.
+  #
+  # It exists because the browser jobs are conditional: a required check that
+  # never reports leaves a PR permanently unmergeable, so the thing GitHub
+  # gates on must always run and always reach a conclusion. Chromium's own job
+  # cannot do that - it is skipped on PRs that touch nothing relevant.
+  #
+  # Firefox and WebKit are deliberately absent from `needs`. They are advisory
+  # (`continue-on-error: true`) and graduate individually per
+  # docs/operations/browser-ci.md; wiring them here would promote them to
+  # blocking as a silent side effect.
+  browser-required-result:
+    name: Results Explorer browser gate
+    needs: [ explorer-changes, chromium ]
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Aggregate browser gate result
+        env:
+          CHANGES_RESULT: ${{ needs.explorer-changes.result }}
+          CHROMIUM_RESULT: ${{ needs.chromium.result }}
+          NEEDED: ${{ needs.explorer-changes.outputs.needed }}
+        run: |
+          set -euo pipefail
+          echo "explorer-changes: ${CHANGES_RESULT} (needed=${NEEDED:-unset})"
+          echo "chromium:         ${CHROMIUM_RESULT}"
+
+          # Fail closed. If change detection itself broke we cannot know
+          # whether the suite was needed, so do not wave the PR through.
+          if [ "${CHANGES_RESULT}" != "success" ]; then
+            echo "::error::explorer-changes did not succeed (${CHANGES_RESULT}); refusing to pass the gate."
+            exit 1
+          fi
+
+          case "${CHROMIUM_RESULT}" in
+            success)
+              echo "Chromium suite passed."
+              ;;
+            skipped)
+              # Only legitimate when detection said the suite was not needed.
+              if [ "${NEEDED}" = "true" ]; then
+                echo "::error::Chromium was skipped even though explorer files changed."
+                exit 1
+              fi
+              echo "No explorer-relevant changes; Chromium suite not required."
+              ;;
+            *)
+              echo "::error::Chromium suite result was '${CHROMIUM_RESULT}'."
+              exit 1
+              ;;
+          esac

--- a/docs/operations/repo-admin-settings.md
+++ b/docs/operations/repo-admin-settings.md
@@ -53,6 +53,7 @@ Required status checks:
 
 ```text
 - ci-required-result
+- Results Explorer browser gate
 ```
 
 `ci-required-result` is the umbrella job in `.github/workflows/pr.yml`
@@ -61,6 +62,17 @@ that aggregates the required-lane jobs: `ci-paths`, `content-guard`,
 `medium-test` (added 2026-07-11, #1139 — the medium tier now gates code
 PRs pre-merge via the same umbrella, no ruleset change needed),
 `explorer-tokens`, `audit-sha`, `package-smoke`, and `dependency-audit`.
+
+`Results Explorer browser gate` (added 2026-08-03) is the umbrella job in
+`.github/workflows/results-explorer-browser.yml`. It is required because the
+Chromium full-suite job's own name has claimed to block since it was written,
+while the ruleset required only `ci-required-result` — so the full `e2e/` suite
+gated nothing. The gate job, not the Chromium job, holds the required context:
+the browser jobs are conditional, and GitHub keeps a PR unmergeable forever
+waiting on a required check that never reports. The gate runs `if: always()`,
+passes when Chromium succeeded or when no explorer-relevant path changed, and
+fails closed if change detection itself broke. Firefox and WebKit stay advisory
+and are deliberately absent from its `needs`.
 Branch protection deliberately keys off the umbrella so the path-aware
 classifier can skip subordinate jobs without making the protected check
 disappear. The classifier fails closed: any path not on the

--- a/tests/unit/release/test_ruleset_drift_review_coverage.py
+++ b/tests/unit/release/test_ruleset_drift_review_coverage.py
@@ -76,7 +76,14 @@ def _live_develop_ruleset(*, review_count: int = 0, code_owner_review: bool = Tr
                 "type": "required_status_checks",
                 "parameters": {
                     "strict_required_status_checks_policy": False,
-                    "required_status_checks": [{"context": "ci-required-result"}],
+                    # Must mirror the develop-squash-only check list in
+                    # docs/operations/repo-admin-settings.md, otherwise these
+                    # fixtures report check drift and mask the review-rule
+                    # behaviour they exist to cover.
+                    "required_status_checks": [
+                        {"context": "ci-required-result"},
+                        {"context": "Results Explorer browser gate"},
+                    ],
                 },
             },
             {"type": "required_linear_history"},

--- a/tests/unit/test_ruleset_drift.py
+++ b/tests/unit/test_ruleset_drift.py
@@ -40,7 +40,10 @@ def test_parse_expected_rulesets_from_admin_runbook() -> None:
     expected = parse_expected_rulesets((REPO_ROOT / "docs" / "operations" / "repo-admin-settings.md").read_text())
 
     assert expected["develop-squash-only"].ref == "refs/heads/develop"
-    assert expected["develop-squash-only"].required_checks == ("ci-required-result",)
+    assert expected["develop-squash-only"].required_checks == (
+        "ci-required-result",
+        "Results Explorer browser gate",
+    )
     assert expected["release-only"].ref == "refs/heads/release"
     assert expected["release-only"].required_checks == ("validate-base", "release-required-result")
     assert expected["release-only"].strict_required_status_checks_policy is False

--- a/tests/unit/workflows/test_results_explorer_browser_gate.py
+++ b/tests/unit/workflows/test_results_explorer_browser_gate.py
@@ -24,7 +24,12 @@ REPO_ROOT = Path(__file__).resolve().parents[3]
 WORKFLOW_PATH = REPO_ROOT / ".github" / "workflows" / "results-explorer-browser.yml"
 
 CHROMIUM_JOB = "chromium"
+GATE_JOB = "browser-required-result"
 ADVISORY_JOBS = ("firefox-smoke", "webkit-smoke")
+
+# The status-check context GitHub sees, and therefore the exact string that
+# must appear in the develop ruleset. It is the job's `name:`, not its id.
+GATE_CONTEXT = "Results Explorer browser gate"
 
 
 @pytest.fixture(scope="module")
@@ -53,6 +58,17 @@ def test_lane_runs_on_develop_pushes(workflow: dict[str, Any]) -> None:
     """
     push_branches = _triggers(workflow)["push"]["branches"]
     assert "develop" in push_branches, f"browser lane does not run on develop pushes: {push_branches}"
+
+
+def test_gate_context_matches_the_documented_required_check(workflow: dict[str, Any]) -> None:
+    """The ruleset pins a context string; renaming the job silently breaks it.
+
+    A required context that no job reports leaves every PR unmergeable, so the
+    job name, the admin runbook, and the live ruleset have to agree.
+    """
+    assert workflow["jobs"][GATE_JOB]["name"] == GATE_CONTEXT
+    runbook = (REPO_ROOT / "docs" / "operations" / "repo-admin-settings.md").read_text(encoding="utf-8")
+    assert GATE_CONTEXT in runbook, "required gate context is not recorded in the repo admin runbook"
 
 
 def test_lane_still_runs_on_pull_requests_into_develop(workflow: dict[str, Any]) -> None:
@@ -92,6 +108,51 @@ def test_advisory_browsers_are_not_silently_promoted(workflow: dict[str, Any]) -
         job = workflow["jobs"][job_id]
         assert job.get("continue-on-error") is True, f"{job_id} was promoted to blocking without an explicit decision"
         assert "non-blocking" in job["name"].lower(), f"{job_id} name no longer marks it advisory"
+
+
+def test_pull_request_trigger_has_no_paths_filter(workflow: dict[str, Any]) -> None:
+    """The required gate must report on *every* PR, so the workflow must start.
+
+    This is the deadlock guard. `Results Explorer browser gate` is a required
+    status check, and GitHub leaves a PR permanently unmergeable while a
+    required check has not reported. A path-filtered workflow does not run at
+    all, so it never reports - which would block every PR that happens to touch
+    nothing under `results-explorer/`. Filtering belongs in `explorer-changes`,
+    not in the trigger.
+    """
+    pull_request = _triggers(workflow)["pull_request"]
+    assert "paths" not in pull_request, (
+        "pull_request has a paths filter; the required gate would never report on unrelated PRs"
+    )
+
+
+def test_expensive_browser_jobs_are_gated_on_change_detection(workflow: dict[str, Any]) -> None:
+    """Dropping the trigger filter must not run a 25-minute suite on every PR."""
+    for job_id in (CHROMIUM_JOB, *ADVISORY_JOBS):
+        job = workflow["jobs"][job_id]
+        assert job.get("if") == "needs.explorer-changes.outputs.needed == 'true'", (
+            f"{job_id} is not gated on explorer-changes; it would run on every PR"
+        )
+
+
+def test_required_gate_job_always_runs_and_gates_on_chromium(workflow: dict[str, Any]) -> None:
+    """The required check must always reach a conclusion, and reflect Chromium."""
+    gate = workflow["jobs"][GATE_JOB]
+    assert gate.get("if") == "always()", "gate job does not always run; a skipped Chromium would leave it unreported"
+    assert CHROMIUM_JOB in gate["needs"], "gate job does not depend on Chromium"
+    assert "explorer-changes" in gate["needs"], "gate job cannot distinguish 'not needed' from 'skipped in error'"
+
+
+def test_required_gate_does_not_silently_promote_advisory_browsers(workflow: dict[str, Any]) -> None:
+    """Firefox and WebKit must stay out of the required gate's dependencies.
+
+    Adding either to `needs` would make it merge-blocking without the explicit
+    per-browser graduation decision that `docs/operations/browser-ci.md`
+    requires.
+    """
+    gate_needs = workflow["jobs"][GATE_JOB]["needs"]
+    for job_id in ADVISORY_JOBS:
+        assert job_id not in gate_needs, f"{job_id} was promoted to blocking via the required gate's needs"
 
 
 def test_chromium_runs_the_full_suite_entrypoint(workflow: dict[str, Any]) -> None:


### PR DESCRIPTION
> Follow-up to #1503, which **auto-merged after its first commit**. develop got the develop-push trigger and the contract tests, but not the gate itself. This is the rest.

## Why the gate job exists at all

Requiring the Chromium job directly would deadlock the repo. The workflow is path-filtered, and **GitHub keeps a PR unmergeable forever waiting on a required check that never reports** — so every PR touching nothing under `results-explorer/` would block permanently.

So the required context goes on an umbrella job, mirroring the existing `ci-required-result` pattern:

- drop the `pull_request` `paths:` filter so the workflow always starts
- move the same allowlist into an `explorer-changes` job
- gate the three expensive browser jobs on it — an unrelated PR costs one cheap job, not a 25-minute suite
- `Results Explorer browser gate` runs `if: always()` and:
  - passes when Chromium succeeded
  - passes when nothing explorer-relevant changed
  - **fails closed** if change detection itself broke, or if Chromium was skipped while explorer files *did* change

Firefox and WebKit are deliberately absent from the gate's `needs` — they're advisory and graduate individually per `docs/operations/browser-ci.md`. Wiring them in would promote them to blocking as a silent side effect.

## Tests

60 pass. The contract tests pin the deadlock guard (`pull_request` must carry no `paths` filter), that the expensive jobs are gated on change detection, that the gate always runs and depends on Chromium, that advisory browsers stay out of its `needs`, and that the job name / admin runbook / ruleset context string agree — a rename silently breaks a required check.

Also updates the ruleset drift expectations and the two synthetic fixtures that mirror the develop check list.

## Sequencing — please merge before the ruleset flips

**The live ruleset must be updated only after this lands.** Adding the required context first would block every open PR on a check no workflow reports yet. I verified this failure mode rather than assuming it: the gate does not currently appear among #1501's 22 checks, because develop doesn't have the job.

Once merged I'll apply:

```bash
gh api -X PUT repos/joeharris76/BenchBox/rulesets/15611785 ...  # add "Results Explorer browser gate"
```