### PR TITLE
refactor(core): move presort sort keys into the benchmark registry

### DIFF
--- a/benchbox/cli/commands/run.py
+++ b/benchbox/cli/commands/run.py
@@ -65,7 +65,11 @@ from benchbox.cli.tuning_runtime import (
     infer_runtime_tuning_mode,
     resolve_dataframe_tuning_config,
 )
-from benchbox.core.benchmark_registry import get_benchmark_default_scale
+from benchbox.core.benchmark_registry import (
+    get_benchmark_default_scale,
+    get_presort_table_configs,
+    presort_capable_benchmarks,
+)
 from benchbox.core.config import DatabaseConfig
 from benchbox.core.constants import QUERY_PHASES, RUN_MODES, VALID_PHASES
 from benchbox.core.platform_registry import PlatformRegistry
@@ -272,19 +276,16 @@ def _resolve_data_organization_payload(
         "iceberg-sorted": "iceberg",
     }
     output_format = output_format_map[presort]
-    if benchmark_key == "tpch":
-        return {
-            "table_configs": {"lineitem": [{"name": "l_shipdate", "order": "asc"}]},
-            "output_format": output_format,
-        }
-    if benchmark_key == "tpcds":
-        return {
-            "table_configs": {"store_sales": [{"name": "ss_sold_date_sk", "order": "asc"}]},
-            "output_format": output_format,
-        }
+
+    # Sort keys are benchmark knowledge: a benchmark supports --presort exactly
+    # when it declares presort_table_configs in the registry.
+    table_configs = get_presort_table_configs(benchmark_key) if benchmark_key else None
+    if table_configs:
+        return {"table_configs": table_configs, "output_format": output_format}
 
     if benchmark_key:
-        raise ValueError("--presort sorted modes are currently supported for tpch and tpcds benchmarks")
+        supported = ", ".join(sorted(presort_capable_benchmarks()))
+        raise ValueError(f"--presort sorted modes are currently supported for {supported} benchmarks")
     return tuning_payload
 
 

--- a/benchbox/core/benchmark_registry.py
+++ b/benchbox/core/benchmark_registry.py
@@ -464,6 +464,28 @@ def validate_scale_factor(
         raise ValueError(f"{benchmark_id.upper()} requires scale_factor >= {min_scale} (got {scale_factor}).")
 
 
+def get_presort_table_configs(benchmark_id: str) -> dict[str, Any] | None:
+    """Return a benchmark's default presort sort keys, or None.
+
+    A benchmark supports `benchbox run --presort` exactly when it declares
+    `presort_table_configs` in the registry. These lived as hardcoded column
+    literals in benchbox/cli/commands/run.py; which column to sort on is
+    benchmark knowledge, not CLI knowledge.
+    """
+    meta = get_benchmark_metadata(benchmark_id)
+    if meta is None:
+        return None
+    configs = meta.get("presort_table_configs")
+    return dict(configs) if configs else None
+
+
+def presort_capable_benchmarks() -> tuple[str, ...]:
+    """Return every benchmark id that declares presort defaults."""
+    return tuple(
+        sorted(bid for bid, meta in _registry().benchmark_metadata.items() if meta.get("presort_table_configs"))
+    )
+
+
 def get_benchmark_surface(benchmark_id: str) -> str:
     """Return the registry-declared surface visibility for a benchmark.
 
@@ -489,6 +511,8 @@ __all__ = sorted(
         "get_all_benchmarks",
         "get_benchmark_class",
         "get_benchmark_class_name",
+        "get_presort_table_configs",
+        "presort_capable_benchmarks",
         "get_benchmark_default_scale",
         "get_benchmark_id_for_class_name",
         "get_benchmark_metadata",

--- a/benchbox/core/benchmark_registry.yaml
+++ b/benchbox/core/benchmark_registry.yaml
@@ -88,6 +88,13 @@ benchmark_metadata:
     display_name: TPC-H
     description: Decision Support Benchmark
     category: TPC
+    # Default sort keys for `benchbox run --presort`. Which column a benchmark
+    # sorts on is benchmark knowledge, not CLI knowledge; it lived as a literal
+    # in cli/commands/run.py before one-engine-core-run-service w5.
+    presort_table_configs:
+      lineitem:
+      - name: l_shipdate
+        order: asc
     support_status: stable
     num_queries: 22
     query_description: 22 analytical queries
@@ -117,6 +124,10 @@ benchmark_metadata:
     supports_statistics_phase: true
   tpcds:
     display_name: TPC-DS
+    presort_table_configs:
+      store_sales:
+      - name: ss_sold_date_sk
+        order: asc
     description: Decision Support Benchmark
     category: TPC
     support_status: stable

--- a/benchbox/core/catalog_schema.py
+++ b/benchbox/core/catalog_schema.py
@@ -36,6 +36,15 @@ class CatalogSchemaError(ValueError):
     """Raised when a migrated catalog fails schema validation."""
 
 
+class PresortColumn(BaseModel):
+    """One sort key in a benchmark's presort defaults."""
+
+    model_config = _STRICT_MODEL_CONFIG
+
+    name: str
+    order: Literal["asc", "desc"] = "asc"
+
+
 class BenchmarkMeta(BaseModel):
     """Per-benchmark metadata entry in ``benchmark_registry.yaml``."""
 
@@ -61,6 +70,11 @@ class BenchmarkMeta(BaseModel):
     # Opt-in: the runner inserts an explicit statistics phase between load and
     # query for this benchmark when the user requests --phases ...,statistics.
     supports_statistics_phase: bool = False
+    # Default sort keys for `benchbox run --presort`, keyed by table name.
+    # Declaring this is what makes a benchmark presort-capable; the CLI used to
+    # hardcode the columns. Validated rather than free-form so a typo fails at
+    # load time instead of producing a silently unsorted run.
+    presort_table_configs: dict[str, list[PresortColumn]] | None = None
 
     @field_validator("estimated_time_range")
     @classmethod

--- a/tests/unit/core/test_presort_registry_defaults.py
+++ b/tests/unit/core/test_presort_registry_defaults.py
@@ -1,0 +1,112 @@
+"""Presort sort keys live in the benchmark registry, not in the CLI.
+
+`one-engine-core-run-service` w5. `benchbox run --presort` used to carry a
+hardcoded `l_shipdate` for tpch and `ss_sold_date_sk` for tpcds inside
+benchbox/cli/commands/run.py. Which column a benchmark sorts on is benchmark
+knowledge; a CLI command file is the wrong owner, and it meant adding presort
+support to a third benchmark required a CLI edit.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from benchbox.core.benchmark_registry import (
+    get_all_benchmarks,
+    get_presort_table_configs,
+    presort_capable_benchmarks,
+)
+
+pytestmark = [
+    pytest.mark.unit,
+    pytest.mark.fast,
+]
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+
+
+class TestRegistryOwnsPresortDefaults:
+    def test_tpch_sorts_lineitem_by_ship_date(self):
+        assert get_presort_table_configs("tpch") == {"lineitem": [{"name": "l_shipdate", "order": "asc"}]}
+
+    def test_tpcds_sorts_store_sales_by_sold_date(self):
+        assert get_presort_table_configs("tpcds") == {"store_sales": [{"name": "ss_sold_date_sk", "order": "asc"}]}
+
+    def test_capability_is_declared_not_hardcoded(self):
+        assert presort_capable_benchmarks() == ("tpcds", "tpch")
+
+    def test_a_benchmark_without_defaults_returns_none(self):
+        assert get_presort_table_configs("ssb") is None
+
+    def test_an_unknown_benchmark_returns_none_rather_than_raising(self):
+        assert get_presort_table_configs("not_a_benchmark") is None
+
+    def test_lookup_is_case_insensitive(self):
+        assert get_presort_table_configs("TPCH") == get_presort_table_configs("tpch")
+
+    def test_callers_cannot_mutate_the_registry_through_the_accessor(self):
+        first = get_presort_table_configs("tpch")
+        first["lineitem"] = "clobbered"
+
+        assert get_presort_table_configs("tpch") == {"lineitem": [{"name": "l_shipdate", "order": "asc"}]}
+
+    def test_every_declared_config_names_a_real_benchmark(self):
+        benchmarks = get_all_benchmarks()
+
+        for benchmark_id in presort_capable_benchmarks():
+            assert benchmark_id in benchmarks
+
+
+class TestCliNoLongerHardcodesSortKeys:
+    def test_run_command_carries_no_benchmark_column_literals(self):
+        source = (REPO_ROOT / "benchbox/cli/commands/run.py").read_text(encoding="utf-8")
+
+        assert "l_shipdate" not in source
+        assert "ss_sold_date_sk" not in source
+
+    def test_run_command_reads_the_registry(self):
+        source = (REPO_ROOT / "benchbox/cli/commands/run.py").read_text(encoding="utf-8")
+
+        assert "get_presort_table_configs" in source
+
+
+class TestPresortPayloadResolution:
+    """The CLI resolver's behavior is unchanged apart from its data source."""
+
+    @staticmethod
+    def _resolve(benchmark, presort, tuning_payload=None):
+        from benchbox.cli.commands.run import _resolve_data_organization_payload
+
+        return _resolve_data_organization_payload(benchmark, presort, tuning_payload)
+
+    @pytest.mark.parametrize(
+        ("presort", "output_format"),
+        [("parquet-sorted", "parquet"), ("delta-sorted", "delta"), ("iceberg-sorted", "iceberg")],
+    )
+    def test_tpch_defaults_resolve_per_output_format(self, presort, output_format):
+        payload = self._resolve("tpch", presort)
+
+        assert payload["output_format"] == output_format
+        assert payload["table_configs"] == {"lineitem": [{"name": "l_shipdate", "order": "asc"}]}
+
+    def test_an_unsupported_benchmark_still_raises(self):
+        with pytest.raises(ValueError, match="tpcds, tpch"):
+            self._resolve("ssb", "parquet-sorted")
+
+    def test_a_non_sorted_presort_value_passes_the_tuning_payload_through(self):
+        tuning = {"table_configs": {"x": []}}
+
+        assert self._resolve("tpch", None, tuning) is tuning
+
+    def test_an_explicit_tuning_payload_wins_over_registry_defaults(self):
+        tuning = {"table_configs": {"custom": []}}
+
+        assert self._resolve("tpch", "parquet-sorted", tuning) is tuning
+
+    def test_delta_presort_overrides_the_output_format_on_a_tuning_payload(self):
+        payload = self._resolve("tpch", "delta-sorted", {"table_configs": {"custom": []}})
+
+        assert payload["output_format"] == "delta"
+        assert payload["table_configs"] == {"custom": []}


### PR DESCRIPTION
Work unit w5 of `one-engine-core-run-service`.

`benchbox run --presort` carried hardcoded columns in the CLI: `l_shipdate` for
tpch and `ss_sold_date_sk` for tpcds, inside
_resolve_data_organization_payload. Which column a benchmark sorts on is
benchmark knowledge, and a CLI command file is the wrong owner -- adding
presort support to a third benchmark meant editing the CLI.

The columns now live in benchmark_registry.yaml as `presort_table_configs`, and
declaring that key is what makes a benchmark presort-capable. The CLI reads
get_presort_table_configs() and builds its unsupported-benchmark error from
presort_capable_benchmarks(), so that message can no longer name a stale set.

The registry entries are schema-validated, not free-form: catalog_schema gains a
PresortColumn model with a Literal["asc", "desc"] order, so a typo fails at load
time rather than producing a silently unsorted run.

Behavior is unchanged. The resolver's precedence is pinned by tests: an explicit
tuning payload still wins over registry defaults, delta/iceberg presort still
override output_format on a supplied payload, a non-sorted presort value still
passes the tuning payload through, and an unsupported benchmark still raises.
The accessor returns a copy, so a caller cannot mutate the registry through it.

## Rung 4 is broader than its own expectation

Rung 4 runs `! grep -rn 'l_shipdate\|ss_sold_date_sk' benchbox/cli/` and expects
"Presort defaults live in benchmark registry metadata". The expectation is met
-- no presort literal remains in run.py, orchestrator.py, or
execution_pipeline.py -- but the command still exits 1, because those column
names also appear in two places that have nothing to do with presort:

  benchbox/cli/tuning.py:781,786   interactive prompt hint and default for the
                                   tuning wizard's sort-column question
  benchbox/cli/commands/convert.py:166,170   `--partition l_shipdate` in the
                                   command's help-text examples

Neither is a presort default, neither file is in this item's only_modify list,
and deleting a column name from a help example would make the docs worse to
satisfy a grep. I have not contorted them. The rung command over-reaches its
expectation; the expectation itself is satisfied and is covered by a test
asserting run.py carries neither literal.

benchbox/cli/commands/run.py stays at 3130 lines, exactly the module-size
guardrail -- the first draft of this change tripped it by one line, so the
explanatory comment is two lines shorter rather than the limit being raised.

Fast lane 27054 -> 27083.
