### PR TITLE
fix(mcp): reject contradictory Databricks clustering at admission

### DIFF
--- a/benchbox/mcp/schemas.py
+++ b/benchbox/mcp/schemas.py
@@ -544,6 +544,56 @@ def _validate_cross_field_policy(platform_name: str, normalized: Mapping[str, ob
         _validate_clickhouse_options(platform_name, normalized)
     elif platform_name == "dask":
         _validate_dask_options(normalized)
+    elif platform_name == "databricks":
+        # Building the intent is the validation: contradictory layout requests
+        # only reveal themselves once both fields are resolved together.
+        build_databricks_clustering_intent(normalized)
+
+
+def build_databricks_clustering_intent(normalized: Mapping[str, object]):
+    """Translate normalized MCP clustering options into effective tuning.
+
+    Returns ``None`` when the request carries no clustering intent.  Both the
+    admission gate and adapter preparation call this, so a combination that is
+    rejected at admission cannot be reconstructed later by a durable replay, and
+    the object the resolver consumes is the one that was validated.
+
+    Raises:
+        MCPValidationError: If the requested layout fields contradict each other.
+    """
+    strategy = normalized.get("databricks_clustering_strategy")
+    columns = normalized.get("liquid_clustering_columns")
+    if strategy is None and columns is None:
+        return None
+
+    from benchbox.core.tuning.interface import UnifiedTuningConfiguration
+
+    tuning_config = UnifiedTuningConfiguration()
+    platform_optimizations = tuning_config.platform_optimizations
+
+    if strategy is not None:
+        strategy = str(strategy).lower()
+        platform_optimizations.databricks_clustering_strategy = strategy
+        platform_optimizations.liquid_clustering_enabled = strategy in {
+            "liquid_clustering",
+            "liquid_clustering_auto",
+        }
+        platform_optimizations.physical_rendering_id = None
+    if columns is not None:
+        parsed_columns = [column.strip() for column in str(columns).split(",") if column.strip()]
+        platform_optimizations.liquid_clustering_columns = parsed_columns
+        platform_optimizations.liquid_clustering_enabled = bool(parsed_columns)
+        if parsed_columns and strategy is None:
+            platform_optimizations.databricks_clustering_strategy = "liquid_clustering"
+
+    try:
+        platform_optimizations.__post_init__()
+    except ValueError as exc:
+        # Surface layout conflicts as a structured validation error at admission
+        # instead of an execution failure discovered by a worker.  The message
+        # is generated from allow-listed option names, not from caller text.
+        raise MCPValidationError(f"Databricks clustering options conflict: {exc}") from exc
+    return tuning_config
 
 
 def validate_query_id(query_id: str) -> str:

--- a/benchbox/mcp/tools/benchmark.py
+++ b/benchbox/mcp/tools/benchmark.py
@@ -38,6 +38,7 @@ from benchbox.mcp.errors import (
 )
 from benchbox.mcp.schemas import (
     MCPValidationError,
+    build_databricks_clustering_intent,
     resolve_clickhouse_connection_profile,
     validate_platform_options,
 )
@@ -109,32 +110,18 @@ def _prepare_adapter_platform_options(platform: str, options: Mapping[str, objec
     if platform_name == "duckdb" and "threads" in normalized:
         normalized["thread_limit"] = normalized.pop("threads")
 
-    if platform_name == "databricks" and (
-        "databricks_clustering_strategy" in normalized or "liquid_clustering_columns" in normalized
-    ):
-        from benchbox.core.tuning.interface import UnifiedTuningConfiguration
-
-        tuning_config = UnifiedTuningConfiguration()
-        platform_optimizations = tuning_config.platform_optimizations
-        strategy = normalized.pop("databricks_clustering_strategy", None)
-        if strategy is not None:
-            strategy = str(strategy).lower()
-            platform_optimizations.databricks_clustering_strategy = strategy
-            platform_optimizations.liquid_clustering_enabled = strategy in {
-                "liquid_clustering",
-                "liquid_clustering_auto",
-            }
-            platform_optimizations.physical_rendering_id = None
-        columns = normalized.pop("liquid_clustering_columns", None)
-        if columns is not None:
-            parsed_columns = [column.strip() for column in str(columns).split(",") if column.strip()]
-            platform_optimizations.liquid_clustering_columns = parsed_columns
-            platform_optimizations.liquid_clustering_enabled = bool(parsed_columns)
-            if parsed_columns and strategy is None:
-                platform_optimizations.databricks_clustering_strategy = "liquid_clustering"
-        platform_optimizations.__post_init__()
-        normalized["tuning_config"] = tuning_config
-        normalized["tuning_enabled"] = True
+    if platform_name == "databricks":
+        # Same translation the admission gate ran, so the object the resolver
+        # consumes is the one that was validated.  `tuning_config` is what
+        # PlatformAdapter turns into `unified_tuning_configuration`, which
+        # `get_effective_tuning_configuration()` returns to the clustering
+        # resolver -- the raw option names would be dropped by `from_config`.
+        tuning_config = build_databricks_clustering_intent(normalized)
+        if tuning_config is not None:
+            normalized.pop("databricks_clustering_strategy", None)
+            normalized.pop("liquid_clustering_columns", None)
+            normalized["tuning_config"] = tuning_config
+            normalized["tuning_enabled"] = True
 
     return normalized
 

--- a/docs/development/mcp-platform-option-contract.md
+++ b/docs/development/mcp-platform-option-contract.md
@@ -21,7 +21,7 @@ permission to expose the underlying adapter's full configuration surface.
 | DataFusion | `parquet_pushdown`, `repartition_joins` | DataFusion execution options | execution | Reject arbitrary SQL or datasource configuration. |
 | DuckDB | `memory_limit`, `threads` | DuckDB adapter settings | resource | Public `threads` maps to adapter `thread_limit`; reject raw SQL settings. |
 | Firebolt | `disable_result_cache`, `strict_validation` | Firebolt execution/validation options | execution | Reject credentials, account, database, and endpoint fields. |
-| Databricks | `databricks_clustering_strategy`, `liquid_clustering_columns` | `PlatformOptimizationConfiguration` | layout | Reject raw connection settings and contradictory layout combinations. |
+| Databricks | `databricks_clustering_strategy`, `liquid_clustering_columns` | `PlatformOptimizationConfiguration` via `build_databricks_clustering_intent()`, reaching the resolver as `unified_tuning_configuration` | layout | Raw option names are dropped by `from_config`, so only the translated tuning object counts. Contradictory combinations are rejected at admission. Reject raw connection settings. |
 | Modin | `engine` | Modin dataframe backend selector | execution | Only reviewed `ray`/`dask`; reject unsupported backend names. |
 | pandas | `dtype_backend` | pandas dataframe dtype backend | execution | Reject package installation and arbitrary dtype expressions. |
 | Polars | `n_rows`, `rechunk` | Polars input and memory layout | resource | Reject filesystem paths and unbounded row counts. |

--- a/docs/reference/mcp.md
+++ b/docs/reference/mcp.md
@@ -247,6 +247,14 @@ modes remain available because they do not hold the request for execution.
   filesystem paths, unbounded values, and driver auto-install/version controls
   fail closed. Authenticated durable jobs persist only this normalized object,
   so retries and worker restarts cannot reintroduce raw request mappings.
+- Databricks clustering options are translated into effective tuning before the
+  adapter is built. `databricks_clustering_strategy` and
+  `liquid_clustering_columns` become a `PlatformOptimizationConfiguration` that
+  the clustering resolver consumes; forwarding the raw names would leave them to
+  be dropped by `from_config` and silently fall back to ZORDER. Contradictory
+  combinations (for example `z_order` with liquid clustering columns) are
+  rejected as validation errors at admission, before a durable job is persisted
+  and before any remote connection.
 - Dask cluster sizing is bounded in aggregate, not only per field. A request's
   `n_workers`, `n_workers` x `threads_per_worker`, and `n_workers` x
   `memory_limit` must all fit inside a server-owned budget, enforced before the

--- a/tests/integration/mcp/test_durable_jobs.py
+++ b/tests/integration/mcp/test_durable_jobs.py
@@ -98,6 +98,40 @@ def test_normalized_platform_options_survive_repository_round_trip(tmp_path: Pat
     assert persisted.request["platform_options"] == {"threads": 4}
 
 
+def test_durable_admission_refuses_contradictory_databricks_clustering(tmp_path: Path) -> None:
+    """A request that can never succeed must not occupy a durable queue slot."""
+    repository = DurableJobRepository(tmp_path / "state.sqlite3", JobLimits())
+
+    with pytest.raises(MCPValidationError, match="clustering options conflict"):
+        validate_platform_options(
+            "databricks",
+            {"databricks_clustering_strategy": "z_order", "liquid_clustering_columns": "a,b"},
+        )
+
+    with repository._connect() as connection:
+        assert connection.execute("SELECT COUNT(*) FROM mcp_benchmark_jobs").fetchone()[0] == 0
+
+
+def test_durable_databricks_requests_persist_only_normalized_intent(tmp_path: Path) -> None:
+    """Replay reconstructs the tuning object; it never replays raw mappings."""
+    repository = DurableJobRepository(tmp_path / "state.sqlite3", JobLimits())
+    options = validate_platform_options(
+        "databricks",
+        {"databricks_clustering_strategy": "liquid_clustering", "liquid_clustering_columns": "a,b"},
+    )
+
+    submitted, _ = repository.submit("tenant-a", {**_request(), "platform": "databricks", "platform_options": options})
+
+    persisted = repository.get_owned(submitted.execution_id, "tenant-a")
+    assert persisted is not None
+    assert persisted.request["platform_options"] == {
+        "databricks_clustering_strategy": "liquid_clustering",
+        "liquid_clustering_columns": "a,b",
+    }
+    # The persisted request survives a JSON round trip and still validates.
+    assert validate_platform_options("databricks", persisted.request["platform_options"]) == options
+
+
 def test_durable_admission_refuses_an_oversized_dask_envelope(tmp_path: Path) -> None:
     """An over-envelope request must never reach the queue, let alone a worker."""
     repository = DurableJobRepository(tmp_path / "state.sqlite3", JobLimits())

--- a/tests/unit/mcp/test_schemas.py
+++ b/tests/unit/mcp/test_schemas.py
@@ -28,6 +28,7 @@ from benchbox.mcp.schemas import (
     MCPValidationError,
     RunBenchmarkInput,
     ValidateConfigInput,
+    build_databricks_clustering_intent,
     load_dask_resource_envelope,
     resolve_clickhouse_connection_profile,
     validate_benchmark_name,
@@ -316,6 +317,51 @@ class TestRunBenchmarkInput:
         assert validate_platform_options("velox", {"deployment": "remote"}) == {"deployment": "remote"}
         with pytest.raises(MCPValidationError):
             validate_platform_options("modin", {"engine": "pandas"})
+
+
+class TestDatabricksClusteringOptions:
+    """Contradictory layout intent must fail at admission, not in a worker."""
+
+    @pytest.mark.parametrize(
+        "options",
+        [
+            {"databricks_clustering_strategy": "z_order", "liquid_clustering_columns": "a,b"},
+            {"databricks_clustering_strategy": "liquid_clustering_auto", "liquid_clustering_columns": "a"},
+            {"databricks_clustering_strategy": "none", "liquid_clustering_columns": "a"},
+        ],
+    )
+    def test_contradictory_layout_combinations_are_rejected(self, options):
+        with pytest.raises(MCPValidationError, match="clustering options conflict"):
+            validate_platform_options("databricks", options)
+
+    @pytest.mark.parametrize(
+        "options",
+        [
+            {"databricks_clustering_strategy": "liquid_clustering", "liquid_clustering_columns": "a,b"},
+            {"liquid_clustering_columns": "a,b"},
+            {"databricks_clustering_strategy": "z_order"},
+            {"databricks_clustering_strategy": "liquid_clustering_auto"},
+            {"databricks_clustering_strategy": "none"},
+        ],
+    )
+    def test_coherent_layout_combinations_are_accepted(self, options):
+        assert validate_platform_options("databricks", options) == options
+
+    def test_intent_translation_is_shared_with_adapter_preparation(self):
+        """Admission validates the same object preparation later hands over."""
+        normalized = validate_platform_options(
+            "databricks",
+            {"databricks_clustering_strategy": "liquid_clustering", "liquid_clustering_columns": "a,b"},
+        )
+        tuning_config = build_databricks_clustering_intent(normalized)
+        assert tuning_config is not None
+        platform_opts = tuning_config.platform_optimizations
+        assert platform_opts.databricks_clustering_strategy == "liquid_clustering"
+        assert platform_opts.liquid_clustering_columns == ["a", "b"]
+        assert platform_opts.liquid_clustering_enabled is True
+
+    def test_no_clustering_request_builds_no_intent(self):
+        assert build_databricks_clustering_intent({}) is None
 
 
 class TestDaskResourceEnvelope:

--- a/tests/unit/platforms/test_databricks_liquid_clustering.py
+++ b/tests/unit/platforms/test_databricks_liquid_clustering.py
@@ -278,3 +278,82 @@ def test_platform_metadata_includes_clustering_strategy_and_operations(_mock_wor
     assert platform_info["configuration"]["z_order_operations"] == []
     assert platform_info["configuration"]["applied_layout_operations"] == []
     assert platform_info["configuration"]["skipped_layout_operations"] == []
+
+
+@patch("benchbox.platforms.databricks.adapter.databricks_sql")
+def test_mcp_clustering_options_reach_the_effective_resolver(_mock_databricks_sql):
+    """MCP intent must survive `from_config`, not just be forwarded to it.
+
+    `from_config` rebuilds its constructor config from an explicit key list, so
+    raw `databricks_clustering_strategy` / `liquid_clustering_columns` kwargs are
+    dropped. Only the translated `tuning_config` becomes
+    `unified_tuning_configuration`, which is what the resolver reads.
+    """
+    from benchbox.mcp.schemas import validate_platform_options
+    from benchbox.mcp.tools.benchmark import _prepare_adapter_platform_options
+
+    normalized = validate_platform_options(
+        "databricks",
+        {"databricks_clustering_strategy": "liquid_clustering", "liquid_clustering_columns": "event_time,customer_id"},
+    )
+    prepared = _prepare_adapter_platform_options("databricks", normalized)
+
+    adapter = DatabricksAdapter.from_config(
+        {
+            "benchmark": "tpch",
+            "scale_factor": 1.0,
+            "server_hostname": "test.cloud.databricks.com",
+            "http_path": "/sql/1.0/warehouses/test",
+            "access_token": "test_token",
+            **prepared,
+        }
+    )
+
+    effective = adapter.get_effective_tuning_configuration()
+    assert effective is not None
+    platform_opts = effective.platform_optimizations
+    assert platform_opts.databricks_clustering_strategy == "liquid_clustering"
+    assert platform_opts.liquid_clustering_columns == ["event_time", "customer_id"]
+    assert platform_opts.liquid_clustering_enabled is True
+    assert adapter._resolve_databricks_clustering_strategy() == "liquid_clustering"
+
+
+@patch("benchbox.platforms.databricks.adapter.databricks_sql")
+def test_mcp_columns_alone_infer_liquid_clustering_at_the_resolver(_mock_databricks_sql):
+    from benchbox.mcp.schemas import validate_platform_options
+    from benchbox.mcp.tools.benchmark import _prepare_adapter_platform_options
+
+    normalized = validate_platform_options("databricks", {"liquid_clustering_columns": "event_time"})
+    prepared = _prepare_adapter_platform_options("databricks", normalized)
+
+    adapter = DatabricksAdapter.from_config(
+        {
+            "benchmark": "tpch",
+            "scale_factor": 1.0,
+            "server_hostname": "test.cloud.databricks.com",
+            "http_path": "/sql/1.0/warehouses/test",
+            "access_token": "test_token",
+            **prepared,
+        }
+    )
+
+    assert adapter._resolve_databricks_clustering_strategy() == "liquid_clustering"
+    assert adapter.get_effective_tuning_configuration().platform_optimizations.liquid_clustering_columns == [
+        "event_time"
+    ]
+
+
+@patch("benchbox.platforms.databricks.adapter.databricks_sql")
+def test_absent_mcp_clustering_options_keep_the_zorder_default(_mock_databricks_sql):
+    """The ZORDER fallback is correct when nothing was requested -- and only then."""
+    adapter = DatabricksAdapter.from_config(
+        {
+            "benchmark": "tpch",
+            "scale_factor": 1.0,
+            "server_hostname": "test.cloud.databricks.com",
+            "http_path": "/sql/1.0/warehouses/test",
+            "access_token": "test_token",
+        }
+    )
+
+    assert adapter._resolve_databricks_clustering_strategy() == "z_order"


### PR DESCRIPTION
Closes the `mcp-v2-databricks-clustering-options-v3` tracker item.

> **Stacked on [#1511](https://github.com/joeharris76/BenchBox/pull/1511)** (itself on
> [#1510](https://github.com/joeharris76/BenchBox/pull/1510)). Base is
> `claude/mcp-v2-dask-resource-envelope` so this PR shows only its own diff.

## What was already fixed, and what wasn't

The item was filed against the state at PR #1465, where clustering options were
forwarded as raw kwargs and dropped by `from_config`. PRs #1486 / #1488 already
added the translation into `tuning_config`. w0 re-verified the chain end to end:

```
tuning_config -> PlatformAdapter.unified_tuning_configuration (base/adapter.py:220)
              -> get_effective_tuning_configuration()          (base/tuning_config.py:79)
              -> _resolve_databricks_clustering_strategy()     (databricks/adapter.py:173)
```

That half is sound, so it is **not** re-implemented here. Two gaps remained:

1. **Contradictory combinations passed admission.**
   `{"databricks_clustering_strategy": "z_order", "liquid_clustering_columns": "a,b"}`
   was accepted, persisted as a durable job, and failed only inside the worker as
   a raw `ValueError`, reported as an execution error rather than a validation error.
2. **No test proved the resolver's answer.** Existing coverage asserted the tuning
   object built in the MCP layer, which cannot detect a regression in `from_config`.

## Change

- Extract `build_databricks_clustering_intent()` and call it from both the
  admission gate and adapter preparation. Building the intent *is* the
  validation — a conflict only appears once strategy and columns resolve
  together — so admission and execution can never disagree.
- Conflicts now raise `MCPValidationError` at admission: before durable
  persistence, before any remote connection.
- New tests drive the whole chain through the real `from_config` and assert
  `_resolve_databricks_clustering_strategy()`, plus the ZORDER default when
  nothing is requested, so a regression to the silent fallback is caught.

## Verification

| Rung | Command | Result |
|---|---|---|
| 1 | `pytest tests/unit/platforms tests/unit/core/tuning tests/unit/mcp/test_schemas.py -q` | 8903 passed |
| 2 | `pytest tests/unit/mcp/test_benchmark_tools.py tests/integration/mcp/test_durable_jobs.py -q` | 57 passed |
| 3 | `ruff check` (scoped) | clean |

**Negative control:** removing the `databricks` branch from
`_validate_cross_field_policy` fails 3 schema tests and the durable-admission test.

No test opens a Databricks connection or uses credentials; the adapter is built with
`databricks_sql` patched, matching the existing idiom in that file.