### PR TITLE
docs(privacy): close retained-field salt decision

### DIFF
--- a/benchbox/core/results/anonymization.py
+++ b/benchbox/core/results/anonymization.py
@@ -110,11 +110,21 @@ def _is_public_pseudonym(value: str, prefix: str) -> bool:
 
 @dataclass
 class AnonymizationConfig:
-    """Configuration for result anonymization."""
+    """Configuration for result anonymization.
+
+    ``machine_id_salt`` defaults to empty. Under that default, public
+    identifier pseudonyms are a confirmation oracle for anyone who knows the
+    documented hash (see ``adr-published-identifier-field-set`` retained-field
+    salt decision). Open-source BenchBox keeps the empty default so a
+    repository-baked salt cannot pretend to be a secret. Operators who publish
+    community-facing results must set a non-empty salt known only to the
+    deployment before the first public export. Already-public-shaped tokens
+    still pass through unchanged (publication fixed point).
+    """
 
     # Machine identification. The salt feeds both get_anonymous_machine_id and
     # the public pseudonym hash, so it is the one knob that changes published
-    # identity.
+    # identity for *raw* values. Empty default = residual confirmation oracle.
     machine_id_salt: Optional[str] = None
 
     # Data anonymization

--- a/docs/development/adr/adr-published-identifier-field-set.md
+++ b/docs/development/adr/adr-published-identifier-field-set.md
@@ -1,7 +1,8 @@
 # ADR: Drop unread identifier fields from the published corpus
 
-- Status: Accepted (implemented at the public anonymization boundary)
-- Date: 2026-08-04
+- Status: Accepted (implemented at the public anonymization boundary;
+  retained-field salt closed 2026-08-05)
+- Date: 2026-08-04; salt amendment 2026-08-05
 - Supersedes nothing. Constrains `benchbox/core/results/anonymization.py` and
   any future re-derivation of `results-data/`.
 
@@ -51,26 +52,65 @@ implemented. Nothing correlates by machine today.
 **Do not publish the six fields that have no consumer.** Remove them at the
 publication boundary rather than pseudonymising them.
 
-For the three that do have a consumer, keep publishing a pseudonym and treat
-the salt question as open (see Consequences).
+For the three that do have a consumer, keep publishing a pseudonym. The
+retained-field salt decision is recorded below (closed 2026-08-05).
 
-## Alternatives considered
+## Retained-field salt decision (2026-08-05)
 
-**Mint a real default salt.** Preserves every field and closes the oracle for
-future captures. Rejected as the primary remedy because it does not close it
-for the corpus already published — those bytes are already public and the
-history is retained — and because it keeps paying a privacy cost for data no
-consumer reads. A hashed `working_dir` has no analytical value; the reductio is
-`database_5d7b725135a6`, which decodes to the string `benchbox`. Salting is
-still the right answer for the three fields with readers, which is why it stays
-open rather than rejected outright.
+**Keep the empty default salt in open-source BenchBox. Do not mint a
+repository-baked default salt. Do not one-time rehash retained fields.**
 
-**Accept the oracle and document it.** Defensible on the material exposed so
-far — a repository path and a database name are low sensitivity. Rejected
-because the exposure scales with contributors, not with us: `engine_host` and a
-submitter's home directory carry real names, and the corpus is meant to accept
-community submissions. Choosing to publish confirmable identifiers on other
-people's behalf is not ours to make silently.
+Retained published identifiers (`endpoint`, `database_name`,
+`submission_path`) therefore remain a **residual confirmation oracle** under
+the empty default: anyone who knows the documented algorithm can hash a
+candidate and match corpus tokens with certainty. That residual is accepted for
+the curated maintainer seed corpus and documented; it is **not** accepted as
+the right default for an operator who will publish other people's submissions.
+
+| Option | Outcome | Decision |
+|---|---|---|
+| Keep empty default salt | Residual oracle on retained fields; fixed point and current corpus bytes unchanged | **Chosen for OSS default** |
+| Mint a baked-in non-empty default salt | Salt is public in git, so the oracle remains; only obscures the empty-string case | **Rejected** |
+| One-time rehash of retained fields under a new salt | Breaks the #1512 publication fixed point; rotates `result_id` again; history still holds the old tokens; without a *secret* salt the oracle returns | **Rejected** |
+| Require a non-empty operator-configured salt before public export | Closes the oracle for deployments that set it; needs a secret outside the repo | **Recommended for community-facing operators** (documented; not a hard fail of the OSS default path in this ADR) |
+
+Rationale:
+
+1. **A salt in the repository is not a secret.** Hashing with a public constant
+   is still a confirmation oracle. "Mint a default salt" only helps if the salt
+   never ships in the open tree.
+2. **The publication fixed point stays.** Already-public-shaped
+   `endpoint_` / `database_` / `path_` tokens continue to pass through. A
+   one-time rehash would not remove retained history tokens on
+   `published-results` and would force another free-only-once `result_id`
+   rotation after #1578.
+3. **The unread-field drop already removed the highest-risk empty-salt
+   surfaces** (`machine_id`, home-directory paths, `engine_host`, …). What
+   remains is low-entropy product material (database names, local endpoints)
+   plus whatever community submitters put in retained keys — the latter is why
+   operators must set a real salt before accepting third-party submissions.
+4. **Operators close the residual.** Set `AnonymizationConfig.machine_id_salt`
+   (or the equivalent export config) to a non-empty value known only to the
+   deployment *before* the first public publish. New raw values then hash under
+   that salt; already-published tokens still pass through by design.
+
+## Alternatives considered (field-set)
+
+**Mint a real default salt (in-repo).** Preserves every field and appears to
+close the oracle for future captures. Rejected as the primary remedy for the
+*unread* fields because it does not close the oracle for the corpus already
+published, keeps paying a privacy cost for data no consumer reads, and — once
+the salt question is examined for retained fields — a baked-in salt is still
+public. A hashed `working_dir` has no analytical value; the reductio is
+`database_5d7b725135a6`, which decodes to the string `benchbox`.
+
+**Accept the oracle and document it (for unread fields).** Defensible on the
+material exposed so far — a repository path and a database name are low
+sensitivity. Rejected for the six unread fields because the exposure scales
+with contributors: `engine_host` and a submitter's home directory carry real
+names. Choosing to publish confirmable identifiers on other people's behalf is
+not ours to make silently. For the three retained fields the residual is
+documented instead of denied (see salt decision above).
 
 **Keep pseudonymising but stop publishing the bundles.** Not a real option; the
 bundles are the product.
@@ -91,10 +131,9 @@ bundles are the product.
   That decision was recorded in `adr-published-results-history-retention.md`
   before reversibility was known, and is re-examined separately under
   `published-history-retention-premise-predates-oracle`.
-- The salt question stays open for `endpoint`, `database_name`, and
-  `submission_path`. Whatever is decided must preserve the publication fixed
-  point from #1512: an already-pseudonymised value passes through unchanged, so
-  rotating the salt does not re-pseudonymise a stored corpus.
+- Retained-field salt decision (2026-08-05): empty OSS default; residual
+  confirmation oracle documented; operator-configured non-empty salt recommended
+  for community-facing publishes; publication fixed point from #1512 preserved.
 
 ## What this does not change
 

--- a/docs/reference/result-formats.md
+++ b/docs/reference/result-formats.md
@@ -477,6 +477,21 @@ config = AnonymizationConfig(
 exporter = ResultExporter(anonymize=True, anonymization_config=config)
 ```
 
+#### Default salt and residual confirmation oracle
+
+`machine_id_salt` defaults to empty. With the empty default, anyone who knows
+the documented algorithm can confirm candidate values against published
+`<kind>_<12 hex>` tokens. Unread identifier fields are omitted entirely (see
+`docs/development/adr/adr-published-identifier-field-set.md`). Retained fields
+(`endpoint`, `database_name`, `submission_path`) still publish pseudonyms, so
+the **residual oracle on those fields is accepted for the OSS default** and
+documented rather than denied.
+
+A non-empty salt closes the oracle only if it is **not** shipped in the public
+tree. Operators who will publish community submissions must set
+`machine_id_salt` to a deployment-private value before the first public export.
+A repository-baked "default salt" would still be public and is rejected.
+
 #### Salt rotation
 
 The salt applies when a **raw** value is hashed. A value that is already a

--- a/tests/unit/scripts/test_corpus_pseudonym_recovery.py
+++ b/tests/unit/scripts/test_corpus_pseudonym_recovery.py
@@ -8,13 +8,15 @@ This gate closes that hole for the unread-identifier drop (ADR
 
 1. Drop-field keys must be absent from every corpus JSON file after re-derive.
 2. Measured recoverable tokens that lived under dropped fields must be gone.
-3. Optional: a fixed safe dictionary of low-entropy *public* candidates must
-   not recover a path/machine/host pseudonym still present in the corpus
-   (prefixes that only the dropped fields used to mint at those keys).
+3. A fixed safe dictionary of low-entropy *public* candidates must not recover
+   a path/machine/host pseudonym still present in the corpus (prefixes that
+   only the dropped fields used to mint at those keys).
 
 Retained fields (``endpoint``, ``database_name``, ``submission_path``) still
-publish pseudonyms; their salt question is open. Do not record or print
-recovered plaintext values in comments, commits, or PR bodies — tokens only.
+publish pseudonyms under the empty OSS default salt. The residual confirmation
+oracle on those fields is an accepted, documented policy (ADR salt decision
+2026-08-05), not a green-gate failure. Do not record or print recovered
+plaintext values in comments, commits, or PR bodies — tokens only.
 """
 
 from __future__ import annotations
@@ -24,7 +26,7 @@ from pathlib import Path
 
 import pytest
 
-from benchbox.core.results.anonymization import AnonymizationManager
+from benchbox.core.results.anonymization import AnonymizationConfig, AnonymizationManager
 
 pytestmark = [
     pytest.mark.unit,
@@ -132,9 +134,9 @@ def test_safe_dictionary_does_not_recover_dropped_field_pseudonyms() -> None:
     """A fixed public dictionary must not confirm path/machine/host tokens.
 
     Only prefixes that dropped fields used to mint at those keys are checked.
-    Retained-field prefixes (database, endpoint) stay out of this sweep until
-    the open salt decision lands — pinning them here would fight the keep-list
-    and the publication fixed point.
+    Retained-field prefixes (database, endpoint, path-under-submission_path)
+    are out of this fail-closed sweep: residual empty-salt recovery there is
+    the accepted OSS default policy, not a re-derive regression.
     """
     manager = AnonymizationManager()
     blob = _corpus_blob()
@@ -149,3 +151,37 @@ def test_safe_dictionary_does_not_recover_dropped_field_pseudonyms() -> None:
     # Deduplicate while preserving order for a stable failure message.
     unique_hits = list(dict.fromkeys(hits))
     assert not unique_hits, f"dictionary-recoverable dropped-field tokens remain: {unique_hits}"
+
+
+def test_retained_field_residual_oracle_is_documented_policy_not_a_gate_failure() -> None:
+    """Empty-salt retained prefixes remain dictionary-confirmable by design.
+
+    Pins the 2026-08-05 ADR decision: residual oracle on retained fields is
+    accepted for the OSS default. This test proves the algorithm property
+    (empty salt + known candidate → stable token) without scanning the corpus
+    for residual hits and without embedding recovered plaintext.
+    """
+    empty = AnonymizationManager()
+    # Public product token only — not a personal or path secret.
+    candidate = "benchbox"
+    token = empty._hash_public_identifier(candidate, "database")
+    assert token.startswith("database_")
+    assert len(token) == len("database_") + 12
+    # Same empty-salt manager always confirms the same candidate.
+    assert empty._hash_public_identifier(candidate, "database") == token
+
+
+def test_operator_salt_defeats_safe_dictionary_for_new_raw_values() -> None:
+    """A deployment-private salt closes the oracle for newly hashed raw values."""
+    salted = AnonymizationManager(AnonymizationConfig(machine_id_salt="deployment-private-test-salt"))
+    empty = AnonymizationManager()
+    for candidate in _SAFE_PUBLIC_DICTIONARY:
+        for prefix in ("database", "endpoint", "path"):
+            assert salted._hash_public_identifier(candidate, prefix) != empty._hash_public_identifier(candidate, prefix)
+
+
+def test_publication_fixed_point_ignores_operator_salt() -> None:
+    """Already-public-shaped tokens pass through even when a salt is configured."""
+    token = AnonymizationManager()._hash_public_identifier("benchbox", "database")
+    salted = AnonymizationManager(AnonymizationConfig(machine_id_salt="deployment-private-test-salt"))
+    assert salted._hash_public_identifier(token, "database") == token


### PR DESCRIPTION
Record keep-empty OSS default with residual confirmation oracle on
retained published identifiers; reject baked-in salts and one-time
rehash. Extend recovery-gate tests for residual policy and operator salt.
