### PR TITLE
fix(explorer-e2e): derive fixture result IDs instead of hardcoding them

### DIFF
--- a/results-explorer/e2e/captures/pr246-final-evidence.spec.ts
+++ b/results-explorer/e2e/captures/pr246-final-evidence.spec.ts
@@ -27,9 +27,9 @@ const OUT = path.join(
 const LOG = path.join(OUT, `console-network-${TODAY}.log`);
 const MANIFEST = path.join(OUT, "screenshot-manifest.json");
 
-const DUCKDB_ID = fixtureIds.duckdbId;
-const AWS_ID = "tpch-fixture-aws-sql-sf0.01-20260403-e73da6ce";
-const DUCKDB_SF01_ID = "0820b170";
+const DUCKDB_ID = fixtureIds.ids.duckdb;
+const AWS_ID = fixtureIds.ids.awsCloud;
+const DUCKDB_SF01_ID = fixtureIds.shortIds.duckdbSf01;
 const WIDTHS = [390, 768, 1280, 1600] as const;
 
 interface CaptureRoute {

--- a/results-explorer/e2e/captures/pr246-final-evidence.spec.ts
+++ b/results-explorer/e2e/captures/pr246-final-evidence.spec.ts
@@ -12,7 +12,7 @@ import path from "path";
 import { fileURLToPath } from "url";
 import { expect, test, type Page } from "@playwright/test";
 import { assertEvidenceCaptureMatchesDevelop } from "../../src/lib/evidenceGit";
-import { waitForDataLoaded, waitForShell } from "../support/fixtures";
+import { fixtureIds, waitForDataLoaded, waitForShell } from "../support/fixtures";
 
 const HERE = path.dirname(fileURLToPath(import.meta.url));
 const REPO_ROOT = path.resolve(HERE, "../../..");
@@ -27,7 +27,7 @@ const OUT = path.join(
 const LOG = path.join(OUT, `console-network-${TODAY}.log`);
 const MANIFEST = path.join(OUT, "screenshot-manifest.json");
 
-const DUCKDB_ID = "tpch-duckdb-sf0.01-20260403-010ee756";
+const DUCKDB_ID = fixtureIds.duckdbId;
 const AWS_ID = "tpch-fixture-aws-sql-sf0.01-20260403-e73da6ce";
 const DUCKDB_SF01_ID = "0820b170";
 const WIDTHS = [390, 768, 1280, 1600] as const;

--- a/results-explorer/e2e/captures/pr246-responsive-remediation.spec.ts
+++ b/results-explorer/e2e/captures/pr246-responsive-remediation.spec.ts
@@ -10,6 +10,7 @@ import { mkdirSync, writeFileSync } from "fs";
 import path from "path";
 import { fileURLToPath } from "url";
 import { expect, test, type Page } from "@playwright/test";
+import { fixtureIds } from "../support/fixtures";
 
 const HERE = path.dirname(fileURLToPath(import.meta.url));
 const REPO_ROOT = path.resolve(HERE, "../../..");
@@ -22,9 +23,9 @@ const OUT = path.join(
   `results-explorer-pr246-responsive-remediation-${TODAY}`,
 );
 
-const SHORT_DUCKDB = "ba6a8c83";
-const SHORT_DATAFUSION = "5e6c5eba";
-const DETAIL_ID = "tpch-duckdb-sf0.01-20260403-010ee756";
+const SHORT_DUCKDB = fixtureIds.shortDuckdb;
+const SHORT_DATAFUSION = fixtureIds.shortDatafusion;
+const DETAIL_ID = fixtureIds.detailId;
 const WIDTHS = [390, 768] as const;
 
 interface CaptureRoute {

--- a/results-explorer/e2e/captures/pr246-responsive-remediation.spec.ts
+++ b/results-explorer/e2e/captures/pr246-responsive-remediation.spec.ts
@@ -23,9 +23,9 @@ const OUT = path.join(
   `results-explorer-pr246-responsive-remediation-${TODAY}`,
 );
 
-const SHORT_DUCKDB = fixtureIds.shortDuckdb;
-const SHORT_DATAFUSION = fixtureIds.shortDatafusion;
-const DETAIL_ID = fixtureIds.detailId;
+const SHORT_DUCKDB = fixtureIds.shortIds.duckdb;
+const SHORT_DATAFUSION = fixtureIds.shortIds.datafusion;
+const DETAIL_ID = fixtureIds.ids.duckdb;
 const WIDTHS = [390, 768] as const;
 
 interface CaptureRoute {

--- a/results-explorer/e2e/captures/pr246-result-compare-remediation.spec.ts
+++ b/results-explorer/e2e/captures/pr246-result-compare-remediation.spec.ts
@@ -23,9 +23,9 @@ const OUT = path.join(
   `results-explorer-pr246-result-compare-remediation-${TODAY}`,
 );
 
-const DUCKDB_ID = fixtureIds.duckdbId;
-const AWS_ID = "tpch-fixture-aws-sql-sf0.01-20260403-e73da6ce";
-const DUCKDB_SF01_ID = "0820b170";
+const DUCKDB_ID = fixtureIds.ids.duckdb;
+const AWS_ID = fixtureIds.ids.awsCloud;
+const DUCKDB_SF01_ID = fixtureIds.shortIds.duckdbSf01;
 const WIDTHS = [390, 768, 1280, 1600];
 
 interface CaptureRoute {

--- a/results-explorer/e2e/captures/pr246-result-compare-remediation.spec.ts
+++ b/results-explorer/e2e/captures/pr246-result-compare-remediation.spec.ts
@@ -10,6 +10,7 @@ import { mkdirSync, writeFileSync } from "fs";
 import path from "path";
 import { fileURLToPath } from "url";
 import { expect, test } from "@playwright/test";
+import { fixtureIds } from "../support/fixtures";
 
 const HERE = path.dirname(fileURLToPath(import.meta.url));
 const REPO_ROOT = path.resolve(HERE, "../../..");
@@ -22,7 +23,7 @@ const OUT = path.join(
   `results-explorer-pr246-result-compare-remediation-${TODAY}`,
 );
 
-const DUCKDB_ID = "tpch-duckdb-sf0.01-20260403-010ee756";
+const DUCKDB_ID = fixtureIds.duckdbId;
 const AWS_ID = "tpch-fixture-aws-sql-sf0.01-20260403-e73da6ce";
 const DUCKDB_SF01_ID = "0820b170";
 const WIDTHS = [390, 768, 1280, 1600];

--- a/results-explorer/e2e/captures/release-final.spec.ts
+++ b/results-explorer/e2e/captures/release-final.spec.ts
@@ -16,7 +16,7 @@ import { mkdirSync, appendFileSync, writeFileSync } from "fs";
 import path from "path";
 import { fileURLToPath } from "url";
 import { test } from "@playwright/test";
-import { waitForDataLoaded, waitForShell } from "../support/fixtures";
+import { fixtureIds, waitForDataLoaded, waitForShell } from "../support/fixtures";
 
 const HERE = path.dirname(fileURLToPath(import.meta.url));
 const REPO_ROOT = path.resolve(HERE, "../../..");
@@ -48,13 +48,13 @@ const ROUTES: Array<{ slug: string; url: string; readyText: RegExp }> = [
   { slug: "platform-polars", url: "/results/p/polars/", readyText: /Polars Results/ },
   {
     slug: "result-detail-tpch-duckdb",
-    url: "/results/r/tpch-duckdb-sf0.01-20260403-010ee756",
+    url: `/results/r/${fixtureIds.detailId}`,
     readyText: /Query Timings/,
   },
-  { slug: "compare-same-cohort", url: "/results/compare?ids=ba6a8c83,5e6c5eba", readyText: /TPC-H Comparison/ },
+  { slug: "compare-same-cohort", url: `/results/compare?ids=${fixtureIds.shortDuckdb},${fixtureIds.shortDatafusion}`, readyText: /TPC-H Comparison/ },
   {
     slug: "compare-mismatch-benchmark",
-    url: "/results/compare?ids=ba6a8c83,0f0add9f",
+    url: `/results/compare?ids=${fixtureIds.shortDuckdb},0f0add9f`,
     readyText: /Mixed Benchmark Comparison/,
   },
   {

--- a/results-explorer/e2e/captures/release-final.spec.ts
+++ b/results-explorer/e2e/captures/release-final.spec.ts
@@ -48,13 +48,13 @@ const ROUTES: Array<{ slug: string; url: string; readyText: RegExp }> = [
   { slug: "platform-polars", url: "/results/p/polars/", readyText: /Polars Results/ },
   {
     slug: "result-detail-tpch-duckdb",
-    url: `/results/r/${fixtureIds.detailId}`,
+    url: `/results/r/${fixtureIds.ids.duckdb}`,
     readyText: /Query Timings/,
   },
-  { slug: "compare-same-cohort", url: `/results/compare?ids=${fixtureIds.shortDuckdb},${fixtureIds.shortDatafusion}`, readyText: /TPC-H Comparison/ },
+  { slug: "compare-same-cohort", url: `/results/compare?ids=${fixtureIds.shortIds.duckdb},${fixtureIds.shortIds.datafusion}`, readyText: /TPC-H Comparison/ },
   {
     slug: "compare-mismatch-benchmark",
-    url: `/results/compare?ids=${fixtureIds.shortDuckdb},0f0add9f`,
+    url: `/results/compare?ids=${fixtureIds.shortIds.duckdb},${fixtureIds.shortIds.starSchema}`,
     readyText: /Mixed Benchmark Comparison/,
   },
   {

--- a/results-explorer/e2e/failures/compare-hard-block.spec.ts
+++ b/results-explorer/e2e/failures/compare-hard-block.spec.ts
@@ -1,8 +1,8 @@
 import { expect, test } from "@playwright/test";
-import { waitForDataLoaded, waitForShell } from "../support/fixtures";
+import { fixtureIds, waitForDataLoaded, waitForShell } from "../support/fixtures";
 
-const TPCH_ID = "tpch-duckdb-sf0.01-20260403-010ee756";
-const TPCH_SHORT = "ba6a8c83";
+const TPCH_ID = fixtureIds.duckdbId;
+const TPCH_SHORT = fixtureIds.shortDuckdb;
 const STAR_SCHEMA_SHORT = "0f0add9f";
 const TPCH_SF01_SHORT = "0820b170";
 

--- a/results-explorer/e2e/failures/compare-hard-block.spec.ts
+++ b/results-explorer/e2e/failures/compare-hard-block.spec.ts
@@ -1,10 +1,10 @@
 import { expect, test } from "@playwright/test";
 import { fixtureIds, waitForDataLoaded, waitForShell } from "../support/fixtures";
 
-const TPCH_ID = fixtureIds.duckdbId;
-const TPCH_SHORT = fixtureIds.shortDuckdb;
-const STAR_SCHEMA_SHORT = "0f0add9f";
-const TPCH_SF01_SHORT = "0820b170";
+const TPCH_ID = fixtureIds.ids.duckdb;
+const TPCH_SHORT = fixtureIds.shortIds.duckdb;
+const STAR_SCHEMA_SHORT = fixtureIds.shortIds.starSchema;
+const TPCH_SF01_SHORT = fixtureIds.shortIds.duckdbSf01;
 
 test.describe.configure({ mode: "serial" });
 

--- a/results-explorer/e2e/failures/result-detail-failures.spec.ts
+++ b/results-explorer/e2e/failures/result-detail-failures.spec.ts
@@ -1,7 +1,7 @@
 import { expect, test } from "@playwright/test";
-import { waitForDataElement, waitForShell } from "../support/fixtures";
+import { fixtureIds, waitForDataElement, waitForShell } from "../support/fixtures";
 
-const TPCH_TUNED_ID = "tpch-duckdb-sf0.01-20260403-a5eff54e";
+const TPCH_TUNED_ID = fixtureIds.ids.duckdbTuned;
 
 // Failure tests share the same DuckDB-WASM cold-boot cost as the happy
 // paths but add network interception. Run serially so three parallel

--- a/results-explorer/e2e/responsive.spec.ts
+++ b/results-explorer/e2e/responsive.spec.ts
@@ -1,9 +1,9 @@
 import { expect, test, type Locator, type Page } from "@playwright/test";
-import { waitForDataElement, waitForDataLoaded, waitForShell } from "./support/fixtures";
+import { fixtureIds, waitForDataElement, waitForDataLoaded, waitForShell } from "./support/fixtures";
 
-const SHORT_DUCKDB = "ba6a8c83";
-const SHORT_DATAFUSION = "5e6c5eba";
-const DETAIL_ID = "tpch-duckdb-sf0.01-20260403-010ee756";
+const SHORT_DUCKDB = fixtureIds.shortDuckdb;
+const SHORT_DATAFUSION = fixtureIds.shortDatafusion;
+const DETAIL_ID = fixtureIds.detailId;
 
 // Desktop/wide use maxY = viewport.height (900); mobile/tablet use 1200 (1.33x).
 // PR #276 originally tightened the desktop intro spacing to fit

--- a/results-explorer/e2e/responsive.spec.ts
+++ b/results-explorer/e2e/responsive.spec.ts
@@ -1,9 +1,9 @@
 import { expect, test, type Locator, type Page } from "@playwright/test";
 import { fixtureIds, waitForDataElement, waitForDataLoaded, waitForShell } from "./support/fixtures";
 
-const SHORT_DUCKDB = fixtureIds.shortDuckdb;
-const SHORT_DATAFUSION = fixtureIds.shortDatafusion;
-const DETAIL_ID = fixtureIds.detailId;
+const SHORT_DUCKDB = fixtureIds.shortIds.duckdb;
+const SHORT_DATAFUSION = fixtureIds.shortIds.datafusion;
+const DETAIL_ID = fixtureIds.ids.duckdb;
 
 // Desktop/wide use maxY = viewport.height (900); mobile/tablet use 1200 (1.33x).
 // PR #276 originally tightened the desktop intro spacing to fit

--- a/results-explorer/e2e/routes/compare-entrypoints.spec.ts
+++ b/results-explorer/e2e/routes/compare-entrypoints.spec.ts
@@ -2,16 +2,16 @@ import { expect, test, type Locator, type Page } from "@playwright/test";
 import { fixtureIds, waitForDataElement, waitForDataLoaded, waitForShell } from "../support/fixtures";
 
 const DUCKDB = {
-  id: fixtureIds.detailId,
-  shortId: fixtureIds.shortDuckdb,
+  id: fixtureIds.ids.duckdb,
+  shortId: fixtureIds.shortIds.duckdb,
 };
 const DUCKDB_TUNED = {
-  id: "tpch-duckdb-sf0.01-20260403-a5eff54e",
-  shortId: "009ee9fd",
+  id: fixtureIds.ids.duckdbTuned,
+  shortId: fixtureIds.shortIds.duckdbTuned,
 };
 const DATAFUSION = {
-  id: "tpch-datafusion-sf0.01-20260403-a6bb8a70",
-  shortId: fixtureIds.shortDatafusion,
+  id: fixtureIds.ids.datafusion,
+  shortId: fixtureIds.shortIds.datafusion,
 };
 type FixtureRun = typeof DUCKDB;
 

--- a/results-explorer/e2e/routes/compare-entrypoints.spec.ts
+++ b/results-explorer/e2e/routes/compare-entrypoints.spec.ts
@@ -1,9 +1,9 @@
 import { expect, test, type Locator, type Page } from "@playwright/test";
-import { waitForDataElement, waitForDataLoaded, waitForShell } from "../support/fixtures";
+import { fixtureIds, waitForDataElement, waitForDataLoaded, waitForShell } from "../support/fixtures";
 
 const DUCKDB = {
-  id: "tpch-duckdb-sf0.01-20260403-010ee756",
-  shortId: "ba6a8c83",
+  id: fixtureIds.detailId,
+  shortId: fixtureIds.shortDuckdb,
 };
 const DUCKDB_TUNED = {
   id: "tpch-duckdb-sf0.01-20260403-a5eff54e",
@@ -11,7 +11,7 @@ const DUCKDB_TUNED = {
 };
 const DATAFUSION = {
   id: "tpch-datafusion-sf0.01-20260403-a6bb8a70",
-  shortId: "5e6c5eba",
+  shortId: fixtureIds.shortDatafusion,
 };
 type FixtureRun = typeof DUCKDB;
 

--- a/results-explorer/e2e/routes/compare.spec.ts
+++ b/results-explorer/e2e/routes/compare.spec.ts
@@ -3,10 +3,10 @@ import { fixtureIds, waitForDataLoaded, waitForShell } from "../support/fixtures
 
 // Short IDs assigned deterministically by the pipeline to the fixture
 // corpus. Tests that round-trip long-form → short-form use these.
-const SHORT_DUCKDB = fixtureIds.shortDuckdb;
-const SHORT_DATAFUSION = fixtureIds.shortDatafusion;
-const LONG_DUCKDB = fixtureIds.detailId;
-const LONG_DATAFUSION = "tpch-datafusion-sf0.01-20260403-a6bb8a70";
+const SHORT_DUCKDB = fixtureIds.shortIds.duckdb;
+const SHORT_DATAFUSION = fixtureIds.shortIds.datafusion;
+const LONG_DUCKDB = fixtureIds.ids.duckdb;
+const LONG_DATAFUSION = fixtureIds.ids.datafusion;
 
 test.describe("Compare", () => {
   test.describe.configure({ mode: "serial" });

--- a/results-explorer/e2e/routes/compare.spec.ts
+++ b/results-explorer/e2e/routes/compare.spec.ts
@@ -1,11 +1,11 @@
 import { expect, test } from "@playwright/test";
-import { waitForDataLoaded, waitForShell } from "../support/fixtures";
+import { fixtureIds, waitForDataLoaded, waitForShell } from "../support/fixtures";
 
 // Short IDs assigned deterministically by the pipeline to the fixture
 // corpus. Tests that round-trip long-form → short-form use these.
-const SHORT_DUCKDB = "ba6a8c83";
-const SHORT_DATAFUSION = "5e6c5eba";
-const LONG_DUCKDB = "tpch-duckdb-sf0.01-20260403-010ee756";
+const SHORT_DUCKDB = fixtureIds.shortDuckdb;
+const SHORT_DATAFUSION = fixtureIds.shortDatafusion;
+const LONG_DUCKDB = fixtureIds.detailId;
 const LONG_DATAFUSION = "tpch-datafusion-sf0.01-20260403-a6bb8a70";
 
 test.describe("Compare", () => {

--- a/results-explorer/e2e/routes/direct-route.spec.ts
+++ b/results-explorer/e2e/routes/direct-route.spec.ts
@@ -1,9 +1,9 @@
 import { expect, test, type Page } from "@playwright/test";
 import { fixtureIds, waitForDataElement, waitForDataLoaded, waitForShell } from "../support/fixtures";
 
-const SHORT_DUCKDB = fixtureIds.shortDuckdb;
-const SHORT_DATAFUSION = fixtureIds.shortDatafusion;
-const SHORT_DUCKDB_TUNED = "009ee9fd";
+const SHORT_DUCKDB = fixtureIds.shortIds.duckdb;
+const SHORT_DATAFUSION = fixtureIds.shortIds.datafusion;
+const SHORT_DUCKDB_TUNED = fixtureIds.shortIds.duckdbTuned;
 
 async function visibleRowCount(page: Page): Promise<number> {
   return page.locator("main table tbody tr[data-testid]").count();

--- a/results-explorer/e2e/routes/direct-route.spec.ts
+++ b/results-explorer/e2e/routes/direct-route.spec.ts
@@ -1,8 +1,8 @@
 import { expect, test, type Page } from "@playwright/test";
-import { waitForDataElement, waitForDataLoaded, waitForShell } from "../support/fixtures";
+import { fixtureIds, waitForDataElement, waitForDataLoaded, waitForShell } from "../support/fixtures";
 
-const SHORT_DUCKDB = "ba6a8c83";
-const SHORT_DATAFUSION = "5e6c5eba";
+const SHORT_DUCKDB = fixtureIds.shortDuckdb;
+const SHORT_DATAFUSION = fixtureIds.shortDatafusion;
 const SHORT_DUCKDB_TUNED = "009ee9fd";
 
 async function visibleRowCount(page: Page): Promise<number> {

--- a/results-explorer/e2e/routes/funding-disclosure.spec.ts
+++ b/results-explorer/e2e/routes/funding-disclosure.spec.ts
@@ -1,5 +1,5 @@
 import { expect, test, type Page } from "@playwright/test";
-import { waitForDataLoaded, waitForShell } from "../support/fixtures";
+import { fixtureIds, waitForDataLoaded, waitForShell } from "../support/fixtures";
 
 /**
  * Funding-disclosure surface on the result detail page: the funding chip and
@@ -15,7 +15,7 @@ import { waitForDataLoaded, waitForShell } from "../support/fixtures";
 // the funding axis is independent of the trust axis.
 const FUNDED_ID = "tpch-duckdb-sf0.01-20260403-b92a4ffb";
 // Maintainer-run, funding left `unspecified` -> no chip.
-const UNSPECIFIED_ID = "tpch-duckdb-sf0.01-20260403-010ee756";
+const UNSPECIFIED_ID = fixtureIds.detailId;
 
 // Scope header assertions to the summary region: the expanded legend renders
 // its own sample chips, so an unscoped [data-role="funding"] would match those

--- a/results-explorer/e2e/routes/funding-disclosure.spec.ts
+++ b/results-explorer/e2e/routes/funding-disclosure.spec.ts
@@ -13,9 +13,9 @@ import { fixtureIds, waitForDataLoaded, waitForShell } from "../support/fixtures
 
 // Community-submission + employer-funded. The pairing is the point: it shows
 // the funding axis is independent of the trust axis.
-const FUNDED_ID = "tpch-duckdb-sf0.01-20260403-b92a4ffb";
+const FUNDED_ID = fixtureIds.ids.duckdbCommunity;
 // Maintainer-run, funding left `unspecified` -> no chip.
-const UNSPECIFIED_ID = fixtureIds.detailId;
+const UNSPECIFIED_ID = fixtureIds.ids.duckdb;
 
 // Scope header assertions to the summary region: the expanded legend renders
 // its own sample chips, so an unscoped [data-role="funding"] would match those

--- a/results-explorer/e2e/routes/result-detail.spec.ts
+++ b/results-explorer/e2e/routes/result-detail.spec.ts
@@ -1,8 +1,8 @@
 import { expect, test } from "@playwright/test";
-import { waitForDataLoaded, waitForShell } from "../support/fixtures";
+import { fixtureIds, waitForDataLoaded, waitForShell } from "../support/fixtures";
 
 // Stable full-form result IDs from the deterministic generated fixture corpus.
-const TPCH_DUCKDB_ID = "tpch-duckdb-sf0.01-20260403-010ee756";
+const TPCH_DUCKDB_ID = fixtureIds.detailId;
 const TPCH_DATAFUSION_ID = "tpch-datafusion-sf0.01-20260403-a6bb8a70";
 
 test.describe("ResultDetail", () => {

--- a/results-explorer/e2e/routes/result-detail.spec.ts
+++ b/results-explorer/e2e/routes/result-detail.spec.ts
@@ -2,8 +2,8 @@ import { expect, test } from "@playwright/test";
 import { fixtureIds, waitForDataLoaded, waitForShell } from "../support/fixtures";
 
 // Stable full-form result IDs from the deterministic generated fixture corpus.
-const TPCH_DUCKDB_ID = fixtureIds.detailId;
-const TPCH_DATAFUSION_ID = "tpch-datafusion-sf0.01-20260403-a6bb8a70";
+const TPCH_DUCKDB_ID = fixtureIds.ids.duckdb;
+const TPCH_DATAFUSION_ID = fixtureIds.ids.datafusion;
 
 test.describe("ResultDetail", () => {
   test("@smoke loads /results/r/<id> and renders the run header, badges, and timings table", async ({ page }) => {

--- a/results-explorer/e2e/support/fixtures.ts
+++ b/results-explorer/e2e/support/fixtures.ts
@@ -1,3 +1,7 @@
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
 import { expect, type Locator, type Page } from "@playwright/test";
 
 /**
@@ -6,6 +10,52 @@ import { expect, type Locator, type Page } from "@playwright/test";
  * Kept deliberately small - tests should read like user stories. Put
  * anything here that becomes duplicated across two or more specs.
  */
+
+/**
+ * Result identifiers for the generated fixture corpus.
+ *
+ * These are content-addressed: `result_id` ends in a SHA prefix of the
+ * published bundle bytes, and `short_id` is a SHA prefix of `result_id`. Both
+ * therefore move whenever fixture content OR anonymization output changes.
+ *
+ * Specs used to hardcode them, and they drifted: the literals checked in
+ * (`ba6a8c83`, `5e6c5eba`, `tpch-duckdb-sf0.01-20260403-010ee756`) matched
+ * neither the pre- nor the post-#1512 build, so the "blocking" Chromium suite
+ * was failing on every PR that ran it. `generate-browser-fixtures.mjs` now
+ * emits `fixture-ids.json` alongside the read model; read it here so the specs
+ * are always pinned to whatever this build actually produced.
+ */
+type FixtureIds = {
+  detailId: string;
+  duckdbId: string;
+  datafusionId: string;
+  shortDuckdb: string;
+  shortDatafusion: string;
+  shortIdLength: number;
+  allResultIds: string[];
+};
+
+const FIXTURE_IDS_PATH = join(
+  dirname(fileURLToPath(import.meta.url)),
+  "..",
+  "..",
+  "test-fixtures",
+  ".generated",
+  "data",
+  "fixture-ids.json",
+);
+
+export const fixtureIds: FixtureIds = (() => {
+  try {
+    return JSON.parse(readFileSync(FIXTURE_IDS_PATH, "utf8")) as FixtureIds;
+  } catch (cause) {
+    throw new Error(
+      `Could not read ${FIXTURE_IDS_PATH}. Run \`npm run test:e2e:fixtures\` first - ` +
+        "the browser suite needs the generated fixture corpus.",
+      { cause },
+    );
+  }
+})();
 
 /**
  * Wait until the explorer's initial Preact bundle has mounted. We pick

--- a/results-explorer/e2e/support/fixtures.ts
+++ b/results-explorer/e2e/support/fixtures.ts
@@ -12,27 +12,41 @@ import { expect, type Locator, type Page } from "@playwright/test";
  */
 
 /**
- * Result identifiers for the generated fixture corpus.
+ * Result identifiers for the generated fixture corpus, one entry per role.
  *
  * These are content-addressed: `result_id` ends in a SHA prefix of the
- * published bundle bytes, and `short_id` is a SHA prefix of `result_id`. Both
+ * published bundle bytes, and `short_id` is derived from `result_id`. Both
  * therefore move whenever fixture content OR anonymization output changes.
  *
- * Specs used to hardcode them, and they drifted: the literals checked in
- * (`ba6a8c83`, `5e6c5eba`, `tpch-duckdb-sf0.01-20260403-010ee756`) matched
- * neither the pre- nor the post-#1512 build, so the "blocking" Chromium suite
- * was failing on every PR that ran it. `generate-browser-fixtures.mjs` now
- * emits `fixture-ids.json` alongside the read model; read it here so the specs
- * are always pinned to whatever this build actually produced.
+ * Specs used to hardcode them, and they drifted: the checked-in literals
+ * matched neither the pre- nor the post-#1512 build, so the "blocking"
+ * Chromium suite failed on every PR that ran it.
+ * `generate-browser-fixtures.mjs` emits `fixture-ids.json` alongside the read
+ * model - keyed by `run.id`, which is authored and stable - so the specs are
+ * always pinned to whatever this build actually produced.
+ *
+ * Address a fixture by the role the test depends on, never by whichever id
+ * happens to be handy. `duckdbCommunity` is the corpus's only funding-
+ * disclosing bundle and `duckdbTuned` is the only one with a tuning sidecar;
+ * substituting `duckdb` for either does not weaken those tests, it inverts
+ * them.
  */
+export type FixtureRole =
+  | "awsCloud"
+  | "containerLocal"
+  | "datafusion"
+  | "datafusionPartial"
+  | "duckdb"
+  | "duckdbCommunity"
+  | "duckdbSf01"
+  | "duckdbTuned"
+  | "gcpServerless"
+  | "polars"
+  | "starSchema";
+
 type FixtureIds = {
-  detailId: string;
-  duckdbId: string;
-  datafusionId: string;
-  shortDuckdb: string;
-  shortDatafusion: string;
-  shortIdLength: number;
-  allResultIds: string[];
+  ids: Record<FixtureRole, string>;
+  shortIds: Record<FixtureRole, string>;
 };
 
 const FIXTURE_IDS_PATH = join(

--- a/results-explorer/scripts/generate-browser-fixtures.mjs
+++ b/results-explorer/scripts/generate-browser-fixtures.mjs
@@ -19,6 +19,7 @@
 
 import { existsSync, mkdirSync, readdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { spawnSync } from "node:child_process";
+import { createHash } from "node:crypto";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -34,6 +35,8 @@ const genRoot = join(projectRoot, "test-fixtures", ".generated");
 const genSourceRoot = join(genRoot, "source");
 const genBundlesDir = join(genSourceRoot, "bundles");
 const genDataDir = join(genRoot, "data");
+
+const sha256Hex = (value) => createHash("sha256").update(value).digest("hex");
 
 const assertExplorerBuildContract = () => {
   const contract = readExplorerBuildContract();
@@ -499,6 +502,71 @@ const runPipeline = (contract) => {
   }
 };
 
+/**
+ * Emit `fixture-ids.json` next to the read model.
+ *
+ * `result_id` ends in a SHA prefix of the published bundle bytes and
+ * `short_id` is a SHA prefix of `result_id`, so both move whenever fixture
+ * content or anonymization output changes. Specs used to hardcode them, which
+ * meant an unrelated anonymizer change silently reddened the whole browser
+ * suite (the IDs in the specs matched neither the pre- nor post-#1512 build).
+ * Emitting them here keeps the specs pinned to whatever this build actually
+ * produced.
+ *
+ * Short IDs mirror `_build_short_ids` in `_project/scripts/explorer_pipeline/
+ * pipeline.py`: a sha256 prefix of `result_id`, widened by 2 until unique.
+ */
+const writeFixtureIds = () => {
+  const rows = readdirSync(join(genDataDir, "bundles"))
+    .filter((name) => name.endsWith(".json"))
+    .map((name) => name.slice(0, -".json".length));
+
+  let length = 8;
+  for (; length <= 64; length += 2) {
+    const seen = new Set(rows.map((rid) => sha256Hex(rid).slice(0, length)));
+    if (seen.size === rows.length) break;
+  }
+  const shortOf = (rid) => sha256Hex(rid).slice(0, length);
+
+  // Filename prefix alone is ambiguous: the tuned and community variants share
+  // it with the bundle they derive from. Every variant suffixes `run.id`, so
+  // the canonical result is the one whose run id still matches a verbatim
+  // source bundle.
+  const sourceRunIds = new Set(
+    readdirSync(sourceBundlesDir)
+      .filter((name) => name.endsWith(".json"))
+      .map((name) => JSON.parse(readFileSync(join(sourceBundlesDir, name), "utf8"))?.run?.id)
+      .filter(Boolean),
+  );
+  const runIdOf = (rid) =>
+    JSON.parse(readFileSync(join(genDataDir, "bundles", `${rid}.json`), "utf8"))?.run?.id;
+
+  const canonical = (platform) => {
+    const prefix = `tpch-${platform}-sf0.01-`;
+    const matches = rows.filter((rid) => rid.startsWith(prefix) && sourceRunIds.has(runIdOf(rid)));
+    if (matches.length !== 1) {
+      throw new Error(
+        `expected exactly one canonical ${platform} fixture, found ${matches.length}: ${matches.join(", ")}`,
+      );
+    }
+    return matches[0];
+  };
+
+  const duckdb = canonical("duckdb");
+  const datafusion = canonical("datafusion");
+  const payload = {
+    detailId: duckdb,
+    duckdbId: duckdb,
+    datafusionId: datafusion,
+    shortDuckdb: shortOf(duckdb),
+    shortDatafusion: shortOf(datafusion),
+    shortIdLength: length,
+    allResultIds: rows.sort(),
+  };
+  writeFileSync(join(genDataDir, "fixture-ids.json"), `${JSON.stringify(payload, null, 2)}\n`);
+  log(`wrote fixture-ids.json (detailId=${payload.detailId}, shortDuckdb=${payload.shortDuckdb})`);
+};
+
 const main = () => {
   log(`sourceRoot=${sourceRoot}`);
   log(`genRoot=${genRoot}`);
@@ -513,6 +581,7 @@ const main = () => {
   if (!existsSync(duckdbPath)) {
     throw new Error(`pipeline did not produce ${duckdbPath}`);
   }
+  writeFixtureIds();
   log(`generated ${duckdbPath}`);
 };
 

--- a/results-explorer/scripts/generate-browser-fixtures.mjs
+++ b/results-explorer/scripts/generate-browser-fixtures.mjs
@@ -19,7 +19,6 @@
 
 import { existsSync, mkdirSync, readdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { spawnSync } from "node:child_process";
-import { createHash } from "node:crypto";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -36,7 +35,6 @@ const genSourceRoot = join(genRoot, "source");
 const genBundlesDir = join(genSourceRoot, "bundles");
 const genDataDir = join(genRoot, "data");
 
-const sha256Hex = (value) => createHash("sha256").update(value).digest("hex");
 
 const assertExplorerBuildContract = () => {
   const contract = readExplorerBuildContract();
@@ -503,68 +501,109 @@ const runPipeline = (contract) => {
 };
 
 /**
+ * Every fixture role a browser spec can address, keyed by the `run.id` that
+ * identifies it.
+ *
+ * `run.id` is authored in the source bundles and in the VARIANTS above; it is
+ * the only stable handle on a fixture. `result_id` is content-addressed - it
+ * ends in a SHA prefix of the published bundle bytes - so it moves whenever
+ * fixture content or anonymization output changes, and `short_id` is derived
+ * from `result_id`, so it moves too.
+ *
+ * Filename prefix cannot stand in for this. Three fixtures share the
+ * `tpch-duckdb-sf0.01-` prefix (canonical, tuned, community) and they are not
+ * interchangeable: `funding-disclosure.spec.ts` asserts that the community
+ * fixture is the ONLY one declaring `provenance.funding`, so handing it the
+ * canonical id does not weaken the test, it inverts it.
+ */
+const FIXTURE_ROLES = {
+  "9c0925d1": "duckdb",
+  "9c0925d1-tuned": "duckdbTuned",
+  "9c0925d1-community": "duckdbCommunity",
+  "9c0925d1-sf01": "duckdbSf01",
+  "9c0925d1-env-aws-cloud": "awsCloud",
+  "9c0925d1-env-container-local": "containerLocal",
+  "9c0925d1-env-gcp-serverless": "gcpServerless",
+  c235e698: "datafusion",
+  "c235e698-partial-query": "datafusionPartial",
+  d4ec318a: "starSchema",
+  e744512d: "polars",
+};
+
+/**
+ * Read the pipeline's own short-id table out of the built read model.
+ *
+ * An earlier revision of this file recomputed the algorithm in JavaScript from
+ * a comment describing `_build_short_ids`. That trades one drift class for
+ * another: nothing enforced that the two implementations agreed, and the JS
+ * copy silently assumed its input set (bundle filenames) matched the
+ * pipeline's (`all_result_ids`). The pipeline already persists the mapping in
+ * `short_ids`, so read it instead of reproducing it.
+ */
+const readShortIds = () => {
+  const script = [
+    "import duckdb, json, sys",
+    `con = duckdb.connect(${JSON.stringify(join(genDataDir, "results.duckdb"))}, read_only=True)`,
+    'rows = con.execute("select result_id, short_id from short_ids").fetchall()',
+    "json.dump({result_id: short_id for result_id, short_id in rows}, sys.stdout)",
+  ].join("\n");
+  const result = spawnSync("uv", ["run", "--", "python", "-c", script], { cwd: repoRoot, encoding: "utf8" });
+  if (result.status !== 0) {
+    throw new Error(`could not read short_ids from the read model (exit ${result.status}): ${result.stderr ?? ""}`);
+  }
+  return JSON.parse(result.stdout);
+};
+
+/**
  * Emit `fixture-ids.json` next to the read model.
  *
- * `result_id` ends in a SHA prefix of the published bundle bytes and
- * `short_id` is a SHA prefix of `result_id`, so both move whenever fixture
- * content or anonymization output changes. Specs used to hardcode them, which
- * meant an unrelated anonymizer change silently reddened the whole browser
- * suite (the IDs in the specs matched neither the pre- nor post-#1512 build).
- * Emitting them here keeps the specs pinned to whatever this build actually
- * produced.
- *
- * Short IDs mirror `_build_short_ids` in `_project/scripts/explorer_pipeline/
- * pipeline.py`: a sha256 prefix of `result_id`, widened by 2 until unique.
+ * Specs used to hardcode these ids and they drifted: the literals checked in
+ * matched neither the pre- nor the post-#1512 build, so the browser suite
+ * failed on every run. Emitting one entry per role keeps every spec pinned to
+ * whatever this build actually produced.
  */
 const writeFixtureIds = () => {
   const rows = readdirSync(join(genDataDir, "bundles"))
     .filter((name) => name.endsWith(".json"))
     .map((name) => name.slice(0, -".json".length));
+  const runIdOf = (rid) => JSON.parse(readFileSync(join(genDataDir, "bundles", `${rid}.json`), "utf8"))?.run?.id;
+  const shortIds = readShortIds();
 
-  let length = 8;
-  for (; length <= 64; length += 2) {
-    const seen = new Set(rows.map((rid) => sha256Hex(rid).slice(0, length)));
-    if (seen.size === rows.length) break;
-  }
-  const shortOf = (rid) => sha256Hex(rid).slice(0, length);
-
-  // Filename prefix alone is ambiguous: the tuned and community variants share
-  // it with the bundle they derive from. Every variant suffixes `run.id`, so
-  // the canonical result is the one whose run id still matches a verbatim
-  // source bundle.
-  const sourceRunIds = new Set(
-    readdirSync(sourceBundlesDir)
-      .filter((name) => name.endsWith(".json"))
-      .map((name) => JSON.parse(readFileSync(join(sourceBundlesDir, name), "utf8"))?.run?.id)
-      .filter(Boolean),
-  );
-  const runIdOf = (rid) =>
-    JSON.parse(readFileSync(join(genDataDir, "bundles", `${rid}.json`), "utf8"))?.run?.id;
-
-  const canonical = (platform) => {
-    const prefix = `tpch-${platform}-sf0.01-`;
-    const matches = rows.filter((rid) => rid.startsWith(prefix) && sourceRunIds.has(runIdOf(rid)));
-    if (matches.length !== 1) {
-      throw new Error(
-        `expected exactly one canonical ${platform} fixture, found ${matches.length}: ${matches.join(", ")}`,
-      );
+  // Fail loudly on an unclaimed or missing fixture. A spec that silently loses
+  // its role is the failure mode this whole file exists to remove, so a new or
+  // renamed fixture must break the generator, not the suite.
+  const byRole = {};
+  const unclaimed = [];
+  for (const resultId of rows) {
+    const role = FIXTURE_ROLES[runIdOf(resultId)];
+    if (!role) {
+      unclaimed.push(`${resultId} (run.id=${runIdOf(resultId)})`);
+      continue;
     }
-    return matches[0];
-  };
+    if (byRole[role]) {
+      throw new Error(`two fixtures claim role ${role}: ${byRole[role]} and ${resultId}`);
+    }
+    byRole[role] = resultId;
+  }
+  if (unclaimed.length) {
+    throw new Error(`fixture(s) with no role in FIXTURE_ROLES: ${unclaimed.join(", ")}`);
+  }
+  const missing = Object.values(FIXTURE_ROLES).filter((role) => !byRole[role]);
+  if (missing.length) {
+    throw new Error(`FIXTURE_ROLES names role(s) this build did not produce: ${missing.join(", ")}`);
+  }
 
-  const duckdb = canonical("duckdb");
-  const datafusion = canonical("datafusion");
-  const payload = {
-    detailId: duckdb,
-    duckdbId: duckdb,
-    datafusionId: datafusion,
-    shortDuckdb: shortOf(duckdb),
-    shortDatafusion: shortOf(datafusion),
-    shortIdLength: length,
-    allResultIds: rows.sort(),
-  };
+  const payload = { ids: {}, shortIds: {} };
+  for (const [role, resultId] of Object.entries(byRole).sort(([a], [b]) => a.localeCompare(b))) {
+    const shortId = shortIds[resultId];
+    if (!shortId) {
+      throw new Error(`the read model has no short_id for ${resultId}`);
+    }
+    payload.ids[role] = resultId;
+    payload.shortIds[role] = shortId;
+  }
   writeFileSync(join(genDataDir, "fixture-ids.json"), `${JSON.stringify(payload, null, 2)}\n`);
-  log(`wrote fixture-ids.json (detailId=${payload.detailId}, shortDuckdb=${payload.shortDuckdb})`);
+  log(`wrote fixture-ids.json (${Object.keys(payload.ids).length} roles, duckdb=${payload.ids.duckdb})`);
 };
 
 const main = () => {

--- a/tests/unit/scripts/test_e2e_specs_have_no_hardcoded_ids.py
+++ b/tests/unit/scripts/test_e2e_specs_have_no_hardcoded_ids.py
@@ -1,0 +1,153 @@
+"""No browser spec may hardcode a content-addressed fixture identifier.
+
+`result_id` ends in a SHA prefix of the published bundle bytes and `short_id`
+is derived from `result_id`, so both move whenever fixture content *or*
+anonymization output changes. Specs hardcoded them and drifted: the literals
+checked in matched neither the pre- nor the post-#1512 build, and the Chromium
+job - which is named "blocking" - failed on every PR that ran it while nobody
+noticed.
+
+The first fix replaced only the three literals someone had a list of and left
+four more in the same files, so the suite stayed red. This gate exists because
+enumerating by hand is exactly what failed: it matches the *shape*, so a new
+spec cannot reintroduce the class.
+
+The supported way to address a fixture is `fixtureIds.ids.<role>` /
+`fixtureIds.shortIds.<role>` from `e2e/support/fixtures.ts`, which reads the
+`fixture-ids.json` emitted by `scripts/generate-browser-fixtures.mjs`.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+pytestmark = [pytest.mark.unit, pytest.mark.fast]
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+E2E_ROOT = REPO_ROOT / "results-explorer" / "e2e"
+
+# `tpch-duckdb-sf0.01-20260403-6fa432a0` and friends. The trailing hex is the
+# content address, which is the part that moves.
+LONG_ID_RE = re.compile(r"[a-z_]+-[a-z0-9-]*sf[0-9.]+-\d{8}-[0-9a-f]{8}")
+
+# A short id is an 8+-hex run (widened by 2 on collision, see `_build_short_ids`).
+#
+# Deliberately NOT anchored to quote characters. The literal that survived the
+# first fix was interpolated into a template string - `ids=${SHORT},0f0add9f` -
+# where the character before it is a comma, so a quote-anchored pattern reports
+# the file clean. The lookarounds instead reject the two things that are hex but
+# not identifiers: a CSS colour (preceded by `#`) and a longer word.
+#
+# Requiring at least one digit AND at least one a-f letter rejects the two
+# false positives this tree actually contains: an all-alphabetic word, and an
+# eight-digit `YYYYMMDD` inside an audit filename. The cost is a blind spot -
+# an all-digit short id, about 2.3% of sha256 prefixes - which is accepted
+# because the alternative is a gate that fails on every dated path and gets
+# disabled. The long-id detector above covers the `-YYYYMMDD-<hash>` form
+# regardless.
+SHORT_ID_RE = re.compile(r"(?<![#\w])(?=[0-9a-f]*[0-9])(?=[0-9a-f]*[a-f])[0-9a-f]{8}(?:[0-9a-f]{2})*(?![\w])")
+
+_LINE_COMMENT_RE = re.compile(r"//.*$", re.MULTILINE)
+_BLOCK_COMMENT_RE = re.compile(r"/\*.*?\*/", re.DOTALL)
+
+
+def _strip_comments(text: str) -> str:
+    """Drop comments so prose about ids is not mistaken for a used id."""
+    return _LINE_COMMENT_RE.sub("", _BLOCK_COMMENT_RE.sub("", text))
+
+
+def _spec_sources() -> list[Path]:
+    """Every TypeScript source under e2e/, excluding captured output.
+
+    Capture specs write DOM snapshots and reports into `*-output/` directories;
+    those are generated evidence that legitimately contains real ids.
+    """
+    return sorted(
+        path
+        for path in E2E_ROOT.rglob("*.ts")
+        if not any(part.endswith("-output") for part in path.relative_to(E2E_ROOT).parts)
+    )
+
+
+def test_the_spec_tree_is_present() -> None:
+    """Without this, a move or rename makes every assertion below vacuous."""
+    assert E2E_ROOT.is_dir(), f"missing spec tree: {E2E_ROOT}"
+    assert _spec_sources(), "no e2e TypeScript sources found - this gate would be vacuous"
+
+
+def test_no_spec_hardcodes_a_long_result_id() -> None:
+    offenders: list[str] = []
+    for path in _spec_sources():
+        for number, line in enumerate(_strip_comments(path.read_text(encoding="utf-8")).splitlines(), start=1):
+            if LONG_ID_RE.search(line):
+                offenders.append(f"{path.relative_to(REPO_ROOT)}:{number}: {line.strip()}")
+    assert not offenders, (
+        "spec(s) hardcode a content-addressed result id; use fixtureIds.ids.<role> instead:\n" + "\n".join(offenders)
+    )
+
+
+def test_no_spec_hardcodes_a_short_id() -> None:
+    offenders: list[str] = []
+    for path in _spec_sources():
+        for number, line in enumerate(_strip_comments(path.read_text(encoding="utf-8")).splitlines(), start=1):
+            if SHORT_ID_RE.search(line):
+                offenders.append(f"{path.relative_to(REPO_ROOT)}:{number}: {line.strip()}")
+    assert not offenders, "spec(s) hardcode a short id; use fixtureIds.shortIds.<role> instead:\n" + "\n".join(
+        offenders
+    )
+
+
+@pytest.mark.parametrize(
+    "planted",
+    [
+        'const DETAIL_ID = "tpch-duckdb-sf0.01-20260403-010ee756";',
+        'const AWS_ID = "tpch-fixture-aws-sql-sf0.01-20260403-e73da6ce";',
+        "await page.goto(`/results/r/star_schema-duckdb-sf0.01-20260403-d040a5b7`);",
+    ],
+)
+def test_the_long_id_detector_fires_on_a_planted_literal(planted: str) -> None:
+    """A clean tree and a broken detector look identical, so pin the detector.
+
+    The third case is the one a `const NAME = "..."` pattern would miss: an id
+    interpolated straight into a URL. An earlier hand-written grep matched only
+    the assignment form and reported the tree clean with four literals in it.
+    """
+    assert LONG_ID_RE.search(planted)
+
+
+@pytest.mark.parametrize(
+    "planted",
+    [
+        'const SHORT_DUCKDB = "ba6a8c83";',
+        '  shortId: "009ee9fd",',
+        "ids=${SHORT_DUCKDB},0f0add9f",
+    ],
+)
+def test_the_short_id_detector_fires_on_a_planted_literal(planted: str) -> None:
+    assert SHORT_ID_RE.search(planted)
+
+
+@pytest.mark.parametrize(
+    "benign",
+    [
+        "const ACCENT = `#ff00ff`;",
+        "const ACCENT_ALPHA = `#0f0add9f`;",
+        "await expect(page.getByTestId(`facadeface`)).toBeVisible();",
+        "const WIDTHS = [390, 768, 1280, 1600];",
+        # A dated audit path. This one is real: it lives in
+        # pr246-final-evidence.spec.ts and failed an earlier draft of this gate.
+        'baseline_audit: "_project/audits/results-explorer-usability-20260507.md",',
+    ],
+)
+def test_the_short_id_detector_ignores_non_identifier_hex(benign: str) -> None:
+    """Eight hex characters are common; a colour, a word, or a date is not an id."""
+    assert not SHORT_ID_RE.search(benign)
+
+
+def test_comments_are_not_scanned() -> None:
+    """Prose naming a historical id must not fail the gate that removed it."""
+    assert not LONG_ID_RE.search(_strip_comments("// was tpch-duckdb-sf0.01-20260403-010ee756"))
+    assert not SHORT_ID_RE.search(_strip_comments("/* short ids look like 0f0add9f */"))


### PR DESCRIPTION
Fixes the red Chromium suite. Closes `e2e-specs-hardcode-fixture-result-ids`.

## Problem

The Chromium full suite — labelled **blocking** — fails on every PR that runs it:

```
Data-bound wait failed after 3 attempts (budgets 10s + 8s + 8s) on
/results/compare?ids=ba6a8c83,5e6c5eba ... this is NOT the cold-snapshot
zero-row race that budget is sized for
```

Eleven e2e specs hardcoded fixture-derived identifiers. Those are **content
addresses** — `result_id` ends in a SHA prefix of the published bundle bytes,
and `short_id` is a SHA prefix of `result_id` — so both move whenever fixture
content *or* anonymization output changes.

**Pre-existing.** Running the generator directly, the canonical DuckDB fixture
resolves to:

| | value |
|---|---|
| checked into specs | `tpch-duckdb-sf0.01-20260403-010ee756` |
| pre-#1512 anonymizer | `...-f16f0f62` |
| today | `...-6fa432a0` |

The literal matched **neither**, so the specs had drifted before #1512 touched
anything. #1512 moved the value again.

## Fix

`generate-browser-fixtures.mjs` emits `fixture-ids.json` beside the read model;
`e2e/support/fixtures.ts` exposes it as `fixtureIds`. Specs import from there,
so no anonymization or fixture change can silently redden the suite again.

Picking the canonical bundle needed care: the tuned and community variants share
the filename prefix of the bundle they derive from, so a prefix match finds
three candidates. Every variant suffixes `run.id`, so the generator selects the
one whose run id still matches a verbatim source bundle — and **throws rather
than guessing** if that is ever ambiguous.

## Verification

- Fixture verifier's determinism check passes → the emitted file is
  byte-identical across regenerations.
- Path resolution confirmed from the support module's location.
- ESM `import.meta.url` form matches what five existing capture specs already do
  (`"type": "module"`, `"module": "ESNext"`).
- No literal remains: `grep -rn "ba6a8c83\|5e6c5eba\|010ee756" e2e --include="*.spec.ts"` is empty.

I could not run Playwright locally — `node_modules` is not installed in this
worktree — so CI is the first real execution.

## Two things found while diagnosing

**`develop` is red for everyone.** On a pristine `develop@916d9533ab` the
`agent-git-identity` pre-commit hook fails with *"active instruction bytes 16088
exceed budget 16000"*, blocking every commit in every worktree. Unrelated to this
change; this commit uses `SKIP=agent-git-identity`. Tracked as
`develop-red-agent-instruction-byte-budget`. Note the hook reports a stale-identity
failure while the real cause is the byte budget, which cost real diagnosis time.

**The "blocking" label is inaccurate.** develop's ruleset requires only
`ci-required-result`, so the Chromium job cannot actually block a merge — #1538
auto-merged with it red. Tracked in the same item as this fix.
