### PR TITLE
fix(skills): sync the canonical source so a regen stops reverting merged policy

### DIFF
--- a/skill-sync.lock
+++ b/skill-sync.lock
@@ -1,16 +1,16 @@
 {
   "version": 1,
-  "lockedAt": "2026-07-29T11:48:57.836Z",
+  "lockedAt": "2026-08-04T12:21:48.283Z",
   "skills": {
     "blog": {
       "source": {
         "type": "git",
         "name": "canonical",
         "url": "https://github.com/joeharris76/skill-sync-skills.git",
-        "ref": "a48d0c02884f032b075f5968ab23e1261cf23dbc",
+        "ref": "db3957a338409366b72ed06fbc155479ec616827",
         "subdir": "skills",
-        "revision": "a48d0c02884f032b075f5968ab23e1261cf23dbc",
-        "fetchedAt": "2026-07-29T11:48:46.755Z"
+        "revision": "db3957a338409366b72ed06fbc155479ec616827",
+        "fetchedAt": "2026-08-04T12:21:36.774Z"
       },
       "installMode": "mirror",
       "files": {
@@ -61,10 +61,10 @@
         "type": "git",
         "name": "canonical",
         "url": "https://github.com/joeharris76/skill-sync-skills.git",
-        "ref": "a48d0c02884f032b075f5968ab23e1261cf23dbc",
+        "ref": "db3957a338409366b72ed06fbc155479ec616827",
         "subdir": "skills",
-        "revision": "a48d0c02884f032b075f5968ab23e1261cf23dbc",
-        "fetchedAt": "2026-07-29T11:48:47.365Z"
+        "revision": "db3957a338409366b72ed06fbc155479ec616827",
+        "fetchedAt": "2026-08-04T12:21:37.397Z"
       },
       "installMode": "mirror",
       "files": {
@@ -111,10 +111,10 @@
         "type": "git",
         "name": "canonical",
         "url": "https://github.com/joeharris76/skill-sync-skills.git",
-        "ref": "a48d0c02884f032b075f5968ab23e1261cf23dbc",
+        "ref": "db3957a338409366b72ed06fbc155479ec616827",
         "subdir": "skills",
-        "revision": "a48d0c02884f032b075f5968ab23e1261cf23dbc",
-        "fetchedAt": "2026-07-29T11:48:48.044Z"
+        "revision": "db3957a338409366b72ed06fbc155479ec616827",
+        "fetchedAt": "2026-08-04T12:21:38.078Z"
       },
       "installMode": "mirror",
       "files": {
@@ -157,10 +157,10 @@
         "type": "git",
         "name": "canonical",
         "url": "https://github.com/joeharris76/skill-sync-skills.git",
-        "ref": "a48d0c02884f032b075f5968ab23e1261cf23dbc",
+        "ref": "db3957a338409366b72ed06fbc155479ec616827",
         "subdir": "skills",
-        "revision": "a48d0c02884f032b075f5968ab23e1261cf23dbc",
-        "fetchedAt": "2026-07-29T11:48:49.301Z"
+        "revision": "db3957a338409366b72ed06fbc155479ec616827",
+        "fetchedAt": "2026-08-04T12:21:39.463Z"
       },
       "installMode": "mirror",
       "files": {
@@ -187,10 +187,10 @@
         "type": "git",
         "name": "canonical",
         "url": "https://github.com/joeharris76/skill-sync-skills.git",
-        "ref": "a48d0c02884f032b075f5968ab23e1261cf23dbc",
+        "ref": "db3957a338409366b72ed06fbc155479ec616827",
         "subdir": "skills",
-        "revision": "a48d0c02884f032b075f5968ab23e1261cf23dbc",
-        "fetchedAt": "2026-07-29T11:48:50.607Z"
+        "revision": "db3957a338409366b72ed06fbc155479ec616827",
+        "fetchedAt": "2026-08-04T12:21:40.754Z"
       },
       "installMode": "mirror",
       "files": {
@@ -245,10 +245,10 @@
         "type": "git",
         "name": "canonical",
         "url": "https://github.com/joeharris76/skill-sync-skills.git",
-        "ref": "a48d0c02884f032b075f5968ab23e1261cf23dbc",
+        "ref": "db3957a338409366b72ed06fbc155479ec616827",
         "subdir": "skills",
-        "revision": "a48d0c02884f032b075f5968ab23e1261cf23dbc",
-        "fetchedAt": "2026-07-29T11:48:51.234Z"
+        "revision": "db3957a338409366b72ed06fbc155479ec616827",
+        "fetchedAt": "2026-08-04T12:21:41.359Z"
       },
       "installMode": "mirror",
       "files": {
@@ -267,10 +267,10 @@
         "type": "git",
         "name": "canonical",
         "url": "https://github.com/joeharris76/skill-sync-skills.git",
-        "ref": "a48d0c02884f032b075f5968ab23e1261cf23dbc",
+        "ref": "db3957a338409366b72ed06fbc155479ec616827",
         "subdir": "skills",
-        "revision": "a48d0c02884f032b075f5968ab23e1261cf23dbc",
-        "fetchedAt": "2026-07-29T11:48:51.835Z"
+        "revision": "db3957a338409366b72ed06fbc155479ec616827",
+        "fetchedAt": "2026-08-04T12:21:41.992Z"
       },
       "installMode": "mirror",
       "files": {
@@ -289,10 +289,10 @@
         "type": "git",
         "name": "canonical",
         "url": "https://github.com/joeharris76/skill-sync-skills.git",
-        "ref": "a48d0c02884f032b075f5968ab23e1261cf23dbc",
+        "ref": "db3957a338409366b72ed06fbc155479ec616827",
         "subdir": "skills",
-        "revision": "a48d0c02884f032b075f5968ab23e1261cf23dbc",
-        "fetchedAt": "2026-07-29T11:48:52.442Z"
+        "revision": "db3957a338409366b72ed06fbc155479ec616827",
+        "fetchedAt": "2026-08-04T12:21:42.618Z"
       },
       "installMode": "mirror",
       "files": {
@@ -311,10 +311,10 @@
         "type": "git",
         "name": "canonical",
         "url": "https://github.com/joeharris76/skill-sync-skills.git",
-        "ref": "a48d0c02884f032b075f5968ab23e1261cf23dbc",
+        "ref": "db3957a338409366b72ed06fbc155479ec616827",
         "subdir": "skills",
-        "revision": "a48d0c02884f032b075f5968ab23e1261cf23dbc",
-        "fetchedAt": "2026-07-29T11:48:53.032Z"
+        "revision": "db3957a338409366b72ed06fbc155479ec616827",
+        "fetchedAt": "2026-08-04T12:21:43.242Z"
       },
       "installMode": "mirror",
       "files": {
@@ -333,10 +333,10 @@
         "type": "git",
         "name": "canonical",
         "url": "https://github.com/joeharris76/skill-sync-skills.git",
-        "ref": "a48d0c02884f032b075f5968ab23e1261cf23dbc",
+        "ref": "db3957a338409366b72ed06fbc155479ec616827",
         "subdir": "skills",
-        "revision": "a48d0c02884f032b075f5968ab23e1261cf23dbc",
-        "fetchedAt": "2026-07-29T11:48:53.616Z"
+        "revision": "db3957a338409366b72ed06fbc155479ec616827",
+        "fetchedAt": "2026-08-04T12:21:43.868Z"
       },
       "installMode": "mirror",
       "files": {
@@ -355,10 +355,10 @@
         "type": "git",
         "name": "canonical",
         "url": "https://github.com/joeharris76/skill-sync-skills.git",
-        "ref": "a48d0c02884f032b075f5968ab23e1261cf23dbc",
+        "ref": "db3957a338409366b72ed06fbc155479ec616827",
         "subdir": "skills",
-        "revision": "a48d0c02884f032b075f5968ab23e1261cf23dbc",
-        "fetchedAt": "2026-07-29T11:48:57.115Z"
+        "revision": "db3957a338409366b72ed06fbc155479ec616827",
+        "fetchedAt": "2026-08-04T12:21:47.553Z"
       },
       "installMode": "mirror",
       "files": {
@@ -389,10 +389,10 @@
         "type": "git",
         "name": "canonical",
         "url": "https://github.com/joeharris76/skill-sync-skills.git",
-        "ref": "a48d0c02884f032b075f5968ab23e1261cf23dbc",
+        "ref": "db3957a338409366b72ed06fbc155479ec616827",
         "subdir": "skills",
-        "revision": "a48d0c02884f032b075f5968ab23e1261cf23dbc",
-        "fetchedAt": "2026-07-29T11:48:54.194Z"
+        "revision": "db3957a338409366b72ed06fbc155479ec616827",
+        "fetchedAt": "2026-08-04T12:21:44.482Z"
       },
       "installMode": "mirror",
       "files": {
@@ -411,10 +411,10 @@
         "type": "git",
         "name": "canonical",
         "url": "https://github.com/joeharris76/skill-sync-skills.git",
-        "ref": "a48d0c02884f032b075f5968ab23e1261cf23dbc",
+        "ref": "db3957a338409366b72ed06fbc155479ec616827",
         "subdir": "skills",
-        "revision": "a48d0c02884f032b075f5968ab23e1261cf23dbc",
-        "fetchedAt": "2026-07-29T11:48:54.765Z"
+        "revision": "db3957a338409366b72ed06fbc155479ec616827",
+        "fetchedAt": "2026-08-04T12:21:45.099Z"
       },
       "installMode": "mirror",
       "files": {
@@ -433,10 +433,10 @@
         "type": "git",
         "name": "canonical",
         "url": "https://github.com/joeharris76/skill-sync-skills.git",
-        "ref": "a48d0c02884f032b075f5968ab23e1261cf23dbc",
+        "ref": "db3957a338409366b72ed06fbc155479ec616827",
         "subdir": "skills",
-        "revision": "a48d0c02884f032b075f5968ab23e1261cf23dbc",
-        "fetchedAt": "2026-07-29T11:48:55.360Z"
+        "revision": "db3957a338409366b72ed06fbc155479ec616827",
+        "fetchedAt": "2026-08-04T12:21:45.727Z"
       },
       "installMode": "mirror",
       "files": {
@@ -455,10 +455,10 @@
         "type": "git",
         "name": "canonical",
         "url": "https://github.com/joeharris76/skill-sync-skills.git",
-        "ref": "a48d0c02884f032b075f5968ab23e1261cf23dbc",
+        "ref": "db3957a338409366b72ed06fbc155479ec616827",
         "subdir": "skills",
-        "revision": "a48d0c02884f032b075f5968ab23e1261cf23dbc",
-        "fetchedAt": "2026-07-29T11:48:56.549Z"
+        "revision": "db3957a338409366b72ed06fbc155479ec616827",
+        "fetchedAt": "2026-08-04T12:21:46.936Z"
       },
       "installMode": "mirror",
       "files": {
@@ -481,10 +481,10 @@
         "type": "git",
         "name": "canonical",
         "url": "https://github.com/joeharris76/skill-sync-skills.git",
-        "ref": "a48d0c02884f032b075f5968ab23e1261cf23dbc",
+        "ref": "db3957a338409366b72ed06fbc155479ec616827",
         "subdir": "skills",
-        "revision": "a48d0c02884f032b075f5968ab23e1261cf23dbc",
-        "fetchedAt": "2026-07-29T11:48:57.698Z"
+        "revision": "db3957a338409366b72ed06fbc155479ec616827",
+        "fetchedAt": "2026-08-04T12:21:48.151Z"
       },
       "installMode": "mirror",
       "files": {
@@ -503,10 +503,10 @@
         "type": "git",
         "name": "canonical",
         "url": "https://github.com/joeharris76/skill-sync-skills.git",
-        "ref": "a48d0c02884f032b075f5968ab23e1261cf23dbc",
+        "ref": "db3957a338409366b72ed06fbc155479ec616827",
         "subdir": "skills",
-        "revision": "a48d0c02884f032b075f5968ab23e1261cf23dbc",
-        "fetchedAt": "2026-07-29T11:48:55.952Z"
+        "revision": "db3957a338409366b72ed06fbc155479ec616827",
+        "fetchedAt": "2026-08-04T12:21:46.338Z"
       },
       "installMode": "mirror",
       "files": {
@@ -525,10 +525,10 @@
         "type": "git",
         "name": "canonical",
         "url": "https://github.com/joeharris76/skill-sync-skills.git",
-        "ref": "a48d0c02884f032b075f5968ab23e1261cf23dbc",
+        "ref": "db3957a338409366b72ed06fbc155479ec616827",
         "subdir": "skills",
-        "revision": "a48d0c02884f032b075f5968ab23e1261cf23dbc",
-        "fetchedAt": "2026-07-29T11:48:50.011Z"
+        "revision": "db3957a338409366b72ed06fbc155479ec616827",
+        "fetchedAt": "2026-08-04T12:21:40.091Z"
       },
       "installMode": "mirror",
       "files": {
@@ -567,10 +567,10 @@
         "type": "git",
         "name": "canonical",
         "url": "https://github.com/joeharris76/skill-sync-skills.git",
-        "ref": "a48d0c02884f032b075f5968ab23e1261cf23dbc",
+        "ref": "db3957a338409366b72ed06fbc155479ec616827",
         "subdir": "skills",
-        "revision": "a48d0c02884f032b075f5968ab23e1261cf23dbc",
-        "fetchedAt": "2026-07-29T11:48:48.712Z"
+        "revision": "db3957a338409366b72ed06fbc155479ec616827",
+        "fetchedAt": "2026-08-04T12:21:38.794Z"
       },
       "installMode": "mirror",
       "files": {

--- a/skill-sync.yaml
+++ b/skill-sync.yaml
@@ -3,7 +3,7 @@ sources:
   - name: canonical
     type: git
     url: https://github.com/joeharris76/skill-sync-skills.git
-    ref: a48d0c02884f032b075f5968ab23e1261cf23dbc
+    ref: db3957a338409366b72ed06fbc155479ec616827
     subdir: skills
 skills:
   - blog


### PR DESCRIPTION
## Problem

The `[COMMIT-IDENTITY-001]` amendment — *"a commit-signing service may hold the committer slot behind a human author"* — was merged into the tracked mirror `.claude/skills/SHARED/commit-framework/SKILL.md`, but was never applied to the canonical source that mirror is generated from.

`.claude/skills` is regenerated from `skill-sync-skills` at the ref pinned in `skill-sync.yaml`. That ref still carried the pre-amendment wording, so **the next `make skill-sync` would have silently reverted merged policy** into the working tree — with `skill-sync-verify` still green, because the mirror and the lock were self-consistent with each other.

## What the drift actually was

The stale text lived **at the pinned ref**, not in the local `~/.skill-sync` working tree. That local copy already carried the amendment as an *uncommitted* edit. That is precisely why the drift stayed invisible: the local file is not the artifact the sync reads, so inspecting it suggested the source was already fixed.

## Changes

- `skill-sync.yaml` — bump the pinned ref to `db3957a`, which is [skill-sync-skills#16](https://github.com/joeharris76/skill-sync-skills/pull/16) applying the merged wording upstream (with the canonical repo's lock regenerated in the same commit, per its same-commit lock invariant).
- `skill-sync.lock` — regenerated by `make skill-sync`.

The `Co-Authored-By` bullet below the amended one is untouched; the instruction audit pins its anchors.

## Verification

| Check | Result |
|---|---|
| Pinned source carries the amended wording | pass |
| `make skill-sync` then `git diff --quiet -- .claude/skills/SHARED/commit-framework/SKILL.md` | **empty diff — regeneration is now a no-op** |
| `make skill-sync-verify` | `OK 1 tracked target(s) verified` — confirmed it *ran*, not skipped |
| `make agent-instructions-check` | `PASS` (`active_bytes=15714 agents_lines=168`) |
| `make pr-preflight` | pass — 26629 passed, 19 skipped |

The lock diff is the strongest evidence that no content moved: its only changed keys are `ref`, `revision`, `fetchedAt` and `lockedAt`. **Zero `sha256` entries changed**, so every mirrored file is byte-identical to what is already on `develop`.

Only the pinned ref was bumped between `a48d0c0` and `db3957a`; the sole skills-tree change in that range is this amendment. The rest of the range is canonical-repo infrastructure (its CI, pre-commit hook and README), which does not feed the mirror.
