### PR TITLE
fix: stop arming auto-merge at PR creation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,7 @@ POOL_CLAIM_MARKER_STALE_SECONDS ?= 600
 # truth instead of repeating the four-deep nested expansion.
 POOL_REPO_CMD = basename "$$(dirname "$$(realpath "$$(git rev-parse --git-common-dir)")")"
 
-.PHONY: test test-unit test-integration test-tpch test-all test-fast test-unlock test-medium test-slow test-stress test-pytest clean lint lint-markers lint-imports lint-explorer-tokens lint-site-theme-tokens artifact-hygiene agent-instructions-check agent-identity-check agent-commit-range-check audit-sha-check agent-write-preflight install develop coverage coverage-fast coverage-all coverage-html coverage-report coverage-check test-duckdb test-sqlite test-read-primitives test-benchmarks test-ci typecheck validate-imports catalog-schema-check format dependency-check docs-build docs-serve docs-clean docs-linkcheck docs-validate docs-check docs-images test-pyspark ci-lint ci-test ci-docs ci-local security-audit spellcheck docstring-coverage test-package test-integration-smoke test-correctness-gate plan-capture-gate correctness-gate-digests-regen test-local-matrix joinorder-verify-reference-results complexity-check complexity-report duplicate-check duplicate-check-verbose duplicate-check-json skill-sync skill-sync-check skill-sync-verify skill-sync-lock-audit mutation-test tpchavoc-equivalence-report tpchavoc-equivalence-report-postgres tpchavoc-equivalence-report-datafusion tpchavoc-equivalence-report-clickhouse tpchavoc-dataframe-equivalence-report ssb-cross-surface-equivalence-report amplab-cross-surface-equivalence-report coffeeshop-cross-surface-equivalence-report clickbench-cross-surface-equivalence-report joinorder-synthetic-cross-surface-equivalence-report h2odb-cross-surface-equivalence-report read-primitives-cross-surface-equivalence-report cross-surface-update-baseline cross-surface-baseline-autodetect oracle-coverage-map oracle-coverage-map-check cross-surface-applicability-report compile-tpcds-binaries parity-fixtures parity-check compat-docs compat-docs-check pr-preflight pr-preflight-fast-tests pr-content-guard pr-open pr-status pr-review-followups pr-review-followups-list dev-loop-metrics shrink-rollup worktree-pool-init worktree-pool-status worktree-pool-check worktree-claim worktree-claim-locked worktree-claim-attempt worktree-release worktree-pool-reset worktree-pool-sweep-stale worktree-pool-disk-clean worktree-list worktree-prune
+.PHONY: test test-unit test-integration test-tpch test-all test-fast test-unlock test-medium test-slow test-stress test-pytest clean lint lint-markers lint-imports lint-explorer-tokens lint-site-theme-tokens artifact-hygiene agent-instructions-check agent-identity-check agent-commit-range-check audit-sha-check agent-write-preflight install develop coverage coverage-fast coverage-all coverage-html coverage-report coverage-check test-duckdb test-sqlite test-read-primitives test-benchmarks test-ci typecheck validate-imports catalog-schema-check format dependency-check docs-build docs-serve docs-clean docs-linkcheck docs-validate docs-check docs-images test-pyspark ci-lint ci-test ci-docs ci-local security-audit spellcheck docstring-coverage test-package test-integration-smoke test-correctness-gate plan-capture-gate correctness-gate-digests-regen test-local-matrix joinorder-verify-reference-results complexity-check complexity-report duplicate-check duplicate-check-verbose duplicate-check-json skill-sync skill-sync-check skill-sync-verify skill-sync-lock-audit mutation-test tpchavoc-equivalence-report tpchavoc-equivalence-report-postgres tpchavoc-equivalence-report-datafusion tpchavoc-equivalence-report-clickhouse tpchavoc-dataframe-equivalence-report ssb-cross-surface-equivalence-report amplab-cross-surface-equivalence-report coffeeshop-cross-surface-equivalence-report clickbench-cross-surface-equivalence-report joinorder-synthetic-cross-surface-equivalence-report h2odb-cross-surface-equivalence-report read-primitives-cross-surface-equivalence-report cross-surface-update-baseline cross-surface-baseline-autodetect oracle-coverage-map oracle-coverage-map-check cross-surface-applicability-report compile-tpcds-binaries parity-fixtures parity-check compat-docs compat-docs-check pr-preflight pr-preflight-fast-tests pr-content-guard pr-open pr-ready pr-arm-auto-merge pr-status pr-review-followups pr-review-followups-list dev-loop-metrics shrink-rollup worktree-pool-init worktree-pool-status worktree-pool-check worktree-claim worktree-claim-locked worktree-claim-attempt worktree-release worktree-pool-reset worktree-pool-sweep-stale worktree-pool-disk-clean worktree-list worktree-prune
 
 # Primary test commands using pytest marker system
 test: test-fast
@@ -1486,7 +1486,7 @@ release-finalize:
 # branches stay live in parallel via worktrees.
 # =============================================================================
 
-.PHONY: pr-preflight pr-preflight-fast-tests pr-content-guard pr-open pr-fanout pr-refresh pr-conflict-scan pr-status pr-review-followups pr-review-followups-list dev-loop-metrics shrink-rollup audit-sha-check agent-write-preflight worktree-pool-init worktree-pool-status worktree-pool-check worktree-claim worktree-claim-locked worktree-claim-attempt worktree-release worktree-release-locked worktree-pool-reset worktree-pool-reset-locked worktree-pool-sweep-stale worktree-pool-sweep-stale-locked worktree-pool-disk-clean worktree-list worktree-prune blind-spots-list blind-spots-report blind-spots-sweep soundness-drain-report soundness-drain-self-test
+.PHONY: pr-preflight pr-preflight-fast-tests pr-content-guard pr-open pr-ready pr-arm-auto-merge pr-fanout pr-refresh pr-conflict-scan pr-status pr-review-followups pr-review-followups-list dev-loop-metrics shrink-rollup audit-sha-check agent-write-preflight worktree-pool-init worktree-pool-status worktree-pool-check worktree-claim worktree-claim-locked worktree-claim-attempt worktree-release worktree-release-locked worktree-pool-reset worktree-pool-reset-locked worktree-pool-sweep-stale worktree-pool-sweep-stale-locked worktree-pool-disk-clean worktree-list worktree-prune blind-spots-list blind-spots-report blind-spots-sweep soundness-drain-report soundness-drain-self-test
 
 agent-write-preflight:
 	@sh scripts/agent_write_preflight.sh
@@ -1587,12 +1587,41 @@ pr-open:
 		fi; \
 	fi && \
 	echo "$$URL" && \
+	if [ "$(READY)" != "1" ]; then \
+		echo "Auto-merge withheld. Run 'make pr-ready' when the branch is final, or 'make pr-open READY=1' to open and arm in one step."; \
+	else \
+		$(MAKE) -s pr-arm-auto-merge URL="$$URL"; \
+	fi
+
+# Arms squash auto-merge for an already-open PR. Split out of pr-open so the
+# soundness check has exactly one implementation and both entry points get it.
+pr-arm-auto-merge:
+	@URL="$(URL)"; \
+	if [ -z "$$URL" ]; then \
+		CURRENT=$$(git branch --show-current); \
+		URL=$$(gh pr list --base develop --head "$$CURRENT" --state open --json url --jq '.[0].url' 2>/dev/null); \
+	fi; \
+	if [ -z "$$URL" ]; then echo "No open PR found for this branch." >&2; exit 1; fi; \
+	git fetch origin develop --quiet; \
 	SOUNDNESS_PATH=$$(git diff --name-only --no-renames origin/develop...HEAD | uv run --project _project/scripts -- python _project/scripts/auto_merge_soundness_paths.py --stdin); \
 	if [ "$$SOUNDNESS_PATH" = "true" ]; then \
 		echo "Soundness-critical paths changed; leaving auto-merge disabled pending review."; \
 	else \
 		gh pr merge --auto --squash "$$URL"; \
 	fi
+
+# Declares the branch final and arms auto-merge.
+#
+# Auto-merge is NOT armed by `pr-open`, because arming at creation is only
+# correct if nothing more will be pushed - and the usual reason something more
+# is pushed is review feedback, which arrives after the PR exists. A PR armed
+# at creation can satisfy its checks and merge while the follow-up commit is
+# still being written, leaving develop with a partial change and the rest
+# orphaned on a closed branch. That happened three times in one session
+# (#1503, #1521, #1531); the last two stranded the very commits that addressed
+# their own review findings.
+pr-ready:
+	@$(MAKE) -s pr-arm-auto-merge
 
 shrink-rollup:
 	@git fetch origin develop --quiet

--- a/docs/operations/dev-loop-worktree-pool.md
+++ b/docs/operations/dev-loop-worktree-pool.md
@@ -38,7 +38,8 @@ The minimum surface for routine work — start here.
 | When | Command | Effect |
 |---|---|---|
 | Start a new task | `make worktree-claim BRANCH=fix/foo` | Pick a free slot, fetch + reset to current `origin/develop`, create branch, refresh `.venv/` only if `uv.lock`/`pyproject.toml` changed, and (re)install the pre-commit hooks (idempotent; `\|\| true` with a notice if `pre-commit` is unavailable). Prints `WORKTREE_PATH=…`. |
-| Inside the slot, ship the work | `make pr-preflight && make pr-open` | Run the local lint + fast-test gate, push, open PR vs `develop`, enable squash auto-merge. Walk away — auto-merge lands it once CI is green. |
+| Inside the slot, ship the work | `make pr-preflight && make pr-open` | Run the local lint + fast-test gate, push, open PR vs `develop`. Auto-merge is **not** armed. |
+| Declare the branch final | `make pr-ready` | Arms squash auto-merge. Walk away — it lands once CI is green. Use `make pr-open READY=1` to open and arm in one step when you already know the branch is done. |
 | After the PR merges | `make worktree-release` | Detach the slot back to `origin/develop`, delete the local feature branch. Refuses unless the PR state is `MERGED` (use `FORCE=1` to escape — only when intentional). |
 | See pool state any time | `make worktree-pool-status` | Tabular: pool, path, branch, state, claim age, venv health, disk size. Read-only; safe to run during other operations. |
 | Assert pool invariants | `make worktree-pool-check` | Read-only; exits non-zero if any slot is missing, has a surviving `.benchbox/claim_in_progress` marker, or there are extra `pool-NN` directories beyond `POOL_SIZE`. Cheap (no `gh` calls); use as a pre-release sanity check or periodic local cron. |
@@ -54,7 +55,7 @@ Reported by `make worktree-pool-status`:
 | State | Meaning | Recovery |
 |---|---|---|
 | `free` | Detached HEAD, clean tree — claimable. | None needed. |
-| `claimed` | On a feature branch, no PR yet or PR open. Active work. | Continue work or `make pr-open`. |
+| `claimed` | On a feature branch, no PR yet or PR open. Active work. | Continue work, `make pr-open`, then `make pr-ready` when final. |
 | `stale` | On a feature branch whose PR is `MERGED`. | `make worktree-pool-sweep-stale` (or `worktree-release` from inside). |
 | `dirty` | Uncommitted changes (excluding `.benchbox/` scratch). | Review, commit/discard manually, then release. |
 | `aborted` | A `.benchbox/claim_in_progress` marker survived a crashed claim. | `make worktree-pool-reset POOL=NN` after reviewing what's there. |

--- a/docs/operations/repo-admin-settings.md
+++ b/docs/operations/repo-admin-settings.md
@@ -135,7 +135,11 @@ The soundness gate, as operated:
   rule-dispatch core), and the gate machinery itself (the predicate,
   `.github/workflows/auto-merge-on-open.yml`, and the PyPI-publishing
   `.github/workflows/release.yml`).
-- `make pr-open` and `auto-merge-on-open.yml` WITHHOLD squash auto-merge for
+- `make pr-open` no longer arms auto-merge at all; `make pr-ready` (or
+  `make pr-open READY=1`) does, so a PR cannot merge while a follow-up commit
+  is still being written. Arming at creation stranded three commits in one
+  session, two of them the fixes for their own review findings.
+- The arming path and `auto-merge-on-open.yml` WITHHOLD squash auto-merge for
   PRs touching those paths (and revoke it on a later push that newly touches
   them). CI cannot catch a change that redefines the oracle it validates
   against, so these PRs must not merge hands-free.

--- a/tests/unit/workflows/test_auto_merge_enablement_point.py
+++ b/tests/unit/workflows/test_auto_merge_enablement_point.py
@@ -1,0 +1,87 @@
+"""Auto-merge must not be armed at PR creation.
+
+Arming at creation is only correct if nothing more will be pushed - and the
+usual reason something more is pushed is review feedback, which arrives after
+the PR exists. A PR armed at creation can satisfy its checks and merge while
+the follow-up commit is still being written, leaving develop with a partial
+change and the remainder orphaned on a closed branch.
+
+That happened three times in one session: #1503 lost the browser gate job its
+own PR body described, and #1521 and #1531 then each lost the very commit that
+addressed their own review findings. No local check can prevent it - in all
+three the working tree was clean when the PR was opened.
+
+So `pr-open` withholds, `pr-ready` arms, and `pr-open READY=1` keeps the
+one-command path for a branch already known to be final.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+pytestmark = [pytest.mark.unit, pytest.mark.fast]
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+MAKEFILE = REPO_ROOT / "Makefile"
+
+ARM_COMMAND = "gh pr merge --auto --squash"
+
+
+def _target_body(name: str) -> str:
+    """Return the recipe lines of a Makefile target."""
+    text = MAKEFILE.read_text(encoding="utf-8")
+    match = re.search(rf"^{re.escape(name)}:.*?\n((?:\t.*\n|\n)*)", text, re.MULTILINE)
+    assert match, f"Makefile has no target {name!r}"
+    return match.group(1)
+
+
+def test_auto_merge_enablement_point_is_not_pr_open() -> None:
+    """`pr-open` must not arm auto-merge on its own.
+
+    This is the assertion that fails on the unfixed tree, where pr-open calls
+    `gh pr merge --auto --squash` directly for any non-soundness branch.
+    """
+    body = _target_body("pr-open")
+    assert ARM_COMMAND not in body, (
+        "pr-open arms auto-merge directly, so a PR can merge before a later commit is pushed"
+    )
+
+
+def test_auto_merge_enablement_point_keeps_a_hands_free_path() -> None:
+    """A finished branch must still reach auto-merge without ceremony.
+
+    Withholding by default is only acceptable while arming stays trivial, so
+    pin both the explicit target and the one-command escape hatch.
+    """
+    text = MAKEFILE.read_text(encoding="utf-8")
+    assert re.search(r"^pr-ready:", text, re.MULTILINE), "no pr-ready target; withholding would be a dead end"
+    assert "READY" in _target_body("pr-open"), "pr-open has no READY=1 path to open and arm in one step"
+
+
+def test_auto_merge_enablement_point_has_one_arming_implementation() -> None:
+    """Both entry points must share one arming path.
+
+    The soundness withhold lives in that path. A second copy is how the two
+    entry points drift until one of them stops checking.
+    """
+    text = MAKEFILE.read_text(encoding="utf-8")
+    assert text.count(ARM_COMMAND) == 1, (
+        f"{ARM_COMMAND!r} appears more than once; the soundness check can drift between copies"
+    )
+
+
+def test_auto_merge_enablement_point_preserves_soundness_withholding() -> None:
+    """Must-preserve: soundness-path PRs are still withheld.
+
+    The arming path has to consult the soundness predicate before it arms, or
+    moving the enablement point would quietly drop the control that keeps
+    oracle-adjacent changes from merging hands-free.
+    """
+    body = _target_body("pr-arm-auto-merge")
+    assert "auto_merge_soundness_paths.py" in body, "arming path no longer consults the soundness predicate"
+    arm_index = body.index(ARM_COMMAND)
+    check_index = body.index("auto_merge_soundness_paths.py")
+    assert check_index < arm_index, "soundness check runs after arming, so it cannot withhold"


### PR DESCRIPTION
## Why

Arming auto-merge at PR creation is only correct if nothing more will be pushed — and the usual reason something more *is* pushed is **review feedback**, which arrives after the PR exists. A PR armed at creation can satisfy its checks and merge while the follow-up commit is still being written, leaving develop with a partial change and the remainder orphaned on a closed branch.

**Three times in one session:**

| PR | What was stranded |
|---|---|
| #1503 | the `Results Explorer browser gate` job its own PR body described |
| #1521 | the commit fixing its own Codex review finding |
| #1531 | the commit fixing its own Codex review finding |

No local check can prevent this — in all three the working tree was **clean** when the PR was opened. And `auto-merge-on-open.yml` reacts to `synchronize`, which is too late when the merge has already happened. So the only real prevention is to stop arming at creation.

## Change

- `make pr-open` opens the PR and **withholds** auto-merge, printing how to arm.
- `make pr-ready` arms it — the branch is declared final.
- `make pr-open READY=1` opens and arms in one step, so a branch you already know is finished still merges hands-free.

Arming lives in **one** place, `pr-arm-auto-merge`, used by both entry points, so the soundness withhold cannot drift between copies. `gh pr merge --auto --squash` now appears **exactly once** in the Makefile.

## Must-preserves

- **Hands-free retained** — pinned by a test asserting both `pr-ready` and the `READY=1` path exist, so withholding can't become a dead end.
- **Soundness withholding retained** — a test asserts the soundness predicate is consulted *before* arming, so moving the enablement point can't quietly drop the control that keeps oracle-adjacent changes off the hands-free path.

## Verification

Falsified against the pre-change Makefile — **3 of 4** new tests fail, including:

```
AssertionError: pr-open arms auto-merge directly, so a PR can merge before a later commit is pushed
AssertionError: no pr-ready target; withholding would be a dead end
```

`tests/unit -k auto_merge`: **47 passed**. `tests/unit/workflows`: **138 passed**.

Both runbooks updated so the documented flow matches — this changes the daily loop, so the docs had to move with it.

## Tradeoff, stated plainly

For a finished PR this is one extra command. That is a real if small cost, accepted deliberately: the alternative left three recovery PRs in a single session, two of them recovering review fixes that were themselves stranded.

Closes `pr-open-auto-merge-prevent-not-just-detect-20260804`.
