### PR TITLE
fix(ci): drop the agent-identity guard that cannot fail

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -315,24 +315,16 @@ jobs:
         continue-on-error: true
         run: make agent-instructions-check
 
-      - name: Validate Git identity is not an agent/service
-        id: guard-agent-identity
-        continue-on-error: true
-        # GitHub's ephemeral checkout has no user.* config. Inject a
-        # non-agent identity only for this read-only resolution check; the
-        # commit-range guard below remains authoritative for PR authorship.
-        env:
-          GIT_CONFIG_COUNT: '2'
-          GIT_CONFIG_KEY_0: user.name
-          GIT_CONFIG_VALUE_0: BenchBox CI
-          GIT_CONFIG_KEY_1: user.email
-          GIT_CONFIG_VALUE_1: ci@benchbox.invalid
-        run: make agent-identity-check
-
-      # Merge-time guard. The step above reads the resolved config, which here
-      # is the runner's own identity; this one inspects the commits the PR
-      # actually carries, which is the only check that can keep agent
-      # authorship off develop.
+      # There is deliberately no CI counterpart to `make agent-identity-check`
+      # (which ci-lint still runs locally). That target resolves identity from
+      # git config, and on an ephemeral runner the config is the runner's own,
+      # so the check can say nothing about what the branch carries. Supplying a
+      # known-good identity to make it runnable only made it incapable of
+      # failing, and a guard that cannot fail is worse than an absent one --
+      # lint-guard-summary reports it as coverage. The commit-range guard below
+      # is the real merge-time control: it reads the commits themselves.
+      # Locally the identity IS the developer's or the agent's, so ci-lint and
+      # the pre-commit hook keep enforcing it where the answer is meaningful.
       - name: Validate no agent authorship or attribution in PR commits
         id: guard-agent-commit-range
         continue-on-error: true


### PR DESCRIPTION
## Problem

`guard-agent-identity` ran `make agent-identity-check` on the CI runner. That target resolves the identity from **git config** — and on an ephemeral checkout the config is the *runner's own*, not anything the branch carries. The check could therefore never say anything about the change under review.

Supplying it a known-good identity (`BenchBox CI <ci@benchbox.invalid>`) made it runnable and, in doing so, **structurally incapable of failing** — while `lint-guard-summary` kept reporting it as coverage. A guard that cannot fail is worse than an absent one: it consumes a required-check slot and advertises protection that does not exist.

## Change

Drop the `guard-agent-identity` step from `.github/workflows/pr.yml`.

`guard-agent-commit-range` is the real merge-time control — it reads the commits themselves, which is the thing that actually travels with the branch. Identity checking is retained everywhere it is meaningful:

| Surface | Control | Still active |
|---|---|---|
| Merge time (CI) | `guard-agent-commit-range` (reads commits) | yes |
| Local `ci-lint` | `agent-identity-check` (config is the developer's/agent's real one) | yes |
| Commit time | `pre-commit` hook | yes |
| Claim time | `make agent-write-preflight` | yes |

## Notes

`test_ci_lint_parity.py` needs no change and gets no `EXCLUDED_STEPS` entry: it constrains CI guards to be a **subset** of `ci-lint`, not the converse, so a local-only guard is legal.

## Verification

- `make pr-preflight` — pass, 26641 passed / 19 skipped
- `todo check-scope ci-agent-identity-guard-vacuity --base origin/develop` — scope OK (1 changed file)
