### PR TITLE
fix(results-explorer): refresh the PR246 capture spec headline

### DIFF
--- a/results-explorer/e2e/captures/pr246-home-remediation.spec.ts
+++ b/results-explorer/e2e/captures/pr246-home-remediation.spec.ts
@@ -53,8 +53,14 @@ test.describe("@pr246-capture Home remediation", () => {
           const targetUrl = url(mode);
           await page.goto(targetUrl, { waitUntil: "domcontentloaded" });
           await page.waitForLoadState("load", { timeout: 10_000 }).catch(() => {});
-          await expect(page.getByRole("heading", { name: "BenchBox Database Leaderboards" })).toBeVisible();
+          // Wait on the data-bound grid FIRST. The loading skeleton and the
+          // loaded hero deliberately share one headline, so a heading assertion
+          // placed ahead of this resolves against the skeleton and would let a
+          // screenshot be taken of the loading state. Same ordering trap that
+          // made e2e/routes/home.spec.ts pass without ever exercising loaded
+          // Home content.
           await expect(page.getByRole("grid", { name: "Cross-benchmark leaderboard" })).toBeVisible();
+          await expect(page.getByRole("heading", { name: "BenchBox Curated Results Preview" })).toBeVisible();
           await expect(page.locator("body")).not.toContainText(/Binder Error|Stack trace|Results snapshot incomplete/i);
           await page.waitForTimeout(800);
           const shot = filename(mode, width);


### PR DESCRIPTION
The opt-in capture spec still asserted `BenchBox Database Leaderboards`, retired in #1496 — so a refresh run would fail before taking a single screenshot. This is the orphaned spec left behind by that rename.

## Also reordered

The heading assertion ran **before** any data-bound wait. Since #1496 the loading skeleton and the loaded hero deliberately share one headline, so asserting it first resolves against the skeleton — and the capture could screenshot the loading state. Moved it after the leaderboard-grid assertion, matching the fix applied to `e2e/routes/home.spec.ts`.

In scope: the item owns this whole file.

## Verification

- retired string gone (`! rg -q -F` rung passes)
- `tsc --noEmit` clean
- **opt-in preserved by construction** — the `test.skip(process.env.PR246_HOME_CAPTURE !== "1")` guard on line 41 is untouched and verified present. I did not spin up the webServer to observe the runtime skip, so that property rests on the guard being unmodified rather than on an observed run.