### PR TITLE
test(submit): pin uncertain+translation-fallback contract

### DIFF
--- a/tests/uat/test_runner.py
+++ b/tests/uat/test_runner.py
@@ -38,6 +38,7 @@ def _write_result_json(
     failed: int = 0,
     compliance_class: str | None = None,
     validation: str | None = None,
+    translation_status: str | None = None,
 ) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
     passed = 1 if failed == 0 else 0
@@ -69,6 +70,8 @@ def _write_result_json(
     }
     if compliance_class is not None:
         payload["benchmark"]["compliance_class"] = compliance_class
+    if translation_status is not None:
+        payload["execution"] = {"translation": {"status": translation_status}}
     path.write_text(json.dumps(payload), encoding="utf-8")
 
 
@@ -552,6 +555,37 @@ def test_classify_for_submit_prefers_unofficial_over_unvalidated(tmp_path: Path)
     result_path = tmp_path / "benchmark_runs" / "results" / "unofficial-unvalidated.json"
     _write_result_json(result_path, compliance_class="unofficial_subscale", validation="not_validated")
     assert runner.classify_for_submit(result_path) is runner.SubmitTerminalState.unofficial
+
+
+def test_classify_for_submit_keeps_uncertain_with_translation_fallback_as_passed_cell(tmp_path: Path):
+    """Uncertain+fallback stays unvalidated (not a cell failure); unvalidated excludes cell FAIL."""
+    result_path = tmp_path / "benchmark_runs" / "results" / "uncertain-fallback.json"
+    _write_result_json(result_path, validation="uncertain", translation_status="fallback")
+    fake_argv = [sys.executable, "-c", f"print({str(result_path)!r})"]
+
+    with patch.object(runner, "benchbox_run_argv", return_value=fake_argv):
+        result = runner.run_cell("duckdb", "tpch", 0.01, timeout_s=10, log_dir=tmp_path)
+
+    assert runner.classify_for_submit(result_path) is runner.SubmitTerminalState.unvalidated
+    assert not runner.submit_state_is_cell_failure(runner.SubmitTerminalState.unvalidated)
+    assert result.status == "passed"
+    assert result.exit_code == 0
+    assert result.submit_terminal_state == "unvalidated"
+
+
+def test_classify_for_submit_marks_translation_fallback_as_cell_failure(tmp_path: Path):
+    """Translation fallback alone is non-clean schema_violation and fails the UAT cell."""
+    result_path = tmp_path / "benchmark_runs" / "results" / "translation-fallback.json"
+    _write_result_json(result_path, validation="passed", translation_status="fallback")
+    fake_argv = [sys.executable, "-c", f"print({str(result_path)!r})"]
+
+    with patch.object(runner, "benchbox_run_argv", return_value=fake_argv):
+        result = runner.run_cell("duckdb", "tpch", 0.01, timeout_s=10, log_dir=tmp_path)
+
+    assert runner.classify_for_submit(result_path) is runner.SubmitTerminalState.schema_violation
+    assert runner.submit_state_is_cell_failure(runner.SubmitTerminalState.schema_violation)
+    assert result.status == "failed"
+    assert result.submit_terminal_state == "schema_violation"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/core/results/test_submit_classifier_contract.py
+++ b/tests/unit/core/results/test_submit_classifier_contract.py
@@ -36,6 +36,7 @@ def _write_result_json(
     failed: int = 0,
     validation: str = "passed",
     compliance_class: str | None = None,
+    translation_status: str | None = None,
 ) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
     passed = 1 if failed == 0 else 0
@@ -53,6 +54,8 @@ def _write_result_json(
     }
     if compliance_class is not None:
         payload["benchmark"]["compliance_class"] = compliance_class
+    if translation_status is not None:
+        payload["execution"] = {"translation": {"status": translation_status}}
     path.write_text(json.dumps(payload), encoding="utf-8")
 
 
@@ -79,6 +82,22 @@ def _loadable_cases(tmp_path: Path) -> list[tuple[str, Path, SubmitTerminalState
     unvalidated_unknown = tmp_path / "unvalidated-unknown.json"
     _write_result_json(unvalidated_unknown, failed=0, validation="unknown")
 
+    # Translation fallback alone is non-clean but not an unvalidated partition
+    # status → schema_violation terminal (not submittable).
+    translation_fallback = tmp_path / "translation-fallback.json"
+    _write_result_json(translation_fallback, failed=0, validation="passed", translation_status="fallback")
+
+    # Uncertain + translation fallback: unvalidated takes precedence over the
+    # translation non-clean reason so the refusal wording stays in the
+    # unvalidated family (claim-weakened), not schema_violation.
+    uncertain_with_translation_fallback = tmp_path / "uncertain-with-translation-fallback.json"
+    _write_result_json(
+        uncertain_with_translation_fallback,
+        failed=0,
+        validation="uncertain",
+        translation_status="fallback",
+    )
+
     unofficial = tmp_path / "unofficial.json"
     _write_result_json(unofficial, compliance_class="unofficial_subscale")
 
@@ -94,10 +113,16 @@ def _loadable_cases(tmp_path: Path) -> list[tuple[str, Path, SubmitTerminalState
         ("clean", clean, SubmitTerminalState.submittable),
         ("query_failure", query_failure, SubmitTerminalState.query_failure),
         ("schema_violation", schema_violation, SubmitTerminalState.schema_violation),
+        ("translation_fallback", translation_fallback, SubmitTerminalState.schema_violation),
         ("unvalidated_not_validated", unvalidated_not_validated, SubmitTerminalState.unvalidated),
         ("unvalidated_not_run", unvalidated_not_run, SubmitTerminalState.unvalidated),
         ("unvalidated_uncertain", unvalidated_uncertain, SubmitTerminalState.unvalidated),
         ("unvalidated_unknown", unvalidated_unknown, SubmitTerminalState.unvalidated),
+        (
+            "uncertain_with_translation_fallback",
+            uncertain_with_translation_fallback,
+            SubmitTerminalState.unvalidated,
+        ),
         ("unofficial", unofficial, SubmitTerminalState.unofficial),
         ("unofficial_and_unvalidated", unofficial_and_unvalidated, SubmitTerminalState.unofficial),
     ]


### PR DESCRIPTION
Classify uncertain with translation fallback as unvalidated (not a UAT
cell failure); translation fallback alone remains schema_violation.
