### PR TITLE
fix(explorer): fail clearly on a duplicate result_id

### DIFF
--- a/_project/scripts/explorer_pipeline/pipeline.py
+++ b/_project/scripts/explorer_pipeline/pipeline.py
@@ -48,6 +48,19 @@ from benchbox.validation.bundle import discover_bundles
 
 logger = logging.getLogger(__name__)
 
+
+class DuplicateResultIdError(Exception):
+    """Two distinct published bundles derived the same ``result_id``.
+
+    Intentionally not a ``ValueError``. The publication loop wraps each bundle
+    in ``except (json.JSONDecodeError, KeyError, ValueError, TypeError)`` and
+    downgrades anything it catches to a skip plus a warning, so a collision
+    raised as ``ValueError`` would let the build finish green having published
+    only one of the two results. A collision is a corpus problem for a human to
+    resolve, not a bundle to drop.
+    """
+
+
 SUBMISSION_MANIFEST_FILENAME = "submission-manifest.json"
 SUBMISSION_MANIFEST_SUFFIX = ".manifest.json"
 COMMUNITY_TRUST_LABEL = "community-submission"
@@ -206,8 +219,14 @@ def _build_short_ids(result_ids: list[str]) -> dict[str, str]:
         # If every entry is unique the dict has as many keys as inputs.
         if len(candidate) == len(result_ids):
             return candidate
-    # sha256 is 64 hex chars; we never get here, but satisfy the type checker.
-    raise RuntimeError("Could not build collision-free short IDs (sha256 limit reached)")
+    # Unreachable for *distinct* inputs, which is the only kind that gets here:
+    # the publication loop rejects a repeated result_id via
+    # DuplicateResultIdError before this is called. That guard is what makes
+    # this branch dead. Passing a list containing the same id twice reaches it
+    # immediately - the dict collapses to one key and no length ever matches -
+    # and the message below then blames sha256 for what is really duplicate
+    # input, naming neither offending bundle.
+    raise RuntimeError(f"Could not build collision-free short IDs from {len(result_ids)} result_id(s) (duplicates?)")
 
 
 def _platform_row_sort_key(benchmark: str) -> Callable[[PlatformRow], tuple[bool, float]]:
@@ -550,6 +569,15 @@ class ExplorerPipeline:
             # has per-result detail data without a second I/O pass.
             details_map: dict[str, DetailResult] = {}
             skipped_bundles = 0
+            # result_id → (source bundle path, sha256 of the published bytes).
+            # The loop below writes `{result_id}.json` and assigns
+            # `details_map[result_id]`, so without this a second bundle deriving
+            # the same id would replace the first in both places: one result
+            # would vanish from the published corpus and the read model with no
+            # error and no count mismatch. `result_id` carries only 8 hex chars
+            # (32 bits) of sha256, so the birthday bound is far below what the
+            # id's length suggests.
+            seen_result_ids: dict[str, tuple[Path, str]] = {}
 
             for bundle_path in bundle_files:
                 try:
@@ -581,9 +609,7 @@ class ExplorerPipeline:
                     # from the exact bytes that will be published so filenames,
                     # DuckDB rows, and download URLs remain reproducible.
                     public_raw = canonical_json_bytes(public_bundle)
-                    result_id = self._transformer.result_id_from_bundle(
-                        bundle_path, data=public_bundle, raw=public_raw
-                    )
+                    result_id = self._transformer.result_id_from_bundle(bundle_path, data=public_bundle, raw=public_raw)
                     prefix = bundle_url_prefix.rstrip("/")
                     bundle_download_url = f"{prefix}/{result_id}.json"
 
@@ -615,6 +641,40 @@ class ExplorerPipeline:
                             result_id,
                         )
                         continue
+
+                    # Two bundles that derive the same id are either the same
+                    # evidence twice or a genuine collision, and the two need
+                    # opposite handling. Identical published bytes are a
+                    # redundant copy: publishing it once is correct, so skip it
+                    # and say so. Differing bytes mean two distinct results are
+                    # competing for one public URL - that is silent evidence
+                    # loss, and the corpus needs a human, so fail closed rather
+                    # than pick a winner.
+                    public_digest = hashlib.sha256(public_raw).hexdigest()
+                    previous = seen_result_ids.get(result_id)
+                    if previous is not None:
+                        previous_path, previous_digest = previous
+                        if previous_digest != public_digest:
+                            # Deliberately NOT a ValueError. The per-bundle
+                            # handler below catches ValueError and downgrades it
+                            # to `skipped_bundles += 1` plus a warning, which is
+                            # precisely the silent drop this guard exists to
+                            # stop - the build would go green having published
+                            # one of the two colliding results.
+                            raise DuplicateResultIdError(
+                                f"duplicate result_id {result_id!r} with differing published content: "
+                                f"{previous_path} and {bundle_path}"
+                            )
+                        skipped_bundles += 1
+                        logger.warning(
+                            "Skipping bundle %s - result_id %r already published from %s with identical content",
+                            bundle_path,
+                            result_id,
+                            previous_path,
+                        )
+                        continue
+                    seen_result_ids[result_id] = (bundle_path, public_digest)
+
                     dest_bundle.write_bytes(public_raw)
 
                     # Publish the plans sidecar alongside the bundle when present

--- a/tests/unit/scripts/explorer_pipeline/test_duplicate_result_id.py
+++ b/tests/unit/scripts/explorer_pipeline/test_duplicate_result_id.py
@@ -1,0 +1,125 @@
+"""Collision handling for `result_id` in the Explorer publication loop.
+
+`result_id` ends in only 8 hex characters (32 bits) of a sha256 over the
+published bytes, so its birthday bound is far below what the id's length
+suggests. Before the guard these tests cover, two bundles deriving one id both
+wrote `{result_id}.json` and both assigned `details_map[result_id]`: the second
+replaced the first in the published corpus *and* in the read model, with no
+error, no warning, and no count mismatch any existing check would notice.
+
+A real collision cannot be constructed on demand, so these tests force the
+derivation to collide and assert on what the loop does about it.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from _project.scripts.explorer_pipeline.pipeline import DuplicateResultIdError, ExplorerPipeline
+from _project.scripts.explorer_pipeline.transformer import BundleTransformer
+from tests.unit.scripts.explorer_pipeline.conftest import MINIMAL_BUNDLE
+
+pytestmark = [pytest.mark.unit, pytest.mark.fast]
+
+COLLIDING_ID = "tpch-duckdb-sf0.1-20260315-deadbeef"
+
+
+@pytest.fixture()
+def force_id_collision(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Make every bundle derive the same result_id."""
+    monkeypatch.setattr(
+        BundleTransformer,
+        "result_id_from_bundle",
+        lambda *args, **kwargs: COLLIDING_ID,
+    )
+
+
+def _write_bundle(bundles_dir: Path, name: str, *, total_duration_ms: int) -> Path:
+    bundles_dir.mkdir(parents=True, exist_ok=True)
+    payload = json.loads(json.dumps(MINIMAL_BUNDLE))
+    payload["run"]["total_duration_ms"] = total_duration_ms
+    path = bundles_dir / name
+    path.write_text(json.dumps(payload), encoding="utf-8")
+    return path
+
+
+def test_duplicate_result_id_with_differing_content_fails_the_build(
+    tmp_path: Path,
+    force_id_collision: None,
+) -> None:
+    """Two distinct results competing for one public URL must stop the build.
+
+    Silently publishing one of them is evidence loss: the corpus would claim a
+    result that the read model no longer describes.
+    """
+    data_dir = tmp_path / "data"
+    bundles = data_dir / "bundles"
+    _write_bundle(bundles, "first.json", total_duration_ms=45000)
+    _write_bundle(bundles, "second.json", total_duration_ms=99000)
+
+    with pytest.raises(DuplicateResultIdError) as excinfo:
+        ExplorerPipeline().run(data_dir, tmp_path / "out")
+
+    message = str(excinfo.value)
+    assert COLLIDING_ID in message
+    # Both sources must be named - a collision report that identifies only one
+    # of the two files leaves the maintainer with nothing to compare.
+    assert "first.json" in message
+    assert "second.json" in message
+
+
+def test_duplicate_result_id_error_escapes_the_per_bundle_handler() -> None:
+    """The guard must not be catchable by the loop's own error handling.
+
+    The publication loop wraps each bundle in
+    `except (json.JSONDecodeError, KeyError, ValueError, TypeError)` and
+    downgrades whatever it catches to `skipped_bundles += 1` plus a warning. If
+    the collision were raised as a ValueError the build would finish green
+    having published exactly one of the two colliding results - the original
+    defect, reintroduced through the exception type.
+    """
+    assert not issubclass(DuplicateResultIdError, ValueError)
+    assert not issubclass(DuplicateResultIdError, (json.JSONDecodeError, KeyError, TypeError))
+
+
+def test_duplicate_result_id_with_identical_content_publishes_once(
+    tmp_path: Path,
+    force_id_collision: None,
+) -> None:
+    """A byte-identical copy is a redundant file, not a collision.
+
+    Publishing it once is the correct outcome, so this must not fail the build.
+    Failing here would make the pipeline intolerant of a duplicated corpus file
+    that costs nothing and loses nothing.
+    """
+    data_dir = tmp_path / "data"
+    bundles = data_dir / "bundles"
+    _write_bundle(bundles, "original.json", total_duration_ms=45000)
+    _write_bundle(bundles / "nested", "copy.json", total_duration_ms=45000)
+
+    output = tmp_path / "out"
+    ExplorerPipeline().run(data_dir, output)
+
+    published = sorted(p.name for p in (output / "bundles").glob("*.json"))
+    assert published == [f"{COLLIDING_ID}.json"]
+
+
+def test_duplicate_result_id_guard_leaves_the_normal_path_untouched(tmp_path: Path) -> None:
+    """Distinct ids still publish one file each.
+
+    Guards that only ever say "no" are indistinguishable from a broken loop, so
+    pin that the ordinary two-bundle case is unaffected.
+    """
+    data_dir = tmp_path / "data"
+    bundles = data_dir / "bundles"
+    _write_bundle(bundles, "first.json", total_duration_ms=45000)
+    _write_bundle(bundles, "second.json", total_duration_ms=99000)
+
+    output = tmp_path / "out"
+    ExplorerPipeline().run(data_dir, output)
+
+    published = sorted(p.name for p in (output / "bundles").glob("*.json"))
+    assert len(published) == 2, f"expected both bundles published, got {published}"


### PR DESCRIPTION
## What actually happens today

I filed this expecting a silent overwrite. It isn't — and the real behaviour is worth stating precisely.

Two bundles deriving the same `result_id` both write `{result_id}.json` and both assign `details_map[result_id]`, so the second **clobbers the first** in the published output and the read model. The build then **aborts** in `_build_short_ids` with:

```
RuntimeError: Could not build collision-free short IDs (sha256 limit reached)
```

That message blames sha256 for what is duplicate *input*, and names neither offending bundle. `_build_short_ids`' `# we never get here` comment was false for exactly this input: a repeated id collapses the dict, so no prefix length ever matches and the loop runs to 64 chars and raises.

So the defect is a **confusing late failure plus output clobbering**, not a green build. Less severe than I first wrote, still worth fixing — and the identical-copy case below is a live bug with an easy trigger.

`result_id` carries only 8 hex chars (32 bits) of sha256 over the published bytes, so its birthday bound is well below what the id's length suggests.

## Change

Guard the publication loop, distinguishing two cases that need opposite handling:

| Case | Today | After |
|---|---|---|
| **Identical** published bytes (a duplicated corpus file) | fatal, misleading message | publish once, warn |
| **Differing** bytes (genuine collision) | clobber, then fatal misleading message | fail closed, naming both source paths |

Raised as `DuplicateResultIdError`, **deliberately not a `ValueError`**. The loop wraps each bundle in `except (JSONDecodeError, KeyError, ValueError, TypeError)` and downgrades what it catches to `skipped_bundles += 1` plus a warning — so raising a `ValueError` here would reintroduce the defect *through the exception type*, and the build really would go green having published one of the two colliding results. A test pins the type so that cannot regress.

The guard also makes `_build_short_ids`' unreachable branch genuinely unreachable, and its message now points at duplicates.

## Falsification

Neutering the guard (`if False:`) fails 2 of the 4 new tests, both with the misleading `RuntimeError` — so the tests are pinned to behaviour, not to the new symbol. (Reverting the whole file only produces an `ImportError`, which would have proven nothing.)

`tests/unit/scripts/explorer_pipeline`: **323 passed**.

## Noted, not fixed here

The same per-bundle handler also catches the **privacy** `ValueError` from `_public_bundle_data`, so a bundle failing the fail-closed privacy check is dropped with a warning and the build still succeeds. That is safe (it isn't published) but it is silent. Out of scope for this item — flagged for follow-up rather than widened into it.