### PR TITLE
refactor(results): one regression and trend policy under every surface

### DIFF
--- a/benchbox/cli/commands/compare.py
+++ b/benchbox/cli/commands/compare.py
@@ -35,6 +35,7 @@ from benchbox.core.results.loader import (
     iter_query_results,
     load_result_file,
 )
+from benchbox.core.results.regression_policy import is_regression
 from benchbox.validation.bundle import COMPANION_SUFFIXES
 
 
@@ -1350,23 +1351,23 @@ def _parse_threshold(threshold_str: str) -> float | None:
 
 
 def _check_regression(comparison: dict[str, Any], threshold: float) -> bool:
-    """Check if any query or overall performance regressed beyond threshold."""
-    # Check overall performance changes
+    """Check if any query or overall performance regressed beyond threshold.
+
+    ``threshold`` is a decimal fraction (``--fail-on-regression 10%`` parses to
+    0.1); the shared policy takes percent, so it is scaled here at the boundary.
+    """
+    threshold_percent = threshold * 100
+
     perf_changes = comparison.get("performance_changes", {})
     for _metric_name, metric_data in perf_changes.items():
         if not isinstance(metric_data, dict):
             continue
-        change_pct = metric_data.get("change_percent", 0)
-        # Positive change = slower = regression
-        if change_pct > (threshold * 100):
+        if is_regression(metric_data.get("change_percent", 0), threshold_percent):
             return True
 
-    # Check per-query regressions
     query_comparisons = comparison.get("query_comparisons", [])
     for query in query_comparisons:
-        change_pct = query.get("change_percent", 0)
-        # Positive change = slower = regression
-        if change_pct > (threshold * 100):
+        if is_regression(query.get("change_percent", 0), threshold_percent):
             return True
 
     return False

--- a/benchbox/cli/commands/report.py
+++ b/benchbox/cli/commands/report.py
@@ -17,6 +17,7 @@ from benchbox.core.results.database import (
     RankingConfig,
     ResultDatabase,
 )
+from benchbox.core.results.regression_policy import is_meaningful_improvement
 
 
 @click.group("report")
@@ -191,7 +192,7 @@ def trends(
 
         if t.is_regression:
             status = "[red]REGRESSION[/red]"
-        elif t.change_pct is not None and t.change_pct < -5:
+        elif is_meaningful_improvement(t.change_pct):
             status = "[green]IMPROVED[/green]"
         else:
             status = "[blue]STABLE[/blue]"

--- a/benchbox/core/results/database.py
+++ b/benchbox/core/results/database.py
@@ -19,13 +19,14 @@ import logging
 import sqlite3
 from collections.abc import Iterator
 from contextlib import contextmanager
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
 from benchbox.core.results.models import BenchmarkResults
 from benchbox.core.results.platform_options import sanitize_platform_options
+from benchbox.core.results.regression_policy import is_regression
 
 logger = logging.getLogger(__name__)
 
@@ -156,7 +157,7 @@ class PerformanceTrend:
     max_geometric_mean_ms: float
     sample_count: int
     change_pct: float | None  # Change from previous period
-    is_regression: bool  # True if >10% slowdown
+    is_regression: bool  # Per benchbox.core.results.regression_policy
 
 
 @dataclass
@@ -894,7 +895,7 @@ class ResultDatabase:
                     max_geometric_mean_ms=current.max_geometric_mean_ms,
                     sample_count=current.sample_count,
                     change_pct=change,
-                    is_regression=change > 10,  # >10% slowdown
+                    is_regression=is_regression(change),
                 )
 
         return trends
@@ -937,8 +938,16 @@ class ResultDatabase:
                     trends = self.get_performance_trends(platform, benchmark, sf, periods=2, period_days=lookback_days)
 
                     for trend in trends:
-                        if trend.is_regression and trend.change_pct and trend.change_pct > threshold_pct:
-                            regressions.append(trend)
+                        # Evaluate against the caller's threshold only.
+                        # Previously this also required trend.is_regression,
+                        # which get_performance_trends computes at the default
+                        # 10% -- so any threshold below 10 was silently inert
+                        # (a 7% slowdown could never be reported at
+                        # --threshold 5). is_regression is recomputed here so
+                        # the returned records agree with the filter that
+                        # selected them.
+                        if is_regression(trend.change_pct, threshold_pct):
+                            regressions.append(replace(trend, is_regression=True))
 
         return regressions
 

--- a/benchbox/core/results/regression_policy.py
+++ b/benchbox/core/results/regression_policy.py
@@ -1,0 +1,153 @@
+"""One regression and trend policy for every BenchBox surface.
+
+Before this module, four places answered the same question differently: CLI
+``compare``'s threshold check, CLI ``report``'s display cutoff, MCP analytics'
+severity ladder and trend thresholds, and a hardcoded ``change > 10`` inside the
+results database. An agent asking over MCP and a human asking over the CLI could
+reach different verdicts from the same result files.
+
+The canonical policy is MCP's, because it was the only one that classified
+rather than merely thresholded: it had a severity ladder, an improvement class,
+and an explicit trend vocabulary. The CLI's caller-supplied threshold semantics
+are preserved as an override on top of it.
+
+Copyright 2026 Joe Harris / BenchBox Project
+
+Licensed under the MIT License. See LICENSE file in the project root for details.
+"""
+
+from __future__ import annotations
+
+from typing import Final, Literal
+
+# A run is a regression when it is more than this much slower than its baseline.
+# Callers may override it -- CLI ``compare --fail-on-regression``, MCP
+# ``analyze_results(threshold_percent=...)``, and ``report --threshold`` all map
+# onto this same parameter -- but every surface starts here.
+DEFAULT_REGRESSION_THRESHOLD_PERCENT: Final = 10.0
+
+# Movement smaller than this is noise, not a trend. This is the cutoff behind
+# report's "IMPROVED" label and MCP's improving/degrading trend directions; they
+# were independently written as 5 and must stay one number.
+TREND_SIGNIFICANCE_PERCENT: Final = 5.0
+
+# Severity ladder, ordered most severe first. Read as "delta_percent >= bound".
+SEVERITY_LADDER: Final = (
+    ("critical", 100.0),
+    ("high", 50.0),
+    ("medium", 25.0),
+)
+DEFAULT_SEVERITY: Final = "low"
+
+ChangeClass = Literal["regression", "improvement", "stable"]
+TrendDirection = Literal["improving", "degrading", "stable", "insufficient_data", "unknown"]
+
+CHANGE_CLASSES: Final = ("regression", "improvement", "stable")
+TREND_DIRECTIONS: Final = ("improving", "degrading", "stable", "insufficient_data", "unknown")
+SEVERITIES: Final = ("critical", "high", "medium", "low")
+
+
+def percent_change(baseline: float, current: float) -> float | None:
+    """Return the percentage change from ``baseline`` to ``current``.
+
+    Positive means slower, which is the sign convention every surface uses.
+    Returns None when ``baseline`` is not strictly positive, because a
+    percentage change against a zero or negative baseline is not meaningful --
+    callers must skip the comparison rather than report a fabricated number.
+    """
+    if baseline <= 0:
+        return None
+    return ((current - baseline) / baseline) * 100.0
+
+
+def classify_severity(delta_percent: float) -> str:
+    """Return the severity band for a regression's percentage change."""
+    for severity, lower_bound in SEVERITY_LADDER:
+        if delta_percent >= lower_bound:
+            return severity
+    return DEFAULT_SEVERITY
+
+
+def classify_change(
+    delta_percent: float,
+    threshold_percent: float = DEFAULT_REGRESSION_THRESHOLD_PERCENT,
+) -> ChangeClass:
+    """Classify one percentage change against a symmetric threshold.
+
+    The threshold is symmetric: a change slower than ``+threshold`` is a
+    regression, faster than ``-threshold`` is an improvement, and anything
+    between is stable.
+    """
+    if delta_percent > threshold_percent:
+        return "regression"
+    if delta_percent < -threshold_percent:
+        return "improvement"
+    return "stable"
+
+
+def is_regression(
+    delta_percent: float | None,
+    threshold_percent: float = DEFAULT_REGRESSION_THRESHOLD_PERCENT,
+) -> bool:
+    """Return True when ``delta_percent`` is a regression at this threshold.
+
+    A None delta -- an unusable baseline -- is not a regression.
+    """
+    if delta_percent is None:
+        return False
+    return classify_change(delta_percent, threshold_percent) == "regression"
+
+
+def classify_trend(values: list[float]) -> tuple[TrendDirection, float]:
+    """Classify a first-to-last trend across ordered measurements.
+
+    Returns the direction and the percentage change. Fewer than two points is
+    ``insufficient_data``; a non-positive first value is ``unknown``. Both
+    return 0.0 rather than a fabricated percentage.
+
+    Movement within +/- ``TREND_SIGNIFICANCE_PERCENT`` is ``stable``.
+    """
+    if len(values) < 2:
+        return "insufficient_data", 0.0
+
+    change = percent_change(values[0], values[-1])
+    if change is None:
+        return "unknown", 0.0
+
+    if change < -TREND_SIGNIFICANCE_PERCENT:
+        return "improving", change
+    if change > TREND_SIGNIFICANCE_PERCENT:
+        return "degrading", change
+    return "stable", change
+
+
+def is_meaningful_improvement(change_percent: float | None) -> bool:
+    """Return True when a change is a large enough speedup to label as improved.
+
+    This is the display-layer cutoff behind ``benchbox report trends``' IMPROVED
+    label. It lives here rather than in the command file because a display
+    cutoff is policy too -- an inline ``-5`` in a render function is how these
+    four implementations drifted apart in the first place.
+    """
+    if change_percent is None:
+        return False
+    return change_percent < -TREND_SIGNIFICANCE_PERCENT
+
+
+__all__ = [
+    "CHANGE_CLASSES",
+    "DEFAULT_REGRESSION_THRESHOLD_PERCENT",
+    "DEFAULT_SEVERITY",
+    "SEVERITIES",
+    "SEVERITY_LADDER",
+    "TREND_DIRECTIONS",
+    "TREND_SIGNIFICANCE_PERCENT",
+    "ChangeClass",
+    "TrendDirection",
+    "classify_change",
+    "classify_severity",
+    "classify_trend",
+    "is_meaningful_improvement",
+    "is_regression",
+    "percent_change",
+]

--- a/benchbox/mcp/tools/analytics.py
+++ b/benchbox/mcp/tools/analytics.py
@@ -21,6 +21,12 @@ from mcp.types import ToolAnnotations
 from benchbox.core.results.exporter import ResultExporter
 from benchbox.core.results.metrics import calculate_named_metric, percentile_ms, sample_stdev_ms
 from benchbox.core.results.query_normalizer import normalize_query_id
+from benchbox.core.results.regression_policy import (
+    classify_change,
+    classify_severity,
+    classify_trend,
+    percent_change,
+)
 from benchbox.mcp.errors import ErrorCode, make_error, make_not_found_error
 from benchbox.mcp.security import PathProvider, resolve_path_provider
 from benchbox.mcp.tools.path_utils import resolve_result_file_path
@@ -534,9 +540,12 @@ def _classify_query_changes(
             continue
 
         delta_ms = new_time - old_time
-        delta_pct = (delta_ms / old_time) * 100
+        delta_pct = percent_change(old_time, new_time)
+        if delta_pct is None:
+            continue
 
-        if delta_pct > threshold_percent:
+        change_class = classify_change(delta_pct, threshold_percent)
+        if change_class == "regression":
             regressions.append(
                 {
                     "query_id": qid,
@@ -544,10 +553,10 @@ def _classify_query_changes(
                     "current_ms": round(new_time, 2),
                     "delta_ms": round(delta_ms, 2),
                     "delta_percent": round(delta_pct, 1),
-                    "severity": _classify_regression_severity(delta_pct),
+                    "severity": classify_severity(delta_pct),
                 }
             )
-        elif delta_pct < -threshold_percent:
+        elif change_class == "improvement":
             improvements.append(
                 {
                     "query_id": qid,
@@ -649,24 +658,6 @@ def _resolve_timestamp_str(timestamp: Any, file_path: Path) -> str:
     return datetime.fromtimestamp(file_path.stat().st_mtime).isoformat()
 
 
-def _compute_trend_direction(runs: list[dict[str, Any]]) -> tuple[str, float]:
-    """Compute trend direction and percentage from ordered data points."""
-    if len(runs) < 2:
-        return "insufficient_data", 0
-
-    first_value = runs[0]["value"]
-    last_value = runs[-1]["value"]
-    if first_value <= 0:
-        return "unknown", 0
-
-    trend_pct = ((last_value - first_value) / first_value) * 100
-    if trend_pct < -5:
-        return "improving", trend_pct
-    elif trend_pct > 5:
-        return "degrading", trend_pct
-    return "stable", trend_pct
-
-
 def _load_trend_data_point(
     file_path: Path,
     platform: str | None,
@@ -748,7 +739,7 @@ def _get_performance_trends_impl(
         }
 
     runs.reverse()
-    trend_direction, trend_pct = _compute_trend_direction(runs)
+    trend_direction, trend_pct = classify_trend([run["value"] for run in runs])
 
     return {
         "status": "success",
@@ -949,15 +940,3 @@ def _format_plan_tree(plan: dict, indent: int = 0) -> str:
             lines.append(_format_plan_tree(children, indent + 1))
 
     return "\n".join(lines)
-
-
-def _classify_regression_severity(delta_pct: float) -> str:
-    """Classify regression severity based on percentage change."""
-    if delta_pct >= 100:
-        return "critical"
-    elif delta_pct >= 50:
-        return "high"
-    elif delta_pct >= 25:
-        return "medium"
-    else:
-        return "low"

--- a/tests/uat/test_no_cli_surface_drift.py
+++ b/tests/uat/test_no_cli_surface_drift.py
@@ -49,6 +49,12 @@ ALLOWED_INTERNAL_CLI_FILES = {
     "benchbox/cli/commands/convert.py",
     "benchbox/cli/commands/df_tuning.py",
     "benchbox/cli/commands/publish.py",
+    # one-engine-unify-regression-policy: the trends table's hardcoded -5%
+    # IMPROVED cutoff now calls
+    # benchbox.core.results.regression_policy.is_meaningful_improvement, so the
+    # display constant lives with the rest of the policy. No click decorator,
+    # command signature, or column changed.
+    "benchbox/cli/commands/report.py",
     "benchbox/cli/commands/run.py",
     "benchbox/cli/commands/run_official.py",
     "benchbox/cli/commands/submit.py",

--- a/tests/unit/cli/test_compare_regression_exit_contract.py
+++ b/tests/unit/cli/test_compare_regression_exit_contract.py
@@ -1,0 +1,108 @@
+"""`benchbox compare --fail-on-regression` exit-code contract.
+
+Scripts and CI jobs branch on this exit status, so it is a public contract even
+though it is only two integers. `one-engine-unify-regression-policy` moved the
+predicate behind it into benchbox.core.results.regression_policy; these tests
+pin the observable behavior across that move.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from benchbox.cli.commands.compare import (
+    _check_regression,
+    _check_regression_threshold,
+    _parse_threshold,
+    _validate_regression_threshold,
+)
+
+pytestmark = [
+    pytest.mark.unit,
+    pytest.mark.fast,
+]
+
+
+def _comparison(query_change: float | None = None, metric_change: float | None = None) -> dict[str, Any]:
+    comparison: dict[str, Any] = {"query_comparisons": [], "performance_changes": {}}
+    if query_change is not None:
+        comparison["query_comparisons"].append({"query_id": "1", "change_percent": query_change})
+    if metric_change is not None:
+        comparison["performance_changes"]["geometric_mean"] = {"change_percent": metric_change}
+    return comparison
+
+
+class TestRegressionExitCode:
+    def test_regression_exits_nonzero(self):
+        with pytest.raises(SystemExit) as exit_info:
+            _check_regression_threshold(_comparison(query_change=25.0), 0.10)
+
+        assert exit_info.value.code == 1
+
+    def test_no_regression_does_not_exit(self):
+        assert _check_regression_threshold(_comparison(query_change=2.0), 0.10) is None
+
+    def test_improvement_does_not_exit(self):
+        assert _check_regression_threshold(_comparison(query_change=-40.0), 0.10) is None
+
+    def test_omitted_threshold_never_exits(self):
+        """Without --fail-on-regression the command must stay exit 0."""
+        assert _check_regression_threshold(_comparison(query_change=500.0), None) is None
+
+    def test_metric_level_regression_also_exits(self):
+        with pytest.raises(SystemExit) as exit_info:
+            _check_regression_threshold(_comparison(metric_change=25.0), 0.10)
+
+        assert exit_info.value.code == 1
+
+    def test_exactly_at_the_threshold_does_not_exit(self):
+        assert _check_regression_threshold(_comparison(query_change=10.0), 0.10) is None
+
+    def test_just_over_the_threshold_exits(self):
+        with pytest.raises(SystemExit) as exit_info:
+            _check_regression_threshold(_comparison(query_change=10.5), 0.10)
+
+        assert exit_info.value.code == 1
+
+
+class TestThresholdParsing:
+    @pytest.mark.parametrize(
+        ("raw", "expected"),
+        [("10%", 0.10), ("5.5%", 0.055), ("0.1", 0.1), ("0.05", 0.05), (" 10% ", 0.10)],
+    )
+    def test_accepted_threshold_spellings(self, raw: str, expected: float):
+        assert _parse_threshold(raw) == pytest.approx(expected)
+
+    @pytest.mark.parametrize("raw", ["abc", "%", "10%%", ""])
+    def test_rejected_threshold_spellings(self, raw: str):
+        assert _parse_threshold(raw) is None
+
+    def test_invalid_threshold_exits_one(self):
+        with pytest.raises(SystemExit) as exit_info:
+            _validate_regression_threshold("not-a-threshold")
+
+        assert exit_info.value.code == 1
+
+    def test_absent_flag_yields_no_threshold(self):
+        assert _validate_regression_threshold(None) is None
+        assert _validate_regression_threshold("") is None
+
+
+class TestFailOnRegressionUsesTheSharedPolicy:
+    @pytest.mark.parametrize("change", [-50.0, -10.0, 0.0, 9.9, 10.0, 10.1, 50.0, 150.0])
+    def test_predicate_matches_core(self, change: float):
+        from benchbox.core.results.regression_policy import is_regression
+
+        assert _check_regression(_comparison(query_change=change), 0.10) is is_regression(change, 10.0)
+
+    def test_caller_threshold_overrides_the_default(self):
+        """A 7% slowdown is a regression at --fail-on-regression 5%, not at 10%."""
+        assert _check_regression(_comparison(query_change=7.0), 0.05) is True
+        assert _check_regression(_comparison(query_change=7.0), 0.10) is False
+
+    def test_non_dict_metric_entries_are_skipped(self):
+        comparison = {"query_comparisons": [], "performance_changes": {"geometric_mean": "not-a-dict"}}
+
+        assert _check_regression(comparison, 0.10) is False

--- a/tests/unit/mcp/test_analytics_tools.py
+++ b/tests/unit/mcp/test_analytics_tools.py
@@ -204,8 +204,8 @@ class TestAnalyticsHelperFunctions:
         assert 2.8 < result < 2.9
 
     def test_classify_regression_severity(self):
-        """Test regression severity classification."""
-        from benchbox.mcp.tools.analytics import _classify_regression_severity
+        """Severity comes from the shared core policy."""
+        from benchbox.core.results.regression_policy import classify_severity as _classify_regression_severity
 
         assert _classify_regression_severity(150) == "critical"
         assert _classify_regression_severity(75) == "high"

--- a/tests/unit/mcp/test_mcp_results_and_analytics.py
+++ b/tests/unit/mcp/test_mcp_results_and_analytics.py
@@ -1266,28 +1266,28 @@ class TestAnalyticsHelpers:
 
     def test_classify_regression_severity_critical(self):
         """>=100% delta is critical."""
-        from benchbox.mcp.tools.analytics import _classify_regression_severity
+        from benchbox.core.results.regression_policy import classify_severity as _classify_regression_severity
 
         assert _classify_regression_severity(100.0) == "critical"
         assert _classify_regression_severity(200.0) == "critical"
 
     def test_classify_regression_severity_high(self):
         """50-99% delta is high."""
-        from benchbox.mcp.tools.analytics import _classify_regression_severity
+        from benchbox.core.results.regression_policy import classify_severity as _classify_regression_severity
 
         assert _classify_regression_severity(50.0) == "high"
         assert _classify_regression_severity(99.0) == "high"
 
     def test_classify_regression_severity_medium(self):
         """25-49% delta is medium."""
-        from benchbox.mcp.tools.analytics import _classify_regression_severity
+        from benchbox.core.results.regression_policy import classify_severity as _classify_regression_severity
 
         assert _classify_regression_severity(25.0) == "medium"
         assert _classify_regression_severity(49.0) == "medium"
 
     def test_classify_regression_severity_low(self):
         """<25% delta is low."""
-        from benchbox.mcp.tools.analytics import _classify_regression_severity
+        from benchbox.core.results.regression_policy import classify_severity as _classify_regression_severity
 
         assert _classify_regression_severity(10.0) == "low"
         assert _classify_regression_severity(24.0) == "low"

--- a/tests/unit/test_regression_policy_parity.py
+++ b/tests/unit/test_regression_policy_parity.py
@@ -1,0 +1,193 @@
+"""Every surface must reach the same regression verdict from the same numbers.
+
+Before `one-engine-unify-regression-policy` four implementations answered this
+question: CLI ``compare``'s threshold check, CLI ``report``'s display cutoff,
+MCP analytics' severity ladder and trend thresholds, and a hardcoded
+``change > 10`` inside the results database. This module pins that they now
+agree, and characterizes the one behavior that deliberately changed.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from benchbox.core.results.regression_policy import (
+    DEFAULT_REGRESSION_THRESHOLD_PERCENT,
+    SEVERITIES,
+    TREND_DIRECTIONS,
+    TREND_SIGNIFICANCE_PERCENT,
+    classify_change,
+    classify_severity,
+    classify_trend,
+    is_meaningful_improvement,
+    is_regression,
+    percent_change,
+)
+
+pytestmark = [
+    pytest.mark.unit,
+    pytest.mark.fast,
+]
+
+# Percentage changes spanning every band boundary, including the exact edges.
+SHARED_DELTAS = [-150.0, -100.0, -50.0, -10.1, -10.0, -5.1, -5.0, 0.0, 5.0, 5.1, 10.0, 10.1, 25.0, 50.0, 100.0, 250.0]
+
+
+class TestPolicyIsSelfConsistent:
+    @pytest.mark.parametrize("delta", SHARED_DELTAS)
+    def test_classification_and_predicate_agree(self, delta: float):
+        assert is_regression(delta) is (classify_change(delta) == "regression")
+
+    @pytest.mark.parametrize("delta", SHARED_DELTAS)
+    def test_severity_is_always_a_declared_band(self, delta: float):
+        assert classify_severity(delta) in SEVERITIES
+
+    def test_thresholds_are_exclusive_at_the_boundary(self):
+        """Exactly at the threshold is stable, not a regression."""
+        assert classify_change(DEFAULT_REGRESSION_THRESHOLD_PERCENT) == "stable"
+        assert classify_change(DEFAULT_REGRESSION_THRESHOLD_PERCENT + 0.1) == "regression"
+        assert classify_change(-DEFAULT_REGRESSION_THRESHOLD_PERCENT) == "stable"
+        assert classify_change(-DEFAULT_REGRESSION_THRESHOLD_PERCENT - 0.1) == "improvement"
+
+    def test_severity_ladder_boundaries(self):
+        assert classify_severity(100.0) == "critical"
+        assert classify_severity(99.9) == "high"
+        assert classify_severity(50.0) == "high"
+        assert classify_severity(49.9) == "medium"
+        assert classify_severity(25.0) == "medium"
+        assert classify_severity(24.9) == "low"
+
+    def test_unusable_baseline_is_not_a_regression(self):
+        assert percent_change(0.0, 100.0) is None
+        assert percent_change(-1.0, 100.0) is None
+        assert is_regression(None) is False
+
+    @pytest.mark.parametrize(
+        ("values", "direction"),
+        [
+            ([], "insufficient_data"),
+            ([100.0], "insufficient_data"),
+            ([0.0, 100.0], "unknown"),
+            ([100.0, 90.0], "improving"),
+            ([100.0, 110.0], "degrading"),
+            ([100.0, 103.0], "stable"),
+            ([100.0, 105.0], "stable"),
+            ([100.0, 95.0], "stable"),
+        ],
+    )
+    def test_trend_directions(self, values: list[float], direction: str):
+        assert classify_trend(values)[0] == direction
+        assert classify_trend(values)[0] in TREND_DIRECTIONS
+
+    def test_trend_reports_zero_rather_than_a_fabricated_percentage(self):
+        assert classify_trend([])[1] == 0.0
+        assert classify_trend([0.0, 100.0])[1] == 0.0
+
+    def test_improvement_label_uses_the_same_significance_cutoff(self):
+        assert is_meaningful_improvement(-TREND_SIGNIFICANCE_PERCENT) is False
+        assert is_meaningful_improvement(-TREND_SIGNIFICANCE_PERCENT - 0.1) is True
+        assert is_meaningful_improvement(None) is False
+        assert classify_trend([100.0, 100.0 - TREND_SIGNIFICANCE_PERCENT - 0.1])[0] == "improving"
+
+
+class TestThreeSurfaceRegressionParity:
+    """CLI compare, MCP analytics, and the results DB must agree."""
+
+    @pytest.mark.parametrize("delta", SHARED_DELTAS)
+    def test_cli_compare_and_core_agree(self, delta: float):
+        from benchbox.cli.commands.compare import _check_regression
+
+        comparison = {"query_comparisons": [{"change_percent": delta}], "performance_changes": {}}
+        # CLI takes the threshold as a decimal fraction.
+        cli_verdict = _check_regression(comparison, DEFAULT_REGRESSION_THRESHOLD_PERCENT / 100)
+
+        assert cli_verdict is is_regression(delta)
+
+    @pytest.mark.parametrize("delta", SHARED_DELTAS)
+    def test_mcp_analytics_and_core_agree(self, delta: float):
+        from benchbox.mcp.tools.analytics import _classify_query_changes
+
+        baseline = 100.0
+        current = baseline * (1 + delta / 100)
+        regressions, improvements, stable = _classify_query_changes(
+            {"1": baseline}, {"1": current}, DEFAULT_REGRESSION_THRESHOLD_PERCENT
+        )
+
+        # Classify the delta the analytics path actually computed, not the
+        # nominal one: `100.0 * (1 + 10.0/100)` is 110.00000000000001, and a
+        # parity test must not turn that float artifact into a policy claim.
+        actual_delta = percent_change(baseline, current)
+        assert actual_delta is not None
+        expected = classify_change(actual_delta)
+        assert bool(regressions) is (expected == "regression")
+        assert bool(improvements) is (expected == "improvement")
+        assert bool(stable) is (expected == "stable")
+
+    @pytest.mark.parametrize("delta", [d for d in SHARED_DELTAS if d > 0])
+    def test_mcp_severity_matches_core(self, delta: float):
+        from benchbox.mcp.tools.analytics import _classify_query_changes
+
+        baseline = 100.0
+        current = baseline * (1 + delta / 100)
+        regressions, _, _ = _classify_query_changes(
+            {"1": baseline}, {"1": current}, DEFAULT_REGRESSION_THRESHOLD_PERCENT
+        )
+
+        if regressions:
+            actual_delta = percent_change(baseline, current)
+            assert actual_delta is not None
+            assert regressions[0]["severity"] == classify_severity(actual_delta)
+
+    @pytest.mark.parametrize("delta", SHARED_DELTAS)
+    def test_results_database_and_core_agree(self, delta: float):
+        """The DB's PerformanceTrend flag is the same predicate."""
+        from benchbox.core.results import database as database_module
+
+        assert database_module.is_regression(delta) is is_regression(delta)
+
+    def test_all_three_surfaces_agree_on_one_shared_delta(self):
+        """A single explicit end-to-end check, not just parametrized pairs."""
+        from benchbox.cli.commands.compare import _check_regression
+        from benchbox.mcp.tools.analytics import _classify_query_changes
+
+        delta = 12.0  # just over the default threshold
+        cli = _check_regression({"query_comparisons": [{"change_percent": delta}]}, 0.10)
+        regressions, _, _ = _classify_query_changes({"1": 100.0}, {"1": 112.0}, 10.0)
+
+        assert cli is True
+        assert len(regressions) == 1
+        assert is_regression(delta) is True
+
+
+class TestNoSurfaceKeepsALocalPolicy:
+    def test_surface_modules_do_not_redefine_policy_helpers(self):
+        import benchbox.cli.commands.compare as compare_module
+        import benchbox.cli.commands.report as report_module
+        import benchbox.mcp.tools.analytics as analytics_module
+
+        for module in (compare_module, report_module, analytics_module):
+            for banned in ("_classify_regression_severity", "_compute_trend_direction"):
+                assert not hasattr(module, banned), f"{module.__name__}.{banned}"
+
+
+class TestReportThresholdIsNoLongerInert:
+    """Characterizes the one deliberate behavior change in this migration."""
+
+    def test_a_sub_default_threshold_now_selects_regressions(self):
+        """Previously `detect_regressions(5.0)` could not report a 7% slowdown.
+
+        get_performance_trends set is_regression at the fixed 10% policy, and
+        detect_regressions required BOTH that flag and change_pct > threshold,
+        so any threshold below 10 was silently inert.
+        """
+        superseded = lambda change, threshold: (change > 10) and (change > threshold)  # noqa: E731
+
+        assert superseded(7.0, 5.0) is False
+        assert is_regression(7.0, 5.0) is True
+
+    def test_thresholds_at_or_above_the_default_are_unchanged(self):
+        superseded = lambda change, threshold: (change > 10) and (change > threshold)  # noqa: E731
+
+        for change in (0.0, 5.0, 7.0, 11.0, 25.0, 120.0):
+            for threshold in (10.0, 15.0, 20.0):
+                assert superseded(change, threshold) is is_regression(change, threshold)


### PR DESCRIPTION
Four implementations answered the same question, so an agent over MCP and a
human over the CLI could reach different verdicts from the same result files:

  benchbox/cli/commands/compare.py    threshold check, no severity, no
                                      improvement class
  benchbox/cli/commands/report.py     hardcoded -5% IMPROVED display cutoff
  benchbox/mcp/tools/analytics.py     severity ladder (100/50/25) plus +/-5%
                                      trend thresholds
  benchbox/core/results/database.py   hardcoded `is_regression = change > 10`

benchbox/core/results/regression_policy.py is now the single source: the
threshold default, the symmetric regression/improvement/stable classification,
the severity ladder, the trend vocabulary, and the display cutoff.

MCP's policy is the canonical one, per the item's approach note, because it was
the only one that classified rather than merely thresholded. The CLI's
caller-supplied threshold semantics are preserved as an override: `compare
--fail-on-regression`, `report --threshold`, and MCP `threshold_percent` all map
onto the same parameter. compare still takes a decimal fraction on its CLI
surface and scales to percent at the boundary.

The report display cutoff moved into core as is_meaningful_improvement rather
than staying an inline `-5` in a render function. A display constant is policy
too; an inline literal in a command file is how these four drifted apart.

## One deliberate behavior change

`benchbox report regressions --threshold N` was silently inert for any N below
10. get_performance_trends set `is_regression = change > 10` at a fixed 10%, and
detect_regressions then required BOTH that flag AND `change_pct > threshold_pct`
-- so a 7% slowdown could never be reported at `--threshold 5`, no matter what
the user asked for. detect_regressions now evaluates the caller's threshold
alone and recomputes is_regression against it, so the returned records agree
with the filter that selected them.

Thresholds at or above 10 are unaffected, which
TestReportThresholdIsNoLongerInert pins by re-running the superseded predicate
alongside the new one across a matrix of changes and thresholds. No other
numbers change: the default threshold stays 10.0, the severity bounds stay
100/50/25, and the trend/display cutoff stays 5.0 -- previously written as three
independent literals, now one constant.

## Coverage

- tests/unit/test_regression_policy_parity.py drives CLI compare, MCP analytics'
  _classify_query_changes, and the database predicate over a shared delta matrix
  that includes every band boundary exactly, and asserts all three agree.
  Boundary semantics are pinned explicitly: exactly at the threshold is stable,
  not a regression.
- tests/unit/cli/test_compare_regression_exit_contract.py is new. The item's
  rung 3 selects `-k 'fail_on_regression or regression_exit'` and expected
  "existing exit-code behavior tests pass" -- but no such tests existed, so the
  rung failed by collecting nothing. The exit-code contract that scripts branch
  on was untested while its predicate was being moved. It now covers regression
  exit 1, clean exit 0, improvement, absent flag, metric-level regressions,
  both threshold boundaries, and threshold parsing.
- A test asserts no surface module still defines _classify_regression_severity
  or _compute_trend_direction.

One parity assertion classifies the delta the analytics path actually computed
rather than the nominal one: `100.0 * (1 + 10.0/100)` is 110.00000000000001, and
a parity test must not turn that float artifact into a policy claim.

report.py joins the CLI-surface-drift allowlist with its rationale: no click
decorator, command signature, or table column changed.

Fast lane 26815 -> 26967 collected (+152), inside the 27050 ceiling.
