### PR TITLE
fix(tracker): make additive bulk_transfer safe against colliding primary keys

### DIFF
--- a/_project/scripts/todo_db.py
+++ b/_project/scripts/todo_db.py
@@ -1073,6 +1073,21 @@ def _pipeline_execute(
     return response
 
 
+def _rowid_alias_pk(table_info: list) -> str | None:
+    """The column name of a single-column INTEGER PRIMARY KEY, else None.
+
+    Only a rowid alias may be reassigned. A composite key (work_units'
+    item_id+wid) and a TEXT key (items.id) both carry meaning that other rows
+    reference, so they are always copied verbatim -- reassigning either would
+    silently break foreign keys rather than collide loudly.
+    """
+    pk_columns = [row for row in table_info if row["pk"]]
+    if len(pk_columns) != 1:
+        return None
+    column = pk_columns[0]
+    return column["name"] if (column["type"] or "").strip().upper() == "INTEGER" else None
+
+
 def bulk_transfer(
     staging: sqlite3.Connection,
     url: str,
@@ -1107,9 +1122,21 @@ def bulk_transfer(
             stmts.append((f"DELETE FROM {table}", []))
     rows_total = 0
     for table in transfer_tables:
-        columns = [row["name"] for row in staging.execute(f"PRAGMA table_info({table})")]
-        insert = f"INSERT INTO {table} ({', '.join(columns)}) VALUES ({', '.join('?' for _ in columns)})"
-        for row in staging.execute(f"SELECT {', '.join(columns)} FROM {table}"):
+        info = list(staging.execute(f"PRAGMA table_info({table})"))
+        columns = [row["name"] for row in info]
+        # Additive transfers must NOT carry rowid-alias primary keys: the target
+        # already holds rows at those ids (production had `finding_events.seq=1`
+        # from an earlier sync), and one collision aborts the entire transfer.
+        # Omitting the column lets SQLite assign fresh ids in INSERT order, so
+        # relative order -- the only thing the append-only tables actually mean
+        # -- is preserved. `--replace` empties the target first, so it keeps
+        # copying ids verbatim and stays byte-for-byte what it was.
+        skip = None if replace else _rowid_alias_pk(info)
+        insert_columns = [c for c in columns if c != skip] if skip else columns
+        placeholders = ", ".join("?" for _ in insert_columns)
+        insert = f"INSERT INTO {table} ({', '.join(insert_columns)}) VALUES ({placeholders})"
+        order = f" ORDER BY {skip}" if skip else ""
+        for row in staging.execute(f"SELECT {', '.join(insert_columns)} FROM {table}{order}"):
             stmts.append((insert, list(row)))
             rows_total += 1
     batches = [stmts[i : i + batch_size] for i in range(0, len(stmts), batch_size)]

--- a/_project/scripts/todo_findings.py
+++ b/_project/scripts/todo_findings.py
@@ -1809,8 +1809,12 @@ def _cmd_import_bulk(conn: Any, actor: str, args: argparse.Namespace) -> int:
                 return 1
             print(f"parity OK: {report['stored_records']}/{report['corpus_records']} records, zero diffs")
             return 0
-        # bulk_transfer copies primary keys verbatim, so staged ids must clear the
-        # target's maxima or the first colliding row aborts the whole transfer.
+        # Defence in depth, no longer the load-bearing guard: bulk_transfer now
+        # omits rowid-alias primary keys on an additive transfer (this call is
+        # additive -- no `replace`), so the target assigns fresh ids and cannot
+        # collide. Retained because it is independently tested and costs one
+        # pass over the staged ids; the offsets it reports below are what WOULD
+        # have been needed, not what the transfer applied.
         applied = offset_staging_pks(staging, maxima)
         raw = todo_db.sqlite3.connect(staging)
         raw.row_factory = todo_db.sqlite3.Row

--- a/tests/unit/scripts/test_todo_db_hosted.py
+++ b/tests/unit/scripts/test_todo_db_hosted.py
@@ -908,6 +908,100 @@ class TestHostedBulkImport:
         assert summary["rows"] > 0
         assert summary["batches"] >= 1
 
+    def test_additive_transfer_into_a_target_holding_the_same_ids(self, staging, tmp_path):
+        """An additive (non---replace) transfer must survive a target that already
+        holds rows at the ids the staging database uses.
+
+        An EMPTY target is exactly what hid this: a full scratch-Turso rehearsal
+        passed because nothing occupied the ids. Production held
+        `finding_events.seq = 1` from an earlier sync, which would have aborted
+        the whole transfer.
+        """
+        primary = FakePrimary(tmp_path / "primary.sqlite")
+        sqlite3.connect(primary.path).executescript(todo_db.SCHEMA_SQL)
+        seed = sqlite3.connect(primary.path)
+        # Occupy events.seq = 1..N, the same rowids the staged events carry.
+        for n in range(3):
+            seed.execute("INSERT INTO events (at, actor, item_id, action) VALUES ('t', 'a', NULL, 'config')")
+        seed.commit()
+        before = seed.execute("SELECT count(*) FROM events").fetchone()[0]
+        staged = staging.execute("SELECT count(*) FROM events").fetchone()[0]
+        seed.close()
+
+        todo_db.bulk_transfer(staging, HOSTED_URL, "tok", post=primary.post)
+
+        check = sqlite3.connect(primary.path)
+        try:
+            assert check.execute("SELECT count(*) FROM events").fetchone()[0] == before + staged
+        finally:
+            check.close()
+
+    def test_additive_transfer_preserves_append_only_order(self, staging, tmp_path):
+        """finding_events/events are append-only audit trails: reassigning ids is
+        only safe if RELATIVE ORDER survives, because order carries the meaning."""
+        primary = FakePrimary(tmp_path / "primary.sqlite")
+        sqlite3.connect(primary.path).executescript(todo_db.SCHEMA_SQL)
+        seed = sqlite3.connect(primary.path)
+        seed.execute("INSERT INTO events (at, actor, item_id, action) VALUES ('t', 'a', NULL, 'config')")
+        seed.commit()
+        seed.close()
+        staged_order = [
+            (r["at"], r["actor"], r["action"]) for r in staging.execute("SELECT * FROM events ORDER BY seq")
+        ]
+
+        todo_db.bulk_transfer(staging, HOSTED_URL, "tok", post=primary.post)
+
+        check = sqlite3.connect(primary.path)
+        check.row_factory = sqlite3.Row
+        try:
+            landed = [
+                (r["at"], r["actor"], r["action"])
+                for r in check.execute("SELECT * FROM events WHERE action != 'config' ORDER BY seq")
+            ]
+        finally:
+            check.close()
+        assert landed == staged_order
+
+    def test_replace_still_copies_ids_verbatim(self, staging, tmp_path):
+        """must-preserve: the --replace path is unchanged, ids included.
+
+        Replace empties the target first, so there is nothing to collide with
+        and the ids carry over exactly. Uses a NON-contiguous staged id so a
+        reassign-from-1 would be visible.
+        """
+        staging.execute("UPDATE events SET seq = 900 WHERE seq = (SELECT max(seq) FROM events)")
+        staging.commit()
+        staged_ids = [r["seq"] for r in staging.execute("SELECT seq FROM events ORDER BY seq")]
+        assert 900 in staged_ids
+
+        primary = FakePrimary(tmp_path / "primary.sqlite")
+        sqlite3.connect(primary.path).executescript(todo_db.SCHEMA_SQL)
+        todo_db.bulk_transfer(staging, HOSTED_URL, "tok", replace=True, post=primary.post)
+
+        check = sqlite3.connect(primary.path)
+        try:
+            landed = [r[0] for r in check.execute("SELECT seq FROM events ORDER BY seq")]
+        finally:
+            check.close()
+        assert landed == staged_ids
+
+    def test_text_and_composite_keys_are_never_reassigned(self, staging, tmp_path):
+        """Only a rowid alias may be reassigned. items.id is TEXT and
+        work_units is keyed (item_id, wid) -- other rows reference both, so
+        reassigning either would break foreign keys silently."""
+        primary = FakePrimary(tmp_path / "primary.sqlite")
+        sqlite3.connect(primary.path).executescript(todo_db.SCHEMA_SQL)
+        todo_db.bulk_transfer(staging, HOSTED_URL, "tok", post=primary.post)
+
+        check = sqlite3.connect(primary.path)
+        try:
+            assert sorted(r[0] for r in check.execute("SELECT id FROM items")) == ["bulk-one", "bulk-two"]
+            assert sorted(tuple(r) for r in check.execute("SELECT item_id, wid FROM work_units")) == sorted(
+                tuple(r) for r in staging.execute("SELECT item_id, wid FROM work_units")
+            )
+        finally:
+            check.close()
+
     def test_bulk_transfer_wraps_in_one_transaction_with_baton(self, staging, tmp_path):
         primary = FakePrimary(tmp_path / "primary.sqlite")
         sqlite3.connect(primary.path).executescript(todo_db.SCHEMA_SQL)


### PR DESCRIPTION
Closes the hazard assessed in [#1519](https://github.com/joeharris76/BenchBox/pull/1519) — this is the fix, not another assessment.

## The bug

`bulk_transfer` copied every column verbatim, primary keys included. An additive (non-`--replace`) transfer into a target that already held rows at the staged ids aborted the **entire** transfer on the first collision. Production hit exactly this shape: `finding_events.seq = 1` left over from an earlier sync.

**An empty target is what hid it.** A full scratch-Turso rehearsal passed because nothing occupied the ids. Both new collision tests seed the target first, and both fail on the unfixed tree with:

```
todo_db.TodoError: hosted pipeline error: UNIQUE constraint failed: events.seq
```

## The fix

Additive transfers omit rowid-alias primary keys, so SQLite assigns fresh ids in INSERT order. Rows are selected `ORDER BY` that key, so **relative order is preserved** — the only thing the append-only audit tables actually mean — and that is asserted, not assumed.

**Only a single-column `INTEGER PRIMARY KEY` is ever reassigned.** `items.id` is TEXT; `work_units` is keyed `(item_id, wid)`. Other rows reference both, so reassigning either would break foreign keys *silently* rather than collide loudly.

**`--replace` is untouched.** It empties the target first, so it still copies ids verbatim — pinned by a test using a non-contiguous staged id (900), which a reassign-from-1 would visibly break.

## must-preserve, checked

| Constraint | How |
|---|---|
| Append-only row ORDER survives | `test_additive_transfer_preserves_append_only_order` |
| `--replace` byte-for-byte equivalent, ids included | `test_replace_still_copies_ids_verbatim` |
| `offset_staging_pks` keeps working, or is removed once subsumed | Kept working; **demoted to defence in depth** |

The findings import calls `bulk_transfer` additively, so `offset_staging_pks` is now subsumed. Its comment claimed *"bulk_transfer copies primary keys verbatim"* — no longer true. Corrected in place rather than removed, since the helper is independently tested and the removal is not needed to fix this.

## Verification

1458 `tests/unit/scripts` tests pass. Three mutations, three distinct kills:

| Mutation | Tests killed |
|---|---|
| Never skip the PK (revert the fix) | 2 |
| Skip the PK on `--replace` too | 1 (the must-preserve test) |
| Reassign TEXT/composite keys as well | 4 |

## Note on the item's own ladder

The tracker item's rung 1 is `pytest tests/unit/scripts/ -q — expected: all pass`, which **passes on the unfixed tree** and so cannot detect this defect. The falsifiable step is w1's "add a failing test", which is what the two seeded-target tests are. Flagging it as another instance of the pattern [#1536](https://github.com/joeharris76/BenchBox/pull/1536) addresses.