### PR TITLE
feat(todo-db): expose audited update verb on the project wrapper

### DIFF
--- a/.claude/skills/todo-db/SKILL.md
+++ b/.claude/skills/todo-db/SKILL.md
@@ -41,8 +41,9 @@ the alert. Auto-remint is only for todo-db >= 0.3 wrappers. Global `--db` /
 (open findings or unsynced drafts); run `todo finding candidates` to triage.
 Banner is stderr-only and zero-suppressed, so stdout stays machine-readable.
 
-Standalone-only actions (`standalone_only_commands` in the skill sidecar,
-currently `update`) exist only in todo-db >= 0.3; rule 4 applies to wrappers.
+Standalone-only actions are declared in the skill sidecar as
+`standalone_only_commands` (currently none for this wrapper); rule 4 applies
+when a future verb is declared.
 
 ## Rules
 

--- a/.claude/skills/todo-db/skill.yaml
+++ b/.claude/skills/todo-db/skill.yaml
@@ -12,5 +12,4 @@ targets:
 # Machine-readable capability boundary: verbs that exist only in the
 # standalone todo-db CLI, never in legacy project wrappers. SKILL.md rule 4
 # applies; consumer command-contract tests key off this declaration.
-standalone_only_commands:
-  update: ">=0.3.0"
+standalone_only_commands: {}

--- a/_project/scripts/todo_db.py
+++ b/_project/scripts/todo_db.py
@@ -2078,6 +2078,211 @@ def update_scope_rules(
     return detail
 
 
+def _validate_item_fields(*, title: str, worktree: str, priority: str, description: str) -> None:
+    """Same field constraints create applies (SQL CHECK + explicit messages)."""
+    if not 5 <= len(title) <= 200:
+        raise TodoError("title must be between 5 and 200 characters")
+    if not worktree or not worktree.strip():
+        raise TodoError("worktree must not be empty")
+    if priority not in PRIORITIES:
+        raise TodoError(f"invalid priority {priority!r}; one of {', '.join(PRIORITIES)}")
+    if len(description) < 10:
+        raise TodoError("description must be at least 10 characters")
+
+
+def _parse_work_edits(specs: list[str]) -> dict[str, str]:
+    """Parse ``WID:NEW-SUMMARY`` flags for ``update --edit-work``."""
+    edits: dict[str, str] = {}
+    for spec in specs:
+        if ":" not in spec:
+            raise TodoError(f"--edit-work expects WID:NEW-SUMMARY, got {spec!r}")
+        wid, summary = spec.split(":", 1)
+        if not WID_RE.match(wid):
+            raise TodoError(f"invalid work-unit id {wid!r} (expect w0..w999)")
+        if wid in edits:
+            raise TodoError(f"duplicate --edit-work for {wid}")
+        edits[wid] = summary
+    return edits
+
+
+def _update_metadata_fields(
+    conn: sqlite3.Connection,
+    item: sqlite3.Row,
+    fields: dict[str, str | None],
+) -> dict[str, dict[str, Any]]:
+    """Apply title/description/priority/worktree changes; return from/to map."""
+    changes: dict[str, dict[str, Any]] = {}
+    for field, value in fields.items():
+        if value is None:
+            continue
+        if value == item[field]:
+            raise TodoError(f"--{field} equals the current value on {item['id']!r}; nothing to update")
+        changes[field] = {"from": item[field], "to": value}
+    merged = {field: changes[field]["to"] if field in changes else item[field] for field in fields}
+    _validate_item_fields(
+        title=merged["title"],
+        worktree=merged["worktree"],
+        priority=merged["priority"],
+        description=merged["description"],
+    )
+    if changes:
+        assignments = ", ".join(f"{field} = ?" for field in changes)
+        values = [change["to"] for change in changes.values()]
+        conn.execute(f"UPDATE items SET {assignments} WHERE id = ?", (*values, item["id"]))
+    return changes
+
+
+def _update_edit_work(
+    conn: sqlite3.Connection, item_id: str, edits: dict[str, str]
+) -> dict[str, dict[str, str]]:
+    work_edited: dict[str, dict[str, str]] = {}
+    for wid, summary in edits.items():
+        unit = _require_unit(conn, item_id, wid)
+        if unit["status"] != "pending":
+            raise TodoError(
+                f"cannot edit {item_id}:{wid}: unit is {unit['status']}; only pending units are"
+                " editable (a done unit's evidence attaches to its summary)"
+            )
+        if summary == unit["summary"]:
+            raise TodoError(f"--edit-work {wid} equals the current summary; nothing to update")
+        if not 5 <= len(summary) <= 200:
+            raise TodoError(f"work-unit summary must be between 5 and 200 characters: {item_id}:{wid}")
+        conn.execute(
+            "UPDATE work_units SET summary = ? WHERE item_id = ? AND wid = ?",
+            (summary, item_id, wid),
+        )
+        work_edited[wid] = {"from": unit["summary"], "to": summary}
+    return work_edited
+
+
+def _update_add_work(
+    conn: sqlite3.Connection, item_id: str, adds: list[dict[str, Any]]
+) -> list[dict[str, Any]]:
+    wid_rows = conn.execute("SELECT wid FROM work_units WHERE item_id = ?", (item_id,))
+    wids = {row["wid"] for row in wid_rows}
+    work_added: list[dict[str, Any]] = []
+    for unit in adds:
+        wid = str(unit.get("id") or unit.get("wid") or "")
+        summary = str(unit.get("summary") or "")
+        if not WID_RE.match(wid):
+            raise TodoError(f"invalid work-unit id {wid!r} on {item_id!r}")
+        if wid in wids:
+            raise TodoError(f"duplicate work-unit id {item_id}:{wid}")
+        if not 5 <= len(summary) <= 200:
+            raise TodoError(f"work-unit summary must be between 5 and 200 characters: {item_id}:{wid}")
+        wids.add(wid)
+        conn.execute(
+            "INSERT INTO work_units (item_id, wid, summary, status) VALUES (?, ?, ?, 'pending')",
+            (item_id, wid, summary),
+        )
+        work_added.append({"id": wid, "summary": summary})
+    for unit, added in zip(adds, work_added, strict=True):
+        needs = [str(needs_wid) for needs_wid in unit.get("needs", ()) or ()]
+        for needs_wid in needs:
+            if needs_wid not in wids:
+                raise TodoError(f"work need {item_id}:{added['id']} -> {needs_wid} references a missing unit")
+            _insert_work_need(conn, item_id, added["id"], needs_wid)
+        if needs:
+            added["needs"] = needs
+    return work_added
+
+
+def _update_verifications(
+    conn: sqlite3.Connection,
+    item_id: str,
+    verify_adds: list[dict[str, str]],
+    verify_drops: list[int],
+) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
+    next_seq = int(
+        conn.execute(
+            "SELECT COALESCE(max(seq), 0) AS seq FROM verifications WHERE item_id = ?",
+            (item_id,),
+        ).fetchone()["seq"]
+    )
+    verify_added: list[dict[str, Any]] = []
+    for entry in verify_adds:
+        next_seq += 1
+        name = str(entry.get("description") or "(no description)")
+        command = entry.get("command")
+        expected = entry.get("expected")
+        conn.execute(
+            "INSERT INTO verifications (item_id, seq, description, command, expected) VALUES (?, ?, ?, ?, ?)",
+            (item_id, next_seq, name, command, expected),
+        )
+        added_verify: dict[str, Any] = {"seq": next_seq, "name": name, "command": command}
+        if expected is not None:
+            added_verify["expected"] = expected
+        verify_added.append(added_verify)
+    verify_dropped: list[dict[str, Any]] = []
+    for seq in verify_drops:
+        row = conn.execute(
+            "SELECT description, command FROM verifications WHERE item_id = ? AND seq = ?",
+            (item_id, seq),
+        ).fetchone()
+        if row is None:
+            raise TodoError(f"no verification seq={seq} on {item_id!r}")
+        conn.execute("DELETE FROM verifications WHERE item_id = ? AND seq = ?", (item_id, seq))
+        verify_dropped.append({"seq": seq, "name": row["description"], "command": row["command"]})
+    return verify_added, verify_dropped
+
+
+def update_item(
+    conn: sqlite3.Connection,
+    actor: str,
+    item_id: str,
+    *,
+    title: str | None = None,
+    description: str | None = None,
+    priority: str | None = None,
+    worktree: str | None = None,
+    add_work: Iterable[dict[str, Any]] = (),
+    edit_work: dict[str, str] | None = None,
+    add_verify: Iterable[dict[str, str]] = (),
+    drop_verify: Iterable[int] = (),
+    reason: str | None = None,
+) -> dict[str, Any]:
+    """Amend item metadata / work / verifications without touching lifecycle.
+
+    One chained ``update`` audit event carries every from/to diff. ``id``,
+    ``state``, and claim identity are immutable through this verb.
+    """
+    fields = {"title": title, "description": description, "priority": priority, "worktree": worktree}
+    adds = [dict(unit) for unit in add_work]
+    edits = dict(edit_work or {})
+    verify_adds = [dict(entry) for entry in add_verify]
+    verify_drops = [int(seq) for seq in drop_verify]
+    reason = reason.strip() if reason and reason.strip() else None
+    if all(value is None for value in fields.values()) and not (adds or edits or verify_adds or verify_drops):
+        raise TodoError("update requires at least one change flag")
+    if verify_drops and reason is None:
+        raise TodoError("--drop-verify removes recorded verification steps; --reason is required")
+
+    with _write_txn(conn):
+        item = _require_item(conn, item_id)
+        if item["state"] in ("done", "dropped") and reason is None:
+            raise TodoError(f"{item_id!r} is {item['state']}; editing a terminal item requires --reason")
+        changes = _update_metadata_fields(conn, item, fields)
+        work_edited = _update_edit_work(conn, item_id, edits)
+        work_added = _update_add_work(conn, item_id, adds)
+        verify_added, verify_dropped = _update_verifications(conn, item_id, verify_adds, verify_drops)
+        detail: dict[str, Any] = {}
+        if changes:
+            detail["changes"] = changes
+        if work_added:
+            detail["work_added"] = work_added
+        if work_edited:
+            detail["work_edited"] = work_edited
+        if verify_added:
+            detail["verify_added"] = verify_added
+        if verify_dropped:
+            detail["verify_dropped"] = verify_dropped
+        if reason is not None:
+            detail["reason"] = reason
+        log_event(conn, actor, item_id, "update", detail)
+        _touch_lease(conn, actor, item_id)
+    return detail
+
+
 def claim_item(
     conn: sqlite3.Connection,
     actor: str,
@@ -3996,6 +4201,29 @@ def main(argv: list[str] | None = None) -> int:
     p.add_argument("--drop-do-not-modify", action="append", default=[], metavar="GLOB")
     p.add_argument("--reason", required=True)
 
+    p = sub.add_parser(
+        "update",
+        help="amend item metadata, work breakdown, or verifications (fully audited; never mutates lifecycle)",
+        description=(
+            "Amend item metadata, work breakdown, or verifications with a single chained "
+            "audit event (from/to diffs). Fully audited; never mutates lifecycle state, "
+            "id, or claim identity."
+        ),
+    )
+    p.add_argument("id")
+    p.add_argument("--title")
+    p.add_argument("--description")
+    p.add_argument("--priority", choices=PRIORITIES)
+    p.add_argument("--worktree")
+    p.add_argument("--add-work", action="append", default=[], metavar="WID:SUMMARY[:needs=w1,w2]")
+    p.add_argument("--edit-work", action="append", default=[], metavar="WID:NEW-SUMMARY")
+    p.add_argument("--add-verify", action="append", default=[], metavar="DESC[::COMMAND[::EXPECTED]]")
+    p.add_argument("--drop-verify", action="append", default=[], type=int, metavar="SEQ")
+    p.add_argument(
+        "--reason",
+        help="required for any edit to a done/dropped item and for --drop-verify",
+    )
+
     for name, help_text in (
         ("show", "show one item"),
         ("claim", "claim an item and print its work order"),
@@ -4343,7 +4571,7 @@ def _cmd_create(conn, actor, args):
     return 0
 
 
-def _cmd_update(conn, actor, args):
+def _cmd_scope_update(conn, actor, args):
     detail = update_scope_rules(
         conn,
         actor,
@@ -4355,6 +4583,26 @@ def _cmd_update(conn, actor, args):
         args.reason,
     )
     changed = [key for key in ("scope_added", "scope_dropped") if detail[key]]
+    print(f"updated {args.id} ({', '.join(changed)})")
+    return 0
+
+
+def _cmd_item_update(conn, actor, args):
+    detail = update_item(
+        conn,
+        actor,
+        args.id,
+        title=args.title,
+        description=args.description,
+        priority=args.priority,
+        worktree=args.worktree,
+        add_work=_parse_work_flag(args.add_work),
+        edit_work=_parse_work_edits(args.edit_work),
+        add_verify=_parse_verify_flag(args.add_verify),
+        drop_verify=args.drop_verify,
+        reason=args.reason,
+    )
+    changed = sorted(key for key in detail if key != "reason")
     print(f"updated {args.id} ({', '.join(changed)})")
     return 0
 
@@ -4660,7 +4908,8 @@ _HANDLERS = {
     "init": _cmd_init,
     "import-yaml": _cmd_import_yaml,
     "create": _cmd_create,
-    "scope-update": _cmd_update,
+    "scope-update": _cmd_scope_update,
+    "update": _cmd_item_update,
     "show": _cmd_show,
     "claim": _cmd_claim,
     "release": _cmd_release,

--- a/_project/scripts/todo_db_standalone_compat.py
+++ b/_project/scripts/todo_db_standalone_compat.py
@@ -28,6 +28,7 @@ COMMANDS = frozenset(
         "init",
         "migrate",
         "create",
+        "update",
         "show",
         "claim",
         "renew",

--- a/_project/specs/todo-db-tracker.md
+++ b/_project/specs/todo-db-tracker.md
@@ -228,6 +228,9 @@ package), env-configured via `TODO_DB_URL` (never echoed). All writes stamp
 
 ```
 todo create   --title ... --worktree ... --priority ... [--edit-body]   # opens/accepts structured flags for guardrail rows
+todo update   <id> [--title ...] [--description ...] [--priority ...] [--worktree ...]
+                  [--add-work ...] [--edit-work ...] [--add-verify ...] [--drop-verify N]
+                  [--reason ...]            # audited metadata/work/verify amend; never mutates lifecycle
 todo scope-update <id> --add-only-modify GLOB [--drop-only-modify GLOB] --reason ...
                                             # atomic, audited scope amendment; also supports do-not-modify
 todo show     <id> [--json]                 # full item incl. guardrail rows
@@ -253,6 +256,12 @@ todo admin migrate                          # only schema-migration path; CLI pi
 The `expected` field is human-readable acceptance guidance shown in the work
 order; commands that need output assertions must encode them directly (for
 example with a test assertion or `grep`).
+
+Every `todo update` amendment records one chained `update` event with
+exact from/to diffs for metadata fields, work-unit adds/edits, and
+verification adds/drops. `id`, `state`, and claim identity are immutable
+through this verb; terminal items and `--drop-verify` require `--reason`.
+No-op edits (flag equals current value) fail without writing an event.
 
 Every `todo scope-update` amendment requires `--reason`. The command validates
 all additions and removals before writing, applies them in one transaction, and

--- a/tests/unit/scripts/test_todo_db_update.py
+++ b/tests/unit/scripts/test_todo_db_update.py
@@ -1,0 +1,260 @@
+"""Tests for the project wrapper's audited ``update`` verb.
+
+Ported from the standalone todo-db update contract: one chained audit event
+with from/to diffs; id/state/claim identity immutable; terminal edits and
+verification drops require ``--reason``.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+pytestmark = [
+    pytest.mark.unit,
+    pytest.mark.fast,
+]
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+
+
+def _load_script():
+    name = "todo_db_update_under_test"
+    path = REPO_ROOT / "_project" / "scripts" / "todo_db.py"
+    spec = importlib.util.spec_from_file_location(name, path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+todo_db = _load_script()
+
+
+@pytest.fixture()
+def conn(tmp_path):
+    connection = todo_db.connect(tmp_path / "todo.sqlite")
+    yield connection
+    connection.close()
+
+
+def _mk(conn, item_id="update-item", **overrides):
+    kwargs = {
+        "item_id": item_id,
+        "title": "Original title",
+        "worktree": "todo-db",
+        "priority": "medium",
+        "description": "The original description before any update.",
+        "work": [{"id": "w0", "summary": "Original pending unit"}],
+        "verifications": [{"description": "Tests", "command": "printf PASS", "expected": "PASS"}],
+    }
+    kwargs.update(overrides)
+    todo_db.create_item(conn, "tester", **kwargs)
+    return item_id
+
+
+def _last_update_event(conn, item_id: str) -> dict:
+    row = conn.execute(
+        "SELECT action, detail FROM events WHERE item_id = ? AND action = 'update' ORDER BY seq DESC LIMIT 1",
+        (item_id,),
+    ).fetchone()
+    assert row is not None
+    return {"action": row["action"], "detail": json.loads(row["detail"])}
+
+
+class TestMetadataUpdate:
+    def test_metadata_updates_carry_exact_from_to_diffs(self, conn):
+        _mk(conn)
+        detail = todo_db.update_item(
+            conn,
+            "tester",
+            "update-item",
+            title="Corrected title",
+            description="The corrected description after review.",
+            priority="high",
+            worktree="other-tree",
+        )
+        item = todo_db.get_item(conn, "update-item")
+        assert item["title"] == "Corrected title"
+        assert item["description"] == "The corrected description after review."
+        assert item["priority"] == "high"
+        assert item["worktree"] == "other-tree"
+        assert item["state"] == "planning"
+        event = _last_update_event(conn, "update-item")
+        assert event["action"] == "update"
+        assert (
+            event["detail"]["changes"]
+            == detail["changes"]
+            == {
+                "title": {"from": "Original title", "to": "Corrected title"},
+                "description": {
+                    "from": "The original description before any update.",
+                    "to": "The corrected description after review.",
+                },
+                "priority": {"from": "medium", "to": "high"},
+                "worktree": {"from": "todo-db", "to": "other-tree"},
+            }
+        )
+        assert "reason" not in event["detail"]
+
+    def test_update_validates_fields(self, conn):
+        _mk(conn)
+        with pytest.raises(todo_db.TodoError, match="title must be between"):
+            todo_db.update_item(conn, "tester", "update-item", title="tiny")
+        with pytest.raises(todo_db.TodoError, match="invalid priority"):
+            todo_db.update_item(conn, "tester", "update-item", priority="urgent")
+        with pytest.raises(todo_db.TodoError, match="worktree must not be empty"):
+            todo_db.update_item(conn, "tester", "update-item", worktree="   ")
+        with pytest.raises(todo_db.TodoError, match="description must be at least"):
+            todo_db.update_item(conn, "tester", "update-item", description="short")
+        assert todo_db.get_item(conn, "update-item")["title"] == "Original title"
+
+    def test_terminal_item_edits_require_reason(self, conn):
+        _mk(conn)
+        todo_db.claim_item(conn, "tester", "update-item")
+        todo_db.done_unit(conn, "tester", "update-item", "w0", "completion evidence")
+        todo_db.complete_item(conn, "tester", "update-item", None)
+        with pytest.raises(todo_db.TodoError, match="requires --reason"):
+            todo_db.update_item(conn, "tester", "update-item", title="Post-completion title")
+        todo_db.update_item(
+            conn,
+            "tester",
+            "update-item",
+            title="Post-completion title",
+            reason="typo found in review",
+        )
+        event = _last_update_event(conn, "update-item")
+        assert event["detail"]["reason"] == "typo found in review"
+        item = todo_db.get_item(conn, "update-item")
+        assert item["title"] == "Post-completion title"
+        assert item["state"] == "done"
+
+
+class TestWorkAndVerifyAmendments:
+    def test_edit_work_only_pending(self, conn):
+        _mk(
+            conn,
+            work=[
+                {"id": "w0", "summary": "Original pending unit"},
+                {"id": "w1", "summary": "Unit to finish"},
+            ],
+        )
+        detail = todo_db.update_item(conn, "tester", "update-item", edit_work={"w0": "Corrected pending unit"})
+        assert detail["work_edited"] == {"w0": {"from": "Original pending unit", "to": "Corrected pending unit"}}
+        assert todo_db.get_item(conn, "update-item")["work"][0]["summary"] == "Corrected pending unit"
+        todo_db.claim_item(conn, "tester", "update-item")
+        todo_db.done_unit(conn, "tester", "update-item", "w1", "unit evidence")
+        with pytest.raises(todo_db.TodoError, match="only pending units"):
+            todo_db.update_item(conn, "tester", "update-item", edit_work={"w1": "Rewriting a done unit"})
+        assert todo_db.get_item(conn, "update-item")["work"][1]["summary"] == "Unit to finish"
+
+    def test_add_work_extends_breakdown(self, conn):
+        _mk(conn)
+        detail = todo_db.update_item(
+            conn,
+            "tester",
+            "update-item",
+            add_work=[{"id": "w1", "summary": "Mid-batch discovered unit", "needs": ["w0"]}],
+        )
+        assert detail["work_added"] == [{"id": "w1", "summary": "Mid-batch discovered unit", "needs": ["w0"]}]
+        unit = todo_db.get_item(conn, "update-item")["work"][1]
+        assert (unit["wid"], unit["status"], unit["needs"]) == ("w1", "pending", ["w0"])
+        with pytest.raises(todo_db.TodoError, match="duplicate work-unit id"):
+            todo_db.update_item(conn, "tester", "update-item", add_work=[{"id": "w0", "summary": "Colliding unit"}])
+
+    def test_verification_amendments(self, conn):
+        _mk(conn)
+        detail = todo_db.update_item(
+            conn,
+            "tester",
+            "update-item",
+            add_verify=[{"description": "Lint", "command": "uv run ruff check ."}],
+        )
+        assert detail["verify_added"] == [{"seq": 2, "name": "Lint", "command": "uv run ruff check ."}]
+        with pytest.raises(todo_db.TodoError, match="--reason is required"):
+            todo_db.update_item(conn, "tester", "update-item", drop_verify=[1])
+        detail = todo_db.update_item(
+            conn,
+            "tester",
+            "update-item",
+            drop_verify=[1],
+            reason="superseded by the lint step",
+        )
+        assert detail["verify_dropped"] == [{"seq": 1, "name": "Tests", "command": "printf PASS"}]
+        assert detail["reason"] == "superseded by the lint step"
+        assert [row["seq"] for row in todo_db.get_item(conn, "update-item")["verifications"]] == [2]
+        with pytest.raises(todo_db.TodoError, match="no verification seq=9"):
+            todo_db.update_item(conn, "tester", "update-item", drop_verify=[9], reason="no such row")
+
+    def test_no_change_flags_and_no_op_edits_rejected(self, conn):
+        _mk(conn)
+        before = conn.execute("SELECT count(*) AS n FROM events").fetchone()["n"]
+        with pytest.raises(todo_db.TodoError, match="at least one change flag"):
+            todo_db.update_item(conn, "tester", "update-item")
+        with pytest.raises(todo_db.TodoError, match="at least one change flag"):
+            todo_db.update_item(conn, "tester", "update-item", reason="a reason is not a change")
+        with pytest.raises(todo_db.TodoError, match="nothing to update"):
+            todo_db.update_item(conn, "tester", "update-item", title="Original title")
+        with pytest.raises(todo_db.TodoError, match="nothing to update"):
+            todo_db.update_item(conn, "tester", "update-item", edit_work={"w0": "Original pending unit"})
+        assert conn.execute("SELECT count(*) AS n FROM events").fetchone()["n"] == before
+
+
+class TestCliSurface:
+    def test_update_help_and_main_path(self, conn, tmp_path, capsys, monkeypatch):
+        db = tmp_path / "cli.sqlite"
+        assert todo_db.main(["--db", str(db), "init"]) == 0
+        assert (
+            todo_db.main(
+                [
+                    "--db",
+                    str(db),
+                    "create",
+                    "cli-item",
+                    "--title",
+                    "CLI item",
+                    "--worktree",
+                    "todo-db",
+                    "--priority",
+                    "medium",
+                    "--description",
+                    "A CLI item exercising the update verb.",
+                    "--work",
+                    "w0:Do the work",
+                ]
+            )
+            == 0
+        )
+        capsys.readouterr()
+        assert todo_db.main(["--db", str(db), "update", "cli-item"]) == 2
+        assert "at least one change flag" in capsys.readouterr().err
+        assert todo_db.main(["--db", str(db), "update", "cli-item", "--title", "CLI item"]) == 2
+        assert "nothing to update" in capsys.readouterr().err
+        assert (
+            todo_db.main(
+                [
+                    "--db",
+                    str(db),
+                    "update",
+                    "cli-item",
+                    "--title",
+                    "CLI item corrected",
+                    "--add-verify",
+                    "Smoke::printf PASS",
+                ]
+            )
+            == 0
+        )
+        assert "updated cli-item (changes, verify_added)" in capsys.readouterr().out
+        with pytest.raises(SystemExit) as help_exit:
+            todo_db.main(["--db", str(db), "update", "--help"])
+        assert help_exit.value.code == 0
+        help_out = capsys.readouterr().out
+        assert "never mutates lifecycle" in help_out
+        assert "--title" in help_out
+        assert "--add-work" in help_out

--- a/tests/unit/scripts/test_todo_wrapper.py
+++ b/tests/unit/scripts/test_todo_wrapper.py
@@ -167,7 +167,9 @@ class TestSkillThinness:
         # Without a declaration the boundary must trip — the declaration is the
         # only sanctioned way to document a wrapper-unsupported verb.
         assert _unknown_commands("run `todo frobnicate` then stop", set()) == {"frobnicate"}
-        assert _unknown_commands("`todo update <id>` corrects items", set()) == {"update"}
+        # update is a real wrapper handler; it must not be flagged as unknown
+        # when the declared standalone set is empty.
+        assert _unknown_commands("`todo update <id>` corrects items", set()) == set()
 
     def test_standalone_only_commands_never_presented_as_wrapper_invocations(self):
         # A declared verb must never appear as a project-wrapper invocation and


### PR DESCRIPTION
## Summary

Exposes the standalone todo-db audited `update` verb through the project wrapper (`_project/scripts/todo update`).

- Metadata (`title`/`description`/`priority`/`worktree`), work-unit add/edit, and verification add/drop
- One chained `update` audit event with exact from/to diffs
- `id`, `state`, and claim identity are immutable through this verb
- Terminal items and `--drop-verify` require `--reason`
- No-op edits (flag equals current value) fail without writing an event

This stops drop+recreate churn for corrections and closes the unaudited side-door path that already produced 9 update events in production.

Follow-on: `wrapper-update-verb-capability-declaration-handoff` moves `update` out of skill `standalone_only_commands`.

Closes tracker item `expose-update-verb-in-project-wrapper`.

## Test plan

- [x] `_project/scripts/todo update --help` exits 0
- [x] `uv run -- python -m pytest tests/unit/scripts/test_todo_db_update.py tests/unit/scripts/test_todo_db.py -q` (87 passed)
- [ ] CI green
