### PR TITLE
fix(todo-db): auto-provision hosted tracker auth via turso CLI

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -71,6 +71,26 @@ GOOGLE_APPLICATION_CREDENTIALS=/path/to/service-account.json
 # REDSHIFT_S3_BUCKET=your-staging-bucket
 
 # ==============================================================================
+# TODO tracker (_project/scripts/todo) hosted backend
+# ==============================================================================
+# The tracker normally resolves its own backend: with none of these set, it
+# auto-provisions a short-lived hosted connection via a logged-in `turso` CLI
+# (see docs/operations/todo-db-benchbox-extraction.md, "Local auth
+# provisioning"). Set these only to override that, e.g. in CI or to pin a
+# specific database/token instead of relying on turso auto-provisioning.
+
+# Hosted database URL (libsql:// or https://); unset to use the local fallback
+# or turso auto-provisioning.
+# TODO_DB_URL=libsql://your-db-name.turso.io
+
+# Auth token for TODO_DB_URL. Never commit a real value.
+# TODO_DB_AUTH_TOKEN=your-turso-auth-token
+
+# turso database name used by auto-provisioning when TODO_DB_URL is unset.
+# Defaults to benchbox-todo.
+# TODO_DB_TURSO_DB=benchbox-todo
+
+# ==============================================================================
 # General BenchBox Settings
 # ==============================================================================
 

--- a/_project/scripts/todo_db.py
+++ b/_project/scripts/todo_db.py
@@ -16,6 +16,8 @@ Backend selection (first match wins):
                             replica at <git root>/.todo-db/replica.db
                             (override: TODO_DB_REPLICA); plaintext
                             http:// is refused
+- turso auto-provision      when none of the above are set and a logged-in
+                            `turso` CLI can mint a short-lived token
 - default                   <git main root>/.todo-db/todo.sqlite (gitignored)
 
 Hosted mode keeps the exact write-transaction discipline of local mode:
@@ -526,21 +528,91 @@ def _require_secure_url(url: str) -> str:
     return url
 
 
-def _resolve_backend(explicit: str | None) -> tuple[Path | str, bool]:
-    """Return ``(backend, implicit_default_local)`` using CLI precedence."""
+def _turso_db_name() -> str:
+    return os.environ.get("TODO_DB_TURSO_DB") or "benchbox-todo"
+
+
+def _try_turso_auto_provision() -> tuple[str, str] | None:
+    """Mint a short-lived hosted backend via the maintainer's logged-in turso CLI.
+
+    Only called from `_resolve_backend` when no explicit backend is configured
+    at all (--db absent, TODO_DB_PATH unset, TODO_DB_URL unset) -- this is the
+    sanctioned local pattern documented in
+    _project/specs/todo-db-tracker.md ("Local auth provisioning"): mint a URL
+    with `turso db show <name> --url` and a token with
+    `turso db tokens create <name> --expiration 1d` (Turso CLI accepts
+    day-granularity expirations or ``never``; sub-day values like ``30m``
+    are rejected).
+
+    Returns ``(url, token)`` on success, ``None`` on ANY failure -- turso not
+    on PATH, not logged in, a nonzero exit, or empty output -- so the caller
+    falls through to the existing implicit-local-fallback behavior. Neither
+    the URL nor the token is ever printed or logged here.
+    """
+    if not shutil.which("turso"):
+        return None
+    name = _turso_db_name()
+    try:
+        show = subprocess.run(
+            ["turso", "db", "show", name, "--url"],
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=15,
+        )
+        if show.returncode != 0:
+            return None
+        url = show.stdout.strip()
+        if not url:
+            return None
+        tokens = subprocess.run(
+            ["turso", "db", "tokens", "create", name, "--expiration", "1d"],
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=15,
+        )
+        if tokens.returncode != 0:
+            return None
+        token = tokens.stdout.strip()
+        if not token:
+            return None
+        return url, token
+    except (OSError, subprocess.SubprocessError):
+        return None
+
+
+def _resolve_backend(explicit: str | None) -> tuple[Path | str, bool, bool]:
+    """Return ``(backend, implicit_default_local, auto_provisioned)``.
+
+    CLI precedence: --db > TODO_DB_PATH > TODO_DB_URL > turso auto-provisioning
+    > local fallback. Auto-provisioning is attempted ONLY when none of the
+    three explicit knobs are set, so explicit config always outranks it and
+    hermetic tests pinning TODO_DB_PATH never invoke it.
+    """
     if explicit:
-        return (_normalize_url(explicit) if _is_hosted_url(explicit) else Path(explicit)), False
+        return (_normalize_url(explicit) if _is_hosted_url(explicit) else Path(explicit)), False, False
     env_path = os.environ.get("TODO_DB_PATH")
     if env_path:
-        return Path(env_path), False
+        return Path(env_path), False, False
     env_url = os.environ.get("TODO_DB_URL")
     if env_url:
-        return _normalize_url(env_url), False
-    return git_main_root() / ".todo-db" / "todo.sqlite", True
+        return _normalize_url(env_url), False, False
+    provisioned = _try_turso_auto_provision()
+    if provisioned:
+        url, token = provisioned
+        # Use the hosted backend exactly as if TODO_DB_URL/TODO_DB_AUTH_TOKEN
+        # had been set: propagate in-process only (never written to disk or
+        # printed) so every downstream reader (_auth_token(), connect_hosted(),
+        # etc.) works unchanged.
+        os.environ["TODO_DB_URL"] = url
+        os.environ["TODO_DB_AUTH_TOKEN"] = token
+        return _normalize_url(url), False, True
+    return git_main_root() / ".todo-db" / "todo.sqlite", True, False
 
 
 def resolve_backend(explicit: str | None) -> Path | str:
-    """Pick the backend: --db > TODO_DB_PATH > TODO_DB_URL > local fallback."""
+    """Pick the backend: --db > TODO_DB_PATH > TODO_DB_URL > auto-provision > local fallback."""
     return _resolve_backend(explicit)[0]
 
 
@@ -1326,7 +1398,7 @@ def _premigrate_freeze_refusal(backend: Path | str, actor: str) -> int | None:
     return 2
 
 
-def _report_backend(backend: Path | str, *, implicit_default_local: bool) -> None:
+def _report_backend(backend: Path | str, *, implicit_default_local: bool, auto_provisioned: bool = False) -> None:
     if isinstance(backend, Path):
         print(f"todo backend: local ({backend})", file=sys.stderr)
         if implicit_default_local:
@@ -1337,7 +1409,10 @@ def _report_backend(backend: Path | str, *, implicit_default_local: bool) -> Non
             )
         return
     # Never print the hosted URL or token: the backend kind is enough.
-    print("todo backend: hosted", file=sys.stderr)
+    if auto_provisioned:
+        print("todo backend: hosted (auto-provisioned via turso CLI)", file=sys.stderr)
+    else:
+        print("todo backend: hosted", file=sys.stderr)
 
 
 def connect_backend(
@@ -1399,7 +1474,13 @@ def _doctor_incompatible_schema_detail(version: int) -> str:
     return f"v{version} is newer than this CLI (v{SCHEMA_VERSION}); use a newer CLI"
 
 
-def run_doctor(backend: Path | str, *, implicit_default_local: bool, as_json: bool = False) -> int:
+def run_doctor(
+    backend: Path | str,
+    *,
+    implicit_default_local: bool,
+    auto_provisioned: bool = False,
+    as_json: bool = False,
+) -> int:
     """Side-effect-free health check over config, identity, reachability, and auth.
 
     The preflight the batch workflow mandates. It performs NO tracker write and
@@ -1422,17 +1503,29 @@ def run_doctor(backend: Path | str, *, implicit_default_local: bool, as_json: bo
     # it is a legitimate scratch target, but it is NOT the production tracker, and
     # a batch run that silently used it would write real work to a throwaway DB.
     if hosted:
-        record("backend", "OK", "hosted (URL withheld)")
-    else:
-        record("backend", "OK", f"local ({backend})")
-    if implicit_default_local:
-        record(
-            "identity",
-            "WARN",
-            "implicit local fallback -- NOT the production tracker; set --db, TODO_DB_PATH, or TODO_DB_URL",
+        backend_detail = (
+            "hosted (auto-provisioned via turso CLI, URL withheld)"
+            if auto_provisioned
+            else "hosted (URL withheld)"
+        )
+        identity_status, identity_detail = (
+            ("OK", "hosted backend auto-provisioned via turso CLI")
+            if auto_provisioned
+            else ("OK", "backend selected explicitly")
         )
     else:
-        record("identity", "OK", "backend selected explicitly")
+        backend_detail = f"local ({backend})"
+        identity_status, identity_detail = (
+            (
+                "WARN",
+                "implicit local fallback -- NOT the production tracker; "
+                "set --db, TODO_DB_PATH, or TODO_DB_URL",
+            )
+            if implicit_default_local
+            else ("OK", "backend selected explicitly")
+        )
+    record("backend", "OK", backend_detail)
+    record("identity", identity_status, identity_detail)
 
     # 2. Auth. Only hosted needs a token; checked before reachability so a missing
     # token reports as auth rather than as a confusing connection error.
@@ -1519,6 +1612,7 @@ def _preconnect_command(
     backend: Path | str,
     *,
     implicit_default_local: bool,
+    auto_provisioned: bool = False,
 ) -> int | None:
     """Handle the commands that must run BEFORE `connect_backend`, else ``None``.
 
@@ -1533,12 +1627,18 @@ def _preconnect_command(
       puts it ahead of the normal freeze gate, so it runs the gate itself.
     """
     if args.command == "doctor":
-        return run_doctor(backend, implicit_default_local=implicit_default_local, as_json=args.as_json)
+        return run_doctor(
+            backend,
+            implicit_default_local=implicit_default_local,
+            auto_provisioned=auto_provisioned,
+            as_json=args.as_json,
+        )
 
     if implicit_default_local and _command_mutates_tracker(args):
         print(
             "error: refusing to write through the implicit local fallback; "
-            "select a backend with --db, TODO_DB_PATH, or TODO_DB_URL",
+            "select a backend with --db, TODO_DB_PATH, or TODO_DB_URL, or log in with "
+            "`turso auth login` so this can auto-provision a hosted backend",
             file=sys.stderr,
         )
         return 2
@@ -4034,9 +4134,15 @@ def main(argv: list[str] | None = None) -> int:
             print(f"error: {exc}", file=sys.stderr)
             return 2
 
-    backend, implicit_default_local = _resolve_backend(args.db)
-    _report_backend(backend, implicit_default_local=implicit_default_local)
-    early = _preconnect_command(args, actor, backend, implicit_default_local=implicit_default_local)
+    backend, implicit_default_local, auto_provisioned = _resolve_backend(args.db)
+    _report_backend(backend, implicit_default_local=implicit_default_local, auto_provisioned=auto_provisioned)
+    early = _preconnect_command(
+        args,
+        actor,
+        backend,
+        implicit_default_local=implicit_default_local,
+        auto_provisioned=auto_provisioned,
+    )
     if early is not None:
         return early
     try:

--- a/_project/specs/todo-db-tracker.md
+++ b/_project/specs/todo-db-tracker.md
@@ -822,9 +822,18 @@ TODO tree from an untrusted source would plant shell commands; do not.
     environment. Local access authenticated via the maintainer's
     logged-in `turso` CLI, minting short-lived DB tokens per invocation
     (`turso db tokens create benchbox-todo`), never stored or echoed.
-    Open provisioning item for the maintainer: add the two variables to
-    local `.env` (per the Credentials bullet above) so local sessions
-    don't depend on the turso CLI login.
+    **Local auto-provisioning now exists** (`_project/scripts/todo_db.py`,
+    `_resolve_backend`/`_try_turso_auto_provision`): when none of --db,
+    `TODO_DB_PATH`, or `TODO_DB_URL` is set, the CLI shells out to the
+    logged-in `turso` CLI itself (`turso db show <name> --url` +
+    `turso db tokens create <name> --expiration 1d` (Turso CLI requires
+    day granularity or ``never``; sub-day values are rejected), db name from
+    `TODO_DB_TURSO_DB`, default `benchbox-todo`) and uses the hosted
+    backend transparently, falling back to the local implicit DB (with a
+    refusal-on-write pointing at `turso auth login` /
+    `TODO_DB_URL`+`TODO_DB_AUTH_TOKEN` / `--db`/`TODO_DB_PATH`) if turso is
+    absent, not logged in, or the mint fails. This closes the former open
+    provisioning item without requiring the two variables in local `.env`.
 - **G2 — CLI MVP:** schema DDL + `create/show/claim/start/done/defer/
   promote/dismiss/complete/ready/list/stats/export` + tests. No repo changes
   to the YAML system yet.

--- a/docs/operations/todo-db-benchbox-extraction.md
+++ b/docs/operations/todo-db-benchbox-extraction.md
@@ -101,6 +101,26 @@ two database secrets are available:
 - `TODO_DB_RO_AUTH_TOKEN` repository secret, passed to the legacy export step
   under its expected variable name but still carrying read-only authority.
 
+### Local auth provisioning
+
+CI supplies `TODO_DB_URL`/`TODO_DB_AUTH_TOKEN` as secrets, but a local checkout
+normally has neither set. `_project/scripts/todo_db.py` handles that case
+itself: when `--db`, `TODO_DB_PATH`, and `TODO_DB_URL` are all unset, it shells
+out to the maintainer's already-logged-in `turso` CLI (`turso db show <name>
+--url` + `turso db tokens create <name> --expiration 1d` (day
+granularity; sub-day values like `30m` are rejected by the Turso CLI),
+db name from
+`TODO_DB_TURSO_DB`, default `benchbox-todo`) and uses the resulting hosted
+backend transparently for that invocation, without ever printing or logging
+the minted URL or token. If `turso` is missing, not logged in, or the mint
+fails for any reason, the CLI falls back to the existing local implicit
+database and its write-refusal error now names all three remediations:
+`turso auth login`, exporting `TODO_DB_URL`/`TODO_DB_AUTH_TOKEN` directly, or
+selecting a backend with `--db`/`TODO_DB_PATH`. Explicit configuration always
+takes precedence over auto-provisioning, and `todo doctor` reports the
+`hosted (auto-provisioned via turso CLI, URL withheld)` backend detail when it
+was used.
+
 `TODO_DB_PACKAGE_VERSION` is an optional repository variable naming an exact,
 approved release. Enabling it also requires `TODO_DB_PACKAGE_URL`, an immutable
 HTTPS wheel URL, and `TODO_DB_PACKAGE_SHA256`, the wheel's lowercase SHA-256

--- a/tests/unit/scripts/conftest.py
+++ b/tests/unit/scripts/conftest.py
@@ -1,9 +1,36 @@
 """conftest for tests/unit/scripts/ - adds the project scripts/ dir to sys.path."""
 
+import shutil
 import sys
 from pathlib import Path
+
+import pytest
 
 # Make scripts/ importable so test modules can use plain imports.
 _scripts_dir = str(Path(__file__).resolve().parents[3] / "scripts")
 if _scripts_dir not in sys.path:
     sys.path.insert(0, _scripts_dir)
+
+
+@pytest.fixture(autouse=True)
+def _todo_db_turso_never_auto_detected(monkeypatch):
+    """Keep todo_db tests hermetic against the host machine's real turso CLI.
+
+    `_project/scripts/todo_db.py`'s backend resolution auto-provisions a
+    hosted backend by shelling out to `turso` when no explicit backend is
+    configured (see `_try_turso_auto_provision`). On a machine where `turso`
+    is on PATH and logged in (e.g. a maintainer's workstation), tests that
+    exercise the implicit-local-fallback path would otherwise silently start
+    making real `turso` subprocess calls -- and possibly real network calls --
+    instead of testing the fallback they intend to. Force `shutil.which`
+    to report `turso` as absent everywhere by default; tests that want to
+    exercise auto-provisioning override `shutil.which` themselves.
+    """
+    real_which = shutil.which
+
+    def which(cmd, *args, **kwargs):
+        if cmd == "turso":
+            return None
+        return real_which(cmd, *args, **kwargs)
+
+    monkeypatch.setattr(shutil, "which", which)

--- a/tests/unit/scripts/test_todo_db_doctor.py
+++ b/tests/unit/scripts/test_todo_db_doctor.py
@@ -226,6 +226,6 @@ def test_implicit_local_fallback_is_warned_not_failed(monkeypatch, tmp_path, cap
     db = tmp_path / "fallback.sqlite"
     assert todo_db.main(["--db", str(db), "init"]) == 0
 
-    monkeypatch.setattr(todo_db, "_resolve_backend", lambda _explicit: (db, True))
+    monkeypatch.setattr(todo_db, "_resolve_backend", lambda _explicit: (db, True, False))
     assert todo_db.main(["doctor"]) == todo_db.DOCTOR_EXIT_OK
     assert "WARN identity" in capsys.readouterr().out

--- a/tests/unit/scripts/test_todo_db_turso_autoprovision.py
+++ b/tests/unit/scripts/test_todo_db_turso_autoprovision.py
@@ -1,0 +1,250 @@
+"""Tests for turso auto-provisioning of the hosted backend.
+
+`_project/scripts/todo_db.py` resolves its backend with precedence
+--db > TODO_DB_PATH > TODO_DB_URL > implicit local fallback. When none of the
+three explicit knobs are set, it now attempts to auto-provision a hosted
+backend via the maintainer's already-logged-in `turso` CLI before falling
+back to the local scratch database (see `_try_turso_auto_provision` and
+`_resolve_backend`). These tests pin:
+
+  - success mints a URL + token and selects the hosted backend transparently;
+  - any failure (turso absent, mint failure) falls through to the existing
+    local-fallback behavior, whose write-refusal error now names `turso auth
+    login` alongside the existing remediations;
+  - auto-provisioning is never attempted when an explicit backend
+    (--db/TODO_DB_PATH/TODO_DB_URL) is configured;
+  - the minted token and URL are never printed, including through `doctor`.
+
+The repo-wide `conftest.py` autouse fixture forces `shutil.which("turso")` to
+report absent by default, so these tests must explicitly opt back in via
+their own `shutil.which` monkeypatch wherever they simulate turso being
+present.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import os
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+_MODULE_PATH = _REPO_ROOT / "_project" / "scripts" / "todo_db.py"
+
+_spec = importlib.util.spec_from_file_location("todo_db_turso_autoprovision_under_test", _MODULE_PATH)
+assert _spec and _spec.loader
+todo_db = importlib.util.module_from_spec(_spec)
+sys.modules["todo_db_turso_autoprovision_under_test"] = todo_db
+_spec.loader.exec_module(todo_db)
+
+pytestmark = [
+    pytest.mark.unit,
+    pytest.mark.fast,
+]
+
+_URL = "libsql://benchbox-todo-test.turso.io"
+_TOKEN = "sekrit-mint-token-xyz"  # noqa: S105 - test fixture value, not a real credential
+
+
+def _make_fake_turso_run(db_name: str = "benchbox-todo", *, url: str = _URL, token: str = _TOKEN):
+    """A subprocess.run stand-in that answers `turso db show`/`tokens create`
+    for the given db name and delegates every other command (notably `git
+    ...`) to the real subprocess.run."""
+    real_run = todo_db.subprocess.run
+    calls: list[list[str]] = []
+
+    def fake_run(cmd, *args, **kwargs):
+        calls.append(list(cmd))
+        if cmd[:1] == ["turso"]:
+            if cmd == ["turso", "db", "show", db_name, "--url"]:
+                return SimpleNamespace(returncode=0, stdout=f"{url}\n", stderr="")
+            if cmd == ["turso", "db", "tokens", "create", db_name, "--expiration", "1d"]:
+                return SimpleNamespace(returncode=0, stdout=f"{token}\n", stderr="")
+            return SimpleNamespace(returncode=1, stdout="", stderr="unexpected turso invocation")
+        return real_run(cmd, *args, **kwargs)
+
+    return fake_run, calls
+
+
+def _clear_backend_env(monkeypatch):
+    monkeypatch.delenv("TODO_DB_PATH", raising=False)
+    monkeypatch.delenv("TODO_DB_URL", raising=False)
+    monkeypatch.delenv("TODO_DB_AUTH_TOKEN", raising=False)
+    monkeypatch.delenv("TODO_DB_TURSO_DB", raising=False)
+
+
+class TestAutoProvisionSuccess:
+    def test_success_selects_hosted_backend_and_propagates_env(self, monkeypatch):
+        _clear_backend_env(monkeypatch)
+        monkeypatch.setattr(todo_db.shutil, "which", lambda name: "/usr/bin/turso" if name == "turso" else None)
+        fake_run, calls = _make_fake_turso_run()
+        monkeypatch.setattr(todo_db.subprocess, "run", fake_run)
+
+        backend, implicit_default_local, auto_provisioned = todo_db._resolve_backend(None)
+
+        assert backend == _URL
+        assert implicit_default_local is False
+        assert auto_provisioned is True
+        # Downstream readers (_auth_token(), connect_hosted(), ...) all key off
+        # these two env vars -- auto-provisioning must behave exactly as if
+        # they had been set explicitly.
+        assert os.environ["TODO_DB_URL"] == _URL
+        assert os.environ["TODO_DB_AUTH_TOKEN"] == _TOKEN
+        assert ["turso", "db", "show", "benchbox-todo", "--url"] in calls
+        assert ["turso", "db", "tokens", "create", "benchbox-todo", "--expiration", "1d"] in calls
+
+    def test_custom_db_name_from_env(self, monkeypatch):
+        _clear_backend_env(monkeypatch)
+        monkeypatch.setenv("TODO_DB_TURSO_DB", "my-custom-db")
+        monkeypatch.setattr(todo_db.shutil, "which", lambda name: "/usr/bin/turso" if name == "turso" else None)
+        fake_run, calls = _make_fake_turso_run(db_name="my-custom-db")
+        monkeypatch.setattr(todo_db.subprocess, "run", fake_run)
+
+        backend, _implicit, auto_provisioned = todo_db._resolve_backend(None)
+
+        assert backend == _URL
+        assert auto_provisioned is True
+        assert ["turso", "db", "show", "my-custom-db", "--url"] in calls
+
+    def test_report_backend_names_auto_provisioning(self, capsys):
+        todo_db._report_backend(_URL, implicit_default_local=False, auto_provisioned=True)
+        err = capsys.readouterr().err
+        assert "hosted (auto-provisioned via turso CLI)" in err
+        assert _URL not in err
+        assert _TOKEN not in err
+
+
+class TestAutoProvisionFailureFallsThrough:
+    def test_turso_absent_falls_through_to_local_fallback(self, monkeypatch, tmp_path, capsys):
+        _clear_backend_env(monkeypatch)
+        monkeypatch.setattr(todo_db, "git_main_root", lambda: tmp_path)
+        # shutil.which("turso") already reports absent via the repo-wide
+        # autouse fixture; this is asserted explicitly here too.
+        assert todo_db.shutil.which("turso") is None
+
+        backend, implicit_default_local, auto_provisioned = todo_db._resolve_backend(None)
+
+        assert isinstance(backend, Path)
+        assert implicit_default_local is True
+        assert auto_provisioned is False
+
+    def test_turso_present_but_show_fails_falls_through(self, monkeypatch, tmp_path):
+        _clear_backend_env(monkeypatch)
+        monkeypatch.setattr(todo_db, "git_main_root", lambda: tmp_path)
+        monkeypatch.setattr(todo_db.shutil, "which", lambda name: "/usr/bin/turso" if name == "turso" else None)
+
+        def fake_run(cmd, *args, **kwargs):
+            if cmd[:1] == ["turso"]:
+                return SimpleNamespace(returncode=1, stdout="", stderr="not logged in")
+            return todo_db.subprocess.run(cmd, *args, **kwargs)
+
+        monkeypatch.setattr(todo_db.subprocess, "run", fake_run)
+
+        backend, implicit_default_local, auto_provisioned = todo_db._resolve_backend(None)
+
+        assert isinstance(backend, Path)
+        assert implicit_default_local is True
+        assert auto_provisioned is False
+
+    def test_write_refusal_error_names_turso_auth_login_remediation(self, monkeypatch, tmp_path, capsys):
+        _clear_backend_env(monkeypatch)
+        monkeypatch.setattr(todo_db, "git_main_root", lambda: tmp_path)
+
+        rc = todo_db.main(["claim", "missing-item"])
+
+        assert rc == 2
+        err = capsys.readouterr().err
+        assert "refusing to write through the implicit local fallback" in err
+        assert "turso auth login" in err
+        assert "TODO_DB_URL" in err
+        assert "TODO_DB_PATH" in err
+        assert not (tmp_path / ".todo-db" / "todo.sqlite").exists()
+
+
+class TestAutoProvisionNeverInvokedWithExplicitBackend:
+    def test_explicit_flag_skips_auto_provision(self, monkeypatch, tmp_path):
+        monkeypatch.delenv("TODO_DB_URL", raising=False)
+
+        def boom(*_args, **_kwargs):
+            raise AssertionError("auto-provisioning must not run when --db is explicit")
+
+        monkeypatch.setattr(todo_db, "_try_turso_auto_provision", boom)
+
+        backend, implicit_default_local, auto_provisioned = todo_db._resolve_backend(str(tmp_path / "todo.sqlite"))
+
+        assert isinstance(backend, Path)
+        assert implicit_default_local is False
+        assert auto_provisioned is False
+
+    def test_env_todo_db_path_skips_auto_provision(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("TODO_DB_PATH", str(tmp_path / "todo.sqlite"))
+        monkeypatch.delenv("TODO_DB_URL", raising=False)
+
+        def boom(*_args, **_kwargs):
+            raise AssertionError("auto-provisioning must not run when TODO_DB_PATH is set")
+
+        monkeypatch.setattr(todo_db, "_try_turso_auto_provision", boom)
+
+        backend, implicit_default_local, auto_provisioned = todo_db._resolve_backend(None)
+
+        assert isinstance(backend, Path)
+        assert implicit_default_local is False
+        assert auto_provisioned is False
+
+    def test_env_todo_db_url_skips_auto_provision(self, monkeypatch):
+        monkeypatch.delenv("TODO_DB_PATH", raising=False)
+        monkeypatch.setenv("TODO_DB_URL", "libsql://explicit-env.turso.io")
+        monkeypatch.setenv("TODO_DB_AUTH_TOKEN", "explicit-env-token")
+
+        def boom(*_args, **_kwargs):
+            raise AssertionError("auto-provisioning must not run when TODO_DB_URL is set")
+
+        monkeypatch.setattr(todo_db, "_try_turso_auto_provision", boom)
+
+        backend, implicit_default_local, auto_provisioned = todo_db._resolve_backend(None)
+
+        assert backend == "libsql://explicit-env.turso.io"
+        assert implicit_default_local is False
+        assert auto_provisioned is False
+
+
+class TestDoctorRedactsAutoProvisionedSecrets:
+    def test_doctor_never_prints_the_auto_provisioned_url_or_token(self, monkeypatch, capsys):
+        _clear_backend_env(monkeypatch)
+        monkeypatch.setattr(todo_db.shutil, "which", lambda name: "/usr/bin/turso" if name == "turso" else None)
+        fake_run, _calls = _make_fake_turso_run()
+        monkeypatch.setattr(todo_db.subprocess, "run", fake_run)
+
+        def boom(*_args, **_kwargs):
+            raise RuntimeError(f"connect failed for {_URL} using {_TOKEN}")
+
+        monkeypatch.setattr(todo_db, "connect_backend", boom)
+
+        rc = todo_db.main(["doctor"])
+
+        assert rc in (todo_db.DOCTOR_EXIT_FAIL, todo_db.DOCTOR_EXIT_AUTH)
+        captured = capsys.readouterr()
+        combined = captured.out + captured.err
+        assert _TOKEN not in combined
+        assert _URL not in combined
+        assert "auto-provisioned" in combined
+
+    def test_doctor_json_never_prints_the_auto_provisioned_url_or_token(self, monkeypatch, capsys):
+        _clear_backend_env(monkeypatch)
+        monkeypatch.setattr(todo_db.shutil, "which", lambda name: "/usr/bin/turso" if name == "turso" else None)
+        fake_run, _calls = _make_fake_turso_run()
+        monkeypatch.setattr(todo_db.subprocess, "run", fake_run)
+
+        def boom(*_args, **_kwargs):
+            raise RuntimeError(f"connect failed for {_URL} using {_TOKEN}")
+
+        monkeypatch.setattr(todo_db, "connect_backend", boom)
+
+        todo_db.main(["doctor", "--json"])
+
+        combined = "".join(capsys.readouterr())
+        assert _TOKEN not in combined
+        assert _URL not in combined


### PR DESCRIPTION
## Summary

Local agent/developer sessions have never had `TODO_DB_URL` / `TODO_DB_AUTH_TOKEN` in the environment — only CI did. Every session depended on knowing the turso mint pattern by heart. This change makes the project wrapper auto-provision a short-lived hosted connection when no backend is selected and a logged-in `turso` CLI is available.

- New precedence: `--db` > `TODO_DB_PATH` > `TODO_DB_URL` > **turso auto-provision** > local fallback
- Mint uses day-granularity expiry (`1d`); Turso CLI rejects sub-day values like `30m`
- Tokens/URLs never printed or written to disk; set only in-process for the invocation
- On any mint failure, falls through to the existing local write-refusal path (now names `turso auth login`)
- Tests hermetically stub `shutil.which("turso")` absent by default so the suite never shells out to a real CLI

Closes tracker item `provision-local-tracker-db-auth`.

## Test plan

- [x] `uv run -- python -m pytest tests/unit/scripts/test_todo_db_turso_autoprovision.py tests/unit/scripts/test_todo_db_doctor.py tests/unit/scripts/test_todo_db.py -q` (106 passed)
- [x] Bare env: `env -u TODO_DB_URL -u TODO_DB_AUTH_TOKEN -u TODO_DB_PATH _project/scripts/todo doctor` exits 0 against production
- [x] Explicit `--db` / `TODO_DB_PATH` / `TODO_DB_URL` never invoke auto-provision (unit coverage)
- [ ] CI green on this PR
