### PR TITLE
fix(worktree): pin human identity per worktree at claim time

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -68,6 +68,10 @@ cd <WORKTREE_PATH>
 make agent-write-preflight
 ```
 
+`worktree-claim` pins your identity to the claimed worktree via
+`git config --worktree`; that outranks the shared config, so a later write
+there cannot reauthor it.
+
 Stop if `git rev-parse --show-toplevel` is the primary clone. Emergency writes
 there require explicit user authorization and
 `BENCHBOX_ALLOW_MAIN_CLONE_WRITE=1`. Preserve unrelated dirty work. Never use
@@ -99,20 +103,14 @@ has an identified durable consumer.
 ## Verification and close-out
 
 Read a claimed TODO's `verification` ladder and run the narrowest proof first.
-Useful local checks:
-
-```bash
-uv run -- python -m pytest -m fast -q
-uv run -- ruff check .
-uv run -- ruff format --check .
-uv run -- ty check
-```
+Useful local checks: `uv run -- python -m pytest -m fast -q`,
+`uv run -- ruff check .`, `uv run -- ruff format --check .`, `uv run -- ty check`.
 
 Before publication, self-review with the `code` skill's review action and fix
 all issues, considerations, and nits unless the user explicitly opts out. Run
-`make pr-preflight` once, then `make pr-open`. Delegate boilerplate gates to a
-low-effort subagent when available; the main agent chooses the command and
-interprets failures. Do not poll CI: pending is a valid terminal state.
+`make pr-preflight` once, then `make pr-open`. Boilerplate gates may go to a
+low-effort subagent; you still choose the command and interpret failures. Do
+not poll CI: pending is a valid terminal state.
 
 Dev PRs target `develop`, use squash merge, and never direct-push protected
 branches. Force-push only feature/pool branches with `--force-with-lease`.

--- a/Makefile
+++ b/Makefile
@@ -1942,6 +1942,8 @@ worktree-claim-attempt:
 			( cd "$$wt" && uv run -- pre-commit install >/dev/null 2>&1 ) \
 				|| echo "note: pre-commit install failed/unavailable in $$wt; codespell etc. won't run at commit time (run \`uv run -- pre-commit install\` manually)" >&2; \
 		fi; \
+		scripts/set_worktree_identity.sh "$$wt" >&2 \
+			|| echo "note: could not pin worktree Git identity in $$wt; commits there resolve identity from the shared config (make agent-write-preflight still refuses an agent author)" >&2; \
 		rm -f "$$marker"; \
 		marker=""; \
 		claim_ok=1; \

--- a/scripts/set_worktree_identity.sh
+++ b/scripts/set_worktree_identity.sh
@@ -1,0 +1,112 @@
+#!/bin/sh
+set -eu
+
+# [COMMIT-IDENTITY-001] Claim-time PREVENTION for shared-clone identity drift.
+#
+# `make agent-write-preflight` detects a contaminated identity, and
+# `agent_instruction_audit.py` warns about one. Both act after the fact. This
+# acts before: it pins the human identity to the claimed worktree so a later
+# write to the shared config cannot reauthor work done here.
+#
+# Why worktree scope is the fix. Linked worktrees share the primary clone's
+# config, and from inside one of them `git config user.email X` (no --global)
+# writes to that COMMON config -- which is exactly the defect this repairs: one
+# such write reauthors the primary clone and every pool worktree at once.
+# Git's precedence is worktree > local > global, so a value written with
+# `--worktree` keeps resolving here no matter what later lands in the common
+# config. Measured: with a worktree override in place, re-contaminating the
+# common config leaves this worktree resolving the human identity, while a
+# sibling worktree without the override goes agent. That is why this must run
+# per worktree, at claim time.
+#
+# This never writes user.* to the common config. `extensions.worktreeConfig` is
+# the one common-config key it sets, because `--worktree` is inert without it;
+# it is not an identity value and carries no authorship.
+
+worktree=${1:-$(pwd)}
+
+git_wt() {
+  git -C "$worktree" "$@"
+}
+
+# Read the identity the human actually owns. Global/system scope only: reading
+# the resolved value would happily echo back a contaminated common config and
+# pin the contamination into worktree scope, which is the one outcome worse
+# than doing nothing.
+name=$(git_wt config --global --get user.name 2>/dev/null || true)
+email=$(git_wt config --global --get user.email 2>/dev/null || true)
+
+if [ -z "$name" ] || [ -z "$email" ]; then
+  cat >&2 <<EOF
+Refusing to set worktree identity: no global Git identity to pin.
+
+  user.name:  ${name:-<unset>}
+  user.email: ${email:-<unset>}
+
+Set the human identity globally first, so every worktree inherits it:
+  git config --global user.name "Your Name"
+  git config --global user.email "you@example.com"
+EOF
+  exit 1
+fi
+
+# Keep these lists in sync with AGENT_NAMES / AGENT_EMAILS in
+# _project/scripts/agent_instruction_audit.py and the same case arms in
+# scripts/agent_write_preflight.sh.
+lower_name=$(printf '%s' "$name" | tr 'A-Z' 'a-z')
+lower_email=$(printf '%s' "$email" | tr 'A-Z' 'a-z')
+
+agent_identity=no
+case "$lower_email" in
+  noreply@anthropic.com | noreply@openai.com) agent_identity=yes ;;
+esac
+case "$lower_name" in
+  chatgpt | claude | codex | gemini | openai) agent_identity=yes ;;
+esac
+
+if [ "$agent_identity" = yes ]; then
+  cat >&2 <<EOF
+Refusing to set worktree identity: the global Git identity is a known
+agent/service identity.
+
+  $name <$email>
+
+Pinning it into worktree scope would make the misattribution durable and
+survive repair of the shared config -- the opposite of this guard's purpose.
+Restore the human global identity, then re-run:
+  make worktree-claim BRANCH=fix/descriptive-slug
+
+For a single commit that an authorized task explicitly wants attributed
+elsewhere, pass the identity per command instead:
+  git -c user.name=... -c user.email=... commit
+EOF
+  exit 1
+fi
+
+# `--worktree` is inert unless the extension is enabled in the common config.
+# Idempotent, and not an identity value.
+if [ "$(git_wt config --get extensions.worktreeConfig 2>/dev/null || true)" != "true" ]; then
+  git_wt config extensions.worktreeConfig true
+fi
+
+# Enabling the extension moves any pre-existing common-config [user] block out
+# of this worktree's precedence path only if we write our own. Write both keys
+# unconditionally-but-idempotently so a partially-set worktree converges.
+current_name=$(git_wt config --worktree --get user.name 2>/dev/null || true)
+current_email=$(git_wt config --worktree --get user.email 2>/dev/null || true)
+
+changed=no
+if [ "$current_name" != "$name" ]; then
+  git_wt config --worktree user.name "$name"
+  changed=yes
+fi
+if [ "$current_email" != "$email" ]; then
+  git_wt config --worktree user.email "$email"
+  changed=yes
+fi
+
+if [ "$changed" = yes ]; then
+  printf 'Pinned worktree Git identity: %s <%s>\n' "$name" "$email"
+else
+  printf 'Worktree Git identity already pinned: %s <%s>\n' "$name" "$email"
+fi

--- a/tests/unit/test_worktree_identity.py
+++ b/tests/unit/test_worktree_identity.py
@@ -1,0 +1,156 @@
+"""Tests for claim-time worktree-scoped Git identity.
+
+The defect under repair: from inside a linked worktree, `git config user.email X`
+(no `--global`) writes to the *common* config, so one write reauthors the primary
+clone and every worktree it owns at once. Worktree scope outranks local scope, so
+an identity pinned per worktree keeps resolving even after that write lands.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import pytest
+
+pytestmark = [pytest.mark.unit, pytest.mark.fast]
+
+ROOT = Path(__file__).resolve().parents[2]
+HELPER = ROOT / "scripts/set_worktree_identity.sh"
+
+HUMAN_NAME = "Some Human"
+HUMAN_EMAIL = "human@example.invalid"
+AGENT_NAME = "Claude"
+AGENT_EMAIL = "noreply@anthropic.com"
+
+
+def _git(cwd: Path, *args: str, check: bool = True) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(["git", "-C", str(cwd), *args], check=check, capture_output=True, text=True)
+
+
+def _run_helper(worktree: Path, home: Path) -> subprocess.CompletedProcess[str]:
+    """Invoke the helper with HOME redirected so the global config is the fixture's."""
+    return subprocess.run(
+        ["sh", str(HELPER), str(worktree)],
+        check=False,
+        capture_output=True,
+        text=True,
+        env={"HOME": str(home), "PATH": "/usr/bin:/bin:/usr/local/bin:/opt/homebrew/bin"},
+    )
+
+
+@pytest.fixture
+def fixture_repo(tmp_path: Path) -> tuple[Path, Path, Path]:
+    """A primary clone with one linked worktree, and an isolated global config."""
+    home = tmp_path / "home"
+    home.mkdir()
+    (home / ".gitconfig").write_text(
+        f"[user]\n\tname = {HUMAN_NAME}\n\temail = {HUMAN_EMAIL}\n",
+        encoding="utf-8",
+    )
+
+    primary = tmp_path / "primary"
+    primary.mkdir()
+    _git(primary, "init", "-q", "-b", "main")
+    _git(primary, "config", "user.name", HUMAN_NAME)
+    _git(primary, "config", "user.email", HUMAN_EMAIL)
+    (primary / "seed.txt").write_text("seed\n", encoding="utf-8")
+    _git(primary, "add", "seed.txt")
+    _git(primary, "commit", "-q", "-m", "seed")
+
+    linked = tmp_path / "linked"
+    _git(primary, "worktree", "add", "-q", "-b", "work", str(linked))
+    return primary, linked, home
+
+
+def _resolved_email(worktree: Path) -> str:
+    return _git(worktree, "config", "--get", "user.email").stdout.strip()
+
+
+def test_pinned_identity_survives_a_contaminated_common_config(fixture_repo) -> None:
+    """The whole point: contaminate the shared config, keep the human identity.
+
+    This is the behaviour the detection-only guards could not provide.
+    """
+    primary, linked, home = fixture_repo
+    result = _run_helper(linked, home)
+    assert result.returncode == 0, result.stderr
+
+    # Reproduce the defect exactly: a plain `git config user.email` from INSIDE
+    # the linked worktree, which lands in the common config.
+    _git(linked, "config", "user.email", AGENT_EMAIL)
+    _git(linked, "config", "user.name", AGENT_NAME)
+
+    assert _resolved_email(linked) == HUMAN_EMAIL
+    # And the write really did hit the shared config, so the test is not vacuous.
+    assert _git(primary, "config", "--local", "--get", "user.email").stdout.strip() == AGENT_EMAIL
+
+
+def test_sibling_worktree_without_the_override_is_contaminated(fixture_repo) -> None:
+    """Negative control: the protection is per worktree, which is why claim time.
+
+    Without this, the previous test could pass for the wrong reason.
+    """
+    primary, linked, home = fixture_repo
+    _run_helper(linked, home)
+    sibling = primary.parent / "sibling"
+    _git(primary, "worktree", "add", "-q", "-b", "other", str(sibling))
+
+    _git(linked, "config", "user.email", AGENT_EMAIL)
+
+    assert _resolved_email(linked) == HUMAN_EMAIL
+    assert _resolved_email(sibling) == AGENT_EMAIL
+
+
+def test_refuses_agent_global_identity(fixture_repo) -> None:
+    """Pinning an agent identity would make the misattribution durable."""
+    primary, linked, home = fixture_repo
+    (home / ".gitconfig").write_text(
+        f"[user]\n\tname = {AGENT_NAME}\n\temail = {AGENT_EMAIL}\n",
+        encoding="utf-8",
+    )
+
+    result = _run_helper(linked, home)
+
+    assert result.returncode != 0
+    assert "known" in result.stderr.lower() and "agent" in result.stderr.lower()
+    written = _git(linked, "config", "--worktree", "--get", "user.email", check=False)
+    assert written.stdout.strip() != AGENT_EMAIL
+
+
+def test_refuses_when_no_global_identity_exists(fixture_repo) -> None:
+    """Nothing human to pin means there is nothing safe to write."""
+    primary, linked, home = fixture_repo
+    (home / ".gitconfig").write_text("", encoding="utf-8")
+
+    result = _run_helper(linked, home)
+
+    assert result.returncode != 0
+    assert "global Git identity" in result.stderr
+
+
+def test_is_idempotent(fixture_repo) -> None:
+    """worktree-claim may run more than once against the same worktree."""
+    primary, linked, home = fixture_repo
+    first = _run_helper(linked, home)
+    second = _run_helper(linked, home)
+
+    assert first.returncode == 0, first.stderr
+    assert second.returncode == 0, second.stderr
+    assert "already pinned" in second.stdout
+    assert _resolved_email(linked) == HUMAN_EMAIL
+
+
+def test_never_writes_identity_into_the_common_config(fixture_repo) -> None:
+    """The guard must not itself become the write it exists to prevent."""
+    primary, linked, home = fixture_repo
+    before = (primary / ".git/config").read_text(encoding="utf-8")
+
+    result = _run_helper(linked, home)
+    assert result.returncode == 0, result.stderr
+
+    after = (primary / ".git/config").read_text(encoding="utf-8")
+    # extensions.worktreeConfig may be added; no identity value may be.
+    assert AGENT_EMAIL not in after
+    for line in set(after.splitlines()) - set(before.splitlines()):
+        assert "user" not in line.lower() or "worktreeconfig" in line.lower()


### PR DESCRIPTION
## Problem

From inside a linked worktree, `git config user.email <value>` with no `--global` writes to the **common** config — the primary clone's `.git/config`. Git's precedence then applies that value to the primary clone *and every worktree it owns*, simultaneously. One obedient session reauthors every other session's work; a single such write is enough to explain agent-authored stashes across four different pool worktrees.

Every existing guard for this is **detection**: `agent-write-preflight` refuses an agent author, `agent-identity-check` warns on an overriding identity, `guard-agent-commit-range` reads the commits at merge time. All of them act after the config has already changed, and the contamination recurred anyway.

## Change: prevention, and it is measured

`make worktree-claim` now pins the human identity into **worktree scope** on the slot it just claimed, via `scripts/set_worktree_identity.sh`.

Worktree scope outranks local scope, so a later contaminating write to the common config cannot displace it. Measured directly rather than assumed:

```
# after pinning the linked worktree, reproduce the defect from inside it
$ git -C linked config user.email noreply@anthropic.com

linked resolves : human@example.invalid      # immune
primary resolves: noreply@anthropic.com      # contaminated, as expected
```

The negative control is part of the suite: a **sibling worktree without the override is contaminated** by the same write. That is why this has to run per worktree, and therefore why claim time is the hook point.

## Safety properties

- **Never writes `user.*` to the common config.** The only common-config key it sets is `extensions.worktreeConfig`, because `--worktree` is inert without it. That key carries no authorship. A test asserts no identity value reaches the shared config.
- **Reads the global identity, not the resolved one.** Reading the resolved value would happily echo back an already-contaminated common config and pin the contamination into worktree scope — strictly worse than doing nothing.
- **Refuses an agent global identity** rather than propagating it; pinning it would make the misattribution durable and survive repair of the shared config.
- **Refuses when there is no global identity to pin**, with the exact commands to set one.
- **Idempotent** — `worktree-claim` may run repeatedly against a slot.
- **Non-fatal in the claim path.** A failure warns and the claim still succeeds, because `make agent-write-preflight` is the hard gate immediately after and still refuses an agent author. `worktree-claim` behaves exactly as before otherwise.
- **The ephemeral-clone path is untouched** — an ephemeral clone never runs `worktree-claim`.

## Verification

| Rung | Result |
|---|---|
| 1 — `pytest tests/unit/test_worktree_identity.py` | fails on `develop` (helper and test absent), passes here |
| 2 — `-k refuses_agent` | passes; agent identity is not written to worktree scope |
| 3 — `pytest tests/unit/test_agent_write_preflight.py` | unchanged, still green |
| 4 — `make agent-identity-check` with a human identity | PASS |
| `make pr-preflight` | pass |

Tests cover: precedence over a contaminated common config; the sibling-worktree negative control; agent-identity refusal; missing-global refusal; idempotence; and that no identity is written to the common config.

## AGENTS.md

Net line count is held flat — the claim-time rule is paid for by compressing prose elsewhere in the file, keeping `agents_lines` within the 170 budget asserted by `_project/evals/agent-instructions/scenarios.json`.
