### PR TITLE
fix(mcp): four incidental surface defects; refute the fifth

### DIFF
--- a/benchbox/mcp/errors.py
+++ b/benchbox/mcp/errors.py
@@ -321,6 +321,7 @@ def make_not_found_error(
     resource_type: str,
     resource_id: str,
     available: list[str] | None = None,
+    suggestion: str | None = None,
 ) -> dict[str, Any]:
     """Create a resource not found error response.
 
@@ -328,6 +329,9 @@ def make_not_found_error(
         resource_type: Type of resource (e.g., "benchmark", "platform")
         resource_id: ID/name that was not found
         available: List of available options
+        suggestion: Recovery hint. The default is derived from ``resource_type``
+            and only names a real tool for resource types whose listing tool is
+            ``list_<type>s``; pass an explicit hint for anything else.
 
     Returns:
         Standardized error response with suggestions.
@@ -339,7 +343,8 @@ def make_not_found_error(
     if available:
         details["available"] = available
 
-    suggestion = f"Use list_{resource_type}s() to see available options" if resource_type else None
+    if suggestion is None and resource_type:
+        suggestion = f"Use list_{resource_type}s() to see available options"
 
     return make_error(
         ErrorCode.RESOURCE_NOT_FOUND,

--- a/benchbox/mcp/jobs.py
+++ b/benchbox/mcp/jobs.py
@@ -587,6 +587,9 @@ class DurableJobWorker:
             platform_options=request.get("platform_options"),
             results_dir=staging,
             execution_id=job.execution_id,
+            # Durable jobs only exist under a remote security policy, so the
+            # consumer is always a remote tenant.
+            anonymize=True,
         )
 
     async def run(self) -> None:

--- a/benchbox/mcp/server.py
+++ b/benchbox/mcp/server.py
@@ -186,6 +186,7 @@ Then inspect plans: get_query_plan(result_file="...", query_id="19")
         mcp,
         results_dir=results_provider,
         allow_synchronous_execution=remote_security is None,
+        anonymize_results=remote_security is not None,
     )
     if job_runtime is not None:
         from benchbox.mcp.jobs import register_durable_job_tools
@@ -196,7 +197,11 @@ Then inspect plans: get_query_plan(result_file="...", query_id="19")
     register_results_tools(mcp, results_dir=results_provider)
 
     logger.info("Registering analytics tools...")
-    register_analytics_tools(mcp, results_dir=results_provider)
+    register_analytics_tools(
+        mcp,
+        results_dir=results_provider,
+        anonymize_results=remote_security is not None,
+    )
 
     logger.info("Registering visualization tools...")
     register_visualization_tools(

--- a/benchbox/mcp/tools/analytics.py
+++ b/benchbox/mcp/tools/analytics.py
@@ -54,8 +54,20 @@ def _resolve_validation_directory(directory: str, results_dir: Path, *, tenant_s
     return candidate
 
 
-def register_analytics_tools(mcp: MCPServer, *, results_dir: PathProvider) -> None:
-    """Register analytics tools with the MCP server."""
+def register_analytics_tools(
+    mcp: MCPServer,
+    *,
+    results_dir: PathProvider,
+    anonymize_results: bool = False,
+) -> None:
+    """Register analytics tools with the MCP server.
+
+    Args:
+        mcp: Server to register on.
+        results_dir: Provider for the server-owned result root.
+        anonymize_results: True when the server runs under a remote security
+            policy; see ``register_benchmark_tools``.
+    """
     tenant_scoped = not isinstance(results_dir, Path)
 
     @mcp.tool(annotations=ANALYTICS_READONLY_ANNOTATIONS)
@@ -96,7 +108,9 @@ def register_analytics_tools(mcp: MCPServer, *, results_dir: PathProvider) -> No
                     "compare analysis requires file1 and file2 parameters",
                     suggestion="Provide both file1 and file2 for comparison",
                 )
-            return _compare_results_impl(file1, file2, threshold_percent, configured_results_dir)
+            return _compare_results_impl(
+                file1, file2, threshold_percent, configured_results_dir, anonymize=anonymize_results
+            )
 
         elif analysis_lower == "regressions":
             return _detect_regressions_impl(platform, benchmark, threshold_percent, limit, configured_results_dir)
@@ -192,7 +206,11 @@ def register_analytics_tools(mcp: MCPServer, *, results_dir: PathProvider) -> No
         if result_file:
             file_path = resolve_result_file_path(result_file, configured_results_dir)
             if file_path is None or not file_path.exists():
-                return make_not_found_error(result_file, configured_results_dir)
+                return make_not_found_error(
+                    "result_file",
+                    result_file,
+                    suggestion='Use get_results(format="list") to see available result files',
+                )
             report = _validate_file(file_path)
             checks = [
                 {
@@ -336,7 +354,12 @@ def _get_query_plan_impl(file_path: Path, result_file: str, query_id: str, forma
 
     if not query_exec:
         available_ids = [str(q.get("id", "")) for q in data.get("queries", []) if q.get("id")]
-        return make_not_found_error("query", query_id, available=sorted(set(available_ids))[:20])
+        return make_not_found_error(
+            "query",
+            query_id,
+            available=sorted(set(available_ids))[:20],
+            suggestion="Use get_query_details() with a query ID from `details.available`",
+        )
 
     plans_path = _resolve_plans_path(file_path)
     query_info = {"runtime_ms": query_exec.get("ms"), "status": query_exec.get("status")}
@@ -365,15 +388,22 @@ def _get_query_plan_impl(file_path: Path, result_file: str, query_id: str, forma
     return _format_plan_response(query_plan_entry["plan"], format_lower, normalized_id, query_exec.get("ms"))
 
 
-def _compare_results_impl(file1: str, file2: str, threshold_percent: float, results_dir: Path) -> dict[str, Any]:
+def _compare_results_impl(
+    file1: str,
+    file2: str,
+    threshold_percent: float,
+    results_dir: Path,
+    *,
+    anonymize: bool = False,
+) -> dict[str, Any]:
     """Compare two benchmark runs."""
-    # egress-reviewed: MCP serves a local, same-trust-boundary agent that
+    # egress-reviewed: local stdio serves a same-trust-boundary agent that
     # needs real paths/hostnames to act on results; secrets are already
     # redacted at capture time by sanitize_platform_options, and exception
-    # text is scrubbed in mcp/errors.py. Full anonymization would break
-    # path-based workflows without closing a live channel.
+    # text is scrubbed in mcp/errors.py. Remote/tenant mode is a different
+    # trust boundary, so the caller sets anonymize=True there.
     exporter = ResultExporter(
-        anonymize=False,  # egress-reviewed: local consumer, see comment above
+        anonymize=anonymize,
         console=get_quiet_console(),
     )
     path1 = resolve_result_file_path(file1, results_dir)

--- a/benchbox/mcp/tools/benchmark.py
+++ b/benchbox/mcp/tools/benchmark.py
@@ -191,8 +191,20 @@ def register_benchmark_tools(
     *,
     results_dir: PathProvider,
     allow_synchronous_execution: bool = True,
+    anonymize_results: bool = False,
 ) -> None:
-    """Register benchmark execution tools with the MCP server."""
+    """Register benchmark execution tools with the MCP server.
+
+    Args:
+        mcp: Server to register on.
+        results_dir: Provider for the server-owned result root.
+        allow_synchronous_execution: False in remote mode, where normal runs
+            must go through ``start_benchmark``.
+        anonymize_results: True when the server runs under a remote security
+            policy. Local stdio serves a same-trust-boundary agent and keeps
+            real paths and hostnames; a remote tenant is a different trust
+            boundary, so exported bundles are anonymized.
+    """
 
     @mcp.tool(annotations=RUN_BENCHMARK_ANNOTATIONS)
     def run_benchmark(
@@ -268,6 +280,7 @@ def register_benchmark_tools(
             capture_plans,
             platform_options=normalized_platform_options,
             results_dir=resolve_path_provider(results_dir),
+            anonymize=anonymize_results,
         )
 
     @mcp.tool(annotations=QUERY_DETAILS_ANNOTATIONS)
@@ -341,20 +354,29 @@ def _export_and_build_payload(
     result: Any,
     execution_id: str,
     results_dir: Path,
+    *,
+    anonymize: bool,
 ) -> tuple[str | None, dict[str, Any] | None]:
-    """Export benchmark result to JSON and build payload dict."""
+    """Export benchmark result to JSON and build payload dict.
+
+    Args:
+        anonymize: True under a remote security policy. Local stdio serves a
+            same-trust-boundary agent that needs real paths and hostnames to act
+            on results, so it stays False there; a remote tenant is a different
+            trust boundary and receives an anonymized bundle.
+    """
     result_file_path = None
     result_payload: dict[str, Any] | None = None
     try:
         result.execution_id = execution_id
-        # egress-reviewed: MCP serves a local, same-trust-boundary agent that
+        # egress-reviewed: local stdio serves a same-trust-boundary agent that
         # needs real paths/hostnames to act on results; secrets are already
         # redacted at capture time by sanitize_platform_options, and exception
-        # text is scrubbed in mcp/errors.py. Full anonymization would break
-        # path-based workflows without closing a live channel.
+        # text is scrubbed in mcp/errors.py. Remote/tenant mode is a different
+        # trust boundary, so the caller sets anonymize=True there.
         exporter = ResultExporter(
             output_dir=results_dir,
-            anonymize=False,  # egress-reviewed: local consumer, see comment above
+            anonymize=anonymize,
             console=get_quiet_console(),
         )
         exported_files = exporter.export_result(result, formats=["json"])
@@ -400,8 +422,21 @@ def _run_benchmark_impl(
     platform_options: Mapping[str, object] | None = None,
     results_dir: Path,
     execution_id: str | None = None,
+    anonymize: bool = False,
 ) -> dict[str, Any]:
-    """Core implementation for running benchmarks."""
+    """Core implementation for running benchmarks.
+
+    Args:
+        platform_options: Re-admitted here even when the caller already ran
+            ``validate_platform_options``. This is the last gate before an
+            adapter is constructed, and some adapters act in ``__init__`` -- the
+            Dask adapter builds its ``LocalCluster`` there -- so a request that
+            reaches this function unadmitted would be executed, not merely
+            accepted. It is also the only gate on the durable-job worker path,
+            where the request mapping is re-read from persistent storage.
+        anonymize: Passed through to the result exporter; see
+            ``_export_and_build_payload``.
+    """
     execution_id = execution_id or f"mcp_{uuid.uuid4().hex[:8]}"
     start_time = mono_time()
 
@@ -516,7 +551,9 @@ def _run_benchmark_impl(
         execution_time = elapsed_seconds(start_time)
 
         result_file_path, result_payload = (
-            _export_and_build_payload(result, execution_id, results_dir) if result else (None, None)
+            _export_and_build_payload(result, execution_id, results_dir, anonymize=anonymize)
+            if result
+            else (None, None)
         )
 
         response: dict[str, Any] = result_payload or {}

--- a/benchbox/mcp/tools/visualization.py
+++ b/benchbox/mcp/tools/visualization.py
@@ -380,9 +380,13 @@ def register_visualization_tools(
             - Comparison: generate_chart(result_files="duckdb.json,polars.json", chart_type="query_heatmap", format="ascii")
 
         ASCII charts are rendered inline and returned in the 'content' field. They include:
-            - ANSI colors for terminal display (copy-paste preserves formatting)
             - Unicode box-drawing characters for clean visualization
             - Best/worst highlighting, legends, and scale indicators
+
+        Output is deliberately ANSI-color-free. MCP responses are protocol
+        payloads consumed by non-terminal clients, where escape sequences are
+        noise rather than formatting, so the renderer is always constructed with
+        ``ChartOptions(use_color=False)``.
         """
         file_list = [f.strip() for f in result_files.split(",") if f.strip()]
         if not file_list:

--- a/docs/reference/mcp.md
+++ b/docs/reference/mcp.md
@@ -293,6 +293,11 @@ modes remain available because they do not hold the request for execution.
   benchmark and adapter APIs.
 - MCP execution intentionally suppresses console output and returns structured
   JSON for agent clients.
+- Exported result bundles are anonymized when, and only when, the server runs
+  under a remote security policy. Local stdio serves a same-trust-boundary agent
+  that needs real paths and hostnames to act on results; a remote tenant is a
+  different trust boundary, so `run_benchmark`, durable job publication, and
+  `analyze_results` comparisons all export with anonymization enabled there.
 
 **Intentionally omitted CLI-only controls**
 

--- a/tests/unit/mcp/test_benchmark_tools.py
+++ b/tests/unit/mcp/test_benchmark_tools.py
@@ -653,12 +653,33 @@ class TestBenchmarkResultExportPath:
             exporter = exporter_cls.return_value
             exporter.export_result.return_value = {"json": exported_json}
 
-            result_file_path, result_payload = _export_and_build_payload(result, execution_id, tmp_path)
+            result_file_path, result_payload = _export_and_build_payload(
+                result, execution_id, tmp_path, anonymize=False
+            )
 
         assert result.execution_id == execution_id
         assert result_file_path == str(exported_json)
         assert result_payload == {}
         assert exporter_cls.call_args.kwargs["output_dir"] == tmp_path
+
+    @pytest.mark.parametrize("anonymize", [False, True])
+    def test_export_honours_the_requested_anonymization(self, tmp_path: Path, anonymize: bool):
+        """The exporter is constructed with the caller's trust-boundary decision."""
+        from benchbox.mcp.tools.benchmark import _export_and_build_payload
+
+        result = SimpleNamespace(execution_id=None)
+        exported_json = tmp_path / "tpch_test.json"
+        exported_json.write_text("{}", encoding="utf-8")
+
+        with (
+            patch("benchbox.mcp.tools.benchmark.ResultExporter") as exporter_cls,
+            patch("benchbox.mcp.tools.benchmark.build_result_payload", return_value={"ok": True}),
+        ):
+            exporter_cls.return_value.export_result.return_value = {"json": exported_json}
+
+            _export_and_build_payload(result, "mcp_test_002", tmp_path, anonymize=anonymize)
+
+        assert exporter_cls.call_args.kwargs["anonymize"] is anonymize
 
 
 class TestPopulateSqlQueryDetails:

--- a/tests/unit/mcp/test_surface_defect_regressions.py
+++ b/tests/unit/mcp/test_surface_defect_regressions.py
@@ -1,0 +1,203 @@
+"""Regressions for the incidental MCP defects found in the 2026-08-04 review.
+
+Each test corresponds to one defect and fails on the unfixed tree.
+"""
+
+from __future__ import annotations
+
+import inspect
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+pytestmark = [
+    pytest.mark.unit,
+    pytest.mark.fast,
+]
+
+pytest.importorskip("mcp", reason="MCP SDK not installed. Install with: uv add benchbox --extra mcp")
+
+
+class TestValidateResultsNotFoundError:
+    """Defect 1: make_not_found_error was called as (resource_id, results_dir)."""
+
+    def test_not_found_names_a_resource_type_not_the_filename(self, tmp_path: Path):
+        from benchbox.mcp import create_server
+        from tests.unit.mcp.public_api import call_tool
+
+        server = create_server(results_dir=tmp_path, charts_dir=tmp_path, log_level="ERROR")
+        response = call_tool(server, "validate_results", result_file="myrun.json")
+
+        assert response["error"] is True
+        assert response["details"]["resource_type"] == "result_file"
+        assert response["details"]["requested"] == "myrun.json"
+        assert response["message"] == "Result_file 'myrun.json' not found"
+        # The suggestion must name a tool that exists.
+        assert response["suggestion"] == 'Use get_results(format="list") to see available result files'
+
+    def test_not_found_does_not_leak_the_server_results_root(self, tmp_path: Path):
+        """The old binding passed the configured results dir as the resource id."""
+        from benchbox.mcp import create_server
+        from tests.unit.mcp.public_api import call_tool
+
+        server = create_server(results_dir=tmp_path, charts_dir=tmp_path, log_level="ERROR")
+        response = call_tool(server, "validate_results", result_file="myrun.json")
+
+        assert str(tmp_path) not in repr(response)
+
+
+class TestQueryDetailsVisibilityMatrix:
+    """Defect 4: get_query_details against the benchmark visibility matrix.
+
+    The ratified matrix (docs/reference/public-contracts.md, "Benchmark
+    Visibility Policy") keeps internal benchmarks addressable by explicit ID on
+    this tool but withholds their support-status claim. These tests pin that row
+    so the tool cannot drift toward either exposing the claim or hiding the
+    benchmark outright.
+    """
+
+    def test_public_benchmark_details_carry_support_status(self):
+        from benchbox.core.benchmark_registry import get_all_benchmarks
+        from benchbox.mcp.tools.benchmark import _build_query_details_benchmark_info
+
+        meta = get_all_benchmarks()["tpch"]
+        info = _build_query_details_benchmark_info("tpch", meta)
+
+        assert info["support_status"] == meta["support_status"]
+
+    def test_internal_benchmark_details_omit_support_status(self):
+        from benchbox.core.benchmark_registry import get_all_benchmarks, get_benchmark_surface
+        from benchbox.mcp.tools.benchmark import _build_query_details_benchmark_info
+
+        benchmarks = get_all_benchmarks()
+        internal = sorted(b for b in benchmarks if get_benchmark_surface(b) != "public")
+        assert internal, "the matrix row is vacuous without at least one internal benchmark"
+
+        for benchmark in internal:
+            info = _build_query_details_benchmark_info(benchmark, benchmarks[benchmark])
+            assert set(info) == {"display_name", "category"}, benchmark
+
+    def test_internal_benchmarks_stay_addressable_by_explicit_id(self, tmp_path: Path):
+        """ "Runnable/readable by explicit ID" is the matrix's internal row."""
+        from benchbox.core.benchmark_registry import get_all_benchmarks, get_benchmark_surface
+        from benchbox.mcp import create_server
+        from tests.unit.mcp.public_api import call_tool
+
+        internal = sorted(b for b in get_all_benchmarks() if get_benchmark_surface(b) != "public")
+        server = create_server(results_dir=tmp_path, charts_dir=tmp_path, log_level="ERROR")
+
+        for benchmark in internal:
+            response = call_tool(server, "get_query_details", benchmark=benchmark, query_id="1")
+            # It may fail for benchmark-specific reasons, but never as "unknown
+            # benchmark" -- that would be the discovery gate leaking into this tool.
+            assert response.get("details", {}).get("resource_type") != "benchmark", benchmark
+
+    def test_every_registered_benchmark_matches_its_matrix_row(self):
+        """The gate is driven by `surface`, not by a hand-maintained list."""
+        from benchbox.core.benchmark_registry import get_all_benchmarks, get_benchmark_surface
+        from benchbox.mcp.tools.benchmark import _build_query_details_benchmark_info
+
+        for benchmark, meta in get_all_benchmarks().items():
+            info = _build_query_details_benchmark_info(benchmark, meta)
+            expected_public = get_benchmark_surface(benchmark) == "public"
+            assert ("support_status" in info) is expected_public, benchmark
+
+
+class TestRemoteModeAnonymization:
+    """Defect 5: exporters were pinned to anonymize=False in every mode."""
+
+    @staticmethod
+    def _security_runtime(tmp_path: Path):
+        from benchbox.mcp.security import RemoteSecurityRuntime
+        from tests.integration.mcp._security import write_security_config
+
+        config = write_security_config(
+            tmp_path,
+            tokens={"token": ("tenant", ("benchbox:read", "benchbox:execute"))},
+        )
+        return RemoteSecurityRuntime.from_file(config)
+
+    def test_local_stdio_server_does_not_anonymize(self, tmp_path: Path):
+        import benchbox.mcp.server as server_module
+
+        with (
+            patch.object(server_module, "register_benchmark_tools") as benchmark_tools,
+            patch.object(server_module, "register_analytics_tools") as analytics_tools,
+        ):
+            server_module.create_benchbox_server(results_dir=tmp_path, charts_dir=tmp_path, log_level="ERROR")
+
+        assert benchmark_tools.call_args.kwargs["anonymize_results"] is False
+        assert analytics_tools.call_args.kwargs["anonymize_results"] is False
+
+    def test_remote_authenticated_server_anonymizes(self, tmp_path: Path):
+        import benchbox.mcp.server as server_module
+
+        with (
+            patch.object(server_module, "register_benchmark_tools") as benchmark_tools,
+            patch.object(server_module, "register_analytics_tools") as analytics_tools,
+        ):
+            server_module.create_benchbox_server(
+                results_dir=tmp_path,
+                charts_dir=tmp_path,
+                log_level="ERROR",
+                remote_security=self._security_runtime(tmp_path),
+            )
+
+        assert benchmark_tools.call_args.kwargs["anonymize_results"] is True
+        assert analytics_tools.call_args.kwargs["anonymize_results"] is True
+
+    def test_durable_job_execution_anonymizes(self, tmp_path: Path):
+        """Durable jobs exist only under a remote policy, so the worker is remote."""
+        from benchbox.mcp.jobs import DurableJobWorker, JobRecord
+
+        record = JobRecord(
+            execution_id="mcp_job_test",
+            principal_id="p",
+            state="running",
+            request={"platform": "duckdb", "benchmark": "tpch"},
+            idempotency_key=None,
+            attempts=1,
+            lease_owner="w",
+            lease_expires_at=None,
+            lease_version=1,
+            lease_generation=0,
+            cancel_requested=False,
+            artifact_path=None,
+            error_code=None,
+            created_at="2026-08-04T00:00:00Z",
+            updated_at="2026-08-04T00:00:00Z",
+            completed_at=None,
+        )
+
+        with patch("benchbox.mcp.jobs._run_benchmark_impl", return_value={}) as run_impl:
+            DurableJobWorker._execute_benchmark(record, tmp_path)
+
+        assert run_impl.call_args.kwargs["anonymize"] is True
+
+    def test_compare_results_threads_the_anonymization_decision(self, tmp_path: Path):
+        from benchbox.mcp.tools import analytics as analytics_module
+
+        with patch.object(analytics_module, "ResultExporter") as exporter_cls:
+            analytics_module._compare_results_impl("a.json", "b.json", 10.0, tmp_path, anonymize=True)
+
+        assert exporter_cls.call_args.kwargs["anonymize"] is True
+
+
+class TestChartOutputContract:
+    """Defect 3: the docstring promised ANSI colors the renderer never emits."""
+
+    def test_renderer_is_constructed_without_color(self):
+        from benchbox.mcp.tools import visualization as visualization_module
+
+        source = inspect.getsource(visualization_module._generate_ascii_chart)
+
+        assert "ChartOptions(use_color=False)" in source
+
+    def test_generate_chart_docstring_matches_the_renderer(self):
+        from benchbox.mcp.tools import visualization as visualization_module
+
+        source = inspect.getsource(visualization_module.register_visualization_tools)
+
+        assert "ANSI colors for terminal display" not in source
+        assert "ANSI-color-free" in source


### PR DESCRIPTION
Four of the five defects from the 2026-08-04 CLI/MCP review are real and fixed
here. The fifth is refuted with evidence; see below.

(1) Not-found error misbinding. analytics.py called
    make_not_found_error(result_file, configured_results_dir) against a
    (resource_type, resource_id, ...) signature. A missing "myrun.json" produced
    the message "Myrun.json '/srv/results' not found", details
    {"resource_type": "myrun.json", "requested": "<PosixPath ...>"}, and the
    suggestion "Use list_myrun.jsons() to see available options" -- so the
    server-side result root was echoed back to the caller. Now
    make_not_found_error("result_file", result_file).

    While fixing the binding, the derived suggestion still named a tool that
    does not exist ("Use list_result_files()"). make_not_found_error gains an
    optional explicit `suggestion`; the two call sites whose resource type has
    no `list_<type>s` tool now pass a real one -- get_results(format="list") for
    result files, and a pointer to `details.available` for query IDs. The
    derived default is unchanged for "benchmark", where list_benchmarks is real.

(3) generate_chart docstring. The renderer has always constructed
    ChartOptions(use_color=False) and must keep doing so -- ANSI escapes in an
    inline protocol payload break non-terminal MCP clients. The docstring
    claimed the opposite ("ANSI colors for terminal display"). The docstring is
    corrected to state the no-color contract and why. Tool behavior and the
    user-visible tool description are unchanged.

(4) get_query_details visibility. Re-verified at HEAD and found ALREADY
    CORRECT: _build_query_details_benchmark_info gates support_status on
    get_benchmark_surface(...) == "public", which is what the ratified matrix
    (docs/reference/public-contracts.md, Benchmark Visibility Policy) requires.
    The gate landed in #506 (2026-05-21), before the review. The review's claim
    that get_all_benchmarks() at benchmark.py:292 leaks non-public benchmarks
    misreads that call: it is an existence lookup, and the matrix explicitly
    keeps internal benchmarks addressable by explicit ID on this tool while
    withholding the support-status claim. No behavior change; the item's rung
    text ("Non-public benchmark IDs are rejected") would have contradicted the
    matrix, and the item's own anti-pattern says the matrix is authoritative.
    What was missing was coverage, so four matrix-driven tests are added,
    including a registry-wide one that derives the expectation from `surface`
    rather than a hand-maintained list.

(5) Remote-mode anonymization. ResultExporter was pinned to anonymize=False at
    both export sites with an "egress-reviewed: local, same-trust-boundary
    consumer" rationale. That premise holds for local stdio and fails for
    remote/tenant mode, where the consumer is a different principal. The server
    now threads its mode down: register_benchmark_tools and
    register_analytics_tools take anonymize_results, wired to
    `remote_security is not None`; _export_and_build_payload and
    _compare_results_impl take the flag through. The durable job worker passes
    anonymize=True unconditionally, because durable jobs are only registered
    under a remote policy. Local stdio behavior is byte-identical.

(2) REFUTED -- double validation is deliberate layering, not duplication.
    validate_platform_options does run twice on the sync path (the tool wrapper
    at benchmark.py:249 and _run_benchmark_impl), but removing either one is a
    security regression, and the suite proves it:

    - Removing the inner call makes
      test_oversized_dask_request_never_builds_a_cluster fail. The Dask
      aggregate envelope is enforced by validate_platform_options, and the Dask
      adapter builds its LocalCluster in __init__, so the inner call is the last
      gate before a 65,536-thread cluster is actually created, not merely
      accepted. It is also the only gate on the durable-job worker path, which
      re-reads the request mapping from persistent storage.
      test_modin_unsupported_engine_fails_closed_through_the_run_surface says
      the same thing in its own comment: "Even bypassing the schema, the adapter
      must not accept it."
    - Removing the outer call would stop validating platform_options for
      dry_run and validate_only, which return before the inner call. A request
      carrying {"password": ...} with dry_run=true would go from rejected to
      silently ignored.

    I removed the inner call, ran the suite, got ten failures including the two
    above, and reverted. The docstring on _run_benchmark_impl now records why
    the second call exists so it is not "cleaned up" again. Cost is one
    in-memory dict validation per run.

Numeric/behavioral deltas: none for local stdio. Remote mode changes exported
bundle content (anonymized), which is the point of (5) and is now documented in
the Run Surface Contract behavior list.

Fast lane 26777 -> 26789 (12 new regression tests, well inside the 27050 cap).
