### PR TITLE
fix(results): delete the legacy anonymization API that never anonymized

### DIFF
--- a/benchbox/core/results/anonymization.py
+++ b/benchbox/core/results/anonymization.py
@@ -109,18 +109,10 @@ def _is_public_pseudonym(value: str, prefix: str) -> bool:
 class AnonymizationConfig:
     """Configuration for result anonymization."""
 
-    # Machine identification
-    include_machine_id: bool = True
+    # Machine identification. The salt feeds both get_anonymous_machine_id and
+    # the public pseudonym hash, so it is the one knob that changes published
+    # identity.
     machine_id_salt: Optional[str] = None
-
-    # Path sanitization
-    anonymize_paths: bool = True
-    allowed_path_prefixes: list[str] = field(default_factory=lambda: ["/tmp", "/var/tmp"])
-
-    # System info
-    include_system_profile: bool = True
-    anonymize_hostnames: bool = True
-    anonymize_usernames: bool = True
 
     # Data anonymization
     pii_patterns: list[str] = field(
@@ -146,8 +138,6 @@ class AnonymizationManager:
         """
         self.config = config or AnonymizationConfig()
         self._machine_id_cache: Optional[str] = None
-        self._path_mapping: dict[str, str] = {}
-        self._hostname_mapping: dict[str, str] = {}
 
     def _get_macos_platform_uuid(self) -> Optional[str]:
         """Get macOS IOPlatformUUID - a stable hardware-based identifier.
@@ -646,119 +636,6 @@ class AnonymizationManager:
         cleaned = _MESSAGE_PATH_RE.sub(lambda match: self._hash_public_identifier(match.group(0), "path"), cleaned)
         return cleaned
 
-    def anonymize_system_profile(self) -> dict[str, Any]:
-        """Generate anonymized system profile information.
-
-        Returns:
-            Dictionary with anonymized system information
-        """
-        if not self.config.include_system_profile:
-            return {}
-
-        profile = {}
-
-        try:
-            # Operating system (safe to include)
-            profile["os_type"] = platform.system()
-            profile["os_release"] = platform.release()
-            profile["architecture"] = platform.machine()
-
-            # Hardware information (generally safe)
-            profile["cpu_count"] = os.cpu_count()
-            profile["python_version"] = platform.python_version()
-
-            # Memory information (if available, in general terms)
-            try:
-                import psutil
-
-                memory = psutil.virtual_memory()
-                # Round to nearest GB for privacy
-                profile["memory_gb"] = round(memory.total / (1024**3))
-            except ImportError:
-                profile["memory_gb"] = None
-
-            # Hostname (anonymized if requested)
-            if self.config.anonymize_hostnames:
-                hostname = platform.node()
-                if hostname not in self._hostname_mapping:
-                    hash_obj = hashlib.md5(hostname.encode())
-                    self._hostname_mapping[hostname] = f"host_{hash_obj.hexdigest()[:8]}"
-                profile["hostname"] = self._hostname_mapping[hostname]
-            else:
-                profile["hostname"] = platform.node()
-
-            # Username (anonymized if requested)
-            if self.config.anonymize_usernames:
-                try:
-                    username = os.getlogin()
-                    hash_obj = hashlib.md5(username.encode())
-                    profile["username"] = f"user_{hash_obj.hexdigest()[:8]}"
-                except Exception:
-                    profile["username"] = "anonymous"
-            else:
-                profile["username"] = os.getlogin() if hasattr(os, "getlogin") else "unknown"
-
-        except Exception as e:
-            logger.warning(f"Failed to collect system profile: {e}")
-            profile["collection_error"] = str(e)
-
-        return profile
-
-    def sanitize_path(self, path: str) -> str:
-        """Sanitize file paths by removing or anonymizing sensitive components.
-
-        Args:
-            path: File path to sanitize
-
-        Returns:
-            Sanitized path string
-        """
-        if not self.config.anonymize_paths:
-            return path
-
-        original_path = str(path)
-
-        # Check if path is in allowed prefixes (keep as-is)
-        for prefix in self.config.allowed_path_prefixes:
-            if original_path.startswith(prefix):
-                return original_path
-
-        # Use cached mapping if available
-        if original_path in self._path_mapping:
-            return self._path_mapping[original_path]
-
-        # Parse path components
-        path_obj = Path(original_path)
-        sanitized_parts = []
-
-        # Handle different path components
-        for i, part in enumerate(path_obj.parts):
-            if i == 0:
-                # Root or drive - keep structure but anonymize
-                if part.startswith("/"):
-                    sanitized_parts.append("/")
-                elif ":" in part:  # Windows drive
-                    sanitized_parts.append("C:")
-                else:
-                    sanitized_parts.append(part)
-            elif part in ["tmp", "temp", "var", "usr", "opt", "home", "Users"]:
-                # Common system directories - keep
-                sanitized_parts.append(part)
-            elif len(part) > 20 or any(char.isdigit() for char in part):
-                # Long names or names with numbers - likely UUIDs or sensitive
-                hash_obj = hashlib.md5(part.encode())
-                sanitized_parts.append(f"dir_{hash_obj.hexdigest()[:8]}")
-            else:
-                # Regular directory names - keep
-                sanitized_parts.append(part)
-
-        sanitized_path = str(Path(*sanitized_parts))
-
-        # Cache the mapping
-        self._path_mapping[original_path] = sanitized_path
-
-        return sanitized_path
-
     def remove_pii(self, text: str) -> str:
         """Remove personally identifiable information from text.
 
@@ -782,164 +659,6 @@ class AnonymizationManager:
             cleaned_text = re.sub(pattern, replacement, cleaned_text, flags=re.IGNORECASE)
 
         return cleaned_text
-
-    def anonymize_query_metadata(self, query_metadata: dict[str, Any]) -> dict[str, Any]:
-        """Anonymize query execution metadata.
-
-        Args:
-            query_metadata: Original query metadata
-
-        Returns:
-            Anonymized metadata dictionary
-        """
-        if not query_metadata:
-            return {}
-
-        anonymized = {}
-
-        for key, value in query_metadata.items():
-            if key in ["query_id", "execution_time", "rows_returned", "status"]:
-                # Safe metadata - keep as-is
-                anonymized[key] = value
-            elif key == "sql_text":
-                # Clean SQL text of PII
-                anonymized[key] = self.remove_pii(str(value))
-            elif key in ["file_path", "data_path", "output_path"]:
-                # Paths - sanitize
-                anonymized[key] = self.sanitize_path(str(value))
-            elif isinstance(value, str):
-                # String values - clean of PII
-                anonymized[key] = self.remove_pii(value)
-            elif isinstance(value, dict):
-                # Nested dictionaries - recurse
-                anonymized[key] = self.anonymize_query_metadata(value)
-            elif isinstance(value, list):
-                # Lists - process each item
-                anonymized[key] = [
-                    self.anonymize_query_metadata(item)
-                    if isinstance(item, dict)
-                    else self.remove_pii(str(item))
-                    if isinstance(item, str)
-                    else item
-                    for item in value
-                ]
-            else:
-                # Other types - keep as-is
-                anonymized[key] = value
-
-        return anonymized
-
-    def anonymize_execution_metadata(self, metadata: dict[str, Any]) -> dict[str, Any]:
-        """Anonymize complete execution metadata.
-
-        Args:
-            metadata: Original execution metadata
-
-        Returns:
-            Fully anonymized metadata dictionary
-        """
-        if not metadata:
-            return {}
-
-        anonymized = {
-            "anonymization_version": "1.0",
-            "anonymized_at": metadata.get("timestamp", "unknown"),
-        }
-
-        # Process each metadata field
-        for key, value in metadata.items():
-            if key in [
-                "benchmark_name",
-                "platform",
-                "scale_factor",
-                "execution_id",
-                "timestamp",
-                "duration_seconds",
-                "total_queries",
-                "successful_queries",
-            ]:
-                # Safe benchmark metadata
-                anonymized[key] = value
-            elif key == "machine_id":
-                # Replace with anonymous ID
-                anonymized["anonymous_machine_id"] = self.get_anonymous_machine_id()
-            elif key == "system_profile":
-                # Anonymize system information
-                anonymized["system_profile"] = self.anonymize_system_profile()
-            elif key in ["database_path", "data_directory", "output_directory"]:
-                # Paths - sanitize
-                anonymized[key] = self.sanitize_path(str(value))
-            elif key == "query_results" and isinstance(value, list):
-                # Query results - anonymize each
-                anonymized[key] = [self.anonymize_query_metadata(query) for query in value]
-            elif isinstance(value, dict):
-                # Nested dictionaries
-                anonymized[key] = self.anonymize_execution_metadata(value)
-            elif isinstance(value, str):
-                # String values
-                anonymized[key] = self.remove_pii(value)
-            else:
-                # Other values - keep as-is
-                anonymized[key] = value
-
-        return anonymized
-
-    def validate_anonymization(self, original_data: dict[str, Any], anonymized_data: dict[str, Any]) -> dict[str, Any]:
-        """Validate that anonymization was successful.
-
-        Args:
-            original_data: Original data before anonymization
-            anonymized_data: Data after anonymization
-
-        Returns:
-            Validation results dictionary
-        """
-        validation = {
-            "is_valid": True,
-            "warnings": [],
-            "errors": [],
-            "checks_performed": [],
-        }
-
-        # Check for potential PII leaks
-        str(original_data).lower()
-        anonymized_str = str(anonymized_data).lower()
-
-        # Check for common PII patterns in anonymized data
-        pii_checks = [
-            (r"\b\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}\b", "IP addresses"),
-            (r"\b[a-z0-9._%+-]+@[a-z0-9.-]+\.[a-z]{2,}\b", "email addresses"),
-            (r"/home/[^/]+", "home directory paths"),
-            (r"/users/[^/]+", "user directory paths"),
-            (r"[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}", "UUIDs"),
-        ]
-
-        for pattern, description in pii_checks:
-            if re.search(pattern, anonymized_str, re.IGNORECASE):
-                validation["warnings"].append(f"Potential {description} found in anonymized data")
-            validation["checks_performed"].append(f"Checked for {description}")
-
-        # Verify anonymous machine ID is present
-        if self.config.include_machine_id:
-            if "anonymous_machine_id" not in anonymized_str:
-                validation["errors"].append("Anonymous machine ID not found in anonymized data")
-            validation["checks_performed"].append("Anonymous machine ID presence")
-
-        # Check that system profile is anonymized
-        if self.config.include_system_profile:
-            if "system_profile" in anonymized_data:
-                profile = anonymized_data["system_profile"]
-                if self.config.anonymize_hostnames and "hostname" in profile:
-                    if not profile["hostname"].startswith("host_"):
-                        validation["warnings"].append("Hostname may not be properly anonymized")
-                if self.config.anonymize_usernames and "username" in profile:
-                    if not profile["username"].startswith("user_"):
-                        validation["warnings"].append("Username may not be properly anonymized")
-            validation["checks_performed"].append("System profile anonymization")
-
-        validation["is_valid"] = len(validation["errors"]) == 0
-
-        return validation
 
 
 def find_public_path_leaks(value: Any, key_path: tuple[str, ...] = ()) -> list[str]:

--- a/docs/reference/result-formats.md
+++ b/docs/reference/result-formats.md
@@ -443,14 +443,20 @@ print(f"Schema version family: {result.schema_version}")
 
 Results are anonymized by default to remove sensitive information:
 
-- Connection strings → hashed
-- Hostnames → generalized
-- Usernames → removed
-- API keys/tokens → stripped
+- Connection strings → redacted
+- Hostnames, endpoints, buckets, accounts → replaced by a stable pseudonym
+- Absolute local paths → replaced by a stable pseudonym
+- Usernames, IPs, emails → stripped
+- API keys/tokens → redacted
 
-### Disable Anonymization
+Identifiers become `<kind>_<12 hex>` — for example `machine_3d46427037d2` — from
+a salted SHA-256. The pseudonym is stable for the same input, so results from
+one machine group together, and anonymizing an already-anonymized payload is a
+no-op rather than a second pseudonym.
 
-Anonymization can be configured programmatically via the Python API:
+A pseudonym is a grouping key only. Because an already-anonymized value passes
+through unchanged, a submitter can hand-craft one, so it is never a provenance
+or trust signal — trust labels carry provenance.
 
 ### Anonymization Config
 
@@ -459,14 +465,21 @@ from benchbox.core.results.exporter import ResultExporter
 from benchbox.core.results.anonymization import AnonymizationConfig
 
 config = AnonymizationConfig(
-    anonymize_hostname=True,
-    anonymize_username=True,
-    anonymize_connection_string=True,
-    preserve_platform_version=True
+    # Scopes every pseudonym to your organization, so the same machine
+    # publishes different pseudonyms under different salts.
+    machine_id_salt="your-org-salt",
+    # Extra regexes stripped from free-text fields, on top of the built-in
+    # IP / email / SSN patterns.
+    custom_sanitizers={r"\bacct-\d+\b": "[REDACTED]"},
 )
 
 exporter = ResultExporter(anonymize=True, anonymization_config=config)
 ```
+
+### Disable Anonymization
+
+Pass `anonymize=False` to `ResultExporter`. Exports then contain raw local
+paths and host details, so treat them as private and do not submit them.
 
 ## Integration Examples
 

--- a/docs/reference/result-formats.md
+++ b/docs/reference/result-formats.md
@@ -465,8 +465,9 @@ from benchbox.core.results.exporter import ResultExporter
 from benchbox.core.results.anonymization import AnonymizationConfig
 
 config = AnonymizationConfig(
-    # Scopes every pseudonym to your organization, so the same machine
-    # publishes different pseudonyms under different salts.
+    # Scopes pseudonyms derived from raw values to your organization, so the
+    # same machine publishes different pseudonyms under different salts.
+    # See the salt-rotation note below for what this does *not* cover.
     machine_id_salt="your-org-salt",
     # Extra regexes stripped from free-text fields, on top of the built-in
     # IP / email / SSN patterns.
@@ -475,6 +476,30 @@ config = AnonymizationConfig(
 
 exporter = ResultExporter(anonymize=True, anonymization_config=config)
 ```
+
+#### Salt rotation
+
+The salt applies when a **raw** value is hashed. A value that is already a
+pseudonym passes through unchanged — that is what makes anonymization
+idempotent — and the pass-through happens *before* the salt is consulted:
+
+```python
+a = AnonymizationManager(AnonymizationConfig(machine_id_salt="org-A"))
+b = AnonymizationManager(AnonymizationConfig(machine_id_salt="org-B"))
+
+a.anonymize_result_payload({"machine_id": raw})   # machine_9ba319f754a5
+b.anonymize_result_payload({"machine_id": raw})   # machine_ac228f1f75af  (differs)
+
+# But B re-anonymizing A's already-published bundle:
+b.anonymize_result_payload({"machine_id": "machine_9ba319f754a5"})
+# -> machine_9ba319f754a5   (unchanged; B's salt is never applied)
+```
+
+So changing the salt does **not** re-pseudonymize an already-anonymized corpus.
+New captures adopt the new salt while stored bundles keep the old pseudonyms,
+which splits one machine across two identities. Rotating the salt therefore
+means re-deriving the corpus from the pre-anonymization originals, not just
+changing the config.
 
 ### Disable Anonymization
 

--- a/tests/unit/cli/test_cli_output.py
+++ b/tests/unit/cli/test_cli_output.py
@@ -717,17 +717,17 @@ class TestResultExporter:
 
     @patch("benchbox.cli.output.console")
     def test_export_with_anonymization(self, mock_console):
-        """Test export with anonymization enabled."""
-        # Create exporter with anonymization
+        """Test export with anonymization enabled.
+
+        Runs the real anonymizer. This used to patch anonymize_execution_metadata
+        and validate_anonymization, but the exporter never called either -- they
+        were part of a legacy API with no production caller, since removed -- so
+        the mocks asserted nothing and only masked which code path ran.
+        """
         anon_exporter = ResultExporter(output_dir=Path(self.temp_dir), anonymize=True)
         result = self.create_cli_result()
 
-        with patch.object(anon_exporter.anonymization_manager, "anonymize_execution_metadata") as mock_anonymize:
-            with patch.object(anon_exporter.anonymization_manager, "validate_anonymization") as mock_validate:
-                mock_anonymize.return_value = {"anonymized": "data"}
-                mock_validate.return_value = {"is_valid": True, "warnings": []}
-
-                exported = anon_exporter.export_result(result, formats=["json"])
+        exported = anon_exporter.export_result(result, formats=["json"])
 
         json_path = exported["json"]
         with open(json_path, encoding="utf-8") as f:

--- a/tests/unit/core/results/test_anonymization.py
+++ b/tests/unit/core/results/test_anonymization.py
@@ -13,6 +13,7 @@ import json
 import re
 import subprocess
 import sys
+from pathlib import Path
 from unittest.mock import MagicMock, Mock, mock_open, patch
 
 import pytest
@@ -1091,6 +1092,26 @@ class TestLegacyAnonymizationSchemeIsGone:
         truncations = re.findall(r"hexdigest\(\)\[:[^\]]+\]", source)
         assert len(truncations) == 2, f"unexpected digest truncations: {truncations}"
 
+    def test_no_sibling_module_mints_a_pseudonym_behind_the_boundary(self):
+        """Widen the check past this one module.
+
+        The rung above reads only ``anonymization.py``, so a second emitter
+        added in a sibling under ``benchbox/core/results/`` would satisfy it
+        while reintroducing exactly the split this class exists to prevent.
+        Scan the package and require that anything minting a ``<prefix>_<hex>``
+        token does it through the shared salted helper.
+        """
+        package = Path(inspect.getfile(sys.modules[AnonymizationManager.__module__])).parent
+        emitter = re.compile(r"f\"[a-z_]+_\{[^}]*hexdigest\(\)")
+        offenders = []
+        for path in sorted(package.glob("*.py")):
+            text = path.read_text(encoding="utf-8")
+            if path.name == "anonymization.py":
+                continue
+            if emitter.search(text):
+                offenders.append(path.name)
+        assert not offenders, f"pseudonym emitters outside the shared helper: {offenders}"
+
     def test_public_surface_is_only_the_salted_boundary(self):
         public = {
             name for name, _ in inspect.getmembers(AnonymizationManager, inspect.isfunction) if not name.startswith("_")
@@ -1101,6 +1122,29 @@ class TestLegacyAnonymizationSchemeIsGone:
             "anonymize_tuning_payload",
             "remove_pii",
         }, public
+
+    def test_salt_does_not_reach_an_already_anonymized_value(self):
+        """Pin the salt/pass-through interaction, including its downside.
+
+        The pass-through is checked BEFORE the salt is applied, so a value that
+        is already a pseudonym survives verbatim no matter whose salt is in
+        play. That is required for idempotence, but it means changing the salt
+        does not re-pseudonymize a stored corpus: new captures adopt the new
+        salt while stored bundles keep the old pseudonyms, splitting one
+        machine across two identities. Rotating the salt requires re-deriving
+        the corpus from pre-anonymization originals. Documented under
+        "Salt rotation" in docs/reference/result-formats.md.
+        """
+        a = AnonymizationManager(AnonymizationConfig(machine_id_salt="org-A"))
+        b = AnonymizationManager(AnonymizationConfig(machine_id_salt="org-B"))
+        raw = {"machine_id": "machine_0123456789abcdef"}
+
+        published_by_a = a.anonymize_result_payload(raw)["machine_id"]
+        published_by_b = b.anonymize_result_payload(raw)["machine_id"]
+        assert published_by_a != published_by_b, "salt must scope pseudonyms derived from raw values"
+
+        reanonymized = b.anonymize_result_payload({"machine_id": published_by_a})["machine_id"]
+        assert reanonymized == published_by_a, "already-anonymized values are salt-independent by design"
 
     def test_no_public_method_returns_a_private_path_verbatim(self):
         """The concrete defect: sanitize_path('/Users/alice/bench') used to

--- a/tests/unit/core/results/test_anonymization.py
+++ b/tests/unit/core/results/test_anonymization.py
@@ -7,7 +7,10 @@ Copyright 2026 Joe Harris / BenchBox Project
 Licensed under the MIT License. See LICENSE file in the project root for details.
 """
 
+import dataclasses
+import inspect
 import json
+import re
 import subprocess
 import sys
 from unittest.mock import MagicMock, Mock, mock_open, patch
@@ -467,107 +470,37 @@ class TestAnonymizationConfig:
         """Test default configuration values."""
         config = AnonymizationConfig()
 
-        assert config.include_machine_id is True
         assert config.machine_id_salt is None
-        assert config.anonymize_paths is True
-        assert config.include_system_profile is True
-        assert config.anonymize_hostnames is True
-        assert config.anonymize_usernames is True
+        assert config.pii_patterns
+        assert config.custom_sanitizers == {}
 
     def test_custom_config(self):
         """Test custom configuration values."""
-        config = AnonymizationConfig(
-            include_machine_id=False,
-            machine_id_salt="custom_salt",
-            anonymize_paths=False,
-        )
+        config = AnonymizationConfig(machine_id_salt="custom_salt")
 
-        assert config.include_machine_id is False
         assert config.machine_id_salt == "custom_salt"
-        assert config.anonymize_paths is False
 
+    def test_no_flag_promises_privacy_it_does_not_deliver(self):
+        """Every remaining field must actually reach published output.
 
-class TestAnonymizeSystemProfile:
-    """Test anonymize_system_profile method."""
-
-    def test_returns_dict_with_expected_keys(self):
-        manager = AnonymizationManager()
-        profile = manager.anonymize_system_profile()
-        assert isinstance(profile, dict)
-        assert "os_type" in profile
-        assert "cpu_count" in profile
-        assert "python_version" in profile
-
-    def test_hostname_is_anonymized(self):
-        config = AnonymizationConfig(anonymize_hostnames=True)
-        manager = AnonymizationManager(config)
-        profile = manager.anonymize_system_profile()
-        assert profile["hostname"].startswith("host_")
-
-    def test_hostname_not_anonymized_when_disabled(self):
-        config = AnonymizationConfig(anonymize_hostnames=False)
-        manager = AnonymizationManager(config)
-        profile = manager.anonymize_system_profile()
-        assert not profile["hostname"].startswith("host_")
-
-    def test_username_anonymized_when_enabled(self):
-        config = AnonymizationConfig(anonymize_usernames=True)
-        manager = AnonymizationManager(config)
-        profile = manager.anonymize_system_profile()
-        username = profile.get("username", "")
-        assert username.startswith("user_") or username == "anonymous"
-
-    def test_include_system_profile_false_returns_empty(self):
-        config = AnonymizationConfig(include_system_profile=False)
-        manager = AnonymizationManager(config)
-        profile = manager.anonymize_system_profile()
-        assert profile == {}
-
-    def test_hostname_is_cached_consistently(self):
-        manager = AnonymizationManager()
-        p1 = manager.anonymize_system_profile()
-        p2 = manager.anonymize_system_profile()
-        assert p1["hostname"] == p2["hostname"]
-
-
-class TestSanitizePath:
-    """Test path sanitization."""
-
-    def test_allowed_prefix_path_unchanged(self):
-        manager = AnonymizationManager()
-        result = manager.sanitize_path("/tmp/benchmark/results.json")
-        assert result == "/tmp/benchmark/results.json"
-
-    def test_path_anonymization_disabled(self):
-        config = AnonymizationConfig(anonymize_paths=False)
-        manager = AnonymizationManager(config)
-        result = manager.sanitize_path("/home/user/secret/data.parquet")
-        assert result == "/home/user/secret/data.parquet"
-
-    def test_long_path_component_hashed(self):
-        manager = AnonymizationManager()
-        # A path component with more than 20 chars should be hashed
-        result = manager.sanitize_path("/some/averylongdirectorynamewithmanychars/file.parquet")
-        assert "averylongdirectorynamewithmanychars" not in result
-        assert "dir_" in result
-
-    def test_path_cache_returns_same_result(self):
-        manager = AnonymizationManager()
-        p = "/home/alice/project/data.csv"
-        r1 = manager.sanitize_path(p)
-        r2 = manager.sanitize_path(p)
-        assert r1 == r2
-
-    def test_common_system_dirs_kept(self):
-        manager = AnonymizationManager()
-        result = manager.sanitize_path("/home/foo")
-        assert "home" in result
-
-    def test_numeric_component_hashed(self):
-        manager = AnonymizationManager()
-        result = manager.sanitize_path("/data/user123/file.parquet")
-        # "user123" has a digit so should be hashed
-        assert "user123" not in result
+        The retired flags (include_machine_id, anonymize_paths,
+        allowed_path_prefixes, include_system_profile, anonymize_hostnames,
+        anonymize_usernames) fed only the deleted legacy API. They read as
+        privacy controls but gated nothing on the publication path, which is
+        the worst kind of config: a caller could set anonymize_paths=False
+        and see no change, or leave it True and assume paths were protected
+        by it. Keep the surface honest.
+        """
+        retired = {
+            "include_machine_id",
+            "anonymize_paths",
+            "allowed_path_prefixes",
+            "include_system_profile",
+            "anonymize_hostnames",
+            "anonymize_usernames",
+        }
+        present = {f.name for f in dataclasses.fields(AnonymizationConfig)}
+        assert not (present & retired), f"dead privacy flags are back: {sorted(present & retired)}"
 
 
 class TestRemovePII:
@@ -605,127 +538,6 @@ class TestRemovePII:
         manager = AnonymizationManager()
         clean = "Benchmark finished in 3.5 seconds"
         assert manager.remove_pii(clean) == clean
-
-
-class TestAnonymizeQueryMetadata:
-    """Test query metadata anonymization."""
-
-    def test_safe_fields_preserved(self):
-        manager = AnonymizationManager()
-        meta = {"query_id": "Q1", "execution_time": 1.5, "rows_returned": 100, "status": "ok"}
-        result = manager.anonymize_query_metadata(meta)
-        assert result["query_id"] == "Q1"
-        assert result["execution_time"] == 1.5
-        assert result["rows_returned"] == 100
-
-    def test_sql_text_pii_removed(self):
-        manager = AnonymizationManager()
-        meta = {"sql_text": "SELECT * FROM t WHERE email = 'user@example.com'"}
-        result = manager.anonymize_query_metadata(meta)
-        assert "user@example.com" not in result["sql_text"]
-
-    def test_file_path_sanitized(self):
-        manager = AnonymizationManager()
-        meta = {"file_path": "/tmp/data.parquet"}
-        result = manager.anonymize_query_metadata(meta)
-        assert result["file_path"] == "/tmp/data.parquet"
-
-    def test_nested_dict_recursed(self):
-        manager = AnonymizationManager()
-        meta = {"nested": {"sql_text": "SELECT 1"}}
-        result = manager.anonymize_query_metadata(meta)
-        assert "nested" in result
-
-    def test_list_values_processed(self):
-        manager = AnonymizationManager()
-        meta = {"tags": ["fast", "192.168.1.1"]}
-        result = manager.anonymize_query_metadata(meta)
-        assert isinstance(result["tags"], list)
-        joined = " ".join(result["tags"])
-        assert "192.168.1.1" not in joined
-
-    def test_empty_dict_returns_empty(self):
-        manager = AnonymizationManager()
-        assert manager.anonymize_query_metadata({}) == {}
-
-
-class TestAnonymizeExecutionMetadata:
-    """Test execution metadata anonymization."""
-
-    def test_safe_benchmark_fields_preserved(self):
-        manager = AnonymizationManager()
-        meta = {
-            "benchmark_name": "tpch",
-            "platform": "duckdb",
-            "scale_factor": 1.0,
-            "execution_id": "run-001",
-        }
-        result = manager.anonymize_execution_metadata(meta)
-        assert result["benchmark_name"] == "tpch"
-        assert result["platform"] == "duckdb"
-
-    def test_machine_id_replaced_with_anonymous(self):
-        manager = AnonymizationManager()
-        meta = {"machine_id": "real-machine-id-12345"}
-        result = manager.anonymize_execution_metadata(meta)
-        assert "anonymous_machine_id" in result
-        assert result["anonymous_machine_id"].startswith("machine_")
-
-    def test_system_profile_included(self):
-        manager = AnonymizationManager()
-        meta = {"system_profile": {"hostname": "myhost", "os_type": "Linux"}}
-        result = manager.anonymize_execution_metadata(meta)
-        assert "system_profile" in result
-
-    def test_data_path_sanitized(self):
-        manager = AnonymizationManager()
-        meta = {"data_directory": "/tmp/bench_data"}
-        result = manager.anonymize_execution_metadata(meta)
-        assert result["data_directory"] == "/tmp/bench_data"
-
-    def test_query_results_list_anonymized(self):
-        manager = AnonymizationManager()
-        meta = {
-            "query_results": [
-                {"query_id": "Q1", "execution_time": 1.0},
-                {"query_id": "Q2", "execution_time": 2.0},
-            ]
-        }
-        result = manager.anonymize_execution_metadata(meta)
-        assert isinstance(result["query_results"], list)
-        assert len(result["query_results"]) == 2
-
-    def test_empty_metadata_returns_empty(self):
-        manager = AnonymizationManager()
-        assert manager.anonymize_execution_metadata({}) == {}
-
-
-class TestValidateAnonymization:
-    """Test anonymization validation."""
-
-    def test_valid_anonymized_data_passes(self):
-        manager = AnonymizationManager()
-        meta = {"benchmark_name": "tpch", "machine_id": "x"}
-        anonymized = manager.anonymize_execution_metadata(meta)
-        validation = manager.validate_anonymization(meta, anonymized)
-        assert validation["is_valid"] is True
-        assert isinstance(validation["checks_performed"], list)
-
-    def test_pii_in_anonymized_data_generates_warning(self):
-        manager = AnonymizationManager()
-        original = {}
-        # Manually inject IP into otherwise clean data
-        anonymized = {"result": "connected to 10.0.0.1"}
-        validation = manager.validate_anonymization(original, anonymized)
-        warnings = " ".join(validation["warnings"])
-        assert "IP" in warnings or "ip" in warnings.lower()
-
-    def test_missing_machine_id_generates_error(self):
-        config = AnonymizationConfig(include_machine_id=True)
-        manager = AnonymizationManager(config)
-        validation = manager.validate_anonymization({}, {"result": "ok"})
-        assert any("machine" in e.lower() for e in validation["errors"])
-        assert validation["is_valid"] is False
 
 
 class TestPublicPayloadSecretKeys:
@@ -1234,3 +1046,70 @@ class TestPublicPseudonymFixedPoint:
     def test_only_the_exact_pseudonym_shape_passes_through(self, value):
         assert not _is_public_pseudonym(value, "path")
         assert AnonymizationManager().anonymize_result_payload({"working_dir": value})["working_dir"] != value
+
+
+class TestLegacyAnonymizationSchemeIsGone:
+    """One salted scheme, no second weaker one.
+
+    The module used to carry a parallel legacy API - sanitize_path,
+    anonymize_query_metadata, anonymize_execution_metadata,
+    anonymize_system_profile, validate_anonymization - that hashed with
+    UNSALTED md5 truncated to 8 hex and, in sanitize_path's case, returned
+    private paths completely unchanged. It had no production caller, so it
+    leaked nothing in practice, but it sat in the same module as the real
+    boundary where a future caller could reasonably have trusted it.
+    """
+
+    LEGACY_METHODS = (
+        "sanitize_path",
+        "anonymize_query_metadata",
+        "anonymize_execution_metadata",
+        "anonymize_system_profile",
+        "validate_anonymization",
+    )
+
+    @pytest.mark.parametrize("name", LEGACY_METHODS)
+    def test_legacy_method_is_gone(self, name):
+        assert not hasattr(AnonymizationManager, name), f"{name} is back on the public surface"
+
+    def test_no_unsalted_md5_pseudonym_scheme_remains(self):
+        """md5 is unsalted and 8 hex here - trivially reversible for a
+        username or hostname. The public boundary uses salted sha256.
+        """
+        source = inspect.getsource(sys.modules[AnonymizationManager.__module__])
+        assert "md5" not in source, "an md5 pseudonym scheme is back in the anonymizer"
+
+    def test_every_pseudonym_emitter_uses_the_shared_salted_helper(self):
+        """Catch a second emitter even if it reaches for sha256.
+
+        The bug was two schemes, not md5 specifically. Any new
+        f"prefix_{...hexdigest()[:n]}" that bypasses _hash_public_identifier
+        would reintroduce it, so pin that the module truncates a digest in
+        exactly the two places that are supposed to.
+        """
+        source = inspect.getsource(sys.modules[AnonymizationManager.__module__])
+        truncations = re.findall(r"hexdigest\(\)\[:[^\]]+\]", source)
+        assert len(truncations) == 2, f"unexpected digest truncations: {truncations}"
+
+    def test_public_surface_is_only_the_salted_boundary(self):
+        public = {
+            name for name, _ in inspect.getmembers(AnonymizationManager, inspect.isfunction) if not name.startswith("_")
+        }
+        assert public == {
+            "get_anonymous_machine_id",
+            "anonymize_result_payload",
+            "anonymize_tuning_payload",
+            "remove_pii",
+        }, public
+
+    def test_no_public_method_returns_a_private_path_verbatim(self):
+        """The concrete defect: sanitize_path('/Users/alice/bench') used to
+        return that string unchanged, and find_public_path_leaks flagged its
+        own module's output as a leak.
+        """
+        manager = AnonymizationManager()
+        private = "/Users/alice/bench"
+        for payload in ({"working_dir": private}, {"database_path": private}, {"note": private}):
+            out = manager.anonymize_result_payload(payload)
+            assert find_public_path_leaks(out) == [], f"{payload} leaked: {out}"
+            assert "alice" not in json.dumps(out)


### PR DESCRIPTION
Implements `legacy-anonymization-api-weak-scheme`.

## Problem

`benchbox/core/results/anonymization.py` carried a **second, much weaker
anonymization scheme** beside the public boundary hardened in #1512.

```python
>>> AnonymizationManager().sanitize_path("/Users/alice/bench")
'/Users/alice/bench'          # unchanged — the username survives
>>> find_public_path_leaks({"p": _})
['p']                         # the repo's own detector flags its own module's output
```

Short, digit-free path components were kept, so a username survived intact.
Alongside it:

| Emitter | Scheme | Fields |
|---|---|---|
| `anonymize_system_profile` | **unsalted MD5**, 8 hex | `host_`, `user_` |
| `sanitize_path` | **unsalted MD5**, 8 hex | `dir_` |
| public boundary | **salted SHA-256**, 12 hex | everything published |

Unsalted MD5 truncated to 8 hex is trivially reversible for common hostnames and
usernames — the two most identifying fields there are.

**Nothing leaked in practice.** `anonymize_execution_metadata` only recursed
into itself, `validate_anonymization` had no caller at all, and nothing outside
tests reached any of them. This was a loaded gun in a privacy-critical module: a
future caller could reasonably have believed `sanitize_path` sanitizes, and no
test caught the username leak.

## Change

Deletes all five legacy methods and the config flags that fed only them.

`include_machine_id` goes too, and that one is worth calling out: it gated
nothing but `validate_anonymization`, so on the publication path it was a
privacy control that controlled nothing. A caller setting `include_machine_id=False`
got no change. Removing it turns a silent lie into a loud `TypeError`.

`AnonymizationConfig` keeps `machine_id_salt`, `pii_patterns`, and
`custom_sanitizers` — all of which reach published output.

Public surface is now four methods, all salted SHA-256:
`get_anonymous_machine_id`, `anonymize_result_payload`,
`anonymize_tuning_payload`, `remove_pii`.

## Tests

`TestLegacyAnonymizationSchemeIsGone` pins that the scheme cannot return:

- the five methods stay absent;
- no `md5` remains in the module;
- **exactly two** digest truncations exist — the real anti-drift rung, since the
  defect was *two schemes*, not MD5 specifically; a new emitter reaching for
  `sha256` would still be caught;
- the public surface is exactly those four methods;
- no public method returns a private path verbatim.

Plus a config test asserting the six retired flags cannot reappear as fields.

## Two things this exposed

**A test that tested nothing.** `tests/unit/cli/test_cli_output.py::test_export_with_anonymization`
patched `anonymize_execution_metadata` and `validate_anonymization` — methods the
exporter never calls. The mocks made it look like anonymization was covered while
asserting nothing about it. It now runs the real anonymizer.

**Docs that never worked.** `docs/reference/result-formats.md` documented an
`AnonymizationConfig` example that raises `TypeError` on develop today — it passes
`anonymize_hostname`/`anonymize_username`/`anonymize_connection_string`/
`preserve_platform_version`, and *none of those have ever been fields*. The
replacement is executed and works, and now documents the pseudonym contract
(`<kind>_<12 hex>`, salted, idempotent, grouping-key-only).

## Verification

Full fast lane: **26642 passed**, 0 failures.
