### PR TITLE
fix(ci): make corpus drift canary directional

### DIFF
--- a/.github/workflows/corpus-drift-check.yml
+++ b/.github/workflows/corpus-drift-check.yml
@@ -19,6 +19,13 @@ name: Corpus Drift Check
 # It only reports. Opening the mirror stays a human step
 # (`gh workflow run sync-results-data-to-published.yml`) so a stale public
 # corpus is loud without this workflow gaining write access to a public branch.
+#
+# Direction matters. A two-way `git diff published develop` also surfaces
+# published-only paths (community submissions that landed on published-results
+# and have not been back-ported to develop). Recommending a full mirror for
+# those paths would *delete* public content. This canary therefore classifies:
+#   - develop-ahead / content-changed: fail + recommend mirror (leak class)
+#   - published-only: report as info, never recommend a destructive mirror
 
 on:
   schedule:
@@ -44,38 +51,137 @@ jobs:
           ref: develop
           fetch-depth: 0
 
-      - name: Compare the mirrored corpus paths
+      - name: Compare the mirrored corpus paths (directional)
         run: |
           set -euo pipefail
-          git fetch --no-tags --depth=1 origin published-results
+          # Explicit refspec so origin/published-results is a named ref, not only FETCH_HEAD.
+          git fetch --no-tags --depth=1 origin published-results:refs/remotes/origin/published-results
+
+          PUB=origin/published-results
+          DEV=HEAD
 
           # Fail clearly rather than silently passing an empty comparison.
-          if ! git cat-file -e FETCH_HEAD:results-data 2>/dev/null; then
+          if ! git cat-file -e "${PUB}:results-data" 2>/dev/null; then
             echo "::error::published-results has no results-data/ tree"
             exit 2
           fi
 
-          # Same path set the sync workflow mirrors.
-          DRIFT=$(git diff --name-only FETCH_HEAD HEAD -- \
-            'results-data/bundles' \
-            'results-data/corpus-inventory.json' \
-            'results-data/CORPUS_NOTES.md' \
-            'results-data/SEED_CORPUS_SPEC.md' \
-            'results-data/README.md' \
-            'results-data/validate_corpus.py')
+          # Same path set the sync workflow mirrors for the corpus tip.
+          # Two-tree compare (no dots): published-results is an orphan branch
+          # with no merge-base with develop.
+          PATHSPECS=(
+            'results-data/bundles'
+            'results-data/corpus-inventory.json'
+            'results-data/CORPUS_NOTES.md'
+            'results-data/SEED_CORPUS_SPEC.md'
+            'results-data/README.md'
+            'results-data/validate_corpus.py'
+          )
 
-          if [[ -z "${DRIFT}" ]]; then
-            echo "Corpus is in sync between develop and published-results."
+          # A = published, B = develop. Diff filter is relative to A→B.
+          #  A: paths present on develop only (or added) — develop is ahead.
+          #  D: paths present on published only — would be deleted by a full mirror.
+          #  M: content differs on both sides — develop is ahead with updates.
+          DEVELOP_AHEAD=$(git diff --name-only --diff-filter=A "${PUB}" "${DEV}" -- "${PATHSPECS[@]}" || true)
+          PUBLISHED_ONLY=$(git diff --name-only --diff-filter=D "${PUB}" "${DEV}" -- "${PATHSPECS[@]}" || true)
+          CONTENT_CHANGED=$(git diff --name-only --diff-filter=M "${PUB}" "${DEV}" -- "${PATHSPECS[@]}" || true)
+
+          STALE_PATHS=$(printf '%s\n%s\n' "${CONTENT_CHANGED}" "${DEVELOP_AHEAD}" | sed '/^$/d' || true)
+
+          if [[ -n "${PUBLISHED_ONLY}" ]]; then
+            PO_COUNT=$(printf '%s\n' "${PUBLISHED_ONLY}" | sed '/^$/d' | wc -l | tr -d ' ')
+            echo "::notice::published-results has ${PO_COUNT} path(s) not on develop (published-only)."
+            echo "These are often community submissions that landed on the public"
+            echo "branch and have not been back-ported. Do NOT run a full mirror"
+            echo "to clear this list — that would delete public content."
+            echo "Published-only paths (first 40):"
+            printf '%s\n' "${PUBLISHED_ONLY}" | head -40
+            echo ""
+          fi
+
+          if [[ -z "${STALE_PATHS}" ]]; then
+            if [[ -z "${PUBLISHED_ONLY}" ]]; then
+              echo "Corpus is in sync between develop and published-results."
+            else
+              echo "No develop-ahead drift. published-only paths were reported above (non-fatal)."
+            fi
             exit 0
           fi
 
-          COUNT=$(printf '%s\n' "${DRIFT}" | wc -l | tr -d ' ')
-          echo "::error::published-results corpus is ${COUNT} path(s) behind develop."
+          COUNT=$(printf '%s\n' "${STALE_PATHS}" | wc -l | tr -d ' ')
+          echo "::error::published-results corpus is ${COUNT} path(s) behind develop (develop-ahead or content-changed)."
           echo "The public corpus is stale. If develop has since sanitized or"
           echo "corrected bundles, the public branch is still serving the old"
           echo "content. Mirror it with:"
           echo "  gh workflow run sync-results-data-to-published.yml --ref develop"
           echo ""
-          echo "Drifted paths (first 40):"
-          printf '%s\n' "${DRIFT}" | head -40
+          echo "Develop-ahead / content-changed paths (first 40):"
+          printf '%s\n' "${STALE_PATHS}" | head -40
           exit 1
+
+      - name: Install uv for the published-tip privacy scan
+        uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: true
+
+      - name: Privacy scan published-results tip for plaintext path leaks
+        run: |
+          set -euo pipefail
+          # Detector lives on develop; scanned bytes come from published-results.
+          # Report-only for the canary surface: exit non-zero on any leak so the
+          # scheduled run is loud, without granting write access to the public branch.
+          git fetch --no-tags --depth=1 origin published-results:refs/remotes/origin/published-results
+          PUB=origin/published-results
+          if ! git cat-file -e "${PUB}:results-data/bundles" 2>/dev/null; then
+            echo "::error::published-results has no results-data/bundles tree"
+            exit 2
+          fi
+
+          uv run -- python - <<'PY'
+          from __future__ import annotations
+
+          import json
+          import subprocess
+          import sys
+
+          from benchbox.core.results.anonymization import find_public_path_leaks
+
+          pub = "origin/published-results"
+          listed = subprocess.check_output(
+              ["git", "ls-tree", "-r", "--name-only", pub, "results-data/"],
+              text=True,
+          )
+          json_paths = [p for p in listed.splitlines() if p.endswith(".json")]
+          if not json_paths:
+              print("::error::published-results results-data/ has no JSON files to scan", file=sys.stderr)
+              sys.exit(2)
+
+          offenders: list[str] = []
+          unreadable: list[str] = []
+          for path in json_paths:
+              try:
+                  raw = subprocess.check_output(["git", "show", f"{pub}:{path}"])
+                  payload = json.loads(raw)
+              except (subprocess.CalledProcessError, UnicodeDecodeError, json.JSONDecodeError) as exc:
+                  unreadable.append(f"{path}: {type(exc).__name__}")
+                  continue
+              leaks = find_public_path_leaks(payload)
+              if leaks:
+                  offenders.append(f"{path}: {', '.join(sorted(set(leaks))[:5])}")
+
+          if unreadable:
+              print(
+                  f"::error::{len(unreadable)} published corpus file(s) could not be parsed (failing closed):",
+                  file=sys.stderr,
+              )
+              print("\n".join(unreadable[:20]), file=sys.stderr)
+              sys.exit(1)
+          if offenders:
+              print(
+                  f"::error::{len(offenders)} published corpus file(s) expose private paths:",
+                  file=sys.stderr,
+              )
+              print("\n".join(offenders[:20]), file=sys.stderr)
+              sys.exit(1)
+          print(f"Privacy scan clean: {len(json_paths)} published JSON surface(s), 0 path leaks.")
+          PY

--- a/tests/unit/scripts/test_corpus_drift_canary.py
+++ b/tests/unit/scripts/test_corpus_drift_canary.py
@@ -1,0 +1,187 @@
+"""Directional corpus-drift canary: develop-ahead vs published-only.
+
+The scheduled workflow `.github/workflows/corpus-drift-check.yml` must:
+
+1. Fail when develop is ahead of published-results on mirrored corpus paths
+   (the leak class that motivated the canary).
+2. Report published-only paths without recommending a full mirror that would
+   delete community submissions.
+3. Never use a direction-blind ``git diff FETCH_HEAD HEAD`` classification.
+4. Include a scheduled privacy scan of the published tip itself.
+
+Behavioral classification is exercised against temporary git repositories so
+the test does not depend on the live ``published-results`` tip.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import pytest
+import yaml
+
+pytestmark = [
+    pytest.mark.unit,
+    pytest.mark.fast,
+]
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+WORKFLOW_PATH = REPO_ROOT / ".github" / "workflows" / "corpus-drift-check.yml"
+CORPUS_PATHSPECS = (
+    "results-data/bundles",
+    "results-data/corpus-inventory.json",
+    "results-data/CORPUS_NOTES.md",
+    "results-data/SEED_CORPUS_SPEC.md",
+    "results-data/README.md",
+    "results-data/validate_corpus.py",
+)
+
+
+def _run(cmd: list[str], *, cwd: Path) -> str:
+    return subprocess.check_output(cmd, cwd=cwd, text=True).strip()
+
+
+def _init_repo(root: Path) -> None:
+    root.mkdir(parents=True, exist_ok=True)
+    _run(["git", "init", "-b", "main"], cwd=root)
+    _run(["git", "config", "user.email", "canary@example.com"], cwd=root)
+    _run(["git", "config", "user.name", "Canary Test"], cwd=root)
+
+
+def _commit_tree(root: Path, files: dict[str, str], message: str) -> str:
+    """Replace the tracked results-data tree with *files*, commit, return SHA."""
+    existing = _run(["git", "ls-files", "results-data"], cwd=root)
+    if existing:
+        _run(["git", "rm", "-rf", "--quiet", "results-data"], cwd=root)
+    for rel, content in files.items():
+        path = root / rel
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(content, encoding="utf-8")
+        _run(["git", "add", rel], cwd=root)
+    _run(["git", "add", "-A"], cwd=root)
+    _run(["git", "commit", "--allow-empty", "-m", message], cwd=root)
+    return _run(["git", "rev-parse", "HEAD"], cwd=root)
+
+
+def classify_corpus_drift(repo: Path, published_ref: str, develop_ref: str) -> dict[str, list[str]]:
+    """Classify two-tree corpus drift the same way the workflow must.
+
+    ``git diff A B`` is A→B: Added = develop-only, Deleted = published-only,
+    Modified = content-changed on both sides.
+    """
+
+    def names(diff_filter: str) -> list[str]:
+        raw = subprocess.check_output(
+            [
+                "git",
+                "diff",
+                "--name-only",
+                f"--diff-filter={diff_filter}",
+                published_ref,
+                develop_ref,
+                "--",
+                *CORPUS_PATHSPECS,
+            ],
+            cwd=repo,
+            text=True,
+        )
+        return [line for line in raw.splitlines() if line]
+
+    develop_ahead = names("A")
+    published_only = names("D")
+    content_changed = names("M")
+    stale = content_changed + develop_ahead
+    return {
+        "develop_ahead": develop_ahead,
+        "published_only": published_only,
+        "content_changed": content_changed,
+        "stale": stale,
+    }
+
+
+def _workflow_run_scripts() -> list[str]:
+    workflow = yaml.safe_load(WORKFLOW_PATH.read_text(encoding="utf-8"))
+    steps = workflow["jobs"]["corpus-drift"]["steps"]
+    return [step.get("run", "") for step in steps if step.get("run")]
+
+
+def test_workflow_is_scheduled_and_report_only() -> None:
+    workflow = yaml.safe_load(WORKFLOW_PATH.read_text(encoding="utf-8"))
+    # PyYAML parses the unquoted workflow key `on:` as boolean True.
+    on_events = workflow[True]
+    assert "schedule" in on_events
+    assert workflow["permissions"]["contents"] == "read"
+    joined = "\n".join(_workflow_run_scripts())
+    assert "gh pr create" not in joined
+    assert "workflow_dispatch" in on_events
+
+
+def test_workflow_does_not_use_direction_blind_fetch_head_head_diff() -> None:
+    text = WORKFLOW_PATH.read_text(encoding="utf-8")
+    assert "FETCH_HEAD HEAD" not in text
+    scripts = "\n".join(_workflow_run_scripts())
+    assert "--diff-filter=A" in scripts
+    assert "--diff-filter=D" in scripts
+    assert "--diff-filter=M" in scripts
+    assert "published-only" in scripts
+    assert "Do NOT run a full mirror" in scripts
+    assert "gh workflow run sync-results-data-to-published.yml" in scripts
+
+
+def test_workflow_includes_published_tip_privacy_scan() -> None:
+    scripts = "\n".join(_workflow_run_scripts())
+    assert "find_public_path_leaks" in scripts
+    assert "published-results" in scripts
+
+
+def test_classifier_separates_published_only_from_develop_ahead(tmp_path: Path) -> None:
+    repo = tmp_path / "corpus"
+    _init_repo(repo)
+
+    published_files = {
+        "results-data/corpus-inventory.json": '{"version": 1}\n',
+        "results-data/bundles/shared.json": '{"id": "shared-v1"}\n',
+        "results-data/bundles/community_only.json": '{"id": "community"}\n',
+    }
+    published_sha = _commit_tree(repo, published_files, "published tip")
+    _run(["git", "branch", "published-results", published_sha], cwd=repo)
+
+    develop_files = {
+        "results-data/corpus-inventory.json": '{"version": 1}\n',
+        "results-data/bundles/shared.json": '{"id": "shared-v2-sanitized"}\n',
+        "results-data/bundles/develop_only.json": '{"id": "new-on-develop"}\n',
+    }
+    develop_sha = _commit_tree(repo, develop_files, "develop tip")
+
+    result = classify_corpus_drift(repo, published_sha, develop_sha)
+
+    assert "results-data/bundles/community_only.json" in result["published_only"]
+    assert "results-data/bundles/develop_only.json" in result["develop_ahead"]
+    assert "results-data/bundles/shared.json" in result["content_changed"]
+    assert "results-data/bundles/community_only.json" not in result["stale"]
+    assert "results-data/bundles/develop_only.json" in result["stale"]
+    assert "results-data/bundles/shared.json" in result["stale"]
+
+
+def test_classifier_in_sync_when_trees_match(tmp_path: Path) -> None:
+    repo = tmp_path / "corpus"
+    _init_repo(repo)
+    files = {
+        "results-data/corpus-inventory.json": '{"version": 1}\n',
+        "results-data/bundles/a.json": '{"id": "a"}\n',
+    }
+    sha = _commit_tree(repo, files, "same")
+    result = classify_corpus_drift(repo, sha, sha)
+    assert result["stale"] == []
+    assert result["published_only"] == []
+
+
+def test_mirror_recommendation_only_for_stale_not_published_only() -> None:
+    """Document the canary policy: only stale paths get the mirror recipe."""
+    scripts = "\n".join(_workflow_run_scripts())
+    # The destructive warning is tied to the published-only branch.
+    published_only_block = scripts.split("published-only")[1].split("Develop-ahead")[0]
+    assert "Do NOT run a full mirror" in published_only_block
+    # The mirror recipe appears in the stale/error path, not as the only advice.
+    assert "gh workflow run sync-results-data-to-published.yml --ref develop" in scripts


### PR DESCRIPTION
Classify develop-ahead vs published-only so a scheduled canary never
recommends a full mirror that would delete community submissions. Add a
published-tip privacy scan and unit coverage for both paths.
