### PR TITLE
fix(ci): close auto-revert identity-check loop

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -891,6 +891,9 @@ guards-fix:
 # check after each guard is what keeps this one shell session (the whole
 # recipe is one logical line via `\` continuations) going past a failing
 # guard instead of `make` aborting at the first nonzero exit.
+# The ephemeral GitHub runner has no user.* config. The ci-lint recipe supplies
+# a synthetic human identity only for the resolved-config audit; the
+# commit-range guard remains authoritative for branch authorship.
 ci-lint:
 	@echo "Running CI lint checks..."
 	@case " $(MAKEFLAGS) " in *" n "*|*" -n "*|*" --just-print "*) echo "Dry-run: ci-lint guards suppressed"; exit 0;; esac; \
@@ -917,8 +920,14 @@ ci-lint:
 	[ $$? -eq 0 ] || failed="$$failed artifact-hygiene"; \
 	$(MAKE) agent-instructions-check; \
 	[ $$? -eq 0 ] || failed="$$failed agent-instructions"; \
+	if [ "$${GITHUB_ACTIONS:-}" = "true" ]; then \
+		export GIT_CONFIG_COUNT=2 GIT_CONFIG_KEY_0=user.name GIT_CONFIG_VALUE_0='BenchBox CI' GIT_CONFIG_KEY_1=user.email GIT_CONFIG_VALUE_1=ci@benchbox.invalid; \
+	fi; \
 	$(MAKE) agent-identity-check; \
 	[ $$? -eq 0 ] || failed="$$failed agent-identity"; \
+	if [ "$${GITHUB_ACTIONS:-}" = "true" ]; then \
+		unset GIT_CONFIG_COUNT GIT_CONFIG_KEY_0 GIT_CONFIG_VALUE_0 GIT_CONFIG_KEY_1 GIT_CONFIG_VALUE_1; \
+	fi; \
 	$(MAKE) agent-commit-range-check; \
 	[ $$? -eq 0 ] || failed="$$failed agent-commit-range"; \
 	$(MAKE) skill-sync-check; \

--- a/tests/system/test_ci_lint_parity.py
+++ b/tests/system/test_ci_lint_parity.py
@@ -208,6 +208,17 @@ def test_lint_job_guards_run_in_ci_lint() -> None:
     )
 
 
+def test_ci_lint_identity_check_supplies_runner_identity() -> None:
+    """The CI runner has no Git config for the resolved-config audit."""
+    recipe = _ci_lint_recipe_text()
+    assert 'if [ "$${GITHUB_ACTIONS:-}" = "true" ]; then' in recipe
+    assert "export GIT_CONFIG_COUNT=2" in recipe
+    assert "GIT_CONFIG_VALUE_0='BenchBox CI'" in recipe
+    assert "GIT_CONFIG_VALUE_1=ci@benchbox.invalid" in recipe
+    assert "unset GIT_CONFIG_COUNT GIT_CONFIG_KEY_0" in recipe
+    assert recipe.count('if [ "$${GITHUB_ACTIONS:-}" = "true" ]; then') == 2
+
+
 def test_excluded_steps_still_exist() -> None:
     """EXCLUDED_STEPS must only reference lint-job steps that still exist,
     under their current name -- otherwise a rename/removal could silently


### PR DESCRIPTION
## Summary

- Fix the post-merge auto-revert regression opened as #1507.
- `make ci-lint` now supplies the same synthetic CI identity used by the workflow-only identity check, but only on GitHub Actions runners, so local invocations continue auditing the caller's resolved Git identity.
- Unset the synthetic identity before `agent-commit-range-check`, which remains the authoritative branch-authorship guard.
- Add a CI-lint parity regression test for the injected identity and cleanup.

## Evidence

The post-merge run for #1494 failed only at `agent-identity-check` with unresolved author/committer identity; the commit-range guard passed. Local verification on the rebased `develop` tree:

- `GITHUB_ACTIONS=true make ci-lint` — the CI-mode identity check passed; the run then correctly failed only at `agent-commit-range` because this task explicitly requires the commit author `Claude <noreply@anthropic.com>`, which conflicts with the repository's human-authorship merge guard.
- `uv run -- python -m pytest tests/system/test_ci_lint_parity.py -q` — 8 passed.
- `uv run -- python -m pytest tests/unit/ -x -q` — 26,483 passed, 23 skipped, 4 subtests passed.
- `make pr-preflight` — passed during push.

The forward fix itself is green; the remaining merge blocker is the explicitly requested commit identity, not the auto-revert defect. Auto-merge is enabled and will remain pending that required repository guard.

This forward fix makes auto-revert PR #1507 obsolete.