### PR TITLE
chore(ci): require owner review for the public anonymizer

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -13,6 +13,13 @@ benchbox/platforms/base/result_capture.py @joeharris76
 benchbox/sql_compat/resolver.py @joeharris76
 benchbox/sql_compat/decision.py @joeharris76
 benchbox/sql_compat/rules/_registration.py @joeharris76
+# Publication privacy: the anonymizer decides every published byte and the
+# public pseudonym identity. Both failure modes are silent (leak a private
+# value, or repartition public identity). The specs YAML defines which keys
+# get hashed, so dropping an entry there is a silent leak with no code diff.
+# Widened after PR #1512.
+benchbox/core/results/anonymization.py @joeharris76
+benchbox/core/results/anonymization_specs.yaml @joeharris76
 # Self-protection: the review-gate machinery and the PyPI-publishing
 # workflow. In-workflow checks are attacker-controlled for same-repo PRs
 # (GitHub runs the PR's own copy of a pull_request-triggered workflow).

--- a/_project/scripts/auto_merge_soundness_paths.py
+++ b/_project/scripts/auto_merge_soundness_paths.py
@@ -35,6 +35,21 @@ SOUNDNESS_PREFIXES = (
     "benchbox/sql_compat/resolver.py",
     "benchbox/sql_compat/decision.py",
     "benchbox/sql_compat/rules/_registration.py",
+    # Publication privacy. This is a deliberate widening beyond "what defines a
+    # correct result": the anonymizer decides every byte that leaves the
+    # project and the public pseudonym identity that groups results by machine.
+    # Both of its failure modes are silent -- a missed key publishes a private
+    # path, and a changed hashing rule repartitions public identity without
+    # anything raising. PR #1512 was exactly that: it changed every published
+    # byte and every public result_id, and auto-merged with no review because
+    # this list did not cover it. Same rationale as release.yml above (that one
+    # is here for publishing to PyPI, not for soundness) -- is_soundness_path
+    # means "needs owner review before auto-merge", which is broader than
+    # soundness alone. anonymization_specs.yaml is listed with it because it
+    # DEFINES which keys get hashed -- dropping one entry there silently stops
+    # anonymizing that field, with no code change to review.
+    "benchbox/core/results/anonymization.py",
+    "benchbox/core/results/anonymization_specs.yaml",
     # Self-protection: the review-gate machinery itself. The in-workflow
     # base-ref execution + self-touch override in auto-merge-on-open.yml is
     # best-effort only for same-repo PRs (GitHub runs the PR's OWN copy of a

--- a/tests/unit/test_auto_merge_soundness_paths.py
+++ b/tests/unit/test_auto_merge_soundness_paths.py
@@ -38,6 +38,13 @@ pytestmark = [pytest.mark.unit, pytest.mark.fast]
         "benchbox/sql_compat/resolver.py",
         "benchbox/sql_compat/decision.py",
         "benchbox/sql_compat/rules/_registration.py",
+        # Publication privacy: the anonymizer decides every published byte and
+        # the public pseudonym identity. Both failure modes are silent, and
+        # PR #1512 auto-merged a change to all of them before this widening.
+        # The specs YAML is included because it defines which keys are hashed:
+        # dropping an entry there is a silent leak with no code diff to review.
+        "benchbox/core/results/anonymization.py",
+        "benchbox/core/results/anonymization_specs.yaml",
         # Self-protection: the review-gate machinery and the PyPI-publishing
         # workflow. In-workflow checks are attacker-controlled for same-repo
         # PRs; the CODEOWNERS/ruleset layer this feeds is the durable control.
@@ -71,6 +78,10 @@ def test_soundness_predicate_matches_review_required_paths(path: str) -> None:
         # A sibling file that merely starts with the same basename must not
         # false-positive against the exact-file entries above.
         "benchbox/platforms/base/result_capture_helpers.py",
+        # The anonymizer entries are exact files, not the results package:
+        # exporter.py and schema.py stay auto-mergeable.
+        "benchbox/core/results/exporter.py",
+        "benchbox/core/results/schema.py",
     ],
 )
 def test_soundness_predicate_ignores_fast_default_paths(path: str) -> None:


### PR DESCRIPTION
Implements `anonymizer-on-auto-merge-soundness-path`.

## Problem

`SOUNDNESS_PREFIXES` did not cover `benchbox/core/results/anonymization.py`.
PR #1512 changed **every published byte and every public `result_id`** for the
whole corpus — and `make pr-open` enabled auto-merge on it with no review,
because the classifier didn't rate the path as needing one.

## Decision

Widen the existing list (option (a) of the three the item recorded).

The recorded `soundness-surface-widening` criteria scope this list to assets
that "define or feed *correct*". The anonymizer isn't that — it governs what
leaves the project and the public pseudonym identity that groups results by
machine. Both of its failure modes are silent: a missed key publishes a private
path, and a changed hashing rule repartitions public identity without anything
raising.

Adding it **follows** the existing precedent rather than breaking it:

- `release.yml` is already on the list because it publishes to PyPI, not for
  soundness;
- the self-protection block covers the gate machinery, also not soundness;
- `is_soundness_path`'s own docstring already reads *"needs review before
  auto-merge"* — broader than soundness alone.

A separate `PRIVACY_PREFIXES` tuple was considered and rejected: it would have
required widening the 1:1 CODEOWNERS pin and every `any_soundness_path` caller
for no behavioural gain.

## `anonymization_specs.yaml` too

Not in the original plan, added on review of the actual failure mode. That file
**defines which keys get hashed** — `identifier_keys`, `endpoint_keys`,
`path_keys` and friends are all loaded from it. Dropping one entry silently
stops anonymizing that field, with **no code diff to review**. Same failure
mode, smaller diff, so it belongs on the same gate.

## Scope

Both entries are **exact files**, not the `benchbox/core/results/` package:

```
benchbox/core/results/anonymization.py        → true   (review required)
benchbox/core/results/anonymization_specs.yaml → true   (review required)
benchbox/core/results/exporter.py             → false  (auto-mergeable)
benchbox/core/results/schema.py               → false  (auto-mergeable)
```

Mirrored 1:1 into `.github/CODEOWNERS`, as the pre-existing
`test_codeowners_matches_soundness_prefixes_1to1` requires, and both entries are
pinned in the review-required parametrization with the two siblings pinned in
the auto-mergeable one.

## Verification

`tests/unit/test_auto_merge_soundness_paths.py`: **36 passed**.

Note this PR gates itself — `auto_merge_soundness_paths.py` is on its own list
(self-protection), so it will not auto-merge.
