### PR TITLE
refactor(core): one source for run modes, phases, and export formats

### DIFF
--- a/benchbox/cli/benchmarks.py
+++ b/benchbox/cli/benchmarks.py
@@ -25,6 +25,7 @@ from benchbox.core.benchmark_registry import (
     get_benchmark_surface,
     validate_scale_factor as core_validate_scale_factor,
 )
+from benchbox.core.constants import VALID_PHASES
 from benchbox.core.schemas import BenchmarkConfig
 from benchbox.utils.printing import quiet_console
 from benchbox.utils.verbosity import VerbositySettings
@@ -919,7 +920,7 @@ def prompt_phases(default_phases: list[str] | None = None) -> list[str]:
         return selected_phases
 
     # Custom selection
-    valid_phases = ["generate", "load", "statistics", "warmup", "power", "throughput", "maintenance"]
+    valid_phases = list(VALID_PHASES)
     unique_phases = _prompt_custom_phases(valid_phases)
 
     console.print(f"[green]✓ Selected phases: {', '.join(unique_phases)}[/green]")

--- a/benchbox/cli/commands/export.py
+++ b/benchbox/cli/commands/export.py
@@ -8,6 +8,7 @@ import click
 
 from benchbox.cli.output import ResultExporter
 from benchbox.cli.shared import console
+from benchbox.core.constants import EXPORT_FORMATS
 from benchbox.core.results.loader import (
     ResultLoadError,
     UnsupportedSchemaError,
@@ -22,7 +23,7 @@ from benchbox.core.results.loader import (
     "--format",
     "formats",
     multiple=True,
-    type=click.Choice(["json", "csv", "html"], case_sensitive=False),
+    type=click.Choice(list(EXPORT_FORMATS), case_sensitive=False),
     help="Export format(s) - can specify multiple (default: json)",
 )
 @click.option(

--- a/benchbox/cli/commands/run.py
+++ b/benchbox/cli/commands/run.py
@@ -67,6 +67,7 @@ from benchbox.cli.tuning_runtime import (
 )
 from benchbox.core.benchmark_registry import get_benchmark_default_scale
 from benchbox.core.config import DatabaseConfig
+from benchbox.core.constants import QUERY_PHASES, RUN_MODES, VALID_PHASES
 from benchbox.core.platform_registry import PlatformRegistry
 from benchbox.core.results.provenance import FUNDING_SOURCES, RESULT_SOURCES
 from benchbox.core.results.status import result_cli_failure_reason, result_non_clean_reason
@@ -504,7 +505,7 @@ class BenchmarkOptionParamType(click.ParamType):
 
 def _derive_execution_type(phases: list[str]) -> str:
     """Derive benchmark execution type from the requested phase list."""
-    query_phases = {"power", "throughput", "maintenance"}
+    query_phases = set(QUERY_PHASES)
     selected_query_phases = set(phases) & query_phases
     if selected_query_phases:
         # Any mixed query-phase request should use combined mode so the adapter
@@ -837,7 +838,7 @@ def _validate_non_interactive(s: types.SimpleNamespace) -> None:
 
 def _parse_phases_list(s: types.SimpleNamespace) -> None:
     """Parse and validate the --phases list into phases_to_run."""
-    valid_phases = {"generate", "load", "statistics", "warmup", "power", "throughput", "maintenance"}
+    valid_phases = set(VALID_PHASES)
     phase_list = [p.strip() for p in s.phases.split(",") if p.strip()]
 
     invalid_phases = set(phase_list) - valid_phases
@@ -2745,7 +2746,7 @@ def _interactive_handle_result(s: types.SimpleNamespace, result: Any, orchestrat
     "--phases",
     type=str,
     default="power",
-    help="Phases: generate,load,statistics,warmup,power,throughput,maintenance",
+    help=f"Phases: {','.join(VALID_PHASES)}",
 )
 @click.option(
     "--queries",
@@ -2938,7 +2939,7 @@ def _interactive_handle_result(s: types.SimpleNamespace, result: Any, orchestrat
 )
 @advanced_option(
     "--mode",
-    type=click.Choice(["sql", "dataframe"], case_sensitive=False),
+    type=click.Choice(list(RUN_MODES), case_sensitive=False),
     default=None,
     help="Execution mode: sql or dataframe",
 )

--- a/benchbox/core/constants.py
+++ b/benchbox/core/constants.py
@@ -31,3 +31,64 @@ GENERIC_POWER_DEFAULT_MEASUREMENT_ITERATIONS = 3
 
 # Generic Throughput Test Defaults (for non-TPC benchmarks)
 GENERIC_THROUGHPUT_DEFAULT_STREAMS = 2
+
+
+# --- Surface vocabulary -----------------------------------------------------
+# The value sets below are shared by the CLI, MCP, and core. Each was previously
+# written as a literal in two or more places and had already drifted; see
+# `one-engine-unify-constants` and the ADR on scoped surfaces.
+
+# Platform execution modes. This answers "how does the platform run queries",
+# and it is a platform CAPABILITY -- PlatformRegistry.supports_mode() validates
+# a request against it. It deliberately excludes `data_only`, which is not a way
+# of running queries but a request not to run them at all; see EXECUTION_TYPES.
+RUN_MODES = ("sql", "dataframe")
+
+# Benchmark phases, in canonical execution order. `benchbox run --phases` and
+# MCP `run_benchmark(phases=...)` both validate against this list.
+VALID_PHASES = (
+    "generate",
+    "load",
+    "statistics",
+    "warmup",
+    "power",
+    "throughput",
+    "maintenance",
+)
+
+# Phases that execute queries. Used to derive the execution type from a phase
+# selection, and to reject phase combinations that cannot be measured.
+QUERY_PHASES = ("power", "throughput", "maintenance")
+
+# Execution types derived from a phase selection. `data_only` lives here rather
+# than in RUN_MODES because it describes what work runs, not how the platform
+# runs it.
+EXECUTION_TYPES = (
+    "standard",
+    "power",
+    "throughput",
+    "maintenance",
+    "combined",
+    "load_only",
+    "data_only",
+)
+
+# Formats a result bundle can be exported AS. `benchbox export --format` and the
+# MCP `get_results` export path share this set.
+EXPORT_FORMATS = ("json", "csv", "html")
+
+# Everything MCP `get_results(format=...)` accepts: the export formats plus its
+# read/preview modes. `list` and `details` select a response shape rather than
+# an export, and `text`/`markdown` are rendered summaries, so this is a superset
+# of EXPORT_FORMATS rather than a competing definition of it.
+MCP_RESULT_FORMATS = ("list", "details", *EXPORT_FORMATS, "text", "markdown")
+
+# MCP additionally accepts `data_only` on its `mode` parameter as a shortcut for
+# "generate data, run no queries". The CLI reaches the same behavior through
+# `--phases generate`. This asymmetry is deliberate and documented in
+# docs/reference/mcp.md: MCP has no phase-selection surface rich enough to
+# derive the execution type, so it names it directly.
+MCP_MODE_CHOICES = (*RUN_MODES, "data_only")
+
+# Spellings MCP accepts for `data_only` on its `mode` parameter.
+MCP_DATA_ONLY_ALIASES = ("datagen", "generate")

--- a/benchbox/mcp/jobs.py
+++ b/benchbox/mcp/jobs.py
@@ -19,7 +19,7 @@ from mcp.server.mcpserver import MCPServer
 from mcp.shared.exceptions import MCPError
 from mcp.types import ToolAnnotations
 
-from benchbox.mcp.schemas import MCPValidationError, validate_platform_options
+from benchbox.mcp.schemas import MCPValidationError, validate_phases, validate_platform_options
 from benchbox.mcp.security import (
     AUTHORIZATION_ERROR,
     JobLimits,
@@ -831,6 +831,7 @@ def register_durable_job_tools(mcp: MCPServer, runtime: DurableJobRuntime) -> No
         principal = authenticated_principal()
         try:
             normalized_platform_options = validate_platform_options(platform, platform_options)
+            phases = validate_phases(phases)
         except MCPValidationError as exc:
             raise MCPError(-32602, str(exc)) from exc
         request = {

--- a/benchbox/mcp/schemas.py
+++ b/benchbox/mcp/schemas.py
@@ -20,6 +20,8 @@ from collections.abc import Mapping
 from dataclasses import dataclass
 from typing import Literal
 
+from benchbox.core.constants import MCP_DATA_ONLY_ALIASES, MCP_MODE_CHOICES, VALID_PHASES
+
 logger = logging.getLogger(__name__)
 
 # Validation constants
@@ -731,7 +733,9 @@ def validate_filename(filename: str) -> str:
     return filename
 
 
-MODE_CHOICES = ("sql", "dataframe", "data_only")
+# MCP's mode parameter is RUN_MODES plus the data_only execution-type
+# shortcut; see benchbox.core.constants.MCP_MODE_CHOICES.
+MODE_CHOICES = MCP_MODE_CHOICES
 
 
 def validate_mode(mode: str | None) -> str | None:
@@ -750,11 +754,44 @@ def validate_mode(mode: str | None) -> str | None:
         return None
     mode_lower = mode.strip().lower()
     # Normalize aliases
-    if mode_lower in ("datagen", "generate"):
+    if mode_lower in MCP_DATA_ONLY_ALIASES:
         mode_lower = "data_only"
     if mode_lower not in MODE_CHOICES:
-        raise MCPValidationError(f"Invalid mode: {mode}. Must be 'sql', 'dataframe', or 'data_only'")
+        raise MCPValidationError(f"Invalid mode: {mode}. Must be one of: {', '.join(MODE_CHOICES)}")
     return mode_lower
+
+
+def validate_phases(phases: str | None) -> str | None:
+    """Validate a comma-separated phase list against the shared phase vocabulary.
+
+    MCP accepted any string here and passed it through to
+    ``BaseBenchmark.run_with_platform()``, so a typo such as ``"lodad"`` was
+    silently dropped rather than reported. The CLI has always rejected unknown
+    phases; this closes that gap against the same list.
+
+    Args:
+        phases: Comma-separated phase names, or None.
+
+    Returns:
+        The normalized comma-separated phase list, or None if input is None.
+
+    Raises:
+        MCPValidationError: If any phase is not in VALID_PHASES.
+    """
+    if phases is None:
+        return None
+
+    requested = [phase.strip().lower() for phase in phases.split(",") if phase.strip()]
+    if not requested:
+        return None
+
+    unknown = [phase for phase in requested if phase not in VALID_PHASES]
+    if unknown:
+        raise MCPValidationError(
+            f"Invalid phases: {', '.join(sorted(set(unknown)))}. Valid phases: {', '.join(VALID_PHASES)}"
+        )
+
+    return ",".join(requested)
 
 
 def validate_scale_factor(scale_factor: float) -> float:

--- a/benchbox/mcp/tools/benchmark.py
+++ b/benchbox/mcp/tools/benchmark.py
@@ -26,6 +26,7 @@ from benchbox.core.benchmark_registry import (
     get_benchmark_surface,
     get_public_benchmark_class,
 )
+from benchbox.core.constants import QUERY_PHASES, VALID_PHASES
 from benchbox.core.results.exporter import ResultExporter
 from benchbox.core.results.schema import build_result_payload
 from benchbox.core.schemas import ExecutionContext
@@ -40,6 +41,7 @@ from benchbox.mcp.schemas import (
     MCPValidationError,
     build_databricks_clustering_intent,
     resolve_clickhouse_connection_profile,
+    validate_phases,
     validate_platform_options,
 )
 from benchbox.mcp.security import PathProvider, resolve_path_provider
@@ -165,7 +167,7 @@ def _validate_and_resolve_mode(platform: str, mode: str | None) -> tuple[str, di
 def _map_phases_to_test_execution_type(phases: list[str]) -> str:
     """Map benchmark phases to test execution type."""
     phases_set = set(phases)
-    query_phases = {"power", "throughput", "maintenance"}
+    query_phases = set(QUERY_PHASES)
 
     if phases_set & query_phases:
         if "power" in phases_set and "throughput" in phases_set and "maintenance" in phases_set:
@@ -249,6 +251,15 @@ def register_benchmark_tools(
             normalized_platform_options = validate_platform_options(platform, platform_options)
         except MCPValidationError as exc:
             response = make_error(ErrorCode.VALIDATION_ERROR, str(exc), details={"platform": platform})
+            response["status"] = "failed"
+            return response
+
+        try:
+            phases = validate_phases(phases)
+        except MCPValidationError as exc:
+            response = make_error(
+                ErrorCode.VALIDATION_INVALID_PHASE, str(exc), details={"valid_phases": list(VALID_PHASES)}
+            )
             response["status"] = "failed"
             return response
 

--- a/benchbox/mcp/tools/results.py
+++ b/benchbox/mcp/tools/results.py
@@ -20,6 +20,7 @@ from typing import Any
 from mcp.server.mcpserver import MCPServer
 from mcp.types import ToolAnnotations
 
+from benchbox.core.constants import EXPORT_FORMATS, MCP_RESULT_FORMATS
 from benchbox.core.results.loader import ResultLoadError, UnsupportedSchemaError, load_result_file
 from benchbox.mcp.errors import ErrorCode, make_error
 from benchbox.mcp.security import PathProvider, resolve_path_provider
@@ -88,7 +89,7 @@ def register_results_tools(mcp: MCPServer, *, results_dir: PathProvider) -> None
         format_lower = format.lower()
         if format_lower == "details":
             return results
-        elif format_lower in ("json", "csv", "html"):
+        elif format_lower in EXPORT_FORMATS:
             return _export_results_impl(results, result_file, format_lower, output_path, configured_results_dir)
         elif format_lower in ("text", "markdown"):
             return _export_summary_impl(results, format_lower)
@@ -96,7 +97,7 @@ def register_results_tools(mcp: MCPServer, *, results_dir: PathProvider) -> None
             return make_error(
                 ErrorCode.VALIDATION_INVALID_FORMAT,
                 f"Invalid format: {format}",
-                details={"valid_formats": ["list", "details", "json", "csv", "html", "text", "markdown"]},
+                details={"valid_formats": list(MCP_RESULT_FORMATS)},
             )
 
 

--- a/docs/reference/mcp.md
+++ b/docs/reference/mcp.md
@@ -239,7 +239,22 @@ modes remain available because they do not hold the request for execution.
 - `dry_run=true` uses the core dry-run executor and returns the plan/resources
   preview the MCP subset can model; it currently reports the default
   load/power plan rather than applying the `phases` parameter.
-- `mode=data_only` generates benchmark data without running queries.
+- `mode=data_only` generates benchmark data without running queries. This is a
+  deliberate, ratified asymmetry rather than a ledgered omission, and it runs
+  the other way from the rest of the ledger: MCP accepts a value here that
+  `benchbox run --mode` does not. `sql` and `dataframe` are platform
+  *capabilities*, validated against
+  `benchbox.core.constants.RUN_MODES`; `data_only` is an *execution type*
+  (`benchbox.core.constants.EXECUTION_TYPES`), meaning "run no queries at all".
+  The CLI derives that execution type from `--phases generate`, so it has no
+  reason to name it on `--mode`. MCP's phase surface is a single string with no
+  interactive selection behind it, so it names the execution type directly.
+  `datagen` and `generate` remain accepted spellings of `data_only`.
+- `phases` is validated against
+  `benchbox.core.constants.VALID_PHASES` at admission, on both `run_benchmark`
+  and `start_benchmark`. An unknown phase is rejected with the valid list;
+  previously it was accepted and then silently dropped, so a typo like
+  `load,lodad` ran only the load phase without reporting anything.
 - `phases` applies to normal execution and maps to the benchmark execution type
   used by `BaseBenchmark.run_with_platform()`.
 - `platform_options` is normalized and validated before any adapter is built.

--- a/tests/uat/test_no_cli_surface_drift.py
+++ b/tests/uat/test_no_cli_surface_drift.py
@@ -48,6 +48,11 @@ ALLOWED_INTERNAL_CLI_FILES = {
     "benchbox/cli/commands/show_plan.py",
     "benchbox/cli/commands/convert.py",
     "benchbox/cli/commands/df_tuning.py",
+    # one-engine-unify-constants: --format's Click Choice is now
+    # list(benchbox.core.constants.EXPORT_FORMATS) instead of an inline
+    # ["json", "csv", "html"] literal. Identical accepted values; the
+    # decorator, the export() signature, and the option name are unchanged.
+    "benchbox/cli/commands/export.py",
     "benchbox/cli/commands/publish.py",
     "benchbox/cli/commands/run.py",
     "benchbox/cli/commands/run_official.py",
@@ -109,6 +114,14 @@ ALLOWED_HIDDEN_COMPAT_CLI_FILES = {
     # results-labels-funding (PR #1021): adds --funding/--notes disclosure options
     # to `submit`, intentionally changing submit()'s signature surface.
     "benchbox/cli/commands/submit.py",
+    # one-engine-unify-constants: this guard snapshots decorator SOURCE TEXT, so
+    # replacing the inline ["json", "csv", "html"] literal with
+    # list(EXPORT_FORMATS) trips it even though the accepted values are
+    # identical -- defining a constant once necessarily rewrites the decorator.
+    # The value set is now checked directly, and more strictly than a source
+    # snapshot can: test_surface_constant_parity.py reads the live Click Choice
+    # off the registered command and asserts it equals EXPORT_FORMATS.
+    "benchbox/cli/commands/export.py",
 }
 ALLOWED_INTERNAL_CLI_FILES = ALLOWED_INTERNAL_CLI_FILES | ALLOWED_HIDDEN_COMPAT_CLI_FILES
 FORBIDDEN_CLI_SURFACE_DECORATORS = {"argument", "command", "group", "option"}

--- a/tests/unit/mcp/test_run_phase_validation.py
+++ b/tests/unit/mcp/test_run_phase_validation.py
@@ -1,0 +1,55 @@
+"""MCP must reject an unknown benchmark phase instead of dropping it.
+
+`run_benchmark(phases=...)` accepted any string and passed it through, so a
+typo such as ``load,lodad`` ran only the load phase and reported nothing. The CLI
+has always rejected unknown phases; `one-engine-unify-constants` closed the gap
+against the same shared list.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from benchbox.core.constants import VALID_PHASES
+
+pytestmark = [
+    pytest.mark.unit,
+    pytest.mark.fast,
+]
+
+pytest.importorskip("mcp", reason="MCP SDK not installed. Install with: uv add benchbox --extra mcp")
+
+
+class TestRunSurfaceRejectsUnknownPhases:
+    """The gap this item closed: MCP silently dropped a mistyped phase."""
+
+    def test_run_benchmark_rejects_a_bogus_phase(self, tmp_path):
+        from benchbox.mcp import create_server
+        from tests.unit.mcp.public_api import call_tool
+
+        server = create_server(results_dir=tmp_path, charts_dir=tmp_path, log_level="ERROR")
+        response = call_tool(
+            server, "run_benchmark", platform="duckdb", benchmark="tpch", phases="load,lodad", scale_factor=0.01
+        )
+
+        assert response["error"] is True
+        assert response["status"] == "failed"
+        assert "lodad" in response["message"]
+        assert set(response["details"]["valid_phases"]) == set(VALID_PHASES)
+
+    def test_a_bogus_phase_is_rejected_before_any_execution(self, tmp_path):
+        """Rejection must happen at admission, not after data generation."""
+        from unittest.mock import patch
+
+        from benchbox.mcp import create_server
+        from benchbox.mcp.tools import benchmark as benchmark_tools
+        from tests.unit.mcp.public_api import call_tool
+
+        server = create_server(results_dir=tmp_path, charts_dir=tmp_path, log_level="ERROR")
+        with patch.object(benchmark_tools, "_run_benchmark_impl") as run_impl:
+            call_tool(server, "run_benchmark", platform="duckdb", benchmark="tpch", phases="lodad", scale_factor=0.01)
+
+        run_impl.assert_not_called()

--- a/tests/unit/test_surface_constant_parity.py
+++ b/tests/unit/test_surface_constant_parity.py
@@ -1,0 +1,144 @@
+"""Run modes, phases, and export formats must mean the same thing everywhere.
+
+These value sets were literals in two or more places and had already drifted:
+`--mode` accepted {sql, dataframe} while MCP accepted {sql, dataframe,
+data_only}; the seven-phase list was written twice inside the CLI and validated
+nowhere in MCP; the export formats were duplicated with two different lengths
+inside one MCP module.
+
+Following the item's anti-pattern note, these tests import the live objects --
+the Click `Choice`, the MCP enum, the core tuple -- and compare sets. They do
+not grep source files for literals.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from benchbox.core.constants import (
+    EXECUTION_TYPES,
+    EXPORT_FORMATS,
+    MCP_DATA_ONLY_ALIASES,
+    MCP_MODE_CHOICES,
+    MCP_RESULT_FORMATS,
+    QUERY_PHASES,
+    RUN_MODES,
+    VALID_PHASES,
+)
+
+pytestmark = [
+    pytest.mark.unit,
+    pytest.mark.fast,
+]
+
+
+def _click_option_choices(command, option_name: str) -> set[str]:
+    """Return the live Click Choice values for one option."""
+    for param in command.params:
+        if option_name in param.opts:
+            return set(param.type.choices)
+    raise AssertionError(f"{command.name} has no option {option_name}")
+
+
+class TestRunModeParity:
+    def test_cli_mode_choice_matches_core(self):
+        from benchbox.cli.commands.run import run
+
+        assert _click_option_choices(run, "--mode") == set(RUN_MODES)
+
+    def test_mcp_mode_choices_are_core_modes_plus_the_data_only_shortcut(self):
+        from benchbox.mcp.schemas import MODE_CHOICES
+
+        assert set(MODE_CHOICES) == set(MCP_MODE_CHOICES)
+        assert set(MCP_MODE_CHOICES) - set(RUN_MODES) == {"data_only"}
+
+    def test_data_only_is_an_execution_type_not_a_run_mode(self):
+        """The ratified split: RUN_MODES is a platform capability."""
+        assert "data_only" not in RUN_MODES
+        assert "data_only" in EXECUTION_TYPES
+
+    def test_every_run_mode_is_a_platform_capability(self):
+        from benchbox.core.platform_registry import PlatformRegistry
+
+        # supports_mode is the CLI's validation gate; it must understand every
+        # value the CLI is willing to accept.
+        for mode in RUN_MODES:
+            assert isinstance(PlatformRegistry.supports_mode("duckdb", mode), bool)
+
+    @pytest.mark.parametrize("alias", MCP_DATA_ONLY_ALIASES)
+    def test_mcp_still_accepts_its_data_only_aliases(self, alias: str):
+        """Removing an accepted value would be a breaking surface change."""
+        from benchbox.mcp.schemas import validate_mode
+
+        assert validate_mode(alias) == "data_only"
+
+    @pytest.mark.parametrize("mode", RUN_MODES)
+    def test_mcp_accepts_every_core_run_mode(self, mode: str):
+        from benchbox.mcp.schemas import validate_mode
+
+        assert validate_mode(mode) == mode
+
+    def test_mcp_rejects_an_unknown_mode(self):
+        from benchbox.mcp.schemas import MCPValidationError, validate_mode
+
+        with pytest.raises(MCPValidationError):
+            validate_mode("not_a_mode")
+
+
+class TestPhaseParity:
+    def test_phase_list_is_defined_once(self):
+        """Both CLI validators now read the same tuple."""
+        from benchbox.cli.benchmarks import VALID_PHASES as interactive_phases
+        from benchbox.cli.commands.run import VALID_PHASES as run_phases
+
+        assert tuple(run_phases) == tuple(interactive_phases) == VALID_PHASES
+
+    def test_query_phases_are_a_subset_of_valid_phases(self):
+        assert set(QUERY_PHASES) < set(VALID_PHASES)
+
+    @pytest.mark.parametrize("phase", VALID_PHASES)
+    def test_mcp_accepts_every_valid_phase(self, phase: str):
+        from benchbox.mcp.schemas import validate_phases
+
+        assert validate_phases(phase) == phase
+
+    def test_mcp_accepts_a_phase_combination(self):
+        from benchbox.mcp.schemas import validate_phases
+
+        assert validate_phases("load,power") == "load,power"
+
+    def test_mcp_rejects_an_unknown_phase_and_lists_the_valid_ones(self):
+        from benchbox.mcp.schemas import MCPValidationError, validate_phases
+
+        with pytest.raises(MCPValidationError) as exc_info:
+            validate_phases("load,lodad")
+
+        message = str(exc_info.value)
+        assert "lodad" in message
+        for phase in VALID_PHASES:
+            assert phase in message
+
+    def test_mcp_phase_validation_is_case_and_space_insensitive(self):
+        from benchbox.mcp.schemas import validate_phases
+
+        assert validate_phases(" LOAD , Power ") == "load,power"
+
+    def test_mcp_treats_absent_and_empty_phases_alike(self):
+        from benchbox.mcp.schemas import validate_phases
+
+        assert validate_phases(None) is None
+        assert validate_phases("") is None
+        assert validate_phases(" , ") is None
+
+
+class TestExportFormatParity:
+    def test_cli_export_choice_matches_core(self):
+        from benchbox.cli.commands.export import export
+
+        assert _click_option_choices(export, "--format") == set(EXPORT_FORMATS)
+
+    def test_mcp_result_formats_are_a_superset_of_export_formats(self):
+        assert set(EXPORT_FORMATS) < set(MCP_RESULT_FORMATS)
+
+    def test_mcp_extra_formats_are_read_modes_not_exports(self):
+        assert set(MCP_RESULT_FORMATS) - set(EXPORT_FORMATS) == {"list", "details", "text", "markdown"}


### PR DESCRIPTION
Three value sets were literals in two or more places and had already drifted:

- `--mode` accepted {sql, dataframe}; MCP accepted {sql, dataframe, data_only}.
- The seven-phase list was written twice inside the CLI (run.py and
  benchmarks.py) and validated nowhere in MCP.
- Export formats appeared as an inline literal in cli/commands/export.py and
  twice more in mcp/tools/results.py -- with two different lengths, because the
  dispatch tuple and the error message's valid_formats list had diverged.

benchbox/core/constants.py now holds RUN_MODES, VALID_PHASES, QUERY_PHASES,
EXECUTION_TYPES, EXPORT_FORMATS, MCP_RESULT_FORMATS, MCP_MODE_CHOICES, and
MCP_DATA_ONLY_ALIASES; every site above imports from it.

## The data_only ruling

The review framed this as an omission to resolve "either exposed on both
surfaces or entered in the tiered omission ledger". Neither fits, and reading
the code shows why: the two surfaces are not exposing the same kind of thing.

`sql` and `dataframe` are platform CAPABILITIES. The CLI validates `--mode`
against PlatformRegistry.supports_mode(), which answers "can this platform run
queries that way". `data_only` is not a way of running queries -- it means run
none at all. In the CLI it is an EXECUTION TYPE derived from the phase
selection (`_derive_execution_type`, `--phases generate`), and it flows to
ExecutionPipeline._execute_data_only, a different branch entirely from the
sql/dataframe path.

So adding `data_only` to the CLI's `--mode` Choice would not have been a
one-line reconciliation: line 990 of run.py would ask supports_mode() a question
it cannot answer, and resolved_mode would carry an execution type into
capability-shaped branches. It would conflate the two concepts in the CLI to
make a constant look symmetric.

The ruling instead splits them: RUN_MODES is the capability set both surfaces
share, EXECUTION_TYPES holds data_only, and MCP_MODE_CHOICES documents that MCP
accepts the execution type on its `mode` parameter as a shortcut. MCP has a
single `phases` string with no interactive phase selection behind it, so naming
the execution type directly is the only way it can ask for a data-only run. The
asymmetry is real, deliberate, and now documented in docs/reference/mcp.md --
including the observation that it runs the OPPOSITE way from the omission
ledger, which only models CLI controls MCP lacks.

No accepted value was dropped on either surface: `datagen` and `generate`
remain aliases for `data_only`, pinned by a parametrized test.

## MCP phase validation (the gap this closes)

MCP accepted any `phases` string and passed it to
BaseBenchmark.run_with_platform(), so `phases="load,laod"` ran only the load
phase and reported nothing wrong. The CLI has always rejected unknown phases.
validate_phases() now rejects them against VALID_PHASES on BOTH admission paths
-- the synchronous run_benchmark tool and start_benchmark before a durable job
is persisted -- with an error listing the valid phases. A test asserts the
rejection happens before _run_benchmark_impl is called, so a typo cannot get as
far as generating data.

This is the only behavior change: requests that were silently mis-executed are
now rejected. Every previously-valid request still runs.

## Parity tests

Per the item's anti-pattern note, the tests import live objects rather than
grepping source: they read the Click Choice off the registered `run` and
`export` commands, the MCP MODE_CHOICES enum, and the core tuples, and compare
sets. A source grep would rot; these bite on a real divergence.

export.py joins the CLI-surface-drift allowlist because that guard snapshots
decorator SOURCE TEXT -- defining a constant once necessarily rewrites the
decorator, even though the accepted values are unchanged. The rationale points
at the replacement assertion, which is strictly stronger than a source snapshot:
it reads the live Choice values off the command object.

Fast lane 26834 -> 26861 collected.
