### PR TITLE
fix(corpus): pin the corpus to LF so byte identity is platform-independent

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -6,3 +6,13 @@
 # each appending a dated entry should compose cleanly on merge instead of
 # conflicting on adjacent lines. See _project/config/fast_lane_ceiling_log.md.
 /_project/config/fast_lane_ceiling_log.md merge=union
+
+# The corpus is compared byte-for-byte against what the Explorer publishes, and
+# the publisher always emits LF (canonical_json_bytes). Without this, a Windows
+# checkout with core.autocrlf=true rewrites every multi-line bundle to CRLF, so
+# the stored bytes disagree with the published bytes for reasons that have
+# nothing to do with their content: nightly saw all 207 primary bundles fail
+# tests/unit/scripts/test_corpus_privacy_invariant.py while the same commit was
+# green on Linux. The tree is entirely text (400 .json, 4 .md, 1 .py), so
+# pinning it wholesale is safe.
+/results-data/** text eol=lf

--- a/tests/unit/scripts/test_corpus_privacy_invariant.py
+++ b/tests/unit/scripts/test_corpus_privacy_invariant.py
@@ -15,6 +15,7 @@ corpus regress while the gate stayed green.
 from __future__ import annotations
 
 import json
+import subprocess
 from pathlib import Path
 
 import pytest
@@ -186,7 +187,52 @@ def test_rederived_corpus_publishes_byte_identically_to_what_is_stored() -> None
     assert scanned, "no primary bundles scanned - this gate would be vacuous"
     assert not drifted, (
         f"{len(drifted)} bundle(s) are not stored at the publication fixed point; "
-        "publishing would rewrite them and change their result IDs:\n" + "\n".join(drifted[:20])
+        "publishing would rewrite them:\n" + "\n".join(drifted[:20])
+    )
+
+
+def test_corpus_checks_out_with_lf_on_every_platform() -> None:
+    """The corpus must be exempt from git's end-of-line translation.
+
+    The gate above compares stored bytes against published bytes, and the
+    publisher always emits LF. So on a checkout where git translates line
+    endings - ``core.autocrlf=true``, the Windows default - every multi-line
+    bundle arrives as CRLF and disagrees with its own published form for
+    reasons that have nothing to do with its content.
+
+    That is not hypothetical: the byte-identity gate landed green and went red
+    in the next nightly, failing all 207 primary bundles on windows-latest 3.10
+    and 3.12 while the same commit passed on ubuntu. PR CI is Linux-only, so
+    the nightly matrix is the first place it can show up.
+
+    Pinning the attribute is the fix rather than comparing newline-insensitively,
+    because the weaker test would go green while still letting a contributor on
+    a translating checkout commit CRLF bundles that permanently disagree with
+    what publication emits.
+    """
+    tracked = subprocess.run(
+        ["git", "ls-files", "-z", "--", "results-data"],
+        capture_output=True,
+        check=True,
+        cwd=REPO_ROOT,
+    ).stdout
+    paths = [name for name in tracked.split(b"\0") if name]
+    assert paths, "no tracked corpus files - this gate would be vacuous"
+
+    attrs = subprocess.run(
+        ["git", "check-attr", "-z", "--stdin", "eol"],
+        input=b"\0".join(paths),
+        capture_output=True,
+        check=True,
+        cwd=REPO_ROOT,
+    ).stdout
+
+    # `check-attr -z` emits a flat NUL-separated stream of (path, attr, value).
+    fields = attrs.split(b"\0")
+    untranslated = [fields[index].decode() for index in range(0, len(fields) - 2, 3) if fields[index + 2] != b"lf"]
+    assert not untranslated, (
+        f"{len(untranslated)} corpus file(s) have no explicit `eol=lf` attribute, so their "
+        "working-tree bytes depend on the platform that checked them out:\n" + "\n".join(untranslated[:20])
     )
 
 


### PR DESCRIPTION
## Problem

`tests/unit/scripts/test_corpus_privacy_invariant.py::test_rederived_corpus_publishes_byte_identically_to_what_is_stored` compares stored corpus bytes against the bytes the Explorer publishes. The publisher always emits LF (`canonical_json_bytes`), but `results-data/**` carried no `text`/`eol` attribute — `git check-attr text eol` reported `unspecified` for both.

So on a checkout where git translates line endings (`core.autocrlf=true`, the Windows default), every multi-line bundle arrives as CRLF and disagrees with its own published form for reasons unrelated to its content.

Nightly Validation on 2026-08-05 failed **all 207 primary bundles** on `windows-latest` 3.10 and 3.12 while the same commit was green on ubuntu. PR CI runs Linux only, so the nightly matrix is the first place this can surface — the gate landed green and went red the next morning.

## Reproduction

207 primary bundles, all 207 multi-line — exactly the Windows failure count, so the cause is systematic rather than per-bundle. Converting one bundle's bytes to CRLF makes the re-derived bytes differ (7522 vs 7777, a 255-byte gap equal to its 255 lines) while `json.loads` parses both forms to the *same* dict. Purely encoding-level.

## Why the attribute and not a looser comparison

A newline-insensitive compare would restore green while still letting a contributor on a translating checkout commit CRLF bundles that permanently disagree with what publication emits. The attribute fixes the mechanism git actually uses.

## Not a content-addressing fix

I initially believed a Windows checkout would derive different `result_id`s. It would not. `pipeline.py:655` sets `public_raw = canonical_json_bytes(public_bundle)` and passes that as the bytes to hash, so the sha8 comes from the canonical re-encoding and was already EOL-stable. This is a repo-hygiene and test-portability fix, at correspondingly lower severity.

## No corpus perturbation

`git add --renormalize results-data` stages **0 files** — every tracked corpus blob is already LF in the index. The attribute is purely forward-looking: no bundle bytes change, no digest moves. That was the main risk and it is disproved rather than assumed.

## Verification

- New `test_corpus_checks_out_with_lf_on_every_platform` asserts every git-tracked path under `results-data` resolves `eol=lf`, and sits next to the gate it protects.
- **Falsified:** with `.gitattributes` reverted to develop's version, the new test fails and lists all tracked corpus files; restoring the attribute makes it pass.
- `tests/unit/scripts/test_corpus_privacy_invariant.py` — 9 passed. `tests/unit/scripts` — 1493 passed.

## Residual

This pins the attribute; it does not prove the outcome on a real Windows checkout. Tomorrow's nightly is the confirming observation — expect the byte-identity failure to drop off `windows-latest` while the 7 pre-existing MCP durable-jobs failures persist.