### PR TITLE
feat(skills): pin todo-db prioritize action via skill-sync

### DIFF
--- a/.claude/skills/todo-db/SKILL.md
+++ b/.claude/skills/todo-db/SKILL.md
@@ -1,15 +1,16 @@
 ---
 name: todo-db
-description: Use when the user asks to "create a TODO", "show TODO items", "manage TODOs", "prioritize TODOs", "implement a TODO", "implement a batch of TODOs", "batch implement TODOs", "complete a TODO", "cleanup TODOs", "review TODO quality", "claim a TODO", "what's ready" / "ready queue", "defer this work", "promote a deferral", "dismiss a deferral", "block"/"unblock a TODO", "create TODOs from a spec", or "todo stats". The production database-backed tracker; all tracker state lives in the shared DB and flows through the `todo` CLI.
-version: 0.3.0
+description: Use when the user asks to "create a TODO", "show TODO items", "manage TODOs", "prioritize TODOs", "top N most important todos", "rank the backlog", "what should we work on", "implement a TODO", "implement a batch of TODOs", "batch implement TODOs", "complete a TODO", "cleanup TODOs", "review TODO quality", "claim a TODO", "what's ready" / "ready queue", "defer this work", "promote a deferral", "dismiss a deferral", "block"/"unblock a TODO", "create TODOs from a spec", or "todo stats". The production database-backed tracker; all tracker state lives in the shared DB and flows through the `todo` CLI (except skill-only analysis actions such as prioritize).
+version: 0.4.0
 tools: Bash, Read, Edit, Write, Task
 ---
 
 # TODO Tracker
 
-Route the requested CLI subcommand to its guide and read that guide before
-acting. The database is the record. Resolve the `todo` command for the
-requested action, not merely by file presence:
+Route the requested action to its guide and read that guide before acting.
+The database is the record. Most actions are CLI subcommands; a few
+(skill-only) are analysis workflows over the same record. Resolve the `todo`
+command for CLI-backed actions, not merely by file presence:
 
 1. If `_project/scripts/todo` exists, inspect its top-level `--help` output.
 2. Use that wrapper only when it advertises the requested subcommand.
@@ -18,6 +19,8 @@ requested action, not merely by file presence:
    identity can be supplied from config, environment, or explicit flags.
 4. If neither command supports the action, report the capability gap and stop;
    never send a standalone-only action to a legacy project wrapper.
+5. Skill-only actions (currently `prioritize`) have no CLI verb — follow their
+   reference guide and use only the inspect verbs the guide names.
 
 Do not assume wrapper behavior from its name. Exit 2 is a generic failure.
 Treat exit 4 as hosted auth failure only when the selected command documents
@@ -33,6 +36,7 @@ Global `--db` / `--actor` flags go before the subcommand.
 | `bootstrap` / `init` / `doctor` | `references/bootstrap.md` |
 | `ready` / `claim` / `start` / `done` / `defer` / `check-scope` / `verify` / `complete` / `promote` / `dismiss` | `references/implement.md` |
 | `create` / `update` / `list` / `show` / `stats` / `deps` / `export` / `block` / `unblock` / `release` / `sweep-stale` / `drop` | `references/queries.md` |
+| `prioritize` (skill-only; no CLI verb) | `references/prioritize.md` |
 | `lint` | `references/review.md` |
 | `finding candidates` / `finding triage` / `finding sync` / `finding promote` | `references/implement.md` |
 | `batch` | `references/batch.md` |

--- a/.claude/skills/todo-db/references/prioritize.md
+++ b/.claude/skills/todo-db/references/prioritize.md
@@ -1,0 +1,167 @@
+# Prioritize TODOs
+
+Produce a ranked shortlist of open tracker items, grouped by topic, without
+rewriting tracker state. This is a **skill action**, not a CLI verb: the
+resolved `todo` command has no `prioritize` subcommand. Read-only by default.
+
+Triggers: "prioritize TODOs", "top N most important", "what should we work on",
+"rank the backlog", "group ready work by topic".
+
+## Preconditions
+
+1. Resolve the `todo` command per SKILL.md (wrapper only when it advertises
+   the inspect verbs you need: at least `doctor`, `stats`, `ready`, `list`,
+   `show`, `deps`).
+2. Run `todo doctor`. Prefer the production backend:
+   - Hosted: `TODO_DB_URL` + `TODO_DB_AUTH_TOKEN` (or the wrapper's remint).
+   - Acceptable read fallback: an explicit embedded replica
+     (`--db <git-root>/.todo-db/replica.db` or `TODO_DB_REPLICA`) when doctor
+     reports schema OK and a non-trivial item count.
+   - Refuse the silent local fallback DB when doctor warns it is **not** the
+     production tracker, unless the user explicitly authorizes analysis on
+     that file. Never run `todo migrate` just to make a stale local spike
+     readable.
+3. If doctor fails on schema/auth/identity, stop and report the gap. Do not
+   invent a parallel backlog from `_project/TODO`, export archives, or chat
+   history.
+
+## Inputs
+
+Parse the request; use defaults when omitted:
+
+| Input | Default | Notes |
+|---|---|---|
+| `N` | 25 | Max ranked items to present |
+| Scope | all open (`planning` + `active`) | May restrict to a worktree, category, or ready-only |
+| Write-back | off | Only rewrite priorities with explicit user authorization |
+
+## Workflow
+
+### 1. Inventory via CLI (always)
+
+Collect the machine picture first:
+
+```sh
+todo doctor
+todo stats
+todo ready
+todo list --priority critical
+todo list --priority high
+todo list --state active
+```
+
+When `N` is large or medium-high matters, also list `--priority medium-high`
+and, if still short, open `medium`. Surface the untriaged-findings stderr
+banner from `ready`/`stats` as a side note (triage via `todo finding
+candidates`); findings are **not** ranked items.
+
+Use `todo show <id>` / `todo show <id> --json` and `todo deps <id>` for any
+item you cannot classify from the list line alone.
+
+### 2. Structured ranking (when CLI lists are too flat)
+
+When the open high-priority set is larger than ~15 or the user wants topic
+groups, build a candidate table. Prefer, in order:
+
+1. `todo export` JSONL/index if present and fresh enough for the question.
+2. Read-only SQL against the **explicit** replica/local path already accepted
+   by doctor (never against a guessed file). Schema is the tracker's own
+   tables (`items`, `item_deps`, optional `findings`); do not assume column
+   names beyond what `PRAGMA table_info` / a sample row shows.
+
+For each open candidate compute:
+
+| Signal | How |
+|---|---|
+| Severity | `critical` > `high` > `medium-high` > `medium` > `low` |
+| Readiness | unblocked (`blocked_reason` empty) and no open dependency edges |
+| Unlock value | count of open items that `needs` this id |
+| In-flight | `active` and/or currently claimed (slight boost, not a free pass) |
+| Blast-radius keywords | privacy/security/correctness tokens in title or category (e.g. leak, secret, credential, egress, pseudonym, oracle, misclassif, provenance, silently, orphan) |
+| Human-only | demote maintainer/admin/settings-only work out of the agent-actionable top N (still list under a "maintainer" footnote when critical) |
+
+Default composite order:
+
+1. severity band
+2. ready before blocked/dependent
+3. blast-radius keyword boost within band
+4. unlock value
+5. active/claimed
+6. stable tie-break on `id`
+
+Do **not** treat "claimed by me" as automatic #1 when a higher-severity
+unclaimed ready item exists.
+
+### 3. Topic grouping
+
+Assign each ranked item exactly one topic. Prefer, in order:
+
+1. Explicit `category` when it is stable and human-meaningful.
+2. Worktree when it is a real program (not a catch-all like `main`).
+3. Keyword buckets from title/description. Reuse buckets that already appear
+   in the inventory rather than inventing a new taxonomy every run. Common
+   BenchBox-shaped buckets (adapt per project): public privacy / credential
+   egress; result integrity & explorer trust; CI / merge / release safety;
+   tracker reliability; UAT operational defects; product/feature spine;
+   architecture / platform.
+
+Keep 4–8 topic groups for a top-25. Merge singletons into a nearest neighbor
+or an "Other high-priority" group rather than emitting fifteen headings.
+
+### 4. Present the shortlist
+
+Default report shape:
+
+1. **Method line** — backend used (hosted / replica path), open counts by
+   priority, `N`, write-back off.
+2. **Grouped tables** — for each topic: rank, id, priority, state, ready?,
+   unlocks, one-line why.
+3. **Suggested execution order** — a short dependency-aware sequence across
+   groups (privacy/security before product spine; tracker lies-to-agents
+   before large batches).
+4. **Demotions** — high/critical items excluded from the top N with reason
+   (blocked, human-only, narrow blast radius, behind deps).
+5. **Side notes** — open findings banner, stale-replica caveat, blocked
+   criticals the user still owns.
+
+Ranks are **session recommendations**. They do not change `priority` in the
+DB.
+
+## Write-back (opt-in only)
+
+Only when the user explicitly asks to apply the ranking (e.g. "write these
+priorities back", "update priorities to match"):
+
+1. Confirm the resolved command supports `update` (standalone todo-db
+   >= 0.3). If the project wrapper lacks it, report the capability gap per
+   SKILL.md rule 4 — do not drop+recreate to change priority.
+2. Update only items whose recommended band differs from stored priority.
+3. Record a one-line reason per update. Prefer band moves
+   (`medium` → `high`) over inventing fractional ranks the schema cannot
+   store.
+4. Re-run `todo stats` and show the before/after open-by-priority counts.
+
+## Anti-patterns
+
+- Ranking from the silent local fallback DB after doctor warned it is not
+  production.
+- Running `todo migrate` on a local spike to "make prioritize work".
+- Treating export archives or `_project/TODO` trees as the live backlog.
+- Rewriting priorities, blocking, or claiming as a side effect of a read-only
+  prioritize request.
+- Dumping all open medium items when the user asked for top 25.
+- One topic per item (topic soup) or a single undifferentiated list when
+  groups were requested.
+- Scoring scripts that hard-code one project's worktree names as the only
+  possible topics without falling back to category/keywords.
+
+## Minimal CLI-only path
+
+If SQL/export is unavailable, still deliver value:
+
+1. `stats` + `ready` + `list --priority critical` + `list --priority high`.
+2. Manually pick up to `N` using severity → ready → unlock (via `todo deps`)
+   → keyword blast radius.
+3. Group by worktree/category from the list lines.
+4. State that unlock counts and blocked reasons may be incomplete without
+   structured dep expansion.

--- a/.claude/skills/todo-db/references/queries.md
+++ b/.claude/skills/todo-db/references/queries.md
@@ -15,5 +15,8 @@
   preserves history and links.
 - Inspect: `todo list [filters]`, `todo show <id> [--json]`, `todo stats`,
   `todo deps <id>`, and `todo export`.
+- Rank / group open work (skill-only, read-only by default): follow
+  `prioritize.md` — not a CLI subcommand; do not invent a `todo prioritize`
+  verb.
 - Block/release/drop: use `todo block <id> --reason ...`, `todo unblock <id>`,
   `todo release <id>`, `todo sweep-stale`, or `todo drop <id> --reason ...`.

--- a/skill-sync.lock
+++ b/skill-sync.lock
@@ -1,16 +1,16 @@
 {
   "version": 1,
-  "lockedAt": "2026-08-05T15:27:56.117Z",
+  "lockedAt": "2026-08-05T19:45:46.309Z",
   "skills": {
     "blog": {
       "source": {
         "type": "git",
         "name": "canonical",
         "url": "https://github.com/joeharris76/skill-sync-skills.git",
-        "ref": "e377ff3e74377e54c2ffbbfcdd5e67bbfd728f19",
+        "ref": "e8e3fe1e6f98cf64a4ff37cfdeb18cf5dab49d3a",
         "subdir": "skills",
-        "revision": "e377ff3e74377e54c2ffbbfcdd5e67bbfd728f19",
-        "fetchedAt": "2026-08-05T15:27:47.276Z"
+        "revision": "e8e3fe1e6f98cf64a4ff37cfdeb18cf5dab49d3a",
+        "fetchedAt": "2026-08-05T19:45:37.673Z"
       },
       "installMode": "mirror",
       "files": {
@@ -61,10 +61,10 @@
         "type": "git",
         "name": "canonical",
         "url": "https://github.com/joeharris76/skill-sync-skills.git",
-        "ref": "e377ff3e74377e54c2ffbbfcdd5e67bbfd728f19",
+        "ref": "e8e3fe1e6f98cf64a4ff37cfdeb18cf5dab49d3a",
         "subdir": "skills",
-        "revision": "e377ff3e74377e54c2ffbbfcdd5e67bbfd728f19",
-        "fetchedAt": "2026-08-05T15:27:48.018Z"
+        "revision": "e8e3fe1e6f98cf64a4ff37cfdeb18cf5dab49d3a",
+        "fetchedAt": "2026-08-05T19:45:38.459Z"
       },
       "installMode": "mirror",
       "files": {
@@ -111,10 +111,10 @@
         "type": "git",
         "name": "canonical",
         "url": "https://github.com/joeharris76/skill-sync-skills.git",
-        "ref": "e377ff3e74377e54c2ffbbfcdd5e67bbfd728f19",
+        "ref": "e8e3fe1e6f98cf64a4ff37cfdeb18cf5dab49d3a",
         "subdir": "skills",
-        "revision": "e377ff3e74377e54c2ffbbfcdd5e67bbfd728f19",
-        "fetchedAt": "2026-08-05T15:27:48.804Z"
+        "revision": "e8e3fe1e6f98cf64a4ff37cfdeb18cf5dab49d3a",
+        "fetchedAt": "2026-08-05T19:45:39.160Z"
       },
       "installMode": "mirror",
       "files": {
@@ -157,10 +157,10 @@
         "type": "git",
         "name": "canonical",
         "url": "https://github.com/joeharris76/skill-sync-skills.git",
-        "ref": "e377ff3e74377e54c2ffbbfcdd5e67bbfd728f19",
+        "ref": "e8e3fe1e6f98cf64a4ff37cfdeb18cf5dab49d3a",
         "subdir": "skills",
-        "revision": "e377ff3e74377e54c2ffbbfcdd5e67bbfd728f19",
-        "fetchedAt": "2026-08-05T15:27:50.308Z"
+        "revision": "e8e3fe1e6f98cf64a4ff37cfdeb18cf5dab49d3a",
+        "fetchedAt": "2026-08-05T19:45:40.898Z"
       },
       "installMode": "mirror",
       "files": {
@@ -187,10 +187,10 @@
         "type": "git",
         "name": "canonical",
         "url": "https://github.com/joeharris76/skill-sync-skills.git",
-        "ref": "e377ff3e74377e54c2ffbbfcdd5e67bbfd728f19",
+        "ref": "e8e3fe1e6f98cf64a4ff37cfdeb18cf5dab49d3a",
         "subdir": "skills",
-        "revision": "e377ff3e74377e54c2ffbbfcdd5e67bbfd728f19",
-        "fetchedAt": "2026-08-05T15:27:51.791Z"
+        "revision": "e8e3fe1e6f98cf64a4ff37cfdeb18cf5dab49d3a",
+        "fetchedAt": "2026-08-05T19:45:42.467Z"
       },
       "installMode": "mirror",
       "files": {
@@ -245,10 +245,10 @@
         "type": "git",
         "name": "canonical",
         "url": "https://github.com/joeharris76/skill-sync-skills.git",
-        "ref": "e377ff3e74377e54c2ffbbfcdd5e67bbfd728f19",
+        "ref": "e8e3fe1e6f98cf64a4ff37cfdeb18cf5dab49d3a",
         "subdir": "skills",
-        "revision": "e377ff3e74377e54c2ffbbfcdd5e67bbfd728f19",
-        "fetchedAt": "2026-08-05T15:27:55.697Z"
+        "revision": "e8e3fe1e6f98cf64a4ff37cfdeb18cf5dab49d3a",
+        "fetchedAt": "2026-08-05T19:45:46.192Z"
       },
       "installMode": "mirror",
       "files": {
@@ -279,10 +279,10 @@
         "type": "git",
         "name": "canonical",
         "url": "https://github.com/joeharris76/skill-sync-skills.git",
-        "ref": "e377ff3e74377e54c2ffbbfcdd5e67bbfd728f19",
+        "ref": "e8e3fe1e6f98cf64a4ff37cfdeb18cf5dab49d3a",
         "subdir": "skills",
-        "revision": "e377ff3e74377e54c2ffbbfcdd5e67bbfd728f19",
-        "fetchedAt": "2026-08-05T15:27:54.935Z"
+        "revision": "e8e3fe1e6f98cf64a4ff37cfdeb18cf5dab49d3a",
+        "fetchedAt": "2026-08-05T19:45:45.538Z"
       },
       "installMode": "mirror",
       "files": {
@@ -305,10 +305,10 @@
         "type": "git",
         "name": "canonical",
         "url": "https://github.com/joeharris76/skill-sync-skills.git",
-        "ref": "e377ff3e74377e54c2ffbbfcdd5e67bbfd728f19",
+        "ref": "e8e3fe1e6f98cf64a4ff37cfdeb18cf5dab49d3a",
         "subdir": "skills",
-        "revision": "e377ff3e74377e54c2ffbbfcdd5e67bbfd728f19",
-        "fetchedAt": "2026-08-05T15:27:52.529Z"
+        "revision": "e8e3fe1e6f98cf64a4ff37cfdeb18cf5dab49d3a",
+        "fetchedAt": "2026-08-05T19:45:43.372Z"
       },
       "installMode": "mirror",
       "files": {
@@ -327,10 +327,10 @@
         "type": "git",
         "name": "canonical",
         "url": "https://github.com/joeharris76/skill-sync-skills.git",
-        "ref": "e377ff3e74377e54c2ffbbfcdd5e67bbfd728f19",
+        "ref": "e8e3fe1e6f98cf64a4ff37cfdeb18cf5dab49d3a",
         "subdir": "skills",
-        "revision": "e377ff3e74377e54c2ffbbfcdd5e67bbfd728f19",
-        "fetchedAt": "2026-08-05T15:27:51.081Z"
+        "revision": "e8e3fe1e6f98cf64a4ff37cfdeb18cf5dab49d3a",
+        "fetchedAt": "2026-08-05T19:45:41.691Z"
       },
       "installMode": "mirror",
       "files": {
@@ -346,17 +346,21 @@
           "sha256": "6fc17f784136f6ae179742379855513792cafcb084feaeb5db73274b3fc22f60",
           "size": 1777
         },
+        "references/prioritize.md": {
+          "sha256": "3b12c55ceea10db384887ee1378d8ec3e0f5344f02f7d577a0f668fe537d7a53",
+          "size": 7014
+        },
         "references/queries.md": {
-          "sha256": "01c5148027786407db44217d055d1551479eed925b53750bb97ed29f00277eeb",
-          "size": 1187
+          "sha256": "6a2df2091e3fd4288ff0689eacd028d0cc81621fb6ce43a258c5f93078574960",
+          "size": 1341
         },
         "references/review.md": {
           "sha256": "716b75c1d896f01219d0d10a00192732d61f471d7f1ea5cbdb837f0a22339013",
           "size": 318
         },
         "SKILL.md": {
-          "sha256": "613c57cbb20c1cc28b0ed6ab77ef7256fa794243252fe4f850e2b9ea6d3236d4",
-          "size": 3124
+          "sha256": "61af6e64d46254111687076de41390ae883f28c685dbf9c803b993e32be6a06d",
+          "size": 3564
         },
         "skill.yaml": {
           "sha256": "e17f6df4c3c3e20399dca7b80f2b0be290cc1f921721f680d44c5a309ae5f7d0",
@@ -369,10 +373,10 @@
         "type": "git",
         "name": "canonical",
         "url": "https://github.com/joeharris76/skill-sync-skills.git",
-        "ref": "e377ff3e74377e54c2ffbbfcdd5e67bbfd728f19",
+        "ref": "e8e3fe1e6f98cf64a4ff37cfdeb18cf5dab49d3a",
         "subdir": "skills",
-        "revision": "e377ff3e74377e54c2ffbbfcdd5e67bbfd728f19",
-        "fetchedAt": "2026-08-05T15:27:49.573Z"
+        "revision": "e8e3fe1e6f98cf64a4ff37cfdeb18cf5dab49d3a",
+        "fetchedAt": "2026-08-05T19:45:40.185Z"
       },
       "installMode": "mirror",
       "files": {
@@ -411,10 +415,10 @@
         "type": "git",
         "name": "canonical",
         "url": "https://github.com/joeharris76/skill-sync-skills.git",
-        "ref": "e377ff3e74377e54c2ffbbfcdd5e67bbfd728f19",
+        "ref": "e8e3fe1e6f98cf64a4ff37cfdeb18cf5dab49d3a",
         "subdir": "skills",
-        "revision": "e377ff3e74377e54c2ffbbfcdd5e67bbfd728f19",
-        "fetchedAt": "2026-08-05T15:27:53.324Z"
+        "revision": "e8e3fe1e6f98cf64a4ff37cfdeb18cf5dab49d3a",
+        "fetchedAt": "2026-08-05T19:45:44.046Z"
       },
       "installMode": "mirror",
       "files": {
@@ -433,10 +437,10 @@
         "type": "git",
         "name": "canonical",
         "url": "https://github.com/joeharris76/skill-sync-skills.git",
-        "ref": "e377ff3e74377e54c2ffbbfcdd5e67bbfd728f19",
+        "ref": "e8e3fe1e6f98cf64a4ff37cfdeb18cf5dab49d3a",
         "subdir": "skills",
-        "revision": "e377ff3e74377e54c2ffbbfcdd5e67bbfd728f19",
-        "fetchedAt": "2026-08-05T15:27:54.105Z"
+        "revision": "e8e3fe1e6f98cf64a4ff37cfdeb18cf5dab49d3a",
+        "fetchedAt": "2026-08-05T19:45:44.797Z"
       },
       "installMode": "mirror",
       "files": {

--- a/skill-sync.yaml
+++ b/skill-sync.yaml
@@ -3,7 +3,7 @@ sources:
   - name: canonical
     type: git
     url: https://github.com/joeharris76/skill-sync-skills.git
-    ref: e377ff3e74377e54c2ffbbfcdd5e67bbfd728f19
+    ref: e8e3fe1e6f98cf64a4ff37cfdeb18cf5dab49d3a
     subdir: skills
 skills:
   - blog


### PR DESCRIPTION
## Summary
- Pins `skill-sync-skills` to `e8e3fe1` (`feat(todo-db): add prioritize skill action (#18)`).
- Rematerializes the tracked `.claude/skills/todo-db` mirror with:
  - `references/prioritize.md` — read-only top-N ranking workflow (CLI inventory, readiness/unlock scoring, topic groups, optional write-back)
  - SKILL.md v0.4.0 route for skill-only `prioritize`
  - pointer from `queries.md`

Source PR: https://github.com/joeharris76/skill-sync-skills/pull/18

## Test plan
- [x] `node skill-sync verify` — tracked claude snapshot matches lock + config
- [x] prioritize.md present under `.claude/skills/todo-db/references/`
- [ ] CI green on develop PR