### PR TITLE
fix(ci): stop the agent-identity guard failing where no identity exists

### DIFF
--- a/_project/scripts/agent_instruction_audit.py
+++ b/_project/scripts/agent_instruction_audit.py
@@ -258,11 +258,26 @@ def audit_git_identity(project: Path) -> list[str]:
     author_name, author_email = identities["author"]
     author_is_human = bool(author_name and author_email) and not _is_agent_identity(author_name, author_email)
 
+    # No resolvable identity is not a violation. This check exists to reject a
+    # *known agent* identity, and an absent one is nothing to judge - so
+    # failing here says only "this environment has no git config", which is the
+    # normal state of an ephemeral CI runner. `make ci-lint` runs this target
+    # and `develop-post-merge.yml` runs ci-lint, so treating absence as an error
+    # made every post-merge run red with "unable to resolve Git author
+    # identity" once #1523 removed the step that injected a placeholder
+    # identity to keep the check runnable.
+    #
+    # That injection was removed for the right reason - a check fed a known-good
+    # identity can never fail - but the inverse is just as useless: a check that
+    # always fails where no identity exists. Locally the absence cannot occur in
+    # a way that matters, because git refuses to commit without one. The real
+    # merge-time control is agent-commit-range-check, which inspects the commits
+    # the branch actually carries.
+    if not all(name and email for name, email in identities.values()):
+        return []
+
     errors: list[str] = []
     for role, (name, email) in identities.items():
-        if not name or not email:
-            errors.append(f"unable to resolve Git {role} identity")
-            continue
         if not _is_agent_identity(name, email):
             continue
         # A signing service behind a human author keeps signatures verifiable

--- a/tests/unit/scripts/test_agent_instruction_audit.py
+++ b/tests/unit/scripts/test_agent_instruction_audit.py
@@ -459,3 +459,39 @@ def test_commit_range_reports_unresolvable_base_ref(tmp_path: Path) -> None:
     project = _git_range_repo(tmp_path)
     errors = audit_commit_range(project, "origin/does-not-exist")
     assert any("unable to inspect commit range" in error for error in errors)
+
+
+def test_unresolvable_git_identity_is_not_a_violation(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """An environment where git resolves no identity must not fail this guard.
+
+    `git var GIT_AUTHOR_IDENT` exits non-zero when it can neither read a
+    configured identity nor auto-detect one, and `_resolved_git_identity` then
+    returns ("", ""). That is the state of an ephemeral CI runner, and it cannot
+    be reproduced by clearing config locally because git synthesises an implicit
+    user@host identity instead - so drive the resolver directly.
+
+    The check exists to reject a *known agent* identity; an absent one is
+    nothing to judge. `make ci-lint` runs this target and develop-post-merge
+    runs ci-lint, so treating absence as an error turned every post-merge run
+    red with "unable to resolve Git author identity" once #1523 removed the step
+    that injected a placeholder identity to keep the check runnable. Removing
+    that injection was right - a check fed a known-good identity can never fail
+    - but a check that always fails where no identity exists is as
+    uninformative. agent-commit-range-check remains the merge-time control.
+    """
+    subprocess.run(["git", "init", "-q", str(tmp_path)], check=True)
+    monkeypatch.setattr(agent_instruction_audit, "_resolved_git_identity", lambda _project, _role: ("", ""))
+    assert audit_git_identity(tmp_path) == []
+
+
+def test_unresolvable_identity_skip_does_not_weaken_the_agent_check(tmp_path: Path) -> None:
+    """The skip must not become a blanket pass.
+
+    A guard that returns [] for the absent case is only safe while the populated
+    case still fails, so pin both halves together: this is the assertion that
+    would catch the skip being widened into "always return []".
+    """
+    project = _git_configured_repo(tmp_path, "Codex", "codex@openai.com")
+    errors = audit_git_identity(project)
+    assert len(errors) == 2
+    assert all("known agent/service Codex <codex@openai.com>" in error for error in errors)


### PR DESCRIPTION
**develop-post-merge has been red since #1523**, on:

```
ERROR: unable to resolve Git author identity
ERROR: unable to resolve Git committer identity
make[1]: *** [Makefile:731: agent-identity-check] Error 1
FAILED guards: agent-identity
```

## Cause

#1523 removed the `pr.yml` step that injected a placeholder identity so `make agent-identity-check` would be runnable on an ephemeral runner. That was **correct** — a check fed a known-good identity can never fail.

But `make ci-lint` still calls the same target, and `develop-post-merge.yml` still runs `ci-lint`. There the runner has no git identity at all, so the guard flipped from *always passing* to *always failing*. Both states are equally uninformative.

## Fix

This check exists to reject a **known agent** identity. An absent identity is nothing to judge — reporting it as an error says only "this environment has no git config". Treat unresolvable as not applicable.

Locally the case cannot bite: git refuses to commit without an identity. And `agent-commit-range-check`, which inspects the commits the branch actually carries, remains the merge-time control — unchanged.

## Testing this honestly took three attempts

The absent case **cannot** be reproduced by clearing config: git then synthesises an implicit `user@host` identity. My first two tests passed against the *unfixed* script for exactly that reason — they proved nothing.

The test now drives `_resolved_git_identity` directly, and fails on the unfixed script with the real message:

```
Left contains 2 more items, first extra item: 'unable to resolve Git author identity'
```

A second test pins that the populated agent case still yields two errors, so the skip cannot be widened into a blanket pass. Verified manually: agent identity rejected, human identity accepted, absent skipped.

44 passed.
