### PR TITLE
fix(explorer): fail the build on a privacy rejection instead of dropping the bundle

### DIFF
--- a/_project/scripts/explorer_pipeline/pipeline.py
+++ b/_project/scripts/explorer_pipeline/pipeline.py
@@ -61,6 +61,22 @@ class DuplicateResultIdError(Exception):
     """
 
 
+class PrivacyRejectionError(Exception):
+    """A bundle, receipt, or plans companion failed the public privacy check.
+
+    Intentionally not a ``ValueError``, for the same reason as
+    ``DuplicateResultIdError`` above: the publication loop downgrades everything
+    in its ``except`` tuple to a skip plus a warning, so a rejection raised as
+    ``ValueError`` let the build finish green having quietly dropped the result.
+
+    That inverts what the check is for. ``find_public_path_leaks`` firing means
+    the fail-closed boundary caught something a human needs to look at - a
+    bundle that was never run through the public boundary, or run through a
+    different one. Dropping it makes the corpus silently incomplete and leaves
+    the leaking bundle in the repository, still leaking.
+    """
+
+
 SUBMISSION_MANIFEST_FILENAME = "submission-manifest.json"
 SUBMISSION_MANIFEST_SUFFIX = ".manifest.json"
 COMMUNITY_TRUST_LABEL = "community-submission"
@@ -216,7 +232,9 @@ def _public_applied_receipt(bundle_path: Path, anonymizer: AnonymizationManager)
         raise ValueError(f"could not sanitize applied receipt {bundle_path.name}: {exc}") from exc
     leaks = find_public_path_leaks(public_receipt)
     if leaks:
-        raise ValueError("public applied receipt privacy check failed for fields: " + ", ".join(sorted(set(leaks))))
+        raise PrivacyRejectionError(
+            "public applied receipt privacy check failed for fields: " + ", ".join(sorted(set(leaks)))
+        )
     return canonical_json_bytes(public_receipt).decode("utf-8")
 
 
@@ -229,7 +247,9 @@ def _public_bundle_data(
     public_bundle = anonymizer.anonymize_result_payload(bundle_data)
     public_leaks = find_public_path_leaks(public_bundle)
     if public_leaks:
-        raise ValueError("public bundle privacy check failed for fields: " + ", ".join(sorted(set(public_leaks))))
+        raise PrivacyRejectionError(
+            "public bundle privacy check failed for fields: " + ", ".join(sorted(set(public_leaks)))
+        )
     return public_bundle, _public_applied_receipt(bundle_path, anonymizer)
 
 
@@ -737,7 +757,12 @@ class ExplorerPipeline:
                                 public_plans = public_anonymizer.anonymize_result_payload(plans_payload)
                                 plans_leaks = find_public_path_leaks(public_plans)
                                 if plans_leaks:
-                                    raise ValueError(
+                                    # Escapes both this block's handler and the
+                                    # per-bundle one. A leaking companion used to
+                                    # be the quietest case of all: the bundle
+                                    # still published, only `plans_published`
+                                    # stayed false, so the corpus looked complete.
+                                    raise PrivacyRejectionError(
                                         "public plans privacy check failed for fields: "
                                         + ", ".join(sorted(set(plans_leaks)))
                                     )

--- a/tests/unit/scripts/explorer_pipeline/test_privacy_rejection.py
+++ b/tests/unit/scripts/explorer_pipeline/test_privacy_rejection.py
@@ -1,0 +1,173 @@
+"""A failed privacy check must stop the build, not drop the bundle.
+
+`find_public_path_leaks` is the fail-closed boundary between the corpus and
+what the Explorer publishes. Before the change these tests cover, every one of
+its three call sites raised `ValueError`, and the publication loop catches
+`ValueError` alongside `JSONDecodeError`, `KeyError` and `TypeError` and
+downgrades all of them to `skipped_bundles += 1` plus a warning.
+
+So the detector firing produced a green build with a quietly shorter corpus,
+and the leaking bundle stayed in the repository, still leaking. That inverts
+what the check is for: it fires precisely when a human needs to look.
+
+The plans companion was quieter still. Its leak was caught by that block's own
+handler, so the bundle published anyway with `plans_published` left false and
+the corpus looked complete.
+
+The leak shape used here is a private path as a *mapping key*, which the
+detector's own docstring records as the one that occurs in practice, and which
+survives `anonymize_result_payload` - the tests fail for the reason under test
+rather than because the anonymizer declined to scrub a value.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+from _project.scripts.explorer_pipeline.pipeline import (
+    ExplorerPipeline,
+    PrivacyRejectionError,
+)
+from _project.scripts.explorer_publish import explorer_publish
+from tests.unit.scripts.explorer_pipeline.conftest import MINIMAL_BUNDLE
+
+pytestmark = [pytest.mark.unit, pytest.mark.fast]
+
+LEAKING_PATH = "/Users/alice/secret/db"
+
+
+def _write_bundle(bundles_dir: Path, name: str, *, leaking: bool = False) -> Path:
+    bundles_dir.mkdir(parents=True, exist_ok=True)
+    payload = json.loads(json.dumps(MINIMAL_BUNDLE))
+    if leaking:
+        payload["config"] = {LEAKING_PATH: 1.2}
+    path = bundles_dir / name
+    path.write_text(json.dumps(payload), encoding="utf-8")
+    return path
+
+
+def test_privacy_rejection_in_a_bundle_fails_the_build(tmp_path: Path) -> None:
+    """A leaking bundle stops publication instead of vanishing from the corpus.
+
+    This is the assertion that fails on the unfixed tree, where the rejection is
+    a ValueError, the loop swallows it, and `run` returns normally having
+    published nothing and reported only a warning.
+    """
+    data_dir = tmp_path / "data"
+    _write_bundle(data_dir / "bundles", "leaky.json", leaking=True)
+
+    with pytest.raises(PrivacyRejectionError) as excinfo:
+        ExplorerPipeline().run(data_dir, tmp_path / "out")
+
+    message = str(excinfo.value)
+    assert "privacy check failed" in message
+    # The detector is value-redacting by contract: the report names the field
+    # path and must never echo the private path it found.
+    assert LEAKING_PATH not in message
+
+
+def test_privacy_rejection_error_escapes_the_per_bundle_handler() -> None:
+    """The rejection must not be catchable by the loop's own error handling.
+
+    The exception type *is* the fix. Reintroducing a ValueError base would
+    restore the original defect without touching a line of the loop, and no
+    other test here would notice.
+    """
+    assert not issubclass(PrivacyRejectionError, ValueError)
+    assert not issubclass(PrivacyRejectionError, (json.JSONDecodeError, KeyError, TypeError))
+
+
+def test_privacy_rejection_in_a_plans_companion_fails_the_build(tmp_path: Path) -> None:
+    """A leaking plans sidecar stops the build too.
+
+    This was the quietest case: the companion block has its own handler, so the
+    rejection never even reached the per-bundle one. The bundle published, only
+    `plans_published` stayed false, and nothing about the corpus looked short.
+    """
+    data_dir = tmp_path / "data"
+    bundle = _write_bundle(data_dir / "bundles", "clean.json")
+    bundle.with_name("clean.plans.json").write_text(
+        json.dumps({"per_path_timings": {LEAKING_PATH: 1.2}}),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(PrivacyRejectionError) as excinfo:
+        ExplorerPipeline().run(data_dir, tmp_path / "out")
+
+    assert "plans privacy check failed" in str(excinfo.value)
+
+
+def test_privacy_rejection_in_an_applied_receipt_fails_the_build(tmp_path: Path) -> None:
+    """A leaking applied receipt stops the build.
+
+    The receipt is taken verbatim from the companion and re-serialized, so it is
+    the path most likely to carry machine-local material into publication.
+    """
+    data_dir = tmp_path / "data"
+    bundle = _write_bundle(data_dir / "bundles", "clean.json")
+    bundle.with_name("clean.applied.json").write_text(
+        json.dumps({"receipt": {"per_path_timings": {LEAKING_PATH: 1.2}}}),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(PrivacyRejectionError) as excinfo:
+        ExplorerPipeline().run(data_dir, tmp_path / "out")
+
+    assert "applied receipt privacy check failed" in str(excinfo.value)
+
+
+def test_privacy_rejection_leaves_a_clean_corpus_publishing(tmp_path: Path) -> None:
+    """Must-preserve: a clean bundle still publishes.
+
+    A guard that only ever raises is indistinguishable from a broken pipeline,
+    and every assertion above would still pass.
+    """
+    data_dir = tmp_path / "data"
+    _write_bundle(data_dir / "bundles", "first.json")
+
+    output = tmp_path / "out"
+    ExplorerPipeline().run(data_dir, output)
+
+    assert list((output / "bundles").glob("*.json")), "clean corpus published nothing"
+
+
+def test_privacy_rejection_still_tolerates_a_malformed_companion(tmp_path: Path) -> None:
+    """Must-preserve: an unparseable plans companion is still only a warning.
+
+    Only the *privacy* rejection was promoted. Broken input stays a skip, or
+    this change would turn every corrupt sidecar into a build outage - a much
+    wider blast radius than the decision covered.
+    """
+    data_dir = tmp_path / "data"
+    bundle = _write_bundle(data_dir / "bundles", "clean.json")
+    bundle.with_name("clean.plans.json").write_text("{not json", encoding="utf-8")
+
+    output = tmp_path / "out"
+    ExplorerPipeline().run(data_dir, output)
+
+    assert list((output / "bundles").glob("*.json")), "a malformed companion should not stop publication"
+
+
+def test_privacy_rejection_makes_the_publish_command_exit_non_zero(tmp_path: Path) -> None:
+    """The exception type only matters if it reaches the exit code.
+
+    `explorer_publish build` wraps the run in `except Exception` and converts it
+    to `SystemExit(1)`. That handler is the last place this fix could be
+    softened back into a warning without any test above noticing, so pin the
+    end-to-end outcome a CI job actually observes.
+    """
+    data_dir = tmp_path / "data"
+    _write_bundle(data_dir / "bundles", "leaky.json", leaking=True)
+
+    result = CliRunner().invoke(
+        explorer_publish,
+        ["build", "--data-dir", str(data_dir), "--output", str(tmp_path / "out")],
+    )
+
+    assert result.exit_code != 0, "a leaking bundle produced a successful publish"
+    assert "privacy check failed" in result.output
+    assert LEAKING_PATH not in result.output


### PR DESCRIPTION
## Problem

`find_public_path_leaks` is the fail-closed boundary between the corpus and what the Explorer publishes. All three of its call sites raised `ValueError`, and the publication loop catches `ValueError` alongside `JSONDecodeError`, `KeyError` and `TypeError`, downgrading all of them to `skipped_bundles += 1` plus a warning.

So the detector firing produced a **green build with a quietly shorter corpus**, and the leaking bundle stayed in the repository, still leaking. That inverts what the check is for: it fires precisely when a human needs to look.

The plans companion was quieter still — its rejection was caught by that block's *own* handler at `pipeline.py:746`, so the bundle published anyway with `plans_published` left false and the corpus looked complete.

## Fix

`PrivacyRejectionError`, deliberately not a `ValueError` — the same reasoning that already governs `DuplicateResultIdError` a few lines above it. Same defect class, same file, same fix.

@joeharris76 chose abort-the-build over publishing the clean bundles and exiting non-zero, and over keeping the skip with louder logging.

## Scope held deliberately narrow

Only the privacy rejection is promoted. `pipeline.py:232` still raises `ValueError` when an applied receipt cannot be *sanitized* at all — that's malformed input, not a privacy rejection, and turning every corrupt sidecar into a build outage is a much wider blast radius than the decision covered. A must-preserve test pins that a malformed companion is still just a warning.

## Verification

| Test | Covers |
|---|---|
| `..._in_a_bundle_fails_the_build` | the main path, and that the message never echoes the private path |
| `..._in_a_plans_companion_fails_the_build` | the case that escaped even the bundle skip |
| `..._in_an_applied_receipt_fails_the_build` | verbatim receipt content |
| `..._error_escapes_the_per_bundle_handler` | the exception type *is* the fix |
| `..._makes_the_publish_command_exit_non_zero` | the CLI's `except Exception` → `SystemExit(1)`, the last place this could be softened back into a warning |
| `..._leaves_a_clean_corpus_publishing` | must-preserve |
| `..._still_tolerates_a_malformed_companion` | must-preserve |

**Falsified:** flipping the base class to `ValueError` — symbol still importable, so the tests fail on *behaviour* rather than an import error — fails 5 of 7, and the captured log reproduces the original defect verbatim:

```
WARNING Skipping plans companion .../clean.plans.json - PrivacyRejectionError: public plans privacy check failed for fields: per_path_timings.<key>
```

The 2 that still pass are the must-preserve pair, which is correct.

`tests/unit/scripts` — 1499 passed.

## Leak shape

The tests use a private path as a **mapping key**, which the detector's own docstring records as the shape that occurs in practice and which survives `anonymize_result_payload`. Value-shaped paths are scrubbed by the anonymizer, so a test built on one would pass for the wrong reason.