### PR TITLE
fix(mcp): close the ClickHouse port and TLS security boundary

### DIFF
--- a/benchbox/mcp/schemas.py
+++ b/benchbox/mcp/schemas.py
@@ -11,13 +11,18 @@ Licensed under the MIT License. See LICENSE file in the project root for details
 
 from __future__ import annotations
 
+import json
+import logging
 import math
+import os
 import re
 from collections.abc import Mapping
 from dataclasses import dataclass
 from typing import Annotated, Literal
 
 from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
+
+logger = logging.getLogger(__name__)
 
 # Validation constants
 MAX_QUERY_IDS = 100  # Maximum number of query IDs per request (DoS protection)
@@ -29,6 +34,13 @@ FILENAME_PATTERN = re.compile(r"^[a-zA-Z0-9_.-]+$")  # Safe filename characters
 PLATFORM_OPTION_NAME_PATTERN = re.compile(r"^[a-z][a-z0-9_]{0,63}$")
 MEMORY_LIMIT_PATTERN = re.compile(r"^(?:[1-9]\d{0,5}(?:\.\d{1,2})?)(?:B|KB|MB|GB|TB)$", re.IGNORECASE)
 IDENTIFIER_LIST_PATTERN = re.compile(r"^[a-zA-Z_][a-zA-Z0-9_]*(?:,[a-zA-Z_][a-zA-Z0-9_]*)*$")
+CLICKHOUSE_PROFILE_NAME_PATTERN = re.compile(r"^[a-z][a-z0-9_]{0,63}$")
+
+# Server-owned ClickHouse connection profiles, as JSON:
+#   {"analytics": {"port": 9440, "secure": true}}
+# Only the operator sets this; MCP callers may name a profile but never describe
+# a destination or a transport policy.
+MCP_CLICKHOUSE_PROFILE_ENV = "BENCHBOX_MCP_CLICKHOUSE_PROFILES"
 
 MAX_PLATFORM_OPTIONS = 16
 MAX_PLATFORM_OPTION_VALUE_LENGTH = 256
@@ -113,13 +125,11 @@ class MCPPlatformOptionContract:
 # or other tenant-owned connection state through request arguments.
 MCP_PLATFORM_OPTION_ALLOWLIST: dict[str, dict[str, MCPPlatformOptionSpec]] = {
     "clickhouse": {
+        "connection_profile": _MCP_OPTION("string"),
         "deployment_mode": _MCP_OPTION("string", choices=("local", "server")),
-        "port": _MCP_OPTION("int", minimum=1, maximum=65_535),
-        "secure": _MCP_OPTION("bool"),
     },
     "clickhouse-server": {
-        "port": _MCP_OPTION("int", minimum=1, maximum=65_535),
-        "secure": _MCP_OPTION("bool"),
+        "connection_profile": _MCP_OPTION("string"),
     },
     "cudf": {
         "device_id": _MCP_OPTION("int", minimum=0, maximum=255),
@@ -189,34 +199,28 @@ def _contract(
     )
 
 
+_CLICKHOUSE_PROFILE_CONTRACT = _contract(
+    "ClickHouseAdapter.from_config(port, secure) resolved from server configuration",
+    "connection",
+    rejected_alternatives=(
+        "caller-supplied port",
+        "caller-supplied secure/TLS policy",
+        "arbitrary destination selection",
+        "transport downgrade",
+    ),
+)
+
+
 # Canonical option-to-consumer matrix.  Keep this map explicit instead of
 # deriving it from the allow-list: an accepted option must have a reviewed
 # consumer and security classification before it can cross the MCP boundary.
 MCP_PLATFORM_OPTION_CONTRACT: dict[str, dict[str, MCPPlatformOptionContract]] = {
     "clickhouse": {
+        "connection_profile": _CLICKHOUSE_PROFILE_CONTRACT,
         "deployment_mode": _contract("ClickHouseAdapter.from_config(deployment_mode)", "execution"),
-        "port": _contract(
-            "ClickHouseAdapter.from_config(port)",
-            "connection",
-            rejected_alternatives=("server-owned port", "arbitrary destination selection"),
-        ),
-        "secure": _contract(
-            "ClickHouseAdapter.from_config(secure)",
-            "connection",
-            rejected_alternatives=("server-owned TLS policy", "transport downgrade"),
-        ),
     },
     "clickhouse-server": {
-        "port": _contract(
-            "ClickHouseAdapter.from_config(port)",
-            "connection",
-            rejected_alternatives=("server-owned port", "arbitrary destination selection"),
-        ),
-        "secure": _contract(
-            "ClickHouseAdapter.from_config(secure)",
-            "connection",
-            rejected_alternatives=("server-owned TLS policy", "transport downgrade"),
-        ),
+        "connection_profile": _CLICKHOUSE_PROFILE_CONTRACT,
     },
     "cudf": {
         "device_id": _contract("cuDF runtime device selection", "device"),
@@ -277,6 +281,89 @@ MCP_PLATFORM_OPTION_CONTRACT: dict[str, dict[str, MCPPlatformOptionContract]] = 
 }
 
 
+def _load_clickhouse_connection_profiles() -> dict[str, dict[str, object]]:
+    """Return the operator-defined ClickHouse connection profiles.
+
+    Profiles are the only supported way to reach a non-default ClickHouse port
+    or a non-default TLS setting from MCP.  The mapping is read from server
+    process configuration, never from request arguments, so a caller can name a
+    reviewed destination but can never describe one.  A malformed registry
+    yields no profiles rather than a partially trusted one.
+    """
+    raw = os.environ.get(MCP_CLICKHOUSE_PROFILE_ENV, "").strip()
+    if not raw:
+        return {}
+    try:
+        decoded = json.loads(raw)
+    except json.JSONDecodeError:
+        logger.error("Ignoring malformed %s: value is not valid JSON", MCP_CLICKHOUSE_PROFILE_ENV)
+        return {}
+    if not isinstance(decoded, dict):
+        logger.error("Ignoring malformed %s: value is not a JSON object", MCP_CLICKHOUSE_PROFILE_ENV)
+        return {}
+
+    profiles: dict[str, dict[str, object]] = {}
+    for name, entry in decoded.items():
+        if not isinstance(name, str) or not CLICKHOUSE_PROFILE_NAME_PATTERN.fullmatch(name):
+            logger.error("Ignoring a %s entry whose profile name is not snake_case", MCP_CLICKHOUSE_PROFILE_ENV)
+            continue
+        if not isinstance(entry, Mapping):
+            logger.error("Ignoring %s profile '%s': value is not an object", MCP_CLICKHOUSE_PROFILE_ENV, name)
+            continue
+        unknown = set(entry) - {"port", "secure"}
+        if unknown:
+            # Fail closed rather than silently dropping operator intent: a
+            # profile carrying hosts, credentials, or paths is a policy error.
+            logger.error(
+                "Ignoring %s profile '%s': only 'port' and 'secure' are supported", MCP_CLICKHOUSE_PROFILE_ENV, name
+            )
+            continue
+        port = entry.get("port")
+        if isinstance(port, bool) or not isinstance(port, int) or not 1 <= port <= 65_535:
+            logger.error(
+                "Ignoring %s profile '%s': 'port' must be an integer in 1-65535", MCP_CLICKHOUSE_PROFILE_ENV, name
+            )
+            continue
+        secure = entry.get("secure", False)
+        if not isinstance(secure, bool):
+            logger.error("Ignoring %s profile '%s': 'secure' must be a boolean", MCP_CLICKHOUSE_PROFILE_ENV, name)
+            continue
+        profiles[name] = {"port": port, "secure": secure}
+    return profiles
+
+
+def resolve_clickhouse_connection_profile(name: str) -> dict[str, object]:
+    """Resolve a named profile to its server-owned connection settings.
+
+    Raises:
+        MCPValidationError: If no such profile is configured on this server.
+    """
+    profile = _load_clickhouse_connection_profiles().get(name)
+    if profile is None:
+        # Deliberately does not echo the requested name or list configured
+        # profiles: that would turn a validation error into a probe oracle.
+        raise MCPValidationError("Platform option 'connection_profile' is not configured on this server")
+    return dict(profile)
+
+
+def _validate_clickhouse_options(platform: str, normalized: Mapping[str, object]) -> None:
+    """Fail closed on ClickHouse connection intent that MCP must not grant."""
+    profile = normalized.get("connection_profile")
+    if profile is None:
+        return
+    if not CLICKHOUSE_PROFILE_NAME_PATTERN.fullmatch(str(profile)):
+        raise MCPValidationError("Platform option 'connection_profile' must be a lowercase snake_case profile name")
+    if platform == "clickhouse" and normalized.get("deployment_mode") != "server":
+        # Local mode runs chDB in-process.  Accepting a connection profile there
+        # would hand local runs a network path they do not otherwise have.
+        raise MCPValidationError("Platform option 'connection_profile' requires deployment_mode='server'")
+    # Existence is checked at admission so an unknown profile is rejected before
+    # a durable job is persisted.  The resolved port/TLS values are deliberately
+    # NOT merged into the normalized request: only the profile name is persisted,
+    # so a retry re-resolves from current server configuration.
+    resolve_clickhouse_connection_profile(str(profile))
+
+
 def _validate_memory_limit(name: str, value: str) -> str:
     """Validate a bounded memory-size option without accepting paths or expressions."""
     if not MEMORY_LIMIT_PATTERN.fullmatch(value):
@@ -298,14 +385,14 @@ def validate_platform_options(platform: str, options: Mapping[str, object] | Non
         raise MCPValidationError(f"Too many platform options (maximum {MAX_PLATFORM_OPTIONS})")
 
     platform_name = validate_platform_name(platform)
-    specs = MCP_PLATFORM_OPTION_ALLOWLIST.get(platform_name)
-    if specs is None and platform_name.endswith("-df"):
-        specs = MCP_PLATFORM_OPTION_ALLOWLIST.get(platform_name[:-3])
-    specs = specs or {}
-    contracts = MCP_PLATFORM_OPTION_CONTRACT.get(platform_name)
-    if contracts is None and platform_name.endswith("-df"):
-        contracts = MCP_PLATFORM_OPTION_CONTRACT.get(platform_name[:-3])
-    contracts = contracts or {}
+    # A "-df" request falls back to the base platform's records, so the policy
+    # key must fall back with it: resolving the fallback once keeps the value
+    # specs, the contract matrix, and the cross-field rules on the same platform.
+    policy_name = platform_name
+    if platform_name not in MCP_PLATFORM_OPTION_ALLOWLIST and platform_name.endswith("-df"):
+        policy_name = platform_name[:-3]
+    specs = MCP_PLATFORM_OPTION_ALLOWLIST.get(policy_name) or {}
+    contracts = MCP_PLATFORM_OPTION_CONTRACT.get(policy_name) or {}
     normalized: dict[str, object] = {}
     for raw_name, raw_value in options.items():
         if not isinstance(raw_name, str) or not PLATFORM_OPTION_NAME_PATTERN.fullmatch(raw_name):
@@ -321,7 +408,19 @@ def validate_platform_options(platform: str, options: Mapping[str, object] | Non
         if name == "liquid_clustering_columns" and not IDENTIFIER_LIST_PATTERN.fullmatch(str(parsed)):
             raise MCPValidationError(f"Platform option '{name}' contains invalid identifiers")
         normalized[name] = parsed
+
+    # Cross-field policy runs after every value is bounded, so it sees the whole
+    # request.  Every admission path (synchronous run_benchmark, durable
+    # start_benchmark, and durable worker replay) reaches this one function, so a
+    # rejected combination can never be persisted or reintroduced by a retry.
+    _validate_cross_field_policy(policy_name, normalized)
     return normalized
+
+
+def _validate_cross_field_policy(platform_name: str, normalized: Mapping[str, object]) -> None:
+    """Apply per-platform rules that individual value bounds cannot express."""
+    if platform_name in {"clickhouse", "clickhouse-server"}:
+        _validate_clickhouse_options(platform_name, normalized)
 
 
 def validate_query_id(query_id: str) -> str:

--- a/benchbox/mcp/tools/benchmark.py
+++ b/benchbox/mcp/tools/benchmark.py
@@ -36,7 +36,11 @@ from benchbox.mcp.errors import (
     make_not_found_error,
     make_unsupported_mode_error,
 )
-from benchbox.mcp.schemas import MCPValidationError, validate_platform_options
+from benchbox.mcp.schemas import (
+    MCPValidationError,
+    resolve_clickhouse_connection_profile,
+    validate_platform_options,
+)
 from benchbox.mcp.security import PathProvider, resolve_path_provider
 from benchbox.utils.clock import elapsed_seconds, mono_time
 from benchbox.utils.path_utils import get_benchmark_runs_datagen_path
@@ -92,6 +96,15 @@ def _prepare_adapter_platform_options(platform: str, options: Mapping[str, objec
     """Translate MCP option names to the adapter and tuning contracts."""
     normalized = dict(options)
     platform_name = platform.lower().removesuffix("-df")
+
+    if platform_name in {"clickhouse", "clickhouse-server"} and "connection_profile" in normalized:
+        # The request carries only a profile name.  Port and TLS policy are read
+        # from server configuration here, at execution time, so a durable retry
+        # re-resolves against current policy instead of replaying a persisted
+        # destination.
+        profile = resolve_clickhouse_connection_profile(str(normalized.pop("connection_profile")))
+        normalized["port"] = profile["port"]
+        normalized["secure"] = profile["secure"]
 
     if platform_name == "duckdb" and "threads" in normalized:
         normalized["thread_limit"] = normalized.pop("threads")
@@ -442,13 +455,23 @@ def _run_benchmark_impl(
 
         benchmark_instance = benchmark_class(scale_factor=scale_factor)
 
+        # Resolved separately from adapter construction so a policy rejection is
+        # reported as a validation error rather than an unsupported platform.
+        try:
+            adapter_options = _prepare_adapter_platform_options(platform, normalized_platform_options)
+        except MCPValidationError as exc:
+            return _make_failed_response(
+                make_error(ErrorCode.VALIDATION_ERROR, str(exc), details={"platform": platform}),
+                execution_id,
+            )
+
         try:
             adapter = _get_platform_adapter(
                 platform,
                 mode=resolved_mode,
                 benchmark=benchmark_lower,
                 scale_factor=scale_factor,
-                **_prepare_adapter_platform_options(platform, normalized_platform_options),
+                **adapter_options,
             )
         except (ValueError, ImportError) as e:
             return _make_failed_response(

--- a/docs/development/mcp-platform-option-contract.md
+++ b/docs/development/mcp-platform-option-contract.md
@@ -13,7 +13,7 @@ permission to expose the underlying adapter's full configuration surface.
 | Platform | Option(s) | Consumer | Security class | Compatibility alias / rejected alternatives |
 |---|---|---|---|---|
 | ClickHouse | `deployment_mode` | `ClickHouseAdapter.from_config` | execution | Connection destinations and transport policy remain server-owned. |
-| ClickHouse | `port`, `secure` | Current adapter fields; removal tracked separately | connection | Reject arbitrary ports, destinations, and TLS downgrade controls. |
+| ClickHouse | `connection_profile` | `ClickHouseAdapter.from_config(port, secure)` resolved from `BENCHBOX_MCP_CLICKHOUSE_PROFILES` | connection | Reject caller-supplied `port`/`secure`, arbitrary destinations, and TLS downgrade. Only the profile name is accepted and persisted. |
 | cuDF | `device_id`, `spill_to_host` | cuDF runtime and memory policy | device/resource | Reject device paths, scheduler endpoints, and package controls. |
 | Dask | `memory_limit`, `n_workers`, `threads_per_worker` | LocalCluster resource envelope | resource | Enforce aggregate limits; reject scheduler endpoints and spill paths. |
 | Dask | `use_distributed` | Dask execution-mode selector | execution | Reject external scheduler selection. |

--- a/docs/operations/mcp-remote-security.md
+++ b/docs/operations/mcp-remote-security.md
@@ -72,6 +72,40 @@ The scope contract is:
   `cancel_benchmark`, still constrained by platform, benchmark, and
   maximum-scale policy.
 
+## Server-owned ClickHouse connection profiles
+
+A request can never set a ClickHouse `port` or `secure` value: a port is part of
+a destination and `secure` is transport policy, so accepting either would let an
+authenticated caller reach another listener on the host or downgrade
+server-owned TLS. Both are rejected for every ClickHouse platform spelling.
+
+To reach a non-default port or TLS setting, define named profiles in the server
+process environment. Only the operator sets this; callers may name a profile but
+never describe one.
+
+```bash
+export BENCHBOX_MCP_CLICKHOUSE_PROFILES='{"analytics": {"port": 9440, "secure": true}}'
+```
+
+Profile names are lowercase snake_case. Each entry accepts only `port`
+(1-65535) and `secure` (boolean, default `false`); a malformed entry, or one
+carrying hosts, credentials, or paths, is discarded and its profile becomes
+unavailable rather than partially trusted.
+
+Callers select a profile with `platform_options`:
+
+```json
+{"platform": "clickhouse-server", "platform_options": {"connection_profile": "analytics"}}
+```
+
+On the `clickhouse` platform a profile additionally requires
+`deployment_mode: "server"` — local mode runs chDB in-process and must not gain
+a network path. Requests, including persisted durable jobs, carry only the
+profile name; the port and TLS policy are resolved from this environment at
+execution time, so withdrawing a profile immediately fails closed for queued
+retries. Rejections never echo the requested profile name, so a caller cannot
+use validation errors to enumerate configured profiles.
+
 ## Durable remote benchmark jobs
 
 Remote clients should use `start_benchmark` instead of holding a

--- a/docs/reference/mcp.md
+++ b/docs/reference/mcp.md
@@ -247,6 +247,14 @@ modes remain available because they do not hold the request for execution.
   filesystem paths, unbounded values, and driver auto-install/version controls
   fail closed. Authenticated durable jobs persist only this normalized object,
   so retries and worker restarts cannot reintroduce raw request mappings.
+- ClickHouse connection destinations are server-owned. A request cannot set
+  `port` or `secure`; both are rejected for every ClickHouse spelling. A
+  non-default port or TLS setting is reachable only through
+  `connection_profile`, which names a profile the operator defined in
+  `BENCHBOX_MCP_CLICKHOUSE_PROFILES` (see
+  [MCP remote security](../operations/mcp-remote-security.md)). Requests carry
+  and persist only the profile name; the port and TLS policy are resolved from
+  server configuration at execution time.
 - The authoritative option-to-consumer, security-class, alias, and rejection
   matrix is maintained in
   `docs/development/mcp-platform-option-contract.md`. Every allow-listed key

--- a/tests/integration/mcp/test_durable_jobs.py
+++ b/tests/integration/mcp/test_durable_jobs.py
@@ -11,7 +11,11 @@ from mcp.shared.exceptions import MCPError
 from mcp.types import TextContent
 
 from benchbox.mcp.jobs import DurableJobRepository, DurableJobWorker
-from benchbox.mcp.schemas import validate_platform_options
+from benchbox.mcp.schemas import (
+    MCP_CLICKHOUSE_PROFILE_ENV,
+    MCPValidationError,
+    validate_platform_options,
+)
 from benchbox.mcp.security import JobLimits, TenantWorkspaceProvider
 from tests.integration.mcp._security import authenticated_http_client, write_security_config
 
@@ -90,6 +94,31 @@ def test_normalized_platform_options_survive_repository_round_trip(tmp_path: Pat
     persisted = repository.get_owned(submitted.execution_id, "tenant-a")
     assert persisted is not None
     assert persisted.request["platform_options"] == {"threads": 4}
+
+
+def test_durable_clickhouse_requests_never_persist_a_connection_tuple(tmp_path: Path, monkeypatch) -> None:
+    """A retry replays the profile name, so it re-resolves against current policy."""
+    monkeypatch.setenv(MCP_CLICKHOUSE_PROFILE_ENV, json.dumps({"reviewed": {"port": 9440, "secure": True}}))
+    repository = DurableJobRepository(tmp_path / "state.sqlite3", JobLimits())
+    options = validate_platform_options("clickhouse-server", {"connection_profile": "reviewed"})
+
+    submitted, _ = repository.submit(
+        "tenant-a", {**_request(), "platform": "clickhouse-server", "platform_options": options}
+    )
+
+    persisted = repository.get_owned(submitted.execution_id, "tenant-a")
+    assert persisted is not None
+    assert persisted.request["platform_options"] == {"connection_profile": "reviewed"}
+    assert "port" not in persisted.request["platform_options"]
+    assert "secure" not in persisted.request["platform_options"]
+
+
+@pytest.mark.parametrize("platform", ["clickhouse", "clickhouse-server"])
+def test_durable_admission_refuses_clickhouse_port_and_tls_overrides(platform: str) -> None:
+    """Both ClickHouse spellings fail closed before a job can be persisted."""
+    for options in ({"port": 9001}, {"secure": False}):
+        with pytest.raises(MCPValidationError, match="not authorized"):
+            validate_platform_options(platform, options)
 
 
 def test_tenant_job_tools_are_remote_only_and_cross_tenant_fail_closed(tmp_path: Path, monkeypatch) -> None:

--- a/tests/unit/mcp/test_benchmark_tools.py
+++ b/tests/unit/mcp/test_benchmark_tools.py
@@ -5,6 +5,7 @@ Copyright 2026 Joe Harris / BenchBox Project
 Licensed under the MIT License. See LICENSE file in the project root for details.
 """
 
+import json
 import sys
 from pathlib import Path
 from types import SimpleNamespace
@@ -168,6 +169,86 @@ class TestRunBenchmarkTool:
         assert response["mcp_metadata"]["status"] == "no_results"
         assert get_adapter.call_args.kwargs["thread_limit"] == 4
 
+    @pytest.mark.parametrize("platform", ["clickhouse", "clickhouse-server"])
+    def test_clickhouse_port_override_is_refused_before_any_adapter_is_built(self, platform, tmp_path: Path):
+        """A request must not be able to point ClickHouse at another listener."""
+        from benchbox.mcp.tools import benchmark as benchmark_tools
+
+        with patch.object(benchmark_tools, "_get_platform_adapter") as get_adapter:
+            response = benchmark_tools._run_benchmark_impl(
+                platform,
+                "tpch",
+                0.01,
+                None,
+                "load,power",
+                "sql",
+                platform_options={"port": 9001, "secure": False},
+                results_dir=tmp_path,
+            )
+
+        assert response["status"] == "failed"
+        get_adapter.assert_not_called()
+
+    def test_clickhouse_profile_resolves_to_the_server_owned_connection_tuple(self, monkeypatch, tmp_path: Path):
+        """The adapter sees the operator's port/TLS, never the caller's."""
+        import json
+
+        from benchbox.mcp.schemas import MCP_CLICKHOUSE_PROFILE_ENV
+        from benchbox.mcp.tools import benchmark as benchmark_tools
+
+        monkeypatch.setenv(MCP_CLICKHOUSE_PROFILE_ENV, json.dumps({"reviewed": {"port": 9440, "secure": True}}))
+
+        class DummyBenchmark:
+            def __init__(self, scale_factor: float) -> None:
+                self.scale_factor = scale_factor
+
+            def run_with_platform(self, *_args, **_kwargs):
+                return None
+
+        with (
+            patch.object(benchmark_tools, "get_all_benchmarks", return_value={"tpch": {"name": "tpch"}}),
+            patch.object(benchmark_tools, "get_public_benchmark_class", return_value=DummyBenchmark),
+            patch.object(benchmark_tools, "_get_platform_adapter", return_value=Mock()) as get_adapter,
+        ):
+            benchmark_tools._run_benchmark_impl(
+                "clickhouse-server",
+                "tpch",
+                0.01,
+                None,
+                "load,power",
+                "sql",
+                platform_options={"connection_profile": "reviewed"},
+                results_dir=tmp_path,
+            )
+
+        kwargs = get_adapter.call_args.kwargs
+        assert kwargs["port"] == 9440
+        assert kwargs["secure"] is True
+        assert "connection_profile" not in kwargs
+
+    def test_clickhouse_profile_withdrawn_by_the_operator_fails_closed(self, monkeypatch, tmp_path: Path):
+        """A replayed request cannot outlive the profile that authorized it."""
+        from benchbox.mcp.schemas import MCP_CLICKHOUSE_PROFILE_ENV
+        from benchbox.mcp.tools import benchmark as benchmark_tools
+
+        monkeypatch.delenv(MCP_CLICKHOUSE_PROFILE_ENV, raising=False)
+
+        with patch.object(benchmark_tools, "_get_platform_adapter") as get_adapter:
+            response = benchmark_tools._run_benchmark_impl(
+                "clickhouse-server",
+                "tpch",
+                0.01,
+                None,
+                "load,power",
+                "sql",
+                platform_options={"connection_profile": "reviewed"},
+                results_dir=tmp_path,
+            )
+
+        assert response["status"] == "failed"
+        assert "reviewed" not in json.dumps(response)
+        get_adapter.assert_not_called()
+
     def test_databricks_layout_options_build_unified_tuning_config(self):
         from benchbox.mcp.tools.benchmark import _prepare_adapter_platform_options
 
@@ -192,10 +273,18 @@ class TestRunBenchmarkTool:
         assert tuning.platform_optimizations.databricks_clustering_strategy == "liquid_clustering"
         assert tuning.platform_optimizations.liquid_clustering_columns == ["customer_id", "order_id"]
 
-    def test_every_matrix_option_reaches_effective_preparation(self):
+    def test_every_matrix_option_reaches_effective_preparation(self, monkeypatch):
         """Each reviewed option reaches a concrete adapter-facing setting."""
-        from benchbox.mcp.schemas import MCP_PLATFORM_OPTION_ALLOWLIST, validate_platform_options
+        import json
+
+        from benchbox.mcp.schemas import (
+            MCP_CLICKHOUSE_PROFILE_ENV,
+            MCP_PLATFORM_OPTION_ALLOWLIST,
+            validate_platform_options,
+        )
         from benchbox.mcp.tools.benchmark import _prepare_adapter_platform_options
+
+        monkeypatch.setenv(MCP_CLICKHOUSE_PROFILE_ENV, json.dumps({"reviewed": {"port": 9440, "secure": True}}))
 
         for platform, specs in MCP_PLATFORM_OPTION_ALLOWLIST.items():
             for option_name, spec in specs.items():
@@ -209,15 +298,27 @@ class TestRunBenchmarkTool:
                     value = spec.choices[0]
                 elif option_name == "liquid_clustering_columns":
                     value = "id"
+                elif option_name == "connection_profile":
+                    value = "reviewed"
                 else:
                     value = "1GB"
 
-                normalized = validate_platform_options(platform, {option_name: value})
+                request: dict[str, object] = {option_name: value}
+                if platform == "clickhouse" and option_name == "connection_profile":
+                    # A profile only applies to server deployments; local mode is in-process.
+                    request["deployment_mode"] = "server"
+
+                normalized = validate_platform_options(platform, request)
                 prepared = _prepare_adapter_platform_options(platform, normalized)
                 if platform == "duckdb" and option_name == "threads":
                     assert prepared == {"thread_limit": value}
                 elif platform == "databricks":
                     assert "tuning_config" in prepared
+                elif option_name == "connection_profile":
+                    # The caller's profile name is replaced by the server-owned tuple.
+                    assert "connection_profile" not in prepared
+                    assert prepared["port"] == 9440
+                    assert prepared["secure"] is True
                 else:
                     assert prepared[option_name] == value
 

--- a/tests/unit/mcp/test_schemas.py
+++ b/tests/unit/mcp/test_schemas.py
@@ -5,12 +5,15 @@ Copyright 2026 Joe Harris / BenchBox Project
 Licensed under the MIT License. See LICENSE file in the project root for details.
 """
 
+import json
+
 import pytest
 from pydantic import ValidationError as PydanticValidationError
 
 from benchbox.mcp.schemas import (
     MAX_QUERY_ID_LENGTH,
     MAX_QUERY_IDS,
+    MCP_CLICKHOUSE_PROFILE_ENV,
     MCP_PLATFORM_OPTION_ALLOWLIST,
     MCP_PLATFORM_OPTION_CONTRACT,
     CompareResultsInput,
@@ -22,6 +25,7 @@ from benchbox.mcp.schemas import (
     MCPValidationError,
     RunBenchmarkInput,
     ValidateConfigInput,
+    resolve_clickhouse_connection_profile,
     validate_benchmark_name,
     validate_filename,
     validate_platform_name,
@@ -308,6 +312,97 @@ class TestRunBenchmarkInput:
         assert validate_platform_options("velox", {"deployment": "remote"}) == {"deployment": "remote"}
         with pytest.raises(MCPValidationError):
             validate_platform_options("modin", {"engine": "pandas"})
+
+
+CLICKHOUSE_PLATFORM_SPELLINGS = ("clickhouse", "clickhouse-server")
+CLICKHOUSE_UNCONFIGURED_SPELLINGS = ("clickhouse-local", "clickhouse-cloud", "chdb", "clickhouse_server")
+
+
+class TestClickHouseConnectionBoundary:
+    """A caller must never name a ClickHouse destination or transport policy."""
+
+    @pytest.mark.parametrize("platform", CLICKHOUSE_PLATFORM_SPELLINGS)
+    @pytest.mark.parametrize("options", [{"port": 9001}, {"secure": False}, {"port": 9001, "secure": True}])
+    def test_port_and_tls_overrides_are_rejected(self, platform, options):
+        """Port is part of a destination and secure is transport policy."""
+        with pytest.raises(MCPValidationError, match="not authorized"):
+            validate_platform_options(platform, options)
+
+    @pytest.mark.parametrize("platform", CLICKHOUSE_UNCONFIGURED_SPELLINGS)
+    def test_other_clickhouse_spellings_expose_no_options(self, platform):
+        with pytest.raises(MCPValidationError, match="not authorized"):
+            validate_platform_options(platform, {"port": 9001})
+
+    def test_run_benchmark_input_rejects_port_override(self):
+        with pytest.raises(PydanticValidationError):
+            RunBenchmarkInput(platform="clickhouse-server", benchmark="tpch", platform_options={"port": 9001})
+
+    def test_unknown_profile_is_rejected_and_is_not_a_probe_oracle(self, monkeypatch):
+        """An unconfigured profile fails closed without echoing the request."""
+        monkeypatch.delenv(MCP_CLICKHOUSE_PROFILE_ENV, raising=False)
+        with pytest.raises(MCPValidationError) as excinfo:
+            validate_platform_options("clickhouse-server", {"connection_profile": "analytics"})
+        assert "analytics" not in str(excinfo.value)
+
+    def test_configured_profile_admits_only_its_name(self, monkeypatch):
+        """The persisted request carries the name, never the resolved tuple."""
+        monkeypatch.setenv(MCP_CLICKHOUSE_PROFILE_ENV, json.dumps({"analytics": {"port": 9440, "secure": True}}))
+        normalized = validate_platform_options("clickhouse-server", {"connection_profile": "analytics"})
+        assert normalized == {"connection_profile": "analytics"}
+
+    def test_local_deployment_cannot_acquire_a_network_path(self, monkeypatch):
+        """chDB local mode is in-process; a profile must not give it a socket."""
+        monkeypatch.setenv(MCP_CLICKHOUSE_PROFILE_ENV, json.dumps({"analytics": {"port": 9440, "secure": True}}))
+        with pytest.raises(MCPValidationError, match="deployment_mode='server'"):
+            validate_platform_options("clickhouse", {"connection_profile": "analytics"})
+        with pytest.raises(MCPValidationError, match="deployment_mode='server'"):
+            validate_platform_options("clickhouse", {"connection_profile": "analytics", "deployment_mode": "local"})
+        assert validate_platform_options(
+            "clickhouse", {"connection_profile": "analytics", "deployment_mode": "server"}
+        ) == {"connection_profile": "analytics", "deployment_mode": "server"}
+
+    @pytest.mark.parametrize(
+        "registry",
+        [
+            "not json",
+            json.dumps(["analytics"]),
+            json.dumps({"Analytics": {"port": 9440}}),
+            json.dumps({"analytics": {"port": 0}}),
+            json.dumps({"analytics": {"port": 70000}}),
+            json.dumps({"analytics": {"port": True}}),
+            json.dumps({"analytics": {"port": "9440"}}),
+            json.dumps({"analytics": {"port": 9440, "secure": "yes"}}),
+            json.dumps({"analytics": {"port": 9440, "host": "10.0.0.5"}}),
+            json.dumps({"analytics": {"port": 9440, "password": "hunter2"}}),
+        ],
+    )
+    def test_malformed_server_registry_fails_closed(self, monkeypatch, registry):
+        """A malformed or over-broad profile is never partially trusted."""
+        monkeypatch.setenv(MCP_CLICKHOUSE_PROFILE_ENV, registry)
+        with pytest.raises(MCPValidationError, match="not configured"):
+            validate_platform_options("clickhouse-server", {"connection_profile": "analytics"})
+
+    def test_profile_name_shape_is_bounded(self, monkeypatch):
+        monkeypatch.setenv(MCP_CLICKHOUSE_PROFILE_ENV, json.dumps({"analytics": {"port": 9440}}))
+        for bad_name in ("Analytics", "../etc/passwd", "a" * 65, "9analytics", ""):
+            with pytest.raises(MCPValidationError):
+                validate_platform_options("clickhouse-server", {"connection_profile": bad_name})
+
+    def test_dataframe_alias_fallback_does_not_bypass_the_policy(self, monkeypatch):
+        """A '-df' spelling inherits the base records, so it inherits the rules."""
+        monkeypatch.setenv(MCP_CLICKHOUSE_PROFILE_ENV, json.dumps({"analytics": {"port": 9440, "secure": True}}))
+        with pytest.raises(MCPValidationError, match="not authorized"):
+            validate_platform_options("clickhouse-df", {"port": 9001})
+        with pytest.raises(MCPValidationError, match="deployment_mode='server'"):
+            validate_platform_options("clickhouse-df", {"connection_profile": "analytics"})
+
+    def test_resolution_returns_the_server_owned_tuple(self, monkeypatch):
+        monkeypatch.setenv(MCP_CLICKHOUSE_PROFILE_ENV, json.dumps({"analytics": {"port": 9440, "secure": True}}))
+        assert resolve_clickhouse_connection_profile("analytics") == {"port": 9440, "secure": True}
+
+    def test_profile_defaults_to_plaintext_only_when_the_operator_says_so(self, monkeypatch):
+        monkeypatch.setenv(MCP_CLICKHOUSE_PROFILE_ENV, json.dumps({"plain": {"port": 9000}}))
+        assert resolve_clickhouse_connection_profile("plain") == {"port": 9000, "secure": False}
 
 
 class TestDryRunInput:


### PR DESCRIPTION
Closes the `mcp-v2-clickhouse-option-security-boundary-v3` tracker item (critical).

## Problem

`platform_options` accepted ClickHouse `port` and `secure` on both the
`clickhouse` and `clickhouse-server` surfaces, and `ClickHouseMetadataMixin.from_config`
passed them straight through to the adapter constructor. Reproduced before the fix:

```
validate_platform_options("clickhouse", {"port": 9001, "secure": False})  -> accepted
ClickHouseAdapter.from_config({...}).port                                 -> 9001
```

A port is part of a destination and `secure` is transport policy. Bounded
numeric/boolean validation does not enforce tenant isolation, so an
authenticated MCP request could probe another listener on the server-owned host
or downgrade server-owned TLS.

## Change

- **Fail closed at the boundary.** `port` and `secure` are removed from
  `MCP_PLATFORM_OPTION_ALLOWLIST` and `MCP_PLATFORM_OPTION_CONTRACT` for both
  ClickHouse spellings. Other spellings (`clickhouse-local`, `clickhouse-cloud`,
  `chdb`) already had no allow-list entry and reject every option.
- **Server-owned profiles.** A non-default port or TLS setting is reachable only
  through `connection_profile`, naming an entry the operator defines in
  `BENCHBOX_MCP_CLICKHOUSE_PROFILES`. Entries accept only `port` and `secure`; a
  malformed or over-broad entry (host, credentials, paths) is discarded rather
  than partially trusted.
- **Name-only persistence.** Admission validates that the profile exists but
  stores only its name. `_prepare_adapter_platform_options` resolves the tuple at
  execution time, so a durable retry re-resolves against current policy and a
  withdrawn profile fails closed.
- **One shared policy point.** Cross-field validation runs inside
  `validate_platform_options`, which synchronous `run_benchmark`, durable
  `start_benchmark`, and durable worker replay all reach. The `-df` alias
  fallback now resolves the policy key alongside the value specs, so a `-df`
  spelling cannot inherit the records without the rules.
- **Local mode stays in-process.** On `clickhouse`, a profile requires
  `deployment_mode=server`, so chDB local runs gain no network path.
- **No probe oracle.** Rejections never echo the requested profile name or list
  configured profiles.

## Verification

| Rung | Command | Result |
|---|---|---|
| 1 | `pytest tests/unit/mcp/test_schemas.py tests/unit/mcp/test_benchmark_tools.py -q` | 121 passed |
| 2 | `pytest tests/unit/platforms tests/integration/mcp/test_durable_jobs.py -q` | 8099 passed |
| 3 | `ruff check` (scoped) | clean |

CI-only gates run locally: `lint-imports` 3 kept / 0 broken; `test_marker_strategy` 10 passed;
`timing_policy_check --strict` 0 violations (26662 / 27050 fast-lane cap).

Tests use fake adapter clients and never use live credentials or scan real ports.

## Scope note

`docs/development/mcp-platform-option-contract.md` was added to the item scope via
`todo scope-update`: its ClickHouse row said "removal tracked separately", and this
change is that removal, so leaving it stale would ship a docs defect.