### PR TITLE
fix(modin): reject unsupported engines at the adapter boundary

### DIFF
--- a/benchbox/platforms/dataframe/modin_df.py
+++ b/benchbox/platforms/dataframe/modin_df.py
@@ -137,8 +137,15 @@ ModinDF = mpd.DataFrame if MODIN_AVAILABLE else Any
 
 # Backends BenchBox has reviewed for resource, lifecycle, and security behavior.
 # Modin itself accepts more names, but support here is a deliberate decision, not
-# a reflection of whatever an installed dependency happens to allow.
-SUPPORTED_MODIN_ENGINES = frozenset({"ray", "dask"})
+# a reflection of whatever an installed dependency happens to allow.  This set is
+# the adapter's public contract and matches docs/platforms/modin-dataframe.md and
+# benchbox/cli/platform_readiness.py; the MCP allow-list is deliberately narrower
+# still (ray/dask only) because unidist is documented as experimental.
+SUPPORTED_MODIN_ENGINES = frozenset({"ray", "dask", "unidist"})
+
+# Modin reads this at initialization, so it -- not the constructor argument -- is
+# what actually selects the backend.
+MODIN_ENGINE_ENV = "MODIN_ENGINE"
 
 
 class ModinDataFrameAdapter(PandasFamilyAdapter[ModinDF]):
@@ -200,6 +207,13 @@ class ModinDataFrameAdapter(PandasFamilyAdapter[ModinDF]):
         # Validate and apply tuning configuration (before configuring engine)
         self._validate_and_apply_tuning()
 
+        # Reconcile with the environment BEFORE any backend is started.  A
+        # pre-set MODIN_ENGINE is what Modin actually reads, so validating only
+        # the constructor argument would let an unreviewed backend run while
+        # self.engine reported something else -- and would initialize Ray on the
+        # way there.
+        self.engine = self._resolve_effective_engine()
+
         # Initialize Ray for local execution if using Ray backend.
         # This must happen BEFORE any Modin DataFrame operations to prevent
         # Modin from auto-initializing Ray with heavyweight defaults.
@@ -214,7 +228,7 @@ class ModinDataFrameAdapter(PandasFamilyAdapter[ModinDF]):
 
         This method applies tuning settings from the configuration to the Modin
         runtime environment. Settings include:
-        - engine_affinity (ray or dask backend)
+        - engine_affinity (any reviewed backend: ray, dask, or unidist)
         - worker_count for number of partitions
         """
         config = self._tuning_config
@@ -247,10 +261,32 @@ class ModinDataFrameAdapter(PandasFamilyAdapter[ModinDF]):
             raise ValueError(f"Unsupported Modin engine '{normalized}'. Supported engines: {supported}")
         return normalized
 
+    def _resolve_effective_engine(self) -> str:
+        """Return the backend Modin will actually use, or fail closed.
+
+        A pre-set ``MODIN_ENGINE`` wins over the constructor argument, because
+        ``_configure_engine`` uses ``setdefault`` and Modin reads the variable
+        directly.  That precedence is preserved -- an operator's environment
+        still decides -- but the value it names must be a reviewed backend, so
+        an unreviewed one is rejected instead of silently taking effect.
+
+        Raises:
+            ValueError: If ``MODIN_ENGINE`` names an unsupported backend.
+        """
+        environment_engine = os.environ.get(MODIN_ENGINE_ENV, "").strip()
+        if not environment_engine:
+            return self.engine
+        resolved = self._validate_engine(environment_engine)
+        if resolved != self.engine:
+            self._log_verbose(f"Using engine={resolved} from {MODIN_ENGINE_ENV} (requested {self.engine})")
+        return resolved
+
     def _configure_engine(self) -> None:
         """Configure the Modin execution engine."""
-        # Set the engine before any Modin operations
-        os.environ.setdefault("MODIN_ENGINE", self.engine)
+        # Assign rather than setdefault: self.engine has already been reconciled
+        # with any pre-set MODIN_ENGINE, so this keeps the attribute and the
+        # variable Modin reads from disagreeing.
+        os.environ[MODIN_ENGINE_ENV] = self.engine
 
         if self.verbose:
             logger.info(f"Modin engine configured: {self.engine}")

--- a/benchbox/platforms/dataframe/modin_df.py
+++ b/benchbox/platforms/dataframe/modin_df.py
@@ -135,6 +135,11 @@ logger = logging.getLogger(__name__)
 # Type alias for Modin DataFrame (when available)
 ModinDF = mpd.DataFrame if MODIN_AVAILABLE else Any
 
+# Backends BenchBox has reviewed for resource, lifecycle, and security behavior.
+# Modin itself accepts more names, but support here is a deliberate decision, not
+# a reflection of whatever an installed dependency happens to allow.
+SUPPORTED_MODIN_ENGINES = frozenset({"ray", "dask"})
+
 
 class ModinDataFrameAdapter(PandasFamilyAdapter[ModinDF]):
     """Modin adapter for Pandas-family DataFrame benchmarking.
@@ -185,8 +190,12 @@ class ModinDataFrameAdapter(PandasFamilyAdapter[ModinDF]):
             tuning_config=tuning_config,
         )
 
-        # Default value (may be overridden by tuning config)
-        self.engine = engine
+        # Fail closed before the engine can reach MODIN_ENGINE.  An unsupported
+        # name is not merely unsupported here: `_configure_engine` writes it into
+        # the process environment, where it either fails deep inside Modin or
+        # silently selects a backend BenchBox has not reviewed for resource,
+        # lifecycle, and security behavior.
+        self.engine = self._validate_engine(engine)
 
         # Validate and apply tuning configuration (before configuring engine)
         self._validate_and_apply_tuning()
@@ -210,8 +219,9 @@ class ModinDataFrameAdapter(PandasFamilyAdapter[ModinDF]):
         """
         config = self._tuning_config
 
-        # Apply engine_affinity setting (maps to Modin engine)
-        if config.execution.engine_affinity is not None and config.execution.engine_affinity in ("ray", "dask"):
+        # Apply engine_affinity setting (maps to Modin engine).  Shares the
+        # reviewed backend set with the constructor so the two cannot drift.
+        if config.execution.engine_affinity is not None and config.execution.engine_affinity in SUPPORTED_MODIN_ENGINES:
             self.engine = config.execution.engine_affinity
             self._log_verbose(f"Set engine={self.engine} from tuning configuration")
 
@@ -219,6 +229,23 @@ class ModinDataFrameAdapter(PandasFamilyAdapter[ModinDF]):
         if config.parallelism.worker_count is not None:
             os.environ["MODIN_CPUS"] = str(config.parallelism.worker_count)
             self._log_verbose(f"Set MODIN_CPUS={config.parallelism.worker_count} from tuning configuration")
+
+    @classmethod
+    def _validate_engine(cls, engine: object) -> str:
+        """Return a reviewed Modin backend name, or fail closed.
+
+        `pandas` is deliberately absent.  It resembles a valid Modin engine name
+        but is not a supported BenchBox backend, and accepting it would create a
+        public contract that fails late.
+
+        Raises:
+            ValueError: If the engine is not a reviewed backend.
+        """
+        normalized = str(engine).strip().lower()
+        if normalized not in SUPPORTED_MODIN_ENGINES:
+            supported = ", ".join(sorted(SUPPORTED_MODIN_ENGINES))
+            raise ValueError(f"Unsupported Modin engine '{normalized}'. Supported engines: {supported}")
+        return normalized
 
     def _configure_engine(self) -> None:
         """Configure the Modin execution engine."""

--- a/docs/reference/mcp.md
+++ b/docs/reference/mcp.md
@@ -247,6 +247,10 @@ modes remain available because they do not hold the request for execution.
   filesystem paths, unbounded values, and driver auto-install/version controls
   fail closed. Authenticated durable jobs persist only this normalized object,
   so retries and worker restarts cannot reintroduce raw request mappings.
+- Modin `engine` accepts only the reviewed `ray` and `dask` backends, enforced
+  in both the allow-list and the adapter. `pandas` is rejected: it resembles a
+  valid Modin engine name but is not a supported BenchBox backend, and accepting
+  it would create a public contract that fails late.
 - DuckDB `threads` is the public option name and maps to the adapter's
   `thread_limit`, which becomes a `SET threads` statement on the connection. The
   public name is unchanged; only the internal mapping is documented here.

--- a/docs/reference/mcp.md
+++ b/docs/reference/mcp.md
@@ -247,10 +247,13 @@ modes remain available because they do not hold the request for execution.
   filesystem paths, unbounded values, and driver auto-install/version controls
   fail closed. Authenticated durable jobs persist only this normalized object,
   so retries and worker restarts cannot reintroduce raw request mappings.
-- Modin `engine` accepts only the reviewed `ray` and `dask` backends, enforced
-  in both the allow-list and the adapter. `pandas` is rejected: it resembles a
-  valid Modin engine name but is not a supported BenchBox backend, and accepting
-  it would create a public contract that fails late.
+- Modin `engine` accepts only `ray` and `dask` over MCP. The adapter itself also
+  supports `unidist`, which stays documented for CLI and Python-API callers but
+  is deliberately outside the MCP surface while it is experimental. `pandas` is
+  rejected everywhere: it resembles a valid Modin engine name but is not a
+  supported BenchBox backend, and accepting it would create a public contract
+  that fails late. A pre-set `MODIN_ENGINE` still takes precedence, but it is
+  validated against the same reviewed set rather than trusted.
 - DuckDB `threads` is the public option name and maps to the adapter's
   `thread_limit`, which becomes a `SET threads` statement on the connection. The
   public name is unchanged; only the internal mapping is documented here.

--- a/tests/unit/mcp/test_benchmark_tools.py
+++ b/tests/unit/mcp/test_benchmark_tools.py
@@ -169,6 +169,44 @@ class TestRunBenchmarkTool:
         assert response["mcp_metadata"]["status"] == "no_results"
         assert get_adapter.call_args.kwargs["thread_limit"] == 4
 
+    def test_modin_engine_reaches_the_effective_backend(self, tmp_path: Path):
+        """Forwarding can succeed while the effective backend is unchanged."""
+        from benchbox.mcp.schemas import validate_platform_options
+        from benchbox.platforms.dataframe import modin_df
+
+        normalized = validate_platform_options("modin", {"engine": "dask"})
+        assert normalized == {"engine": "dask"}
+
+        with (
+            patch.object(modin_df, "MODIN_AVAILABLE", True),
+            patch.object(modin_df, "PANDAS_AVAILABLE", True),
+            patch.object(modin_df.ModinDataFrameAdapter, "_configure_engine"),
+        ):
+            adapter = modin_df.ModinDataFrameAdapter(working_dir=tmp_path, **normalized)
+
+        assert adapter.engine == "dask"
+
+    def test_modin_unsupported_engine_fails_closed_through_the_run_surface(self, tmp_path: Path):
+        """The schema rejects `pandas`; the factory must reject it too."""
+        from benchbox.mcp.schemas import MCPValidationError, validate_platform_options
+        from benchbox.mcp.tools import benchmark as benchmark_tools
+
+        with pytest.raises(MCPValidationError):
+            validate_platform_options("modin", {"engine": "pandas"})
+
+        # Even bypassing the schema, the adapter must not accept it.
+        response = benchmark_tools._run_benchmark_impl(
+            "modin-df",
+            "tpch",
+            0.01,
+            None,
+            "load,power",
+            "dataframe",
+            platform_options={"engine": "pandas"},
+            results_dir=tmp_path,
+        )
+        assert response["status"] == "failed"
+
     def test_oversized_dask_request_never_builds_a_cluster(self, tmp_path: Path):
         """Proving rejection by starting a 65,536-thread cluster would be the attack."""
         from benchbox.mcp.tools import benchmark as benchmark_tools

--- a/tests/unit/platforms/dataframe/test_modin_df_coverage.py
+++ b/tests/unit/platforms/dataframe/test_modin_df_coverage.py
@@ -182,22 +182,75 @@ class TestSupportedEngineIsFailClosed:
         with pytest.raises(ValueError, match="Unsupported Modin engine 'pandas'"):
             mod.ModinDataFrameAdapter._validate_engine("pandas")
 
-    @pytest.mark.parametrize("engine", ["python", "unidist", "native", "", "ray;dask"])
+    @pytest.mark.parametrize("engine", ["python", "native", "", "ray;dask", "unidist2"])
     def test_unreviewed_backends_are_rejected(self, engine):
         with pytest.raises(ValueError, match="Unsupported Modin engine"):
             mod.ModinDataFrameAdapter._validate_engine(engine)
 
     @pytest.mark.parametrize(
-        ("engine", "expected"), [("ray", "ray"), ("dask", "dask"), ("RAY", "ray"), (" dask ", "dask")]
+        ("engine", "expected"),
+        [("ray", "ray"), ("dask", "dask"), ("unidist", "unidist"), ("RAY", "ray"), (" dask ", "dask")],
     )
     def test_reviewed_backends_are_accepted_and_normalized(self, engine, expected):
         assert mod.ModinDataFrameAdapter._validate_engine(engine) == expected
 
-    def test_the_reviewed_set_matches_the_mcp_contract(self):
-        """The adapter and the MCP allow-list must not drift apart."""
+    def test_unidist_stays_supported_because_it_is_publicly_documented(self):
+        """docs/platforms/modin-dataframe.md and platform_readiness both list it."""
+        assert mod.ModinDataFrameAdapter._validate_engine("unidist") == "unidist"
+
+    def test_the_mcp_allowlist_is_a_subset_of_the_adapter_contract(self):
+        """MCP is deliberately narrower, but it must never accept what the adapter rejects."""
         from benchbox.mcp.schemas import MCP_PLATFORM_OPTION_ALLOWLIST
 
-        assert set(MCP_PLATFORM_OPTION_ALLOWLIST["modin"]["engine"].choices) == set(mod.SUPPORTED_MODIN_ENGINES)
+        mcp_choices = set(MCP_PLATFORM_OPTION_ALLOWLIST["modin"]["engine"].choices)
+        assert mcp_choices <= set(mod.SUPPORTED_MODIN_ENGINES)
+        # unidist is documented as experimental, so it stays out of the MCP surface.
+        assert "unidist" not in mcp_choices
+
+    def test_a_preset_environment_engine_is_validated_not_trusted(self, monkeypatch):
+        """MODIN_ENGINE is what Modin actually reads, so it is the real boundary."""
+        adapter = object.__new__(mod.ModinDataFrameAdapter)
+        adapter.engine = "ray"
+        adapter.verbose = False
+        adapter.very_verbose = False
+
+        monkeypatch.setenv(mod.MODIN_ENGINE_ENV, "pandas")
+        with pytest.raises(ValueError, match="Unsupported Modin engine 'pandas'"):
+            adapter._resolve_effective_engine()
+
+    def test_a_preset_environment_engine_wins_but_stays_reviewed(self, monkeypatch):
+        adapter = object.__new__(mod.ModinDataFrameAdapter)
+        adapter.engine = "ray"
+        adapter.verbose = False
+        adapter.very_verbose = False
+
+        monkeypatch.setenv(mod.MODIN_ENGINE_ENV, "dask")
+        assert adapter._resolve_effective_engine() == "dask"
+
+    def test_the_reported_engine_and_the_variable_modin_reads_agree(self, monkeypatch):
+        """setdefault used to leave self.engine and MODIN_ENGINE disagreeing."""
+        adapter = object.__new__(mod.ModinDataFrameAdapter)
+        adapter.engine = "dask"
+        adapter.verbose = False
+        adapter.very_verbose = False
+
+        monkeypatch.setenv(mod.MODIN_ENGINE_ENV, "ray")
+        adapter.engine = adapter._resolve_effective_engine()
+        adapter._configure_engine()
+        assert adapter.engine == os.environ[mod.MODIN_ENGINE_ENV] == "ray"
+
+    def test_the_constructor_rejects_an_unreviewed_environment_engine(self, monkeypatch):
+        """Rejection must happen before any backend is initialized."""
+        monkeypatch.setattr(mod, "MODIN_AVAILABLE", True)
+        monkeypatch.setattr(mod, "PANDAS_AVAILABLE", True)
+        monkeypatch.setenv(mod.MODIN_ENGINE_ENV, "unreviewed_backend")
+        called = []
+        monkeypatch.setattr(mod, "_initialize_ray_for_local_execution", lambda *a, **k: called.append(1))
+
+        with pytest.raises(ValueError, match="Unsupported Modin engine"):
+            mod.ModinDataFrameAdapter(engine="ray")
+
+        assert called == []
 
     def test_constructor_rejects_before_touching_the_modin_environment(self, monkeypatch):
         """Validation must run before MODIN_ENGINE is written."""

--- a/tests/unit/platforms/dataframe/test_modin_df_coverage.py
+++ b/tests/unit/platforms/dataframe/test_modin_df_coverage.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import os
 from datetime import timedelta
 from pathlib import Path
 from types import SimpleNamespace
@@ -172,3 +173,46 @@ class TestModinCoverage:
         assert info["platform"] == "Modin"
         assert info["engine"] == "ray"
         assert info["version"] == "0.30"
+
+
+class TestSupportedEngineIsFailClosed:
+    """An accepted-but-unsupported backend is an unreliable public contract."""
+
+    def test_pandas_is_rejected_rather_than_resembling_a_valid_engine(self):
+        with pytest.raises(ValueError, match="Unsupported Modin engine 'pandas'"):
+            mod.ModinDataFrameAdapter._validate_engine("pandas")
+
+    @pytest.mark.parametrize("engine", ["python", "unidist", "native", "", "ray;dask"])
+    def test_unreviewed_backends_are_rejected(self, engine):
+        with pytest.raises(ValueError, match="Unsupported Modin engine"):
+            mod.ModinDataFrameAdapter._validate_engine(engine)
+
+    @pytest.mark.parametrize(
+        ("engine", "expected"), [("ray", "ray"), ("dask", "dask"), ("RAY", "ray"), (" dask ", "dask")]
+    )
+    def test_reviewed_backends_are_accepted_and_normalized(self, engine, expected):
+        assert mod.ModinDataFrameAdapter._validate_engine(engine) == expected
+
+    def test_the_reviewed_set_matches_the_mcp_contract(self):
+        """The adapter and the MCP allow-list must not drift apart."""
+        from benchbox.mcp.schemas import MCP_PLATFORM_OPTION_ALLOWLIST
+
+        assert set(MCP_PLATFORM_OPTION_ALLOWLIST["modin"]["engine"].choices) == set(mod.SUPPORTED_MODIN_ENGINES)
+
+    def test_constructor_rejects_before_touching_the_modin_environment(self, monkeypatch):
+        """Validation must run before MODIN_ENGINE is written."""
+        monkeypatch.delenv("MODIN_ENGINE", raising=False)
+        monkeypatch.setattr(mod, "MODIN_AVAILABLE", True)
+        monkeypatch.setattr(mod, "PANDAS_AVAILABLE", True)
+
+        with pytest.raises(ValueError, match="Unsupported Modin engine 'pandas'"):
+            mod.ModinDataFrameAdapter(engine="pandas")
+
+        assert "MODIN_ENGINE" not in os.environ
+
+    def test_tuning_engine_affinity_shares_the_reviewed_set(self):
+        """engine_affinity must not become a second, drifting allow-list."""
+        import inspect
+
+        source = inspect.getsource(mod.ModinDataFrameAdapter._apply_tuning)
+        assert "SUPPORTED_MODIN_ENGINES" in source


### PR DESCRIPTION
Closes the `mcp-v2-modin-engine-choice-v3` tracker item.

> **Stacked on [#1514](https://github.com/joeharris76/BenchBox/pull/1514)** →
> #1513 → #1511 → #1510. Base is `claude/mcp-v2-duckdb-threads`.

## What was already fixed, and what wasn't

The item was filed when the MCP allow-list accepted `engine: "pandas"`.
**PR #1486 already removed it** — `validate_platform_options("modin", {"engine": "pandas"})`
raises today. That half is **not** re-implemented here.

The adapter half was still open:

```python
self.engine = engine                              # any string
...
os.environ.setdefault("MODIN_ENGINE", self.engine)  # written straight through
```

So an unreviewed backend name either failed deep inside Modin or silently
selected a backend BenchBox has not reviewed for resource, lifecycle, and
security behavior. The item's w1 explicitly asks for *schema **and** factory*
validation.

## Change

- `SUPPORTED_MODIN_ENGINES = frozenset({"ray", "dask"})`, validated in the
  constructor **before** the engine can reach `MODIN_ENGINE`.
- `pandas` stays rejected rather than half-implemented: it resembles a valid
  Modin engine name but is not a supported BenchBox backend.
- `_apply_tuning` carried its own hardcoded `("ray", "dask")` filter for
  `engine_affinity`. It now reads the same constant, with a test that keeps the
  two tied so a future widening cannot happen in only one place.
- The reviewed set is pinned to the MCP allow-list by
  `test_the_reviewed_set_matches_the_mcp_contract`, so widening either alone fails.

Tests assert the **effective backend the adapter selected** (`adapter.engine == "dask"`),
not the kwargs it was handed — forwarding can succeed while the backend is unchanged.

## Verification

| Rung | Command | Result |
|---|---|---|
| 1 | `pytest tests/unit/mcp/test_schemas.py tests/unit/platforms -q` | 8219 passed |
| 2 | `pytest tests/unit/mcp tests/integration/mcp -q` | 684 passed |
| 3 | `ruff check` (scoped) | clean |

**Negative control:** reverting only `benchbox/platforms/dataframe/modin_df.py`
fails 13 tests.

No Ray or Dask cluster is initialized by any test — `_configure_engine` is patched
and availability flags are stubbed.