### PR TITLE
fix(todo-db): demote falsifiability lint to advisory

### DIFF
--- a/_project/scripts/todo_db.py
+++ b/_project/scripts/todo_db.py
@@ -3398,39 +3398,51 @@ def _export_substring_scan_verifications(item: dict) -> list[int]:
     return [ver["seq"] for ver in item["verifications"] if _is_export_substring_scan(ver.get("command") or "")]
 
 
-def lint_item_notes(conn: sqlite3.Connection, item_id: str, *, item: dict[str, Any] | None = None) -> list[str]:
-    """Advisory notes, not defects: policy skips that would otherwise be
-    silent. A category exemption from the falsifiability check is author-
-    selectable free text, so lint says when it applied - an exemption you
-    can see is auditable, one you cannot is a hole."""
-    item = item if item is not None else get_item(conn, item_id)
-    notes = []
-    if (
+def _falsifiability_check_applies(conn: sqlite3.Connection, item: dict[str, Any]) -> bool:
+    """Whether the item is in scope for the falsifiability advisory check."""
+    return (
         get_config(conn, "lint.require_falsifiable_rung") == "on"
         and item["state"] in ("planning", "active")
-        and (item.get("category") or "") in _FALSIFIABILITY_EXEMPT_CATEGORIES
         and any((v.get("command") or "").strip() for v in item["verifications"])
-    ):
+    )
+
+
+def lint_item_notes(conn: sqlite3.Connection, item_id: str, *, item: dict[str, Any] | None = None) -> list[str]:
+    """Advisory notes, not defects: do not affect lint's exit code.
+
+    The falsifiability check is advisory by design: a gate whose only remedy
+    is drop+recreate was itself generating the duplication statistics used to
+    argue against the tracker. The check still reports; it no longer fails
+    the command.
+    """
+    item = item if item is not None else get_item(conn, item_id)
+    notes = []
+    if not _falsifiability_check_applies(conn, item):
+        return notes
+    category = item.get("category") or ""
+    if category in _FALSIFIABILITY_EXEMPT_CATEGORIES:
         notes.append(
             f"note: falsifiability check skipped - category '{item['category']}' is exempt "
             "(tripwires/acceptance runs legitimately pass on the current tree)"
         )
-    # Deliberately avoids the phrase the finding uses, so a caller grepping for
-    # the finding does not match a grandfathered item and read the backlog as
-    # unfixed.
-    if (
-        get_config(conn, "lint.require_falsifiable_rung") == "on"
-        and item["state"] in ("planning", "active")
-        and (item.get("category") or "") not in _FALSIFIABILITY_EXEMPT_CATEGORIES
-        and any((v.get("command") or "").strip() for v in item["verifications"])
-        and not _has_falsifiable_rung(item)
-        and _falsifiability_grandfathered(conn, item)
-    ):
+        return notes
+    if _has_falsifiable_rung(item):
+        return notes
+    if _falsifiability_grandfathered(conn, item):
+        # Deliberately avoids the exact "no falsifiability" phrase so a caller
+        # grepping for that advisory does not match a grandfathered item and
+        # read the backlog as unfixed.
         notes.append(
             f"note: unfalsifiable ladder, grandfathered - created {item['created_at']}, "
             f"before the rule landed {_FALSIFIABILITY_RULE_EPOCH}. Ladders are create-time-only; "
             "fix by drop+recreate when you next claim this item"
         )
+        return notes
+    notes.append(
+        "note: no falsifiability: every rung's expected text reads as passing on the unfixed tree "
+        "(an unrunnable rung does not count) - at least one rung must fail while the defect "
+        "exists, e.g. 'exits 1 on an unfixed tree' (advisory; does not fail lint)"
+    )
     return notes
 
 
@@ -3469,23 +3481,11 @@ def lint_item(conn: sqlite3.Connection, item_id: str, *, item: dict[str, Any] | 
         findings.append("description cites point-in-time evidence but has no w0 re-validation unit")
     if not item["work"] and item["state"] in ("planning", "active"):
         findings.append("no work breakdown")
-    if (
-        get_config(conn, "lint.require_falsifiable_rung") == "on"
-        and item["state"] in ("planning", "active")
-        and (item.get("category") or "") not in _FALSIFIABILITY_EXEMPT_CATEGORIES
-        and any((v.get("command") or "").strip() for v in item["verifications"])
-        and not _has_falsifiable_rung(item)
-        and not _falsifiability_grandfathered(conn, item)
-    ):
-        findings.append(
-            "no falsifiability: every rung's expected text reads as passing on the unfixed tree "
-            "(an unrunnable rung does not count) - at least one rung must fail while the defect "
-            "exists, e.g. 'exits 1 on an unfixed tree'"
-        )
+    # Falsifiability is advisory (see lint_item_notes); it deliberately does
+    # not contribute findings that fail the lint exit code.
     if get_config(conn, "lint.require_scope_test_files") == "on" and item["state"] in ("planning", "active"):
         findings.extend(_missing_scope_test_files(item))
     return findings
-
 
 # ---------------------------------------------------------------------------
 # Export
@@ -4298,7 +4298,15 @@ def main(argv: list[str] | None = None) -> int:
     p.add_argument("id")
     p.add_argument("--run", type=int, metavar="SEQ")
 
-    p = sub.add_parser("lint", help="mechanical quality checks")
+    p = sub.add_parser(
+        "lint",
+        help="mechanical quality checks (falsifiability is advisory and does not fail the exit code)",
+        description=(
+            "Mechanical quality checks over item structure. Findings fail the "
+            "command (exit 1). The falsifiability rule is advisory: unfalsifiable "
+            "ladders are still reported as notes but do not fail lint."
+        ),
+    )
     p.add_argument(
         "--include-done",
         action="store_true",

--- a/tests/unit/scripts/test_todo_db_freeze.py
+++ b/tests/unit/scripts/test_todo_db_freeze.py
@@ -544,20 +544,23 @@ class TestFalsifiabilityGrandfathering:
         # grepping for the finding reads a cleared backlog as unfixed.
         assert "no falsifiability" not in notes[0]
 
-    def test_a_post_rule_item_is_still_a_finding(self, conn):
+    def test_a_post_rule_item_is_still_reported_as_advisory_note(self, conn):
         item = self._new(conn)
-        assert [f for f in todo_db.lint_item(conn, item) if "no falsifiability" in f]
+        assert not [f for f in todo_db.lint_item(conn, item) if "no falsifiability" in f]
+        assert [n for n in todo_db.lint_item_notes(conn, item) if "no falsifiability" in n]
 
     def test_grandfathering_can_be_switched_off_to_audit_the_backlog(self, conn):
         item = self._old(conn)
         todo_db.set_config(conn, "tester", "lint.grandfather_falsifiability", "off")
-        assert [f for f in todo_db.lint_item(conn, item) if "no falsifiability" in f]
+        assert not [f for f in todo_db.lint_item(conn, item) if "no falsifiability" in f]
+        assert [n for n in todo_db.lint_item_notes(conn, item) if "no falsifiability" in n]
 
     def test_a_missing_creation_stamp_buys_no_exemption(self, conn):
         """Otherwise clearing created_at becomes an opt-out."""
         item = self._old(conn, "undated-item")
         conn.execute("UPDATE items SET created_at = '' WHERE id = ?", (item,))
-        assert [f for f in todo_db.lint_item(conn, item) if "no falsifiability" in f]
+        assert not [f for f in todo_db.lint_item(conn, item) if "no falsifiability" in f]
+        assert [n for n in todo_db.lint_item_notes(conn, item) if "no falsifiability" in n]
 
     def test_a_pre_rule_item_with_a_good_ladder_gets_no_note(self, conn):
         """Grandfathering reports only items that would otherwise trip."""

--- a/tests/unit/scripts/test_todo_db_v2.py
+++ b/tests/unit/scripts/test_todo_db_v2.py
@@ -812,10 +812,11 @@ class TestLintExemptionVisibility:
         notes = todo_db.lint_item_notes(conn, "flake-exempt")
         assert any("exempt" in n for n in notes)
 
-    def test_normal_category_gets_finding_not_note(self, conn):
+    def test_normal_category_gets_advisory_note_not_finding(self, conn):
         self._mk_exempt(conn, "normal-cat", "security")
-        assert any("falsifiability" in f for f in todo_db.lint_item(conn, "normal-cat"))
-        assert todo_db.lint_item_notes(conn, "normal-cat") == []
+        assert not any("falsifiability" in f for f in todo_db.lint_item(conn, "normal-cat"))
+        notes = todo_db.lint_item_notes(conn, "normal-cat")
+        assert any("no falsifiability" in n for n in notes)
 
     def test_exemption_note_does_not_affect_exit_code(self, conn, capsys, monkeypatch):
         self._mk_exempt(conn, "flake-exit", "flake")
@@ -867,7 +868,8 @@ class TestLintFalsifiabilityAndScopeCompleteness:
                 {"description": "suite green", "command": "uv run -- pytest tests -q", "expected": "all pass"}
             ],
         )
-        assert any("falsifiability" in f for f in todo_db.lint_item(conn, "pass-only"))
+        assert not any("falsifiability" in f for f in todo_db.lint_item(conn, "pass-only"))
+        assert any("no falsifiability" in n for n in todo_db.lint_item_notes(conn, "pass-only"))
 
     def test_falsifiability_accepts_a_gating_rung(self, conn):
         self._mk_item(
@@ -899,8 +901,9 @@ class TestLintFalsifiabilityAndScopeCompleteness:
             ],
         )
         findings = todo_db.lint_item(conn, "broken-gate")
-        assert any("falsifiability" in f for f in findings)
+        assert not any("falsifiability" in f for f in findings)
         assert any("cannot execute" in f for f in findings)
+        assert any("no falsifiability" in n for n in todo_db.lint_item_notes(conn, "broken-gate"))
 
     def test_falsifiability_exempts_flake_tripwires(self, conn):
         self._mk_item(


### PR DESCRIPTION
## Summary

Demotes the falsifiability lint rule from a **gating finding** (fails `todo lint`) to an **advisory note** (still printed, does not affect exit code).

A gate whose only remedy is drop+recreate was driving the drop+recreate duplication statistics used to argue against the tracker. Detection remains; exit-status posture is what changes.

- Unfalsifiable ladders report `note: no falsifiability: ... (advisory; does not fail lint)`
- Category exemptions and grandfathering notes are unchanged
- Other lint findings still fail the command as before
- `todo lint --help` documents the advisory posture

Closes tracker item `demote-falsifiability-lint-to-advisory`.

## Test plan

- [x] `_project/scripts/todo lint --help | grep -qi advisor`
- [x] `uv run -- python -m pytest tests/unit/scripts/test_todo_db_v2.py tests/unit/scripts/test_todo_db_freeze.py tests/unit/scripts/test_todo_db.py -q` (242 passed)
- [ ] CI green
