### PR TITLE
fix(core,mcp): close two Phase 1 review findings

### DIFF
--- a/benchbox/core/results/metrics.py
+++ b/benchbox/core/results/metrics.py
@@ -27,6 +27,10 @@ def percentile_ms(times_ms: Sequence[float], p: float) -> float:
     """Return the p-th percentile of ``times_ms`` using the nearest-rank method.
 
     ``p`` is a fraction in ``[0, 1]``: ``percentile_ms(times, 0.95)`` is p95.
+    A ``p`` outside that range raises ``ValueError`` rather than being clamped.
+    The surface-local implementations this function replaced took ``p`` on a
+    0-100 scale, so ``percentile_ms(times, 95)`` is the likely porting mistake;
+    clamping it would silently return ``max(times_ms)`` and call it a p95.
 
     BenchBox uses nearest-rank -- rank ``ceil(n * p)``, clamped to ``[1, n]`` --
     as its single percentile definition, for two reasons:
@@ -40,7 +44,13 @@ def percentile_ms(times_ms: Sequence[float], p: float) -> float:
        adopting it repo-wide changes no archived number.
 
     Returns 0.0 for an empty sequence.
+
+    Raises:
+        ValueError: If ``p`` is outside ``[0, 1]``.
     """
+    if not 0.0 <= p <= 1.0:
+        raise ValueError(f"percentile must be a fraction in [0, 1], got {p!r} (use 0.95 for p95, not 95)")
+
     sorted_times = sorted(times_ms)
     n = len(sorted_times)
     if n == 0:

--- a/benchbox/mcp/tools/analytics.py
+++ b/benchbox/mcp/tools/analytics.py
@@ -394,9 +394,13 @@ def _compare_results_impl(
     threshold_percent: float,
     results_dir: Path,
     *,
-    anonymize: bool = False,
+    anonymize: bool,
 ) -> dict[str, Any]:
-    """Compare two benchmark runs."""
+    """Compare two benchmark runs.
+
+    ``anonymize`` is required rather than defaulted: it governs a trust
+    boundary, and a permissive default fails open on the remote path.
+    """
     # egress-reviewed: local stdio serves a same-trust-boundary agent that
     # needs real paths/hostnames to act on results; secrets are already
     # redacted at capture time by sanitize_platform_options, and exception

--- a/benchbox/mcp/tools/benchmark.py
+++ b/benchbox/mcp/tools/benchmark.py
@@ -422,7 +422,7 @@ def _run_benchmark_impl(
     platform_options: Mapping[str, object] | None = None,
     results_dir: Path,
     execution_id: str | None = None,
-    anonymize: bool = False,
+    anonymize: bool,
 ) -> dict[str, Any]:
     """Core implementation for running benchmarks.
 
@@ -435,7 +435,10 @@ def _run_benchmark_impl(
             accepted. It is also the only gate on the durable-job worker path,
             where the request mapping is re-read from persistent storage.
         anonymize: Passed through to the result exporter; see
-            ``_export_and_build_payload``.
+            ``_export_and_build_payload``. Required rather than defaulted: it
+            governs a trust boundary, and a default would make "the caller
+            forgot" indistinguishable from "the caller chose local", failing
+            open on exactly the remote path that needs it.
     """
     execution_id = execution_id or f"mcp_{uuid.uuid4().hex[:8]}"
     start_time = mono_time()

--- a/tests/unit/core/results/test_timing_statistics.py
+++ b/tests/unit/core/results/test_timing_statistics.py
@@ -159,7 +159,22 @@ class TestCanonicalPercentile:
 
         assert percentile_ms(times, 0.0) == 10.0
         assert percentile_ms(times, 1.0) == 30.0
-        assert percentile_ms(times, 2.0) == 30.0
+
+    @pytest.mark.parametrize("p", [95, 50, 99, 100, 1.01, -0.01, -1])
+    def test_out_of_range_percentile_is_rejected_not_clamped(self, p: float):
+        """The deleted implementations took p on a 0-100 scale.
+
+        Clamping `percentile_ms(times, 95)` would silently return max(times)
+        and label it a p95, which is the exact porting mistake this migration
+        makes easy to write.
+        """
+        with pytest.raises(ValueError, match=r"\[0, 1\]"):
+            percentile_ms([10.0, 20.0, 30.0], p)
+
+    def test_the_range_guard_runs_before_the_empty_shortcut(self):
+        """An empty sequence must not mask a bad percentile argument."""
+        with pytest.raises(ValueError):
+            percentile_ms([], 95)
 
     def test_input_order_does_not_matter(self):
         assert percentile_ms([30.0, 10.0, 20.0], 0.95) == percentile_ms([10.0, 20.0, 30.0], 0.95)

--- a/tests/unit/mcp/test_benchmark_tools.py
+++ b/tests/unit/mcp/test_benchmark_tools.py
@@ -164,6 +164,7 @@ class TestRunBenchmarkTool:
                 "sql",
                 platform_options={"threads": 4},
                 results_dir=tmp_path,
+                anonymize=False,
             )
 
         assert response["mcp_metadata"]["status"] == "no_results"
@@ -204,6 +205,7 @@ class TestRunBenchmarkTool:
             "dataframe",
             platform_options={"engine": "pandas"},
             results_dir=tmp_path,
+            anonymize=False,
         )
         assert response["status"] == "failed"
 
@@ -221,6 +223,7 @@ class TestRunBenchmarkTool:
                 "dataframe",
                 platform_options={"n_workers": 256, "threads_per_worker": 256},
                 results_dir=tmp_path,
+                anonymize=False,
             )
 
         assert response["status"] == "failed"
@@ -261,6 +264,7 @@ class TestRunBenchmarkTool:
                 "dataframe",
                 platform_options={"n_workers": 256, "threads_per_worker": 256},
                 results_dir=tmp_path,
+                anonymize=False,
             )
 
         local_cluster.assert_not_called()
@@ -290,6 +294,7 @@ class TestRunBenchmarkTool:
                 "dataframe",
                 platform_options={"n_workers": 4, "threads_per_worker": 4, "memory_limit": "4GB"},
                 results_dir=tmp_path,
+                anonymize=False,
             )
 
         kwargs = get_adapter.call_args.kwargs
@@ -312,6 +317,7 @@ class TestRunBenchmarkTool:
                 "sql",
                 platform_options={"port": 9001, "secure": False},
                 results_dir=tmp_path,
+                anonymize=False,
             )
 
         assert response["status"] == "failed"
@@ -347,6 +353,7 @@ class TestRunBenchmarkTool:
                 "sql",
                 platform_options={"connection_profile": "reviewed"},
                 results_dir=tmp_path,
+                anonymize=False,
             )
 
         kwargs = get_adapter.call_args.kwargs
@@ -371,6 +378,7 @@ class TestRunBenchmarkTool:
                 "sql",
                 platform_options={"connection_profile": "reviewed"},
                 results_dir=tmp_path,
+                anonymize=False,
             )
 
         assert response["status"] == "failed"

--- a/tests/unit/mcp/test_mcp_benchmark_stdout_suppression.py
+++ b/tests/unit/mcp/test_mcp_benchmark_stdout_suppression.py
@@ -39,7 +39,14 @@ def test_run_benchmark_impl_suppresses_transitive_stdout() -> None:
             patch("benchbox.mcp.tools.benchmark._get_platform_adapter", return_value=object()),
         ):
             response = _run_benchmark_impl(
-                "duckdb", "tpch", 0.01, None, "load,power", "sql", results_dir=Path("benchmark_runs/results")
+                "duckdb",
+                "tpch",
+                0.01,
+                None,
+                "load,power",
+                "sql",
+                results_dir=Path("benchmark_runs/results"),
+                anonymize=False,
             )
         assert response["mcp_metadata"]["status"] in {"completed", "no_results"}
         assert captured.getvalue() == ""

--- a/tests/unit/mcp/test_surface_defect_regressions.py
+++ b/tests/unit/mcp/test_surface_defect_regressions.py
@@ -183,6 +183,26 @@ class TestRemoteModeAnonymization:
 
         assert exporter_cls.call_args.kwargs["anonymize"] is True
 
+    @pytest.mark.parametrize(
+        ("module_path", "function_name"),
+        [
+            ("benchbox.mcp.tools.benchmark", "_run_benchmark_impl"),
+            ("benchbox.mcp.tools.benchmark", "_export_and_build_payload"),
+            ("benchbox.mcp.tools.analytics", "_compare_results_impl"),
+        ],
+    )
+    def test_anonymize_has_no_permissive_default(self, module_path: str, function_name: str):
+        """A default would make "forgot the kwarg" look like "chose local"."""
+        import importlib
+        import inspect
+
+        parameter = inspect.signature(getattr(importlib.import_module(module_path), function_name)).parameters[
+            "anonymize"
+        ]
+
+        assert parameter.kind is inspect.Parameter.KEYWORD_ONLY
+        assert parameter.default is inspect.Parameter.empty
+
 
 class TestChartOutputContract:
     """Defect 3: the docstring promised ANSI colors the renderer never emits."""


### PR DESCRIPTION
Adversarial review of the merged one-engine Phase 1 diff (#1548-#1551),
reviewers prompted to refute. Two confirmed findings; a third is out of scope
and is recorded as tracker deferral #689 on one-engine-residual-dedup.

(1) percentile_ms silently returned max(times) for an out-of-range percentile.

    The three implementations this migration deleted all took the percentile on
    a 0-100 scale, so `percentile_ms(times, 95)` is the porting mistake the
    change makes easy to write. Clamping turned it into rank
    min(max(1, ceil(n*95)), n) = n, i.e. the maximum, reported as a p95: 310.0ms
    instead of 200.0ms over the 22 TPC-H fixture timings, with no error.

    percentile_ms now raises ValueError outside [0, 1], before the empty-input
    shortcut so an empty sequence cannot mask a bad argument. Every current call
    site was audited and all 13 already pass fractions, so this is latent
    hardening, not a live-bug fix; no reported number changes.

(2) The anonymization control defaulted to the permissive value.

    _run_benchmark_impl and _compare_results_impl took `anonymize: bool = False`
    while the innermost _export_and_build_payload correctly required it. That
    default makes "the caller forgot the kwarg" indistinguishable from "the
    caller is local", and it fails open on exactly the remote/tenant path the
    flag exists to protect: a new durable code path that omitted it would ship a
    bundle with real filesystem paths and hostnames to another principal.

    Both are now keyword-only and required, matching _export_and_build_payload.
    Eight test call sites state their trust boundary explicitly. A signature
    test pins all three so a permissive default cannot come back.

Both fixes were mutation-checked: removing the range guard fails 8 tests,
restoring the permissive default fails 1.

Verified clean during the same pass, with evidence:

- No result-bundle numeric drift. TimingStatsCalculator is bit-identical to its
  pre-migration implementation across 14 inputs including empty, single-element,
  all-zero, negative, and n=1000 random cases.
- No layering violation: lint-imports 3/3 contracts kept; core imports no
  platforms or cli; benchbox.mcp imports no benchbox.cli.
- No weakened MCP security invariants: 84 allowlist/admission/tenancy/ClickHouse
  /Dask tests pass; the double-validation "defect" stays correctly refuted.
- No dangling symbols: repo-wide sweep over all 24 deleted names returns only
  the deliberate negative tests.
- No contract-test tautologies: eight independent mutations (ledger tier flip,
  ledger row deletion, restoring the retired framing, reverting the percentile
  method, disabling remote anonymization, re-breaking the not-found arg binding,
  leaking support_status for internal benchmarks, restoring a dead lazy
  re-export) each killed at least one test.
- No anonymization gap in get_results: it re-serializes the stored bundle, which
  remote mode now writes anonymized.

Fast lane green at 26815.
