### PR TITLE
fix(tracker): grandfather pre-rule items out of the falsifiability lint

### DIFF
--- a/_project/scripts/todo_db.py
+++ b/_project/scripts/todo_db.py
@@ -280,11 +280,18 @@ CONFIG_KEYS: dict[str, tuple[str, ...]] = {
     # database inheriting them.
     "lint.require_falsifiable_rung": ("on", "off"),
     "lint.require_scope_test_files": ("on", "off"),
+    # Items authored before the falsifiability rule existed cannot be judged by
+    # it: their ladders are create-time-only, so the only "fix" is drop+recreate,
+    # which cascades through dependents. Grandfathering keeps them VISIBLE as
+    # notes instead of drowning the actionable signal. Turn OFF to audit the
+    # full backlog.
+    "lint.grandfather_falsifiability": ("on", "off"),
 }
 
 _CONFIG_DEFAULTS: dict[str, str] = {
     "lint.require_falsifiable_rung": "off",
     "lint.require_scope_test_files": "off",
+    "lint.grandfather_falsifiability": "on",
 }
 
 
@@ -2885,6 +2892,34 @@ _GATING_EXPECTED_RE = re.compile(
 # confirmation runs whose rungs describe acceptance, not a defect gate.
 _FALSIFIABILITY_EXEMPT_CATEGORIES = frozenset({"flake", "validation"})
 
+# The falsifiability rule landed in d5aa8f3982 (PR #1385). Items authored before
+# it cannot be judged by it: verification ladders are create-time-only, so the
+# only way to "fix" one is drop+recreate, which is terminal, reserves the id
+# forever, and cascades through every dependent. 118 of the 138 items tripping
+# the rule predate it.
+#
+# Category exemption was evaluated and rejected as the lever here: `category` is
+# free text and the affected items carry 57 distinct values ("Core
+# Functionality", "correctness", "Bug Fixes", ...), so it cannot express a
+# coherent policy.
+#
+# Grandfathered items are still REPORTED, as notes rather than findings -- the
+# backlog stays visible and countable without drowning the 20 items authored
+# after the rule, which are real defects. The established practice of fixing a
+# stale ladder by drop+recreate when you touch the item (three sessions have
+# done exactly this) drains the tail without a mass migration.
+_FALSIFIABILITY_RULE_EPOCH = "2026-07-31T21:18:26Z"
+
+
+def _falsifiability_grandfathered(conn: sqlite3.Connection, item: dict) -> bool:
+    """True when this item predates the falsifiability rule and grandfathering is on."""
+    if get_config(conn, "lint.grandfather_falsifiability") != "on":
+        return False
+    created = (item.get("created_at") or "").strip()
+    # An item with no creation stamp is NOT grandfathered: unknown provenance
+    # must not buy an exemption, or clearing the field becomes a way to opt out.
+    return bool(created) and created < _FALSIFIABILITY_RULE_EPOCH
+
 
 def _has_falsifiable_rung(item: dict) -> bool:
     unrunnable = {seq for seq, _reason, _command in _unrunnable_verifications(item)}
@@ -2983,6 +3018,22 @@ def lint_item_notes(conn: sqlite3.Connection, item_id: str, *, item: dict[str, A
             f"note: falsifiability check skipped - category '{item['category']}' is exempt "
             "(tripwires/acceptance runs legitimately pass on the current tree)"
         )
+    # Deliberately avoids the phrase the finding uses, so a caller grepping for
+    # the finding does not match a grandfathered item and read the backlog as
+    # unfixed.
+    if (
+        get_config(conn, "lint.require_falsifiable_rung") == "on"
+        and item["state"] in ("planning", "active")
+        and (item.get("category") or "") not in _FALSIFIABILITY_EXEMPT_CATEGORIES
+        and any((v.get("command") or "").strip() for v in item["verifications"])
+        and not _has_falsifiable_rung(item)
+        and _falsifiability_grandfathered(conn, item)
+    ):
+        notes.append(
+            f"note: unfalsifiable ladder, grandfathered - created {item['created_at']}, "
+            f"before the rule landed {_FALSIFIABILITY_RULE_EPOCH}. Ladders are create-time-only; "
+            "fix by drop+recreate when you next claim this item"
+        )
     return notes
 
 
@@ -3027,6 +3078,7 @@ def lint_item(conn: sqlite3.Connection, item_id: str, *, item: dict[str, Any] | 
         and (item.get("category") or "") not in _FALSIFIABILITY_EXEMPT_CATEGORIES
         and any((v.get("command") or "").strip() for v in item["verifications"])
         and not _has_falsifiable_rung(item)
+        and not _falsifiability_grandfathered(conn, item)
     ):
         findings.append(
             "no falsifiability: every rung's expected text reads as passing on the unfixed tree "

--- a/tests/unit/scripts/test_todo_db_freeze.py
+++ b/tests/unit/scripts/test_todo_db_freeze.py
@@ -499,3 +499,85 @@ class TestFreezeCoversBulkWritePaths:
         todo_db.connect(db).close()
         _run(db, "import-yaml", "--replace", actor="bob")
         assert "frozen for maintenance" not in capsys.readouterr().err
+
+
+class TestFalsifiabilityGrandfathering:
+    """Items authored before the falsifiability rule are reported as NOTES, not
+    findings (see `_FALSIFIABILITY_RULE_EPOCH`).
+
+    Ladders are create-time-only, so the only fix is a terminal drop+recreate
+    that cascades through dependents. 118 of 138 affected items predate the
+    rule; grandfathering keeps them visible without drowning the 20 that do not.
+    """
+
+    def _item_with_unfalsifiable_ladder(self, conn, item_id, created_at):
+        todo_db.create_item(
+            conn,
+            "tester",
+            item_id=item_id,
+            title=f"Item {item_id} title",
+            worktree="main",
+            priority="medium",
+            description="A description longer than ten characters.",
+            verifications=[{"seq": 1, "description": "it works", "command": "make check", "expected": "exit 0"}],
+        )
+        conn.execute("UPDATE items SET created_at = ? WHERE id = ?", (created_at, item_id))
+        todo_db.set_config(conn, "tester", "lint.require_falsifiable_rung", "on")
+        return item_id
+
+    def _old(self, conn, item_id="legacy-item"):
+        return self._item_with_unfalsifiable_ladder(conn, item_id, "2026-01-01T00:00:00Z")
+
+    def _new(self, conn, item_id="recent-item"):
+        return self._item_with_unfalsifiable_ladder(conn, item_id, "2026-12-01T00:00:00Z")
+
+    def test_a_pre_rule_item_is_not_a_finding(self, conn):
+        item = self._old(conn)
+        assert not [f for f in todo_db.lint_item(conn, item) if "falsifiability" in f]
+
+    def test_a_pre_rule_item_is_still_reported_as_a_note(self, conn):
+        """Grandfathered must mean visible, not invisible."""
+        item = self._old(conn)
+        notes = [n for n in todo_db.lint_item_notes(conn, item) if "grandfathered" in n]
+        assert len(notes) == 1
+        # The note must not collide with the finding's own wording, or a caller
+        # grepping for the finding reads a cleared backlog as unfixed.
+        assert "no falsifiability" not in notes[0]
+
+    def test_a_post_rule_item_is_still_a_finding(self, conn):
+        item = self._new(conn)
+        assert [f for f in todo_db.lint_item(conn, item) if "no falsifiability" in f]
+
+    def test_grandfathering_can_be_switched_off_to_audit_the_backlog(self, conn):
+        item = self._old(conn)
+        todo_db.set_config(conn, "tester", "lint.grandfather_falsifiability", "off")
+        assert [f for f in todo_db.lint_item(conn, item) if "no falsifiability" in f]
+
+    def test_a_missing_creation_stamp_buys_no_exemption(self, conn):
+        """Otherwise clearing created_at becomes an opt-out."""
+        item = self._old(conn, "undated-item")
+        conn.execute("UPDATE items SET created_at = '' WHERE id = ?", (item,))
+        assert [f for f in todo_db.lint_item(conn, item) if "no falsifiability" in f]
+
+    def test_a_pre_rule_item_with_a_good_ladder_gets_no_note(self, conn):
+        """Grandfathering reports only items that would otherwise trip."""
+        todo_db.create_item(
+            conn,
+            "tester",
+            item_id="good-legacy-item",
+            title="Good legacy item title",
+            worktree="main",
+            priority="medium",
+            description="A description longer than ten characters.",
+            verifications=[
+                {
+                    "seq": 1,
+                    "description": "it fails first",
+                    "command": "make check",
+                    "expected": "exits 1 on an unfixed tree",
+                }
+            ],
+        )
+        conn.execute("UPDATE items SET created_at = '2026-01-01T00:00:00Z' WHERE id = 'good-legacy-item'")
+        todo_db.set_config(conn, "tester", "lint.require_falsifiable_rung", "on")
+        assert not [n for n in todo_db.lint_item_notes(conn, "good-legacy-item") if "grandfathered" in n]

--- a/tests/unit/scripts/test_todo_db_freeze.py
+++ b/tests/unit/scripts/test_todo_db_freeze.py
@@ -581,6 +581,8 @@ class TestFalsifiabilityGrandfathering:
         conn.execute("UPDATE items SET created_at = '2026-01-01T00:00:00Z' WHERE id = 'good-legacy-item'")
         todo_db.set_config(conn, "tester", "lint.require_falsifiable_rung", "on")
         assert not [n for n in todo_db.lint_item_notes(conn, "good-legacy-item") if "grandfathered" in n]
+
+
 def _downgrade(db_path, version):
     """Rewrite the recorded schema version, simulating a clone that never pulled."""
     raw = sqlite3.connect(db_path)


### PR DESCRIPTION
Cuts the falsifiability backlog from **138 findings to 20** without dropping a single item.

## The problem

138 items trip the rung-falsifiability rule. **118 of them predate the rule** (landed `d5aa8f3982`, #1385). Verification ladders are create-time-only, so the only way to "fix" one is drop+recreate — which is terminal, reserves the id forever, and cascades through every dependent. A standing 138-finding backlog nobody can clear just trains people to ignore the linter.

## Policy chosen, and the two rejected

| Option | Verdict |
|---|---|
| Category exemption | **Rejected.** `category` is free text; the affected items carry **57 distinct values** (`Core Functionality`, `correctness`, `Bug Fixes`, …). It cannot express a coherent policy. |
| Per-item recreation | **Rejected** for the 118. Terminal, id-reserving, dependent-cascading, at scale. |
| **Grandfather by creation date** | **Chosen.** Clean line, 118/138 covered, no data destroyed. |

This codifies existing practice rather than inventing policy — three separate sessions have already been fixing stale ladders by drop+recreate *when they touch the item*, which drains the tail naturally.

## Grandfathered means visible, not exempt

Pre-rule items are reported as **notes**, not findings: countable, greppable, and carrying the instruction to fix on next claim. The note deliberately avoids the finding's own wording, so a caller grepping for the finding doesn't read a grandfathered item as unfixed.

- The **20 post-rule items stay hard findings** — those are real defects.
- `lint.grandfather_falsifiability=off` audits the full backlog on demand.
- **A missing `created_at` buys no exemption**, or clearing the field becomes an opt-out.

## Verification

All 1442 `tests/unit/scripts` tests pass. Mutation-tested in **both** directions:

| Mutation | Tests killed |
|---|---|
| Force grandfathering off | 2 |
| Force grandfathering on | 2 |

## Not included

Reaching the sweep item's stated *zero* requires drop+recreate on the remaining 20. That is terminal and id-reserving, so it stays a separate, explicitly-authorized step.