### PR TITLE
fix(ci): report a real check on published-results mirror PRs

### DIFF
--- a/.github/workflows/sync-results-data-to-published.yml
+++ b/.github/workflows/sync-results-data-to-published.yml
@@ -282,12 +282,26 @@ jobs:
         # SHA, is what makes the PR's statusCheckRollup non-empty. It must carry
         # the same condition as "Open or update draft PR" so every mirror PR gets
         # it, not just some.
-        if: steps.drift.outputs.has_drift == 'true' && steps.build.outputs.has_changes == 'true'
+        #
+        # `always()`: without it, a step-level failure anywhere above (a flaky
+        # `astral-sh/setup-uv`, a `git diff` error inside the validate step —
+        # anything the validate step's own `set -uo pipefail` capture does not
+        # convert into a reported state) skips every later step, so no status
+        # AND no mirror PR. That would be a new way for the corpus mirror to
+        # silently not exist, which is worse than the blind PR this change is
+        # removing: develop's Corpus Drift Check would stay red with nothing
+        # open to explain it. An unreachable verdict is reported as `error`.
+        if: always() && steps.drift.outputs.has_drift == 'true' && steps.build.outputs.has_changes == 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           STATE: ${{ steps.validate.outputs.state }}
           DESCRIPTION: ${{ steps.validate.outputs.description }}
         run: |
+          # Empty means the validate step never reached its `GITHUB_OUTPUT`
+          # write. Never default this to `success`: an absent verdict is the
+          # one case where the PR carries no evidence either way.
+          STATE="${STATE:-error}"
+          DESCRIPTION="${DESCRIPTION:-Validation did not complete; see the workflow run.}"
           SHA=$(git rev-parse HEAD)
           gh api "repos/${{ github.repository }}/statuses/${SHA}" \
             -f state="${STATE}" \
@@ -296,7 +310,11 @@ jobs:
             -f target_url="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
 
       - name: Open or update draft PR
-        if: steps.drift.outputs.has_drift == 'true' && steps.build.outputs.has_changes == 'true'
+        # `always()` for the same reason as the status step above: the mirror PR
+        # existing is what keeps develop's Corpus Drift Check actionable, so it
+        # must not be collateral damage from a toolchain hiccup in the new
+        # validation steps. Before those steps existed this could not happen.
+        if: always() && steps.drift.outputs.has_drift == 'true' && steps.build.outputs.has_changes == 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           MIRROR_BRANCH: ${{ steps.build.outputs.mirror_branch }}
@@ -343,9 +361,13 @@ jobs:
         # Runs after the PR/status steps above on purpose: the PR must still
         # exist and carry the failing status for a maintainer to act on, not
         # disappear because this job stopped early.
-        if: steps.validate.outputs.state == 'failure'
+        #
+        # `!= 'success'` rather than `== 'failure'`: an empty state means the
+        # validate step never produced a verdict, and a run that could not
+        # determine whether the corpus is publishable must not be green.
+        if: always() && steps.drift.outputs.has_drift == 'true' && steps.build.outputs.has_changes == 'true' && steps.validate.outputs.state != 'success'
         run: |
-          echo "::error::Mirrored corpus content failed validation; see the corpus-mirror/validate-bundles status on the mirror PR for detail."
+          echo "::error::Mirrored corpus content did not pass validation; see the corpus-mirror/validate-bundles status on the mirror PR for detail."
           exit 1
 
       - name: No-op summary

--- a/.github/workflows/sync-results-data-to-published.yml
+++ b/.github/workflows/sync-results-data-to-published.yml
@@ -14,6 +14,22 @@ name: Sync results-data to published-results
 # on the public corpus branch. Validator changes mirror both the thin
 # `scripts/validate_submission.py` entrypoint and its shared
 # `benchbox/validation/bundle.py` implementation.
+#
+# The mirror PR's author is this workflow's own GITHUB_TOKEN identity
+# (github-actions[bot]). GitHub never starts `pull_request`-triggered workflow
+# runs for events raised by GITHUB_TOKEN — documented recursion prevention,
+# not something a trigger filter can work around — so `validate-submission.yml`
+# never fires on this PR even though its `paths:` filter matches every file
+# the PR touches. Left alone, the PR's statusCheckRollup is empty: not zero
+# failures, zero checks. See #1542 and
+# `docs/operations/results-phase-2-runbook.md` §1.2. The "Validate mirrored
+# corpus content" / "Report validation as a commit status" steps below are the
+# fix: this run validates the exact content it is about to propose and posts
+# the result as a commit status on the mirror branch's head SHA. A commit
+# status is a plain write via the Statuses API, not a workflow trigger, so it
+# is unaffected by the GITHUB_TOKEN recursion rule and needs no new
+# credential — `statuses: write` only widens the permissions already granted
+# to the token this workflow already holds.
 
 on:
   push:
@@ -33,6 +49,7 @@ on:
 permissions:
   contents: write
   pull-requests: write
+  statuses: write
 
 concurrency:
   group: sync-results-to-published-${{ github.ref }}
@@ -189,6 +206,95 @@ jobs:
           # same SHA collide.
           PRE_COMMIT_ALLOW_NO_CONFIG=1 git push --force-with-lease origin "${MIRROR_BRANCH}"
 
+      # w0: which checks genuinely protect a corpus-only branch. `published-results`
+      # carries results-data/, a slim results-validation subset of benchbox/, and
+      # docs — not the develop package or test suite. Reimporting develop's
+      # lint/type/pytest matrix here would gate corpus content on checks that have
+      # nothing to do with it (rejected by the ADR for the same reason it rejected
+      # routing submissions through develop directly). The two checks that ARE
+      # domain-appropriate are exactly the ones `validate-submission.yml` already
+      # runs for a human-authored submission PR: does each changed bundle pass
+      # schema/hash/privacy validation, and is the generated inventory still
+      # current. Run precisely those two, reusing the identical vendored scripts
+      # and the identical `--no-project --python 3.11` invocation convention
+      # documented in `adr-published-results-slim-corpus-branch.md`, so the mirror
+      # PR is judged by the same bar a contributor PR would be.
+      - name: Install uv
+        if: steps.drift.outputs.has_drift == 'true' && steps.build.outputs.has_changes == 'true'
+        uses: astral-sh/setup-uv@v4
+
+      - name: Set up Python
+        if: steps.drift.outputs.has_drift == 'true' && steps.build.outputs.has_changes == 'true'
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Validate mirrored corpus content
+        # The working tree right now (after `git switch --force-create` and the
+        # path-level checkouts above) IS the exact content the PR will present as
+        # its diff — validating it here checks precisely what a reviewer would
+        # see, not a proxy for it. `set -u`/`pipefail` without `-e`: a validator
+        # failure must be captured as a reported state, not abort the job before
+        # the PR / status steps below ever run.
+        if: steps.drift.outputs.has_drift == 'true' && steps.build.outputs.has_changes == 'true'
+        id: validate
+        run: |
+          set -uo pipefail
+
+          CHANGED_BUNDLES=$(git diff --no-renames --name-only --diff-filter=ACMR origin/published-results HEAD -- \
+            'results-data/bundles/*.json' 'results-data/bundles/**/*.json' \
+            | grep -vi '\.plans\.json$' \
+            | grep -vi '\.tuning\.json$' \
+            | grep -vi '\.applied\.json$' \
+            | grep -vi '\.manifest\.json$' \
+            || true)
+
+          STATE="success"
+          DESCRIPTION="Corpus content validated before mirroring."
+
+          if [[ -n "${CHANGED_BUNDLES}" ]]; then
+            echo "Validating changed bundle(s):"
+            printf '  %s\n' "${CHANGED_BUNDLES}"
+            # No --require-manifest: this run IS the maintainer-run mirror that
+            # validate-submission.yml's own "Validate bundles" step already
+            # waives the sidecar requirement for (same auto/results-mirror-*
+            # same-repo signal) — the seed-corpus, sidecar-less path is
+            # legitimate here too, not a gap.
+            if ! printf '%s\n' "${CHANGED_BUNDLES}" | xargs -d '\n' uv run --no-project --python 3.11 -- python scripts/validate_submission.py; then
+              STATE="failure"
+              DESCRIPTION="scripts/validate_submission.py rejected the mirrored bundle content."
+            fi
+          fi
+
+          if [[ "${STATE}" == "success" ]]; then
+            if ! uv run --no-project --python 3.11 -- python scripts/generate_corpus_inventory.py --check; then
+              STATE="failure"
+              DESCRIPTION="results-data/corpus-inventory.json is stale for the mirrored content."
+            fi
+          fi
+
+          echo "state=${STATE}" >> "$GITHUB_OUTPUT"
+          echo "description=${DESCRIPTION}" >> "$GITHUB_OUTPUT"
+
+      - name: Report validation as a commit status on the mirror PR
+        # This is the fix for Cause 1 (see the workflow-level comment above): a
+        # commit status posted by THIS run, tied to the mirror branch's own head
+        # SHA, is what makes the PR's statusCheckRollup non-empty. It must carry
+        # the same condition as "Open or update draft PR" so every mirror PR gets
+        # it, not just some.
+        if: steps.drift.outputs.has_drift == 'true' && steps.build.outputs.has_changes == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          STATE: ${{ steps.validate.outputs.state }}
+          DESCRIPTION: ${{ steps.validate.outputs.description }}
+        run: |
+          SHA=$(git rev-parse HEAD)
+          gh api "repos/${{ github.repository }}/statuses/${SHA}" \
+            -f state="${STATE}" \
+            -f context="corpus-mirror/validate-bundles" \
+            -f description="${DESCRIPTION}" \
+            -f target_url="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+
       - name: Open or update draft PR
         if: steps.drift.outputs.has_drift == 'true' && steps.build.outputs.has_changes == 'true'
         env:
@@ -232,6 +338,15 @@ jobs:
             echo "PR #${EXISTING} already open for ${MIRROR_BRANCH}; updating body."
             gh pr edit "${EXISTING}" --body "${BODY}"
           fi
+
+      - name: Fail the run if mirrored content failed validation
+        # Runs after the PR/status steps above on purpose: the PR must still
+        # exist and carry the failing status for a maintainer to act on, not
+        # disappear because this job stopped early.
+        if: steps.validate.outputs.state == 'failure'
+        run: |
+          echo "::error::Mirrored corpus content failed validation; see the corpus-mirror/validate-bundles status on the mirror PR for detail."
+          exit 1
 
       - name: No-op summary
         if: steps.drift.outputs.has_drift != 'true' || steps.build.outputs.has_changes != 'true'

--- a/docs/operations/results-phase-2-runbook.md
+++ b/docs/operations/results-phase-2-runbook.md
@@ -36,6 +36,56 @@ If the workflow's heuristics ever miss a path (or a one-off mirror is
 needed outside the trigger conditions), trigger it manually via
 `workflow_dispatch` from the Actions tab.
 
+#### Why the mirror PR needs its own check, and what still doesn't run there
+
+The mirror PR is opened by `sync-results-data-to-published.yml` using its own
+`GITHUB_TOKEN`, so its author is `github-actions[bot]`. GitHub never starts
+`pull_request`-triggered workflow runs for events raised by `GITHUB_TOKEN`
+(documented recursion prevention) — so `validate-submission.yml`, despite
+being wired to fire on exactly this PR's base and paths, never actually runs
+on it. #1542 shipped with an empty `statusCheckRollup` for exactly this
+reason: not zero failures, zero checks.
+
+The sync workflow now closes that gap itself: before opening or updating the
+PR, it runs the same two corpus gates `validate-submission.yml` would have
+(bundle validation via `scripts/validate_submission.py`, inventory freshness
+via `scripts/generate_corpus_inventory.py --check`) against the exact content
+it is about to mirror, and posts the result as a `corpus-mirror/validate-bundles`
+commit status on the mirror branch's head SHA. A commit status is a plain
+Statuses-API write, not a workflow trigger, so it is unaffected by the
+GITHUB_TOKEN recursion rule above and needed no new credential — only a
+`statuses: write` permission grant on the token this workflow already holds.
+
+A separate, narrower gap remains and is **not** fixed by the above:
+`published-results` carries exactly one workflow file
+(`validate-submission.yml`). `pr-base-guard.yml` — the repo-wide check that
+every PR gets regardless of base, added precisely so a PR against an
+unexpected base branch cannot show zero checks — cannot run against
+`published-results` because its file simply does not exist there, whatever
+its trigger says. It cannot be added by the sync workflow either:
+`GITHUB_TOKEN` cannot push changes under `.github/workflows/` regardless of
+the `permissions:` block granted to it (a hard-coded GitHub Actions
+restriction — see the "workflow file itself is NOT auto-mirrored" section of
+[`adr-published-results-slim-corpus-branch.md`](../development/adr/adr-published-results-slim-corpus-branch.md),
+which already documents this exact restriction for `validate-submission.yml`
+edits). Porting `pr-base-guard.yml` (or any future repo-wide guard) onto
+`published-results` is therefore a **manual** maintainer step, using the same
+diff-and-reapply protocol the ADR already prescribes for validator changes:
+
+```bash
+git diff origin/develop:.github/workflows/pr-base-guard.yml \
+         origin/published-results:.github/workflows/pr-base-guard.yml
+```
+
+then apply and push directly to `published-results` (or a PR against it) as
+a maintainer with `contents: write` access. In practice this matters less
+than it sounds: `pr-base-guard.yml` only protects against a PR whose base is
+some *other* branch entirely, and every route onto `published-results`
+(contributor submissions, this sync workflow) already targets it directly —
+but a future stacked-PR mistake against this branch would still see zero
+checks until this manual port happens. Treat it as tracked debt, not a
+silent gap.
+
 ### 1.3 Explorer publish path
 
 The static explorer at `benchbox.dev/results/` is intended to build and

--- a/docs/operations/results-phase-2-runbook.md
+++ b/docs/operations/results-phase-2-runbook.md
@@ -86,6 +86,24 @@ but a future stacked-PR mistake against this branch would still see zero
 checks until this manual port happens. Treat it as tracked debt, not a
 silent gap.
 
+Two honest limits on what the new status does and does not buy, so nobody
+reads more protection into a green badge than is there:
+
+- **It is advisory, not enforcing.** No ruleset targets `published-results` —
+  the repo's rulesets target `develop`, `release`, `v*` branches, and tags — so
+  a maintainer can still flip a mirror PR ready and merge it with the status
+  red. The status makes the verdict *visible*; the maintainer review step the
+  draft state exists for is still what enforces it.
+- **It is self-attested.** The run that builds the mirror content is the run
+  that validates it and posts the verdict, so it catches bad *content*
+  (a bundle that fails schema, hash, or privacy validation; a stale inventory)
+  but not tampering with the mirror branch after the fact. A later
+  `--force-with-lease` push from another run re-posts against the new head SHA,
+  so a stale green status cannot ride on top of new bytes — but a direct manual
+  push to `auto/results-mirror-*` would leave the last status attached to an
+  older SHA, and the PR would show no status for the new one rather than a
+  wrong one.
+
 ### 1.3 Explorer publish path
 
 The static explorer at `benchbox.dev/results/` is intended to build and

--- a/tests/unit/workflows/test_published_results_base_ci.py
+++ b/tests/unit/workflows/test_published_results_base_ci.py
@@ -1,0 +1,197 @@
+"""A `published-results` mirror PR must not present an empty check list.
+
+#1542 (`chore(corpus): mirror results-data changes from develop@355cc445`,
+base `published-results`) shipped with `statusCheckRollup: []` - not zero
+failures, zero checks. Two causes, only one fixable from `develop`:
+
+Cause 1 (fixed here): the PR's author is `app/github-actions` - this
+workflow's own `GITHUB_TOKEN` identity. GitHub never starts
+`pull_request`-triggered workflow runs for events raised by `GITHUB_TOKEN`
+(documented recursion prevention). `validate-submission.yml` is wired to fire
+on exactly this PR's base and paths and never will, no matter what its
+trigger says.
+
+Cause 2 (not fixable from here): `published-results` carries exactly one
+workflow file. `pr-base-guard.yml` - added in #1563 precisely to give a
+zero-CI PR at least one check - cannot run there because its file does not
+exist on that branch, and `GITHUB_TOKEN` cannot push `.github/workflows/`
+changes regardless of the `permissions:` block granted to it (a hard-coded
+GitHub Actions restriction, not a configuration choice - see
+`adr-published-results-slim-corpus-branch.md`'s "workflow file itself is NOT
+auto-mirrored" section). That gap needs a maintainer to manually port the
+guard onto `published-results`, tracked in
+`docs/operations/results-phase-2-runbook.md`.
+
+The fix pinned here: `sync-results-data-to-published.yml` now validates the
+exact content it is about to mirror (the same two gates
+`validate-submission.yml` would have run: bundle validation and inventory
+freshness) and posts the result as a commit status on the mirror branch's
+head SHA. A commit status is a plain Statuses-API write, not a workflow
+trigger, so it is unaffected by the GITHUB_TOKEN recursion rule and needs no
+new credential - `statuses: write` only widens the permissions already
+granted to the token this workflow already holds.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+import yaml
+
+pytestmark = [pytest.mark.unit, pytest.mark.fast]
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+WORKFLOWS = REPO_ROOT / ".github" / "workflows"
+SYNC = WORKFLOWS / "sync-results-data-to-published.yml"
+
+STATUS_API_FRAGMENT = "statuses/"
+OPEN_PR_STEP_NAME = "Open or update draft PR"
+VALIDATE_STEP_NAME = "Validate mirrored corpus content"
+STATUS_STEP_NAME = "Report validation as a commit status on the mirror PR"
+
+
+def _triggers(workflow: dict[str, Any]) -> dict[str, Any]:
+    """Return the `on:` block.
+
+    PyYAML resolves an unquoted ``on`` key to boolean ``True`` under YAML 1.1,
+    so accept either spelling rather than reading an empty trigger set and
+    passing vacuously.
+    """
+    triggers = workflow.get("on", workflow.get(True))
+    assert triggers is not None, "workflow has no `on:` block"
+    return triggers
+
+
+def _load(path: Path) -> dict[str, Any]:
+    return yaml.safe_load(path.read_text(encoding="utf-8"))
+
+
+def _steps() -> list[dict[str, Any]]:
+    workflow = _load(SYNC)
+    return workflow["jobs"]["mirror"]["steps"]
+
+
+def _step(name: str) -> dict[str, Any]:
+    for step in _steps():
+        if step.get("name") == name:
+            return step
+    raise AssertionError(f"sync-results-data-to-published.yml has no step named {name!r}")
+
+
+def test_published_results_base_mirror_pr_reports_a_commit_status() -> None:
+    """The sync workflow must post a check onto the mirror PR it opens.
+
+    This is the fix for Cause 1. Without it, #1542-style PRs show
+    `statusCheckRollup: []` forever - `validate-submission.yml` structurally
+    cannot fire on a GITHUB_TOKEN-authored PR event, so nothing else will ever
+    report either.
+    """
+    step = _step(STATUS_STEP_NAME)
+    run = step.get("run", "")
+    assert STATUS_API_FRAGMENT in run, (
+        "no step posts to the Statuses API; a mirror PR still ends up with an empty statusCheckRollup"
+    )
+    workflow = _load(SYNC)
+    assert workflow["permissions"].get("statuses") == "write", (
+        "workflow lacks statuses: write, so a status-posting call would 403 even if attempted"
+    )
+
+
+def test_published_results_base_mirror_pr_status_condition_matches_pr_creation() -> None:
+    """Every mirror PR must get the status, not just some of them.
+
+    If the status step's `if:` were narrower than the PR-opening step's, some
+    mirror PRs would open with a check and others would silently keep the
+    original zero-check bug - a partial fix that looks complete in the common
+    case and regresses exactly the case #1542 hit.
+    """
+    open_pr_condition = _step(OPEN_PR_STEP_NAME).get("if")
+    status_condition = _step(STATUS_STEP_NAME).get("if")
+    assert status_condition == open_pr_condition, (
+        f"status step condition {status_condition!r} does not match the PR-opening "
+        f"step condition {open_pr_condition!r}; some mirror PRs would still end up uncovered"
+    )
+
+
+def test_published_results_base_mirror_pr_status_reflects_real_validation() -> None:
+    """The posted status must be derived from an actual validator run, not a rubber stamp.
+
+    A step that always reports `state=success` would make the PR page look
+    safe while checking nothing - worse than the current honest emptiness,
+    because a false green is harder to notice than no check at all. The
+    status step must consume the validate step's own output, and that output
+    must in turn depend on running `validate_submission.py` and
+    `generate_corpus_inventory.py --check` against the mirrored content.
+    """
+    status_step = _step(STATUS_STEP_NAME)
+    status_env = status_step.get("env", {})
+    assert status_env.get("STATE") == "${{ steps.validate.outputs.state }}", (
+        "status step does not read steps.validate.outputs.state; it cannot be reporting a real result"
+    )
+
+    validate_run = _step(VALIDATE_STEP_NAME).get("run", "")
+    assert "scripts/validate_submission.py" in validate_run, (
+        "validate step never invokes scripts/validate_submission.py; the reported check validates nothing"
+    )
+    assert "scripts/generate_corpus_inventory.py" in validate_run and "--check" in validate_run, (
+        "validate step never checks corpus-inventory.json freshness"
+    )
+    assert 'STATE="failure"' in validate_run, (
+        "validate step has no failure path; a broken bundle would still report state=success"
+    )
+
+
+def test_published_results_base_mirror_validation_runs_before_the_pr_is_opened() -> None:
+    """Validation must happen before the PR exists, matching the chosen design.
+
+    Guidance considered and rejected a new PAT/App-token credential for this
+    repo; the token-free alternative is the creating workflow validating its
+    own content and reporting on itself, which only works if validation runs
+    ahead of (or at worst alongside) PR creation rather than after it.
+    """
+    names = [step.get("name") for step in _steps()]
+    assert names.index(VALIDATE_STEP_NAME) < names.index(OPEN_PR_STEP_NAME), (
+        "validation step runs after the PR is opened; the PR could exist before its content is checked"
+    )
+    assert names.index(STATUS_STEP_NAME) < names.index(OPEN_PR_STEP_NAME), (
+        "status is posted after the PR is opened rather than before/alongside it"
+    )
+
+
+def test_published_results_base_mirror_stays_a_corpus_check_not_develops_matrix() -> None:
+    """Must-preserve: `published-results` stays a slim corpus branch.
+
+    w0 concluded the domain-appropriate gate for a corpus-only branch is
+    exactly `validate-submission.yml`'s own two checks (bundle validation,
+    inventory freshness) - not develop's lint/type/pytest matrix. A future
+    edit that starts running `ruff`, `ty`, or the fast test suite here would
+    quietly reintroduce the ADR-rejected "keep published-results synced with
+    develop continuously" design (full package surface for a corpus mirror).
+    """
+    # Concatenate only the executable `run:` bodies, not the surrounding YAML
+    # comments - a comment explaining what NOT to do (as this file's own w0
+    # rationale does, right above this test) would otherwise trip a naive
+    # whole-file substring check and fail for the wrong reason.
+    run_bodies = "\n".join(step.get("run", "") for step in _steps())
+    for forbidden in ("ruff check", "ruff format", "ty check", "pytest", "uv sync --group dev"):
+        assert forbidden not in run_bodies, (
+            f"{forbidden!r} appears in a sync workflow run step; this imports develop's CI matrix onto a corpus mirror"
+        )
+
+
+def test_published_results_base_guard_still_has_no_branch_filter() -> None:
+    """Cross-check against #1563's guard: must-preserve constraint from this TODO.
+
+    `pr-base-guard.yml`'s unfiltered trigger is what stops it from becoming a
+    required check that can never report (the same failure mode this whole
+    TODO is about). Nothing in this change may add a `branches:`/`paths:`
+    filter to it - re-assert the guard file's own invariant here so a future
+    edit that touches both files in the same PR cannot regress this one
+    silently.
+    """
+    guard = WORKFLOWS / "pr-base-guard.yml"
+    pull_request = _triggers(_load(guard))["pull_request"] or {}
+    assert "branches" not in pull_request
+    assert "paths" not in pull_request

--- a/tests/unit/workflows/test_published_results_base_ci.py
+++ b/tests/unit/workflows/test_published_results_base_ci.py
@@ -195,3 +195,56 @@ def test_published_results_base_guard_still_has_no_branch_filter() -> None:
     pull_request = _triggers(_load(guard))["pull_request"] or {}
     assert "branches" not in pull_request
     assert "paths" not in pull_request
+
+
+def test_published_results_base_mirror_survives_a_failure_in_its_own_validation_steps() -> None:
+    """Adding validation must not create a new way for the mirror PR to not exist.
+
+    The status and PR-opening steps come after the new "Install uv" / "Set up
+    Python" / "Validate mirrored corpus content" steps. GitHub skips every
+    later step once one fails, so without ``always()`` a flaky toolchain setup
+    - or any error the validate step's ``set -uo pipefail`` capture does not
+    convert into a reported state - would skip BOTH, leaving no status and no
+    mirror PR at all.
+
+    That is strictly worse than the blind PR this change removes: develop's
+    Corpus Drift Check would stay red with nothing open to explain why, and
+    before these steps existed the PR was always created. Availability of the
+    mirror PR is the property being protected here, not its verdict.
+    """
+    for step_name in (STATUS_STEP_NAME, OPEN_PR_STEP_NAME):
+        condition = _step(step_name).get("if", "")
+        assert "always()" in condition, (
+            f"{step_name!r} does not use always(), so a failure in the validation steps above it "
+            "would skip it and the mirror PR would silently not exist"
+        )
+
+
+def test_published_results_base_mirror_never_reports_success_without_a_verdict() -> None:
+    """An unreachable verdict must not read as a passing check.
+
+    ``always()`` means the status step can run when the validate step never
+    wrote its outputs, so the state can arrive empty. Defaulting that to
+    ``success`` would post a green check for content nothing examined - the
+    original zero-check bug wearing a passing badge, which is worse than the
+    empty rollup because it stops anyone looking.
+    """
+    body = _step(STATUS_STEP_NAME)["run"]
+    assert 'STATE="${STATE:-error}"' in body, (
+        "the status step does not default an absent verdict to `error`; an empty state would be posted as-is "
+        "or, worse, silently treated as success"
+    )
+    assert "STATE:-success" not in body, "an absent verdict defaults to success"
+
+
+def test_published_results_base_mirror_run_is_red_unless_validation_passed() -> None:
+    """The run must fail on a missing verdict, not only on an explicit failure.
+
+    ``state == 'failure'`` alone leaves the empty case green: the workflow
+    would report success having never established whether the corpus it just
+    proposed is publishable.
+    """
+    condition = _step("Fail the run if mirrored content failed validation").get("if", "")
+    assert "!= 'success'" in condition, (
+        f"failure gate is {condition!r}; a run that could not determine the verdict would still be green"
+    )


### PR DESCRIPTION
## Problem

[#1542](https://github.com/joeharris76/BenchBox/pull/1542) has an **empty `statusCheckRollup`** — zero checks, not zero failures.

The cause is not a missing workflow. `validate-submission.yml` lives on `published-results`, triggers on `pull_request` → `published-results` with `paths: results-data/bundles/**`, and **all 100 of #1542's changed files are under that path**. It should have run.

It didn't because the PR's author is `app/github-actions`: `sync-results-data-to-published.yml:195` opens it with `secrets.GITHUB_TOKEN`, and GitHub never starts `pull_request`-triggered runs for `GITHUB_TOKEN` events — documented recursion prevention, not something a trigger filter can reach. The irony is that `validate-submission.yml`'s own comment already documents that this mirror PR is opened with `GITHUB_TOKEN`; nobody joined that to "so this workflow never runs on it."

## Fix — token-free

The sync workflow validates the exact content it is about to propose (the same two gates `validate-submission.yml` would run: `validate_submission.py` and `generate_corpus_inventory.py --check`) and posts the verdict as a `corpus-mirror/validate-bundles` commit status on the mirror branch head.

A commit status is a Statuses-API write, not a workflow trigger, so it is unaffected by the recursion rule and needs **no new credential** — only `statuses: write` on the token the workflow already holds.

## Scope: what's meaningful for a corpus-only branch

`published-results` carries `results-data/`, a slim validation subset of `benchbox/`, two scripts, and docs. Develop's lint/type/pytest matrix has nothing to check there, and the ADR already rejected routing corpus contributions through it. So the mirror PR is judged by exactly the bar a contributor submission PR is judged by — reusing the identical vendored scripts. A test pins that no develop-matrix command creeps into the sync workflow.

## Review found an availability regression

The status and PR-opening steps sit *after* the new setup and validation steps. GitHub skips every later step once one fails, so a flaky `setup-uv` — or any error the validate step's `set -uo pipefail` capture doesn't convert into a reported state — would skip **both**: no status *and* no mirror PR.

That is strictly worse than the blind PR being fixed. Before these steps existed the PR was always created; after, develop's Corpus Drift Check could stay red with nothing open to explain why.

Fixed: both steps run under `always()`, an absent verdict posts as `error` rather than defaulting, and the failure gate is `!= 'success'` rather than `== 'failure'`. **Never default an absent verdict to success** — a green check on content nothing examined is worse than an empty rollup, because it stops anyone looking.

## What this does NOT fix

`published-results` carries exactly one workflow file, so `pr-base-guard.yml` cannot run there — a guard only runs where its file exists. And it cannot be put there by automation: **`GITHUB_TOKEN` cannot push changes under `.github/workflows/` regardless of the `permissions:` block**, which the ADR already documents for `validate-submission.yml` edits. Porting it is a manual maintainer step, written up in the runbook as tracked debt rather than left silent.

Two limits are recorded so a green badge isn't over-read:

- **Advisory, not enforcing.** No ruleset targets `published-results`, so a red mirror PR can still be merged. The draft state and maintainer review are what enforce.
- **Self-attested.** The run that builds the content validates it, so it catches bad content but not a later manual push to the mirror branch. A `--force-with-lease` push from another run re-posts against the new SHA, so a stale green cannot ride on new bytes.

## Falsification

| Neuter | Result |
|---|---|
| Validate step rubber-stamps `STATE="success"` without running either validator (name/id/outputs unchanged) | 1 failure — `validate step never invokes scripts/validate_submission.py` |
| Revert the `always()` guards, the `error` default, and the failure gate | exactly the 3 new availability tests fail; the other 6 pass |

`tests/unit/workflows` 153 passed · `test_stacked_pr_base_guard.py` 5 passed · `pr-base-guard.yml` untouched, still no branch or path filter.