### PR TITLE
fix(duckdb): apply the MCP threads option to the real adapter

### DIFF
--- a/benchbox/platforms/duckdb.py
+++ b/benchbox/platforms/duckdb.py
@@ -577,8 +577,12 @@ class DuckDBAdapter(PlatformAdapter):
         # Force recreate
         adapter_config["force_recreate"] = config.get("force", False)
 
-        # Pass through other relevant config
+        # Pass through other relevant config.  `thread_limit` is read by
+        # `__init__` and applied as a DuckDB `SET threads` statement; omitting it
+        # here silently discards the caller's request, because `__init__` only
+        # ever sees this rebuilt config, never the original.
         for key in [
+            "thread_limit",
             "tuning_config",
             "tuning_enabled",
             "unified_tuning_configuration",

--- a/docs/reference/mcp.md
+++ b/docs/reference/mcp.md
@@ -247,6 +247,9 @@ modes remain available because they do not hold the request for execution.
   filesystem paths, unbounded values, and driver auto-install/version controls
   fail closed. Authenticated durable jobs persist only this normalized object,
   so retries and worker restarts cannot reintroduce raw request mappings.
+- DuckDB `threads` is the public option name and maps to the adapter's
+  `thread_limit`, which becomes a `SET threads` statement on the connection. The
+  public name is unchanged; only the internal mapping is documented here.
 - Databricks clustering options are translated into effective tuning before the
   adapter is built. `databricks_clustering_strategy` and
   `liquid_clustering_columns` become a `PlatformOptimizationConfiguration` that

--- a/tests/integration/mcp/test_durable_jobs.py
+++ b/tests/integration/mcp/test_durable_jobs.py
@@ -98,6 +98,33 @@ def test_normalized_platform_options_survive_repository_round_trip(tmp_path: Pat
     assert persisted.request["platform_options"] == {"threads": 4}
 
 
+def test_durable_replay_applies_duckdb_threads_to_the_real_adapter(tmp_path: Path) -> None:
+    """A replayed request must still change DuckDB execution, not just forward a key."""
+    from benchbox.mcp.tools.benchmark import _prepare_adapter_platform_options
+    from benchbox.platforms.duckdb import DuckDBAdapter
+
+    repository = DurableJobRepository(tmp_path / "state.sqlite3", JobLimits())
+    options = validate_platform_options("duckdb", {"threads": 5})
+    submitted, _ = repository.submit("tenant-a", {**_request(), "platform_options": options})
+
+    persisted = repository.get_owned(submitted.execution_id, "tenant-a")
+    assert persisted is not None
+    assert persisted.request["platform_options"] == {"threads": 5}
+
+    # Replay the persisted request exactly as the worker would.
+    prepared = _prepare_adapter_platform_options("duckdb", persisted.request["platform_options"])
+    adapter = DuckDBAdapter.from_config(
+        {
+            "benchmark": "tpch",
+            "scale_factor": 0.01,
+            "database_path": str(tmp_path / "replay.duckdb"),
+            **prepared,
+        }
+    )
+
+    assert adapter.thread_limit == 5
+
+
 def test_durable_admission_refuses_contradictory_databricks_clustering(tmp_path: Path) -> None:
     """A request that can never succeed must not occupy a durable queue slot."""
     repository = DurableJobRepository(tmp_path / "state.sqlite3", JobLimits())

--- a/tests/unit/platforms/test_duckdb_adapter.py
+++ b/tests/unit/platforms/test_duckdb_adapter.py
@@ -1615,3 +1615,73 @@ class TestDuckDBAdapter:
         assert any("delta_scan(" in sql for sql in executed_sql)
         assert not any("iceberg_scan(" in sql for sql in executed_sql)
         assert adapter.external_format == "delta"
+
+
+class TestMCPThreadsReachTheEffectiveSetting:
+    """The public MCP `threads` option must change DuckDB execution."""
+
+    @staticmethod
+    def _adapter_from_mcp_request(tmp_path: Path, options: dict):
+        from benchbox.mcp.schemas import validate_platform_options
+        from benchbox.mcp.tools.benchmark import _prepare_adapter_platform_options
+
+        normalized = validate_platform_options("duckdb", options)
+        prepared = _prepare_adapter_platform_options("duckdb", normalized)
+        return DuckDBAdapter.from_config(
+            {
+                "benchmark": "tpch",
+                "scale_factor": 0.01,
+                "database_path": str(tmp_path / "mcp_threads.duckdb"),
+                **prepared,
+            }
+        )
+
+    def test_from_config_preserves_the_translated_thread_limit(self, tmp_path: Path):
+        """`from_config` rebuilds its config from a key list; `threads` must survive it."""
+        adapter = self._adapter_from_mcp_request(tmp_path, {"threads": 7})
+
+        assert adapter.thread_limit == 7
+        assert adapter.get_platform_info()["configuration"]["thread_limit"] == 7
+
+    def test_connection_emits_the_thread_setting(self, tmp_path: Path):
+        """A deterministic connection spy proves the SET statement is issued."""
+        adapter = self._adapter_from_mcp_request(tmp_path, {"threads": 7})
+
+        connection = Mock()
+        with (
+            patch.object(adapter, "_duckdb_module") as duckdb_module,
+            patch.object(adapter, "_detect_connection_version", return_value=None),
+            patch.object(adapter, "handle_existing_database"),
+        ):
+            duckdb_module.connect.return_value = connection
+            adapter.create_connection()
+
+        assert call("SET threads TO 7") in connection.execute.call_args_list
+
+    def test_a_real_connection_reports_the_requested_thread_count(self, tmp_path: Path):
+        """The strongest evidence: DuckDB itself reports the setting."""
+        adapter = self._adapter_from_mcp_request(tmp_path, {"threads": 3})
+
+        connection = adapter.create_connection()
+        try:
+            assert connection.execute("SELECT current_setting('threads')").fetchone()[0] == 3
+        finally:
+            with contextlib.suppress(Exception):
+                connection.close()
+
+    def test_without_the_option_duckdb_keeps_its_own_default(self, tmp_path: Path):
+        """The mapping must not impose a thread limit on requests that omit it."""
+        adapter = self._adapter_from_mcp_request(tmp_path, {})
+
+        assert adapter.thread_limit is None
+
+        connection = Mock()
+        with (
+            patch.object(adapter, "_duckdb_module") as duckdb_module,
+            patch.object(adapter, "_detect_connection_version", return_value=None),
+            patch.object(adapter, "handle_existing_database"),
+        ):
+            duckdb_module.connect.return_value = connection
+            adapter.create_connection()
+
+        assert not any("SET threads" in str(executed) for executed in connection.execute.call_args_list)


### PR DESCRIPTION
Closes the `mcp-v2-duckdb-threads-effective-setting-v3` tracker item.

> **Stacked on [#1513](https://github.com/joeharris76/BenchBox/pull/1513)** →
> [#1511](https://github.com/joeharris76/BenchBox/pull/1511) →
> [#1510](https://github.com/joeharris76/BenchBox/pull/1510). Base is
> `claude/mcp-v2-databricks-clustering` so this PR shows only its own diff.

## Problem

MCP exposed `threads`; the adapter consumes `thread_limit`. The translation
existed and the value reached the factory — but `DuckDBAdapter.from_config`
rebuilds its constructor config from explicit key lists, and `thread_limit` was
in none of them:

```
_prepare_adapter_platform_options("duckdb", {"threads": 7}) -> {"thread_limit": 7}
DuckDBAdapter.from_config({..., "thread_limit": 7}).thread_limit -> None
```

`__init__` only ever sees the rebuilt config, so `SET threads TO n`
(`duckdb.py:802`) never fired. Requesting threads through MCP changed nothing.

The existing test asserted `get_adapter.call_args.kwargs["thread_limit"]` against
a **mocked** factory — forwarding succeeded, application did not. That is the
false-green the tracker item named.

## Change

One line of substance: `thread_limit` joins the `from_config` pass-through list.
The value of this PR is the evidence, at three depths:

| Test | Proves |
|---|---|
| `test_from_config_preserves_the_translated_thread_limit` | constructed adapter state, and `platform_info` |
| `test_connection_emits_the_thread_setting` | connection spy sees `call("SET threads TO 7")` |
| `test_a_real_connection_reports_the_requested_thread_count` | DuckDB itself reports `current_setting('threads') == 3` |
| `test_without_the_option_duckdb_keeps_its_own_default` | omitting the option emits no `SET threads` |

Plus a durable-replay test: the persisted request round-trips as `{"threads": 5}`
and replaying it through the real `from_config` yields `thread_limit == 5`.

**Negative control:** reverting only `benchbox/platforms/duckdb.py` fails three of
the four — the real-connection one with `assert 2 == 3`, DuckDB using its own
default instead of the requested value.

The public option name stays `threads`; only the internal mapping is documented.
Tests use an isolated `tmp_path` database and never touch user benchmark artifacts.

## Verification

| Rung | Command | Result |
|---|---|---|
| 1 | `pytest tests/unit/platforms tests/unit/mcp/test_benchmark_tools.py -q` | 8143 passed |
| 2 | `pytest tests/integration/mcp/test_durable_jobs.py -q` | 13 passed |
| 3 | `ruff check` (scoped) | clean |

## Known adjacent issue, deliberately not fixed here

`from_config` drops `max_temp_directory_size` and `progress_bar` the same way —
both are read by `__init__` (`duckdb.py:661,664`) and applied as `SET` statements
(`duckdb.py:797,807`) but appear in no pass-through list, so CLI/API callers
supplying them are silently ignored. Left alone because neither is an MCP option
and applying them would change existing CLI behavior outside this change's
verification ladder. Recorded as tracker deferral #686 and dismissed with that
rationale rather than silently dropped; it wants its own item with CLI-facing tests.