### PR TITLE
ci: fail a PR whose base is not an integration branch

### DIFF
--- a/.github/workflows/pr-base-guard.yml
+++ b/.github/workflows/pr-base-guard.yml
@@ -1,0 +1,55 @@
+name: PR base guard
+
+# Every other PR workflow filters on `branches: [develop]` (or release /
+# published-results), so a PR whose base is another feature branch triggers
+# NOTHING - not pr.yml, not ci-required-result, not the browser lane. The PR
+# page then looks calm rather than alarming: there are no failing checks
+# because there are no checks at all, and the content reaches develop later
+# attributed to the parent's PR, having never been validated on its own.
+#
+# This workflow carries no `branches:` filter, so it is the one check such a
+# PR does get. On a normal base it passes in seconds; on a stacked base it
+# fails loudly and says what to do.
+#
+# It must never become a required context that cannot report - the failure it
+# exists to fix. That is why the filter is absent rather than set to a wide
+# list: a list can go stale as branches are added, absence cannot.
+
+on:
+  pull_request:
+    # `edited` is included so retargeting an existing PR re-evaluates. Without
+    # it, a PR opened against develop and later repointed at a feature branch
+    # would keep its stale green result.
+    types: [opened, reopened, synchronize, edited]
+
+permissions:
+  contents: read
+
+jobs:
+  base-branch:
+    name: PR base branch is an integration branch
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check base branch
+        env:
+          BASE_REF: ${{ github.base_ref }}
+        run: |
+          set -euo pipefail
+          case "$BASE_REF" in
+            develop|release|published-results)
+              echo "Base branch '$BASE_REF' is an integration branch; the normal CI lanes apply."
+              ;;
+            *)
+              echo "::error::PR base branch is '$BASE_REF', not develop, release or published-results."
+              echo ""
+              echo "Every PR workflow in this repository filters on those branches, so this PR"
+              echo "runs no CI at all - no pr.yml, no ci-required-result, no browser lane. Its"
+              echo "content reaches develop only when the parent merges, at which point it has"
+              echo "never been validated on its own and is attributed to the parent's PR."
+              echo ""
+              echo "develop squash-merges, so a stacked chain also needs a rebase and force-push"
+              echo "after every parent merge. Retarget this PR at develop, or fold the change"
+              echo "into the parent PR."
+              exit 1
+              ;;
+          esac

--- a/tests/unit/workflows/test_stacked_pr_base_guard.py
+++ b/tests/unit/workflows/test_stacked_pr_base_guard.py
@@ -1,0 +1,112 @@
+"""A PR based on a feature branch must not present an empty check list.
+
+Every other PR workflow filters on `branches: [develop]` (or release /
+published-results), so a PR whose base is another feature branch triggers
+nothing at all. The PR page looks calm rather than alarming - no failing
+checks, because no checks - and the content reaches develop only when the
+parent merges, never having been validated on its own.
+
+`pr-base-guard.yml` is the one check such a PR does get. These tests pin the
+two properties that make it work: it carries no branch filter (so it always
+reports), and it rejects a base that is not an integration branch.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+import yaml
+
+pytestmark = [pytest.mark.unit, pytest.mark.fast]
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+WORKFLOWS = REPO_ROOT / ".github" / "workflows"
+GUARD = WORKFLOWS / "pr-base-guard.yml"
+
+INTEGRATION_BRANCHES = {"develop", "release", "published-results"}
+
+
+def _triggers(workflow: dict[str, Any]) -> dict[str, Any]:
+    """Return the `on:` block.
+
+    PyYAML resolves an unquoted ``on`` key to boolean ``True`` under YAML 1.1,
+    so accept either spelling rather than reading an empty trigger set and
+    passing vacuously.
+    """
+    triggers = workflow.get("on", workflow.get(True))
+    assert triggers is not None, "workflow has no `on:` block"
+    return triggers
+
+
+def _load(path: Path) -> dict[str, Any]:
+    return yaml.safe_load(path.read_text(encoding="utf-8"))
+
+
+def test_stacked_pr_base_guard_exists() -> None:
+    assert GUARD.is_file(), "pr-base-guard.yml is missing; a stacked PR would present an empty check list"
+
+
+def test_stacked_pr_base_guard_has_no_branch_filter() -> None:
+    """The guard must run on every PR, whatever its base.
+
+    A branch list would defeat the purpose twice over: a stacked base would not
+    match it, and the list would go stale as branches are added. Absence cannot
+    go stale.
+    """
+    pull_request = _triggers(_load(GUARD))["pull_request"] or {}
+    assert "branches" not in pull_request, (
+        "pr-base-guard filters on branches, so the stacked PRs it exists to catch would not trigger it"
+    )
+    assert "paths" not in pull_request, "pr-base-guard is path-filtered, so a stacked PR could still report nothing"
+
+
+def test_stacked_pr_base_guard_reevaluates_when_a_pr_is_retargeted() -> None:
+    """Retargeting an open PR must re-run the guard.
+
+    Without `edited`, a PR opened against develop and later repointed at a
+    feature branch keeps its stale green result.
+    """
+    types = (_triggers(_load(GUARD))["pull_request"] or {}).get("types", [])
+    assert "edited" in types, "guard does not re-evaluate on retarget; a repointed PR keeps a stale pass"
+    assert "opened" in types
+
+
+def test_stacked_pr_base_guard_accepts_only_integration_branches() -> None:
+    """The guard's accept list must be exactly the branches CI actually covers."""
+    body = GUARD.read_text(encoding="utf-8")
+    accepted = {branch for branch in INTEGRATION_BRANCHES if branch in body}
+    assert accepted == INTEGRATION_BRANCHES, (
+        f"guard does not name every integration branch: missing {INTEGRATION_BRANCHES - accepted}"
+    )
+    assert "exit 1" in body, "guard never fails, so a stacked PR would still show an all-green check list"
+
+
+def test_every_other_pr_workflow_still_filters_to_integration_branches() -> None:
+    """Pin the premise this guard exists for.
+
+    If the other workflows ever stop filtering, stacked PRs would get real CI
+    and this guard becomes redundant rather than load-bearing - which is worth
+    noticing deliberately rather than discovering later.
+    """
+    filtered: list[str] = []
+    for path in sorted(WORKFLOWS.glob("*.yml")):
+        if path.name == GUARD.name:
+            continue
+        workflow = _load(path)
+        if not isinstance(workflow, dict):
+            continue
+        triggers = workflow.get("on", workflow.get(True))
+        if not isinstance(triggers, dict):
+            continue
+        pull_request = triggers.get("pull_request")
+        if pull_request is None:
+            continue
+        branches = (pull_request or {}).get("branches")
+        if branches:
+            filtered.append(path.name)
+            assert set(branches) <= INTEGRATION_BRANCHES, (
+                f"{path.name} filters on {branches}, which is outside the known integration branches"
+            )
+    assert filtered, "no PR workflow filters on an integration branch; this guard's premise no longer holds"


### PR DESCRIPTION
## The gap

Every workflow with a `pull_request` trigger filters on `develop`, `release` or `published-results`:

| Filter | Workflows |
|---|---|
| `[develop]` | auto-merge-on-open, extension-smoke, gitignore-lint, **pr.yml** |
| `[release, develop]` | docs, results-explorer-browser |
| `[release]` | lint, perf-smoke, test, validate-release-pr |
| `[published-results]` | validate-submission |

A PR based on another feature branch matches **none** of them, so it triggers nothing at all — no `pr.yml`, no `ci-required-result`, no browser lane. The PR page looks calm rather than alarming: there are no failing checks because there are no checks. The content reaches develop only when the parent merges, at which point it has never been validated on its own and is attributed to the parent's PR.

**Two are live right now:** #1520 based on `claude/mcp-v2-modin-engine`, #1515 on `claude/mcp-v2-duckdb-threads`.

I found this while auditing which PRs the browser-gate ruleset flip would strand — I had assumed their missing gate check meant they predated the workflow, when in fact they receive no CI at all.

## Detect, not prevent

A `make pr-open` refusal would only cover PRs opened through that path; the web UI and `gh pr create` bypass it. A workflow with no branch filter is authoritative for every PR however it was created. Prevention in `pr-open` remains a possible addition, not a substitute.

## Why it can't repeat the failure it fixes

The guard carries **no** `branches` and **no** `paths` filter, so it always runs and therefore always reports — it cannot become the never-reporting required context it exists to prevent. The filter is absent rather than set to a wide list because a list goes stale as branches are added and absence does not. `edited` is in `types` so retargeting an open PR re-evaluates instead of keeping a stale green.

## Tests

Five, including one that pins the **premise** — that every other PR workflow still filters to integration branches — so this guard becoming redundant is noticed deliberately rather than discovered later.

Falsified two ways:
- deleting the workflow → 4 of 5 fail
- adding `branches: [develop]` → `pr-base-guard filters on branches, so the stacked PRs it exists to catch would not trigger it`

`tests/unit/workflows`: **140 passed**.

## Note for the two live PRs

Once this lands, #1520 and #1515 will show a red base-guard check. That is correct and is the point — but it means they need retargeting at develop or folding into their parents before they can be treated as validated.

Closes `stacked-prs-receive-zero-ci-20260804`.
