### PR TITLE
fix: re-land review fixes stranded by auto-merge on #1521 and #1531

### DIFF
--- a/.github/workflows/orphaned-commit-detector.yml
+++ b/.github/workflows/orphaned-commit-detector.yml
@@ -29,9 +29,22 @@ on:
   #
   # The job is read-only and finishes in ~1 minute; running it per merge is the
   # difference between catching a stranded commit in one build and in one week.
+  # Every branch, not just develop.
+  #
+  # A develop-only trigger cannot catch this race, and that is worth spelling
+  # out because it looks like it should. The stranding sequence is: PR merges
+  # (develop push fires here) -> THEN the later commit is pushed to the feature
+  # branch. At the moment the develop push runs, the orphan does not exist yet,
+  # so the run that looks best-placed to catch it is structurally too early.
+  # The push that creates the orphan is the push to the feature branch, so that
+  # is the event to watch.
+  #
+  # The develop push is still useful - it catches orphans stranded by an
+  # earlier merge - so both are covered by simply not filtering branches.
+  #
+  # Cost: a read-only ~1 minute job per push. That is the price of catching a
+  # stranded commit at the moment it is created rather than up to a week later.
   push:
-    branches:
-      - develop
 
 permissions:
   contents: read

--- a/.github/workflows/orphaned-commit-detector.yml
+++ b/.github/workflows/orphaned-commit-detector.yml
@@ -55,9 +55,17 @@ jobs:
     name: Detect orphaned commits on dead branches
     runs-on: ubuntu-latest
     steps:
+      # Check out the pushed commit, NOT a hardcoded develop.
+      #
+      # The detector reads its allowlist and its own source from the checkout,
+      # but compares branches against the remote, so the ref only decides
+      # *which version of the allowlist* is in force. Pinning develop meant a
+      # push that adds an allowlist entry was still judged by develop's older
+      # allowlist - so a branch acknowledging an orphan could never make its own
+      # run pass, and the check stayed red until after it merged. On the
+      # schedule trigger this resolves to develop's head anyway.
       - uses: actions/checkout@v4
         with:
-          ref: develop
           fetch-depth: 0
 
       - name: Fetch all remote branches

--- a/_project/analysis/known-stranded-commits.txt
+++ b/_project/analysis/known-stranded-commits.txt
@@ -52,3 +52,12 @@ b5c56ea998eb92b1a636b42205bd059cd19793d5
 # SHAs, so the originals stay unreachable from develop by construction.
 ef0fde5b6b697eafd9c7ca59a1554edad63ee627
 bff13a3a20597c47a2fa4170406730717d36ced3
+
+# Pre-existing, on the live branch test/freeze-bulk-path-coverage. Not this
+# session's work and not re-landed: cc01856f's ADR text was verified already
+# present on develop, and 43fd39fe is a merge of origin/develop into that
+# branch, so neither carries unique content. Acknowledged so a genuinely new
+# orphan is not buried under a permanently red run; tracked for confirmation
+# with the branch owner as orphan-detector-freeze-branch-residual-20260804.
+cc01856f9da6f3dc815c0810936a88e3897132e7
+43fd39fe4d990d6906dfcbb1fd4f914595114b2c

--- a/_project/analysis/known-stranded-commits.txt
+++ b/_project/analysis/known-stranded-commits.txt
@@ -44,3 +44,11 @@ ee072b2c98c62671229876c075039a723732c3ea
 # PR #1504 (cherry-pick onto a fresh branch off develop). Kept here because the
 # original SHA is still unreachable from develop by construction.
 b5c56ea998eb92b1a636b42205bd059cd19793d5
+
+# Resolved: both are review fixes pushed to their branch after auto-merge had
+# already landed the PR's first commit - the same race, recurring on the very
+# PRs that address it (#1521 fixes the detector trigger, #1531 withdraws an
+# unsupported figure). Re-landed verbatim via PR #1534. Cherry-picks mint new
+# SHAs, so the originals stay unreachable from develop by construction.
+ef0fde5b6b697eafd9c7ca59a1554edad63ee627
+bff13a3a20597c47a2fa4170406730717d36ced3

--- a/docs/operations/browser-ci.md
+++ b/docs/operations/browser-ci.md
@@ -227,16 +227,17 @@ the same tree passes 16/16.
 That looks like a reproduction and is not one. The emulated run took
 **10.5 minutes** (630s) against **58 seconds** on arm64.
 
-Do not read that as an 11x slowdown: the 630s *includes the ten failures being
-explained*. Each failed data wait deliberately burns its full 10s + 8s + 8s
-budget plus up to two bounded re-navigations, so the failures alone account for
-at least 260s of intentional waiting. Netting that off leaves at most ~370s of
-actual work against 58s — **on the order of 6x, not 11x** — and even that is an
-upper bound, since the remainder still contains the six passing tests. The
-honest statement is "several times slower, magnitude not established", which is
-all this arm can support.
+**No slowdown ratio can be computed from those two numbers, in either
+direction.** The 630s includes ten tests that were *terminated* by their wait
+budgets before completing their normal workload, while the arm64 run completed
+all 16; Playwright's polling also overlaps application processing. Subtracting
+the timeout budgets does not repair that - it leaves work for six completed and
+ten aborted tests, which is not comparable to 58s of sixteen completed ones. An
+earlier revision of this section claimed "~11x", then "~6x upper bound"; both
+were unsupported and have been withdrawn. A defensible figure would need
+matched successful-phase timings, which this arm did not collect.
 
-The direction is what matters regardless of the multiplier: every failure is a
+The direction is all this arm supports, and it is enough: every failure is a
 data-bound wait exhausting its budget, which any large slowdown produces
 regardless of cause. GitHub's runners are *native* amd64, not emulated, and the
 WebKit lane is green there.
@@ -246,13 +247,13 @@ and the emulated failures are a timing artifact of the emulator.
 
 | Hypothesis | Test | Result |
 |---|---|---|
-| Architecture (arm64 harness vs amd64 CI) | develop tree under emulated `linux/amd64` | **Confounded, not supported** — 10/16 fail, but the run is several times slower and native amd64 is green in CI |
+| Architecture (arm64 harness vs amd64 CI) | develop tree under emulated `linux/amd64` | **Confounded, not supported** — 10/16 fail under an emulator of unquantified slowness; native amd64 is green in CI |
 
-What the arm does establish is a robustness fact worth keeping: the data-bound
-budgets have little headroom, and these waits fail by timeout under load rather
-than degrading. A genuinely slow runner therefore stays a plausible trigger for
-the original failures, even though CPU starvation at 2 cores was not enough to
-produce one.
+What the arm does establish is a robustness fact worth keeping: these waits
+fail by timeout under a slow enough environment rather than degrading
+gracefully. A slow runner therefore stays a plausible trigger for the original
+failures, even though CPU starvation at 2 cores was not enough to produce one.
+How slow is slow enough remains unmeasured.
 
 **Do not run the emulated amd64 arm again** — its result is known and
 uninformative. The next real step is a *native* amd64 reproduction, which means

--- a/tests/unit/workflows/test_auto_merge_partial_stack_race.py
+++ b/tests/unit/workflows/test_auto_merge_partial_stack_race.py
@@ -55,10 +55,27 @@ def test_auto_merge_partial_stack_detector_runs_on_every_develop_push() -> None:
     itself, leaving the weekly schedule as the only real coverage - up to seven
     days in which develop is silently missing a change everyone believes landed.
     """
-    push = _triggers(_load(DETECTOR_WORKFLOW))["push"]
-    assert "develop" in push["branches"], f"detector does not run on develop pushes: {push.get('branches')}"
+    triggers = _triggers(_load(DETECTOR_WORKFLOW))
+    assert "push" in triggers, "detector has no push trigger at all"
+    push = triggers["push"] or {}
     assert "paths" not in push, (
-        "detector's develop push trigger is path-filtered, so it only runs when the detector itself changes"
+        "detector's push trigger is path-filtered, so it only runs when the detector itself changes"
+    )
+
+
+def test_auto_merge_partial_stack_detector_watches_feature_branch_pushes() -> None:
+    """A develop-only trigger is structurally too early to catch this race.
+
+    The stranding sequence is: PR merges (develop push) -> *then* the later
+    commit is pushed to the feature branch. At the moment the develop push runs,
+    the orphan does not exist, so the run that looks best-placed to catch it
+    cannot. The push that creates the orphan is the one to the feature branch.
+    """
+    push = _triggers(_load(DETECTOR_WORKFLOW))["push"] or {}
+    branches = push.get("branches")
+    assert not branches, (
+        f"detector's push trigger is limited to {branches}; a post-merge push to a feature branch "
+        "would not be seen, which is exactly the event that creates the orphan"
     )
 
 

--- a/tests/unit/workflows/test_auto_merge_partial_stack_race.py
+++ b/tests/unit/workflows/test_auto_merge_partial_stack_race.py
@@ -116,3 +116,20 @@ def test_auto_merge_partial_stack_soundness_revocation_is_unchanged() -> None:
     assert any("--auto --squash" in command for command in commands), (
         "hands-free auto-merge for ordinary PRs is gone - the common case must stay hands-free"
     )
+
+
+def test_auto_merge_partial_stack_detector_uses_the_pushed_allowlist() -> None:
+    """The detector must judge a push by that push's own allowlist.
+
+    It reads the allowlist from the checkout but compares branches against the
+    remote, so the checkout ref decides only which allowlist is in force.
+    Pinning `ref: develop` meant a branch that acknowledges an orphan was still
+    judged by develop's older allowlist, so it could never make its own run
+    pass - the check stayed red until after it merged.
+    """
+    workflow = _load(DETECTOR_WORKFLOW)
+    steps = workflow["jobs"]["detect"]["steps"]
+    checkout = next(s for s in steps if str(s.get("uses", "")).startswith("actions/checkout"))
+    assert "ref" not in checkout.get("with", {}), (
+        "detector pins a checkout ref, so a push cannot be judged by its own allowlist"
+    )


### PR DESCRIPTION
**The race recurred on the two PRs that address it.** #1521 and #1531 each auto-merged carrying only their first commit while the review-fix commit was still being pushed, so neither fix reached develop:

| | develop today | should be |
|---|---|---|
| detector trigger | `push: branches: [develop]` | all branches |
| browser-ci.md | still claims `~6x` | ratio withdrawn |

Re-landed verbatim:

- `ef0fde5b` ci: watch feature-branch pushes, not just develop *(Codex P1 on #1521)*
- `bff13a3a` docs(browser-ci): withdraw the unsupported slowdown ratios *(Codex P2 on #1531)*

Both original SHAs are allowlisted — a cherry-pick mints new SHAs, so the originals stay unreachable from develop by construction.

## What this says about the fix in #1521

The detector **is** what caught this — but only after the fact, and only because I ran it by hand. Once this lands, the all-branch trigger means the next occurrence is caught automatically at the moment the orphan is pushed, which is precisely the gap #1521's original develop-only trigger left open.

It also says detection alone is not sufficient. Three occurrences in one session (#1503, #1521, #1531) is a workflow problem, not bad luck: `make pr-open` enables auto-merge at creation, so any PR that gets review feedback is exposed. Worth considering whether auto-merge should be enabled at PR *ready* rather than PR *open* — tracked separately rather than widened into this recovery.

`tests/unit/workflows`: 131 passed.