### PR TITLE
ci: run the orphaned-commit detector on every develop push

### DIFF
--- a/.github/workflows/orphaned-commit-detector.yml
+++ b/.github/workflows/orphaned-commit-detector.yml
@@ -18,15 +18,20 @@ on:
     # Weekly, Monday 07:00 UTC (after the submission-validator drift check).
     - cron: "0 7 * * 1"
   workflow_dispatch: {}
-  # Also run when the detector or its allowlist changes, so a regression in the
-  # detector itself (or a bad allowlist edit) surfaces immediately.
+  # Run on EVERY develop push, not just changes to the detector itself.
+  #
+  # The weekly schedule above is a backstop, not a guard: it leaves up to seven
+  # days in which develop is silently missing a change that everyone believes
+  # landed. That is not hypothetical - PR #1503 auto-merged carrying only its
+  # first commit, and the orphan (b5c56ea9) was found by hand days before the
+  # schedule would have fired. A develop push is exactly the moment a squash
+  # merge can strand a commit, so check then.
+  #
+  # The job is read-only and finishes in ~1 minute; running it per merge is the
+  # difference between catching a stranded commit in one build and in one week.
   push:
     branches:
       - develop
-    paths:
-      - "_project/scripts/detect_orphaned_commits.py"
-      - "_project/analysis/known-stranded-commits.txt"
-      - ".github/workflows/orphaned-commit-detector.yml"
 
 permissions:
   contents: read

--- a/_project/analysis/known-stranded-commits.txt
+++ b/_project/analysis/known-stranded-commits.txt
@@ -37,3 +37,10 @@ cf394466a1422db63ea93546ef1d870d6d90c28a
 # "{query_id}#{stream_id}:{test_type}" scheme landed through #976/#979/#989,
 # with a regression test in tests/unit/core/results/test_loader.py.
 ee072b2c98c62671229876c075039a723732c3ea
+
+# Resolved: PR #1503 auto-merged carrying only its first commit while this
+# commit was still being written, so the "Results Explorer browser gate" job
+# its own PR body described never landed. Content was re-landed verbatim via
+# PR #1504 (cherry-pick onto a fresh branch off develop). Kept here because the
+# original SHA is still unreachable from develop by construction.
+b5c56ea998eb92b1a636b42205bd059cd19793d5

--- a/tests/unit/workflows/test_auto_merge_partial_stack_race.py
+++ b/tests/unit/workflows/test_auto_merge_partial_stack_race.py
@@ -1,0 +1,101 @@
+"""Guards against auto-merge landing a PR before its later commits are pushed.
+
+`make pr-open` enables squash auto-merge at PR creation. When work continues on
+the branch afterwards, the PR can satisfy its checks and merge while a later
+commit is still being written, so develop receives a partial change and the
+remaining commit is orphaned: the branch is merged, the PR is closed, and
+nothing reports that part of the work never landed.
+
+This is not hypothetical. PR #1503 merged carrying only its first commit; the
+`Results Explorer browser gate` job that its own PR body described never landed,
+and the orphan (b5c56ea9) was found by hand. The detector's own header records
+three earlier occurrences in the same remediation.
+
+`auto-merge-on-open.yml` cannot prevent it: it reacts to `synchronize`, and in
+this race there is no later push to react to *until after* the merge has already
+happened. So the guard is detection, and detection is only useful if it runs
+close to the event - hence the trigger assertions below.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+import yaml
+
+pytestmark = [pytest.mark.unit, pytest.mark.fast]
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+DETECTOR_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "orphaned-commit-detector.yml"
+AUTO_MERGE_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "auto-merge-on-open.yml"
+
+
+def _load(path: Path) -> dict[str, Any]:
+    return yaml.safe_load(path.read_text(encoding="utf-8"))
+
+
+def _triggers(workflow: dict[str, Any]) -> dict[str, Any]:
+    """Return the `on:` block.
+
+    PyYAML resolves an unquoted ``on`` key to the boolean ``True`` under YAML
+    1.1, so accept either spelling rather than reading an empty trigger set and
+    passing vacuously.
+    """
+    triggers = workflow.get("on", workflow.get(True))
+    assert triggers is not None, "workflow has no `on:` block"
+    return triggers
+
+
+def test_auto_merge_partial_stack_detector_runs_on_every_develop_push() -> None:
+    """The detector must run at the moment a squash merge can strand a commit.
+
+    A `paths:` filter here would scope the push trigger to edits of the detector
+    itself, leaving the weekly schedule as the only real coverage - up to seven
+    days in which develop is silently missing a change everyone believes landed.
+    """
+    push = _triggers(_load(DETECTOR_WORKFLOW))["push"]
+    assert "develop" in push["branches"], f"detector does not run on develop pushes: {push.get('branches')}"
+    assert "paths" not in push, (
+        "detector's develop push trigger is path-filtered, so it only runs when the detector itself changes"
+    )
+
+
+def test_auto_merge_partial_stack_detector_keeps_its_scheduled_backstop() -> None:
+    """Per-merge runs are the guard; the schedule still catches what they miss.
+
+    A push run only sees branches that exist at that moment. The schedule is
+    what eventually catches a branch pushed long after its PR closed.
+    """
+    triggers = _triggers(_load(DETECTOR_WORKFLOW))
+    assert "schedule" in triggers, "the weekly backstop was dropped when the push trigger was added"
+
+
+def test_auto_merge_partial_stack_detector_failure_is_actionable() -> None:
+    """The detector must keep its allowlist escape hatch.
+
+    Without one, a single acknowledged orphan makes every subsequent run red and
+    the signal decays into noise that people learn to scroll past.
+    """
+    allowlist = REPO_ROOT / "_project" / "analysis" / "known-stranded-commits.txt"
+    assert allowlist.is_file(), "the acknowledged-orphan allowlist is missing"
+    detector = (REPO_ROOT / "_project" / "scripts" / "detect_orphaned_commits.py").read_text(encoding="utf-8")
+    assert "known-stranded-commits" in detector, "detector no longer consults the allowlist"
+
+
+def test_auto_merge_partial_stack_soundness_revocation_is_unchanged() -> None:
+    """Must-preserve: soundness PRs still have auto-merge withheld and revoked.
+
+    The detector change must not have disturbed the auto-merge path itself.
+    """
+    workflow = _load(AUTO_MERGE_WORKFLOW)
+    types = _triggers(workflow)["pull_request"]["types"]
+    assert "synchronize" in types, "auto-merge no longer re-evaluates on push, so a later soundness commit can ride"
+
+    steps = [step for job in workflow["jobs"].values() for step in job.get("steps", [])]
+    commands = [step.get("run", "") for step in steps]
+    assert any("--disable-auto" in command for command in commands), "soundness revocation step is gone"
+    assert any("--auto --squash" in command for command in commands), (
+        "hands-free auto-merge for ordinary PRs is gone - the common case must stay hands-free"
+    )


### PR DESCRIPTION
## The race

`make pr-open` enables squash auto-merge at PR creation. If work continues on the branch afterwards, the PR can satisfy its checks and merge **while a later commit is still being written** — develop gets a partial change, the branch is merged, the PR is closed, and nothing reports that part of the work never landed.

PR #1503 merged carrying only its first commit; the `Results Explorer browser gate` job its own body described never landed. The detector's own header records **three earlier occurrences** in this same remediation.

## Why not fix it in `auto-merge-on-open.yml`

It can't be. That workflow reacts to `synchronize` — and in this race there is no later push to react to *until after the merge has already happened*. Withholding auto-merge was rejected outright: the item's must-preserve requires an ordinary fully-pushed PR to keep merging hands-free.

So the guard is **detection** — and a detector for exactly this class already exists. The gap was cadence, not absence.

## Change

Its develop push trigger was path-filtered to edits of *the detector itself*, leaving the weekly schedule as the only real coverage — up to seven days in which develop is silently missing a change everyone believes landed. Drop the filter so it runs at the moment a squash merge can strand a commit. The schedule stays as a backstop for branches pushed long after their PR closed.

## Verification

Run live against current state, it flags **5 orphans across 3 branches** — including my own `b5c56ea9` from #1503, now allowlisted (content re-landed verbatim via #1504).

4 tests pin: the trigger, the retained schedule, the allowlist escape hatch (one acknowledged orphan must not make every later run red and decay the signal), and — as a must-preserve regression guard — that auto-merge still re-evaluates on `synchronize`, still revokes for soundness paths, and still enables `--auto --squash`. Falsified by restoring the paths filter. Rung 2 (`pytest -k auto_merge`): **36 passed**.

## Heads-up: this will be red on merge

Four orphans remain that are **not mine to resolve**, and two are genuinely lost work:

| Commit | Branch | Status |
|---|---|---|
| `62fa0131` docs(agents): forbid standing agent attribution | `claude/git-identity-cloud-rca-maiixe` | **lost** — `agent-attribution-surfaces.md` absent from develop |
| `670fc009` fix(ci): drop the agent-identity guard that cannot fail | same | **lost** — develop still has the guard |
| `cc01856f` docs(decisions): ADR text | `test/freeze-bulk-path-coverage` | already on develop — allowlist candidate |
| `43fd39fe` merge commit | same | benign |

The detector is telling the truth, and it is non-blocking (push-triggered, not a required check). But develop will show a red detector run until those are re-landed or allowlisted. I have not touched another session's in-flight work — asking before acting.