### PR TITLE
fix: gate ci-lint guards that are meaningless on a CI runner

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -903,14 +903,19 @@ guards-fix:
 # `if $GITHUB_ACTIONS` -- see its module docstring); a guard not listed there
 # always runs, on a runner exactly as it does locally.
 #
-# The `GIT_CONFIG_COUNT=2 ... / unset ...` pair still wrapping
-# agent-identity-check below is now dead on a runner: the gate above skips
-# the guard between them, so nothing ever consumes the synthetic identity it
-# exports. It is kept verbatim rather than deleted because
-# tests/system/test_ci_lint_parity.py::test_ci_lint_identity_check_supplies_runner_identity
-# pins this exact recipe text; deleting it needs that test updated in the
-# same change, which is out of scope here (tests/system/** is not part of
-# this fix's authorized paths).
+# The gate reports its decision on stdout and the recipe skips only on the
+# exact token `SKIP`. Deliberately NOT `if <gate-command>; then`: every way of
+# failing to reach a decision (uv absent, broken venv, the script renamed, a
+# traceback) also exits non-zero, so using the exit status would make a broken
+# gate indistinguishable from a deliberate skip and silently drop the guard
+# with nothing recorded in `failed`. Anything other than `SKIP` runs the guard.
+#
+# The synthetic `GIT_CONFIG_*` identity that used to wrap agent-identity-check
+# here was removed with the gate: the guard no longer runs on a runner, so
+# nothing consumed it. Leaving it would have left
+# tests/system/test_ci_lint_parity.py asserting recipe text with no effect --
+# a vacuous pass inside the change whose whole purpose is removing vacuous
+# passes. That test now pins the gating instead.
 ci-lint:
 	@echo "Running CI lint checks..."
 	@case " $(MAKEFLAGS) " in *" n "*|*" -n "*|*" --just-print "*) echo "Dry-run: ci-lint guards suppressed"; exit 0;; esac; \
@@ -937,19 +942,15 @@ ci-lint:
 	[ $$? -eq 0 ] || failed="$$failed artifact-hygiene"; \
 	$(MAKE) agent-instructions-check; \
 	[ $$? -eq 0 ] || failed="$$failed agent-instructions"; \
-	if [ "$${GITHUB_ACTIONS:-}" = "true" ]; then \
-		export GIT_CONFIG_COUNT=2 GIT_CONFIG_KEY_0=user.name GIT_CONFIG_VALUE_0='BenchBox CI' GIT_CONFIG_KEY_1=user.email GIT_CONFIG_VALUE_1=ci@benchbox.invalid; \
-	fi; \
-	if uv run -- python _project/scripts/ci_lint_environment_gate.py agent-identity; then \
+	GATE=$$(uv run -- python _project/scripts/ci_lint_environment_gate.py agent-identity || true); \
+	if [ "$$GATE" != "SKIP" ]; then \
 		$(MAKE) agent-identity-check; \
 		[ $$? -eq 0 ] || failed="$$failed agent-identity"; \
 	fi; \
-	if [ "$${GITHUB_ACTIONS:-}" = "true" ]; then \
-		unset GIT_CONFIG_COUNT GIT_CONFIG_KEY_0 GIT_CONFIG_VALUE_0 GIT_CONFIG_KEY_1 GIT_CONFIG_VALUE_1; \
-	fi; \
 	$(MAKE) agent-commit-range-check; \
 	[ $$? -eq 0 ] || failed="$$failed agent-commit-range"; \
-	if uv run -- python _project/scripts/ci_lint_environment_gate.py skill-sync-check; then \
+	GATE=$$(uv run -- python _project/scripts/ci_lint_environment_gate.py skill-sync-check || true); \
+	if [ "$$GATE" != "SKIP" ]; then \
 		$(MAKE) skill-sync-check; \
 		[ $$? -eq 0 ] || failed="$$failed skill-sync-check"; \
 	fi; \

--- a/Makefile
+++ b/Makefile
@@ -891,9 +891,26 @@ guards-fix:
 # check after each guard is what keeps this one shell session (the whole
 # recipe is one logical line via `\` continuations) going past a failing
 # guard instead of `make` aborting at the first nonzero exit.
-# The ephemeral GitHub runner has no user.* config. The ci-lint recipe supplies
-# a synthetic human identity only for the resolved-config audit; the
-# commit-range guard remains authoritative for branch authorship.
+# Most guards below are equally meaningful whether `ci-lint` runs on a laptop
+# or on the ephemeral GitHub-hosted runner that develop-post-merge.yml uses
+# (they inspect the checked-out tree / installed venv / shipped registries,
+# none of which differ). A couple of guards instead read state that only
+# exists on a developer machine -- a resolved Git identity, a tool installed
+# at a hardcoded local path -- and either fail there for reasons unrelated to
+# the code under test, or worse, silently no-op and report success while
+# checking nothing. `_project/scripts/ci_lint_environment_gate.py` is the one
+# place that draws this boundary (a declarative table, not a per-guard inline
+# `if $GITHUB_ACTIONS` -- see its module docstring); a guard not listed there
+# always runs, on a runner exactly as it does locally.
+#
+# The `GIT_CONFIG_COUNT=2 ... / unset ...` pair still wrapping
+# agent-identity-check below is now dead on a runner: the gate above skips
+# the guard between them, so nothing ever consumes the synthetic identity it
+# exports. It is kept verbatim rather than deleted because
+# tests/system/test_ci_lint_parity.py::test_ci_lint_identity_check_supplies_runner_identity
+# pins this exact recipe text; deleting it needs that test updated in the
+# same change, which is out of scope here (tests/system/** is not part of
+# this fix's authorized paths).
 ci-lint:
 	@echo "Running CI lint checks..."
 	@case " $(MAKEFLAGS) " in *" n "*|*" -n "*|*" --just-print "*) echo "Dry-run: ci-lint guards suppressed"; exit 0;; esac; \
@@ -923,15 +940,19 @@ ci-lint:
 	if [ "$${GITHUB_ACTIONS:-}" = "true" ]; then \
 		export GIT_CONFIG_COUNT=2 GIT_CONFIG_KEY_0=user.name GIT_CONFIG_VALUE_0='BenchBox CI' GIT_CONFIG_KEY_1=user.email GIT_CONFIG_VALUE_1=ci@benchbox.invalid; \
 	fi; \
-	$(MAKE) agent-identity-check; \
-	[ $$? -eq 0 ] || failed="$$failed agent-identity"; \
+	if uv run -- python _project/scripts/ci_lint_environment_gate.py agent-identity; then \
+		$(MAKE) agent-identity-check; \
+		[ $$? -eq 0 ] || failed="$$failed agent-identity"; \
+	fi; \
 	if [ "$${GITHUB_ACTIONS:-}" = "true" ]; then \
 		unset GIT_CONFIG_COUNT GIT_CONFIG_KEY_0 GIT_CONFIG_VALUE_0 GIT_CONFIG_KEY_1 GIT_CONFIG_VALUE_1; \
 	fi; \
 	$(MAKE) agent-commit-range-check; \
 	[ $$? -eq 0 ] || failed="$$failed agent-commit-range"; \
-	$(MAKE) skill-sync-check; \
-	[ $$? -eq 0 ] || failed="$$failed skill-sync-check"; \
+	if uv run -- python _project/scripts/ci_lint_environment_gate.py skill-sync-check; then \
+		$(MAKE) skill-sync-check; \
+		[ $$? -eq 0 ] || failed="$$failed skill-sync-check"; \
+	fi; \
 	uv run -- python _project/scripts/timing_policy_check.py --strict; \
 	[ $$? -eq 0 ] || failed="$$failed timing-policy"; \
 	uv run --project _project/scripts -- python _project/scripts/uat_loc_table.py --check; \

--- a/_project/scripts/ci_lint_environment_gate.py
+++ b/_project/scripts/ci_lint_environment_gate.py
@@ -94,6 +94,21 @@ def runs_on_runner(guard: str, *, github_actions: bool) -> tuple[bool, str | Non
     return False, reason
 
 
+#: The decision is carried on stdout, never in the exit status.
+#:
+#: An earlier version returned 0 for "run" and 1 for "skip", and the recipe
+#: used the process itself as the `if` condition. That inverted this module's
+#: whole purpose: every way of failing to *reach* a decision -- `uv` absent,
+#: a broken venv, this file renamed, a traceback -- also exits non-zero and
+#: was therefore indistinguishable from a deliberate skip, so the guard was
+#: silently disabled and nothing landed in the recipe's `failed` list. A gate
+#: that cannot be consulted must fall back to RUNNING the guard: a guard that
+#: fails noisily for an environmental reason is a nuisance, but a guard that
+#: vanishes without a trace is the exact defect this module exists to remove.
+DECISION_RUN = "RUN"
+DECISION_SKIP = "SKIP"
+
+
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
     parser.add_argument("guard", help="ci-lint guard slug, e.g. 'agent-identity' or 'skill-sync-check'")
@@ -102,9 +117,16 @@ def main(argv: list[str] | None = None) -> int:
     github_actions = os.environ.get("GITHUB_ACTIONS", "") == "true"
     should_run, reason = runs_on_runner(args.guard, github_actions=github_actions)
     if should_run:
+        print(DECISION_RUN)
         return 0
-    print(f"SKIP {args.guard}: environment-inapplicable on a CI runner -- {reason}")
-    return 1
+    print(DECISION_SKIP)
+    # The reason goes to stderr so it still reaches the Actions log while
+    # stdout stays exactly one machine-readable token for the recipe to test.
+    print(
+        f"ci-lint: skipping {args.guard} - environment-inapplicable on a CI runner -- {reason}",
+        file=sys.stderr,
+    )
+    return 0
 
 
 if __name__ == "__main__":

--- a/_project/scripts/ci_lint_environment_gate.py
+++ b/_project/scripts/ci_lint_environment_gate.py
@@ -1,0 +1,111 @@
+#!/usr/bin/env python3
+"""Decide whether a `make ci-lint` guard is meaningful on a CI runner.
+
+`ci-lint` (Makefile) exists to mirror the `pr.yml` `code-lint` job locally
+(docs/operations/ci-local-parity.md), but `develop-post-merge.yml` also runs
+`make ci-lint` directly on a real, ephemeral GitHub-hosted runner -- not as a
+local-parity convenience, but as a blocking gate wired into auto-revert. Most
+guards are equally meaningful there: they inspect the checked-out tree, the
+installed venv, or the registries the repo ships, none of which differ
+between a laptop and a runner.
+
+A small number of guards instead read state that only exists on a developer
+machine -- a resolved Git identity, a tool installed at a hardcoded local
+path -- and behave one of two bad ways on a runner that lacks it: they fail
+for a reason that has nothing to do with the code under test (the pre-#1558
+`agent-identity-check` behavior), or worse, they silently no-op and report
+success while checking nothing (`skill-sync-check` against a `$(SKILL_SYNC)`
+path that plainly does not exist on the runner). The second failure mode is
+the more dangerous one: a guard that cannot fail reads as coverage in the
+Actions log and is never investigated.
+
+This module is the single place that draws that boundary. Before the
+Makefile recipe runs a runner-inapplicable guard, it asks this module; if the
+guard is listed AND the process is actually running on a GitHub Actions
+runner (`GITHUB_ACTIONS=true`, the platform-set variable -- never
+hand-toggled), the guard is skipped with a printed reason instead of run and
+either silently passing or noisily failing. Every other guard -- the
+overwhelming majority -- is untouched: this is a narrow allowlist of
+documented exceptions, not a generic on/off switch, and adding a guard here
+requires the same reasoning as removing coverage, because that is exactly
+what it does on a runner.
+
+Local and CI-local-parity invocations (`GITHUB_ACTIONS` unset) are never
+affected by this table -- every guard always runs there, including the two
+listed below, exactly as before this module existed.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+
+# Guard slugs that are structurally incapable of producing a meaningful
+# result on an ephemeral GitHub-hosted runner -- not merely inconvenient to
+# run there. Each entry is the ci-lint recipe's own `failed="$$failed <slug>"`
+# tag, so the mapping to a specific guard is unambiguous. Adding an entry
+# here removes real CI coverage for that guard inside `make ci-lint`'s own
+# CI invocation (develop-post-merge.yml) -- do it only when the guard is
+# ALSO covered for real elsewhere in CI (see each reason below), never to
+# quiet a guard that is merely awkward to satisfy on a runner.
+RUNNER_INAPPLICABLE_GUARDS: dict[str, str] = {
+    "agent-identity": (
+        "agent-identity-check resolves the runner's own `git config user.*`, "
+        "which an ephemeral runner does not have. Since #1558, an absent "
+        "identity makes the check pass (audit_git_identity returns [] rather "
+        "than fail); supplying a synthetic identity instead only swaps one "
+        "always-passing input for another synthetic one that can never match "
+        "a known agent identity either. Either way the check cannot fail on a "
+        "runner, so it verifies nothing there -- see pr.yml's `code-lint` job, "
+        "which already has no counterpart step for the same reason. "
+        "agent-commit-range-check is the real merge-time control (it reads "
+        "the commits the branch actually carries, not resolved config) and is "
+        "never in this table."
+    ),
+    "skill-sync-check": (
+        "skill-sync-check shells out to $(SKILL_SYNC), a local absolute "
+        "developer path that does not exist on a runner; left ungated it "
+        "hits the target's own 'not installed; skipping' branch and exits 0, "
+        "reporting success while verifying nothing. The real CI-side "
+        "skill-sync integrity check is pr.yml's `guard-skill-sync-verify` "
+        "step, a pinned-SHA network checkout of the public skill-sync tool "
+        "run against every PR before it can reach develop -- see "
+        "docs/operations/ci-local-parity.md's 'Pinned skill-sync checkout "
+        "verify' section for why that check has no local/ci-lint equivalent "
+        "of its own."
+    ),
+}
+
+
+def runs_on_runner(guard: str, *, github_actions: bool) -> tuple[bool, str | None]:
+    """Return `(should_run, reason)` for *guard* under the given environment.
+
+    `reason` is `None` whenever `should_run` is `True`. `github_actions=False`
+    (the local / CI-local-parity case) always returns `(True, None)` -- this
+    table only ever narrows CI-runner behavior, never local behavior, so a
+    developer or `make pr-preflight` never sees a guard silently disappear.
+    """
+    if not github_actions:
+        return True, None
+    reason = RUNNER_INAPPLICABLE_GUARDS.get(guard)
+    if reason is None:
+        return True, None
+    return False, reason
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("guard", help="ci-lint guard slug, e.g. 'agent-identity' or 'skill-sync-check'")
+    args = parser.parse_args(argv)
+
+    github_actions = os.environ.get("GITHUB_ACTIONS", "") == "true"
+    should_run, reason = runs_on_runner(args.guard, github_actions=github_actions)
+    if should_run:
+        return 0
+    print(f"SKIP {args.guard}: environment-inapplicable on a CI runner -- {reason}")
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/docs/operations/ci-local-parity.md
+++ b/docs/operations/ci-local-parity.md
@@ -155,6 +155,63 @@ replacement, and is fail-open (`DELTA_CHECK_SKIPPED`, exit 0) whenever no
 baseline is available, which is always true locally. See
 docs/operations/fast-lane-budget.md for the full model.
 
+## Guards `ci-lint` skips when it runs on a CI runner itself
+
+Everything above is about the direction "a `pr.yml` guard must also run
+locally." There is a second, separate direction this doc did not previously
+cover: `develop-post-merge.yml`'s `lint` job runs `make ci-lint` directly on
+a real, ephemeral GitHub-hosted runner (not as a local-parity convenience --
+as a blocking gate wired into `auto-revert-on-failure`). Most `ci-lint`
+guards are equally meaningful there, because they inspect the checked-out
+tree, the installed venv, or a registry the repo ships -- none of which
+differ between a laptop and a runner. A couple of guards instead read state
+that only exists on a developer machine, and behave one of two bad ways on a
+runner that lacks it:
+
+- **Fail for a reason that has nothing to do with the code under test.**
+  `agent-identity-check` did exactly this before #1558/#1509: it resolves
+  `git config user.*`, an ephemeral runner has none, and the check treated
+  "no identity" as a hard failure -- reddening every post-merge run for an
+  environment fact, not a defect.
+- **Silently no-op and report success while checking nothing.** This is the
+  more dangerous failure mode: a guard that cannot fail reads as coverage in
+  the Actions log and is never investigated. `skill-sync-check` does this
+  today if left unguarded -- it shells out to `$(SKILL_SYNC)`, a local
+  absolute developer path that plainly does not exist on a runner, hits its
+  own "not installed; skipping" branch, and exits 0.
+
+`_project/scripts/ci_lint_environment_gate.py` is the single place that
+draws this boundary: a small, declarative `RUNNER_INAPPLICABLE_GUARDS` table
+mapping a guard slug to why it cannot produce a meaningful result on
+`GITHUB_ACTIONS=true`. The `ci-lint` recipe calls it immediately before each
+listed guard (`if uv run -- python _project/scripts/ci_lint_environment_gate.py <slug>; then ...; fi`)
+instead of the guard's own ad hoc `if [ "$$GITHUB_ACTIONS" = "true" ]`
+special-case -- exactly the pattern the old `agent-identity-check` synthetic-identity
+injection was, and the reason a *general* mechanism replaced it rather than
+gaining a second one for `skill-sync-check`. A guard not listed in the table
+always runs, on a runner exactly as it does locally -- the table is a narrow,
+reasoned allowlist of exceptions, not a generic on/off switch, and adding an
+entry removes real CI coverage inside `make ci-lint`'s own CI invocation
+unless that guard is *also* covered for real somewhere else in CI:
+
+- `agent-identity-check` has no CI-runner equivalent anywhere, by design --
+  see `pr.yml`'s `code-lint` job, which has no counterpart step for the same
+  reason. `agent-commit-range-check` is the real merge-time control (it
+  reads the commits a branch actually carries, not resolved config) and is
+  never in the gate's table; it keeps running unconditionally, in `ci-lint`
+  and in `pr.yml`.
+- `skill-sync-check`'s real CI-side coverage is `pr.yml`'s
+  `guard-skill-sync-verify` step (the pinned-SHA network checkout described
+  above), which runs against every PR before it can reach develop. Skipping
+  the local-path-based `skill-sync-check` inside `ci-lint`'s own CI
+  invocation does not remove coverage that existed there -- it removes a
+  guard that was already structurally unable to check anything on a runner.
+
+`GITHUB_ACTIONS` is never hand-toggled here: it is the platform-set variable
+every GitHub Actions job already has, so local runs (including
+`pr-preflight`) are unaffected -- both listed guards keep running locally
+exactly as before this table existed.
+
 ## `pr-preflight` and the content guard
 
 `make pr-preflight-fast-tests` (called by `make pr-preflight`) always runs

--- a/docs/operations/ci-local-parity.md
+++ b/docs/operations/ci-local-parity.md
@@ -184,11 +184,31 @@ runner that lacks it:
 draws this boundary: a small, declarative `RUNNER_INAPPLICABLE_GUARDS` table
 mapping a guard slug to why it cannot produce a meaningful result on
 `GITHUB_ACTIONS=true`. The `ci-lint` recipe calls it immediately before each
-listed guard (`if uv run -- python _project/scripts/ci_lint_environment_gate.py <slug>; then ...; fi`)
-instead of the guard's own ad hoc `if [ "$$GITHUB_ACTIONS" = "true" ]`
+listed guard and skips only on the exact stdout token `SKIP`:
+
+```sh
+GATE=$(uv run -- python _project/scripts/ci_lint_environment_gate.py <slug> || true)
+if [ "$GATE" != "SKIP" ]; then <guard>; fi
+```
+
+This replaces the guard's own ad hoc `if [ "$$GITHUB_ACTIONS" = "true" ]`
 special-case -- exactly the pattern the old `agent-identity-check` synthetic-identity
 injection was, and the reason a *general* mechanism replaced it rather than
-gaining a second one for `skill-sync-check`. A guard not listed in the table
+gaining a second one for `skill-sync-check`.
+
+**The decision travels on stdout, never in the exit status, and the gate fails
+closed.** Using the gate process itself as the `if` condition looks equivalent
+and is not: every way of failing to *reach* a decision -- `uv` absent, a broken
+venv, the script renamed, any traceback -- also exits non-zero, so a broken gate
+would be indistinguishable from a deliberate skip and the guard would vanish
+with nothing recorded in `failed`. That is the same "guard that cannot fail"
+defect the gate exists to remove, one layer up. Anything other than `SKIP` runs
+the guard; the human-readable reason goes to stderr so it still reaches the
+Actions log. `tests/unit/scripts/test_ci_lint_environment_boundary.py::TestGateFailsClosed`
+extracts the recipe's own condition and executes it against an uninvokable gate
+to pin this behaviourally rather than by pattern-matching the shell text.
+
+A guard not listed in the table
 always runs, on a runner exactly as it does locally -- the table is a narrow,
 reasoned allowlist of exceptions, not a generic on/off switch, and adding an
 entry removes real CI coverage inside `make ci-lint`'s own CI invocation

--- a/tests/system/test_ci_lint_parity.py
+++ b/tests/system/test_ci_lint_parity.py
@@ -208,15 +208,36 @@ def test_lint_job_guards_run_in_ci_lint() -> None:
     )
 
 
-def test_ci_lint_identity_check_supplies_runner_identity() -> None:
-    """The CI runner has no Git config for the resolved-config audit."""
+def test_ci_lint_identity_check_is_gated_rather_than_fed_a_synthetic_identity() -> None:
+    """The runner has no Git identity, so the audit is skipped, not faked.
+
+    This test used to pin a ``GIT_CONFIG_COUNT=2 ... / unset ...`` pair that
+    injected a synthetic ``BenchBox CI`` identity so the resolved-config audit
+    had something to read on a runner. That only ever swapped one input the
+    audit cannot fail on for another: a synthetic identity matches no known
+    agent either, so the guard passed without verifying anything.
+
+    The guard is now skipped on a runner via the environment gate, and the
+    synthetic identity is gone because nothing consumed it. Pinning the old
+    text here would have made this test assert recipe content with no
+    behaviour behind it - a vacuous pass, which is the exact defect class the
+    gate exists to remove.
+
+    ``agent-commit-range-check`` stays unconditional and is the real
+    merge-time authorship control; it is asserted separately below.
+    """
     recipe = _ci_lint_recipe_text()
-    assert 'if [ "$${GITHUB_ACTIONS:-}" = "true" ]; then' in recipe
-    assert "export GIT_CONFIG_COUNT=2" in recipe
-    assert "GIT_CONFIG_VALUE_0='BenchBox CI'" in recipe
-    assert "GIT_CONFIG_VALUE_1=ci@benchbox.invalid" in recipe
-    assert "unset GIT_CONFIG_COUNT GIT_CONFIG_KEY_0" in recipe
-    assert recipe.count('if [ "$${GITHUB_ACTIONS:-}" = "true" ]; then') == 2
+    assert "ci_lint_environment_gate.py agent-identity" in recipe, (
+        "ci-lint no longer consults the environment gate before agent-identity-check"
+    )
+    assert "GIT_CONFIG_COUNT" not in recipe, (
+        "the synthetic runner identity is back; the audit it fed is skipped on CI, so it feeds nothing"
+    )
+    # The control that must never be gated.
+    assert "ci_lint_environment_gate.py agent-commit-range" not in recipe, (
+        "agent-commit-range-check is gated; it is the merge-time authorship control and must always run"
+    )
+    assert "$(MAKE) agent-commit-range-check" in recipe
 
 
 def test_excluded_steps_still_exist() -> None:

--- a/tests/unit/scripts/test_ci_lint_environment_boundary.py
+++ b/tests/unit/scripts/test_ci_lint_environment_boundary.py
@@ -1,0 +1,228 @@
+"""`make ci-lint` must not confuse "runs on CI" with "means something on CI".
+
+`develop-post-merge.yml` runs `make ci-lint` directly on a real, ephemeral
+GitHub-hosted runner (not as a local-parity convenience -- as a blocking gate
+wired into `auto-revert-on-failure`). Two of its ~23 guards read state that
+only exists on a developer machine and used to handle that badly:
+`agent-identity-check` resolves a Git identity the runner does not have (a
+noisy, environment-caused failure before #1558), and `skill-sync-check`
+shells out to a hardcoded local absolute path that plainly does not exist on
+a runner (a *silent* no-op that exits 0 and reads as coverage in the Actions
+log while checking nothing -- the more dangerous failure mode, because nobody
+investigates a green check).
+
+`_project/scripts/ci_lint_environment_gate.py` is the fix: one declarative
+table of guards that cannot produce a meaningful result on
+`GITHUB_ACTIONS=true`, consulted by the `ci-lint` recipe before each listed
+guard, replacing the ad hoc per-guard `if $GITHUB_ACTIONS` special case.
+
+Every test below is chosen to fail for a specific wrong "fix", not just to
+exercise the happy path:
+
+* `..._never_gates_the_commit_range_control` and
+  `..._leaves_real_guards_unconditional` fail if the exception table (or the
+  Makefile wiring) is widened past the two documented guards -- the
+  "disable everything on CI" cheat that would satisfy a shallower test
+  asserting only "ci-lint exits 0 on a runner".
+* `..._gates_agent_identity_check_on_a_runner` and
+  `..._gates_skill_sync_check_on_a_runner` parse the actual `ci-lint` recipe
+  text and fail if the gate script exists and classifies correctly but was
+  never wired into the Makefile -- the specific way a "fix" could add a
+  correct-looking module that changes nothing about what `make ci-lint`
+  actually runs.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import re
+import sys
+from pathlib import Path
+
+import pytest
+
+pytestmark = [pytest.mark.unit, pytest.mark.fast]
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+MAKEFILE = REPO_ROOT / "Makefile"
+GATE_SCRIPT = REPO_ROOT / "_project" / "scripts" / "ci_lint_environment_gate.py"
+GATE_INVOCATION = "_project/scripts/ci_lint_environment_gate.py"
+
+# Guards that stay unconditional on CI: a representative sample spanning
+# every invocation shape `ci-lint` uses (bare `uv run ...`, `$(MAKE) <target>`
+# with and without a `-check` suffix on its failure tag), plus the one guard
+# the task explicitly forbids ever gating. If a "fix" widened the exception
+# table to cover any of these -- even accidentally, e.g. by keying the table
+# on a prefix instead of an exact slug -- real CI coverage would shrink and
+# these assertions catch it.
+ALWAYS_ON_GUARDS = (
+    "ruff-check",
+    "ruff-format",
+    "ty-check",
+    "artifact-hygiene",
+    "agent-instructions",
+    "audit-deps",
+    "spellcheck",
+    "agent-commit-range",
+)
+
+
+def _load_gate():
+    spec = importlib.util.spec_from_file_location("ci_lint_environment_gate_under_test", GATE_SCRIPT)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def _ci_lint_recipe_text() -> str:
+    """Tab-indented recipe body of the `ci-lint:` Makefile target."""
+    text = MAKEFILE.read_text(encoding="utf-8")
+    match = re.search(r"^ci-lint:.*?\n((?:\t.*\n|\n)*)", text, re.MULTILINE)
+    assert match, "Makefile has no top-level 'ci-lint:' target"
+    return match.group(1)
+
+
+class TestClassificationTable:
+    """The gate's own decision function, independent of how the Makefile calls it."""
+
+    def test_ci_lint_environment_boundary_skips_agent_identity_on_a_runner(self) -> None:
+        gate = _load_gate()
+        should_run, reason = gate.runs_on_runner("agent-identity", github_actions=True)
+        assert should_run is False
+        assert reason, "a skipped guard must carry a printable reason, not a silent False"
+
+    def test_ci_lint_environment_boundary_skips_skill_sync_check_on_a_runner(self) -> None:
+        gate = _load_gate()
+        should_run, reason = gate.runs_on_runner("skill-sync-check", github_actions=True)
+        assert should_run is False
+        assert reason, "a skipped guard must carry a printable reason, not a silent False"
+
+    def test_ci_lint_environment_boundary_never_gates_the_commit_range_control(self) -> None:
+        """agent-commit-range-check is the real merge-time authorship control
+        (it reads the commits a branch actually carries, not resolved
+        config) -- it must run unconditionally everywhere, including CI.
+        A table that ever returns False for it is the actual coverage
+        regression the task's constraints forbid, not a hardening."""
+        gate = _load_gate()
+        for github_actions in (True, False):
+            should_run, reason = gate.runs_on_runner("agent-commit-range", github_actions=github_actions)
+            assert should_run is True
+            assert reason is None
+
+    def test_ci_lint_environment_boundary_leaves_real_guards_unconditional(self) -> None:
+        """A guard not in the documented exception table must run on CI
+        exactly as it does locally -- this is what stops the mechanism from
+        becoming a generic on/off switch instead of a narrow, reasoned
+        allowlist."""
+        gate = _load_gate()
+        for slug in ALWAYS_ON_GUARDS:
+            should_run, reason = gate.runs_on_runner(slug, github_actions=True)
+            assert should_run is True, f"{slug!r} must stay unconditional on a CI runner"
+            assert reason is None
+
+    def test_ci_lint_environment_boundary_only_narrows_ci_never_local(self) -> None:
+        """`github_actions=False` (local dev, `pr-preflight`, CI-local-parity
+        runs) must be unaffected by the table -- including for the two
+        guards it DOES skip on a runner. A fix that also skipped them
+        locally would silently drop local pre-push coverage no one asked
+        for."""
+        gate = _load_gate()
+        for slug in ("agent-identity", "skill-sync-check", *ALWAYS_ON_GUARDS):
+            should_run, reason = gate.runs_on_runner(slug, github_actions=False)
+            assert should_run is True, f"{slug!r} must run locally regardless of the CI exception table"
+            assert reason is None
+
+
+class TestGateCli:
+    """The actual command line `ci-lint` invokes (`uv run -- python ... <slug>`)."""
+
+    def test_ci_lint_environment_boundary_cli_skips_on_a_runner(self, monkeypatch, capsys) -> None:
+        gate = _load_gate()
+        monkeypatch.setenv("GITHUB_ACTIONS", "true")
+        assert gate.main(["agent-identity"]) == 1
+        out = capsys.readouterr().out
+        assert "SKIP agent-identity" in out
+
+    def test_ci_lint_environment_boundary_cli_runs_off_a_runner(self, monkeypatch, capsys) -> None:
+        gate = _load_gate()
+        monkeypatch.delenv("GITHUB_ACTIONS", raising=False)
+        assert gate.main(["agent-identity"]) == 0
+        assert capsys.readouterr().out == ""
+
+    def test_ci_lint_environment_boundary_cli_ignores_non_true_values(self, monkeypatch) -> None:
+        """GitHub Actions itself only ever sets the literal string `true`;
+        a stray/falsy value (unset, empty, `false`) must never trip the
+        skip path -- otherwise a locally-exported `GITHUB_ACTIONS=1` for
+        some unrelated tool would silently start skipping real guards."""
+        gate = _load_gate()
+        for value in ("false", "", "1", "True"):
+            monkeypatch.setenv("GITHUB_ACTIONS", value)
+            assert gate.main(["agent-identity"]) == 0
+
+
+class TestMakefileWiring:
+    """Does `ci-lint` actually CALL the gate, not just define it?
+
+    A module with correct classification logic that the Makefile never
+    invokes changes nothing about what `make ci-lint` runs on a real
+    runner -- these assertions parse the recipe text itself so that specific
+    half-fix cannot pass.
+    """
+
+    def test_ci_lint_environment_boundary_gates_agent_identity_check_on_a_runner(self) -> None:
+        body = _ci_lint_recipe_text()
+        gate_call = f"{GATE_INVOCATION} agent-identity"
+        assert gate_call in body, "ci-lint does not consult the environment gate before agent-identity-check"
+        gate_index = body.index(gate_call)
+        guard_index = body.index("$(MAKE) agent-identity-check")
+        assert gate_index < guard_index, "the gate must run BEFORE agent-identity-check, not after or not at all"
+
+    def test_ci_lint_environment_boundary_gates_skill_sync_check_on_a_runner(self) -> None:
+        body = _ci_lint_recipe_text()
+        gate_call = f"{GATE_INVOCATION} skill-sync-check"
+        assert gate_call in body, "ci-lint does not consult the environment gate before skill-sync-check"
+        gate_index = body.index(gate_call)
+        guard_index = body.index("$(MAKE) skill-sync-check")
+        assert gate_index < guard_index, "the gate must run BEFORE skill-sync-check, not after or not at all"
+
+    def test_ci_lint_environment_boundary_never_gates_commit_range_in_the_makefile(self) -> None:
+        body = _ci_lint_recipe_text()
+        assert f"{GATE_INVOCATION} agent-commit-range" not in body, (
+            "agent-commit-range-check must never be routed through the environment gate -- "
+            "it is the merge-time authorship control and stays unconditional"
+        )
+
+    def test_ci_lint_environment_boundary_leaves_real_guard_commands_unconditional(self) -> None:
+        """Spot-check that ordinary guard invocations are still bare
+        recipe lines, not newly nested under a gate `if`/`fi` -- catches a
+        fix that widened gating past the two documented exceptions by
+        editing the wrong lines."""
+        body = _ci_lint_recipe_text()
+        for command in (
+            "uv run ruff check .",
+            "uv run ruff format --check .",
+            "uv run ty check",
+            "$(MAKE) artifact-hygiene",
+            "$(MAKE) agent-instructions-check",
+            "$(MAKE) agent-commit-range-check",
+            "$(MAKE) audit-deps",
+            "$(MAKE) spellcheck",
+        ):
+            assert command in body, f"expected guard command {command!r} missing from ci-lint recipe"
+
+    def test_ci_lint_environment_boundary_uses_one_general_mechanism(self) -> None:
+        """The fix this test pins replaced the old per-member
+        `if [ "$GITHUB_ACTIONS" = "true" ]` special case with a single
+        script consulted uniformly. Both gated guards must route through
+        the SAME script (not two separate ad hoc mechanisms), which is
+        what makes adding a third gated guard later a one-line table entry
+        instead of another copy-pasted shell conditional."""
+        body = _ci_lint_recipe_text()
+        assert body.count(GATE_INVOCATION) == 2, (
+            f"expected exactly 2 calls into {GATE_INVOCATION} (agent-identity, skill-sync-check); "
+            "a differing count means the general mechanism was abandoned for a per-member one-off, "
+            "or a guard was gated that should not be"
+        )

--- a/tests/unit/scripts/test_ci_lint_environment_boundary.py
+++ b/tests/unit/scripts/test_ci_lint_environment_boundary.py
@@ -36,6 +36,7 @@ from __future__ import annotations
 
 import importlib.util
 import re
+import subprocess
 import sys
 from pathlib import Path
 
@@ -142,25 +143,34 @@ class TestGateCli:
     def test_ci_lint_environment_boundary_cli_skips_on_a_runner(self, monkeypatch, capsys) -> None:
         gate = _load_gate()
         monkeypatch.setenv("GITHUB_ACTIONS", "true")
-        assert gate.main(["agent-identity"]) == 1
-        out = capsys.readouterr().out
-        assert "SKIP agent-identity" in out
+        # Exit status stays 0: it reports "the gate ran", not the decision.
+        # See TestGateFailsClosed for why conflating the two drops guards.
+        assert gate.main(["agent-identity"]) == 0
+        assert capsys.readouterr().out.strip() == gate.DECISION_SKIP
 
     def test_ci_lint_environment_boundary_cli_runs_off_a_runner(self, monkeypatch, capsys) -> None:
         gate = _load_gate()
         monkeypatch.delenv("GITHUB_ACTIONS", raising=False)
         assert gate.main(["agent-identity"]) == 0
-        assert capsys.readouterr().out == ""
+        assert capsys.readouterr().out.strip() == gate.DECISION_RUN
 
-    def test_ci_lint_environment_boundary_cli_ignores_non_true_values(self, monkeypatch) -> None:
+    def test_ci_lint_environment_boundary_cli_ignores_non_true_values(self, monkeypatch, capsys) -> None:
         """GitHub Actions itself only ever sets the literal string `true`;
         a stray/falsy value (unset, empty, `false`) must never trip the
         skip path -- otherwise a locally-exported `GITHUB_ACTIONS=1` for
-        some unrelated tool would silently start skipping real guards."""
+        some unrelated tool would silently start skipping real guards.
+
+        Asserts the emitted decision, not the exit status: `main` returns 0
+        for both decisions now, so an exit-status assertion here would pass
+        no matter which branch was taken.
+        """
         gate = _load_gate()
         for value in ("false", "", "1", "True"):
             monkeypatch.setenv("GITHUB_ACTIONS", value)
-            assert gate.main(["agent-identity"]) == 0
+            gate.main(["agent-identity"])
+            assert capsys.readouterr().out.strip() == gate.DECISION_RUN, (
+                f"GITHUB_ACTIONS={value!r} was treated as a runner, so real guards would be skipped"
+            )
 
 
 class TestMakefileWiring:
@@ -226,3 +236,89 @@ class TestMakefileWiring:
             "a differing count means the general mechanism was abandoned for a per-member one-off, "
             "or a guard was gated that should not be"
         )
+
+
+class TestGateFailsClosed:
+    """A gate that cannot be consulted must run the guard, not skip it.
+
+    This is the property the first version of this fix got backwards. It used
+    the gate process itself as the `if` condition - exit 0 to run, exit 1 to
+    skip - which makes every way of failing to *reach* a decision (`uv`
+    absent, a broken venv, the script renamed, any traceback) exit non-zero
+    and therefore indistinguishable from a deliberate skip. The guard was
+    then silently dropped with nothing recorded in the recipe's `failed`
+    list: a guard that cannot fail, which is the exact defect the gate was
+    written to remove, reproduced one layer up.
+    """
+
+    def test_ci_lint_environment_boundary_decision_is_on_stdout_not_the_exit_status(self) -> None:
+        """The gate must exit 0 for both decisions, distinguishing them by output."""
+        gate = _load_gate()
+        assert gate.main(["agent-identity"]) == 0, "a RUN decision must not be signalled by a non-zero exit"
+        assert gate.main(["skill-sync-check"]) == 0, "a SKIP decision must not be signalled by a non-zero exit"
+
+    def test_ci_lint_environment_boundary_emits_a_single_decision_token(
+        self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """stdout carries exactly one machine-readable token; the reason goes to stderr.
+
+        If the human-readable reason shared stdout with the token, the recipe's
+        string comparison would stop matching and every guard would run again -
+        failing closed, but silently undoing the fix.
+        """
+        gate = _load_gate()
+        monkeypatch.setenv("GITHUB_ACTIONS", "true")
+
+        gate.main(["skill-sync-check"])
+        captured = capsys.readouterr()
+        assert captured.out.strip() == gate.DECISION_SKIP
+        assert "hardcoded" in captured.err or "does not exist on a runner" in captured.err, (
+            "the skip reason no longer reaches stderr, so an Actions log shows a guard vanishing with no explanation"
+        )
+
+        gate.main(["ruff-check"])
+        assert capsys.readouterr().out.strip() == gate.DECISION_RUN
+
+    def test_ci_lint_environment_boundary_runs_the_guard_when_the_gate_is_broken(self) -> None:
+        """Execute the recipe's OWN condition against a gate that cannot run.
+
+        Asserting on Makefile text alone would not catch this: `if <cmd>; then`
+        and a `!= SKIP` comparison look equally reasonable in a diff, and only
+        one of them is safe. So take the real lines out of the recipe, swap the
+        gate command for one that fails the way a missing interpreter would,
+        and check which branch a shell actually takes.
+        """
+        lines = _ci_lint_recipe_text().splitlines()
+        for slug, guard in (("agent-identity", "agent-identity-check"), ("skill-sync-check", "skill-sync-check")):
+            start = next(
+                (i for i, line in enumerate(lines) if f"{GATE_INVOCATION} {slug}" in line),
+                None,
+            )
+            assert start is not None, f"ci-lint never consults the gate for {slug!r}"
+            end = next(
+                (i for i in range(start + 1, len(lines)) if f"$(MAKE) {guard}" in lines[i]),
+                None,
+            )
+            assert end is not None, f"no {guard!r} invocation follows its gate call"
+
+            # Take the recipe's own gating lines, stopping before the guard
+            # itself so `$(MAKE)` never reaches the shell. `$$` is make's
+            # escape for a literal `$`. Whatever shape the condition has -
+            # a `GATE=...` capture, a bare `if <cmd>; then` - it is exercised
+            # as written rather than pattern-matched, so a future rewrite is
+            # judged on behaviour instead of on looking familiar.
+            block = "\n".join(line.rstrip("\\").strip() for line in lines[start:end]).replace("$$", "$")
+            # Simulate the gate being uninvokable, NOT deciding to skip.
+            broken = re.sub(r"uv run\b.*?" + re.escape(slug), "command-that-does-not-exist", block, count=1)
+            assert "command-that-does-not-exist" in broken, f"could not neutralise the gate command for {slug!r}"
+
+            result = subprocess.run(
+                ["sh", "-c", f"{broken} echo RAN; else echo SKIPPED; fi"],
+                capture_output=True,
+                text=True,
+            )
+            assert result.stdout.strip() == "RAN", (
+                f"a broken gate silently skips {guard}: the recipe treats 'could not decide' as 'skip', "
+                f"so the guard disappears with nothing recorded in `failed`. Shell said "
+                f"{result.stdout.strip()!r} for block:\n{broken}"
+            )


### PR DESCRIPTION
## Problem

`develop-post-merge.yml` runs `make ci-lint` on an ephemeral GitHub-hosted runner as a blocking gate wired into auto-revert. Two of its ~24 guards read state that only exists on a developer machine, and each failed a different way:

- **`agent-identity-check`** resolves `git config user.*`, which a runner does not have. Before #1558 that reddened post-merge runs for an environment fact. After #1558 it passes — but only because an absent identity now returns `[]`, and because the recipe injected a synthetic `BenchBox CI` identity. Either way it *cannot fail there*, so it verified nothing.
- **`skill-sync-check`** shells out to `$(SKILL_SYNC)` — `/Users/joe/Developer/skill-sync/dist/cli/index.js`, a hardcoded developer path. On a runner it hits the target's own "not installed; skipping" branch and exits 0. **A silent no-op that reads as coverage in the Actions log.**

The second mode is the dangerous one: nobody investigates a green check.

The inline `if [ "$GITHUB_ACTIONS" = "true" ]` block that fed the synthetic identity was itself the smell — a one-off patch for one member, with no general rule behind it.

## Fix

One declarative table (`RUNNER_INAPPLICABLE_GUARDS` in `_project/scripts/ci_lint_environment_gate.py`), consulted uniformly. A guard not listed always runs, on a runner exactly as locally. Adding a third exception is a table entry, not another copy-pasted conditional.

**Exactly 2 of ~24 guards are gated.** `agent-commit-range-check` — the real merge-time authorship control — is never gated and is asserted so in three separate tests.

## Review found the gate reproducing its own defect

The first implementation used the gate process as the `if` condition: exit 0 to run, exit 1 to skip. Every way of failing to *reach* a decision also exits non-zero — `uv` absent, broken venv, script renamed, any traceback — so a broken gate was indistinguishable from a deliberate skip and the guard vanished with nothing in `failed`. Demonstrated:

```
$ if uv run -- python .../ci_lint_environment_gate_TYPO.py agent-identity
-> guard SILENTLY SKIPPED
$ if PATH=/usr/bin:/bin uv run -- python .../ci_lint_environment_gate.py agent-identity
-> guard SILENTLY SKIPPED
```

The decision now travels on stdout as a single token; the recipe skips only on an exact `SKIP` and anything else runs the guard. The reason moves to stderr so it still reaches the log.

Review also removed the synthetic `GIT_CONFIG` identity, now dead. `tests/system/test_ci_lint_parity.py` pinned that exact text, so leaving both would have shipped a **newly vacuous test inside the change whose purpose is removing vacuous passes**. That test now pins the gating and asserts the synthetic identity has not come back. Item scope was widened to `tests/system/**` with the reason recorded on the tracker.

One test asserted `main() == 0` to mean "run"; under the new contract `main` always returns 0, so it had gone vacuous. It now asserts the emitted decision.

## Falsification

Three independent neuters, each caught by a disjoint subset:

| Neuter | Caught by |
|---|---|
| Revert Makefile wiring, keep the module importable | 3 wiring tests, `AssertionError` not `ImportError` |
| Keep wiring, make `runs_on_runner` always return `True` | 3 classification/CLI tests |
| Revert to the exit-status construct | `TestGateFailsClosed` — takes the recipe's own lines, swaps the gate for an uninvokable command, runs them; shell reports `SKIPPED` where `RAN` is required |

The third fails *behaviourally* rather than on a regex miss — an earlier version of it failed with "could not locate the gate condition", which would not have survived a plausible rewrite.

## Coverage

Two guards now run in **zero** places on CI, both previously vacuous there:

- `agent-identity` — no environment anywhere gives a runner a real developer identity. `pr.yml`'s `code-lint` job already omits it for the same reason.
- `skill-sync-check` — the real check is `pr.yml`'s `guard-skill-sync-verify`, a pinned-SHA network checkout gating every PR. Unchanged.

Everything else, including `agent-commit-range-check`, is untouched and unconditional.

## Verification

`test_ci_lint_environment_boundary.py` 16 passed · `test_agent_instruction_audit.py` 50 passed · `test_ci_lint_parity.py` 8 passed · `tests/unit/scripts` 1516 passed · `make -n ci-lint` parses.

## Noted, not fixed

`uv-lock-revision-check` is a no-op whenever `ci-lint` runs on a clean checkout with no explicit `BASE_REF` — `HEAD:uv.lock` always equals the working tree there. That is not a *developer-machine* assumption (it is equally a no-op locally on a clean tree), so it is out of this defect's scope. Flagged rather than silently left.