### PR TITLE
fix(mcp): enforce an aggregate Dask resource envelope

### DIFF
--- a/benchbox/mcp/schemas.py
+++ b/benchbox/mcp/schemas.py
@@ -364,15 +364,121 @@ def _validate_clickhouse_options(platform: str, normalized: Mapping[str, object]
     resolve_clickhouse_connection_profile(str(profile))
 
 
-def _validate_memory_limit(name: str, value: str) -> str:
-    """Validate a bounded memory-size option without accepting paths or expressions."""
+def _memory_size_bytes(value: str) -> float | None:
+    """Return a bounded memory-size string in bytes, or None if it is not one."""
     if not MEMORY_LIMIT_PATTERN.fullmatch(value):
-        raise MCPValidationError(f"Platform option '{name}' must use a bounded memory size")
+        return None
     number, unit = re.fullmatch(r"([0-9]+(?:\.[0-9]+)?)([A-Za-z]+)", value).groups()  # type: ignore[union-attr]
     multipliers = {"B": 1, "KB": 1 << 10, "MB": 1 << 20, "GB": 1 << 30, "TB": 1 << 40}
-    if float(number) * multipliers[unit.upper()] > MAX_MEMORY_LIMIT_BYTES:
+    return float(number) * multipliers[unit.upper()]
+
+
+def _validate_memory_limit(name: str, value: str) -> str:
+    """Validate a bounded memory-size option without accepting paths or expressions."""
+    size = _memory_size_bytes(value)
+    if size is None:
+        raise MCPValidationError(f"Platform option '{name}' must use a bounded memory size")
+    if size > MAX_MEMORY_LIMIT_BYTES:
         raise MCPValidationError(f"Platform option '{name}' exceeds the permitted memory limit")
     return value
+
+
+@dataclass(frozen=True, slots=True)
+class DaskResourceEnvelope:
+    """Server-owned aggregate ceiling for one MCP-requested Dask cluster.
+
+    Dask's per-field maxima bound each knob in isolation, but the pressure a
+    request actually puts on the host is the *product* of the worker count and
+    the per-worker thread and memory limits.  This record is the aggregate
+    budget that product must fit inside.
+    """
+
+    max_workers: int
+    max_total_threads: int
+    max_total_memory_bytes: float
+
+
+# Effective adapter defaults for fields the request leaves unset.  These mirror
+# the conservative local caps in benchbox/platforms/dataframe/dask_df.py, so an
+# omitted field can never contribute more than the adapter would actually apply.
+_DASK_DEFAULT_WORKERS = 2
+_DASK_DEFAULT_THREADS_PER_WORKER = 2
+_DASK_DEFAULT_MEMORY_PER_WORKER_BYTES = float(2 << 30)
+
+# Server-owned aggregate budget.  Deliberately far below the per-field maxima:
+# n_workers=256 x threads_per_worker=256 would otherwise admit a 65,536-thread
+# cluster advertising 256 TB of memory from a single request.
+MCP_DASK_MAX_WORKERS_ENV = "BENCHBOX_MCP_DASK_MAX_WORKERS"
+MCP_DASK_MAX_TOTAL_THREADS_ENV = "BENCHBOX_MCP_DASK_MAX_TOTAL_THREADS"
+MCP_DASK_MAX_TOTAL_MEMORY_ENV = "BENCHBOX_MCP_DASK_MAX_TOTAL_MEMORY"
+_DASK_DEFAULT_MAX_WORKERS = 16
+_DASK_DEFAULT_MAX_TOTAL_THREADS = 64
+_DASK_DEFAULT_MAX_TOTAL_MEMORY = "64GB"
+
+
+def _envelope_int(env_name: str, default: int, *, maximum: int) -> int:
+    """Read one operator-supplied integer budget, falling back when unusable."""
+    raw = os.environ.get(env_name, "").strip()
+    if not raw:
+        return default
+    try:
+        value = int(raw)
+    except ValueError:
+        logger.error("Ignoring malformed %s: value is not an integer", env_name)
+        return default
+    if not 1 <= value <= maximum:
+        logger.error("Ignoring out-of-range %s: value must be in 1-%d", env_name, maximum)
+        return default
+    return value
+
+
+def load_dask_resource_envelope() -> DaskResourceEnvelope:
+    """Return the server-owned aggregate Dask budget for this process."""
+    raw_memory = os.environ.get(MCP_DASK_MAX_TOTAL_MEMORY_ENV, "").strip()
+    memory_bytes = _memory_size_bytes(raw_memory) if raw_memory else None
+    if raw_memory and memory_bytes is None:
+        logger.error("Ignoring malformed %s: value is not a bounded memory size", MCP_DASK_MAX_TOTAL_MEMORY_ENV)
+    if memory_bytes is None:
+        memory_bytes = _memory_size_bytes(_DASK_DEFAULT_MAX_TOTAL_MEMORY)
+    assert memory_bytes is not None
+    return DaskResourceEnvelope(
+        max_workers=_envelope_int(MCP_DASK_MAX_WORKERS_ENV, _DASK_DEFAULT_MAX_WORKERS, maximum=256),
+        max_total_threads=_envelope_int(
+            MCP_DASK_MAX_TOTAL_THREADS_ENV, _DASK_DEFAULT_MAX_TOTAL_THREADS, maximum=65_536
+        ),
+        max_total_memory_bytes=memory_bytes,
+    )
+
+
+def _validate_dask_options(normalized: Mapping[str, object]) -> None:
+    """Reject a Dask request whose aggregate footprint exceeds the host budget.
+
+    Runs before adapter construction: ``DaskDataFrameAdapter.__init__`` builds
+    the ``LocalCluster`` itself, so a guard placed any later would have to start
+    the oversized cluster to discover it was oversized.
+    """
+    envelope = load_dask_resource_envelope()
+
+    workers = normalized.get("n_workers", _DASK_DEFAULT_WORKERS)
+    threads_per_worker = normalized.get("threads_per_worker", _DASK_DEFAULT_THREADS_PER_WORKER)
+    assert isinstance(workers, int) and isinstance(threads_per_worker, int)
+
+    if workers > envelope.max_workers:
+        raise MCPValidationError("Dask 'n_workers' exceeds the server's worker budget")
+
+    total_threads = workers * threads_per_worker
+    if total_threads > envelope.max_total_threads:
+        # The product, not either field alone, is the CPU pressure on the host.
+        raise MCPValidationError("Dask 'n_workers' x 'threads_per_worker' exceeds the server's total thread budget")
+
+    memory_limit = normalized.get("memory_limit")
+    per_worker_bytes = (
+        _memory_size_bytes(str(memory_limit)) if memory_limit is not None else _DASK_DEFAULT_MEMORY_PER_WORKER_BYTES
+    )
+    assert per_worker_bytes is not None  # already bounded by _validate_memory_limit
+    if workers * per_worker_bytes > envelope.max_total_memory_bytes:
+        # memory_limit is per worker, so the advertised total scales with n_workers.
+        raise MCPValidationError("Dask 'n_workers' x 'memory_limit' exceeds the server's total memory budget")
 
 
 def validate_platform_options(platform: str, options: Mapping[str, object] | None) -> dict[str, object]:
@@ -421,6 +527,8 @@ def _validate_cross_field_policy(platform_name: str, normalized: Mapping[str, ob
     """Apply per-platform rules that individual value bounds cannot express."""
     if platform_name in {"clickhouse", "clickhouse-server"}:
         _validate_clickhouse_options(platform_name, normalized)
+    elif platform_name == "dask":
+        _validate_dask_options(normalized)
 
 
 def validate_query_id(query_id: str) -> str:

--- a/benchbox/mcp/schemas.py
+++ b/benchbox/mcp/schemas.py
@@ -414,6 +414,10 @@ MCP_DASK_MAX_TOTAL_MEMORY_ENV = "BENCHBOX_MCP_DASK_MAX_TOTAL_MEMORY"
 _DASK_DEFAULT_MAX_WORKERS = 16
 _DASK_DEFAULT_MAX_TOTAL_THREADS = 64
 _DASK_DEFAULT_MAX_TOTAL_MEMORY = "64GB"
+# A units slip or an extra digit ("999999TB") is syntactically valid, so the
+# memory override needs the same out-of-range guard the integer budgets have --
+# otherwise a typo silently disables the aggregate memory ceiling entirely.
+_DASK_MAX_TOTAL_MEMORY_CEILING_BYTES = float(16 << 40)
 
 
 def _envelope_int(env_name: str, default: int, *, maximum: int) -> int:
@@ -438,6 +442,13 @@ def load_dask_resource_envelope() -> DaskResourceEnvelope:
     memory_bytes = _memory_size_bytes(raw_memory) if raw_memory else None
     if raw_memory and memory_bytes is None:
         logger.error("Ignoring malformed %s: value is not a bounded memory size", MCP_DASK_MAX_TOTAL_MEMORY_ENV)
+    if memory_bytes is not None and memory_bytes > _DASK_MAX_TOTAL_MEMORY_CEILING_BYTES:
+        logger.error(
+            "Ignoring out-of-range %s: value must not exceed %dTB",
+            MCP_DASK_MAX_TOTAL_MEMORY_ENV,
+            int(_DASK_MAX_TOTAL_MEMORY_CEILING_BYTES) >> 40,
+        )
+        memory_bytes = None
     if memory_bytes is None:
         memory_bytes = _memory_size_bytes(_DASK_DEFAULT_MAX_TOTAL_MEMORY)
     assert memory_bytes is not None
@@ -483,8 +494,12 @@ def _validate_dask_options(normalized: Mapping[str, object]) -> None:
 
 def validate_platform_options(platform: str, options: Mapping[str, object] | None) -> dict[str, object]:
     """Return canonical, bounded MCP platform options or fail closed."""
+    # An omitted request and an empty one must validate identically.  Returning
+    # early for None would skip the cross-field policy, so a request that names
+    # no options at all would escape the server's resource envelope and run on
+    # adapter defaults that may exceed it.
     if options is None:
-        return {}
+        options = {}
     if not isinstance(options, Mapping):
         raise MCPValidationError("platform_options must be an object")
     if len(options) > MAX_PLATFORM_OPTIONS:

--- a/docs/development/mcp-platform-option-contract.md
+++ b/docs/development/mcp-platform-option-contract.md
@@ -15,7 +15,7 @@ permission to expose the underlying adapter's full configuration surface.
 | ClickHouse | `deployment_mode` | `ClickHouseAdapter.from_config` | execution | Connection destinations and transport policy remain server-owned. |
 | ClickHouse | `connection_profile` | `ClickHouseAdapter.from_config(port, secure)` resolved from `BENCHBOX_MCP_CLICKHOUSE_PROFILES` | connection | Reject caller-supplied `port`/`secure`, arbitrary destinations, and TLS downgrade. Only the profile name is accepted and persisted. |
 | cuDF | `device_id`, `spill_to_host` | cuDF runtime and memory policy | device/resource | Reject device paths, scheduler endpoints, and package controls. |
-| Dask | `memory_limit`, `n_workers`, `threads_per_worker` | LocalCluster resource envelope | resource | Enforce aggregate limits; reject scheduler endpoints and spill paths. |
+| Dask | `memory_limit`, `n_workers`, `threads_per_worker` | LocalCluster resource envelope, bounded in aggregate by `load_dask_resource_envelope()` before adapter construction | resource | Per-field maxima are insufficient: worker count, `n_workers` x `threads_per_worker`, and `n_workers` x `memory_limit` are each capped by a server-owned budget. Reject scheduler endpoints and spill paths. |
 | Dask | `use_distributed` | Dask execution-mode selector | execution | Reject external scheduler selection. |
 | DataFusion | `batch_size`, `memory_limit`, `target_partitions` | DataFusion execution configuration | resource | Reject filesystem paths and unbounded worker controls. |
 | DataFusion | `parquet_pushdown`, `repartition_joins` | DataFusion execution options | execution | Reject arbitrary SQL or datasource configuration. |

--- a/docs/operations/mcp-remote-security.md
+++ b/docs/operations/mcp-remote-security.md
@@ -127,9 +127,15 @@ oversized cluster to discover it was oversized.
 `memory_limit` is per worker, so the advertised total scales with `n_workers`.
 Fields the request omits are scored using the adapter's own conservative local
 caps (2 workers, 2 threads per worker, 2 GB per worker), so an omitted field
-never contributes more than the adapter would actually apply. A malformed or
-out-of-range override is ignored in favour of the reviewed default rather than
-being partially trusted.
+never contributes more than the adapter would actually apply. A request that
+omits `platform_options` entirely is held to the same envelope as an empty one,
+so an optionless run cannot escape a budget tighter than those defaults.
+
+A malformed or out-of-range override is ignored in favour of the reviewed
+default rather than being partially trusted. Every override is bounded:
+`..._MAX_WORKERS` at 256, `..._MAX_TOTAL_THREADS` at 65536, and
+`..._MAX_TOTAL_MEMORY` at 16 TB — so a units slip such as `999999TB` falls back
+to the default instead of silently disabling the memory ceiling.
 
 This envelope is an additional per-run guard. The server-wide and per-principal
 concurrency limits in `admission` remain enforced independently.

--- a/docs/operations/mcp-remote-security.md
+++ b/docs/operations/mcp-remote-security.md
@@ -106,6 +106,34 @@ execution time, so withdrawing a profile immediately fails closed for queued
 retries. Rejections never echo the requested profile name, so a caller cannot
 use validation errors to enumerate configured profiles.
 
+## Dask aggregate resource envelope
+
+Dask's per-field bounds constrain each knob in isolation, but the pressure a
+request puts on the host is their product. Without an aggregate ceiling,
+`n_workers: 256` combined with `threads_per_worker: 256` describes a
+65,536-thread `LocalCluster` advertising 256 TB of memory from a single request.
+
+Every MCP-requested Dask cluster must therefore fit inside a server-owned
+aggregate budget, checked before the adapter is constructed — the adapter builds
+its `LocalCluster` in `__init__`, so a later guard would have to start the
+oversized cluster to discover it was oversized.
+
+| Budget | Env var | Default |
+|---|---|---|
+| Worker count | `BENCHBOX_MCP_DASK_MAX_WORKERS` | `16` |
+| `n_workers` x `threads_per_worker` | `BENCHBOX_MCP_DASK_MAX_TOTAL_THREADS` | `64` |
+| `n_workers` x `memory_limit` | `BENCHBOX_MCP_DASK_MAX_TOTAL_MEMORY` | `64GB` |
+
+`memory_limit` is per worker, so the advertised total scales with `n_workers`.
+Fields the request omits are scored using the adapter's own conservative local
+caps (2 workers, 2 threads per worker, 2 GB per worker), so an omitted field
+never contributes more than the adapter would actually apply. A malformed or
+out-of-range override is ignored in favour of the reviewed default rather than
+being partially trusted.
+
+This envelope is an additional per-run guard. The server-wide and per-principal
+concurrency limits in `admission` remain enforced independently.
+
 ## Durable remote benchmark jobs
 
 Remote clients should use `start_benchmark` instead of holding a

--- a/docs/reference/mcp.md
+++ b/docs/reference/mcp.md
@@ -247,6 +247,11 @@ modes remain available because they do not hold the request for execution.
   filesystem paths, unbounded values, and driver auto-install/version controls
   fail closed. Authenticated durable jobs persist only this normalized object,
   so retries and worker restarts cannot reintroduce raw request mappings.
+- Dask cluster sizing is bounded in aggregate, not only per field. A request's
+  `n_workers`, `n_workers` x `threads_per_worker`, and `n_workers` x
+  `memory_limit` must all fit inside a server-owned budget, enforced before the
+  adapter builds its `LocalCluster` (see
+  [MCP remote security](../operations/mcp-remote-security.md)).
 - ClickHouse connection destinations are server-owned. A request cannot set
   `port` or `secure`; both are rejected for every ClickHouse spelling. A
   non-default port or TLS setting is reachable only through

--- a/tests/integration/mcp/test_durable_jobs.py
+++ b/tests/integration/mcp/test_durable_jobs.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
+from unittest.mock import patch
 
 import anyio
 import pytest
@@ -13,6 +14,7 @@ from mcp.types import TextContent
 from benchbox.mcp.jobs import DurableJobRepository, DurableJobWorker
 from benchbox.mcp.schemas import (
     MCP_CLICKHOUSE_PROFILE_ENV,
+    MCP_DASK_MAX_TOTAL_THREADS_ENV,
     MCPValidationError,
     validate_platform_options,
 )
@@ -94,6 +96,39 @@ def test_normalized_platform_options_survive_repository_round_trip(tmp_path: Pat
     persisted = repository.get_owned(submitted.execution_id, "tenant-a")
     assert persisted is not None
     assert persisted.request["platform_options"] == {"threads": 4}
+
+
+def test_durable_admission_refuses_an_oversized_dask_envelope(tmp_path: Path) -> None:
+    """An over-envelope request must never reach the queue, let alone a worker."""
+    repository = DurableJobRepository(tmp_path / "state.sqlite3", JobLimits())
+
+    with pytest.raises(MCPValidationError, match="thread budget"):
+        validate_platform_options("dask", {"n_workers": 16, "threads_per_worker": 256})
+
+    with repository._connect() as connection:
+        queued = connection.execute("SELECT COUNT(*) FROM mcp_benchmark_jobs").fetchone()[0]
+    assert queued == 0
+
+
+def test_durable_worker_replay_re_enforces_the_dask_envelope(tmp_path: Path, monkeypatch) -> None:
+    """A budget tightened after submission is applied on replay, not bypassed."""
+    repository = DurableJobRepository(tmp_path / "state.sqlite3", JobLimits())
+    options = validate_platform_options("dask", {"n_workers": 8, "threads_per_worker": 4})
+    submitted, _ = repository.submit(
+        "tenant-a", {**_request(), "platform": "dask-df", "mode": "dataframe", "platform_options": options}
+    )
+
+    # The operator narrows the budget while the job is still queued.
+    monkeypatch.setenv(MCP_DASK_MAX_TOTAL_THREADS_ENV, "8")
+
+    claimed = repository.claim("worker-a")
+    assert claimed is not None
+    with patch("benchbox.mcp.tools.benchmark._get_platform_adapter") as get_adapter:
+        response = DurableJobWorker._execute_benchmark(claimed, tmp_path / "staging")
+
+    assert response["status"] == "failed"
+    get_adapter.assert_not_called()
+    assert repository.get(submitted.execution_id) is not None
 
 
 def test_durable_clickhouse_requests_never_persist_a_connection_tuple(tmp_path: Path, monkeypatch) -> None:

--- a/tests/unit/mcp/test_benchmark_tools.py
+++ b/tests/unit/mcp/test_benchmark_tools.py
@@ -169,6 +169,96 @@ class TestRunBenchmarkTool:
         assert response["mcp_metadata"]["status"] == "no_results"
         assert get_adapter.call_args.kwargs["thread_limit"] == 4
 
+    def test_oversized_dask_request_never_builds_a_cluster(self, tmp_path: Path):
+        """Proving rejection by starting a 65,536-thread cluster would be the attack."""
+        from benchbox.mcp.tools import benchmark as benchmark_tools
+
+        with patch.object(benchmark_tools, "_get_platform_adapter") as get_adapter:
+            response = benchmark_tools._run_benchmark_impl(
+                "dask-df",
+                "tpch",
+                0.01,
+                None,
+                "load,power",
+                "dataframe",
+                platform_options={"n_workers": 256, "threads_per_worker": 256},
+                results_dir=tmp_path,
+            )
+
+        assert response["status"] == "failed"
+        # The adapter builds its LocalCluster in __init__, so never reaching the
+        # factory is the only evidence that no cluster was created.
+        get_adapter.assert_not_called()
+
+    def test_dask_local_cluster_is_never_constructed_for_a_rejected_request(self, tmp_path: Path):
+        """Spy one level deeper: LocalCluster itself must not be touched.
+
+        Every downstream collaborator is stubbed so that on an unfixed tree this
+        fails on the assertion rather than by starting a real cluster or a real
+        benchmark.
+        """
+        pytest.importorskip("dask.distributed")
+        from benchbox.mcp.tools import benchmark as benchmark_tools
+        from benchbox.platforms.dataframe import dask_df
+
+        class DummyBenchmark:
+            def __init__(self, scale_factor: float) -> None:
+                self.scale_factor = scale_factor
+
+            def run_with_platform(self, *_args, **_kwargs):
+                return None
+
+        with (
+            patch.object(benchmark_tools, "get_all_benchmarks", return_value={"tpch": {"name": "tpch"}}),
+            patch.object(benchmark_tools, "get_public_benchmark_class", return_value=DummyBenchmark),
+            patch.object(dask_df, "LocalCluster") as local_cluster,
+            patch.object(dask_df, "Client"),
+        ):
+            benchmark_tools._run_benchmark_impl(
+                "dask-df",
+                "tpch",
+                0.01,
+                None,
+                "load,power",
+                "dataframe",
+                platform_options={"n_workers": 256, "threads_per_worker": 256},
+                results_dir=tmp_path,
+            )
+
+        local_cluster.assert_not_called()
+
+    def test_dask_request_inside_the_envelope_still_reaches_the_adapter(self, tmp_path: Path):
+        """The envelope is a ceiling, not a ban on tuning."""
+        from benchbox.mcp.tools import benchmark as benchmark_tools
+
+        class DummyBenchmark:
+            def __init__(self, scale_factor: float) -> None:
+                self.scale_factor = scale_factor
+
+            def run_with_platform(self, *_args, **_kwargs):
+                return None
+
+        with (
+            patch.object(benchmark_tools, "get_all_benchmarks", return_value={"tpch": {"name": "tpch"}}),
+            patch.object(benchmark_tools, "get_public_benchmark_class", return_value=DummyBenchmark),
+            patch.object(benchmark_tools, "_get_platform_adapter", return_value=Mock()) as get_adapter,
+        ):
+            benchmark_tools._run_benchmark_impl(
+                "dask-df",
+                "tpch",
+                0.01,
+                None,
+                "load,power",
+                "dataframe",
+                platform_options={"n_workers": 4, "threads_per_worker": 4, "memory_limit": "4GB"},
+                results_dir=tmp_path,
+            )
+
+        kwargs = get_adapter.call_args.kwargs
+        assert kwargs["n_workers"] == 4
+        assert kwargs["threads_per_worker"] == 4
+        assert kwargs["memory_limit"] == "4GB"
+
     @pytest.mark.parametrize("platform", ["clickhouse", "clickhouse-server"])
     def test_clickhouse_port_override_is_refused_before_any_adapter_is_built(self, platform, tmp_path: Path):
         """A request must not be able to point ClickHouse at another listener."""

--- a/tests/unit/mcp/test_schemas.py
+++ b/tests/unit/mcp/test_schemas.py
@@ -396,6 +396,36 @@ class TestDaskResourceEnvelope:
         assert envelope.max_total_threads == 64
         assert envelope.max_total_memory_bytes == float(64 << 30)
 
+    @pytest.mark.parametrize("value", ["999999TB", "17TB", "1000000GB"])
+    def test_an_out_of_range_memory_override_cannot_disable_the_ceiling(self, monkeypatch, value):
+        """A units slip must not silently remove the aggregate memory guard."""
+        monkeypatch.setenv(MCP_DASK_MAX_TOTAL_MEMORY_ENV, value)
+        assert load_dask_resource_envelope().max_total_memory_bytes == float(64 << 30)
+        with pytest.raises(MCPValidationError, match="total memory budget"):
+            validate_platform_options("dask", {"n_workers": 16, "memory_limit": "1024GB"})
+
+    def test_an_in_range_memory_override_is_still_honoured(self, monkeypatch):
+        monkeypatch.setenv(MCP_DASK_MAX_TOTAL_MEMORY_ENV, "16TB")
+        assert load_dask_resource_envelope().max_total_memory_bytes == float(16 << 40)
+
+    def test_an_omitted_request_is_held_to_the_same_envelope_as_an_empty_one(self, monkeypatch):
+        """None and {} must validate identically.
+
+        `start_benchmark` drops an empty `platform_options` from the persisted
+        request, so the durable worker replays `None`. If `None` short-circuited
+        validation, an ordinary optionless request would start the adapter's
+        default cluster while ignoring a tighter operator budget.
+        """
+        monkeypatch.setenv(MCP_DASK_MAX_WORKERS_ENV, "1")
+        for omitted in (None, {}):
+            with pytest.raises(MCPValidationError, match="worker budget"):
+                validate_platform_options("dask", omitted)
+
+    def test_an_optionless_request_still_passes_under_the_default_budget(self):
+        """The uniform check must not reject ordinary optionless runs."""
+        assert validate_platform_options("dask", None) == {}
+        assert validate_platform_options("duckdb", None) == {}
+
 
 CLICKHOUSE_PLATFORM_SPELLINGS = ("clickhouse", "clickhouse-server")
 CLICKHOUSE_UNCONFIGURED_SPELLINGS = ("clickhouse-local", "clickhouse-cloud", "chdb", "clickhouse_server")

--- a/tests/unit/mcp/test_schemas.py
+++ b/tests/unit/mcp/test_schemas.py
@@ -14,6 +14,9 @@ from benchbox.mcp.schemas import (
     MAX_QUERY_ID_LENGTH,
     MAX_QUERY_IDS,
     MCP_CLICKHOUSE_PROFILE_ENV,
+    MCP_DASK_MAX_TOTAL_MEMORY_ENV,
+    MCP_DASK_MAX_TOTAL_THREADS_ENV,
+    MCP_DASK_MAX_WORKERS_ENV,
     MCP_PLATFORM_OPTION_ALLOWLIST,
     MCP_PLATFORM_OPTION_CONTRACT,
     CompareResultsInput,
@@ -25,6 +28,7 @@ from benchbox.mcp.schemas import (
     MCPValidationError,
     RunBenchmarkInput,
     ValidateConfigInput,
+    load_dask_resource_envelope,
     resolve_clickhouse_connection_profile,
     validate_benchmark_name,
     validate_filename,
@@ -312,6 +316,85 @@ class TestRunBenchmarkInput:
         assert validate_platform_options("velox", {"deployment": "remote"}) == {"deployment": "remote"}
         with pytest.raises(MCPValidationError):
             validate_platform_options("modin", {"engine": "pandas"})
+
+
+class TestDaskResourceEnvelope:
+    """One request must not be able to size a cluster the host cannot run."""
+
+    def test_independent_maxima_cannot_be_multiplied_into_a_thread_bomb(self):
+        """n_workers=256 x threads_per_worker=256 is 65,536 threads."""
+        with pytest.raises(MCPValidationError, match="total thread budget"):
+            validate_platform_options("dask", {"n_workers": 16, "threads_per_worker": 256})
+
+    def test_worker_count_alone_is_bounded(self):
+        with pytest.raises(MCPValidationError, match="worker budget"):
+            validate_platform_options("dask", {"n_workers": 256})
+
+    def test_per_worker_memory_is_multiplied_by_the_worker_count(self):
+        """memory_limit is per worker, so the advertised total scales with it."""
+        assert validate_platform_options("dask", {"n_workers": 8, "memory_limit": "8GB"}) == {
+            "n_workers": 8,
+            "memory_limit": "8GB",
+        }
+        with pytest.raises(MCPValidationError, match="total memory budget"):
+            validate_platform_options("dask", {"n_workers": 8, "memory_limit": "9GB"})
+
+    @pytest.mark.parametrize(
+        ("options", "expected"),
+        [
+            ({"n_workers": 16, "threads_per_worker": 4}, True),
+            ({"n_workers": 16, "threads_per_worker": 5}, False),
+            ({"n_workers": 17, "threads_per_worker": 1}, False),
+            ({"n_workers": 1, "threads_per_worker": 64}, True),
+            ({"n_workers": 1, "threads_per_worker": 65}, False),
+        ],
+    )
+    def test_aggregate_boundaries_are_exact(self, options, expected):
+        if expected:
+            assert validate_platform_options("dask", options) == options
+        else:
+            with pytest.raises(MCPValidationError):
+                validate_platform_options("dask", options)
+
+    def test_omitted_fields_use_the_adapters_own_conservative_caps(self):
+        """An unset field contributes no more than the adapter would apply."""
+        assert validate_platform_options("dask", {"threads_per_worker": 32}) == {"threads_per_worker": 32}
+        with pytest.raises(MCPValidationError, match="total thread budget"):
+            validate_platform_options("dask", {"threads_per_worker": 33})
+
+    def test_dataframe_alias_is_covered_by_the_same_envelope(self):
+        with pytest.raises(MCPValidationError, match="worker budget"):
+            validate_platform_options("dask-df", {"n_workers": 256})
+
+    def test_operator_can_widen_or_narrow_the_budget(self, monkeypatch):
+        monkeypatch.setenv(MCP_DASK_MAX_WORKERS_ENV, "4")
+        monkeypatch.setenv(MCP_DASK_MAX_TOTAL_THREADS_ENV, "8")
+        monkeypatch.setenv(MCP_DASK_MAX_TOTAL_MEMORY_ENV, "8GB")
+        envelope = load_dask_resource_envelope()
+        assert envelope.max_workers == 4
+        assert envelope.max_total_threads == 8
+        assert envelope.max_total_memory_bytes == float(8 << 30)
+        with pytest.raises(MCPValidationError, match="worker budget"):
+            validate_platform_options("dask", {"n_workers": 5})
+
+    @pytest.mark.parametrize(
+        ("env_name", "value"),
+        [
+            (MCP_DASK_MAX_WORKERS_ENV, "not-a-number"),
+            (MCP_DASK_MAX_WORKERS_ENV, "0"),
+            (MCP_DASK_MAX_WORKERS_ENV, "-5"),
+            (MCP_DASK_MAX_WORKERS_ENV, "100000"),
+            (MCP_DASK_MAX_TOTAL_THREADS_ENV, "nonsense"),
+            (MCP_DASK_MAX_TOTAL_MEMORY_ENV, "/etc/passwd"),
+            (MCP_DASK_MAX_TOTAL_MEMORY_ENV, "lots"),
+        ],
+    )
+    def test_malformed_operator_budget_falls_back_to_the_reviewed_default(self, monkeypatch, env_name, value):
+        monkeypatch.setenv(env_name, value)
+        envelope = load_dask_resource_envelope()
+        assert envelope.max_workers == 16
+        assert envelope.max_total_threads == 64
+        assert envelope.max_total_memory_bytes == float(64 << 30)
 
 
 CLICKHOUSE_PLATFORM_SPELLINGS = ("clickhouse", "clickhouse-server")


### PR DESCRIPTION
Closes the `mcp-v2-dask-resource-envelope-v3` tracker item (critical).

> **Stacked on [#1510](https://github.com/joeharris76/BenchBox/pull/1510).** Base is
> `claude/mcp-v2-platform-options-e5427e` so this PR shows only its own diff; GitHub
> retargets to `develop` automatically once #1510 merges.

## Problem

`n_workers` and `threads_per_worker` were each bounded at 256, independently.
Their product is the actual CPU pressure, and it was unbounded:

```
validate_platform_options("dask", {"n_workers": 256, "threads_per_worker": 256,
                                   "memory_limit": "1024GB"})   -> accepted
# 65,536 threads, 256 TB advertised, from one authenticated request
```

`DaskDataFrameAdapter.__init__` builds its `LocalCluster` during construction,
so nothing downstream could have stopped it.

## Change

- **Aggregate budget.** `load_dask_resource_envelope()` returns a server-owned
  ceiling on worker count, `n_workers` x `threads_per_worker`, and
  `n_workers` x `memory_limit`. Defaults 16 workers / 64 total threads / 64GB,
  retunable via `BENCHBOX_MCP_DASK_MAX_WORKERS`, `..._MAX_TOTAL_THREADS`,
  `..._MAX_TOTAL_MEMORY`. Malformed or out-of-range overrides fall back to the
  reviewed default.
- **Per-worker semantics respected.** `memory_limit` is per worker, so the
  advertised total is multiplied by `n_workers`.
- **Omitted fields are scored honestly.** Unset fields use the adapter's own
  conservative local caps (2 / 2 / 2GB), so an omitted field never contributes
  more than the adapter would actually apply.
- **One shared policy function.** The guard runs inside
  `validate_platform_options`, which synchronous admission, durable persistence,
  and durable worker replay all reach — so a rejected request cannot be queued,
  and a budget tightened after submission still applies on replay.
- **Additive, not a replacement.** The existing `admission` concurrency and
  queue limits are unchanged.

## Verification

| Rung | Command | Result |
|---|---|---|
| 1 | `pytest tests/unit/mcp/test_schemas.py tests/unit/mcp/test_benchmark_tools.py -q` | 143 passed |
| 2 | `pytest tests/integration/mcp/test_durable_jobs.py -q` | 10 passed |
| 3 | `ruff check` (scoped) | clean |

CI-only gates run locally: `lint-imports` 3 kept / 0 broken; `timing_policy_check --strict` 0 violations.

**Negative control:** removing the `dask` branch from `_validate_cross_field_policy`
fails 11 of the new tests, so none of them passes vacuously.

**No test starts a real cluster.** Rejection is asserted before adapter
construction, and a `LocalCluster` spy (with `Client` also stubbed) proves the
cluster class is never called — the spy fails on the assertion rather than by
starting anything.

## Scope note

`docs/development/mcp-platform-option-contract.md` was added to the item scope via
`todo scope-update`: its Dask row said "Enforce aggregate limits", which this change
implements, so the matrix would otherwise misstate the boundary.