### PR TITLE
fix(results): make public anonymization reach a fixed point

### DIFF
--- a/_project/scripts/results_explorer_corpus_migrate.py
+++ b/_project/scripts/results_explorer_corpus_migrate.py
@@ -13,7 +13,6 @@ import argparse
 import hashlib
 import json
 import os
-import re
 import sys
 import tempfile
 from pathlib import Path
@@ -33,7 +32,6 @@ DEFAULT_MANIFEST = BUNDLES_DIR / "path-privacy-migration.manifest.json"
 COMPANION_SUFFIXES = (".plans.json", ".tuning.json", ".applied.json")
 MANIFEST_SUFFIX = ".manifest.json"
 STRUCTURAL_MANIFEST_KEYS = frozenset({"bundle_file", "bundle_hash", "companion_hashes"})
-_PUBLIC_HASH_RE = re.compile(r"^(?:machine|host|path|endpoint|bucket|prefix|arn|table|column|database)_[0-9a-f]{8,64}$")
 
 
 def _sha256(raw: bytes) -> str:
@@ -70,19 +68,8 @@ def _load_json(path: Path) -> tuple[Any, bytes]:
 
 def _public_companion_payload(path: Path, payload: Any, manager: AnonymizationManager) -> Any:
     if path.name.endswith(".tuning.json") and isinstance(payload, dict):
-        return _preserve_public_hashes(payload, manager.anonymize_tuning_payload(payload))
-    return _preserve_public_hashes(payload, manager.anonymize_result_payload(payload))  # type: ignore[arg-type]
-
-
-def _preserve_public_hashes(original: Any, anonymized: Any) -> Any:
-    """Keep already-public identifier hashes stable across repeated migrations."""
-    if isinstance(original, dict) and isinstance(anonymized, dict):
-        return {key: _preserve_public_hashes(original.get(key), value) for key, value in anonymized.items()}
-    if isinstance(original, list) and isinstance(anonymized, list):
-        return [_preserve_public_hashes(old, new) for old, new in zip(original, anonymized, strict=False)]
-    if isinstance(original, str) and _PUBLIC_HASH_RE.fullmatch(original):
-        return original
-    return anonymized
+        return manager.anonymize_tuning_payload(payload)
+    return manager.anonymize_result_payload(payload)  # type: ignore[arg-type]
 
 
 def _manifest_path(bundle_path: Path) -> Path | None:
@@ -136,7 +123,7 @@ def migrate(*, bundles_dir: Path, write: bool, manifest_path: Path) -> dict[str,
         data, raw = _load_json(bundle_path)
         if not isinstance(data, dict):
             raise ValueError(f"primary bundle must be an object: {bundle_path}")
-        public_data = _preserve_public_hashes(data, manager.anonymize_result_payload(data))
+        public_data = manager.anonymize_result_payload(data)
         if _semantic_signature(data) != _semantic_signature(public_data):
             raise ValueError(f"semantic fields changed during privacy migration: {bundle_path}")
         public_raw = canonical_json_bytes(public_data)
@@ -169,7 +156,7 @@ def migrate(*, bundles_dir: Path, write: bool, manifest_path: Path) -> dict[str,
             manifest_data, manifest_raw = _load_json(manifest)
             if not isinstance(manifest_data, dict):
                 raise ValueError(f"submission manifest must be an object: {manifest}")
-            public_manifest = _preserve_public_hashes(manifest_data, _sanitize_manifest(manifest_data, manager))
+            public_manifest = _sanitize_manifest(manifest_data, manager)
             public_manifest["bundle_hash"] = _sha256(public_raw)
             hashes = public_manifest.get("companion_hashes")
             if isinstance(hashes, dict):

--- a/benchbox/core/results/anonymization.py
+++ b/benchbox/core/results/anonymization.py
@@ -85,6 +85,26 @@ def _compact_key(key: str) -> str:
     return re.sub(r"[^a-z0-9]+", "", key.lower())
 
 
+# Width of the digest carried by a public pseudonym. Shared by the emitter and
+# the recognizer below so the two cannot drift into a non-idempotent pair.
+_PUBLIC_HASH_WIDTH = 12
+_PUBLIC_HASH_DIGITS = frozenset("0123456789abcdef")
+
+
+def _is_public_pseudonym(value: str, prefix: str) -> bool:
+    """Return whether *value* is already the pseudonym ``prefix`` would emit.
+
+    Deliberately scoped to one prefix and to the exact emitted digest width
+    rather than matching any pseudonym-shaped token: see
+    ``AnonymizationManager._hash_public_identifier``.
+    """
+    marker = f"{prefix}_"
+    if not value.startswith(marker):
+        return False
+    digest = value[len(marker) :]
+    return len(digest) == _PUBLIC_HASH_WIDTH and all(char in _PUBLIC_HASH_DIGITS for char in digest)
+
+
 @dataclass
 class AnonymizationConfig:
     """Configuration for result anonymization."""
@@ -576,8 +596,29 @@ class AnonymizationManager:
         return None
 
     def _hash_public_identifier(self, value: str, prefix: str) -> str:
+        """Hash one identifier into a stable public pseudonym.
+
+        Anonymization has to reach a fixed point. Curated bundles are stored
+        already-anonymized, so the Explorer publication boundary re-anonymizes
+        values this method produced; hashing them a second time would mint a
+        different pseudonym for the same machine than a freshly submitted run
+        gets, and pseudonym stability is what lets the Explorer group results
+        by machine at all. A value already carrying *this* prefix's pseudonym
+        shape therefore passes through untouched.
+
+        The pass-through is scoped to ``prefix`` and to the exact emitted
+        digest width, not to pseudonym shape in general. That keeps a
+        capture-side ``machine_<16 hex>`` hashed, so internal and public
+        identities stay decoupled, and stops a ``host_`` token from surviving
+        verbatim inside a ``path_`` field. A submitter can still hand-craft a
+        value of this shape to pick their own pseudonym, so a pseudonym is a
+        grouping key only - never a provenance or trust signal. Provenance is
+        carried by trust labels.
+        """
+        if _is_public_pseudonym(value, prefix):
+            return value
         salt = self.config.machine_id_salt or ""
-        digest = hashlib.sha256(f"{salt}|{prefix}|{value}".encode()).hexdigest()[:12]
+        digest = hashlib.sha256(f"{salt}|{prefix}|{value}".encode()).hexdigest()[:_PUBLIC_HASH_WIDTH]
         return f"{prefix}_{digest}"
 
     @staticmethod

--- a/tests/unit/core/results/test_anonymization.py
+++ b/tests/unit/core/results/test_anonymization.py
@@ -15,9 +15,11 @@ from unittest.mock import MagicMock, Mock, mock_open, patch
 import pytest
 
 from benchbox.core.results.anonymization import (
+    _IDENTIFIER_KEYS,
     PUBLIC_REDACTED_VALUE,
     AnonymizationConfig,
     AnonymizationManager,
+    _is_public_pseudonym,
     find_public_path_leaks,
 )
 
@@ -1128,3 +1130,107 @@ class TestPublicPayloadPathPrivacy:
         assert find_public_path_leaks(payload)
         out = AnonymizationManager().anonymize_result_payload(payload)
         assert "/root/private-run" not in json.dumps(out, default=str)
+
+
+class TestPublicPseudonymFixedPoint:
+    """Anonymization must reach a fixed point.
+
+    Curated bundles are stored already-anonymized, so the Explorer publication
+    boundary anonymizes values this module produced. Hashing a pseudonym again
+    mints a second token for the same machine, so the corpus and a freshly
+    submitted run from that machine would group apart. Nothing fails when this
+    breaks - the grouping is just silently wrong - so it is pinned here.
+    """
+
+    PAYLOAD = {
+        "environment": {"machine_id": "machine_0123456789ab", "platform_runtime": {"engine_host": "db.internal"}},
+        "platform": {
+            "config": {
+                "working_dir": "/Users/alice/benchbox",
+                "database": "analytics",
+                "endpoint": "https://example.invalid/warehouse",
+                "s3_bucket": "alice-results",
+                "role_arn": "arn:aws:iam::1234:role/bench",
+            }
+        },
+        "config": {"platform_options": {"account_id": "acct-1", "cluster_id": "c-1", "schema_name": "public"}},
+    }
+
+    def test_result_payload_anonymization_is_idempotent(self):
+        manager = AnonymizationManager()
+        once = manager.anonymize_result_payload(self.PAYLOAD)
+        assert manager.anonymize_result_payload(once) == once
+
+    def test_tuning_payload_anonymization_is_idempotent(self):
+        """Tuning hashes table/column names into mapping *keys*, so re-walking
+        an already-anonymized companion re-hashes the keys as well as values.
+        """
+        manager = AnonymizationManager()
+        payload = {
+            "source_file": "examples/tunings/custom.yaml",
+            "requested": {
+                "table_tunings": {"lineitem": {"columns": [{"name": "l_orderkey"}]}},
+                "constraints": {"primary_key": {"table": "orders", "columns": ["o_orderkey"]}},
+            },
+        }
+        once = manager.anonymize_tuning_payload(payload)
+        assert manager.anonymize_tuning_payload(once) == once
+
+    def test_pseudonym_survives_a_second_pass_unchanged(self):
+        manager = AnonymizationManager()
+        once = manager.anonymize_result_payload(self.PAYLOAD)
+        twice = manager.anonymize_result_payload(once)
+        assert twice["environment"]["machine_id"] == once["environment"]["machine_id"]
+        assert twice["platform"]["config"]["working_dir"] == once["platform"]["config"]["working_dir"]
+
+    def test_every_emitted_pseudonym_is_recognized_as_one(self):
+        """Pin the emitter against the recognizer.
+
+        These are two halves of one contract - the ``[:12]`` slice and the
+        width the pass-through accepts. Widening one alone silently restores
+        the double-hash bug, and no payload-level test would notice.
+        """
+        manager = AnonymizationManager()
+        for prefix in sorted(set(_IDENTIFIER_KEYS.values()) | {"path", "host", "endpoint", "table", "column"}):
+            emitted = manager._hash_public_identifier("some-private-value", prefix)
+            assert _is_public_pseudonym(emitted, prefix), f"{prefix}: emitted {emitted!r} is not recognized"
+            assert manager._hash_public_identifier(emitted, prefix) == emitted
+
+    def test_capture_side_machine_id_is_still_hashed(self):
+        """The pass-through must not decouple-proof internal identity.
+
+        ``get_anonymous_machine_id`` emits a 16-hex token; the public boundary
+        re-hashes it to a 12-hex one so the internal id is never published. A
+        width-agnostic pass-through would publish the internal id verbatim.
+        """
+        manager = AnonymizationManager()
+        internal = manager.get_anonymous_machine_id()
+        published = manager.anonymize_result_payload({"machine_id": internal})["machine_id"]
+        assert published != internal
+        assert _is_public_pseudonym(published, "machine")
+
+    def test_pass_through_does_not_cross_prefixes(self):
+        """A token only survives in the field family that would mint it.
+
+        Without prefix scoping, a ``host_``-shaped value would survive verbatim
+        inside a path field, letting a submitted payload carry a chosen token
+        into a namespace the anonymizer never assigned it to.
+        """
+        manager = AnonymizationManager()
+        out = manager.anonymize_result_payload({"working_dir": "host_0123456789ab"})
+        assert out["working_dir"] != "host_0123456789ab"
+        assert _is_public_pseudonym(out["working_dir"], "path")
+
+    @pytest.mark.parametrize(
+        "value",
+        [
+            "path_0123456789",  # too short
+            "path_0123456789abc",  # too long
+            "path_0123456789zz",  # not hex
+            "path_",  # no digest
+            "pathx_0123456789ab",  # prefix is not an exact match
+        ],
+    )
+    def test_only_the_exact_pseudonym_shape_passes_through(self, value):
+        assert not _is_public_pseudonym(value, "path")
+        assert AnonymizationManager().anonymize_result_payload({"working_dir": value})["working_dir"] != value

--- a/tests/unit/scripts/test_corpus_privacy_invariant.py
+++ b/tests/unit/scripts/test_corpus_privacy_invariant.py
@@ -19,7 +19,7 @@ from pathlib import Path
 
 import pytest
 
-from benchbox.core.results.anonymization import find_public_path_leaks
+from benchbox.core.results.anonymization import AnonymizationManager, find_public_path_leaks
 
 pytestmark = [
     pytest.mark.unit,
@@ -105,6 +105,42 @@ def test_code_test_is_gated_by_ci_required_result() -> None:
     workflow = yaml.safe_load((REPO_ROOT / ".github/workflows/pr.yml").read_text(encoding="utf-8"))
     needs = workflow["jobs"]["ci-required-result"]["needs"]
     assert "code-test" in needs, "ci-required-result no longer gates on code-test"
+
+
+def _anonymize(payload: dict, path: Path, manager: AnonymizationManager) -> dict:
+    """Route one corpus file through the entry point its publisher would use."""
+    if path.name.endswith(".tuning.json"):
+        return manager.anonymize_tuning_payload(payload)
+    return manager.anonymize_result_payload(payload)
+
+
+def test_anonymizing_the_corpus_twice_matches_anonymizing_it_once() -> None:
+    """Publication must be a fixed point over every curated bundle.
+
+    The corpus is stored already-anonymized, so the Explorer boundary
+    anonymizes these payloads a second time. If that second pass re-hashes the
+    pseudonyms, a curated bundle and a fresh submission from the *same machine*
+    publish different ``machine_id`` values and the Explorer groups them apart.
+    Nothing raises when this regresses - only the grouping is wrong - so scan
+    the real corpus rather than a fixture.
+    """
+    manager = AnonymizationManager()
+    unstable: list[str] = []
+    scanned = 0
+
+    for path in _corpus_json_files():
+        payload = json.loads(path.read_text(encoding="utf-8"))
+        if not isinstance(payload, dict):
+            continue
+        scanned += 1
+        once = _anonymize(payload, path, manager)
+        if _anonymize(once, path, manager) != once:
+            unstable.append(str(path.relative_to(REPO_ROOT)))
+
+    assert scanned, "no corpus mappings scanned - the fixed-point gate would be vacuous"
+    assert not unstable, f"{len(unstable)} corpus file(s) change under a second anonymization pass:\n" + "\n".join(
+        unstable[:20]
+    )
 
 
 def test_detector_still_flags_a_planted_leak() -> None:


### PR DESCRIPTION
## Problem

`AnonymizationManager.anonymize_result_payload` was not idempotent.
`_hash_public_identifier` hashed whatever it was handed, with no notion that the
value might already be a pseudonym it produced. Curated bundles are stored
already-anonymized, so the Explorer publication boundary hashed them a second
time.

Measured on `develop` across the whole corpus, before the fix:

```
source machine_id    : machine_3d46427037d2
published machine_id : machine_f8dd3066dcd1
IDEMPOTENT? False   (a publish pass changed bytes for 203/203 bundles)
```

Nothing failed — the grouping was just wrong. A curated bundle reached the
Explorer as a two-pass pseudonym, while a fresh community submission from the
**same physical machine** arrived as a one-pass pseudonym. One machine, two
public `machine_id` values. Same for `host_`, `path_`, and every other
identifier family. Pseudonym stability is the whole basis for correlating
results from one machine, so this silently broke it.

## Fix

A value already carrying its own prefix's pseudonym shape now passes through, so
anonymization reaches a fixed point.

The check is scoped to **the prefix being applied** and to **the exact emitted
digest width**, rather than to pseudonym shape in general:

- a capture-side `machine_<16 hex>` is still hashed, so the internal machine id
  is never published verbatim — internal and public identity stay decoupled;
- a `host_` token cannot survive verbatim inside a `path_` field.

This is deliberately tighter than the `^(?:machine|host|path|...)_[0-9a-f]{8,64}$`
pattern that existed in the migration tool, which would have done both of those
things. It also needs no prefix list: it derives from the prefix in hand, and
there are 27 prefixes in use versus the 10 that pattern enumerated.

**Security note.** A submitter can still hand-craft a value of this shape to pick
their own pseudonym. Pseudonym identity is therefore a grouping key only — never
a provenance or trust signal. Trust labels carry provenance. This is documented
on the method.

## Verification

- Publication is idempotent for **203/203** corpus bundles (was 0/203).
- For all **206** pre-#1467 originals, a fresh submission and the curated bundle
  now publish the **same** `machine_id` — the cross-corpus grouping bug is gone.
- `find_public_path_leaks` reports **zero** leaks over both corpora at one and
  two passes.
- Full fast lane: 26621 passed, 0 failures.
- Negative control: reverting the pass-through fails 5 of the new gates,
  including the corpus-wide one.

## On re-deriving the corpus

Not needed, and not done. The premise that the stored corpus is two passes from
raw does not hold: for **206/206** pre-#1467 originals,
`H(raw₁₆) == the current stored 12-hex value`. The corpus was always exactly one
pass from raw — only *publication* was doubling it. Fixing the boundary is
sufficient, and the corpus is untouched.

Published bytes do change, so every `result_id` changes. That is free right now:
`origin/release` carries zero bundles (verified).

## Also

Drops `_preserve_public_hashes` from `results_explorer_corpus_migrate.py`. It was
a looser copy of this same recognition, and it is now a **no-op on all 203
bundles** — the migration reports 207/207 unchanged without it. Keeping a second,
divergent authority would have meant a re-migration of raw bundles could publish
internal 16-hex machine ids. The anonymizer is now the single authority.

## Tests

- `TestPublicPseudonymFixedPoint` in `tests/unit/core/results/test_anonymization.py`
  — fixed point for result and tuning payloads, emitter/recognizer agreement
  (pins `[:12]` against the accepted width so they cannot drift apart), plus the
  two scoping guards above.
- `test_anonymizing_the_corpus_twice_matches_anonymizing_it_once` in
  `tests/unit/scripts/test_corpus_privacy_invariant.py` — whole-corpus gate,
  guarded against a vacuous scan, in the same module as the existing corpus
  privacy invariant.
