### PR TITLE
fix(explorer): include companions in the duplicate result_id identity

### DIFF
--- a/_project/scripts/explorer_pipeline/pipeline.py
+++ b/_project/scripts/explorer_pipeline/pipeline.py
@@ -131,6 +131,11 @@ def _promote_staged_output(staged_dir: Path, output_dir: Path) -> None:
             logger.warning("Could not remove legacy artifact %s", output_dir / legacy_file)
 
 
+# Bounded read size for companion hashing; keeps memory flat regardless of
+# how large a corpus-controlled companion file is.
+_DIGEST_CHUNK_BYTES = 1024 * 1024
+
+
 def _publication_digest(bundle_path: Path, public_raw: bytes) -> str:
     """Digest everything a result publishes under its ``result_id``.
 
@@ -146,6 +151,13 @@ def _publication_digest(bundle_path: Path, public_raw: bytes) -> str:
     artifact, so it needs no sanitizing - and reading raw means a companion
     differing only in private, later-redacted content still marks the two
     bundles distinct, which fails safe.
+
+    Companions are hashed **incrementally**. ``read_bytes()`` would materialize
+    a whole corpus-controlled file, which for an oversized legacy
+    ``.applied.json`` bypasses the ``APPLIED_COMPANION_MAX_BYTES`` guard in
+    ``_applied_receipt`` - that path deliberately stats the file and returns a
+    truncation marker without reading it, so slurping here could exhaust memory
+    on a corpus that previously built fine.
     """
     hasher = hashlib.sha256()
     hasher.update(public_raw)
@@ -153,7 +165,9 @@ def _publication_digest(bundle_path: Path, public_raw: bytes) -> str:
         companion = bundle_path.with_name(f"{bundle_path.stem}{suffix}")
         hasher.update(suffix.encode())
         try:
-            hasher.update(hashlib.sha256(companion.read_bytes()).hexdigest().encode())
+            with companion.open("rb") as handle:
+                for chunk in iter(lambda handle=handle: handle.read(_DIGEST_CHUNK_BYTES), b""):
+                    hasher.update(chunk)
         except OSError:
             # Absent (or unreadable) is part of the identity: a bundle with no
             # plans must not digest the same as one that has them.

--- a/_project/scripts/explorer_pipeline/pipeline.py
+++ b/_project/scripts/explorer_pipeline/pipeline.py
@@ -44,7 +44,7 @@ from _project.scripts.explorer_pipeline.transformer import (
 from _project.scripts.results_explorer_snapshot_invariants import check_snapshot
 from benchbox.core.results.anonymization import AnonymizationManager, find_public_path_leaks
 from benchbox.core.results.canonical_json import canonical_json_bytes
-from benchbox.validation.bundle import discover_bundles
+from benchbox.validation.bundle import COMPANION_SUFFIXES, discover_bundles
 
 logger = logging.getLogger(__name__)
 
@@ -129,6 +129,36 @@ def _promote_staged_output(staged_dir: Path, output_dir: Path) -> None:
             # path (a directory, a deletion-denying ACL) must not turn a
             # successful publish into a reported failure and an ambiguous retry.
             logger.warning("Could not remove legacy artifact %s", output_dir / legacy_file)
+
+
+def _publication_digest(bundle_path: Path, public_raw: bytes) -> str:
+    """Digest everything a result publishes under its ``result_id``.
+
+    The duplicate-id guard uses this to decide whether two bundles are the same
+    evidence twice or a genuine collision. Hashing only the primary bundle is
+    not enough: companions publish as ``{result_id}.plans.json``, keyed by the
+    same id, so two byte-identical primaries whose sidecars differ - one
+    carrying plans, the other not - would look identical here while actually
+    publishing different evidence. Skipping the second would silently drop its
+    sidecar, the same class of loss the guard exists to stop, one file over.
+
+    Companions are read raw. This digest is an identity check, never a published
+    artifact, so it needs no sanitizing - and reading raw means a companion
+    differing only in private, later-redacted content still marks the two
+    bundles distinct, which fails safe.
+    """
+    hasher = hashlib.sha256()
+    hasher.update(public_raw)
+    for suffix in COMPANION_SUFFIXES:
+        companion = bundle_path.with_name(f"{bundle_path.stem}{suffix}")
+        hasher.update(suffix.encode())
+        try:
+            hasher.update(hashlib.sha256(companion.read_bytes()).hexdigest().encode())
+        except OSError:
+            # Absent (or unreadable) is part of the identity: a bundle with no
+            # plans must not digest the same as one that has them.
+            hasher.update(b"-")
+    return hasher.hexdigest()
 
 
 def _is_vendor_subtree(bundle_path: Path, bundles_dir: Path) -> bool:
@@ -650,7 +680,7 @@ class ExplorerPipeline:
                     # competing for one public URL - that is silent evidence
                     # loss, and the corpus needs a human, so fail closed rather
                     # than pick a winner.
-                    public_digest = hashlib.sha256(public_raw).hexdigest()
+                    public_digest = _publication_digest(bundle_path, public_raw)
                     previous = seen_result_ids.get(result_id)
                     if previous is not None:
                         previous_path, previous_digest = previous

--- a/tests/unit/scripts/explorer_pipeline/test_duplicate_result_id.py
+++ b/tests/unit/scripts/explorer_pipeline/test_duplicate_result_id.py
@@ -18,7 +18,12 @@ from pathlib import Path
 
 import pytest
 
-from _project.scripts.explorer_pipeline.pipeline import DuplicateResultIdError, ExplorerPipeline
+from _project.scripts.explorer_pipeline.pipeline import (
+    _DIGEST_CHUNK_BYTES,
+    DuplicateResultIdError,
+    ExplorerPipeline,
+    _publication_digest,
+)
 from _project.scripts.explorer_pipeline.transformer import BundleTransformer
 from tests.unit.scripts.explorer_pipeline.conftest import MINIMAL_BUNDLE
 
@@ -144,3 +149,33 @@ def test_duplicate_result_id_guard_leaves_the_normal_path_untouched(tmp_path: Pa
 
     published = sorted(p.name for p in (output / "bundles").glob("*.json"))
     assert len(published) == 2, f"expected both bundles published, got {published}"
+
+
+def test_duplicate_result_id_digest_streams_companions_larger_than_one_chunk(tmp_path: Path) -> None:
+    """A companion bigger than the read chunk must still hash correctly.
+
+    Companions are hashed incrementally rather than via `read_bytes()`, because
+    slurping a corpus-controlled file bypasses the APPLIED_COMPANION_MAX_BYTES
+    guard in `_applied_receipt` - that path stats the file and returns a
+    truncation marker without reading it, so a whole-file read here could
+    exhaust memory on a corpus that previously built fine. Chunking is only
+    correct if it covers the entire file, so pin that a multi-chunk companion
+    changes the digest rather than being silently truncated at one chunk.
+    """
+    bundles = tmp_path / "bundles"
+    bundle = _write_bundle(bundles, "big.json", total_duration_ms=45000)
+    public_raw = bundle.read_bytes()
+
+    baseline = _publication_digest(bundle, public_raw)
+
+    plans = bundle.with_name("big.plans.json")
+    plans.write_bytes(b"a" * (_DIGEST_CHUNK_BYTES + 512))
+    with_companion = _publication_digest(bundle, public_raw)
+    assert with_companion != baseline
+
+    # Flip a byte past the first chunk boundary: if hashing stopped at one
+    # chunk this would be indistinguishable from the file above.
+    payload = bytearray(b"a" * (_DIGEST_CHUNK_BYTES + 512))
+    payload[_DIGEST_CHUNK_BYTES + 100] = ord("b")
+    plans.write_bytes(bytes(payload))
+    assert _publication_digest(bundle, public_raw) != with_companion

--- a/tests/unit/scripts/explorer_pipeline/test_duplicate_result_id.py
+++ b/tests/unit/scripts/explorer_pipeline/test_duplicate_result_id.py
@@ -107,6 +107,27 @@ def test_duplicate_result_id_with_identical_content_publishes_once(
     assert published == [f"{COLLIDING_ID}.json"]
 
 
+def test_duplicate_result_id_identical_primaries_with_differing_companions_fail(
+    tmp_path: Path,
+    force_id_collision: None,
+) -> None:
+    """Byte-identical primaries are not identical results if their sidecars differ.
+
+    Companions publish as `{result_id}.plans.json`, keyed by the same id. If the
+    guard hashed only the primary bundle, a copy carrying plans that the first
+    lacked would be treated as redundant and skipped, silently dropping that
+    evidence - the same loss the guard exists to prevent, one file over.
+    """
+    data_dir = tmp_path / "data"
+    bundles = data_dir / "bundles"
+    _write_bundle(bundles, "first.json", total_duration_ms=45000)
+    second = _write_bundle(bundles / "nested", "second.json", total_duration_ms=45000)
+    second.with_name("second.plans.json").write_text(json.dumps({"q1": "PLAN"}), encoding="utf-8")
+
+    with pytest.raises(DuplicateResultIdError):
+        ExplorerPipeline().run(data_dir, tmp_path / "out")
+
+
 def test_duplicate_result_id_guard_leaves_the_normal_path_untouched(tmp_path: Path) -> None:
     """Distinct ids still publish one file each.
 


### PR DESCRIPTION
Addresses Codex **P1** on #1516 (already merged, so this is a follow-up). The finding is correct and it is a real hole in the guard I just added.

## The bug

The identical-content skip hashed **only the primary bundle**. But companions publish as `{result_id}.plans.json`, keyed by the same id. Two byte-identical primaries whose sidecars differ — one carrying plans, the other not — digested the same, so the second was treated as a redundant copy and skipped, **silently dropping its sidecar**.

That is the same class of evidence loss the guard was added to stop, one file over.

## Fix

Digest the primary plus every entry in `COMPANION_SUFFIXES`, with **absence itself part of the identity** so a bundle with no plans cannot match one that has them.

Companions are read raw, deliberately: this digest is an identity check and never a published artifact, so it needs no sanitizing — and reading raw means a companion differing only in private, later-redacted content still marks the two bundles distinct, which fails safe.

## Verification

- **Falsified** by digesting the primary only: the new test fails.
- `tests/unit/scripts/explorer_pipeline`: **324 passed**
- real 207-bundle corpus still builds (207 processed, 207 published)

## Identity findings on this PR: refuted

Codex also flagged the commit as authored by `Codex <codex@openai.com>`. That is incorrect — every commit is:

```
author=Joe Harris <joeharris76@gmail.com> | committer=Joe Harris <joeharris76@gmail.com>
```

Same for #1517, #1518 and #1521. On #1521 it cited commit `4fbd4b77a101`, which is not on that branch at all.