### PR TITLE
ci: run the orphan backstop daily, not weekly

### DIFF
--- a/.github/workflows/orphaned-commit-detector.yml
+++ b/.github/workflows/orphaned-commit-detector.yml
@@ -15,8 +15,18 @@ name: Orphaned Commit Detector
 
 on:
   schedule:
-    # Weekly, Monday 07:00 UTC (after the submission-validator drift check).
-    - cron: "0 7 * * 1"
+    # Daily, 07:00 UTC. Deliberately not weekly.
+    #
+    # The push trigger below cannot cover every case: for a `push` event GitHub
+    # runs the workflow file *from the pushed commit*, so an orphaning push to a
+    # branch created before that trigger landed - and never rebased - runs the
+    # branch's own older workflow and detects nothing. Those orphans are only
+    # ever caught here.
+    #
+    # This run is the one that reads develop's workflow and allowlist and scans
+    # every branch, so it is the true backstop. Weekly left a stale-branch
+    # orphan invisible for up to seven days; daily bounds it to one.
+    - cron: "0 7 * * *"
   workflow_dispatch: {}
   # Run on EVERY develop push, not just changes to the detector itself.
   #

--- a/tests/unit/workflows/test_auto_merge_partial_stack_race.py
+++ b/tests/unit/workflows/test_auto_merge_partial_stack_race.py
@@ -133,3 +133,24 @@ def test_auto_merge_partial_stack_detector_uses_the_pushed_allowlist() -> None:
     assert "ref" not in checkout.get("with", {}), (
         "detector pins a checkout ref, so a push cannot be judged by its own allowlist"
     )
+
+
+def test_auto_merge_partial_stack_backstop_runs_at_least_daily() -> None:
+    """The schedule is the only cover for orphans pushed to stale branches.
+
+    For a `push` event GitHub runs the workflow file from the pushed commit, so
+    an orphaning push to a branch created before the all-branch trigger landed -
+    and never rebased - runs that branch's older workflow and detects nothing.
+    Only the scheduled run, which reads develop's workflow and allowlist and
+    scans every branch, catches those. A weekly cadence left them invisible for
+    up to seven days.
+    """
+    schedule = _triggers(_load(DETECTOR_WORKFLOW))["schedule"]
+    crons = [entry["cron"] for entry in schedule]
+    assert crons, "detector has no scheduled backstop"
+    for cron in crons:
+        day_of_week = cron.split()[4]
+        day_of_month = cron.split()[2]
+        assert day_of_week == "*" and day_of_month == "*", (
+            f"backstop cron {cron!r} runs less often than daily; a stale-branch orphan stays invisible until it fires"
+        )


### PR DESCRIPTION
Addresses Codex **P2** on #1534 (merged, so this is a follow-up). Correct finding, and it exposes a real limit of the all-branch trigger I added.

## The gap

For a `push` event GitHub runs the workflow file **from the pushed commit**. So an orphaning push to a branch created before the all-branch trigger landed — and never rebased — runs that branch's *older* workflow and detects nothing.

Those orphans are only ever caught by the **scheduled** run, which reads develop's workflow and allowlist and scans every branch. That makes the schedule the true backstop rather than a formality — and weekly left a stale-branch orphan invisible for up to seven days. Daily bounds it to one.

## Test

Rejects any cron that is not *at least* daily rather than pinning the exact expression, so tightening the cadence stays allowed and loosening it does not. Falsified by restoring the weekly cron:

```
AssertionError: backstop cron '0 7 * * 1' runs less often than daily;
a stale-branch orphan stays invisible until it fires
```

## Identity finding: refuted

`c19c1b5f` is not on #1534 — that branch carried `22e6aec5` and `e2c62d05`, both `author=Joe Harris <joeharris76@gmail.com>`. Sixth instance across this batch; every one verified false against actual commit metadata.