### PR TITLE
test: close two Phase 2 review findings

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -30,6 +30,7 @@ from typing import Any
 
 import pytest
 
+from benchbox.utils.config_interface import set_config_provider
 from benchbox.utils.printing import set_quiet
 
 # Sphinx 11 deprecations in third-party extensions (sphinx_tags, myst_parser, ablog, napoleon).
@@ -344,6 +345,32 @@ def _reset_global_quiet_state():
     """
     yield
     set_quiet(False)
+
+
+@pytest.fixture(autouse=True)
+def _reset_global_config_provider():
+    """Never let the CLI's config provider leak across tests.
+
+    benchbox.utils.config_interface keeps a process-global provider that the
+    CLI installs from its group callback (install_cli_config_provider, added
+    with the utils -> cli dependency inversion in #1556). Any test that invokes
+    a CLI subcommand therefore makes CLIConfigProvider -- backed by a real
+    ConfigManager reading ~/.benchbox/config.yaml -- the provider for every
+    LATER test in the same xdist worker. A test that then builds an
+    ExecutionConfigHelper() or an execution manager without passing
+    config_manager silently reads the developer's real config instead of
+    SimpleConfigProvider's documented defaults, and does so only when it
+    happens to be scheduled after a CLI test on that worker.
+
+    Resetting AFTER each test (post-yield) mirrors _reset_global_quiet_state
+    and contains the blast radius to the leaking test itself.
+
+    ``set_config_provider`` is imported at module scope for the same reason
+    that fixture documents: this teardown runs after EVERY test, including
+    tests that monkeypatch ``builtins.__import__`` for their own duration.
+    """
+    yield
+    set_config_provider(None)
 
 
 def pytest_runtest_setup(item) -> None:

--- a/tests/unit/test_regression_policy_parity.py
+++ b/tests/unit/test_regression_policy_parity.py
@@ -171,23 +171,94 @@ class TestNoSurfaceKeepsALocalPolicy:
 
 
 class TestReportThresholdIsNoLongerInert:
-    """Characterizes the one deliberate behavior change in this migration."""
+    """Characterizes the one deliberate behavior change in this migration.
 
-    def test_a_sub_default_threshold_now_selects_regressions(self):
-        """Previously `detect_regressions(5.0)` could not report a 7% slowdown.
+    These drive ResultDatabase.detect_regressions itself. An earlier version of
+    this class compared a locally-defined lambda against is_regression, which
+    proved only that two expressions in the test file disagree -- restoring the
+    superseded filter in database.py left every test green.
+    """
+
+    @staticmethod
+    def _trend(change_pct: float | None, *, is_regression_flag: bool):
+        from datetime import datetime, timezone
+
+        from benchbox.core.results.database import PerformanceTrend
+
+        moment = datetime(2026, 8, 4, tzinfo=timezone.utc)
+        return PerformanceTrend(
+            platform="duckdb",
+            benchmark="tpch",
+            scale_factor=1.0,
+            period_start=moment,
+            period_end=moment,
+            avg_geometric_mean_ms=100.0,
+            min_geometric_mean_ms=90.0,
+            max_geometric_mean_ms=110.0,
+            sample_count=3,
+            change_pct=change_pct,
+            is_regression=is_regression_flag,
+        )
+
+    def _detect(self, tmp_path, trend, threshold: float):
+        from unittest.mock import patch
+
+        from benchbox.core.results.database import ResultDatabase
+
+        db = ResultDatabase(tmp_path / "results.db")
+        with (
+            patch.object(ResultDatabase, "get_platforms", return_value=["duckdb"]),
+            patch.object(ResultDatabase, "get_benchmarks", return_value=["tpch"]),
+            patch.object(ResultDatabase, "get_performance_trends", return_value=[trend]),
+            patch.object(db, "_connection") as connection,
+        ):
+            cursor = connection.return_value.__enter__.return_value.cursor.return_value
+            cursor.fetchall.return_value = [(1.0,)]
+            return db.detect_regressions(threshold_pct=threshold)
+
+    def test_a_sub_default_threshold_now_selects_regressions(self, tmp_path):
+        """A 7% slowdown was unreportable at --threshold 5.
 
         get_performance_trends set is_regression at the fixed 10% policy, and
         detect_regressions required BOTH that flag and change_pct > threshold,
-        so any threshold below 10 was silently inert.
+        so the flag vetoed every threshold below 10.
         """
-        superseded = lambda change, threshold: (change > 10) and (change > threshold)  # noqa: E731
+        trend = self._trend(7.0, is_regression_flag=False)
 
-        assert superseded(7.0, 5.0) is False
-        assert is_regression(7.0, 5.0) is True
+        found = self._detect(tmp_path, trend, threshold=5.0)
 
-    def test_thresholds_at_or_above_the_default_are_unchanged(self):
+        assert len(found) == 1
+        assert found[0].change_pct == 7.0
+
+    def test_the_returned_record_agrees_with_the_filter(self, tmp_path):
+        """A row selected as a regression must not report is_regression False."""
+        trend = self._trend(7.0, is_regression_flag=False)
+
+        found = self._detect(tmp_path, trend, threshold=5.0)
+
+        assert found[0].is_regression is True
+
+    def test_a_change_under_the_threshold_is_still_excluded(self, tmp_path):
+        trend = self._trend(3.0, is_regression_flag=False)
+
+        assert self._detect(tmp_path, trend, threshold=5.0) == []
+
+    def test_the_default_threshold_is_unchanged(self, tmp_path):
+        """At the default, selection matches the superseded filter exactly."""
+        assert self._detect(tmp_path, self._trend(12.0, is_regression_flag=True), threshold=10.0)
+        assert self._detect(tmp_path, self._trend(7.0, is_regression_flag=False), threshold=10.0) == []
+
+    def test_a_missing_change_is_not_a_regression(self, tmp_path):
+        """change_pct is None for the oldest period in a window."""
+        trend = self._trend(None, is_regression_flag=False)
+
+        assert self._detect(tmp_path, trend, threshold=5.0) == []
+
+    def test_thresholds_at_or_above_the_default_are_unchanged(self, tmp_path):
         superseded = lambda change, threshold: (change > 10) and (change > threshold)  # noqa: E731
 
         for change in (0.0, 5.0, 7.0, 11.0, 25.0, 120.0):
             for threshold in (10.0, 15.0, 20.0):
-                assert superseded(change, threshold) is is_regression(change, threshold)
+                trend = self._trend(change, is_regression_flag=change > 10)
+                selected = bool(self._detect(tmp_path, trend, threshold=threshold))
+                assert selected is superseded(change, threshold), (change, threshold)


### PR DESCRIPTION
Adversarial review of the merged Phase 2 diff (#1553-#1556), reviewers prompted
to refute. Two confirmed findings, both in the tests rather than the runtime.

(1) The headline behavior change of #1554 had no test on the production path.

    TestReportThresholdIsNoLongerInert compared a locally-defined lambda against
    is_regression. That proves two expressions in the test file disagree; it
    never called ResultDatabase.detect_regressions. Reverting database.py to the
    superseded filter -- `trend.is_regression and trend.change_pct and
    trend.change_pct > threshold_pct` -- left all 105 tests in the module green,
    so the "--threshold below 10 is silently inert" bug could be reintroduced
    without a single failure.

    The class now drives detect_regressions itself with crafted
    PerformanceTrend records, and covers what the lambda could not: that a row
    selected as a regression does not come back reporting is_regression False,
    and that a None change_pct (the oldest period in a window) is not selected.
    The same mutation now fails two tests.

(2) The utils -> cli dependency inversion in #1556 leaks across tests.

    install_cli_config_provider sets process-global state from the CLI group
    callback, so any test invoking a CLI subcommand makes CLIConfigProvider --
    backed by a real ConfigManager reading ~/.benchbox/config.yaml -- the
    provider for every LATER test in the same xdist worker. A later test
    building ExecutionConfigHelper() without a config_manager then silently
    reads the developer's real config instead of SimpleConfigProvider's
    defaults, and only when it happens to be scheduled after a CLI test on that
    worker. Verified: a fresh process resolves SimpleConfigProvider; after
    `cli run --help` the identical call resolves CLIConfigProvider.

    No production consumer is affected today -- nothing constructs those classes
    without passing config_manager -- so this is a test-isolation defect, not a
    product one. But it is the same shape as the _QUIET leak that produced a
    develop-red on run 28706929881, so it gets the same treatment: an autouse
    post-yield fixture in tests/conftest.py, modelled on and cross-referenced
    with _reset_global_quiet_state, including its module-scope import rationale.

Verified clean in the same pass, with evidence:

- No numeric or classification drift beyond the disclosed detect_regressions
  fix: widening the threshold band by 2x fails 6 tests across the parity and
  exit-code suites.
- Phase validation rejects only genuinely invalid phases. All seven VALID_PHASES
  round-trip; `execute` and `all` are rejected, neither is a documented phase on
  either surface, and the CLI has always rejected them.
- No dangling symbols: the only hits for the four deleted policy/statistics
  helpers are import aliases pointing at their core replacements.
- No weakened MCP security invariants: 90 allowlist/admission/tenancy/ClickHouse
  /Dask/anonymization tests pass.
- No layering regression: lint-imports 3/3 kept, now WITHOUT the
  utils.config_interface -> cli.config ignore entry.
- No further tautologies: mutations that add data_only back to RUN_MODES, drop
  MCP phase validation, and make the resources rebuild their own payload each
  fail 2 tests; restoring the utils -> cli import fails 1.

Fast lane 26987 -> 26991.
