### PR TITLE
fix/unvalidated submit terminal state

### DIFF
--- a/_project/specs/uat-framework.md
+++ b/_project/specs/uat-framework.md
@@ -148,7 +148,7 @@ tests/uat/
 | `phases/enumerate.py` | Resolve final cell list for execute given config filters and registry truth; honour min/max scale | 100 | 296 |
 | `phases/execute.py` | Sequential iteration over (platform, benchmark, rung); invokes runner+ladder+cleanup; owns Docker platform-boundary lifecycle | 220 | 997 |
 | `phases/validate.py` | Call `benchbox.validation.bundle` in-process; write validator TSV; compute clean-rate floor | 100 | 304 |
-| `phases/package.py` | Read `submit_terminal_state`; invoke `benchbox submit --output` or `--service`; `draft-pr`/`merged-to-published-results` are **stubs** (dispatcher only, per `PR_STUB_TERMINAL_STATES`) that emit the same argv as `local-stage` plus an operator warning -- PR-opening to `published-results` is not implemented | 130 | 170 |
+| `phases/package.py` | Read `submit_terminal_state`; invoke `benchbox submit --output` or `--service`; `draft-pr`/`merged-to-published-results` are **stubs** (dispatcher only, per `PR_STUB_TERMINAL_STATES`) that emit the same argv as `local-stage` plus an operator warning -- PR-opening to `published-results` is not implemented | 130 | 180 |
 | `phases/explorer_smoke.py` | Branch-presence-guarded explorer smoke: always-on corpus contract, delegates build+Playwright to the Results Explorer | 60 | 387 |
 | `phases/report.py` | Read each phase's outputs; emit `matrix_summary.tsv`; cross-scale coverage check | 130 | 462 |
 | `orchestrator.py` | Walk YAML `phases:` list in order; surface phase failures; respect `dry_run:` toggle | 100 | 906 |
@@ -179,13 +179,13 @@ remain hand-tracked.
 - core exercise (execute/matrix/runner/enumerate/cleanup/ladder): 2,365
 - preflight/compat/timeouts: 1,008
 - Docker lifecycle (default-OFF, incl. `container_cleanup.py`): 1,743
-- chartered evidence artifacts (validate/report/package/cells_io/gate_summary): 1,674
+- chartered evidence artifacts (validate/report/package/cells_io/gate_summary): 1,684
 - explorer-prep: 387
 - throughput: 316
 - artifact hygiene: 315
 - package init markers: 23
 
-**Total: 10,294 production LOC across 26 modules.**
+**Total: 10,304 production LOC across 26 modules.**
 
 <!-- UAT-LOC-SUMMARY:END -->
 

--- a/benchbox/cli/commands/submit.py
+++ b/benchbox/cli/commands/submit.py
@@ -32,7 +32,7 @@ from benchbox.core.results.loader import (
     load_result_file,
 )
 from benchbox.core.results.provenance import FUNDING_SOURCES, normalize_funding
-from benchbox.core.results.status import result_non_clean_reason
+from benchbox.core.results.status import result_non_clean_reason, result_unvalidated_reason
 from benchbox.core.results.submission_history import record_hosted_submission
 from benchbox.core.results.submit_classification import (
     SubmitTerminalState,
@@ -185,6 +185,29 @@ def _build_submission_manifest(
     if submission_notes:
         manifest["submission_notes"] = submission_notes
     return manifest
+
+
+def _refuse_non_submittable_result(ctx: click.Context, result: object, submit_state: SubmitTerminalState) -> None:
+    """Print a state-specific refusal message and exit non-zero.
+
+    Unvalidated results get distinct wording so operators do not confuse
+    never-validated runs with schema/integrity failures.
+    """
+    if submit_state is SubmitTerminalState.unvalidated:
+        unvalidated_reason = result_unvalidated_reason(result) or result_non_clean_reason(result)
+        console.print(
+            f"\n[red]❌ Submission refused: result is unvalidated ({unvalidated_reason})[/red]\n"
+            "   Validation never executed (or was skipped); the result is not eligible\n"
+            "   for public submission until validation produces a clean pass."
+        )
+    else:
+        non_clean_reason = result_non_clean_reason(result)
+        console.print(
+            f"\n[red]❌ Submission refused: result is not a clean pass ({non_clean_reason})[/red]\n"
+            "   Query-level failures remain visible in the result artifact, but\n"
+            "   partial runs are not eligible for public submission or leaderboard display."
+        )
+    ctx.exit(1)
 
 
 def _validate_submission_bundle_for_dry_run(ctx: click.Context, source_path: Path) -> None:
@@ -653,13 +676,7 @@ def submit(
         return
 
     if submit_state is not SubmitTerminalState.submittable:
-        non_clean_reason = result_non_clean_reason(result)
-        console.print(
-            f"\n[red]❌ Submission refused: result is not a clean pass ({non_clean_reason})[/red]\n"
-            "   Query-level failures remain visible in the result artifact, but\n"
-            "   partial runs are not eligible for public submission or leaderboard display."
-        )
-        ctx.exit(1)
+        _refuse_non_submittable_result(ctx, result, submit_state)
         return
 
     companions = [

--- a/benchbox/cli/commands/submit.py
+++ b/benchbox/cli/commands/submit.py
@@ -195,11 +195,27 @@ def _refuse_non_submittable_result(ctx: click.Context, result: object, submit_st
     """
     if submit_state is SubmitTerminalState.unvalidated:
         unvalidated_reason = result_unvalidated_reason(result) or result_non_clean_reason(result)
-        console.print(
-            f"\n[red]❌ Submission refused: result is unvalidated ({unvalidated_reason})[/red]\n"
-            "   Validation never executed (or was skipped); the result is not eligible\n"
-            "   for public submission until validation produces a clean pass."
-        )
+        # Branch copy on the concrete status: "never executed" is wrong for
+        # uncertain (validation ran but the correctness claim is weakened).
+        status = None
+        if unvalidated_reason and unvalidated_reason.startswith("validation_status="):
+            status = unvalidated_reason.split("=", 1)[1]
+        if status == "uncertain":
+            detail = (
+                "   Validation completed with an uncertain correctness claim; the result is\n"
+                "   not eligible for public submission until validation produces a clean pass."
+            )
+        elif status in {"not_run", "not_validated", "unknown"}:
+            detail = (
+                "   Validation never executed (or was skipped); the result is not eligible\n"
+                "   for public submission until validation produces a clean pass."
+            )
+        else:
+            detail = (
+                "   The result is not a clean validation pass and is not eligible for public\n"
+                "   submission until validation produces a clean pass."
+            )
+        console.print(f"\n[red]❌ Submission refused: result is unvalidated ({unvalidated_reason})[/red]\n{detail}")
     else:
         non_clean_reason = result_non_clean_reason(result)
         console.print(

--- a/benchbox/core/results/status.py
+++ b/benchbox/core/results/status.py
@@ -15,9 +15,11 @@ NON_CLEAN_TRANSLATION_STATUSES: frozenset[str] = frozenset({"fallback", "failed"
 # executed — DataFrame mode, --validation disabled — is not a failed run.
 # Matches the v0.3.0 exit semantics.
 CLI_FAILURE_VALIDATION_STATUSES: frozenset[str] = frozenset({"failed", "interrupted", "partial", "error"})
-# Derived partition of NON_CLEAN that is not a CLI-level failure: validation
-# never executed (DataFrame mode, --validation disabled, not_run, ...).
-# Keep derived — do not hand-maintain a third literal set.
+# Derived partition of NON_CLEAN that is not a CLI-level failure: statuses that
+# keep the bundle non-clean for publication without making the run a CLI
+# failure. Includes never-executed validation (not_run, not_validated, unknown)
+# and claim-weakened validation (uncertain). Keep derived — do not hand-maintain
+# a third literal set.
 UNVALIDATED_VALIDATION_STATUSES: frozenset[str] = NON_CLEAN_VALIDATION_STATUSES - CLI_FAILURE_VALIDATION_STATUSES
 
 
@@ -111,12 +113,14 @@ def result_cli_failure_reason(result: Any) -> str | None:
 
 
 def result_unvalidated_reason(result: Any) -> str | None:
-    """Return a reason when a result is unvalidated (validation never executed).
+    """Return a reason when validation is non-clean but not a CLI-level failure.
 
     Distinct from CLI failures and schema/integrity violations: statuses in
     :data:`UNVALIDATED_VALIDATION_STATUSES` keep the result non-clean for
-    publication but are not schema-violation terminal states. Returns ``None``
-    when there are failed queries (those take precedence) or when the
+    publication but are not schema-violation terminal states. The partition
+    includes both never-executed validation (``not_run``/``not_validated``/
+    ``unknown``) and claim-weakened validation (``uncertain``). Returns
+    ``None`` when there are failed queries (those take precedence) or when the
     validation status is not in the unvalidated partition.
     """
     if result_failed_query_count(result):

--- a/benchbox/core/results/status.py
+++ b/benchbox/core/results/status.py
@@ -15,6 +15,10 @@ NON_CLEAN_TRANSLATION_STATUSES: frozenset[str] = frozenset({"fallback", "failed"
 # executed — DataFrame mode, --validation disabled — is not a failed run.
 # Matches the v0.3.0 exit semantics.
 CLI_FAILURE_VALIDATION_STATUSES: frozenset[str] = frozenset({"failed", "interrupted", "partial", "error"})
+# Derived partition of NON_CLEAN that is not a CLI-level failure: validation
+# never executed (DataFrame mode, --validation disabled, not_run, ...).
+# Keep derived — do not hand-maintain a third literal set.
+UNVALIDATED_VALIDATION_STATUSES: frozenset[str] = NON_CLEAN_VALIDATION_STATUSES - CLI_FAILURE_VALIDATION_STATUSES
 
 
 def normalize_validation_status(value: Any) -> str | None:
@@ -103,6 +107,24 @@ def result_cli_failure_reason(result: Any) -> str | None:
     translation_status = _result_translation_status(result)
     if translation_status in NON_CLEAN_TRANSLATION_STATUSES:
         return f"translation_status={translation_status}"
+    return None
+
+
+def result_unvalidated_reason(result: Any) -> str | None:
+    """Return a reason when a result is unvalidated (validation never executed).
+
+    Distinct from CLI failures and schema/integrity violations: statuses in
+    :data:`UNVALIDATED_VALIDATION_STATUSES` keep the result non-clean for
+    publication but are not schema-violation terminal states. Returns ``None``
+    when there are failed queries (those take precedence) or when the
+    validation status is not in the unvalidated partition.
+    """
+    if result_failed_query_count(result):
+        return None
+
+    status = normalize_validation_status(getattr(result, "validation_status", None))
+    if status in UNVALIDATED_VALIDATION_STATUSES:
+        return f"validation_status={status}"
     return None
 
 

--- a/benchbox/core/results/submit_classification.py
+++ b/benchbox/core/results/submit_classification.py
@@ -25,7 +25,11 @@ from benchbox.core.results.loader import (
     UnsupportedSchemaError,
     load_result_file,
 )
-from benchbox.core.results.status import result_failed_query_count, result_non_clean_reason
+from benchbox.core.results.status import (
+    result_failed_query_count,
+    result_non_clean_reason,
+    result_unvalidated_reason,
+)
 from benchbox.validation.bundle import CLI_REFUSED_COMPLIANCE_CLASSES
 
 
@@ -36,6 +40,7 @@ class SubmitTerminalState(str, Enum):
     unofficial = "unofficial"
     query_failure = "query_failure"
     schema_violation = "schema_violation"
+    unvalidated = "unvalidated"
     missing_manifest = "missing_manifest"
 
 
@@ -43,10 +48,10 @@ def classify_loaded_result(result: Any) -> SubmitTerminalState:
     """Classify an already-loaded result object (no I/O).
 
     Unofficial TPC-DS compliance classes remain successful but non-submittable;
-    non-clean results are refused, splitting query-level failures from other
-    schema/integrity problems. Compliance is checked before clean-ness so a
-    result that is both unofficial and non-clean classifies as ``unofficial``,
-    matching the CLI's branch order.
+    non-clean results are refused, splitting query-level failures, never-
+    validated runs, and other schema/integrity problems. Compliance is checked
+    before clean-ness so a result that is both unofficial and non-clean
+    classifies as ``unofficial``, matching the CLI's branch order.
     """
     if getattr(result, "compliance_class", None) in CLI_REFUSED_COMPLIANCE_CLASSES:
         return SubmitTerminalState.unofficial
@@ -55,6 +60,8 @@ def classify_loaded_result(result: Any) -> SubmitTerminalState:
     if non_clean_reason:
         if result_failed_query_count(result):
             return SubmitTerminalState.query_failure
+        if result_unvalidated_reason(result):
+            return SubmitTerminalState.unvalidated
         return SubmitTerminalState.schema_violation
     return SubmitTerminalState.submittable
 

--- a/tests/uat/phases/package.py
+++ b/tests/uat/phases/package.py
@@ -138,8 +138,18 @@ def run_package(
     for result_path in result_paths:
         if classify_results and result_path.exists():
             submit_state = classify_for_submit(result_path)
-            if submit_state is SubmitTerminalState.unofficial:
-                warn(f"[package] skipping unofficial result {result_path}: submit_terminal_state=unofficial")
+            # Soft-skip states that are successful runs but non-submittable: they
+            # must not inflate package failure_count (same posture as unofficial).
+            # Integrity failures (query_failure / schema_violation / missing_manifest)
+            # still count as package failures.
+            if submit_state in {
+                SubmitTerminalState.unofficial,
+                SubmitTerminalState.unvalidated,
+            }:
+                warn(
+                    f"[package] skipping {submit_state.value} result {result_path}: "
+                    f"submit_terminal_state={submit_state.value}"
+                )
                 continue
             if submit_state is not SubmitTerminalState.submittable:
                 warn(

--- a/tests/uat/test_package.py
+++ b/tests/uat/test_package.py
@@ -108,10 +108,95 @@ def test_package_counts_failures(tmp_path: Path):
         result_paths=[tmp_path / f"r{i}.json" for i in range(3)],
         submissions_dir=tmp_path / "subs",
         runner=runner,
+        # Missing paths skip classification; exercise submit-runner failure counts.
+        classify_results=False,
     )
     assert result.success_count == 2
     assert result.failure_count == 1
     assert result.exit_code() == 1
+
+
+def _write_minimal_result(path: Path, *, validation: str = "passed", compliance_class: str | None = None) -> None:
+    import json
+
+    payload = {
+        "version": "2.1",
+        "run": {"id": "pkg", "timestamp": "2026-01-01T00:00:00", "total_duration_ms": 1},
+        "benchmark": {"id": "tpch", "name": "TPC-H", "scale_factor": 0.01, "test_type": "power"},
+        "platform": {"name": "DuckDB"},
+        "summary": {
+            "queries": {"total": 1, "passed": 1, "failed": 0},
+            "validation": {"status": validation},
+        },
+        "queries": [{"id": "Q1", "status": "SUCCESS", "execution_time_ms": 1}],
+        "phases": {},
+    }
+    if compliance_class is not None:
+        payload["benchmark"]["compliance_class"] = compliance_class
+    path.write_text(json.dumps(payload), encoding="utf-8")
+
+
+def test_package_skips_unvalidated_without_counting_failure(tmp_path: Path):
+    """Unvalidated (never-validated) results soft-skip like unofficial; not package failures."""
+    cfg = validate_config({"name": "x", "package": {"submit_terminal_state": "local-stage"}})
+    clean = tmp_path / "clean.json"
+    unvalidated = tmp_path / "unvalidated.json"
+    _write_minimal_result(clean, validation="passed")
+    _write_minimal_result(unvalidated, validation="not_validated")
+    runner = _fake_runner_factory([0])
+    warnings: list[str] = []
+    result = package.run_package(
+        cfg,
+        result_paths=[clean, unvalidated],
+        submissions_dir=tmp_path / "subs",
+        runner=runner,
+        warn=warnings.append,
+        classify_results=True,
+    )
+    assert result.success_count == 1
+    assert result.failure_count == 0
+    assert result.exit_code() == 0
+    assert len(result.invocations) == 1
+    assert any("unvalidated" in w for w in warnings)
+
+
+def test_package_skips_unofficial_without_counting_failure(tmp_path: Path):
+    cfg = validate_config({"name": "x", "package": {"submit_terminal_state": "local-stage"}})
+    unofficial = tmp_path / "unofficial.json"
+    _write_minimal_result(unofficial, compliance_class="unofficial_subscale")
+    runner = _fake_runner_factory([])
+    warnings: list[str] = []
+    result = package.run_package(
+        cfg,
+        result_paths=[unofficial],
+        submissions_dir=tmp_path / "subs",
+        runner=runner,
+        warn=warnings.append,
+        classify_results=True,
+    )
+    assert result.success_count == 0
+    assert result.failure_count == 0
+    assert result.invocations == ()
+    assert any("unofficial" in w for w in warnings)
+
+
+def test_package_counts_schema_violation_as_failure(tmp_path: Path):
+    cfg = validate_config({"name": "x", "package": {"submit_terminal_state": "local-stage"}})
+    bad = tmp_path / "schema.json"
+    _write_minimal_result(bad, validation="failed")
+    runner = _fake_runner_factory([])
+    warnings: list[str] = []
+    result = package.run_package(
+        cfg,
+        result_paths=[bad],
+        submissions_dir=tmp_path / "subs",
+        runner=runner,
+        warn=warnings.append,
+        classify_results=True,
+    )
+    assert result.failure_count == 1
+    assert result.invocations == ()
+    assert any("schema_violation" in w for w in warnings)
 
 
 @pytest.mark.parametrize("state", sorted(package.PR_STUB_TERMINAL_STATES))

--- a/tests/uat/test_runner.py
+++ b/tests/uat/test_runner.py
@@ -483,8 +483,18 @@ def test_classify_for_submit_vocabulary_and_clean_result(tmp_path: Path):
         "unofficial",
         "query_failure",
         "schema_violation",
+        "unvalidated",
         "missing_manifest",
     }
+
+
+def test_submit_state_is_cell_failure_excludes_unvalidated() -> None:
+    """Unvalidated cells stay PASSED; only integrity failures downgrade the cell."""
+    assert not runner.submit_state_is_cell_failure("unvalidated")
+    assert not runner.submit_state_is_cell_failure(runner.SubmitTerminalState.unvalidated)
+    assert runner.submit_state_is_cell_failure("schema_violation")
+    assert runner.submit_state_is_cell_failure("query_failure")
+    assert runner.submit_state_is_cell_failure("missing_manifest")
 
 
 def test_classify_for_submit_marks_query_failure_and_run_cell_failed(tmp_path: Path):

--- a/tests/uat/test_runner.py
+++ b/tests/uat/test_runner.py
@@ -32,9 +32,17 @@ def _isolate_cwd(tmp_path: Path, monkeypatch):
     monkeypatch.chdir(tmp_path)
 
 
-def _write_result_json(path: Path, *, failed: int = 0, compliance_class: str | None = None) -> None:
+def _write_result_json(
+    path: Path,
+    *,
+    failed: int = 0,
+    compliance_class: str | None = None,
+    validation: str | None = None,
+) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
     passed = 1 if failed == 0 else 0
+    if validation is None:
+        validation = "passed" if failed == 0 else "failed"
     payload = {
         "version": "2.1",
         "run": {
@@ -54,7 +62,7 @@ def _write_result_json(path: Path, *, failed: int = 0, compliance_class: str | N
         "platform": {"name": "DuckDB"},
         "summary": {
             "queries": {"total": 1, "passed": passed, "failed": failed},
-            "validation": {"status": "passed" if failed == 0 else "failed"},
+            "validation": {"status": validation},
         },
         "queries": [{"id": "Q1", "status": "SUCCESS" if failed == 0 else "ERROR", "execution_time_ms": 1}],
         "phases": {},
@@ -522,6 +530,28 @@ def test_classify_for_submit_keeps_unofficial_as_passed_cell(tmp_path: Path):
     assert runner.classify_for_submit(result_path) is runner.SubmitTerminalState.unofficial
     assert result.status == "passed"
     assert result.submit_terminal_state == "unofficial"
+
+
+def test_classify_for_submit_keeps_unvalidated_as_passed_cell(tmp_path: Path):
+    """Never-validated results must not flip UAT cells to FAILED (DataFrame false 0%)."""
+    result_path = tmp_path / "benchmark_runs" / "results" / "unvalidated.json"
+    _write_result_json(result_path, validation="not_validated")
+    fake_argv = [sys.executable, "-c", f"print({str(result_path)!r})"]
+
+    with patch.object(runner, "benchbox_run_argv", return_value=fake_argv):
+        result = runner.run_cell("duckdb", "tpch", 0.01, timeout_s=10, log_dir=tmp_path)
+
+    assert runner.classify_for_submit(result_path) is runner.SubmitTerminalState.unvalidated
+    assert result.status == "passed"
+    assert result.exit_code == 0
+    assert result.submit_terminal_state == "unvalidated"
+
+
+def test_classify_for_submit_prefers_unofficial_over_unvalidated(tmp_path: Path):
+    """Compliance refusal still wins when a result is both unofficial and unvalidated."""
+    result_path = tmp_path / "benchmark_runs" / "results" / "unofficial-unvalidated.json"
+    _write_result_json(result_path, compliance_class="unofficial_subscale", validation="not_validated")
+    assert runner.classify_for_submit(result_path) is runner.SubmitTerminalState.unofficial
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/cli/commands/test_submit.py
+++ b/tests/unit/cli/commands/test_submit.py
@@ -171,6 +171,24 @@ def test_submit_refuses_partial_query_failure(monkeypatch: pytest.MonkeyPatch, t
     assert not out_dir.exists()
 
 
+def test_submit_refuses_unvalidated_with_distinct_message(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    src = tmp_path / "tpch_duckdb_unvalidated.json"
+    src.write_text('{"schema_version": "2.0"}', encoding="utf-8")
+    unvalidated = _fake_result()
+    unvalidated.validation_status = "not_validated"
+    unvalidated.failed_queries = 0
+    monkeypatch.setattr(sub, "load_result_file", lambda *_a, **_k: (unvalidated, {}))
+
+    out_dir = tmp_path / "submission"
+    result = CliRunner().invoke(sub.submit, [str(src), "--output", str(out_dir)])
+
+    assert result.exit_code == 1
+    assert "unvalidated" in result.output
+    assert "validation_status=not_validated" in result.output
+    assert "schema violation" not in result.output.lower()
+    assert not out_dir.exists()
+
+
 # ---------------------------------------------------------------------------
 # 4b. Packaged CONTRIBUTING.md aligns with canonical docs/contributing-results.md
 #     (regression for dry-run-followup-package-canonical-contributing)

--- a/tests/unit/core/results/test_status.py
+++ b/tests/unit/core/results/test_status.py
@@ -7,11 +7,15 @@ from types import SimpleNamespace
 import pytest
 
 from benchbox.core.results.status import (
+    CLI_FAILURE_VALIDATION_STATUSES,
+    NON_CLEAN_VALIDATION_STATUSES,
+    UNVALIDATED_VALIDATION_STATUSES,
     bundle_failed_query_count,
     bundle_is_clean_pass,
     result_cli_failure_reason,
     result_failed_query_count,
     result_is_clean_pass,
+    result_unvalidated_reason,
 )
 
 pytestmark = [
@@ -109,3 +113,28 @@ def test_translation_fallback_is_a_cli_failure() -> None:
         execution_metadata={"translation": {"status": "fallback"}},
     )
     assert result_cli_failure_reason(result) == "translation_status=fallback"
+
+
+def test_validation_status_set_partition() -> None:
+    """UNVALIDATED is the derived NON_CLEAN - CLI_FAILURE partition; keep it that way."""
+    assert CLI_FAILURE_VALIDATION_STATUSES < NON_CLEAN_VALIDATION_STATUSES
+    assert UNVALIDATED_VALIDATION_STATUSES == NON_CLEAN_VALIDATION_STATUSES - CLI_FAILURE_VALIDATION_STATUSES
+    assert UNVALIDATED_VALIDATION_STATUSES
+    assert not (UNVALIDATED_VALIDATION_STATUSES & CLI_FAILURE_VALIDATION_STATUSES)
+
+
+@pytest.mark.parametrize("status", sorted(UNVALIDATED_VALIDATION_STATUSES))
+def test_result_unvalidated_reason_for_unvalidated_statuses(status: str) -> None:
+    result = SimpleNamespace(total_queries=1, successful_queries=1, failed_queries=0, validation_status=status)
+    assert result_unvalidated_reason(result) == f"validation_status={status}"
+
+
+def test_result_unvalidated_reason_none_when_query_failed() -> None:
+    result = SimpleNamespace(total_queries=2, successful_queries=1, failed_queries=1, validation_status="not_run")
+    assert result_unvalidated_reason(result) is None
+
+
+@pytest.mark.parametrize("status", sorted(CLI_FAILURE_VALIDATION_STATUSES))
+def test_result_unvalidated_reason_none_for_cli_failure_statuses(status: str) -> None:
+    result = SimpleNamespace(total_queries=1, successful_queries=1, failed_queries=0, validation_status=status)
+    assert result_unvalidated_reason(result) is None

--- a/tests/unit/core/results/test_submit_classifier_contract.py
+++ b/tests/unit/core/results/test_submit_classifier_contract.py
@@ -73,8 +73,22 @@ def _loadable_cases(tmp_path: Path) -> list[tuple[str, Path, SubmitTerminalState
     unvalidated_not_run = tmp_path / "unvalidated-not-run.json"
     _write_result_json(unvalidated_not_run, failed=0, validation="not_run")
 
+    unvalidated_uncertain = tmp_path / "unvalidated-uncertain.json"
+    _write_result_json(unvalidated_uncertain, failed=0, validation="uncertain")
+
+    unvalidated_unknown = tmp_path / "unvalidated-unknown.json"
+    _write_result_json(unvalidated_unknown, failed=0, validation="unknown")
+
     unofficial = tmp_path / "unofficial.json"
     _write_result_json(unofficial, compliance_class="unofficial_subscale")
+
+    unofficial_and_unvalidated = tmp_path / "unofficial-and-unvalidated.json"
+    _write_result_json(
+        unofficial_and_unvalidated,
+        failed=0,
+        validation="not_validated",
+        compliance_class="unofficial_subscale",
+    )
 
     return [
         ("clean", clean, SubmitTerminalState.submittable),
@@ -82,7 +96,10 @@ def _loadable_cases(tmp_path: Path) -> list[tuple[str, Path, SubmitTerminalState
         ("schema_violation", schema_violation, SubmitTerminalState.schema_violation),
         ("unvalidated_not_validated", unvalidated_not_validated, SubmitTerminalState.unvalidated),
         ("unvalidated_not_run", unvalidated_not_run, SubmitTerminalState.unvalidated),
+        ("unvalidated_uncertain", unvalidated_uncertain, SubmitTerminalState.unvalidated),
+        ("unvalidated_unknown", unvalidated_unknown, SubmitTerminalState.unvalidated),
         ("unofficial", unofficial, SubmitTerminalState.unofficial),
+        ("unofficial_and_unvalidated", unofficial_and_unvalidated, SubmitTerminalState.unofficial),
     ]
 
 
@@ -134,5 +151,10 @@ def test_submit_classifier_contract_cli_refusal_tracks_state(tmp_path: Path, mon
                 assert "unvalidated" in result.output, label
                 assert "validation_status=" in result.output, label
                 assert "schema violation" not in result.output.lower(), label
+                if "uncertain" in label:
+                    assert "uncertain correctness claim" in result.output, label
+                    assert "never executed" not in result.output, label
+                elif "not_validated" in label or "not_run" in label or "unknown" in label:
+                    assert "never executed" in result.output or "was skipped" in result.output, label
             else:
                 assert "not a clean pass" in result.output, label

--- a/tests/unit/core/results/test_submit_classifier_contract.py
+++ b/tests/unit/core/results/test_submit_classifier_contract.py
@@ -67,6 +67,12 @@ def _loadable_cases(tmp_path: Path) -> list[tuple[str, Path, SubmitTerminalState
     schema_violation = tmp_path / "schema-violation.json"
     _write_result_json(schema_violation, failed=0, validation="failed")
 
+    unvalidated_not_validated = tmp_path / "unvalidated-not-validated.json"
+    _write_result_json(unvalidated_not_validated, failed=0, validation="not_validated")
+
+    unvalidated_not_run = tmp_path / "unvalidated-not-run.json"
+    _write_result_json(unvalidated_not_run, failed=0, validation="not_run")
+
     unofficial = tmp_path / "unofficial.json"
     _write_result_json(unofficial, compliance_class="unofficial_subscale")
 
@@ -74,6 +80,8 @@ def _loadable_cases(tmp_path: Path) -> list[tuple[str, Path, SubmitTerminalState
         ("clean", clean, SubmitTerminalState.submittable),
         ("query_failure", query_failure, SubmitTerminalState.query_failure),
         ("schema_violation", schema_violation, SubmitTerminalState.schema_violation),
+        ("unvalidated_not_validated", unvalidated_not_validated, SubmitTerminalState.unvalidated),
+        ("unvalidated_not_run", unvalidated_not_run, SubmitTerminalState.unvalidated),
         ("unofficial", unofficial, SubmitTerminalState.unofficial),
     ]
 
@@ -121,5 +129,10 @@ def test_submit_classifier_contract_cli_refusal_tracks_state(tmp_path: Path, mon
             assert "Submission refused" in result.output, label
             if expected is SubmitTerminalState.unofficial:
                 assert "compliance_class" in result.output, label
+            elif expected is SubmitTerminalState.unvalidated:
+                # Distinct wording: must name unvalidated, not imply schema violation.
+                assert "unvalidated" in result.output, label
+                assert "validation_status=" in result.output, label
+                assert "schema violation" not in result.output.lower(), label
             else:
                 assert "not a clean pass" in result.output, label


### PR DESCRIPTION
- **fix(results): classify unvalidated runs distinctly from schema violations**
- **test(uat): pin unvalidated cells stay PASSED through run_cell**
