### PR TITLE
feat(todo-db): fence stale clones with a v5 schema bump (ADR D2 reversed)

### DIFF
--- a/_project/decisions/todo-db-cutover-write-freeze-2026-08-01.md
+++ b/_project/decisions/todo-db-cutover-write-freeze-2026-08-01.md
@@ -34,15 +34,23 @@ on its own so a holder that dies mid-cutover cannot wedge the tracker.
 | ID | Decision | Choice | Reason |
 |---|---|---|---|
 | D1 | What gates the destructive restore | The **leased write freeze**, never a claim check. | Claims do not cover unclaimed writes, which are the majority of tracker mutation. Empirically the dominant write mode. |
-| D2 | Enforce the freeze by bumping `SCHEMA_VERSION` so stale clones hard-fail? | **No.** `SCHEMA_VERSION` stays 4; the freeze remains **advisory** against clones running a pre-#1377 CLI. | See "D2 rationale" below. This is the change's known, accepted weakness. |
+| D2 | Enforce the freeze by bumping `SCHEMA_VERSION` so stale clones hard-fail? | **Yes — reversed 2026-08-04 by Joe.** `SCHEMA_VERSION` moves 4 → 5. The freeze is no longer advisory: a clone that never pulled is fenced out of the tracker entirely until it migrates. | The original "no" traded a permanent cost against a transient window. Joe's ruling: an advisory gate on a *destructive* restore is not a gate. See "D2 rationale" below, retained and annotated so the reversal is auditable rather than silent. |
 | D3 | Consequence of D2 for the runbook | The freeze is **necessary but not sufficient**. The runbook MUST pair it with independently verified quiescence. Neither gate alone authorizes the restore. | A stale clone writes straight through a live freeze. Quiescence alone was never a gate. Both, together, or not at all. |
 | D4 | How quiescence is measured | The `stats["events"]` fingerprint (`count`, `last_seq`, `latest`) compared across a window, by a probe that **fails when it cannot read the fingerprint**. | The previous probe shelled out to `todo stats --json`, which does not exist; it compared two empty strings and passed unconditionally. See "The vacuous rung". |
 | D5 | Freeze TTL bounds | Finite, positive, `<= MAX_FREEZE_TTL_HOURS` (168h); default 2h. Malformed/torn freeze state reads as **live** (fails closed); `freeze` itself stays exempt from the gate so a torn freeze is always liftable. | A freeze is a maintenance window, not a standing state. A safety gate whose degraded state is "unlocked" is the wrong default; one that cannot be lifted is the other wrong default. Both were real defects (PR #1386). |
-| D7 | Fixing create-time-only fields with todo-db 0.3's audited `update` verb, before the cutover | **Not available.** todo-db 0.3 is `SCHEMA_VERSION = 5` and refuses a v4 database outright: *"database contains a different tracker schema (item_deps, items, meta, work_units); use a dedicated todo-db path"*. It fails **safe** — detects the foreign schema, refuses, does not corrupt. | The verb only becomes usable *after* the cutover, and the cutover is gated on a probe that `update` would have fixed. Circular. Verified 2026-08-01 against a local v4 database, never production. |
+| D7 | Fixing create-time-only fields with todo-db 0.3's audited `update` verb, before the cutover | **Not available.** todo-db 0.3 refuses this database outright: *"database contains a different tracker schema (item_deps, items, meta, work_units); use a dedicated todo-db path"*. It fails **safe** — detects the foreign schema, refuses, does not corrupt. | The verb only becomes usable *after* the cutover, and the cutover is gated on a probe that `update` would have fixed. Circular. Verified 2026-08-01 against a local database, never production. **Mechanism corrected 2026-08-04 — see "D7 correction".** |
 | D8 | The vacuous rung on the freeze item | **Superseded, not edited.** The operative quiescence gate is the probe on `cutover-record-corrections-and-quiescence-probe`. Rung 1 of `tracker-cutover-needs-a-write-freeze-not-a-claim-check` is void and MUST NOT be used to certify quiescence. | Ladders are create-time-only and D7 rules out an in-place edit. The freeze item has **zero** dependents, so drop+recreate would be cheap — but its work is already done and merged, and its ladder only matters at completion time. Superseding is proportionate; dropping a live-claimed item to correct a rung is not. |
+| D9 | What migration 5 contains | **Nothing.** v5 is a declared *fence* migration: it moves the version number and carries no DDL. The contract checker was taught to accept a fence only when the inventory declares `"kind": "fence"` with a written `fence_rationale`. | The freeze lives in `meta` rows, so there was no schema delta to hang the bump on, and inventing DDL purely to justify the number would have been worse. The two-way check keeps the guard's real purpose — catching a builder that silently returns `[]` — fully intact, and stops "fence" becoming a label that ships unreviewed DDL. |
+| D10 | A stale clone under a foreign freeze can neither read nor migrate | **Intended.** Fencing stale clones out mid-cutover is the point of D2. `todo doctor` is the deliberate escape hatch: it reports schema mismatch as a check result instead of raising, so the operator can always learn *why* everything stopped. | The alternative — exempting `migrate` from the freeze — reopens the #1386 defect that `migrate` is a bulk write which must not run mid-cutover. The refusal message was corrected at the same time: it told a fenced clone "Reads still work", which D2 had just made false. |
+| D11 | The migration item's stale `must-preserve` rule | **Left in place, superseded by its block reason** (ruled by Joe, 2026-08-04). Not edited, not recreated. | `preserves` is create-time-only — confirmed 2026-08-04 that the new `scope-update` verb covers scope globs *only*. Correcting it means dropping and recreating the item **and all 5 dependents**, since deps are also create-time-only: 6 new ids, 6 terminal `dropped` rows, and every external reference to the old ids goes dead. Disproportionate to a field whose staleness is already documented where a reader will hit it. Same reasoning as D8. |
 | D6 | Rollback storage | A durable local backup **outside** the repo (`~/todo-db-backups/`) plus a 17-table snapshot, both taken immediately before the restore and retained until an audit verify passes against the hosted DB post-cutover. | The prior attempt ran in an ephemeral container that restarted mid-session. Ephemeral disk is not a rollback path. |
 
-### D2 rationale — why `SCHEMA_VERSION` is not bumped
+### D2 rationale — why `SCHEMA_VERSION` was not bumped, and why that reversed
+
+**Status: REVERSED 2026-08-04.** The argument below is retained because it is
+still the correct statement of what the bump costs — the bump was taken *with*
+these costs, not because they were shown to be wrong. Read it as the price paid,
+not as current guidance.
 
 Enforcement lives only in the new `main()`. A session running a pre-#1377
 `todo_db.py` has no gate and writes through a live freeze. Bumping
@@ -61,11 +69,43 @@ but the cost is disqualifying:
   unable to read (schema mismatch) *and* unable to migrate (frozen) until the
   holder lifts the freeze. Correct, but a hard lockout.
 
-**Accepted residual risk**: a stale clone can corrupt a cutover. D3 is the
-mitigation — quiescence is verified independently, so a stale writer is
-*detected* even though it is not *blocked*. If enforcement is ever wanted, the
-right vehicle is `-v2`'s "graceful read-only degradation" option (reads keep
-working across a version gap, writes refuse), not a bare bump.
+**What changed.** Joe reversed this on 2026-08-04. The residual risk the old
+text accepted — "a stale clone can corrupt a cutover", mitigated only by
+*detecting* the stale writer rather than *blocking* it — was judged too weak a
+guarantee for an irreversible `restore-legacy --replace`. D3 still stands:
+quiescence remains a required, independent gate. The bump adds enforcement; it
+does not replace verification.
+
+The third bullet above predicted the hard lockout, and it happens exactly as
+described — confirmed by running it, not by reading the diff. It is now D10, and
+accepted rather than avoided. `todo doctor` is the escape hatch.
+
+Two claims in the original text were **wrong**, and both are corrected below:
+
+- The "graceful read-only degradation" alternative was rejected on 2026-08-04 in
+  favour of a plain bump. Exempting read-only subcommands means every subcommand
+  must be correctly classified read-vs-write forever, and misclassifying one
+  write as a read silently reopens the hole the bump exists to close.
+- D7's stated mechanism was wrong. See below.
+
+### D7 correction — todo-db 0.3 does not refuse on the version number
+
+The original D7 said todo-db 0.3 is `SCHEMA_VERSION = 5` and refuses a v4
+database. Both halves are wrong, verified 2026-08-04 at tag `v0.3.0`, `main`,
+and the working branch:
+
+- todo-db 0.3 is **`SCHEMA_VERSION = 4`**, not 5 (`src/todo_db/database.py:19`).
+- Its refusal is **structural, not a version comparison**. `_migrate()` looks for
+  its own `schema_migrations` table; finding none, it checks for the foreign
+  tables `{items, work_units, item_deps, meta}` and raises `SchemaMismatchError`
+  (`src/todo_db/database.py:617`). It never reads `meta.schema_version` to make
+  that call.
+
+**Why this matters for D2**: the obvious objection to bumping — that BenchBox
+claiming v5 would collide with todo-db's "v5" and turn a fail-safe into a
+fail-open — **does not exist**. A structural check cannot be defeated by a
+version bump. D7's *conclusion* is unchanged and if anything stronger: `update`
+remains unusable pre-cutover, and no version number we choose can change that.
 
 ### The vacuous rung
 
@@ -90,6 +130,11 @@ create-time-only, so the replacement ships on a successor item.
 Each step is a gate. A failure at any step aborts; do not continue and do not
 "verify by success message".
 
+0. **Land and propagate the v5 fence FIRST (D2/D9/D10).** The fence must be on
+   `develop` and every active clone must have run `todo migrate` *before* step 4.
+   A clone that pulls after the freeze is taken can neither read nor migrate
+   until the freeze lifts — intended, but do not discover it mid-cutover. Confirm
+   with `todo doctor` from each active worktree: `schema OK v5`.
 1. **Preconditions.** `todo-db >= 0.3` CLI reachable and at `origin/main`.
    Durable backup dir exists outside the repo. No other session active.
 2. **Backup.** `~/todo-db-backups/benchbox-todo-<UTC>.db` **plus**

--- a/_project/scripts/todo
+++ b/_project/scripts/todo
@@ -5,6 +5,6 @@
 set -euo pipefail
 # Keep this declaration synchronized with todo_db.SCHEMA_VERSION. The required
 # schema-migration inventory gate rejects a wrapper/CLI mismatch before merge.
-TODO_SCHEMA_VERSION=4
+TODO_SCHEMA_VERSION=5
 ROOT="$(git rev-parse --show-toplevel)"
 exec uv run --project "$ROOT/_project/scripts" -- python "$ROOT/_project/scripts/todo_db.py" "$@"

--- a/_project/scripts/todo_db.py
+++ b/_project/scripts/todo_db.py
@@ -79,7 +79,7 @@ if _self_module is not None:
 # touches todo_db. See todo_findings.py's header.
 import todo_findings  # noqa: E402
 
-SCHEMA_VERSION = 4
+SCHEMA_VERSION = 5
 
 # Applied in order by `todo migrate`. v3 lands the findings domain; v4 adds the
 # lossless homes for legacy capture fields and makes finding_links.target_item
@@ -88,6 +88,15 @@ SCHEMA_VERSION = 4
 # database can still climb through it. That a migrated database ends up identical
 # to a fresh one is pinned by a test rather than by sharing one DDL string, since
 # ALTER-based deltas can never be literally the same text as the CREATEs.
+#
+# v5 carries NO DDL, and that is deliberate (ADR D2/D9). Its only job is to move
+# the version number so a stale clone hard-fails instead of being politely asked
+# not to write: the freeze is advisory, and an un-pulled clone never sees it. The
+# freeze itself lives in `meta` rows, so there was no schema delta to attach the
+# bump to, and inventing one purely to justify the number would have been worse.
+# Consequence to keep in mind when reading this file: from v5 on, the version is
+# a WRITE FENCE as well as a shape descriptor -- v5 and v4 are structurally
+# identical, so never infer shape from the number alone.
 MIGRATIONS: dict[int, list[str]] = {
     2: [
         "ALTER TABLE work_units ADD COLUMN started_at TEXT",
@@ -96,13 +105,16 @@ MIGRATIONS: dict[int, list[str]] = {
     ],
     3: todo_findings.finding_schema_statements(),
     4: todo_findings.finding_migration_v4_statements(),
+    5: [],
 }
 
 # The migration builders are intentionally callable so the findings schema can
 # remain the single DDL source. Keep an explicit statement-count contract next
 # to the runtime map: a future helper cannot silently return an empty or
-# truncated migration without failing immediately at import time.
-MIGRATION_STATEMENT_COUNTS: dict[int, int] = {2: 3, 3: 6, 4: 8}
+# truncated migration without failing immediately at import time. v5's declared
+# 0 is what makes the empty fence migration an assertion rather than a hole --
+# a helper that silently returned [] would still have to be declared here.
+MIGRATION_STATEMENT_COUNTS: dict[int, int] = {2: 3, 3: 6, 4: 8, 5: 0}
 if {revision: len(statements) for revision, statements in MIGRATIONS.items()} != MIGRATION_STATEMENT_COUNTS:
     raise RuntimeError("MIGRATIONS do not match MIGRATION_STATEMENT_COUNTS")
 
@@ -1189,12 +1201,27 @@ def _freeze_refusal(conn: sqlite3.Connection, actor: str, args: argparse.Namespa
     return 2
 
 
-def _freeze_refusal_message(live: dict[str, Any]) -> str:
-    return (
+def _freeze_refusal_message(live: dict[str, Any], *, reads_work: bool = True) -> str:
+    """The freeze refusal. `reads_work` must be False for a clone whose schema is
+    behind SCHEMA_VERSION.
+
+    "Reads still work" is true for a current clone and FALSE for a stale one:
+    since v5 the version check fences every subcommand, so a stale clone under a
+    foreign freeze has no working command at all except `doctor` (which reports
+    rather than raises). Telling that operator reads work would send them to
+    debug a backend that is behaving exactly as designed.
+    """
+    head = (
         f"error: tracker is frozen for maintenance by {live['holder']} since {live['since']}"
         f"{': ' + live['reason'] if live['reason'] else ''}. "
-        f"Reads still work; writes resume when the holder runs `todo freeze --release` "
-        f"or the {live['ttl_hours']}h lease lapses."
+    )
+    lapse = f"the holder runs `todo freeze --release` or the {live['ttl_hours']}h lease lapses"
+    if reads_work:
+        return head + f"Reads still work; writes resume when {lapse}."
+    return head + (
+        f"This clone's schema is also behind, so reads are fenced too until it migrates -- "
+        f"and `migrate` is itself a write. Wait until {lapse}, then re-run `todo migrate`. "
+        f"`todo doctor` works throughout."
     )
 
 
@@ -1215,7 +1242,8 @@ def _premigrate_freeze_refusal(backend: Path | str, actor: str) -> int | None:
         else:
             conn = _hosted_raw_connect(backend, sync_required=True)
         try:
-            if _schema_version(conn) is None:
+            version = _schema_version(conn)
+            if version is None:
                 return None  # fresh/schemaless database: no freeze can be stored
             live = get_freeze(conn)
         finally:
@@ -1228,7 +1256,9 @@ def _premigrate_freeze_refusal(backend: Path | str, actor: str) -> int | None:
         return 2
     if not live or live["holder"] == actor:
         return None
-    print(_freeze_refusal_message(live), file=sys.stderr)
+    # A caller reaching `migrate` with a current schema is a no-op migrator whose
+    # reads genuinely still work; one that is behind is fenced out of everything.
+    print(_freeze_refusal_message(live, reads_work=version >= SCHEMA_VERSION), file=sys.stderr)
     return 2
 
 

--- a/_project/scripts/todo_schema_migration_check.py
+++ b/_project/scripts/todo_schema_migration_check.py
@@ -31,7 +31,15 @@ def _integer_assignment(module: ast.Module, name: str, source: Path) -> int:
     raise SchemaMigrationError(f"{source}: missing {name} assignment")
 
 
-def _migration_revisions(module: ast.Module, source: Path) -> list[int]:
+def _migration_revisions(module: ast.Module, source: Path) -> tuple[list[int], set[int]]:
+    """Returns the declared revisions and which of them carry no statements.
+
+    An empty migration is no longer rejected outright: a FENCE migration (one
+    that moves SCHEMA_VERSION purely to lock out stale clones, ADR D2/D9) has no
+    DDL by design. It is still rejected unless the inventory declares it as one,
+    so the case this guard actually exists for -- a builder that silently returns
+    [] -- fails exactly as before.
+    """
     for node in module.body:
         targets: list[ast.expr]
         if isinstance(node, ast.Assign):
@@ -45,13 +53,14 @@ def _migration_revisions(module: ast.Module, source: Path) -> list[int]:
         if not isinstance(value, ast.Dict):
             raise SchemaMigrationError(f"{source}: MIGRATIONS must be a dict literal")
         revisions: list[int] = []
+        empty: set[int] = set()
         for key, statements in zip(value.keys, value.values, strict=True):
             if not isinstance(key, ast.Constant) or not isinstance(key.value, int):
                 raise SchemaMigrationError(f"{source}: every MIGRATIONS key must be an integer literal")
             if isinstance(statements, (ast.List, ast.Tuple)) and not statements.elts:
-                raise SchemaMigrationError(f"{source}: migration {key.value} has no statements")
+                empty.add(key.value)
             revisions.append(key.value)
-        return revisions
+        return revisions, empty
     raise SchemaMigrationError(f"{source}: missing MIGRATIONS assignment")
 
 
@@ -72,17 +81,53 @@ def _migration_statement_counts(module: ast.Module, source: Path) -> dict[int, i
         for key, count in zip(value.keys, value.values, strict=True):
             if not isinstance(key, ast.Constant) or not isinstance(key.value, int):
                 raise SchemaMigrationError(f"{source}: every migration-count key must be an integer literal")
-            if not isinstance(count, ast.Constant) or not isinstance(count.value, int) or count.value <= 0:
-                raise SchemaMigrationError(f"{source}: migration {key.value} needs a positive statement count")
+            # 0 is legal only for a fence migration, cross-checked against the
+            # inventory below; a negative or non-integer count is never legal.
+            if not isinstance(count, ast.Constant) or not isinstance(count.value, int) or count.value < 0:
+                raise SchemaMigrationError(f"{source}: migration {key.value} needs a non-negative statement count")
             counts[key.value] = count.value
         return counts
     raise SchemaMigrationError(f"{source}: missing MIGRATION_STATEMENT_COUNTS assignment")
 
 
+def _check_fence_declaration(
+    entry: dict,
+    *,
+    revision: int,
+    expected_count: int,
+    is_empty: bool,
+    inventory: Path,
+) -> None:
+    """A statement-free migration must be an explicit, reasoned fence, and a
+    migration declared as a fence must genuinely carry no DDL.
+
+    Both directions are enforced: the first keeps an accidentally-empty migration
+    failing closed (the case this guard was written for), the second keeps
+    "fence" from becoming a label that ships unreviewed DDL under a claim that
+    there is none.
+    """
+    declared_fence = entry.get("kind") == "fence"
+    if is_empty and not declared_fence:
+        raise SchemaMigrationError(
+            f'{inventory}: revision {revision} has no statements; declare "kind": "fence" '
+            f"with a fence_rationale, or give the migration real DDL"
+        )
+    if not declared_fence:
+        return
+    if not is_empty:
+        raise SchemaMigrationError(
+            f'{inventory}: revision {revision} is declared "kind": "fence" but carries '
+            f"{expected_count} statement(s); a fence must carry no DDL"
+        )
+    rationale = entry.get("fence_rationale")
+    if not isinstance(rationale, str) or not rationale.strip():
+        raise SchemaMigrationError(f"{inventory}: fence revision {revision} needs a non-empty fence_rationale")
+
+
 def validate_contract(*, tracker: Path, wrapper: Path, inventory: Path) -> None:
     module = ast.parse(tracker.read_text(encoding="utf-8"), filename=str(tracker))
     schema_version = _integer_assignment(module, "SCHEMA_VERSION", tracker)
-    revisions = _migration_revisions(module, tracker)
+    revisions, empty_revisions = _migration_revisions(module, tracker)
     statement_counts = _migration_statement_counts(module, tracker)
     expected_revisions = list(range(2, schema_version + 1))
     if revisions != expected_revisions:
@@ -134,6 +179,13 @@ def validate_contract(*, tracker: Path, wrapper: Path, inventory: Path) -> None:
                 f"{inventory}: revision {revision} statement_count={entry.get('statement_count')!r} "
                 f"does not match runtime contract {expected_count}"
             )
+        _check_fence_declaration(
+            entry,
+            revision=revision,
+            expected_count=expected_count,
+            is_empty=revision in empty_revisions or expected_count == 0,
+            inventory=inventory,
+        )
     current = entries[-1]
     evidence = current.get("deployment_evidence")
     if not isinstance(evidence, str) or not evidence.strip():

--- a/_project/todo-schema-migrations.json
+++ b/_project/todo-schema-migrations.json
@@ -1,5 +1,5 @@
 {
-  "schema_version": 4,
+  "schema_version": 5,
   "migrations": [
     {
       "revision": 2,
@@ -18,6 +18,15 @@
       "statement_count": 8,
       "summary": "Preserve legacy finding capture fields and deferrable item links",
       "deployment_order": "The hosted primary was migrated to revision 4 before revision-4-only tracker writes resumed.",
+      "deployment_evidence": "_project/decisions/todo-db-cutover-write-freeze-2026-08-01.md"
+    },
+    {
+      "revision": 5,
+      "statement_count": 0,
+      "kind": "fence",
+      "fence_rationale": "The maintenance freeze is advisory: it lives in meta rows that a clone which never pulled does not read, so a stale clone writes straight through a live freeze and its writes are destroyed by restore-legacy --replace. Moving SCHEMA_VERSION is the only enforcement that reaches such a clone. There was no schema delta to attach the bump to, and inventing DDL purely to justify the number would have been worse.",
+      "summary": "Write fence against stale clones; carries no DDL",
+      "deployment_order": "Fence code must ship BEFORE the cutover freeze is taken: a clone that pulls after the freeze starts can neither read nor migrate until the freeze lifts.",
       "deployment_evidence": "_project/decisions/todo-db-cutover-write-freeze-2026-08-01.md"
     }
   ]

--- a/tests/unit/scripts/test_todo_db_freeze.py
+++ b/tests/unit/scripts/test_todo_db_freeze.py
@@ -499,3 +499,108 @@ class TestFreezeCoversBulkWritePaths:
         todo_db.connect(db).close()
         _run(db, "import-yaml", "--replace", actor="bob")
         assert "frozen for maintenance" not in capsys.readouterr().err
+
+
+def _downgrade(db_path, version):
+    """Rewrite the recorded schema version, simulating a clone that never pulled."""
+    raw = sqlite3.connect(db_path)
+    raw.execute("UPDATE meta SET value = ? WHERE key = 'schema_version'", (str(version),))
+    raw.commit()
+    raw.close()
+
+
+def _shape(db_path):
+    raw = sqlite3.connect(db_path)
+    try:
+        return sorted(raw.execute("SELECT type, name, sql FROM sqlite_master").fetchall())
+    finally:
+        raw.close()
+
+
+class TestSchemaVersionFencesStaleClones:
+    """v5 is a write fence, not a shape change (ADR D2/D9).
+
+    The freeze alone is advisory: a clone that never pulled does not know the
+    freeze exists and writes straight through it. Moving SCHEMA_VERSION is what
+    turns "please don't" into "cannot". The accepted cost is that a stale clone
+    loses reads too, because the version check runs before every subcommand.
+    """
+
+    @pytest.fixture()
+    def stale_db(self, tmp_path):
+        db = tmp_path / "todo.sqlite"
+        connection = todo_db.connect(db)
+        _mk(connection, "existing-item")
+        connection.commit()
+        connection.close()
+        _downgrade(db, todo_db.SCHEMA_VERSION - 1)
+        return db
+
+    # These two are RELATIVE to SCHEMA_VERSION, so they survive reverting the bump
+    # -- verified by mutation. They do not pin v5; they pin that the fence covers
+    # READS as well as writes, which is the design that was chosen over exempting
+    # read-only subcommands. Deleting the read case is the regression to catch.
+    def test_a_stale_clone_cannot_read(self, stale_db, capsys):
+        assert _run(stale_db, "list", actor="bob") == 2
+        assert "run `todo migrate`" in capsys.readouterr().err
+
+    def test_a_stale_clone_cannot_write(self, stale_db, capsys):
+        assert _run(stale_db, "create", "some-new-item", actor="bob") != 0
+        assert "run `todo migrate`" in capsys.readouterr().err
+
+    def test_migrate_lifts_the_fence(self, stale_db, capsys):
+        assert _run(stale_db, "migrate", actor="bob") == 0
+        capsys.readouterr()
+        assert _run(stale_db, "list", actor="bob") == 0
+
+    def test_the_fence_migration_carries_no_ddl(self, tmp_path):
+        """v5 must stay empty: a later DDL statement smuggled into the fence
+        would make a migrated database diverge from a fresh one."""
+        assert todo_db.MIGRATIONS[todo_db.SCHEMA_VERSION] == []
+        migrated = tmp_path / "migrated.sqlite"
+        todo_db.connect(migrated).close()
+        _downgrade(migrated, todo_db.SCHEMA_VERSION - 1)
+        assert todo_db.migrate_db(migrated, actor="tester") == [todo_db.SCHEMA_VERSION]
+        fresh = tmp_path / "fresh.sqlite"
+        todo_db.connect(fresh).close()
+        assert _shape(migrated) == _shape(fresh)
+
+
+class TestTheWedgeIsExplained:
+    """A stale clone under a foreign freeze has no working command but `doctor`.
+
+    That wedge is intended -- fencing stale clones out mid-cutover is the point.
+    What is NOT acceptable is telling that operator "Reads still work", which the
+    refusal did verbatim until the fence landed and made it false.
+    """
+
+    @pytest.fixture()
+    def frozen_db(self, tmp_path):
+        db = tmp_path / "todo.sqlite"
+        connection = todo_db.connect(db)
+        todo_db.set_freeze(connection, "alice", "cutover", ttl_hours=1)
+        connection.commit()
+        connection.close()
+        return db
+
+    def test_a_wedged_clone_is_not_told_that_reads_work(self, frozen_db, capsys):
+        _downgrade(frozen_db, todo_db.SCHEMA_VERSION - 1)
+        assert _run(frozen_db, "migrate", actor="bob") == 2
+        err = capsys.readouterr().err
+        assert "Reads still work" not in err
+        assert "reads are fenced too" in err
+        assert "`todo doctor` works throughout" in err
+
+    def test_a_current_clone_is_still_told_that_reads_work(self, frozen_db, capsys):
+        """Control: the honest message must not be lost for the clone it fits."""
+        assert _run(frozen_db, "migrate", actor="bob") == 2
+        assert "Reads still work" in capsys.readouterr().err
+
+    def test_doctor_survives_the_wedge(self, frozen_db, capsys):
+        """The one command that must keep working, since it is how the operator
+        learns why everything else stopped."""
+        _downgrade(frozen_db, todo_db.SCHEMA_VERSION - 1)
+        _run(frozen_db, "doctor", actor="bob")
+        out = capsys.readouterr().out
+        assert f"expected v{todo_db.SCHEMA_VERSION}" in out
+        assert "run `todo migrate`" in out

--- a/tests/unit/scripts/test_todo_db_hosted.py
+++ b/tests/unit/scripts/test_todo_db_hosted.py
@@ -1069,7 +1069,7 @@ class TestHostedMigrate:
             todo_db.connect_backend(HOSTED_URL)
         # ... and migrate must fix it in place, applying every pending version
         applied = todo_db.migrate_backend(HOSTED_URL)
-        assert applied == [2, 3, 4]
+        assert applied == sorted(todo_db.MIGRATIONS)
         conn = todo_db.connect_backend(HOSTED_URL)
         cols = [row[1] for row in conn.execute("PRAGMA table_info(work_units)").fetchall()]
         assert "started_at" in cols

--- a/tests/unit/scripts/test_todo_findings.py
+++ b/tests/unit/scripts/test_todo_findings.py
@@ -1028,7 +1028,8 @@ class TestV4MigrationEquivalence:
         raw.commit()
         raw.close()
 
-        assert todo_db.migrate_db(migrated_path) == [4]
+        # Relative to MIGRATIONS so a later fence/bump does not need this edited.
+        assert todo_db.migrate_db(migrated_path) == [r for r in sorted(todo_db.MIGRATIONS) if r > 3]
         migrated = todo_db.connect(migrated_path)
         assert self._schema(migrated) == self._schema(fresh)
 
@@ -1082,7 +1083,8 @@ class TestV4MigrationEquivalence:
         conn.commit()
         conn.close()
 
-        assert todo_db.migrate_db(migrated_path) == [4]
+        # Relative to MIGRATIONS so a later fence/bump does not need this edited.
+        assert todo_db.migrate_db(migrated_path) == [r for r in sorted(todo_db.MIGRATIONS) if r > 3]
         conn = todo_db.connect(migrated_path)
         finding = todo_findings.get_finding(conn, "2026-01-02-030405-kept")
         assert finding["disposition"] == "promoted"

--- a/tests/unit/scripts/test_todo_schema_migration_check.py
+++ b/tests/unit/scripts/test_todo_schema_migration_check.py
@@ -141,3 +141,60 @@ def test_todo_schema_migration_revision_is_atomic(tmp_path: Path, monkeypatch: p
     conn.close()
     assert version == "3"
     assert probe is None
+
+
+def _inventory_with(tmp_path: Path, mutate) -> Path:
+    record = json.loads(_contract_paths()["inventory"].read_text(encoding="utf-8"))
+    mutate(record)
+    inventory = tmp_path / "migrations.json"
+    inventory.write_text(json.dumps(record), encoding="utf-8")
+    return inventory
+
+
+def _expect(inventory: Path, match: str) -> None:
+    paths = _contract_paths()
+    with pytest.raises(todo_schema_migration_check.SchemaMigrationError, match=match):
+        todo_schema_migration_check.validate_contract(
+            tracker=paths["tracker"], wrapper=paths["wrapper"], inventory=inventory
+        )
+
+
+def test_an_empty_migration_is_rejected_unless_declared_a_fence(tmp_path: Path) -> None:
+    """The guard this relaxation must not lose: a migration that ends up empty by
+    accident -- a builder returning [] -- still fails closed."""
+
+    def undeclare(record):
+        record["migrations"][-1].pop("kind")
+
+    _expect(_inventory_with(tmp_path, undeclare), "has no statements")
+
+
+def test_a_fence_may_not_smuggle_ddl(tmp_path: Path) -> None:
+    """The other direction: "fence" must not become a way to ship unreviewed DDL
+    under a label that says there is none."""
+
+    def claim_fence(record):
+        record["migrations"][-2]["kind"] = "fence"
+
+    _expect(_inventory_with(tmp_path, claim_fence), "must carry no DDL")
+
+
+def test_a_fence_needs_a_written_rationale(tmp_path: Path) -> None:
+    def blank_rationale(record):
+        record["migrations"][-1]["fence_rationale"] = "   "
+
+    _expect(_inventory_with(tmp_path, blank_rationale), "fence_rationale")
+
+
+def test_a_negative_statement_count_is_never_legal(tmp_path: Path) -> None:
+    """Relaxing `<= 0` to `< 0` must not have opened the door wider than intended."""
+    tracker = tmp_path / "todo_db.py"
+    tracker.write_text(
+        "SCHEMA_VERSION = 2\nMIGRATIONS = {2: ['a']}\nMIGRATION_STATEMENT_COUNTS = {2: -1}\n",
+        encoding="utf-8",
+    )
+    paths = _contract_paths()
+    with pytest.raises(todo_schema_migration_check.SchemaMigrationError, match="non-negative"):
+        todo_schema_migration_check.validate_contract(
+            tracker=tracker, wrapper=paths["wrapper"], inventory=paths["inventory"]
+        )


### PR DESCRIPTION
## What

Moves `SCHEMA_VERSION` 4 → 5 so a clone that never pulled is fenced out of the tracker instead of writing through a live maintenance freeze. Reverses ADR **D2** on Joe's ruling (2026-08-04).

## Why

The freeze lives in `meta` rows. A stale clone does not read them, does not know the freeze exists, and its writes are destroyed silently by `restore-legacy --replace` — with the rebuilt audit chain still verifying, because it is rehashed from the same snapshot. Advisory enforcement on an irreversible restore is not enforcement.

## v5 carries no DDL, and that is declared

There was no schema delta to attach the bump to. Rather than invent DDL to justify the number, v5 is a **fence migration**. `todo_schema_migration_check` previously rejected *any* empty migration; it now accepts one only when the inventory declares `"kind": "fence"` with a written `fence_rationale`, and rejects a fence that carries DDL. Both directions are enforced, so the case the guard actually exists for — a builder silently returning `[]` — still fails closed.

## Found by running it

The freeze refusal told a fenced clone **"Reads still work"** — which this change had just made false. It now explains that reads are fenced too, that `migrate` is itself a write, and that `todo doctor` still works. `doctor` survives the wedge because it reports schema mismatch as a check result rather than raising.

## Accepted cost (ADR D10)

A stale clone under a foreign freeze has **no working command but `doctor`**. That is the enforcement, not a defect. The runbook gains a **step 0**: the fence must land and propagate to every active clone *before* the cutover freeze is taken.

The alternative — exempting read-only subcommands — was considered and rejected: it requires every subcommand to be correctly classified read-vs-write forever, and misclassifying one write as a read silently reopens the hole.

## ADR D7 was wrong in both halves

Verified at tag `v0.3.0`, `main`, and the working branch:

- todo-db 0.3 is **`SCHEMA_VERSION = 4`**, not 5.
- Its refusal is **structural, not a version comparison** — `_migrate()` detects the foreign tables `{items, work_units, item_deps, meta}` and raises `SchemaMismatchError`. It never reads `meta.schema_version` for that decision.

This removes the obvious objection to bumping: BenchBox claiming v5 cannot collide with todo-db's version handling, because a structural check cannot be defeated by a version number. D7's conclusion is unchanged.

Also records **D11**: the migration item's stale `must-preserve` stays superseded rather than cascading a 6-item drop+recreate (`scope-update` covers scope globs only — confirmed).

## Verification

All 1447 `tests/unit/scripts` tests pass. Tests proven non-vacuous by mutation:

| Mutation | Tests killed |
|---|---|
| Revert the version bump | 2 |
| Revert the refusal-message fix | 1 |
| Drop the fence cross-check | 3 |

Two of the new tests are *relative* to `SCHEMA_VERSION` and survive reverting the bump — noted in-file rather than left overstated; they pin that the fence covers reads, which is the design chosen over exempting them.

Gates run locally: `timing_policy_check --strict`, `lint-markers`, `lint-imports`, contract checker. Fast-lane cap has headroom (26691 / 27050), no bump needed.