### PR TITLE
docs(browser-ci): close the amd64 arm of the WebKit investigation

### DIFF
--- a/docs/operations/browser-ci.md
+++ b/docs/operations/browser-ci.md
@@ -211,10 +211,42 @@ Two container gotchas cost real time; both are worked around above:
 | Fixed by the 1.62.1 bump | Same known-bad tree upgraded to 1.62.1 | **Refuted** — passes at both versions |
 | CPU/memory starvation on shared runners | develop tree at 2 cores / 2 GB, 3 consecutive runs | **Refuted** — 3/3 pass (10.0s, 9.0s, 8.7s) |
 
-The uncontrolled variable that remains is **architecture**: the reproduction
-above runs `linux/arm64`, while GitHub's `ubuntu-latest` is `linux/amd64`.
-Anyone picking this up should start by re-running the harness under
-`--platform linux/amd64` before opening any other line of inquiry.
+### The amd64 arm (2026-08-04)
+
+The architecture variable left open above has now been run. It does not close
+the investigation, and the reason is worth recording so nobody re-runs it
+expecting an answer.
+
+Under `--platform linux/amd64` (Rosetta emulation on Apple silicon; requires
+`softwareupdate --install-rosetta`, otherwise the container fails to bootstrap
+with `Rosetta is not installed`) the develop tree fails **10 of 16** WebKit
+`@smoke` tests, `benchmark-index` 3/3, with the CI signature exactly:
+`waitForDataLoaded` throwing at `e2e/support/fixtures.ts:124`. On `linux/arm64`
+the same tree passes 16/16.
+
+That looks like a reproduction and is not one. The emulated run took
+**10.5 minutes** against **58 seconds** on arm64 — roughly **11x slower**. Every
+failure is a data-bound wait exhausting its 10s + 8s + 8s budget, which is what
+an 11x slowdown produces regardless of cause. GitHub's runners are *native*
+amd64, not emulated, and the WebKit lane is green there.
+
+So the architecture hypothesis is **not supported**: native amd64 passes in CI,
+and the emulated failures are a timing artifact of the emulator.
+
+| Hypothesis | Test | Result |
+|---|---|---|
+| Architecture (arm64 harness vs amd64 CI) | develop tree under emulated `linux/amd64` | **Confounded, not supported** — 10/16 fail but the run is ~11x slower; native amd64 is green in CI |
+
+What the arm does establish is a robustness fact worth keeping: the data-bound
+budgets have little headroom. An ~11x slowdown is extreme, but it shows these
+waits fail by timeout under load rather than degrading, so a genuinely slow
+runner is a plausible trigger for the original failures even though CPU
+starvation at 2 cores was not enough to produce one.
+
+**Do not run the emulated amd64 arm again** — its result is known and
+uninformative. The next real step is a *native* amd64 reproduction, which means
+running the harness on a GitHub runner (`workflow_dispatch` on
+`results-explorer-browser.yml`) rather than locally.
 
 ## Triage rule
 


### PR DESCRIPTION
Runs the one variable left open on 2026-08-03. **It does not close the investigation** — and the reason is the point of the write-up.

## Result

Under emulated `linux/amd64`, the develop tree fails **10 of 16** WebKit `@smoke` tests and `benchmark-index` **3/3**, with the exact CI signature: `waitForDataLoaded` throwing at `e2e/support/fixtures.ts:124`. On `linux/arm64` the same tree passes **16/16**.

## Why that is not a reproduction

The emulated run took **10.5 minutes** against **58 seconds** on arm64 — roughly **11× slower**. Every failure is a data-bound wait exhausting its 10s + 8s + 8s budget, which an 11× slowdown produces regardless of cause.

GitHub's runners are *native* amd64, not emulated, and the WebKit lane is **green** there. So the architecture hypothesis is **not supported** — it is confounded, and the confound points the other way.

| Hypothesis | Test | Result |
|---|---|---|
| Architecture (arm64 harness vs amd64 CI) | develop under emulated `linux/amd64` | **Confounded, not supported** |

## What it did establish

The data-bound budgets have little headroom and fail by **timeout under load** rather than degrading. An 11× slowdown is extreme, but it keeps 'genuinely slow runner' alive as a trigger even though 2-core starvation wasn't enough to produce one.

## Practical notes

- Records the **Rosetta prerequisite** — the container fails to bootstrap with `Rosetta is not installed` until `softwareupdate --install-rosetta` runs (which needed no elevation).
- Adds an explicit **"do not run the emulated amd64 arm again"** so the next person doesn't repeat it.
- Names the next real step: a **native** amd64 run via `workflow_dispatch` on `results-explorer-browser.yml`, not another local one.

Docs-only.