### PR TITLE
fix(results): omit empty client_host after public identifier drop

### DIFF
--- a/benchbox/core/results/anonymization.py
+++ b/benchbox/core/results/anonymization.py
@@ -55,6 +55,10 @@ _MESSAGE_KEYS = set(_ANONYMIZATION_SPECS["message_keys"])
 # Unread identifier fields: omit at the public boundary rather than publish a
 # confirmable pseudonym. Compact forms; see anonymization_specs.yaml.
 _PUBLIC_DROP_KEYS = frozenset(_ANONYMIZATION_SPECS["public_drop_keys"])
+# Optional nested maps that collapse to `{}` after drop keys are removed.
+# Omit the empty block rather than publishing a hollow object (e.g. client_host
+# that only held machine_id). Compact forms match ``_compact_key``.
+_PUBLIC_EMPTY_OPTIONAL_MAP_KEYS = frozenset({"clienthost"})
 
 _MESSAGE_PATH_RE = re.compile(
     r"(?<![A-Za-z0-9_])("
@@ -508,9 +512,23 @@ class AnonymizationManager:
                     continue
                 child_path = (*key_path, str(key))
                 if self._is_secret_metadata_key(child_path):
-                    anonymized[key] = PUBLIC_REDACTED_VALUE if child not in (None, "") else child
+                    child_value = PUBLIC_REDACTED_VALUE if child not in (None, "") else child
                 else:
-                    anonymized[key] = self._anonymize_public_value(child, child_path)
+                    child_value = self._anonymize_public_value(child, child_path)
+                # After dropping identifier-only content (e.g. client_host with
+                # only machine_id), omit the empty optional block rather than
+                # publishing a hollow object. Non-empty profiles keep.
+                # Already-empty `{}` maps in stored corpus pass through so the
+                # publication fixed point is not broken without a re-derive.
+                if (
+                    isinstance(child_value, dict)
+                    and not child_value
+                    and isinstance(child, dict)
+                    and child
+                    and _compact_key(str(key)) in _PUBLIC_EMPTY_OPTIONAL_MAP_KEYS
+                ):
+                    continue
+                anonymized[key] = child_value
             return anonymized
 
         if isinstance(value, (set, frozenset)):

--- a/tests/unit/core/results/test_anonymization.py
+++ b/tests/unit/core/results/test_anonymization.py
@@ -1005,6 +1005,41 @@ class TestPublicUnreadIdentifierDrop:
         assert out["environment"]["client_host"]["hostname"].startswith("host_")
         assert out["environment"]["platform_runtime"]["runtime_type"] == "local"
 
+    def test_empty_client_host_omitted_after_machine_id_drop(self):
+        """client_host that only held machine_id must not publish as {}."""
+        out = AnonymizationManager().anonymize_result_payload(
+            {"environment": {"client_host": {"machine_id": "raw-machine"}, "other": 1}}
+        )
+        assert "client_host" not in out.get("environment", {})
+        assert out["environment"]["other"] == 1
+
+    def test_already_empty_client_host_passes_through_for_fixed_point(self):
+        """Stored `client_host: {}` is left alone until an explicit re-derive."""
+        payload = {"environment": {"client_host": {}}}
+        out = AnonymizationManager().anonymize_result_payload(payload)
+        assert out["environment"]["client_host"] == {}
+
+    def test_nonempty_client_host_profile_still_exports(self):
+        out = AnonymizationManager().anonymize_result_payload(
+            {
+                "environment": {
+                    "client_host": {
+                        "machine_id": "raw-machine",
+                        "os": "macOS",
+                        "arch": "arm64",
+                        "cpu": "Apple M-series",
+                        "memory_gb": 32,
+                    }
+                }
+            }
+        )
+        host = out["environment"]["client_host"]
+        assert "machine_id" not in host
+        assert host["os"] == "macOS"
+        assert host["arch"] == "arm64"
+        assert host["cpu"] == "Apple M-series"
+        assert host["memory_gb"] == 32
+
     def test_drop_is_idempotent_when_fields_already_absent(self):
         manager = AnonymizationManager()
         once = manager.anonymize_result_payload({"platform": {"config": {"endpoint": "https://x.example"}}})


### PR DESCRIPTION
When client_host only carried machine_id, the drop left a hollow {}.
Omit those empty optional maps; keep non-empty host profiles intact.
