### PR TITLE
fix(core): gate transactional staging reuse on a provenance manifest

### DIFF
--- a/benchbox/core/transaction_primitives/benchmark.py
+++ b/benchbox/core/transaction_primitives/benchmark.py
@@ -465,6 +465,12 @@ class TransactionPrimitivesBenchmark(TransactionalBenchmarkBase["OperationResult
                     except Exception:
                         status[table_name] = 0
 
+            # Record this setup()'s provenance (benchmark, scale, spec version,
+            # source digest) so is_setup() can require an exact match rather
+            # than trusting a bare COUNT(*) that a stale staging set from a
+            # different scale/seed would also satisfy.
+            self._write_staging_manifest(connection, required_tables)
+
             self.log_verbose(f"Setup complete: {status}")
 
             return {
@@ -557,13 +563,22 @@ class TransactionPrimitivesBenchmark(TransactionalBenchmarkBase["OperationResult
         self.log_verbose("Reset complete")
 
     def is_setup(self, connection: DatabaseConnection) -> bool:
-        """Check if staging tables are ready.
+        """Check if staging tables are ready for THIS run.
+
+        Requires both that the key staging tables exist and have data, AND
+        that the staging provenance manifest (see
+        ``TransactionalBenchmarkBase._staging_manifest_matches``) matches
+        this benchmark's scale/spec/source. A staging set left over from a
+        different scale factor (or a legacy database with no manifest at
+        all) fails this check and forces one rebuild, rather than silently
+        benchmarking the wrong data volume.
 
         Args:
             connection: Database connection
 
         Returns:
-            True if all staging tables exist and have data
+            True if all staging tables exist, have data, and their manifest
+            matches this run's provenance.
         """
         try:
             # Check that key staging tables exist and have data
@@ -571,7 +586,7 @@ class TransactionPrimitivesBenchmark(TransactionalBenchmarkBase["OperationResult
                 result = connection.execute(f"SELECT COUNT(*) FROM {table_name}").fetchone()
                 if not result or result[0] == 0:
                     return False
-            return True
+            return self._staging_manifest_matches(connection, ["orders", "lineitem", "customer"])
         except Exception:
             return False
 

--- a/benchbox/core/transactional/benchmark_base.py
+++ b/benchbox/core/transactional/benchmark_base.py
@@ -9,14 +9,17 @@ to implement their spec-specific ``execute_operation``, ``setup``,
 
 from __future__ import annotations
 
+import hashlib
 import re
 from abc import abstractmethod
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Generic, Optional, TypeVar, Union
 
 from benchbox.base import BaseBenchmark, GeneratorOutputDirMixin
 from benchbox.core.connection import DatabaseConnection
 from benchbox.core.operations import OperationExecutor
+from benchbox.core.primitives_benchmark_utils import quote_identifier
 from benchbox.core.transactional.operations_registry_base import OperationsRegistryBase
 
 ResultT = TypeVar("ResultT")
@@ -27,6 +30,11 @@ _SET_THEN_BEGIN_ISOLATION_RE = re.compile(
     r"BEGIN\s+TRANSACTION\s*;",
     re.IGNORECASE,
 )
+
+
+def _sql_escape(value: Any) -> str:
+    """Escape a value for embedding in a single-quoted SQL string literal."""
+    return str(value).replace("'", "''")
 
 
 class TransactionalBenchmarkBase(GeneratorOutputDirMixin, BaseBenchmark, OperationExecutor, Generic[ResultT]):
@@ -298,6 +306,110 @@ class TransactionalBenchmarkBase(GeneratorOutputDirMixin, BaseBenchmark, Operati
                 connection.rollback()
         except Exception as exc:
             self.log_verbose(f"Warning: rollback after operation error failed: {exc}")
+
+    # ------------------------------------------------------------------
+    # Staging provenance manifest
+    #
+    # Shared by transaction_primitives and write_primitives is_setup()/
+    # setup() overrides -- implemented ONCE here so the two families cannot
+    # drift the way the plain-COUNT is_setup checks did (see TODO
+    # transactional-staging-reuse-ignores-provenance). A staging set left
+    # over from a different scale/spec/source cannot silently satisfy
+    # is_setup() for the current run: setup() records this run's provenance
+    # in a single-row-per-benchmark manifest table, and is_setup() requires
+    # an exact match. A missing manifest (every pre-existing database, since
+    # no prior code ever wrote one) is NOT treated as "probably fine" -- it
+    # returns False and forces one self-healing rebuild.
+    # ------------------------------------------------------------------
+
+    #: In-database table recording the provenance (benchmark, scale, spec
+    #: version, source digest) of the staging data the most recent setup()
+    #: produced. Keyed by ``benchmark`` so transaction_primitives and
+    #: write_primitives sharing one physical database do not clobber each
+    #: other's row.
+    _STAGING_MANIFEST_TABLE = "benchbox_staging_manifest"
+
+    def _quote_identifier(self, identifier: str) -> str:
+        """Quote a SQL identifier. Subclasses override for dialect-specific quoting."""
+        return quote_identifier(identifier)
+
+    def _staging_provenance_key(self) -> tuple[str, str, str]:
+        """Return ``(benchmark_id, scale, spec_version)`` identifying this run's staging provenance."""
+        benchmark_id = getattr(self, "_benchmark_label", self.__class__.__name__)
+        return str(benchmark_id), str(self.scale_factor), str(getattr(self, "_version", "unknown"))
+
+    def _staging_source_digest(self, connection: DatabaseConnection, source_tables: list[str]) -> str:
+        """Fingerprint the live TPC-H source tables backing this benchmark's staging data.
+
+        Hashes ordered ``table:row_count`` pairs so a manifest written against
+        one data volume cannot match a differently-provisioned database even
+        when ``scale_factor`` happens to read the same (e.g. a reused
+        directory whose actual row counts diverge from the label). A table
+        access failure counts as ``count=0`` rather than aborting -- mirrors
+        :func:`benchbox.core.primitives_benchmark_utils.table_exists`'s
+        fail-closed philosophy, so a partially loaded source cannot produce a
+        stable-looking digest.
+        """
+        parts = []
+        for table in source_tables:
+            try:
+                quoted = self._quote_identifier(table)
+                result = connection.execute(f"SELECT COUNT(*) FROM {quoted}").fetchone()
+                count = result[0] if result else 0
+            except Exception:
+                count = 0
+            parts.append(f"{table}:{count}")
+        payload = "|".join(parts)
+        return hashlib.sha256(payload.encode("utf-8")).hexdigest()
+
+    def _write_staging_manifest(self, connection: DatabaseConnection, source_tables: list[str]) -> None:
+        """Persist this setup()'s staging provenance so a later is_setup() can require an exact match.
+
+        Called from inside the subclass's own ``setup()`` -- the same
+        connection/lock discipline as the staging tables themselves, so a
+        write failure here raises like any other setup step and rolls back
+        via ``_rollback_connection_after_error`` in ``_prepare_operation``.
+        """
+        benchmark_id, scale, spec_version = self._staging_provenance_key()
+        source_digest = self._staging_source_digest(connection, source_tables)
+        quoted_table = self._quote_identifier(self._STAGING_MANIFEST_TABLE)
+
+        connection.execute(
+            f"CREATE TABLE IF NOT EXISTS {quoted_table} ("
+            "benchmark VARCHAR, scale VARCHAR, spec_version VARCHAR, "
+            "source_digest VARCHAR, created_at VARCHAR)"
+        )
+        connection.execute(f"DELETE FROM {quoted_table} WHERE benchmark = '{_sql_escape(benchmark_id)}'")
+        created_at = datetime.now(timezone.utc).isoformat()
+        connection.execute(
+            f"INSERT INTO {quoted_table} (benchmark, scale, spec_version, source_digest, created_at) VALUES "
+            f"('{_sql_escape(benchmark_id)}', '{_sql_escape(scale)}', '{_sql_escape(spec_version)}', "
+            f"'{_sql_escape(source_digest)}', '{_sql_escape(created_at)}')"
+        )
+
+    def _staging_manifest_matches(self, connection: DatabaseConnection, source_tables: list[str]) -> bool:
+        """Return True iff a manifest row exists whose benchmark/scale/spec/digest match this run.
+
+        A missing manifest table (never written -- true of every pre-existing
+        database) or any read error is NOT reuse-eligible: it returns False
+        and forces one rebuild rather than assuming a legacy database is
+        fine, which is the exact bug this manifest replaces.
+        """
+        benchmark_id, scale, spec_version = self._staging_provenance_key()
+        source_digest = self._staging_source_digest(connection, source_tables)
+        quoted_table = self._quote_identifier(self._STAGING_MANIFEST_TABLE)
+        try:
+            query = (
+                f"SELECT COUNT(*) FROM {quoted_table} WHERE "
+                f"benchmark = '{_sql_escape(benchmark_id)}' AND "
+                f"scale = '{_sql_escape(scale)}' AND "
+                f"spec_version = '{_sql_escape(spec_version)}' AND "
+                f"source_digest = '{_sql_escape(source_digest)}'"
+            )
+            result = connection.execute(query).fetchone()
+            return bool(result and result[0])
+        except Exception:
+            return False
 
     # ------------------------------------------------------------------
     # run_benchmark (identical across both families)

--- a/benchbox/core/write_primitives/benchmark.py
+++ b/benchbox/core/write_primitives/benchmark.py
@@ -850,6 +850,12 @@ class WritePrimitivesBenchmark(TransactionalBenchmarkBase["OperationResult"]):
                     except Exception:
                         status[table_name] = 0
 
+            # Record this setup()'s provenance (benchmark, scale, spec version,
+            # source digest) so is_setup() can require an exact match rather
+            # than trusting a bare COUNT(*) that a stale staging set from a
+            # different scale/seed would also satisfy.
+            self._write_staging_manifest(connection, required_tables)
+
             self.log_verbose(f"Setup complete: {status}")
 
             return {
@@ -953,13 +959,22 @@ class WritePrimitivesBenchmark(TransactionalBenchmarkBase["OperationResult"]):
         self.log_verbose("Reset complete")
 
     def is_setup(self, connection: DatabaseConnection) -> bool:
-        """Check if staging tables are ready.
+        """Check if staging tables are ready for THIS run.
+
+        Requires both that the required staging tables exist and have data,
+        AND that the staging provenance manifest (see
+        ``TransactionalBenchmarkBase._staging_manifest_matches``) matches
+        this benchmark's scale/spec/source. A staging set left over from a
+        different scale factor (or a legacy database with no manifest at
+        all) fails this check and forces one rebuild, rather than silently
+        benchmarking the wrong data volume.
 
         Args:
             connection: Database connection
 
         Returns:
-            True if all staging tables exist and have data
+            True if all required staging tables exist, have data, and their
+            manifest matches this run's provenance.
         """
         try:
             # Check that required staging tables exist and have data
@@ -979,7 +994,7 @@ class WritePrimitivesBenchmark(TransactionalBenchmarkBase["OperationResult"]):
                 result = connection.execute(f"SELECT COUNT(*) FROM {quoted}").fetchone()
                 if not result or result[0] == 0:
                     return False
-            return True
+            return self._staging_manifest_matches(connection, ["orders", "lineitem"])
         except Exception:
             return False
 

--- a/tests/unit/core/test_benchmark_edge_cases.py
+++ b/tests/unit/core/test_benchmark_edge_cases.py
@@ -290,10 +290,23 @@ def test_transaction_primitives_reset_and_setup_checks(tmp_path):
     bench._populate_staging_table = lambda _c, t, s: populated.append((t, s))
     bench.reset(conn)
     assert ("txn_orders", "orders") in populated
-    assert bench.is_setup(conn) is True
 
+    # reset() repopulates staging tables but writes no provenance manifest -- only
+    # setup() does -- so populated-but-unmanifested tables are not reuse-eligible
+    # (TODO transactional-staging-reuse-ignores-provenance-20260805). Matching
+    # manifests round-trip against real DuckDB in
+    # tests/unit/core/transactional/test_staging_provenance.py; _StatefulConn drops
+    # WHERE clauses, so it cannot tell a current manifest from a stale one.
+    manifest = bench._STAGING_MANIFEST_TABLE
+    assert not any(sql.startswith("INSERT INTO") and manifest in sql for sql in conn.executed)
+    # False because the manifest gate rejected it, not because a table looked empty.
+    assert bench.is_setup(conn) is False
+    assert any(manifest in sql for sql in conn.executed)
+
+    # Empty staging tables short-circuit before the manifest is ever consulted.
     conn_zero = _StatefulConn({"txn_orders": 0, "txn_lineitem": 1, "txn_customer": 1})
     assert bench.is_setup(conn_zero) is False
+    assert not any(manifest in sql for sql in conn_zero.executed)
 
     bench.load_data(conn)
     bench.teardown(conn)

--- a/tests/unit/core/transactional/__init__.py
+++ b/tests/unit/core/transactional/__init__.py
@@ -1,0 +1,4 @@
+"""Unit tests for the shared transactional benchmark base.
+
+Copyright 2026 Joe Harris / BenchBox Project
+"""

--- a/tests/unit/core/transactional/test_staging_provenance.py
+++ b/tests/unit/core/transactional/test_staging_provenance.py
@@ -1,0 +1,211 @@
+"""Unit tests for the shared staging provenance manifest.
+
+TODO transactional-staging-reuse-ignores-provenance-20260805: before this
+manifest existed, `is_setup()` decided readiness with a bare
+`SELECT COUNT(*)` on the staging tables. A staging set left over from a
+scale-0.01 run satisfied `is_setup` for a scale-1.0 run against the SAME
+physical database: setup() was skipped, the benchmark executed against the
+wrong data volume, and the run reported a PASS with meaningless timings --
+a silent wrong-results bug, not a hygiene issue.
+
+These tests exercise the fix directly against a real (in-memory) DuckDB
+connection -- the manifest read/write path is SQL executed through
+`connection.execute`, so a mock would only prove the mock's own scripted
+behavior, not that the manifest round-trips through a real engine.
+
+Copyright 2026 Joe Harris / BenchBox Project
+
+Licensed under the MIT License. See LICENSE file in the project root for details.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import duckdb
+import pytest
+
+from benchbox.core.transaction_primitives.benchmark import TransactionPrimitivesBenchmark
+from benchbox.core.write_primitives.benchmark import WritePrimitivesBenchmark
+
+pytestmark = [pytest.mark.unit, pytest.mark.fast, pytest.mark.duckdb, pytest.mark.database]
+
+
+def _minimal_tpch_conn() -> duckdb.DuckDBPyConnection:
+    """A tiny in-memory DuckDB database with orders/lineitem/customer populated.
+
+    Deliberately minimal (a handful of rows) -- these tests exercise
+    provenance bookkeeping, not TPC-H data-generation fidelity.
+    """
+    conn = duckdb.connect(":memory:")
+    conn.execute("""
+        CREATE TABLE orders (
+            o_orderkey INTEGER, o_custkey INTEGER, o_orderstatus VARCHAR,
+            o_totalprice DECIMAL(15,2), o_orderdate DATE, o_orderpriority VARCHAR,
+            o_clerk VARCHAR, o_shippriority INTEGER, o_comment VARCHAR
+        )
+    """)
+    conn.execute("""
+        CREATE TABLE lineitem (
+            l_orderkey INTEGER, l_partkey INTEGER, l_suppkey INTEGER, l_linenumber INTEGER,
+            l_quantity DECIMAL(15,2), l_extendedprice DECIMAL(15,2), l_discount DECIMAL(15,2),
+            l_tax DECIMAL(15,2), l_returnflag VARCHAR, l_linestatus VARCHAR,
+            l_shipdate DATE, l_commitdate DATE, l_receiptdate DATE,
+            l_shipinstruct VARCHAR, l_shipmode VARCHAR, l_comment VARCHAR
+        )
+    """)
+    conn.execute("""
+        CREATE TABLE customer (
+            c_custkey INTEGER, c_name VARCHAR, c_address VARCHAR, c_nationkey INTEGER,
+            c_phone VARCHAR, c_acctbal DECIMAL(15,2), c_mktsegment VARCHAR, c_comment VARCHAR
+        )
+    """)
+    conn.execute("""
+        INSERT INTO orders VALUES
+        (1, 100, 'O', 150.50, '2024-01-01', '1-URGENT', 'Clerk#001', 0, 'o1'),
+        (2, 101, 'O', 250.75, '2024-01-02', '2-HIGH', 'Clerk#002', 0, 'o2'),
+        (3, 102, 'O', 350.00, '2024-01-03', '3-MEDIUM', 'Clerk#003', 0, 'o3')
+    """)
+    conn.execute("""
+        INSERT INTO lineitem VALUES
+        (1, 1001, 201, 1, 10.0, 100.0, 0.05, 0.01, 'N', 'O',
+         '2024-01-15', '2024-01-10', '2024-01-20', 'NONE', 'TRUCK', 'l1'),
+        (2, 1002, 202, 1, 20.0, 200.0, 0.05, 0.01, 'N', 'O',
+         '2024-01-16', '2024-01-11', '2024-01-21', 'NONE', 'MAIL', 'l2'),
+        (3, 1003, 203, 1, 15.0, 150.0, 0.10, 0.02, 'N', 'O',
+         '2024-01-17', '2024-01-12', '2024-01-22', 'NONE', 'SHIP', 'l3')
+    """)
+    conn.execute("""
+        INSERT INTO customer VALUES
+        (100, 'Customer#100', '123 Main St', 1, '555-1234', 1000.00, 'AUTOMOBILE', 'c1'),
+        (101, 'Customer#101', '456 Oak Ave', 1, '555-5678', 2000.00, 'BUILDING', 'c2'),
+        (102, 'Customer#102', '789 Pine Rd', 1, '555-9999', 3000.00, 'MACHINERY', 'c3')
+    """)
+    return conn
+
+
+@pytest.fixture
+def loaded_tpch_conn():
+    conn = _minimal_tpch_conn()
+    yield conn
+    conn.close()
+
+
+class TestTransactionPrimitivesStagingProvenance:
+    """TransactionPrimitivesBenchmark.is_setup() via the shared manifest."""
+
+    def test_no_manifest_is_not_setup(self, tmp_path: Path, loaded_tpch_conn):
+        bench = TransactionPrimitivesBenchmark(scale_factor=0.01, output_dir=tmp_path)
+        assert bench.is_setup(loaded_tpch_conn) is False
+
+    def test_matching_manifest_skips_rebuild(self, tmp_path: Path, loaded_tpch_conn):
+        bench = TransactionPrimitivesBenchmark(scale_factor=0.01, output_dir=tmp_path)
+        bench.setup(loaded_tpch_conn, force=False)
+        assert bench.is_setup(loaded_tpch_conn) is True
+
+        # A second instance at the SAME scale/spec, reusing the same physical
+        # database, must also see the manifest as current -- this is the
+        # intentional-reuse path the fix must not disable.
+        same_scale_bench = TransactionPrimitivesBenchmark(scale_factor=0.01, output_dir=tmp_path)
+        assert same_scale_bench.is_setup(loaded_tpch_conn) is True
+
+    def test_scale_mismatch_forces_rebuild(self, tmp_path: Path, loaded_tpch_conn):
+        """The exact bug: staging tables from a scale-0.01 run must not satisfy
+        is_setup() for a scale-1.0 run against the same physical database."""
+        small = TransactionPrimitivesBenchmark(scale_factor=0.01, output_dir=tmp_path)
+        small.setup(loaded_tpch_conn, force=False)
+        assert small.is_setup(loaded_tpch_conn) is True
+
+        large = TransactionPrimitivesBenchmark(scale_factor=1.0, output_dir=tmp_path)
+        assert large.is_setup(loaded_tpch_conn) is False
+
+    def test_legacy_populated_unmanifested_database_forces_rebuild(self, tmp_path: Path, loaded_tpch_conn):
+        """A database populated by pre-manifest code (staging tables present
+        and non-empty, but `benchbox_staging_manifest` never written) must be
+        treated as NOT set up -- defaulting a missing manifest to "probably
+        fine" would just reinstate the bug this manifest exists to close."""
+        bench = TransactionPrimitivesBenchmark(scale_factor=0.01, output_dir=tmp_path)
+
+        loaded_tpch_conn.execute("CREATE TABLE txn_orders AS SELECT * FROM orders")
+        loaded_tpch_conn.execute("CREATE TABLE txn_lineitem AS SELECT * FROM lineitem")
+        loaded_tpch_conn.execute("CREATE TABLE txn_customer AS SELECT * FROM customer")
+
+        assert bench.is_setup(loaded_tpch_conn) is False
+
+        # And it self-heals: running setup() writes the manifest, after which
+        # is_setup() reports True for this same benchmark/scale.
+        bench.setup(loaded_tpch_conn, force=False)
+        assert bench.is_setup(loaded_tpch_conn) is True
+
+
+class TestWritePrimitivesStagingProvenance:
+    """WritePrimitivesBenchmark.is_setup() via the shared manifest."""
+
+    def test_no_manifest_is_not_setup(self, tmp_path: Path, loaded_tpch_conn):
+        bench = WritePrimitivesBenchmark(scale_factor=0.01, output_dir=tmp_path)
+        assert bench.is_setup(loaded_tpch_conn) is False
+
+    def test_matching_manifest_skips_rebuild(self, tmp_path: Path, loaded_tpch_conn):
+        bench = WritePrimitivesBenchmark(scale_factor=0.01, output_dir=tmp_path)
+        bench.setup(loaded_tpch_conn, force=False)
+        assert bench.is_setup(loaded_tpch_conn) is True
+
+        same_scale_bench = WritePrimitivesBenchmark(scale_factor=0.01, output_dir=tmp_path)
+        assert same_scale_bench.is_setup(loaded_tpch_conn) is True
+
+    def test_scale_mismatch_forces_rebuild(self, tmp_path: Path, loaded_tpch_conn):
+        small = WritePrimitivesBenchmark(scale_factor=0.01, output_dir=tmp_path)
+        small.setup(loaded_tpch_conn, force=False)
+        assert small.is_setup(loaded_tpch_conn) is True
+
+        large = WritePrimitivesBenchmark(scale_factor=1.0, output_dir=tmp_path)
+        assert large.is_setup(loaded_tpch_conn) is False
+
+    def test_legacy_populated_unmanifested_database_forces_rebuild(self, tmp_path: Path, loaded_tpch_conn):
+        bench = WritePrimitivesBenchmark(scale_factor=0.01, output_dir=tmp_path)
+
+        loaded_tpch_conn.execute("CREATE TABLE update_ops_orders AS SELECT * FROM orders")
+        loaded_tpch_conn.execute("CREATE TABLE delete_ops_orders AS SELECT * FROM orders")
+        loaded_tpch_conn.execute("CREATE TABLE delete_ops_lineitem AS SELECT * FROM lineitem")
+        loaded_tpch_conn.execute("CREATE TABLE merge_ops_target AS SELECT * FROM orders")
+        loaded_tpch_conn.execute("CREATE TABLE merge_ops_source AS SELECT * FROM orders")
+        loaded_tpch_conn.execute("CREATE TABLE merge_ops_lineitem_target AS SELECT * FROM lineitem")
+        loaded_tpch_conn.execute(
+            "CREATE TABLE ddl_truncate_target AS SELECT o_orderkey, o_custkey, o_orderdate FROM orders"
+        )
+
+        assert bench.is_setup(loaded_tpch_conn) is False
+
+        bench.setup(loaded_tpch_conn, force=False)
+        assert bench.is_setup(loaded_tpch_conn) is True
+
+
+class TestStagingManifestHelpers:
+    """Direct coverage of the shared TransactionalBenchmarkBase manifest helpers."""
+
+    def test_source_digest_reflects_row_counts(self, tmp_path: Path, loaded_tpch_conn):
+        bench = TransactionPrimitivesBenchmark(scale_factor=0.01, output_dir=tmp_path)
+        digest_before = bench._staging_source_digest(loaded_tpch_conn, ["orders", "lineitem", "customer"])
+
+        loaded_tpch_conn.execute(
+            "INSERT INTO orders VALUES (4, 103, 'O', 50.0, '2024-01-04', '3-MEDIUM', 'Clerk#004', 0, 'o4')"
+        )
+        digest_after = bench._staging_source_digest(loaded_tpch_conn, ["orders", "lineitem", "customer"])
+
+        assert digest_before != digest_after
+
+    def test_manifest_missing_table_does_not_match(self, tmp_path: Path, loaded_tpch_conn):
+        bench = TransactionPrimitivesBenchmark(scale_factor=0.01, output_dir=tmp_path)
+        assert bench._staging_manifest_matches(loaded_tpch_conn, ["orders", "lineitem", "customer"]) is False
+
+    def test_write_then_match_round_trips(self, tmp_path: Path, loaded_tpch_conn):
+        bench = TransactionPrimitivesBenchmark(scale_factor=0.01, output_dir=tmp_path)
+        bench._write_staging_manifest(loaded_tpch_conn, ["orders", "lineitem", "customer"])
+        assert bench._staging_manifest_matches(loaded_tpch_conn, ["orders", "lineitem", "customer"]) is True
+
+    def test_different_spec_version_does_not_match(self, tmp_path: Path, loaded_tpch_conn):
+        bench = TransactionPrimitivesBenchmark(scale_factor=0.01, output_dir=tmp_path)
+        bench._write_staging_manifest(loaded_tpch_conn, ["orders", "lineitem", "customer"])
+
+        bench._version = "2.0"
+        assert bench._staging_manifest_matches(loaded_tpch_conn, ["orders", "lineitem", "customer"]) is False


### PR DESCRIPTION
## Problem

`is_setup()` in `transaction_primitives` and `write_primitives` decided staging
readiness with a bare `SELECT COUNT(*)`. Staging tables left over from a
scale-0.01 run therefore satisfied `is_setup()` for a scale-1.0 run against the
same physical database: `setup()` was skipped, the benchmark executed against the
wrong data volume, and the run reported a PASS with meaningless timings. That is
a silent wrong-results bug, not a hygiene issue.

Closes TODO `transactional-staging-reuse-ignores-provenance-20260805`.

## Change

Two commits:

1. **`fix(core)`** — `setup()` now writes a single-row-per-benchmark
   `benchbox_staging_manifest` table (benchmark, scale, spec_version,
   source_digest, created_at) through a shared helper on
   `TransactionalBenchmarkBase`, so the two families cannot drift the way the
   plain-COUNT checks did. Both `is_setup()` overrides delegate to a shared
   `_staging_manifest_matches()` that requires an exact match *in addition to*
   the existing populated-table check.

   A missing manifest — true of every pre-existing database, since no prior code
   ever wrote one — is deliberately **not** treated as "probably fine". It
   returns `False` and self-heals with one rebuild on next use. Defaulting it to
   reuse-eligible would just reinstate the bug.

2. **`test(core)`** — updates the one out-of-scope test that asserted the old
   contract. `test_transaction_primitives_reset_and_setup_checks` asserted
   `is_setup()` was `True` for a connection whose staging tables were populated
   directly by the `_StatefulConn` constructor — no `setup()` call, and a
   `reset()` with `_populate_staging_table` stubbed out, so no manifest is ever
   written. That is precisely the legacy populated-but-unmanifested database the
   first commit makes ineligible for reuse, so the assertion inverted.

## Why the test asserts the new behavior instead of faking a manifest

The alternative was teaching `_StatefulConn` to recognise the manifest INSERT so
the original `is_setup() is True` assertion could stand. That mock matches
`SELECT COUNT(*)` on table name alone and discards the `WHERE` clause, so a
manifest-aware version would report a match for *any*
benchmark/scale/spec/digest — the assertion would pass even against a broken
match predicate, proving nothing about the gate being added.

So the edge-case test now pins the mechanism rather than the boolean: `reset()`
issues no manifest INSERT, `is_setup()` is `False`, and a manifest query *does*
appear in `conn.executed` — showing the staging-count loop passed and the new
gate is what rejected it. The `conn_zero` case additionally asserts it
short-circuits before the manifest is consulted, keeping the two `False`
assertions on genuinely distinct branches. It references
`_STAGING_MANIFEST_TABLE` rather than a hardcoded name, so a rename fails loudly
instead of going vacuous.

Real manifest round-trips run against live DuckDB in the new
`tests/unit/core/transactional/test_staging_provenance.py`: matching manifest
skips rebuild, scale mismatch forces rebuild, legacy unmanifested database forces
rebuild then self-heals, and digest/spec-version sensitivity.

`_StatefulConn` and `test_write_primitives_setup_walk` are unchanged.

## Verification

- `make pr-preflight` — all lint, artifact-hygiene, DDL-drift, oracle-coverage,
  dependency-audit, and spellcheck gates pass.
- Fast suite: **27138 passed, 19 skipped, 0 failed**. Run single-threaded on the
  documented lock-free path because another worktree held the shared test lock;
  the earlier blocked stage was lock contention, not a failure.
- The updated assertion was confirmed to **fail** against the pre-fix
  `is_setup()` (`assert True is False`), so it is a real regression guard rather
  than a test that merely tolerates the new code.
- Not a soundness path per `_project/scripts/auto_merge_soundness_paths.py`.
  Auto-merge intentionally not armed.
