### PR TITLE
fix(velox): enumerate deployments instead of defaulting to remote

### DIFF
--- a/benchbox/platforms/velox.py
+++ b/benchbox/platforms/velox.py
@@ -69,6 +69,12 @@ except ImportError:
 _GLUTEN_PLUGIN_CLASS = "org.apache.gluten.GlutenPlugin"
 _COLUMNAR_SHUFFLE_MANAGER = "org.apache.spark.shuffle.sort.ColumnarShuffleManager"
 
+# The only deployments the adapter implements.  "docker" is deliberately absent:
+# the docker/velox/ tree is packaging infrastructure for local development, not a
+# deployment mode with its own lifecycle, endpoint, isolation, and cleanup
+# contract.  Treating it as one would silently mean "remote".
+SUPPORTED_VELOX_DEPLOYMENTS = frozenset({"local", "remote"})
+
 
 class VeloxAdapter(SparkLikeAdapterMixin, SparkDataLoadMixin, SparkQueryExecutionMixin, PlatformAdapter):
     """Apache Gluten + Velox Spark acceleration platform adapter.
@@ -101,6 +107,25 @@ class VeloxAdapter(SparkLikeAdapterMixin, SparkDataLoadMixin, SparkQueryExecutio
     _df_caching_supported: bool = False
     _catalog_clear_cache_supported: bool = False
 
+    @classmethod
+    def _validate_deployment(cls, deployment: object) -> str:
+        """Return a supported deployment name, or fail closed.
+
+        Raises:
+            ValueError: If the deployment is not one the adapter implements.
+        """
+        normalized = str(deployment).strip().lower()
+        if normalized not in SUPPORTED_VELOX_DEPLOYMENTS:
+            supported = ", ".join(sorted(SUPPORTED_VELOX_DEPLOYMENTS))
+            hint = ""
+            if normalized == "docker":
+                hint = (
+                    " Docker is packaging infrastructure for local development, not a deployment mode;"
+                    " use deployment='local' inside the container."
+                )
+            raise ValueError(f"Unsupported Velox deployment '{normalized}'. Supported deployments: {supported}.{hint}")
+        return normalized
+
     def __init__(self, **config):
         super().__init__(**config)
 
@@ -112,8 +137,13 @@ class VeloxAdapter(SparkLikeAdapterMixin, SparkDataLoadMixin, SparkQueryExecutio
 
         self._dialect = "spark"
 
-        # Deployment mode: "local" | "remote"
-        self.deployment = config.get("deployment") or config.get("deployment_mode") or "local"
+        # Deployment mode: "local" | "remote".  Enumerated rather than compared
+        # against "local", because every downstream branch is `if local: ... else:
+        # <remote>`; an unrecognized value would otherwise route execution to a
+        # Spark-Connect endpoint the caller never asked for.
+        self.deployment = self._validate_deployment(
+            config.get("deployment") or config.get("deployment_mode") or "local"
+        )
 
         if self.deployment == "local":
             self._df_caching_supported = True

--- a/docs/reference/mcp.md
+++ b/docs/reference/mcp.md
@@ -247,6 +247,12 @@ modes remain available because they do not hold the request for execution.
   filesystem paths, unbounded values, and driver auto-install/version controls
   fail closed. Authenticated durable jobs persist only this normalized object,
   so retries and worker restarts cannot reintroduce raw request mappings.
+- Velox `deployment` accepts only `local` and `remote`, enumerated in both the
+  allow-list and the adapter. Unknown values are rejected rather than treated as
+  remote, so a request can never redirect execution to an endpoint it did not
+  name. `docker` is rejected: the `docker/velox/` tree is packaging
+  infrastructure for local development, not a deployment mode with its own
+  lifecycle, endpoint, isolation, and cleanup contract.
 - Modin `engine` accepts only `ray` and `dask` over MCP. The adapter itself also
   supports `unidist`, which stays documented for CLI and Python-API callers but
   is deliberately outside the MCP surface while it is experimental. `pandas` is

--- a/tests/unit/platforms/test_velox_adapter.py
+++ b/tests/unit/platforms/test_velox_adapter.py
@@ -110,6 +110,27 @@ class TestVeloxAdapterInit:
         adapter = VeloxAdapter(deployment_mode="remote")
         assert adapter.deployment == "remote"
 
+    @pytest.mark.parametrize("key", ["deployment", "deployment_mode"])
+    def test_constructor_rejects_docker_through_either_spelling(self, mock_pyspark, key):
+        """The factory, not just the validator, must fail closed."""
+        from benchbox.platforms.velox import VeloxAdapter
+
+        with pytest.raises(ValueError, match="Unsupported Velox deployment 'docker'"):
+            VeloxAdapter(**{key: "docker"})
+
+    def test_supported_deployments_still_select_their_own_endpoints(self, mock_pyspark):
+        """Enumerating must not disturb the modes the adapter does implement."""
+        from benchbox.platforms.velox import VeloxAdapter
+
+        local = VeloxAdapter(deployment="local")
+        assert local.deployment == "local"
+        assert local._df_caching_supported is True
+
+        remote = VeloxAdapter(deployment="remote", endpoint="sc://remote:50051")
+        assert remote.deployment == "remote"
+        assert remote.endpoint == "sc://remote:50051"
+        assert remote._df_caching_supported is False
+
     def test_get_target_dialect(self, mock_pyspark):
         from benchbox.platforms.velox import VeloxAdapter
 
@@ -651,3 +672,43 @@ class TestVeloxRegistration:
         assert "velox" in PLATFORM_TO_EXTRA
         assert PLATFORM_TO_EXTRA["velox"] == "velox"
         assert PLATFORM_TO_EXTRA.get("gluten-velox") == "velox"
+
+
+class TestDeploymentContractIsEnumerated:
+    """Any non-'local' value used to mean 'remote'. It must mean 'rejected'."""
+
+    def test_docker_is_rejected_rather_than_silently_becoming_remote(self):
+        from benchbox.platforms.velox import VeloxAdapter
+
+        with pytest.raises(ValueError, match="Unsupported Velox deployment 'docker'"):
+            VeloxAdapter._validate_deployment("docker")
+
+    def test_the_docker_rejection_points_at_the_real_workflow(self):
+        """Docker is packaging infrastructure, not a deployment mode."""
+        from benchbox.platforms.velox import VeloxAdapter
+
+        with pytest.raises(ValueError, match="packaging infrastructure"):
+            VeloxAdapter._validate_deployment("docker")
+
+    @pytest.mark.parametrize("deployment", ["kubernetes", "k8s", "cluster", "", "sc://evil:50051", "Remote-ish"])
+    def test_unknown_values_are_rejected_not_routed_to_an_endpoint(self, deployment):
+        from benchbox.platforms.velox import VeloxAdapter
+
+        with pytest.raises(ValueError, match="Unsupported Velox deployment"):
+            VeloxAdapter._validate_deployment(deployment)
+
+    @pytest.mark.parametrize(
+        ("deployment", "expected"),
+        [("local", "local"), ("remote", "remote"), ("LOCAL", "local"), (" remote ", "remote")],
+    )
+    def test_supported_deployments_are_accepted_and_normalized(self, deployment, expected):
+        from benchbox.platforms.velox import VeloxAdapter
+
+        assert VeloxAdapter._validate_deployment(deployment) == expected
+
+    def test_the_supported_set_matches_the_mcp_contract(self):
+        """The adapter and the MCP allow-list must not drift apart."""
+        from benchbox.mcp.schemas import MCP_PLATFORM_OPTION_ALLOWLIST
+        from benchbox.platforms.velox import SUPPORTED_VELOX_DEPLOYMENTS
+
+        assert set(MCP_PLATFORM_OPTION_ALLOWLIST["velox"]["deployment"].choices) == set(SUPPORTED_VELOX_DEPLOYMENTS)


### PR DESCRIPTION
Closes the `mcp-v2-velox-deployment-choice-v3` tracker item. Final item of the
six-item MCP v2 `platform_options` remediation batch.

> **Stacked on [#1515](https://github.com/joeharris76/BenchBox/pull/1515)** →
> #1514 → #1513 → #1511 → #1510. Base is `claude/mcp-v2-modin-engine`.

## What was already fixed, and what wasn't

**PR #1486 already** changed the allow-list from `("local", "docker")` to
`("local", "remote")`, so `deployment: "docker"` is rejected by the schema today.
Not re-implemented here.

The adapter half was still open (`velox.py:116`):

```python
self.deployment = config.get("deployment") or config.get("deployment_mode") or "local"
```

Every downstream branch is `if self.deployment == "local": ... else: <remote>`.
So **any** unrecognized value — `docker`, a typo, a future mode — silently routed
execution to the Spark-Connect path with `endpoint` defaulting to
`sc://localhost:50051`. That is the item's stated anti-pattern: *"Do not leave any
non-local string implicitly mapped to remote."*

## Change

- `SUPPORTED_VELOX_DEPLOYMENTS = frozenset({"local", "remote"})`, validated in the
  constructor **before** the endpoint and caching branches run.
- Both spellings (`deployment` and the `deployment_mode` factory alias) reach the
  same validation.
- `docker` stays **rejected, not half-implemented.** `docker/velox/` is packaging
  infrastructure for local development, not a deployment mode with its own
  lifecycle, endpoint, isolation, and cleanup contract — adding a partial Docker
  branch would recreate the ambiguous ownership this bug already has. The
  rejection message points at the real workflow: `deployment='local'` inside the
  container. (`docker/**` and `deploy/**` are `do_not_modify` for this item.)

Tests assert the **deployment and endpoint the factory selects**, not schema
serialization — including a case where a raw `sc://evil:50051` string is rejected
rather than becoming an endpoint. `test_the_supported_set_matches_the_mcp_contract`
pins the adapter's set to the MCP allow-list so widening either alone fails.

## Verification

| Rung | Command | Result |
|---|---|---|
| 1 | `pytest tests/unit/platforms tests/unit/mcp/test_schemas.py -q` | 8235 passed |
| 2 | `pytest tests/unit/mcp tests/integration/mcp -q` | 684 passed |
| 3 | `ruff check` (scoped) | clean |

CI-only gates run locally: `lint-imports` 3 kept / 0 broken; `lint-markers` 10 passed;
`timing_policy_check --strict` 0 violations.

**Negative control:** reverting only `benchbox/platforms/velox.py` fails 15 tests.

No live Velox service, Docker daemon, or credential is used.