### PR TITLE
fix(agents): name the audit check that failed and give the budget headroom

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -133,8 +133,12 @@ repos:
         stages: [pre-commit]
         files: ^(AGENTS\.md|CLAUDE\.md|GEMINI\.md|ANTIGRAVITY\.md|\.claude/(commands/|settings\.json)|\.claude/skills/|docs/(development/agent-|operations/agent-instruction)|_project/(evals/agent-instructions/|scripts/agent_instruction_audit\.py)|skill-sync\.(yaml|lock))
 
+      # Runs the whole instruction audit, not only the identity check, so the
+      # name cannot claim one check. The script prints `FAIL (<checks>)` naming
+      # what actually failed - a byte-budget failure used to surface here as a
+      # Git identity problem.
       - id: agent-git-identity
-        name: reject stale agent Git identity
+        name: agent instruction + Git identity audit
         entry: make agent-identity-check
         language: system
         pass_filenames: false

--- a/_project/scripts/agent_instruction_audit.py
+++ b/_project/scripts/agent_instruction_audit.py
@@ -8,6 +8,7 @@ import json
 import os
 import re
 import subprocess
+from collections.abc import Iterable
 from dataclasses import asdict, dataclass
 from pathlib import Path
 from typing import Any
@@ -121,6 +122,21 @@ class Metrics:
 
 def _read(project: Path, relative: str) -> str:
     return (project / relative).read_text(encoding="utf-8")
+
+
+def _tag(check: str, errors: Iterable[str]) -> list[str]:
+    """Prefix each message with the check that produced it."""
+    return [f"{check}: {error}" for error in errors]
+
+
+def failing_checks(errors: Iterable[str]) -> list[str]:
+    """Distinct check names present in *errors*, in first-seen order."""
+    seen: list[str] = []
+    for error in errors:
+        check = error.split(":", 1)[0]
+        if check not in seen:
+            seen.append(check)
+    return seen
 
 
 def collect_metrics(project: Path) -> Metrics:
@@ -441,34 +457,70 @@ def audit_scenarios(scenarios: list[dict[str, Any]], policy_text: str) -> list[s
     return errors
 
 
+# Fraction of a budget at which the surface is reported as nearly full. #1541
+# added 88 bytes to a 16000-byte ceiling and reddened develop for everyone with
+# no prior signal; a headroom band turns "over budget" from a cliff into a slope.
+HEADROOM_WARNING_RATIO = 0.97
+
+
+def budget_headroom_warnings(metrics: Metrics, budgets: dict[str, Any]) -> list[str]:
+    """Warn when a budgeted metric is close to its ceiling but not yet over it.
+
+    Deliberately a warning, never an error: the budget itself stays the gate.
+    A second failing threshold would just be a lower budget, and the point is to
+    give the next docs change lead time, not to move the wall in.
+    """
+    warnings: list[str] = []
+    measured = [
+        ("active instruction bytes", metrics.active_bytes, budgets["active_bytes"]),
+        ("AGENTS.md lines", metrics.agents_lines, budgets["agents_lines"]),
+        *((f"{name} bytes", size, budgets["adapter_bytes"]) for name, size in metrics.adapter_bytes.items()),
+    ]
+    for label, value, ceiling in measured:
+        if ceiling and value <= ceiling and value >= ceiling * HEADROOM_WARNING_RATIO:
+            warnings.append(f"{label} {value} is within {ceiling - value} of the {ceiling} budget")
+    return warnings
+
+
 def audit(project: Path, corpus: dict[str, Any]) -> tuple[Metrics, list[str]]:
+    """Run every non-Git check and return its errors tagged with the check name.
+
+    Each message is prefixed `<check>: ` so a caller - in particular the
+    pre-commit hook, which invokes this through one entry point - can say which
+    check failed. Before that, a byte-budget failure surfaced under a hook named
+    "reject stale agent Git identity", which sent at least one investigation
+    after a Git config problem that did not exist.
+    """
     errors: list[str] = []
     metrics = collect_metrics(project)
     budgets = corpus["budgets"]
     baseline = corpus["baseline"]
 
+    budget_errors: list[str] = []
     if metrics.active_bytes > budgets["active_bytes"]:
-        errors.append(f"active instruction bytes {metrics.active_bytes} exceed budget {budgets['active_bytes']}")
+        budget_errors.append(f"active instruction bytes {metrics.active_bytes} exceed budget {budgets['active_bytes']}")
     if metrics.active_bytes >= baseline["active_bytes"]:
-        errors.append("active instruction surface did not improve on the recorded baseline")
+        budget_errors.append("active instruction surface did not improve on the recorded baseline")
     if metrics.agents_lines > budgets["agents_lines"]:
-        errors.append(f"AGENTS.md lines {metrics.agents_lines} exceed budget {budgets['agents_lines']}")
+        budget_errors.append(f"AGENTS.md lines {metrics.agents_lines} exceed budget {budgets['agents_lines']}")
     for name, size in metrics.adapter_bytes.items():
         if size > budgets["adapter_bytes"]:
-            errors.append(f"{name} bytes {size} exceed adapter budget {budgets['adapter_bytes']}")
+            budget_errors.append(f"{name} bytes {size} exceed adapter budget {budgets['adapter_bytes']}")
         adapter = _read(project, name)
         if "AGENTS.md" not in adapter:
-            errors.append(f"{name} does not point to AGENTS.md")
+            budget_errors.append(f"{name} does not point to AGENTS.md")
+    errors.extend(_tag("budget", budget_errors))
 
     active = "\n".join(_read(project, path) for path in ACTIVE_TEXT)
     command_text = "\n".join(
         path.read_text(encoding="utf-8") for path in sorted((project / ".claude/commands").glob("*.md"))
     )
+    surface_errors: list[str] = []
     if LEGACY_REVIEW_DOC in command_text:
-        errors.append(f"a .claude/commands surface binds to the superseded {LEGACY_REVIEW_DOC}")
+        surface_errors.append(f"a .claude/commands surface binds to the superseded {LEGACY_REVIEW_DOC}")
     settings = json.loads(_read(project, ".claude/settings.json"))
     if settings.get("hooks"):
-        errors.append(".claude/settings.json contains executable hooks; use explicit gates")
+        surface_errors.append(".claude/settings.json contains executable hooks; use explicit gates")
     forbidden_active = {
         "imposed Claude co-author": "Co-Authored-By: Claude",
         "imposed Claude author": "author Claude",
@@ -479,17 +531,18 @@ def audit(project: Path, corpus: dict[str, Any]) -> tuple[Metrics, list[str]]:
     }
     for label, needle in forbidden_active.items():
         if needle.casefold() in (active + "\n" + command_text).casefold():
-            errors.append(f"{label} pattern remains: {needle}")
+            surface_errors.append(f"{label} pattern remains: {needle}")
     settings_text = _read(project, ".claude/settings.json")
     for label, needle in forbidden_settings.items():
         if needle.casefold() in settings_text.casefold():
-            errors.append(f"{label} pattern remains in project settings: {needle}")
+            surface_errors.append(f"{label} pattern remains in project settings: {needle}")
+    errors.extend(_tag("surface", surface_errors))
 
     policy_text = _read(project, "AGENTS.md") + "\n" + _read(project, "docs/development/agent-review-protocol.md")
-    errors.extend(audit_review_policy(project))
-    errors.extend(audit_commit_policy(project))
+    errors.extend(_tag("review-policy", audit_review_policy(project)))
+    errors.extend(_tag("commit-policy", audit_commit_policy(project)))
 
-    errors.extend(audit_scenarios(corpus["scenarios"], policy_text))
+    errors.extend(_tag("scenarios", audit_scenarios(corpus["scenarios"], policy_text)))
 
     return metrics, errors
 
@@ -510,15 +563,24 @@ def main() -> int:
     metrics, errors = audit(args.project.resolve(), corpus)
     warnings: list[str] = []
     if args.check_git_identity:
-        errors.extend(audit_git_identity(args.project.resolve()))
-        warnings.extend(audit_identity_overrides(args.project.resolve()))
+        errors.extend(_tag("git-identity", audit_git_identity(args.project.resolve())))
+        warnings.extend(_tag("git-identity", audit_identity_overrides(args.project.resolve())))
     if args.check_commit_range:
-        errors.extend(audit_commit_range(args.project.resolve(), args.check_commit_range))
-    result = {"ok": not errors, "metrics": asdict(metrics), "errors": errors, "warnings": warnings}
+        errors.extend(_tag("commit-range", audit_commit_range(args.project.resolve(), args.check_commit_range)))
+    warnings.extend(_tag("budget", budget_headroom_warnings(metrics, corpus["budgets"])))
+    checks = failing_checks(errors)
+    result = {
+        "ok": not errors,
+        "metrics": asdict(metrics),
+        "errors": errors,
+        "warnings": warnings,
+        "failing_checks": checks,
+    }
     if args.as_json:
         print(json.dumps(result, indent=2, sort_keys=True))
     else:
-        print(f"agent-instructions: {'PASS' if not errors else 'FAIL'}")
+        summary = "PASS" if not errors else f"FAIL ({', '.join(checks)})"
+        print(f"agent-instructions: {summary}")
         print(f"active_bytes={metrics.active_bytes} agents_lines={metrics.agents_lines}")
         for name, size in metrics.adapter_bytes.items():
             print(f"{name}={size} bytes")

--- a/docs/development/agent-review-protocol.md
+++ b/docs/development/agent-review-protocol.md
@@ -42,21 +42,6 @@ shorter here, but a contradiction is drift and the canonical behavior wins.
 
 ## Audit evidence provenance
 
-`_project/audits/*.md` uses distinct SHA fields for distinct claims:
-
-| Convention | Meaning | Numeric measurement binding |
-|---|---|---|
-| `develop_sha` | Develop base or lineage the audit describes | Necessary, but not sufficient for measured results |
-| `checked_sha` | Exact non-base tree under test | `measured_at_sha` must match it |
-| Test-result counts | Passed, failed, skipped, or timed-out totals | Require `measured_at_sha` |
-| Inventory counts | Counted tests, queries, bundles, findings, comments, and similar entities | Require `measured_at_sha` |
-| Dates, versions, PR/issue references | Narrative identifiers, not empirical results | Do not require fabricated measurement provenance |
-
-`measured_at_sha` binds the original numeric evidence to the exact commit that
-produced it. It equals `checked_sha` when that field exists, otherwise
-`develop_sha`. A later spot replay does not replace or refresh the original
-measurement: record its commit as `replay_sha` and describe exactly what was
-rerun in `replay_scope`. The replay commit must descend from the measured
-commit, and both must be reachable from the audit's committed tree when the
-record is validated. If a replay contradicts a number, correct the claim using
-new evidence instead of using `replay_sha` to bless the stale value.
+Audit records bind numbers to the tree that produced them through distinct SHA
+fields. `make audit-sha-check` enforces it; the conventions are documented in
+`docs/development/audit-evidence-provenance.md`.

--- a/docs/development/audit-evidence-provenance.md
+++ b/docs/development/audit-evidence-provenance.md
@@ -1,0 +1,35 @@
+# Audit evidence provenance
+
+Reference for the SHA fields in `_project/audits/*.md`. The rules here are
+enforced mechanically by `_project/scripts/audit_sha_check.py` (`make
+audit-sha-check`), which is the authority; this page explains what each field
+means and why the distinctions matter.
+
+This lives outside `docs/development/agent-review-protocol.md` because it is a
+records convention for one directory, not review behaviour every session must
+carry. The protocol file counts against the agent instruction byte budget
+enforced by `_project/scripts/agent_instruction_audit.py`; reference material
+that a session reads on demand does not belong in that surface.
+
+## Field conventions
+
+`_project/audits/*.md` uses distinct SHA fields for distinct claims:
+
+| Convention | Meaning | Numeric measurement binding |
+|---|---|---|
+| `develop_sha` | Develop base or lineage the audit describes | Necessary, but not sufficient for measured results |
+| `checked_sha` | Exact non-base tree under test | `measured_at_sha` must match it |
+| Test-result counts | Passed, failed, skipped, or timed-out totals | Require `measured_at_sha` |
+| Inventory counts | Counted tests, queries, bundles, findings, comments, and similar entities | Require `measured_at_sha` |
+| Dates, versions, PR/issue references | Narrative identifiers, not empirical results | Do not require fabricated measurement provenance |
+
+## Binding numbers to the tree that produced them
+
+`measured_at_sha` binds the original numeric evidence to the exact commit that
+produced it. It equals `checked_sha` when that field exists, otherwise
+`develop_sha`. A later spot replay does not replace or refresh the original
+measurement: record its commit as `replay_sha` and describe exactly what was
+rerun in `replay_scope`. The replay commit must descend from the measured
+commit, and both must be reachable from the audit's committed tree when the
+record is validated. If a replay contradicts a number, correct the claim using
+new evidence instead of using `replay_sha` to bless the stale value.

--- a/tests/unit/scripts/test_agent_instruction_audit.py
+++ b/tests/unit/scripts/test_agent_instruction_audit.py
@@ -495,3 +495,78 @@ def test_unresolvable_identity_skip_does_not_weaken_the_agent_check(tmp_path: Pa
     errors = audit_git_identity(project)
     assert len(errors) == 2
     assert all("known agent/service Codex <codex@openai.com>" in error for error in errors)
+
+
+# ---------------------------------------------------------------------------
+# Check attribution and budget headroom.
+#
+# The pre-commit hook runs the whole audit through one entry point, so before
+# these landed a byte-budget failure was reported under a hook named "reject
+# stale agent Git identity" and sent an investigation after a Git config problem
+# that did not exist.
+# ---------------------------------------------------------------------------
+
+
+def test_every_error_names_the_check_that_produced_it(tmp_path: Path) -> None:
+    """A caller must be able to say which check failed, not just that one did."""
+    project = _candidate(tmp_path)
+    (project / "AGENTS.md").write_text("Co-Authored-By: Claude\n", encoding="utf-8")
+    _, errors = audit(project, CORPUS)
+    assert errors, "the mutated candidate must fail, or this asserts nothing"
+    known = {"budget", "surface", "review-policy", "commit-policy", "scenarios", "git-identity", "commit-range"}
+    unattributed = [error for error in errors if error.split(":", 1)[0] not in known]
+    assert not unattributed, f"errors with no check name: {unattributed}"
+
+
+def test_a_budget_failure_is_attributed_to_budget_not_identity(tmp_path: Path) -> None:
+    """The exact misreport this guards: over-budget must not read as identity."""
+    project = _candidate(tmp_path)
+    corpus = json.loads(json.dumps(CORPUS))
+    corpus["budgets"]["active_bytes"] = 1
+    _, errors = audit(project, corpus)
+    over = [error for error in errors if "exceed budget" in error]
+    assert over, "shrinking the budget must produce an over-budget error"
+    assert all(error.startswith("budget: ") for error in over)
+    assert agent_instruction_audit.failing_checks(errors)[0] == "budget"
+
+
+def test_failing_checks_lists_each_check_once_in_first_seen_order() -> None:
+    assert agent_instruction_audit.failing_checks(["budget: a", "scenarios: b", "budget: c"]) == [
+        "budget",
+        "scenarios",
+    ]
+
+
+def test_headroom_warns_near_the_ceiling_and_stays_a_warning() -> None:
+    """A near-full surface warns; only exceeding the ceiling is an error."""
+    metrics, _ = audit(ROOT, CORPUS)
+    budgets = dict(CORPUS["budgets"], active_bytes=metrics.active_bytes + 1)
+    warnings = agent_instruction_audit.budget_headroom_warnings(metrics, budgets)
+    assert any("active instruction bytes" in warning for warning in warnings)
+    # The same near-full state must not be an error - the budget is the gate.
+    _, errors = audit(ROOT, dict(CORPUS, budgets=budgets))
+    assert not [error for error in errors if "exceed budget" in error]
+
+
+def test_headroom_is_silent_with_room_to_spare() -> None:
+    metrics, _ = audit(ROOT, CORPUS)
+    budgets = dict(CORPUS["budgets"], active_bytes=metrics.active_bytes * 10)
+    warnings = agent_instruction_audit.budget_headroom_warnings(metrics, budgets)
+    assert not [warning for warning in warnings if "active instruction bytes" in warning]
+
+
+def test_the_precommit_hook_name_does_not_claim_a_single_check() -> None:
+    """The hook runs the full audit, so its name must not promise only identity.
+
+    Pinning the name is the only mechanical guard available here: pre-commit
+    prints the hook name, not the command, when a hook fails.
+    """
+    import yaml
+
+    config = yaml.safe_load((ROOT / ".pre-commit-config.yaml").read_text(encoding="utf-8"))
+    hooks = [hook for repo in config["repos"] for hook in repo.get("hooks", [])]
+    hook = next(hook for hook in hooks if hook["id"] == "agent-git-identity")
+    assert "agent-identity-check" in hook["entry"], "this test tracks the full-audit entry point"
+    assert "instruction" in hook["name"].casefold(), (
+        f"hook name {hook['name']!r} names only the identity check while running the whole audit"
+    )


### PR DESCRIPTION
Closes the misreporting half of `agent-identity-hook-misreports-failing-check`.

## The defect

The pre-commit hook runs the **whole** instruction audit through one entry
point (`make agent-identity-check`) but was named *"reject stale agent Git
identity"*. Pre-commit prints the hook **name**, not the command, when a hook
fails, so any of ~20 unrelated failures — byte budget, policy anchors,
scenarios, forbidden patterns — surfaced as a Git config problem. A byte-budget
failure on develop cost real diagnosis time before the true cause was found.

## Change

| | |
|---|---|
| Attribution | every error is tagged `budget:`, `surface:`, `review-policy:`, `commit-policy:`, `scenarios:`, `git-identity:`, `commit-range:` |
| Output | `agent-instructions: FAIL (budget)` + a `failing_checks` field in `--json` |
| Hook | keeps its id, renamed to *"agent instruction + Git identity audit"* |
| Headroom | a metric at ≥97% of its ceiling now warns, with the remaining margin |

Existing tests assert error **substrings**, not equality, so the prefix does not
break them.

## Why the headroom matters right now

Develop was independently returned to green while this branch was in progress
by tightening AGENTS.md wording. That lands active bytes at **15993 against a
16000 ceiling — 7 bytes of room**. The next one-line addition to any of the six
active files reddens develop again for everyone, and under the current output it
would once more be reported as a stale Git identity.

So the `Audit evidence provenance` section moves out of the always-loaded
surface into its own doc. It is a records convention for `_project/audits/*.md`,
enforced mechanically by `audit_sha_check.py` — not review behaviour every
session must carry, and AGENTS.md already says detailed operations belong in
linked docs.

```
active bytes  15993 -> 14894   (budget 16000, unchanged)
headroom          7 -> 1106
```

No policy ID, anchor, or scenario text was touched; no doc links the moved
section by anchor.

## Deliberately not done

- **The budget is not raised.** The item's must-preserve forbids papering over
  content growth, and the budget is the forcing function.
- **The headroom band is a warning, never an error.** A second failing threshold
  would just be a lower budget. `main()` already excludes warnings from exit
  status.

## Verification

```
make agent-identity-check                     exit 0   (was exit 2 at this branch's base)
pytest tests/unit/scripts/test_agent_instruction_audit.py   50 passed
ruff check / ruff format                      clean on both changed Python files
forced over-budget corpus                     "FAIL (budget)" + "ERROR: budget: ..."
```

Five new tests: error attribution, a budget failure attributed to `budget` and
not identity, `failing_checks` ordering, headroom firing near the ceiling and
staying silent with room to spare, and the hook name not claiming a single check.

## Correction to the tracker record

`w0`'s evidence was written against this branch's original base (`916d9533ab`),
where the audit failed at 16088 bytes. Develop was fixed independently before
this landed, so this PR's contribution is headroom and attribution, not the
initial restoration to green. The measurements above are against current
develop.
