### PR TITLE
refactor(core): add the run service with its config-resolution port

### DIFF
--- a/benchbox/cli/orchestrator.py
+++ b/benchbox/cli/orchestrator.py
@@ -21,15 +21,12 @@ from benchbox.core.benchmark_loader import (
 
 # Import from common_types to avoid circular imports
 from benchbox.core.config import BenchmarkConfig, RunConfig
-from benchbox.core.constants import (
-    GENERIC_POWER_DEFAULT_MEASUREMENT_ITERATIONS,
-    GENERIC_POWER_DEFAULT_WARMUP_ITERATIONS,
-)
 from benchbox.core.hooks.platform_hooks import PlatformHookRegistry
 from benchbox.core.platform_config import get_platform_config as _core_get_platform_config
 from benchbox.core.platform_registry import PlatformRegistry
 from benchbox.core.results.driver_metadata import apply_driver_metadata
 from benchbox.core.results.models import BenchmarkResults
+from benchbox.core.run_service import resolve_run_config
 from benchbox.core.runner.dataframe_runner import is_dataframe_execution
 from benchbox.core.runner.runner import (
     LifecyclePhases,
@@ -487,9 +484,13 @@ class BenchmarkOrchestrator:
         return adapter
 
     def _prepare_run_config(self, config: BenchmarkConfig, database_config) -> RunConfig:
-        """Prepare benchmark run configuration using structured dataclass."""
+        """Prepare benchmark run configuration using structured dataclass.
 
-        # Get tuning configuration if available for distinct naming
+        Resolution itself lives in benchbox.core.run_service. What stays here is
+        the part core cannot own: DirectoryManager is CLI-layer, so the CLI
+        computes the database path and hands the service data instead of a
+        directory manager.
+        """
         tuning_config = None
         if config.options:
             tuning_config = config.options.get("unified_tuning_configuration")
@@ -501,36 +502,7 @@ class BenchmarkOrchestrator:
             tuning_config=tuning_config,
         )
 
-        options = config.options or {}
-        iterations = int(
-            options.get("power_iterations", GENERIC_POWER_DEFAULT_MEASUREMENT_ITERATIONS)
-            or GENERIC_POWER_DEFAULT_MEASUREMENT_ITERATIONS
-        )
-        warmups = int(
-            options.get("power_warmup_iterations", GENERIC_POWER_DEFAULT_WARMUP_ITERATIONS)
-            or GENERIC_POWER_DEFAULT_WARMUP_ITERATIONS
-        )
-        fail_fast = bool(options.get("power_fail_fast", False))
-
-        return RunConfig(
-            query_subset=config.queries,
-            concurrent_streams=config.concurrency,
-            test_execution_type=getattr(config, "test_execution_type", "standard"),
-            scale_factor=config.scale_factor,
-            capture_plans=config.capture_plans,
-            analyze_plans=getattr(config, "analyze_plans", None),
-            strict_plan_capture=config.strict_plan_capture,
-            seed=int(options.get("seed")) if options.get("seed") is not None else None,
-            connection={"database_path": str(database_path)},
-            verbose=self._verbosity.verbose,
-            verbose_level=self._verbosity.level,
-            verbose_enabled=self._verbosity.verbose_enabled,
-            very_verbose=self._verbosity.very_verbose,
-            quiet=self._verbosity.quiet,
-            iterations=max(1, iterations),
-            warm_up_iterations=max(0, warmups),
-            power_fail_fast=fail_fast,
-        )
+        return resolve_run_config(config, database_path=database_path, verbosity=self._verbosity)
 
     def _should_offer_credential_setup(self, database_config, error: Exception) -> bool:
         """Check if error indicates missing credentials for a cloud platform.

--- a/benchbox/core/run_service.py
+++ b/benchbox/core/run_service.py
@@ -1,0 +1,166 @@
+"""Shared run service: the one engine below the CLI and MCP surfaces.
+
+Per `docs/development/adr/adr-one-engine-scoped-surfaces.md`, all benchmark
+business logic lives in `benchbox.core` below both surfaces. This module is
+where run orchestration lands.
+
+Layering is the constraint that shapes every signature here: core sits below
+`benchbox.platforms` and `benchbox.cli`, so this module must import neither.
+Anything a surface owns -- an adapter, a directory layout, a console, an
+interactive prompt -- arrives as a resolved input or an injected factory. That
+is why :func:`resolve_run_config` takes an already-computed ``database_path``
+instead of a ``DirectoryManager``: the manager is CLI-layer, the path is data.
+
+This first increment covers request/plan types and configuration resolution
+only. Execution orchestration follows in a later work unit.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, Protocol
+
+from benchbox.core.config import BenchmarkConfig, RunConfig
+from benchbox.core.constants import (
+    GENERIC_POWER_DEFAULT_MEASUREMENT_ITERATIONS,
+    GENERIC_POWER_DEFAULT_WARMUP_ITERATIONS,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping
+
+
+class VerbosityLike(Protocol):
+    """The verbosity surface :func:`resolve_run_config` reads.
+
+    Structural rather than nominal so the CLI's ``VerbositySettings`` satisfies
+    it without core depending on the concrete type, and so a caller with no
+    verbosity concept can pass :class:`SilentVerbosity`.
+    """
+
+    @property
+    def verbose(self) -> bool: ...
+
+    @property
+    def level(self) -> int: ...
+
+    @property
+    def verbose_enabled(self) -> bool: ...
+
+    @property
+    def very_verbose(self) -> bool: ...
+
+    @property
+    def quiet(self) -> bool: ...
+
+
+@dataclass(frozen=True)
+class SilentVerbosity:
+    """Verbosity for callers that have no console.
+
+    MCP suppresses console output and returns structured JSON, so it has no
+    verbosity flags to forward; this is the value it will pass rather than
+    inventing CLI-shaped settings.
+    """
+
+    verbose: bool = False
+    level: int = 0
+    verbose_enabled: bool = False
+    very_verbose: bool = False
+    quiet: bool = True
+
+
+@dataclass(frozen=True)
+class RunRequest:
+    """A fully-resolved, surface-neutral description of a benchmark run.
+
+    "Fully resolved" is the contract: every interactive decision, credential
+    prompt, and default has already been settled by the surface. The service
+    never asks a question.
+    """
+
+    platform: str
+    benchmark: str
+    scale_factor: float
+    queries: list[str] | None = None
+    phases: list[str] | None = None
+    mode: str | None = None
+    capture_plans: bool = False
+    platform_options: Mapping[str, object] = field(default_factory=dict)
+    options: Mapping[str, Any] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class RunPlan:
+    """The resolved plan for one run: what will execute, and how."""
+
+    request: RunRequest
+    benchmark_config: BenchmarkConfig
+    run_config: RunConfig
+    execution_type: str
+    resolved_mode: str | None = None
+
+
+def resolve_run_config(
+    config: BenchmarkConfig,
+    *,
+    database_path: str | Path,
+    verbosity: VerbosityLike,
+) -> RunConfig:
+    """Build the :class:`RunConfig` for one benchmark run.
+
+    Moved verbatim from ``BenchmarkOrchestrator._prepare_run_config``; the only
+    changes are that the two surface-owned inputs it used to reach for through
+    ``self`` are now parameters:
+
+    - ``database_path`` replaces ``self.directory_manager.get_database_path(...)``,
+      because ``DirectoryManager`` is CLI-layer and core may not import it. The
+      caller computes the path; the tuning-aware naming rules stay where they
+      already live, in ``benchbox.utils.database_naming``.
+    - ``verbosity`` replaces ``self._verbosity``.
+
+    Every value derivation below -- the ``or DEFAULT`` fallbacks, the clamps,
+    and the ``is not None`` seed check that preserves a zero seed -- is
+    unchanged, and is pinned by
+    ``tests/unit/cli/test_run_config_resolution_characterization.py``.
+    """
+    options = config.options or {}
+    iterations = int(
+        options.get("power_iterations", GENERIC_POWER_DEFAULT_MEASUREMENT_ITERATIONS)
+        or GENERIC_POWER_DEFAULT_MEASUREMENT_ITERATIONS
+    )
+    warmups = int(
+        options.get("power_warmup_iterations", GENERIC_POWER_DEFAULT_WARMUP_ITERATIONS)
+        or GENERIC_POWER_DEFAULT_WARMUP_ITERATIONS
+    )
+    fail_fast = bool(options.get("power_fail_fast", False))
+
+    return RunConfig(
+        query_subset=config.queries,
+        concurrent_streams=config.concurrency,
+        test_execution_type=getattr(config, "test_execution_type", "standard"),
+        scale_factor=config.scale_factor,
+        capture_plans=config.capture_plans,
+        analyze_plans=getattr(config, "analyze_plans", None),
+        strict_plan_capture=config.strict_plan_capture,
+        seed=int(options.get("seed")) if options.get("seed") is not None else None,
+        connection={"database_path": str(database_path)},
+        verbose=verbosity.verbose,
+        verbose_level=verbosity.level,
+        verbose_enabled=verbosity.verbose_enabled,
+        very_verbose=verbosity.very_verbose,
+        quiet=verbosity.quiet,
+        iterations=max(1, iterations),
+        warm_up_iterations=max(0, warmups),
+        power_fail_fast=fail_fast,
+    )
+
+
+__all__ = [
+    "RunPlan",
+    "RunRequest",
+    "SilentVerbosity",
+    "VerbosityLike",
+    "resolve_run_config",
+]

--- a/tests/unit/core/test_run_service.py
+++ b/tests/unit/core/test_run_service.py
@@ -1,0 +1,159 @@
+"""The core run service: request/plan types and configuration resolution.
+
+`one-engine-core-run-service` w2. The characterization suite in
+tests/unit/cli/test_run_config_resolution_characterization.py already runs
+through this code, because BenchmarkOrchestrator._prepare_run_config now
+delegates here -- that is the pure-move proof. What this module adds is the
+service's own contract: that it can be called with no CLI object at all, and
+that core stays below platforms and cli.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import pytest
+
+from benchbox.core.config import BenchmarkConfig
+from benchbox.core.constants import GENERIC_POWER_DEFAULT_MEASUREMENT_ITERATIONS
+from benchbox.core.run_service import (
+    RunPlan,
+    RunRequest,
+    SilentVerbosity,
+    resolve_run_config,
+)
+
+pytestmark = [
+    pytest.mark.unit,
+    pytest.mark.fast,
+]
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+RUN_SERVICE_SOURCE = REPO_ROOT / "benchbox/core/run_service.py"
+
+
+def _config(**kwargs) -> BenchmarkConfig:
+    return BenchmarkConfig(
+        name=kwargs.pop("name", "tpch"),
+        display_name=kwargs.pop("display_name", "TPC-H"),
+        scale_factor=kwargs.pop("scale_factor", 1.0),
+        **kwargs,
+    )
+
+
+class TestLayering:
+    """The constraint that shapes every signature in the module."""
+
+    def test_run_service_imports_neither_platforms_nor_cli(self):
+        tree = ast.parse(RUN_SERVICE_SOURCE.read_text(encoding="utf-8"))
+        modules = {node.module for node in ast.walk(tree) if isinstance(node, ast.ImportFrom) and node.module}
+        modules |= {alias.name for node in ast.walk(tree) if isinstance(node, ast.Import) for alias in node.names}
+
+        offenders = [m for m in modules if m.startswith(("benchbox.platforms", "benchbox.cli"))]
+
+        assert offenders == []
+
+    def test_the_service_resolves_without_importing_the_cli(self):
+        """A caller with no CLI must get a RunConfig, not an ImportError."""
+        run_config = resolve_run_config(_config(), database_path="/tmp/x.duckdb", verbosity=SilentVerbosity())
+
+        assert run_config.connection["database_path"] == "/tmp/x.duckdb"
+
+
+class TestResolveRunConfig:
+    def test_a_path_object_is_stringified(self):
+        run_config = resolve_run_config(_config(), database_path=Path("/tmp/db.duckdb"), verbosity=SilentVerbosity())
+
+        assert run_config.connection["database_path"] == "/tmp/db.duckdb"
+        assert isinstance(run_config.connection["database_path"], str)
+
+    def test_defaults_match_the_core_constants(self):
+        run_config = resolve_run_config(_config(), database_path="x", verbosity=SilentVerbosity())
+
+        assert run_config.iterations == GENERIC_POWER_DEFAULT_MEASUREMENT_ITERATIONS
+
+    def test_silent_verbosity_produces_a_quiet_run_config(self):
+        """The value MCP will pass, having no console to configure."""
+        run_config = resolve_run_config(_config(), database_path="x", verbosity=SilentVerbosity())
+
+        assert run_config.quiet is True
+        assert run_config.verbose is False
+        assert run_config.very_verbose is False
+        assert run_config.verbose_level == 0
+
+    def test_the_caller_options_mapping_is_not_mutated(self):
+        options = {"seed": 3}
+        snapshot = dict(options)
+
+        resolve_run_config(_config(options=options), database_path="x", verbosity=SilentVerbosity())
+
+        assert options == snapshot
+
+
+class TestOrchestratorDelegatesRatherThanDuplicates:
+    """A reintroduced local copy is how these surfaces drifted apart before."""
+
+    def test_orchestrator_produces_the_same_run_config_as_the_service(self, tmp_path):
+        from benchbox.cli.orchestrator import BenchmarkOrchestrator
+
+        class _DatabaseConfig:
+            type = "duckdb"
+
+        orchestrator = BenchmarkOrchestrator(base_dir=str(tmp_path))
+        config = _config(options={"seed": 5, "power_iterations": 2}, queries=["1"])
+
+        via_cli = orchestrator._prepare_run_config(config, _DatabaseConfig())
+        database_path = orchestrator.directory_manager.get_database_path(
+            config.name, config.scale_factor, "duckdb", tuning_config=None
+        )
+        via_core = resolve_run_config(config, database_path=database_path, verbosity=orchestrator._verbosity)
+
+        assert via_cli.model_dump() == via_core.model_dump()
+
+    def test_orchestrator_no_longer_defines_its_own_resolution(self):
+        source = (REPO_ROOT / "benchbox/cli/orchestrator.py").read_text(encoding="utf-8")
+
+        assert "resolve_run_config" in source
+        # The moved arithmetic must not survive alongside the delegation.
+        assert "GENERIC_POWER_DEFAULT_MEASUREMENT_ITERATIONS" not in source
+
+
+class TestRequestAndPlanTypes:
+    def test_run_request_carries_a_fully_resolved_description(self):
+        request = RunRequest(platform="duckdb", benchmark="tpch", scale_factor=1.0)
+
+        assert request.queries is None
+        assert request.phases is None
+        assert request.capture_plans is False
+        assert dict(request.platform_options) == {}
+
+    def test_run_request_is_immutable(self):
+        """The service never renegotiates its inputs."""
+        request = RunRequest(platform="duckdb", benchmark="tpch", scale_factor=1.0)
+
+        with pytest.raises(AttributeError):
+            request.platform = "sqlite"  # type: ignore[misc]
+
+    def test_two_requests_with_the_same_inputs_are_equal(self):
+        first = RunRequest(platform="duckdb", benchmark="tpch", scale_factor=1.0)
+        second = RunRequest(platform="duckdb", benchmark="tpch", scale_factor=1.0)
+
+        assert first == second
+
+    def test_run_plan_binds_a_request_to_its_resolved_config(self):
+        request = RunRequest(platform="duckdb", benchmark="tpch", scale_factor=1.0)
+        config = _config()
+        run_config = resolve_run_config(config, database_path="x", verbosity=SilentVerbosity())
+
+        plan = RunPlan(
+            request=request,
+            benchmark_config=config,
+            run_config=run_config,
+            execution_type="power",
+        )
+
+        assert plan.request is request
+        assert plan.run_config is run_config
+        assert plan.execution_type == "power"
+        assert plan.resolved_mode is None


### PR DESCRIPTION
Work unit w2 of `one-engine-core-run-service`: request/plan types and
configuration resolution. No execution orchestration yet -- that is w3.

benchbox/core/run_service.py holds RunRequest, RunPlan, and
resolve_run_config. BenchmarkOrchestrator._prepare_run_config now delegates to
it, so rung 1 (service exists AND the CLI orchestrator consumes it) is
satisfied and the w1 characterization suite exercises the new path.

## Why the signature looks the way it does

Layering is the whole design constraint: core sits below platforms and cli, so
the service may import neither. The two things _prepare_run_config used to
reach for through `self` become parameters:

- `database_path` replaces `self.directory_manager.get_database_path(...)`.
  DirectoryManager is CLI-layer. The CLI computes the path and hands the
  service data; the tuning-aware naming rules stay where they already live in
  benchbox.utils.database_naming, so w1's characterization of that naming --
  including that a bare-string tuning config collides with an untuned run's
  filename -- continues to describe the same code.
- `verbosity` replaces `self._verbosity`, typed as a structural Protocol so the
  CLI's VerbositySettings satisfies it without core depending on the concrete
  type. SilentVerbosity is the value MCP will pass in the adoption item, having
  no console to configure.

## Pure move

The resolution body is moved verbatim. Every derivation is unchanged: the
`or DEFAULT` fallbacks that make 0 and None behave alike, the max(1, ...) and
max(0, ...) clamps, and the `is not None` seed check that preserves a zero
seed. The proof is that w1's characterization suite passes unmodified through
the delegation, plus a direct assertion that the orchestrator and the service
produce identical RunConfig model dumps for the same inputs.

The orchestrator no longer imports the iteration constants; a test asserts that,
so the moved arithmetic cannot quietly reappear next to the delegation.

## Coverage

An AST test asserts run_service.py imports nothing from benchbox.platforms or
benchbox.cli -- the same shape of guard used for the MCP boundary, and stricter
than lint-imports because it names this module specifically. Another calls the
service with SilentVerbosity and no CLI object at all, which is the MCP path
before MCP exists as a caller.

Rungs 1, 2, 3, and 5 pass; rung 4 is presort, which is w5.
