### PR TITLE
refactor(core): move run execution into the service behind an adapter factory

### DIFF
--- a/benchbox/cli/orchestrator.py
+++ b/benchbox/cli/orchestrator.py
@@ -24,15 +24,8 @@ from benchbox.core.config import BenchmarkConfig, RunConfig
 from benchbox.core.hooks.platform_hooks import PlatformHookRegistry
 from benchbox.core.platform_config import get_platform_config as _core_get_platform_config
 from benchbox.core.platform_registry import PlatformRegistry
-from benchbox.core.results.driver_metadata import apply_driver_metadata
 from benchbox.core.results.models import BenchmarkResults
-from benchbox.core.run_service import resolve_run_config
-from benchbox.core.runner.dataframe_runner import is_dataframe_execution
-from benchbox.core.runner.runner import (
-    LifecyclePhases,
-    ValidationOptions,
-    run_benchmark_lifecycle,
-)
+from benchbox.core.run_service import execute_run, resolve_lifecycle_phases, resolve_run_config
 from benchbox.core.schemas import ExecutionContext
 from benchbox.platforms import get_adapter, get_platform_adapter
 from benchbox.utils.cloud_storage import is_databricks_path
@@ -258,13 +251,6 @@ class BenchmarkOrchestrator:
         self.console.print(f"[blue]Initializing {config.name} benchmark...[/blue]")
 
         try:
-            # Preserve the exact requested phases for downstream execution logic.
-            # This lets combined mode run only the phases the user asked for.
-            if phases_to_run:
-                options = dict(getattr(config, "options", {}) or {})
-                options["requested_phases"] = list(phases_to_run)
-                config.options = options
-
             # Resolve benchmark instance (keeps tests patchable)
             benchmark = self._get_benchmark_instance(config, system_profile)
             self.console.print(
@@ -289,77 +275,29 @@ class BenchmarkOrchestrator:
             self._apply_default_cloud_output_dir(database_config)
             output_root = self._resolve_output_root(config, benchmark, platform_cfg)
 
-            # Use LifecyclePhases as single source of truth
-            if phases_to_run:
-                # Map CLI phases directly to LifecyclePhases
-                phases = LifecyclePhases(
-                    generate="generate" in phases_to_run,
-                    load="load" in phases_to_run,
-                    execute=any(p in phases_to_run for p in ["warmup", "power", "throughput", "maintenance"]),
-                    statistics="statistics" in phases_to_run,
-                )
-            else:
-                # Default to standard lifecycle (generate + load + execute);
-                # the statistics phase stays opt-in.
-                phases = LifecyclePhases(generate=True, load=True, execute=True)
+            self._warn_on_execute_without_load(config, database_config, phases_to_run)
 
-            # Validate phase combinations and warn about potential issues
-            if phases.execute and not phases.load and database_config is not None:
-                # Only warn for full benchmark runs, not read-only test types (power/throughput)
-                # Power and Throughput tests are designed to query existing data without loading
-                test_execution_type = getattr(config, "test_execution_type", "standard")
-                readonly_tests = ["power", "throughput"]
-                cloud_platforms = ["databricks", "snowflake", "bigquery", "redshift"]
-
-                if test_execution_type not in readonly_tests and database_config.type.lower() in cloud_platforms:
-                    self.console.print(
-                        "[yellow]⚠️  Executing without load phase - assuming data already exists in database[/yellow]"
-                    )
-
-            # Validation options from CLI config
             opts = getattr(config, "options", {}) or {}
-            validation = ValidationOptions(
-                enable_preflight_validation=bool(opts.get("enable_preflight_validation")),
-                enable_postgen_manifest_validation=bool(opts.get("enable_postgen_manifest_validation", False)),
-                enable_postload_validation=bool(opts.get("enable_postload_validation", False)),
-            )
+            monitor = progress.get_monitor() if progress is not None else None
 
-            # Extract monitor from progress if provided
-            monitor = None
-            if progress is not None:
-                monitor = progress.get_monitor()
+            def build_adapter(*, execution_mode, output_root, phases):
+                return self._build_platform_adapter(
+                    database_config, execution_mode, output_root, opts, platform_cfg, benchmark, phases, config
+                )
 
-            # Detect execution mode for logging purposes
-            execution_mode = getattr(database_config, "execution_mode", None) if database_config else None
-            if execution_mode is None and database_config is not None:
-                execution_mode = PlatformRegistry.get_default_mode(database_config.type)
-                if is_dataframe_execution(database_config):
-                    execution_mode = "dataframe"
-
-            adapter = self._build_platform_adapter(
-                database_config, execution_mode, output_root, opts, platform_cfg, benchmark, phases, config
-            )
-
-            # Delegate lifecycle to core runner (handles both SQL and DataFrame adapters)
-            result = run_benchmark_lifecycle(
-                benchmark_config=config,
+            return execute_run(
+                config=config,
+                benchmark_instance=benchmark,
                 database_config=database_config,
                 system_profile=system_profile,
                 platform_config=platform_cfg,
-                phases=phases,
-                validation_opts=validation,
                 output_root=output_root,
-                benchmark_instance=benchmark,
-                platform_adapter=adapter,
+                phases_to_run=phases_to_run,
+                adapter_factory=build_adapter,
                 verbosity=self._verbosity,
                 monitor=monitor,
-                enable_resource_monitoring=False,
                 execution_context=execution_context,
             )
-
-            # Canonical runtime metadata enrichment for all `benchbox run` paths.
-            apply_driver_metadata(result, database_config=database_config, platform_adapter=adapter)
-            return result
 
         except Exception as e:
             # Check if this is a missing credentials error for a cloud platform
@@ -382,6 +320,22 @@ class BenchmarkOrchestrator:
             # Fall through to existing error handling
             self.console.print(f"[red]❌ Benchmark execution failed: {e}[/red]")
             return _build_failure_result(config, e)
+
+    def _warn_on_execute_without_load(self, config, database_config, phases_to_run) -> None:
+        """Warn when a cloud run queries without loading. Console-only, CLI-scoped."""
+        if database_config is None:
+            return
+        phases = resolve_lifecycle_phases(phases_to_run)
+        if not (phases.execute and not phases.load):
+            return
+        # Power and Throughput tests are designed to query existing data without loading.
+        test_execution_type = getattr(config, "test_execution_type", "standard")
+        readonly_tests = ["power", "throughput"]
+        cloud_platforms = ["databricks", "snowflake", "bigquery", "redshift"]
+        if test_execution_type not in readonly_tests and database_config.type.lower() in cloud_platforms:
+            self.console.print(
+                "[yellow]⚠️  Executing without load phase - assuming data already exists in database[/yellow]"
+            )
 
     def _apply_default_cloud_output_dir(self, database_config) -> None:
         """If no custom output dir is set and this run stages remotely, pull default from credentials.

--- a/benchbox/core/run_service.py
+++ b/benchbox/core/run_service.py
@@ -11,8 +11,9 @@ interactive prompt -- arrives as a resolved input or an injected factory. That
 is why :func:`resolve_run_config` takes an already-computed ``database_path``
 instead of a ``DirectoryManager``: the manager is CLI-layer, the path is data.
 
-This first increment covers request/plan types and configuration resolution
-only. Execution orchestration follows in a later work unit.
+This module covers request/plan types, configuration resolution, and execution
+orchestration. Everything that needs a console, an interactive prompt, or a
+concrete adapter class stays in the surface layer.
 """
 
 from __future__ import annotations
@@ -25,10 +26,22 @@ from benchbox.core.config import BenchmarkConfig, RunConfig
 from benchbox.core.constants import (
     GENERIC_POWER_DEFAULT_MEASUREMENT_ITERATIONS,
     GENERIC_POWER_DEFAULT_WARMUP_ITERATIONS,
+    QUERY_PHASES,
+)
+from benchbox.core.platform_registry import PlatformRegistry
+from benchbox.core.results.driver_metadata import apply_driver_metadata
+from benchbox.core.runner.dataframe_runner import is_dataframe_execution
+from benchbox.core.runner.runner import (
+    LifecyclePhases,
+    ValidationOptions,
+    run_benchmark_lifecycle,
 )
 
 if TYPE_CHECKING:
     from collections.abc import Mapping
+
+    from benchbox.core.results.models import BenchmarkResults
+    from benchbox.core.schemas import ExecutionContext
 
 
 class VerbosityLike(Protocol):
@@ -157,10 +170,151 @@ def resolve_run_config(
     )
 
 
+class AdapterFactory(Protocol):
+    """Builds the platform adapter for one run.
+
+    This is the injection point the layering contract forces. Constructing an
+    adapter means importing ``benchbox.platforms``, which core sits below, so
+    the surface supplies a callable instead. The CLI passes a closure over its
+    console and verbosity; MCP will pass one over its own adapter resolution.
+
+    Returning None is meaningful: a data-only run has no database to adapt.
+    """
+
+    def __call__(
+        self,
+        *,
+        execution_mode: str | None,
+        output_root: Any,
+        phases: LifecyclePhases,
+    ) -> Any | None: ...
+
+
+def resolve_lifecycle_phases(phases_to_run: list[str] | None) -> LifecyclePhases:
+    """Map a requested phase list onto the runner's lifecycle flags.
+
+    ``None`` means the standard lifecycle -- generate, load, execute -- with the
+    statistics phase staying opt-in.
+    """
+    if not phases_to_run:
+        return LifecyclePhases(generate=True, load=True, execute=True)
+
+    return LifecyclePhases(
+        generate="generate" in phases_to_run,
+        load="load" in phases_to_run,
+        execute=any(phase in phases_to_run for phase in ("warmup", *QUERY_PHASES)),
+        statistics="statistics" in phases_to_run,
+    )
+
+
+def resolve_validation_options(options: Mapping[str, Any] | None) -> ValidationOptions:
+    """Read the three validation toggles out of a benchmark's options."""
+    opts = options or {}
+    return ValidationOptions(
+        enable_preflight_validation=bool(opts.get("enable_preflight_validation")),
+        enable_postgen_manifest_validation=bool(opts.get("enable_postgen_manifest_validation", False)),
+        enable_postload_validation=bool(opts.get("enable_postload_validation", False)),
+    )
+
+
+def resolve_execution_mode(database_config: Any) -> str | None:
+    """Determine the execution mode for a run, or None with no database.
+
+    An explicit ``execution_mode`` on the database config wins. Otherwise the
+    platform registry's default applies, upgraded to ``dataframe`` when the
+    config describes a DataFrame execution.
+    """
+    if database_config is None:
+        return None
+
+    execution_mode = getattr(database_config, "execution_mode", None)
+    if execution_mode is not None:
+        return execution_mode
+
+    execution_mode = PlatformRegistry.get_default_mode(database_config.type)
+    if is_dataframe_execution(database_config):
+        execution_mode = "dataframe"
+    return execution_mode
+
+
+def stamp_requested_phases(config: BenchmarkConfig, phases_to_run: list[str] | None) -> None:
+    """Record the exact phases requested on the config's options.
+
+    Combined mode reads this downstream to run only what was asked for, rather
+    than everything the execution type implies.
+    """
+    if not phases_to_run:
+        return
+    options = dict(getattr(config, "options", {}) or {})
+    options["requested_phases"] = list(phases_to_run)
+    config.options = options
+
+
+def execute_run(
+    *,
+    config: BenchmarkConfig,
+    benchmark_instance: Any,
+    database_config: Any,
+    system_profile: Any,
+    platform_config: Mapping[str, Any] | None,
+    output_root: Any,
+    phases_to_run: list[str] | None,
+    adapter_factory: AdapterFactory,
+    verbosity: VerbosityLike,
+    monitor: Any = None,
+    execution_context: ExecutionContext | None = None,
+) -> BenchmarkResults:
+    """Run one benchmark through the core lifecycle.
+
+    Every input is already resolved by the surface: the benchmark instance, the
+    platform config, and the output root all arrive built. The adapter is the
+    one thing this function asks for, through ``adapter_factory``, because
+    building it requires ``benchbox.platforms``.
+
+    Moved from ``BenchmarkOrchestrator.execute_benchmark``. What did NOT move is
+    everything interaction-scoped: console output, the cloud-platform
+    load-phase warning, and the credential-setup retry all stay in the CLI,
+    which is where the new contract puts them.
+    """
+    stamp_requested_phases(config, phases_to_run)
+
+    phases = resolve_lifecycle_phases(phases_to_run)
+    validation = resolve_validation_options(getattr(config, "options", None))
+    execution_mode = resolve_execution_mode(database_config)
+
+    adapter = adapter_factory(execution_mode=execution_mode, output_root=output_root, phases=phases)
+
+    result = run_benchmark_lifecycle(
+        benchmark_config=config,
+        database_config=database_config,
+        system_profile=system_profile,
+        platform_config=platform_config,
+        phases=phases,
+        validation_opts=validation,
+        output_root=output_root,
+        benchmark_instance=benchmark_instance,
+        platform_adapter=adapter,
+        verbosity=verbosity,
+        monitor=monitor,
+        enable_resource_monitoring=False,
+        execution_context=execution_context,
+    )
+
+    # Canonical runtime metadata enrichment for every run path.
+    apply_driver_metadata(result, database_config=database_config, platform_adapter=adapter)
+    return result
+
+
 __all__ = [
+    "AdapterFactory",
     "RunPlan",
     "RunRequest",
     "SilentVerbosity",
     "VerbosityLike",
+    "execute_run",
+    "resolve_execution_mode",
+    "resolve_lifecycle_phases",
     "resolve_run_config",
+    "resolve_validation_options",
+    "stamp_requested_phases",
 ]

--- a/tests/integration/test_tpch_verbosity_flow.py
+++ b/tests/integration/test_tpch_verbosity_flow.py
@@ -104,7 +104,7 @@ def test_verbosity_settings_flow_through_orchestrator(monkeypatch, tmp_path):
     monkeypatch.setattr("benchbox.cli.orchestrator.get_platform_adapter", lambda *a, **k: _StubAdapter())
 
     # Mock the lifecycle function
-    monkeypatch.setattr("benchbox.cli.orchestrator.run_benchmark_lifecycle", fake_run_benchmark_lifecycle)
+    monkeypatch.setattr("benchbox.core.run_service.run_benchmark_lifecycle", fake_run_benchmark_lifecycle)
 
     # Also need to patch _get_benchmark_instance to actually instantiate the stub
     def mock_get_benchmark_instance(self, config, system_profile):

--- a/tests/unit/cli/test_cli_orchestrator.py
+++ b/tests/unit/cli/test_cli_orchestrator.py
@@ -52,7 +52,7 @@ class TestBenchmarkOrchestrator:
         self.orchestrator.set_custom_output_dir(test_dir)
         assert self.orchestrator.custom_output_dir == test_dir
 
-    @patch("benchbox.cli.orchestrator.run_benchmark_lifecycle")
+    @patch("benchbox.core.run_service.run_benchmark_lifecycle")
     @patch("benchbox.cli.orchestrator.get_platform_adapter")
     @patch("benchbox.cli.orchestrator.console")
     def test_execute_benchmark_standard_mode(self, mock_console, mock_get_adapter, mock_lifecycle):
@@ -137,7 +137,7 @@ class TestBenchmarkOrchestrator:
         # Verify platform adapter was called
         mock_get_adapter.assert_called_once()
 
-    @patch("benchbox.cli.orchestrator.run_benchmark_lifecycle")
+    @patch("benchbox.core.run_service.run_benchmark_lifecycle")
     @patch("benchbox.cli.orchestrator.get_platform_adapter")
     def test_execute_benchmark_enriches_driver_metadata_on_canonical_path(self, mock_get_adapter, mock_lifecycle):
         """Driver metadata is propagated on orchestrator/lifecycle path."""
@@ -508,7 +508,7 @@ class TestBenchmarkOrchestrator:
         assert run_config.connection is not None
         assert "database_path" in run_config.connection
 
-    @patch("benchbox.cli.orchestrator.run_benchmark_lifecycle")
+    @patch("benchbox.core.run_service.run_benchmark_lifecycle")
     def test_execute_data_only_mode_success(self, mock_lifecycle):
         """Test data-only mode execution success using lifecycle path."""
         config = BenchmarkConfig(name="tpch", display_name="TPC-H", scale_factor=0.01, test_execution_type="data_only")
@@ -538,7 +538,7 @@ class TestBenchmarkOrchestrator:
         assert isinstance(result, BenchmarkResults)
         assert result.test_execution_type == "data_only"
 
-    @patch("benchbox.cli.orchestrator.run_benchmark_lifecycle")
+    @patch("benchbox.core.run_service.run_benchmark_lifecycle")
     def test_execute_data_only_mode_error(self, mock_lifecycle):
         """Test data-only mode execution error using lifecycle path."""
         config = BenchmarkConfig(name="tpch", display_name="TPC-H", scale_factor=0.01, test_execution_type="data_only")

--- a/tests/unit/cli/test_cli_parameter_consistency.py
+++ b/tests/unit/cli/test_cli_parameter_consistency.py
@@ -290,7 +290,7 @@ class TestCLIParameterConsistency:
         orchestrator = BenchmarkOrchestrator()
 
         # Mock the orchestrator-local lifecycle import used by execute_benchmark().
-        with patch("benchbox.cli.orchestrator.run_benchmark_lifecycle") as mock_lifecycle:
+        with patch("benchbox.core.run_service.run_benchmark_lifecycle") as mock_lifecycle:
             mock_result = MagicMock()
             mock_lifecycle.return_value = mock_result
 

--- a/tests/unit/cli/test_cli_power_throughput.py
+++ b/tests/unit/cli/test_cli_power_throughput.py
@@ -126,7 +126,7 @@ class TestBenchmarkOrchestratorPowerThroughput:
         self.orchestrator.directory_manager.get_datagen_path = Mock(return_value="/tmp/test_datagen")
         self.orchestrator.directory_manager.get_database_path = Mock(return_value="/tmp/test_db.duckdb")
 
-    @patch("benchbox.cli.orchestrator.run_benchmark_lifecycle")
+    @patch("benchbox.core.run_service.run_benchmark_lifecycle")
     @patch("benchbox.cli.orchestrator.get_platform_adapter")
     @patch.object(BenchmarkOrchestrator, "_get_benchmark_instance")
     def test_power_test_execution_type(self, mock_get_benchmark, mock_get_platform, mock_lifecycle):
@@ -212,7 +212,7 @@ class TestBenchmarkOrchestratorPowerThroughput:
         # Metrics come from lifecycle result
         assert getattr(result, "power_at_size", None) == 123.45
 
-    @patch("benchbox.cli.orchestrator.run_benchmark_lifecycle")
+    @patch("benchbox.core.run_service.run_benchmark_lifecycle")
     @patch("benchbox.cli.orchestrator.get_platform_adapter")
     @patch.object(BenchmarkOrchestrator, "_get_benchmark_instance")
     def test_throughput_test_execution_type(self, mock_get_benchmark, mock_get_platform, mock_lifecycle):
@@ -297,7 +297,7 @@ class TestBenchmarkOrchestratorPowerThroughput:
         assert result is not None
         assert getattr(result, "throughput_at_size", None) == 987.65
 
-    @patch("benchbox.cli.orchestrator.run_benchmark_lifecycle")
+    @patch("benchbox.core.run_service.run_benchmark_lifecycle")
     @patch("benchbox.cli.orchestrator.get_platform_adapter")
     @patch.object(BenchmarkOrchestrator, "_get_benchmark_instance")
     def test_combined_test_execution_type(self, mock_get_benchmark, mock_get_platform, mock_lifecycle):

--- a/tests/unit/cli/test_orchestrator_validation.py
+++ b/tests/unit/cli/test_orchestrator_validation.py
@@ -75,7 +75,7 @@ class TestBenchmarkOrchestratorValidation:
                 return_value=bench_instance,
             ),
             patch("benchbox.cli.orchestrator.get_platform_adapter", return_value=Mock()) as mock_adapter,
-            patch("benchbox.cli.orchestrator.run_benchmark_lifecycle") as mock_run,
+            patch("benchbox.core.run_service.run_benchmark_lifecycle") as mock_run,
         ):
             mock_result = Mock(spec=BenchmarkResults)
             mock_run.return_value = mock_result
@@ -132,7 +132,7 @@ class TestBenchmarkOrchestratorValidation:
                 return_value=bench_instance,
             ),
             patch("benchbox.cli.orchestrator.get_platform_adapter") as mock_adapter,
-            patch("benchbox.cli.orchestrator.run_benchmark_lifecycle") as mock_run,
+            patch("benchbox.core.run_service.run_benchmark_lifecycle") as mock_run,
         ):
             mock_run.return_value = Mock(spec=BenchmarkResults)
             self.orchestrator.execute_benchmark(config, _mk_system_profile(), database_config=None)
@@ -156,7 +156,7 @@ class TestBenchmarkOrchestratorValidation:
                 "_get_benchmark_instance",
                 return_value=bench_instance,
             ),
-            patch("benchbox.cli.orchestrator.run_benchmark_lifecycle") as mock_run,
+            patch("benchbox.core.run_service.run_benchmark_lifecycle") as mock_run,
         ):
             mock_run.return_value = Mock(spec=BenchmarkResults)
             result = self.orchestrator.execute_benchmark(
@@ -196,7 +196,7 @@ class TestBenchmarkOrchestratorValidation:
                 return_value=bench_instance,
             ),
             patch("benchbox.cli.orchestrator.get_platform_adapter", return_value=adapter) as mock_get_adapter,
-            patch("benchbox.cli.orchestrator.run_benchmark_lifecycle") as mock_run,
+            patch("benchbox.core.run_service.run_benchmark_lifecycle") as mock_run,
         ):
             mock_run.return_value = Mock(spec=BenchmarkResults)
             result = self.orchestrator.execute_benchmark(

--- a/tests/unit/core/test_run_service.py
+++ b/tests/unit/core/test_run_service.py
@@ -157,3 +157,206 @@ class TestRequestAndPlanTypes:
         assert plan.run_config is run_config
         assert plan.execution_type == "power"
         assert plan.resolved_mode is None
+
+
+class TestExecutionPort:
+    """w3: orchestration in core, adapter construction injected by the surface."""
+
+    @staticmethod
+    def _phases(**kwargs):
+        from benchbox.core.run_service import resolve_lifecycle_phases
+
+        return resolve_lifecycle_phases(kwargs.get("phases_to_run"))
+
+    def test_no_phase_list_means_the_standard_lifecycle(self):
+        from benchbox.core.run_service import resolve_lifecycle_phases
+
+        phases = resolve_lifecycle_phases(None)
+
+        assert (phases.generate, phases.load, phases.execute) == (True, True, True)
+        assert phases.statistics is False
+
+    def test_an_empty_phase_list_is_treated_as_absent(self):
+        from benchbox.core.run_service import resolve_lifecycle_phases
+
+        assert resolve_lifecycle_phases([]) == resolve_lifecycle_phases(None)
+
+    @pytest.mark.parametrize("query_phase", ["warmup", "power", "throughput", "maintenance"])
+    def test_any_query_phase_sets_execute(self, query_phase: str):
+        from benchbox.core.run_service import resolve_lifecycle_phases
+
+        assert resolve_lifecycle_phases([query_phase]).execute is True
+
+    def test_statistics_stays_opt_in(self):
+        from benchbox.core.run_service import resolve_lifecycle_phases
+
+        assert resolve_lifecycle_phases(["load"]).statistics is False
+        assert resolve_lifecycle_phases(["load", "statistics"]).statistics is True
+
+    def test_validation_options_default_to_off(self):
+        from benchbox.core.run_service import resolve_validation_options
+
+        options = resolve_validation_options(None)
+
+        assert options.enable_preflight_validation is False
+        assert options.enable_postgen_manifest_validation is False
+        assert options.enable_postload_validation is False
+
+    def test_validation_options_are_read_from_config_options(self):
+        from benchbox.core.run_service import resolve_validation_options
+
+        options = resolve_validation_options({"enable_postload_validation": True})
+
+        assert options.enable_postload_validation is True
+
+    def test_execution_mode_is_none_without_a_database(self):
+        from benchbox.core.run_service import resolve_execution_mode
+
+        assert resolve_execution_mode(None) is None
+
+    def test_an_explicit_execution_mode_wins(self):
+        from benchbox.core.run_service import resolve_execution_mode
+
+        class _Config:
+            execution_mode = "dataframe"
+            type = "duckdb"
+
+        assert resolve_execution_mode(_Config()) == "dataframe"
+
+    def test_requested_phases_are_stamped_for_combined_mode(self):
+        from benchbox.core.run_service import stamp_requested_phases
+
+        config = _config()
+        stamp_requested_phases(config, ["power", "throughput"])
+
+        assert config.options["requested_phases"] == ["power", "throughput"]
+
+    def test_stamping_nothing_leaves_options_alone(self):
+        from benchbox.core.run_service import stamp_requested_phases
+
+        config = _config(options={"seed": 1})
+        stamp_requested_phases(config, None)
+
+        assert "requested_phases" not in (config.options or {})
+
+    def test_the_adapter_factory_receives_the_resolved_phases(self):
+        """The injection seam: core asks, the surface builds."""
+        from unittest.mock import patch
+
+        from benchbox.core.run_service import execute_run
+
+        seen = {}
+
+        def factory(*, execution_mode, output_root, phases):
+            seen["execution_mode"] = execution_mode
+            seen["output_root"] = output_root
+            seen["phases"] = phases
+            return "ADAPTER"
+
+        with (
+            patch("benchbox.core.run_service.run_benchmark_lifecycle", return_value="RESULT") as lifecycle,
+            patch("benchbox.core.run_service.apply_driver_metadata"),
+        ):
+            result = execute_run(
+                config=_config(),
+                benchmark_instance=object(),
+                database_config=None,
+                system_profile=None,
+                platform_config=None,
+                output_root="/tmp/out",
+                phases_to_run=["load", "power"],
+                adapter_factory=factory,
+                verbosity=SilentVerbosity(),
+            )
+
+        assert result == "RESULT"
+        assert seen["execution_mode"] is None
+        assert seen["output_root"] == "/tmp/out"
+        assert seen["phases"].load is True and seen["phases"].execute is True
+        assert lifecycle.call_args.kwargs["platform_adapter"] == "ADAPTER"
+
+    def test_a_factory_returning_none_is_honoured(self):
+        """A data-only run has no database to adapt."""
+        from unittest.mock import patch
+
+        from benchbox.core.run_service import execute_run
+
+        with (
+            patch("benchbox.core.run_service.run_benchmark_lifecycle", return_value="RESULT") as lifecycle,
+            patch("benchbox.core.run_service.apply_driver_metadata"),
+        ):
+            execute_run(
+                config=_config(),
+                benchmark_instance=object(),
+                database_config=None,
+                system_profile=None,
+                platform_config=None,
+                output_root="/tmp/out",
+                phases_to_run=["generate"],
+                adapter_factory=lambda **_: None,
+                verbosity=SilentVerbosity(),
+            )
+
+        assert lifecycle.call_args.kwargs["platform_adapter"] is None
+
+    def test_driver_metadata_is_applied_to_every_result(self):
+        from unittest.mock import patch
+
+        from benchbox.core.run_service import execute_run
+
+        with (
+            patch("benchbox.core.run_service.run_benchmark_lifecycle", return_value="RESULT"),
+            patch("benchbox.core.run_service.apply_driver_metadata") as enrich,
+        ):
+            execute_run(
+                config=_config(),
+                benchmark_instance=object(),
+                database_config=None,
+                system_profile=None,
+                platform_config=None,
+                output_root="/tmp/out",
+                phases_to_run=None,
+                adapter_factory=lambda **_: "ADAPTER",
+                verbosity=SilentVerbosity(),
+            )
+
+        enrich.assert_called_once()
+        assert enrich.call_args.kwargs["platform_adapter"] == "ADAPTER"
+
+
+class TestInteractionStaysInTheCli:
+    """The anti-pattern: interaction-scoped code must not follow into core."""
+
+    def test_core_emits_no_console_output(self):
+        """Structural, not substring: no print calls, no console imports."""
+        tree = ast.parse(RUN_SERVICE_SOURCE.read_text(encoding="utf-8"))
+
+        called = {
+            node.func.id for node in ast.walk(tree) if isinstance(node, ast.Call) and isinstance(node.func, ast.Name)
+        }
+        attribute_calls = {
+            node.func.attr
+            for node in ast.walk(tree)
+            if isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute)
+        }
+        modules = {node.module for node in ast.walk(tree) if isinstance(node, ast.ImportFrom) and node.module}
+
+        assert "print" not in called
+        assert "print" not in attribute_calls
+        assert not any(m.startswith("rich") or m.endswith("printing") for m in modules)
+
+    def test_the_credential_retry_stayed_behind(self):
+        """Interactive recovery is CLI-scoped and must not have followed."""
+        tree = ast.parse(RUN_SERVICE_SOURCE.read_text(encoding="utf-8"))
+        defined = {node.name for node in ast.walk(tree) if isinstance(node, ast.FunctionDef)}
+
+        assert not any("credential" in name.lower() for name in defined)
+
+        cli_source = (REPO_ROOT / "benchbox/cli/orchestrator.py").read_text(encoding="utf-8")
+        assert "_offer_and_run_credential_setup" in cli_source
+
+    def test_the_cli_still_owns_the_load_phase_warning(self):
+        source = (REPO_ROOT / "benchbox/cli/orchestrator.py").read_text(encoding="utf-8")
+
+        assert "_warn_on_execute_without_load" in source
+        assert "assuming data already exists" in source

--- a/tests/unit/test_orchestrator_data_generation_flags.py
+++ b/tests/unit/test_orchestrator_data_generation_flags.py
@@ -99,7 +99,7 @@ def test_force_regenerate_flag_passed_to_benchmark():
         patch.object(BenchmarkOrchestrator, "_get_platform_config", return_value={"type": "duckdb"}),
         patch("benchbox.cli.orchestrator.get_platform_adapter", return_value=Mock()),
         patch(
-            "benchbox.cli.orchestrator.run_benchmark_lifecycle",
+            "benchbox.core.run_service.run_benchmark_lifecycle",
             side_effect=lambda **kwargs: lifecycle_calls.append(kwargs) or Mock(),
         ),
     ):


### PR DESCRIPTION
Work unit w3 of `one-engine-core-run-service`: execution orchestration ports
into benchbox/core/run_service.py, with adapter construction injected by the
surface.

## The seam

Building an adapter means importing benchbox.platforms, which core sits below,
so execute_run takes an AdapterFactory Protocol instead. The CLI passes a
closure over its console, verbosity, platform config, and benchmark instance;
MCP will pass its own in the adoption item. Returning None is meaningful -- a
data-only run has no database to adapt -- and that is covered.

Everything else the lifecycle needs was already core: LifecyclePhases,
ValidationOptions, and run_benchmark_lifecycle all live in
benchbox.core.runner.runner, PlatformRegistry and is_dataframe_execution in
core, apply_driver_metadata in core.results. The adapter really was the only
platforms-shaped dependency, which is why one injection point is enough.

## What moved, and what deliberately did not

Moved: the requested-phases stamp that combined mode reads downstream, the
phase-list to LifecyclePhases mapping, ValidationOptions construction,
execution-mode detection (explicit mode wins, else registry default upgraded to
dataframe), the run_benchmark_lifecycle call, and the driver-metadata
enrichment.

Stayed in the CLI, per the item's interaction-scoped anti-pattern: all console
output, the credential-setup retry (which recurses into execute_benchmark after
an interactive prompt), and the cloud-platform "executing without load phase"
warning. That warning was inline in the middle of the moved block, so it is now
_warn_on_execute_without_load -- same console string, same trigger conditions,
called before the port. Tests assert core defines no credential function, makes
no print call, and imports nothing from rich or benchbox.utils.printing, and
that the CLI still owns both the warning and the retry.

## Test seam relocation

Six test modules patched `benchbox.cli.orchestrator.run_benchmark_lifecycle`.
The call now lives in core, so those patches are repointed to
`benchbox.core.run_service.run_benchmark_lifecycle`. The assertions are
unchanged -- same kwargs, same behavior -- only the patch target moved, which is
what a pure move should require.

Rungs 1, 2, 3, and 5 pass. Fast lane 27066 -> 27085.
