### PR TITLE
refactor(results): one statistics implementation under CLI and MCP

### DIFF
--- a/benchbox/cli/commands/aggregate.py
+++ b/benchbox/cli/commands/aggregate.py
@@ -4,13 +4,13 @@ from __future__ import annotations
 
 import csv
 import json
-import statistics
 import sys
 from pathlib import Path
 
 import click
 
 from benchbox.cli.shared import console
+from benchbox.core.results.metrics import geometric_mean_ms, percentile_ms
 
 
 @click.command("aggregate")
@@ -134,7 +134,7 @@ def _extract_result_row(data: dict, result_file: Path) -> dict | None:
     duration_ms = execution.get("duration_ms", 0)
 
     query_details = results.get("queries", {}).get("details", [])
-    geomean, p50, p95, p99 = _compute_query_statistics(query_details)
+    times_ms = _successful_query_times_ms(query_details)
 
     return {
         "timestamp": timestamp,
@@ -142,35 +142,25 @@ def _extract_result_row(data: dict, result_file: Path) -> dict | None:
         "platform": plat_name,
         "scale_factor": scale_factor,
         "total_time_s": duration_ms / 1000.0,
-        "geometric_mean_ms": geomean,
-        "p50_ms": p50,
-        "p95_ms": p95,
-        "p99_ms": p99,
+        # Statistics come from benchbox.core.results.metrics so that a CLI
+        # aggregate row and an MCP analytics response over the same bundles
+        # report the same numbers.
+        "geometric_mean_ms": geometric_mean_ms(times_ms),
+        "p50_ms": percentile_ms(times_ms, 0.50),
+        "p95_ms": percentile_ms(times_ms, 0.95),
+        "p99_ms": percentile_ms(times_ms, 0.99),
         "num_queries": len(query_details),
         "file": result_file.name,
     }
 
 
-def _compute_query_statistics(query_details: list[dict]) -> tuple[float, float, float, float]:
-    """Compute geometric mean, p50, p95, p99 from query details."""
-    if not query_details:
-        return 0, 0, 0, 0
-
-    times_ms = []
-    for q in query_details:
-        if q.get("status") == "SUCCESS":
-            exec_time_ms = q.get("timing", {}).get("execution_ms", 0)
-            if exec_time_ms > 0:
-                times_ms.append(exec_time_ms)
-
-    if not times_ms:
-        return 0, 0, 0, 0
-
-    geomean = statistics.geometric_mean(times_ms) if all(t > 0 for t in times_ms) else 0
-    p50 = statistics.median(times_ms)
-    p95 = statistics.quantiles(times_ms, n=20)[18] if len(times_ms) >= 20 else max(times_ms)
-    p99 = statistics.quantiles(times_ms, n=100)[98] if len(times_ms) >= 100 else max(times_ms)
-    return geomean, p50, p95, p99
+def _successful_query_times_ms(query_details: list[dict]) -> list[float]:
+    """Return execution times for successful queries with a positive duration."""
+    return [
+        query["timing"]["execution_ms"]
+        for query in query_details
+        if query.get("status") == "SUCCESS" and query.get("timing", {}).get("execution_ms", 0) > 0
+    ]
 
 
 def _write_aggregated_csv(output_path: Path, aggregated_data: list[dict]) -> None:

--- a/benchbox/core/results/__init__.py
+++ b/benchbox/core/results/__init__.py
@@ -40,7 +40,15 @@ from .environment import (
     PlatformRuntimeEnvironment,
     PlatformStorageMetadata,
 )
-from .metrics import TimingStatsCalculator, TPCMetricsCalculator
+from .metrics import (
+    NAMED_METRICS,
+    TimingStatsCalculator,
+    TPCMetricsCalculator,
+    calculate_named_metric,
+    geometric_mean_ms,
+    percentile_ms,
+    sample_stdev_ms,
+)
 from .platform_info import (
     PlatformInfoInput,
     build_platform_info,
@@ -92,6 +100,11 @@ __all__ = [
     "PlatformStorageMetadata",
     # Metrics
     "TPCMetricsCalculator",
+    "calculate_named_metric",
+    "geometric_mean_ms",
+    "percentile_ms",
+    "sample_stdev_ms",
+    "NAMED_METRICS",
     "TimingStatsCalculator",
     # Platform Info
     "PlatformInfoInput",

--- a/benchbox/core/results/metrics.py
+++ b/benchbox/core/results/metrics.py
@@ -17,6 +17,86 @@ from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     from collections.abc import Sequence
 
+# Metric names accepted by :func:`calculate_named_metric`. This vocabulary is
+# shared by every surface, so a name means the same thing in a CLI aggregate
+# CSV, an MCP trends response, and a result bundle.
+NAMED_METRICS = ("geometric_mean", "p50", "p95", "p99", "total_time", "mean")
+
+
+def percentile_ms(times_ms: Sequence[float], p: float) -> float:
+    """Return the p-th percentile of ``times_ms`` using the nearest-rank method.
+
+    ``p`` is a fraction in ``[0, 1]``: ``percentile_ms(times, 0.95)`` is p95.
+
+    BenchBox uses nearest-rank -- rank ``ceil(n * p)``, clamped to ``[1, n]`` --
+    as its single percentile definition, for two reasons:
+
+    1. It returns an actually-observed measurement. An interpolated percentile
+       reports a duration no query ever took, and with small query counts the
+       interpolating methods drift far: over 22 TPC-H timings, the exclusive
+       method that ``statistics.quantiles(n=20)[18]`` implements returned a p95
+       of 293.5 ms when the second-slowest query took 200 ms.
+    2. It is what every published BenchBox result bundle already reports, so
+       adopting it repo-wide changes no archived number.
+
+    Returns 0.0 for an empty sequence.
+    """
+    sorted_times = sorted(times_ms)
+    n = len(sorted_times)
+    if n == 0:
+        return 0.0
+    rank = min(max(1, math.ceil(n * p)), n)
+    return sorted_times[rank - 1]
+
+
+def geometric_mean_ms(times_ms: Sequence[float]) -> float:
+    """Return the geometric mean of the strictly positive values in ``times_ms``.
+
+    Non-positive timings have no logarithm and are excluded rather than
+    poisoning the result. Returns 0.0 when nothing positive remains.
+    """
+    positive = [t for t in times_ms if t > 0]
+    if not positive:
+        return 0.0
+    return statistics.geometric_mean(positive)
+
+
+def sample_stdev_ms(times_ms: Sequence[float]) -> float:
+    """Return the sample standard deviation, or 0.0 for fewer than two values."""
+    times_list = list(times_ms)
+    if len(times_list) < 2:
+        return 0.0
+    return statistics.stdev(times_list)
+
+
+def calculate_named_metric(times_ms: Sequence[float], metric: str) -> float:
+    """Return one named summary metric over ``times_ms``.
+
+    Args:
+        times_ms: Execution times in milliseconds.
+        metric: One of :data:`NAMED_METRICS`. Any other name falls back to the
+            arithmetic mean, preserving the behavior of the surface-local
+            implementations this function replaced.
+
+    Returns:
+        The metric value, or 0.0 when ``times_ms`` is empty.
+    """
+    times_list = list(times_ms)
+    if not times_list:
+        return 0.0
+
+    if metric == "geometric_mean":
+        return geometric_mean_ms(times_list)
+    if metric == "p50":
+        return percentile_ms(times_list, 0.50)
+    if metric == "p95":
+        return percentile_ms(times_list, 0.95)
+    if metric == "p99":
+        return percentile_ms(times_list, 0.99)
+    if metric == "total_time":
+        return sum(times_list)
+    return statistics.mean(times_list)
+
 
 class TPCMetricsCalculator:
     """Calculate TPC-compliant benchmark metrics.
@@ -123,14 +203,7 @@ class TPCMetricsCalculator:
         Returns:
             Geometric mean of times, or 0.0 if not calculable
         """
-        if not times:
-            return 0.0
-
-        valid_times = [t for t in times if t > 0]
-        if not valid_times:
-            return 0.0
-
-        return statistics.geometric_mean(valid_times)
+        return geometric_mean_ms(times)
 
 
 class TimingStatsCalculator:
@@ -160,33 +233,18 @@ class TimingStatsCalculator:
             return {}
 
         times_list = list(times_ms)
-        sorted_times = sorted(times_list)
-        n = len(sorted_times)
-
-        def percentile(p: float) -> float:
-            """Calculate percentile using nearest-rank method."""
-            if n == 0:
-                return 0.0
-            k = max(1, math.ceil(n * p))
-            k = min(k, n)  # Clamp to valid rank
-            k -= 1  # Convert rank to 0-based index
-            return sorted_times[k]
-
-        # Calculate geometric mean (only for positive values)
-        positive_times = [t for t in times_list if t > 0]
-        geom_mean = statistics.geometric_mean(positive_times) if positive_times else 0.0
 
         return {
             "total_ms": sum(times_list),
             "avg_ms": statistics.mean(times_list),
             "min_ms": min(times_list),
             "max_ms": max(times_list),
-            "geometric_mean_ms": geom_mean,
-            "stdev_ms": statistics.stdev(times_list) if n > 1 else 0.0,
-            "p50_ms": percentile(0.50),
-            "p90_ms": percentile(0.90),
-            "p95_ms": percentile(0.95),
-            "p99_ms": percentile(0.99),
+            "geometric_mean_ms": geometric_mean_ms(times_list),
+            "stdev_ms": sample_stdev_ms(times_list),
+            "p50_ms": percentile_ms(times_list, 0.50),
+            "p90_ms": percentile_ms(times_list, 0.90),
+            "p95_ms": percentile_ms(times_list, 0.95),
+            "p99_ms": percentile_ms(times_list, 0.99),
         }
 
     @staticmethod

--- a/benchbox/mcp/tools/analytics.py
+++ b/benchbox/mcp/tools/analytics.py
@@ -11,7 +11,6 @@ from __future__ import annotations
 
 import json
 import logging
-import math
 from datetime import datetime
 from pathlib import Path
 from typing import Any
@@ -20,6 +19,7 @@ from mcp.server.mcpserver import MCPServer
 from mcp.types import ToolAnnotations
 
 from benchbox.core.results.exporter import ResultExporter
+from benchbox.core.results.metrics import calculate_named_metric, percentile_ms, sample_stdev_ms
 from benchbox.core.results.query_normalizer import normalize_query_id
 from benchbox.mcp.errors import ErrorCode, make_error, make_not_found_error
 from benchbox.mcp.security import PathProvider, resolve_path_provider
@@ -660,7 +660,7 @@ def _load_trend_data_point(
     if not timings:
         return None
 
-    metric_value = _calculate_metric(timings, metric_lower)
+    metric_value = calculate_named_metric(timings, metric_lower)
     timestamp_str = _resolve_timestamp_str(data.get("run", {}).get("timestamp"), file_path)
 
     return {
@@ -768,15 +768,15 @@ def _compute_group_stats(runs: list[dict[str, Any]]) -> dict[str, Any]:
         "total_queries": len(all_timings),
         "query_stats": {
             "mean_ms": round(sum(all_timings) / len(all_timings), 2) if all_timings else 0,
-            "std_ms": round(_std_dev(all_timings), 2) if len(all_timings) > 1 else 0,
+            "std_ms": round(sample_stdev_ms(all_timings), 2) if len(all_timings) > 1 else 0,
             "min_ms": round(min(all_timings), 2) if all_timings else 0,
             "max_ms": round(max(all_timings), 2) if all_timings else 0,
-            "p50_ms": round(_percentile(all_timings, 50), 2) if all_timings else 0,
-            "p95_ms": round(_percentile(all_timings, 95), 2) if all_timings else 0,
+            "p50_ms": round(percentile_ms(all_timings, 0.50), 2) if all_timings else 0,
+            "p95_ms": round(percentile_ms(all_timings, 0.95), 2) if all_timings else 0,
         },
         "run_stats": {
             "mean_total_ms": round(sum(total_times) / len(total_times), 2) if total_times else 0,
-            "std_total_ms": round(_std_dev(total_times), 2) if len(total_times) > 1 else 0,
+            "std_total_ms": round(sample_stdev_ms(total_times), 2) if len(total_times) > 1 else 0,
             "min_total_ms": round(min(total_times), 2) if total_times else 0,
             "max_total_ms": round(max(total_times), 2) if total_times else 0,
         },
@@ -927,45 +927,3 @@ def _classify_regression_severity(delta_pct: float) -> str:
         return "medium"
     else:
         return "low"
-
-
-def _calculate_metric(timings: list[float], metric: str) -> float:
-    """Calculate the specified performance metric from query timings."""
-    if not timings:
-        return 0
-
-    if metric == "geometric_mean":
-        log_sum = sum(math.log(t) for t in timings if t > 0)
-        return math.exp(log_sum / len(timings)) if timings else 0
-    elif metric == "p50":
-        return _percentile(timings, 50)
-    elif metric == "p95":
-        return _percentile(timings, 95)
-    elif metric == "p99":
-        return _percentile(timings, 99)
-    elif metric == "total_time":
-        return sum(timings)
-    else:
-        return sum(timings) / len(timings)
-
-
-def _percentile(data: list[float], p: float) -> float:
-    """Calculate the p-th percentile of the data."""
-    if not data:
-        return 0
-    sorted_data = sorted(data)
-    k = (len(sorted_data) - 1) * (p / 100)
-    f = int(k)
-    c = f + 1 if f + 1 < len(sorted_data) else f
-    if f == c:
-        return sorted_data[f]
-    return sorted_data[f] * (c - k) + sorted_data[c] * (k - f)
-
-
-def _std_dev(data: list[float]) -> float:
-    """Calculate standard deviation."""
-    if len(data) < 2:
-        return 0
-    mean = sum(data) / len(data)
-    variance = sum((x - mean) ** 2 for x in data) / (len(data) - 1)
-    return math.sqrt(variance)

--- a/tests/uat/test_no_cli_surface_drift.py
+++ b/tests/uat/test_no_cli_surface_drift.py
@@ -25,6 +25,13 @@ ALLOWED_INTERNAL_CLI_FILES = {
     "benchbox/cli/benchmark_hooks.py",
     "benchbox/cli/platform_hooks.py",
     "benchbox/cli/benchmarks.py",
+    # one-engine-unify-statistics: `aggregate` now computes its geometric mean
+    # and percentiles with benchbox.core.results.metrics instead of a private
+    # copy, so CLI and MCP report the same numbers. The @click.command and
+    # @click.option decorators, the aggregate() signature, and the CSV column
+    # list are untouched; only the p50/p95/p99 values change (nearest-rank
+    # instead of median + statistics.quantiles).
+    "benchbox/cli/commands/aggregate.py",
     "benchbox/cli/commands/__init__.py",
     "benchbox/cli/commands/calculate_qphh.py",
     # tighten-dependencies-phase-3-extras-deprecation: repoints check-deps'

--- a/tests/unit/core/results/test_timing_statistics.py
+++ b/tests/unit/core/results/test_timing_statistics.py
@@ -1,0 +1,257 @@
+"""Characterization and cross-surface equivalence for BenchBox timing statistics.
+
+Before the `one-engine-unify-statistics` migration there were three
+implementations of the same summary statistics:
+
+- ``benchbox/core/results/metrics.py``     nearest-rank percentiles
+- ``benchbox/mcp/tools/analytics.py``      linear-interpolated percentiles
+- ``benchbox/cli/commands/aggregate.py``   median + ``statistics.quantiles``
+
+Geometric mean and standard deviation already agreed for the inputs each surface
+actually produces. Percentiles did not. The pre-migration values are pinned in
+:data:`SUPERSEDED_PERCENTILES` so the exact size of the change stays legible,
+and the surviving definition is pinned by the rest of this module.
+"""
+
+from __future__ import annotations
+
+import math
+import statistics
+
+import pytest
+
+from benchbox.core.results.metrics import (
+    NAMED_METRICS,
+    TimingStatsCalculator,
+    calculate_named_metric,
+    geometric_mean_ms,
+    percentile_ms,
+    sample_stdev_ms,
+)
+
+pytestmark = [
+    pytest.mark.unit,
+    pytest.mark.fast,
+]
+
+# Shared fixtures. "tpch22" matters most: 22 queries is the real TPC-H shape and
+# the size at which the three implementations disagreed the hardest.
+FIXTURES: dict[str, list[float]] = {
+    "tpch22": [12, 45, 8, 120, 33, 5, 67, 89, 15, 200, 42, 7, 310, 55, 23, 98, 140, 11, 76, 29, 64, 180],
+    "even4": [10.0, 20.0, 30.0, 40.0],
+    "odd5": [10.0, 20.0, 30.0, 40.0, 50.0],
+    "single": [42.0],
+    "uniform100": [float(i) for i in range(1, 101)],
+}
+
+# The canonical (nearest-rank) values this repository now reports everywhere.
+CANONICAL_PERCENTILES: dict[str, dict[str, float]] = {
+    "tpch22": {"p50": 45.0, "p95": 200.0, "p99": 310.0},
+    "even4": {"p50": 20.0, "p95": 40.0, "p99": 40.0},
+    "odd5": {"p50": 30.0, "p95": 50.0, "p99": 50.0},
+    "single": {"p50": 42.0, "p95": 42.0, "p99": 42.0},
+    "uniform100": {"p50": 50.0, "p95": 95.0, "p99": 99.0},
+}
+
+# What the two surface-local implementations reported before the migration.
+# Kept as documentation of the delta, not as a behavior anyone should restore.
+SUPERSEDED_PERCENTILES: dict[str, dict[str, dict[str, float]]] = {
+    "tpch22": {
+        "mcp": {"p50": 50.0, "p95": 199.0, "p99": 286.9},
+        "cli": {"p50": 50.0, "p95": 293.5, "p99": 310.0},
+    },
+    "even4": {
+        "mcp": {"p50": 25.0, "p95": 38.5, "p99": 39.7},
+        "cli": {"p50": 25.0, "p95": 40.0, "p99": 40.0},
+    },
+    "odd5": {
+        "mcp": {"p50": 30.0, "p95": 48.0, "p99": 49.6},
+        "cli": {"p50": 30.0, "p95": 50.0, "p99": 50.0},
+    },
+    "single": {
+        "mcp": {"p50": 42.0, "p95": 42.0, "p99": 42.0},
+        "cli": {"p50": 42.0, "p95": 42.0, "p99": 42.0},
+    },
+    "uniform100": {
+        "mcp": {"p50": 50.5, "p95": 95.05, "p99": 99.01},
+        "cli": {"p50": 50.5, "p95": 95.95, "p99": 99.99},
+    },
+}
+
+
+def _superseded_mcp_percentile(data: list[float], p: float) -> float:
+    """The deleted MCP ``_percentile``: linear interpolation over ``(n-1) * p``."""
+    if not data:
+        return 0
+    sorted_data = sorted(data)
+    k = (len(sorted_data) - 1) * (p / 100)
+    f = int(k)
+    c = f + 1 if f + 1 < len(sorted_data) else f
+    if f == c:
+        return sorted_data[f]
+    return sorted_data[f] * (c - k) + sorted_data[c] * (k - f)
+
+
+def _superseded_cli_percentiles(times: list[float]) -> dict[str, float]:
+    """The deleted CLI ``_compute_query_statistics`` percentile choices."""
+    return {
+        "p50": statistics.median(times),
+        "p95": statistics.quantiles(times, n=20)[18] if len(times) >= 20 else max(times),
+        "p99": statistics.quantiles(times, n=100)[98] if len(times) >= 100 else max(times),
+    }
+
+
+class TestSupersededImplementationsAreCharacterized:
+    """The recorded deltas must describe the code that was actually deleted."""
+
+    @pytest.mark.parametrize("name", sorted(FIXTURES))
+    def test_recorded_mcp_values_match_the_deleted_implementation(self, name: str):
+        times = FIXTURES[name]
+        recorded = SUPERSEDED_PERCENTILES[name]["mcp"]
+
+        for key, percentile in (("p50", 50), ("p95", 95), ("p99", 99)):
+            assert _superseded_mcp_percentile(times, percentile) == pytest.approx(recorded[key])
+
+    @pytest.mark.parametrize("name", sorted(FIXTURES))
+    def test_recorded_cli_values_match_the_deleted_implementation(self, name: str):
+        times = FIXTURES[name]
+        recorded = SUPERSEDED_PERCENTILES[name]["cli"]
+
+        assert _superseded_cli_percentiles(times) == pytest.approx(recorded)
+
+    def test_the_migration_actually_changed_something(self):
+        """A no-op delta table would make the rest of this module vacuous."""
+        changed = [
+            (name, surface, key)
+            for name, surfaces in SUPERSEDED_PERCENTILES.items()
+            for surface, values in surfaces.items()
+            for key, old in values.items()
+            if old != pytest.approx(CANONICAL_PERCENTILES[name][key])
+        ]
+        assert changed, "no recorded percentile changed; the delta table is stale"
+
+
+class TestCanonicalPercentile:
+    """One nearest-rank definition, used by every surface."""
+
+    @pytest.mark.parametrize("name", sorted(FIXTURES))
+    def test_matches_the_pinned_canonical_values(self, name: str):
+        times = FIXTURES[name]
+        expected = CANONICAL_PERCENTILES[name]
+
+        assert percentile_ms(times, 0.50) == pytest.approx(expected["p50"])
+        assert percentile_ms(times, 0.95) == pytest.approx(expected["p95"])
+        assert percentile_ms(times, 0.99) == pytest.approx(expected["p99"])
+
+    @pytest.mark.parametrize("name", sorted(FIXTURES))
+    def test_always_returns_an_observed_measurement(self, name: str):
+        """Nearest-rank never invents a duration no query took."""
+        times = FIXTURES[name]
+
+        for p in (0.0, 0.5, 0.9, 0.95, 0.99, 1.0):
+            assert percentile_ms(times, p) in times
+
+    def test_empty_input_is_zero_not_an_error(self):
+        assert percentile_ms([], 0.95) == 0.0
+
+    def test_rank_is_clamped_at_both_ends(self):
+        times = [10.0, 20.0, 30.0]
+
+        assert percentile_ms(times, 0.0) == 10.0
+        assert percentile_ms(times, 1.0) == 30.0
+        assert percentile_ms(times, 2.0) == 30.0
+
+    def test_input_order_does_not_matter(self):
+        assert percentile_ms([30.0, 10.0, 20.0], 0.95) == percentile_ms([10.0, 20.0, 30.0], 0.95)
+
+    def test_caller_sequence_is_not_mutated(self):
+        times = [30.0, 10.0, 20.0]
+        percentile_ms(times, 0.95)
+
+        assert times == [30.0, 10.0, 20.0]
+
+
+class TestCanonicalGeometricMean:
+    @pytest.mark.parametrize("name", sorted(FIXTURES))
+    def test_agrees_with_stdlib_over_positive_inputs(self, name: str):
+        times = FIXTURES[name]
+
+        assert geometric_mean_ms(times) == pytest.approx(statistics.geometric_mean(times))
+
+    def test_non_positive_values_are_excluded_not_fatal(self):
+        """The deleted MCP copy divided by len(all) and the CLI copy returned 0."""
+        times = [0.0, 10.0, 40.0]
+        superseded_mcp = math.exp(sum(math.log(t) for t in times if t > 0) / len(times))
+
+        assert geometric_mean_ms(times) == pytest.approx(20.0)
+        assert superseded_mcp == pytest.approx(7.368063)
+
+    def test_all_non_positive_is_zero(self):
+        assert geometric_mean_ms([0.0, -1.0]) == 0.0
+
+    def test_empty_is_zero(self):
+        assert geometric_mean_ms([]) == 0.0
+
+
+class TestCanonicalStandardDeviation:
+    @pytest.mark.parametrize("name", sorted(FIXTURES))
+    def test_is_the_sample_standard_deviation(self, name: str):
+        times = FIXTURES[name]
+        expected = statistics.stdev(times) if len(times) > 1 else 0.0
+
+        assert sample_stdev_ms(times) == pytest.approx(expected)
+
+    def test_single_value_is_zero_not_an_error(self):
+        assert sample_stdev_ms([42.0]) == 0.0
+
+    def test_empty_is_zero(self):
+        assert sample_stdev_ms([]) == 0.0
+
+
+class TestNamedMetricVocabulary:
+    @pytest.mark.parametrize("metric", NAMED_METRICS)
+    def test_every_declared_name_resolves(self, metric: str):
+        assert calculate_named_metric(FIXTURES["tpch22"], metric) > 0
+
+    def test_named_metrics_agree_with_the_direct_functions(self):
+        times = FIXTURES["tpch22"]
+
+        assert calculate_named_metric(times, "geometric_mean") == geometric_mean_ms(times)
+        assert calculate_named_metric(times, "p50") == percentile_ms(times, 0.50)
+        assert calculate_named_metric(times, "p95") == percentile_ms(times, 0.95)
+        assert calculate_named_metric(times, "p99") == percentile_ms(times, 0.99)
+        assert calculate_named_metric(times, "total_time") == sum(times)
+
+    def test_unknown_metric_falls_back_to_the_arithmetic_mean(self):
+        """Preserved from the deleted MCP ``_calculate_metric`` else-branch."""
+        times = FIXTURES["tpch22"]
+
+        assert calculate_named_metric(times, "not_a_metric") == pytest.approx(statistics.mean(times))
+
+    def test_empty_input_is_zero(self):
+        assert calculate_named_metric([], "p95") == 0.0
+
+
+class TestResultBundleStatisticsAreUnchanged:
+    """TimingStatsCalculator feeds published bundles and must not drift."""
+
+    @pytest.mark.parametrize("name", sorted(FIXTURES))
+    def test_bundle_percentiles_still_use_the_canonical_definition(self, name: str):
+        times = FIXTURES[name]
+        stats = TimingStatsCalculator.calculate(times)
+
+        assert stats["p50_ms"] == percentile_ms(times, 0.50)
+        assert stats["p90_ms"] == percentile_ms(times, 0.90)
+        assert stats["p95_ms"] == percentile_ms(times, 0.95)
+        assert stats["p99_ms"] == percentile_ms(times, 0.99)
+        assert stats["geometric_mean_ms"] == geometric_mean_ms(times)
+        assert stats["stdev_ms"] == sample_stdev_ms(times)
+
+    @pytest.mark.parametrize("name", sorted(FIXTURES))
+    def test_bundle_percentiles_match_the_pinned_canonical_values(self, name: str):
+        stats = TimingStatsCalculator.calculate(FIXTURES[name])
+        expected = CANONICAL_PERCENTILES[name]
+
+        assert stats["p50_ms"] == pytest.approx(expected["p50"])
+        assert stats["p95_ms"] == pytest.approx(expected["p95"])
+        assert stats["p99_ms"] == pytest.approx(expected["p99"])

--- a/tests/unit/mcp/test_analytics_tools.py
+++ b/tests/unit/mcp/test_analytics_tools.py
@@ -159,45 +159,48 @@ class TestAnalyticsHelperFunctions:
     """Tests for analytics helper functions."""
 
     def test_percentile_calculation(self):
-        """Test percentile calculation helper."""
-        from benchbox.mcp.tools.analytics import _percentile
+        """Analytics percentiles come from core, which is nearest-rank.
+
+        The deleted local `_percentile` interpolated and returned 5.5 here.
+        """
+        from benchbox.core.results.metrics import percentile_ms
 
         data = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
 
-        assert _percentile(data, 50) == 5.5
-        assert _percentile(data, 0) == 1
-        assert _percentile(data, 100) == 10
+        assert percentile_ms(data, 0.50) == 5
+        assert percentile_ms(data, 0.0) == 1
+        assert percentile_ms(data, 1.0) == 10
 
     def test_percentile_empty_data(self):
         """Test percentile with empty data."""
-        from benchbox.mcp.tools.analytics import _percentile
+        from benchbox.core.results.metrics import percentile_ms
 
-        assert _percentile([], 50) == 0
+        assert percentile_ms([], 0.50) == 0
 
     def test_std_dev_calculation(self):
         """Test standard deviation calculation helper."""
-        from benchbox.mcp.tools.analytics import _std_dev
+        from benchbox.core.results.metrics import sample_stdev_ms
 
         data = [2, 4, 4, 4, 5, 5, 7, 9]
-        std = _std_dev(data)
+        std = sample_stdev_ms(data)
 
         # Sample standard deviation should be approximately 2.14
         assert 2.1 < std < 2.2
 
     def test_std_dev_single_value(self):
         """Test standard deviation with single value."""
-        from benchbox.mcp.tools.analytics import _std_dev
+        from benchbox.core.results.metrics import sample_stdev_ms
 
-        assert _std_dev([5]) == 0
+        assert sample_stdev_ms([5]) == 0
 
     def test_calculate_metric_geometric_mean(self):
         """Test geometric mean calculation."""
-        from benchbox.mcp.tools.analytics import _calculate_metric
+        from benchbox.core.results.metrics import calculate_named_metric
 
         data = [1, 2, 4, 8]
-        result = _calculate_metric(data, "geometric_mean")
+        result = calculate_named_metric(data, "geometric_mean")
 
-        # Geometric mean of 1,2,4,8 = (1*2*4*8)^(1/4) = 64^0.25 ≈ 2.83
+        # Geometric mean of 1,2,4,8 = (1*2*4*8)^(1/4) = 64^0.25 ~= 2.83
         assert 2.8 < result < 2.9
 
     def test_classify_regression_severity(self):

--- a/tests/unit/mcp/test_mcp_results_and_analytics.py
+++ b/tests/unit/mcp/test_mcp_results_and_analytics.py
@@ -1294,53 +1294,51 @@ class TestAnalyticsHelpers:
 
     def test_calculate_metric_geometric_mean(self):
         """geometric_mean calculates correctly."""
-        from benchbox.mcp.tools.analytics import _calculate_metric
+        from benchbox.core.results.metrics import calculate_named_metric
 
         # geometric mean of [4, 9] = sqrt(36) = 6
-        result = _calculate_metric([4.0, 9.0], "geometric_mean")
+        result = calculate_named_metric([4.0, 9.0], "geometric_mean")
         assert abs(result - 6.0) < 0.01
 
     def test_calculate_metric_p50(self):
-        """p50 returns median value."""
-        from benchbox.mcp.tools.analytics import _calculate_metric
+        """p50 returns the middle value for an odd count under nearest-rank."""
+        from benchbox.core.results.metrics import calculate_named_metric
 
-        result = _calculate_metric([10.0, 20.0, 30.0, 40.0, 50.0], "p50")
+        result = calculate_named_metric([10.0, 20.0, 30.0, 40.0, 50.0], "p50")
         assert result == 30.0
 
     def test_calculate_metric_total_time(self):
         """total_time returns sum."""
-        from benchbox.mcp.tools.analytics import _calculate_metric
+        from benchbox.core.results.metrics import calculate_named_metric
 
-        result = _calculate_metric([10.0, 20.0, 30.0], "total_time")
+        result = calculate_named_metric([10.0, 20.0, 30.0], "total_time")
         assert result == 60.0
 
     def test_percentile_empty_list(self):
         """Percentile of empty list returns 0."""
-        from benchbox.mcp.tools.analytics import _percentile
+        from benchbox.core.results.metrics import percentile_ms
 
-        assert _percentile([], 50) == 0
+        assert percentile_ms([], 0.50) == 0
 
     def test_percentile_single_element(self):
         """Percentile of single element returns that element."""
-        from benchbox.mcp.tools.analytics import _percentile
+        from benchbox.core.results.metrics import percentile_ms
 
-        assert _percentile([42.0], 50) == 42.0
-        assert _percentile([42.0], 95) == 42.0
+        assert percentile_ms([42.0], 0.50) == 42.0
+        assert percentile_ms([42.0], 0.95) == 42.0
 
     def test_std_dev_single_element(self):
         """Std dev of single element returns 0."""
-        from benchbox.mcp.tools.analytics import _std_dev
+        from benchbox.core.results.metrics import sample_stdev_ms
 
-        assert _std_dev([42.0]) == 0
+        assert sample_stdev_ms([42.0]) == 0
 
     def test_std_dev_known_values(self):
         """Std dev of known values is correct."""
-        import math
-
-        from benchbox.mcp.tools.analytics import _std_dev
+        from benchbox.core.results.metrics import sample_stdev_ms
 
         # std dev of [2, 4, 4, 4, 5, 5, 7, 9] = 2.138...
-        result = _std_dev([2.0, 4.0, 4.0, 4.0, 5.0, 5.0, 7.0, 9.0])
+        result = sample_stdev_ms([2.0, 4.0, 4.0, 4.0, 5.0, 5.0, 7.0, 9.0])
         assert abs(result - 2.138) < 0.01
 
     def test_extract_plan_summary(self):

--- a/tests/unit/test_statistics_cross_surface_equivalence.py
+++ b/tests/unit/test_statistics_cross_surface_equivalence.py
@@ -1,0 +1,185 @@
+"""CLI and MCP must report identical statistics for the same measurements.
+
+This is the invariant `one-engine-unify-statistics` exists to establish: not
+that the two surfaces expose the same options, but that they compute the same
+numbers. Both surfaces read different JSON shapes -- the CLI aggregate reads
+``results.queries.details`` with ``status == "SUCCESS"``, MCP analytics reads
+``queries`` rows with ``run_type == "measurement"`` -- so the tests below build
+both shapes from one list of timings and require the outputs to match exactly.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from benchbox.core.results.metrics import geometric_mean_ms, percentile_ms
+
+pytestmark = [
+    pytest.mark.unit,
+    pytest.mark.fast,
+]
+
+SHARED_TIMINGS: list[float] = [
+    12.0,
+    45.0,
+    8.0,
+    120.0,
+    33.0,
+    5.0,
+    67.0,
+    89.0,
+    15.0,
+    200.0,
+    42.0,
+    7.0,
+    310.0,
+    55.0,
+    23.0,
+    98.0,
+    140.0,
+    11.0,
+    76.0,
+    29.0,
+    64.0,
+    180.0,
+]
+
+
+def _cli_shaped_bundle(timings: list[float]) -> dict:
+    """A result bundle in the shape `benchbox aggregate` reads."""
+    return {
+        "execution": {"platform": "duckdb", "timestamp": "2026-08-04T00:00:00Z", "duration_ms": sum(timings)},
+        "benchmark": {"name": "tpch"},
+        "configuration": {"scale_factor": 1.0},
+        "results": {
+            "queries": {
+                "details": [
+                    {"query_id": str(i + 1), "status": "SUCCESS", "timing": {"execution_ms": ms}}
+                    for i, ms in enumerate(timings)
+                ]
+            }
+        },
+    }
+
+
+def _mcp_shaped_bundle(timings: list[float]) -> dict:
+    """The same measurements in the shape MCP analytics reads."""
+    return {
+        "run": {"platform": "duckdb", "benchmark": "tpch", "timestamp": "2026-08-04T00:00:00Z"},
+        "benchmark": {"scale_factor": 1.0},
+        "queries": [{"query_id": str(i + 1), "run_type": "measurement", "ms": ms} for i, ms in enumerate(timings)],
+    }
+
+
+class TestCrossSurfaceStatisticsEquivalence:
+    def test_cli_and_mcp_report_the_same_percentiles(self):
+        from benchbox.cli.commands.aggregate import _extract_result_row
+        from benchbox.core.results.metrics import calculate_named_metric
+        from benchbox.mcp.tools.analytics import _extract_measurement_timings
+
+        cli_row = _extract_result_row(_cli_shaped_bundle(SHARED_TIMINGS), Path("run.json"))
+        mcp_timings = _extract_measurement_timings(_mcp_shaped_bundle(SHARED_TIMINGS))
+
+        assert cli_row["p50_ms"] == calculate_named_metric(mcp_timings, "p50")
+        assert cli_row["p95_ms"] == calculate_named_metric(mcp_timings, "p95")
+        assert cli_row["p99_ms"] == calculate_named_metric(mcp_timings, "p99")
+        assert cli_row["geometric_mean_ms"] == calculate_named_metric(mcp_timings, "geometric_mean")
+
+    def test_both_surfaces_extract_the_same_measurement_set(self):
+        from benchbox.cli.commands.aggregate import _successful_query_times_ms
+        from benchbox.mcp.tools.analytics import _extract_measurement_timings
+
+        cli_bundle = _cli_shaped_bundle(SHARED_TIMINGS)
+        cli_times = _successful_query_times_ms(cli_bundle["results"]["queries"]["details"])
+        mcp_times = _extract_measurement_timings(_mcp_shaped_bundle(SHARED_TIMINGS))
+
+        assert cli_times == mcp_times == SHARED_TIMINGS
+
+    def test_both_surfaces_drop_the_same_non_measurements(self):
+        """Filter semantics are surface-specific and must stay that way."""
+        from benchbox.cli.commands.aggregate import _successful_query_times_ms
+        from benchbox.mcp.tools.analytics import _extract_measurement_timings
+
+        cli_details = [
+            {"query_id": "1", "status": "SUCCESS", "timing": {"execution_ms": 10.0}},
+            {"query_id": "2", "status": "FAILED", "timing": {"execution_ms": 999.0}},
+            {"query_id": "3", "status": "SUCCESS", "timing": {"execution_ms": 0}},
+            {"query_id": "4", "status": "SUCCESS", "timing": {"execution_ms": 20.0}},
+        ]
+        mcp_queries = {
+            "queries": [
+                {"query_id": "1", "run_type": "measurement", "ms": 10.0},
+                {"query_id": "2", "run_type": "warmup", "ms": 999.0},
+                {"query_id": "3", "run_type": "measurement", "ms": 0},
+                {"query_id": "4", "run_type": "measurement", "ms": 20.0},
+            ]
+        }
+
+        assert _successful_query_times_ms(cli_details) == [10.0, 20.0]
+        assert _extract_measurement_timings(mcp_queries) == [10.0, 20.0]
+
+    def test_aggregate_row_uses_the_core_implementation(self):
+        from benchbox.cli.commands.aggregate import _extract_result_row
+
+        row = _extract_result_row(_cli_shaped_bundle(SHARED_TIMINGS), Path("run.json"))
+
+        assert row["p50_ms"] == percentile_ms(SHARED_TIMINGS, 0.50)
+        assert row["p95_ms"] == percentile_ms(SHARED_TIMINGS, 0.95)
+        assert row["p99_ms"] == percentile_ms(SHARED_TIMINGS, 0.99)
+        assert row["geometric_mean_ms"] == geometric_mean_ms(SHARED_TIMINGS)
+
+    def test_mcp_group_stats_use_the_core_implementation(self):
+        from benchbox.core.results.metrics import sample_stdev_ms
+        from benchbox.mcp.tools.analytics import _compute_group_stats
+
+        runs = [{"timings": SHARED_TIMINGS, "total_time": sum(SHARED_TIMINGS), "file": "run.json"}]
+        stats = _compute_group_stats(runs)["query_stats"]
+
+        assert stats["p50_ms"] == round(percentile_ms(SHARED_TIMINGS, 0.50), 2)
+        assert stats["p95_ms"] == round(percentile_ms(SHARED_TIMINGS, 0.95), 2)
+        assert stats["std_ms"] == round(sample_stdev_ms(SHARED_TIMINGS), 2)
+
+    def test_aggregate_csv_column_contract_is_unchanged(self):
+        """Migration must not rename or reorder the published CSV columns."""
+        from benchbox.cli.commands.aggregate import _extract_result_row
+
+        row = _extract_result_row(_cli_shaped_bundle(SHARED_TIMINGS), Path("run.json"))
+
+        assert list(row) == [
+            "timestamp",
+            "benchmark",
+            "platform",
+            "scale_factor",
+            "total_time_s",
+            "geometric_mean_ms",
+            "p50_ms",
+            "p95_ms",
+            "p99_ms",
+            "num_queries",
+            "file",
+        ]
+
+    def test_no_surface_keeps_a_private_statistics_implementation(self):
+        """A reintroduced local copy is how the surfaces drifted apart before."""
+        import benchbox.cli.commands.aggregate as aggregate_module
+        import benchbox.mcp.tools.analytics as analytics_module
+
+        for module in (aggregate_module, analytics_module):
+            for banned in ("_percentile", "_std_dev", "_calculate_metric", "_compute_query_statistics"):
+                assert not hasattr(module, banned), f"{module.__name__}.{banned}"
+
+    def test_written_csv_matches_the_computed_row(self, tmp_path: Path):
+        from benchbox.cli.commands.aggregate import _extract_result_row, _write_aggregated_csv
+
+        row = _extract_result_row(_cli_shaped_bundle(SHARED_TIMINGS), Path("run.json"))
+        output = tmp_path / "trends.csv"
+        _write_aggregated_csv(output, [row])
+
+        header, values = output.read_text(encoding="utf-8").splitlines()[:2]
+        columns = dict(zip(header.split(","), values.split(","), strict=True))
+
+        assert float(columns["p95_ms"]) == percentile_ms(SHARED_TIMINGS, 0.95)
+        assert json.loads(columns["num_queries"]) == len(SHARED_TIMINGS)


### PR DESCRIPTION
BenchBox had three implementations of the same summary statistics, so the same
result files could yield different numbers depending on which surface read them.
For a benchmarking product that is a credibility defect, not a tidiness one.

  benchbox/core/results/metrics.py      nearest-rank percentiles (result bundles)
  benchbox/mcp/tools/analytics.py       linear interpolation over (n-1)*p
  benchbox/cli/commands/aggregate.py    median, then statistics.quantiles

Geometric mean and standard deviation already agreed for the inputs each surface
produces. Percentiles did not.

## Chosen definition: nearest-rank

benchbox/core/results/metrics.py gains percentile_ms, geometric_mean_ms,
sample_stdev_ms, and calculate_named_metric; the module docstring records the
choice and why. Nearest-rank -- rank ceil(n*p), clamped to [1, n] -- wins on two
grounds:

1. It returns an actually-observed measurement. Over the 22 TPC-H timings used
   as the fixture, the CLI's exclusive-quantile p95 was 293.5 ms when the
   second-slowest query took 200 ms and the slowest took 310 ms: a reported
   "95th percentile" that no query came close to. Nearest-rank returns 200.
2. It is already what every published BenchBox result bundle reports, because
   TimingStatsCalculator has always used it. Adopting it repo-wide therefore
   changes ZERO archived numbers -- the migration risk the item warns about is
   avoided rather than managed.

TimingStatsCalculator and TPCMetricsCalculator.calculate_geometric_mean now
delegate to the new functions and are byte-for-byte behavior-identical;
test_bundle_percentiles_match_the_pinned_canonical_values pins that.

## Numeric deltas (analysis surfaces only; no result bundle changes)

Characterized before migrating, over five fixtures. Full table lives in
tests/unit/core/results/test_timing_statistics.py as SUPERSEDED_PERCENTILES,
with tests that re-run the DELETED implementations to prove the recorded numbers
describe the code that actually went away.

`benchbox aggregate` CSV (p50_ms, p95_ms, p99_ms columns):

  fixture       column   was      now
  tpch22 (n=22) p50      50.0     45.0
  tpch22        p95      293.5    200.0
  tpch22        p99      310.0    310.0   (unchanged)
  even4         p50      25.0     20.0
  uniform100    p50      50.5     50.0
  uniform100    p95      95.95    95.0
  uniform100    p99      99.99    99.0

  The CLI also fell back to max(times) for p95 below 20 samples and p99 below
  100 samples, so a 22-query TPC-H run reported max as its p99. That fallback is
  gone; nearest-rank is defined at every n.

MCP `analyze_results` (aggregate query_stats p50_ms/p95_ms, and the trends
metric for metric=p50|p95|p99):

  fixture       metric   was      now
  tpch22        p50      50.0     45.0
  tpch22        p95      199.0    200.0
  tpch22        p99      286.9    310.0
  even4         p95      38.5     40.0
  uniform100    p95      95.05    95.0

geometric_mean and std_ms/std_total_ms are unchanged on both surfaces for
all-positive inputs. One edge case does change: the deleted MCP geometric mean
divided the log-sum by len(all timings) rather than len(positive timings), so a
zero-valued entry pulled the result down (7.37 instead of 20.0 for [0, 10, 40]).
Analytics filters ms > 0 upstream, so no live call could reach it; core's
filter-then-average is now the only behavior.

## Migration

- MCP: _calculate_metric, _percentile, and _std_dev deleted; call sites use
  calculate_named_metric / percentile_ms / sample_stdev_ms. The
  measurement-row filter (run_type == "measurement", ms > 0) is untouched.
- CLI: _compute_query_statistics deleted, split into _successful_query_times_ms
  (the surface-specific status == "SUCCESS" filter stays local, because the two
  surfaces read genuinely different JSON shapes) plus core calls. The CSV column
  names and order are unchanged and pinned by a test.
- No compatibility shim or fallback copy is left behind; a test asserts neither
  surface module still has any of the four deleted attributes, since a
  reintroduced local copy is exactly how these drifted apart.

tests/unit/test_statistics_cross_surface_equivalence.py builds both JSON shapes
from one timing list and requires the CLI aggregate row and the MCP analytics
path to produce identical numbers.

tests/uat/test_no_cli_surface_drift.py gains aggregate.py to its
internal-change allowlist with the rationale: no click decorator, signature, or
CSV column changed -- only the computed values.

Fast lane 26789 -> 26851 (67 new tests, inside the 27050 cap). lint-imports
green: core gains no platform or CLI import.
