### PR TITLE
fix(ci): allow partial seed validation on trusted corpus mirrors

### DIFF
--- a/.github/workflows/sync-results-data-to-published.yml
+++ b/.github/workflows/sync-results-data-to-published.yml
@@ -260,7 +260,14 @@ jobs:
             # waives the sidecar requirement for (same auto/results-mirror-*
             # same-repo signal) — the seed-corpus, sidecar-less path is
             # legitimate here too, not a gap.
-            if ! printf '%s\n' "${CHANGED_BUNDLES}" | xargs -d '\n' uv run --no-project --python 3.11 -- python scripts/validate_submission.py; then
+            #
+            # --allow-partial-validation: the curated seed corpus intentionally
+            # includes summary.validation=partial cohorts for compare depth.
+            # Community submissions still require passed (validate-submission.yml
+            # never passes this flag). Privacy leaks and inventory staleness
+            # still fail closed below.
+            if ! printf '%s\n' "${CHANGED_BUNDLES}" | xargs -d '\n' uv run --no-project --python 3.11 -- \
+              python scripts/validate_submission.py --allow-partial-validation; then
               STATE="failure"
               DESCRIPTION="scripts/validate_submission.py rejected the mirrored bundle content."
             fi

--- a/benchbox/validation/bundle.py
+++ b/benchbox/validation/bundle.py
@@ -66,6 +66,9 @@ COMPANION_SUFFIXES = (".plans.json", ".tuning.json", ".applied.json")
 SUBMISSION_MANIFEST_FILENAME = "submission-manifest.json"
 SUBMISSION_MANIFEST_SUFFIX = ".manifest.json"
 PUBLIC_CLEAN_VALIDATION_STATUS = "passed"
+# Maintainer seed corpus includes partial cohorts by design. Trusted mirror
+# validation may accept these; community submissions may not.
+PUBLIC_MIRROR_ALLOWED_VALIDATION_STATUSES = frozenset({"passed", "partial"})
 PUBLIC_NON_CLEAN_TRANSLATION_STATUSES = {"fallback", "failed"}
 CLI_REFUSED_COMPLIANCE_CLASSES = frozenset({"unofficial_nonstandard", "unofficial_subscale"})
 
@@ -288,7 +291,12 @@ def _validate_platform_section(platform: Any, vr: ValidationResult) -> None:
             vr.warn(f"Unknown platform name: {pl_name!r}")
 
 
-def _validate_summary_section(summary: Any, vr: ValidationResult) -> None:
+def _validate_summary_section(
+    summary: Any,
+    vr: ValidationResult,
+    *,
+    allow_partial_validation: bool = False,
+) -> None:
     if not isinstance(summary, dict):
         vr.error("'summary' must be a dict")
         return
@@ -299,9 +307,19 @@ def _validate_summary_section(summary: Any, vr: ValidationResult) -> None:
             vr.warn("summary.queries.total is 0 - empty result?")
 
     validation_status = _normalize_status(summary.get("validation"))
-    if validation_status != PUBLIC_CLEAN_VALIDATION_STATUS:
+    allowed = (
+        PUBLIC_MIRROR_ALLOWED_VALIDATION_STATUSES
+        if allow_partial_validation
+        else frozenset({PUBLIC_CLEAN_VALIDATION_STATUS})
+    )
+    if validation_status not in allowed:
         if validation_status is None:
             vr.error("summary.validation is required for public submissions and must be 'passed'")
+        elif allow_partial_validation:
+            vr.error(
+                f"summary.validation must be one of {sorted(allowed)} for trusted mirror "
+                f"validation, got {validation_status!r}"
+            )
         else:
             vr.error(f"summary.validation must be 'passed' for public submissions, got {validation_status!r}")
 
@@ -543,7 +561,12 @@ def _validate_queries_section(queries: Any, vr: ValidationResult) -> None:
         vr.error("All query timings are 0ms - likely invalid data")
 
 
-def _validate_bundle(data: dict, vr: ValidationResult) -> None:
+def _validate_bundle(
+    data: dict,
+    vr: ValidationResult,
+    *,
+    allow_partial_validation: bool = False,
+) -> None:
     """Run all validation checks on a parsed bundle dict."""
     _capture_metadata(data, vr)
 
@@ -556,7 +579,11 @@ def _validate_bundle(data: dict, vr: ValidationResult) -> None:
     _validate_run_section(data.get("run", {}), vr)
     _validate_benchmark_section(data.get("benchmark", {}), vr)
     _validate_platform_section(data.get("platform", {}), vr)
-    _validate_summary_section(data.get("summary", {}), vr)
+    _validate_summary_section(
+        data.get("summary", {}),
+        vr,
+        allow_partial_validation=allow_partial_validation,
+    )
     _validate_translation_section(data, vr)
     _validate_public_cost_section(data, vr)
     _validate_queries_section(data.get("queries", []), vr)
@@ -808,7 +835,12 @@ def _is_submission_manifest_path(path: Path) -> bool:
     return name == SUBMISSION_MANIFEST_FILENAME or name.endswith(SUBMISSION_MANIFEST_SUFFIX)
 
 
-def validate_bundles(paths: list[Path], require_manifest: bool = False) -> list[ValidationResult]:
+def validate_bundles(
+    paths: list[Path],
+    require_manifest: bool = False,
+    *,
+    allow_partial_validation: bool = False,
+) -> list[ValidationResult]:
     """Validate a list of bundle files. Returns one ValidationResult per file.
 
     When ``require_manifest`` is True, a primary bundle with no paired
@@ -819,6 +851,11 @@ def validate_bundles(paths: list[Path], require_manifest: bool = False) -> list[
     mirror PRs that sync develop's corpus onto ``published-results``. Without
     it, a community bundle submitted without a sidecar would pass validation and
     then inherit the ``maintainer-run`` trust label (and ranking eligibility).
+
+    When ``allow_partial_validation`` is True, ``summary.validation`` may be
+    ``passed`` or ``partial``. That is for the trusted maintainer mirror path
+    only: the seed corpus intentionally includes partial cohorts. Community
+    submissions must leave the flag off so partial remains refused.
     """
     results = []
     for bundle_path in paths:
@@ -848,7 +885,7 @@ def validate_bundles(paths: list[Path], require_manifest: bool = False) -> list[
             results.append(vr)
             continue
 
-        _validate_bundle(data, vr)
+        _validate_bundle(data, vr, allow_partial_validation=allow_partial_validation)
 
         # Bound an adjacent applied companion even if a hand-authored manifest
         # omitted it. The manifest hash contract is checked separately below;

--- a/scripts/validate_submission.py
+++ b/scripts/validate_submission.py
@@ -153,6 +153,7 @@ def main(argv: list[str] | None = None) -> int:
     args = argv if argv is not None else sys.argv[1:]
     pr_comment_path: Path | None = None
     require_manifest = False
+    allow_partial_validation = False
     positional: list[str] = []
     i = 0
     while i < len(args):
@@ -164,12 +165,19 @@ def main(argv: list[str] | None = None) -> int:
             require_manifest = True
             i += 1
             continue
+        if args[i] == "--allow-partial-validation":
+            # Trusted maintainer mirror only: seed corpus includes partial
+            # cohorts. Community CI must not pass this flag.
+            allow_partial_validation = True
+            i += 1
+            continue
         positional.append(args[i])
         i += 1
 
     if not positional:
         print(
-            "Usage: validate_submission.py [--pr-comment <path>] [--require-manifest] <dir-or-files...>",
+            "Usage: validate_submission.py [--pr-comment <path>] [--require-manifest] "
+            "[--allow-partial-validation] <dir-or-files...>",
             file=sys.stderr,
         )
         return 1
@@ -188,7 +196,11 @@ def main(argv: list[str] | None = None) -> int:
         print("No bundle files found.", file=sys.stderr)
         return 1
 
-    results = validate_bundles(paths, require_manifest=require_manifest)
+    results = validate_bundles(
+        paths,
+        require_manifest=require_manifest,
+        allow_partial_validation=allow_partial_validation,
+    )
     _append_public_privacy_errors(paths, results)
     print(format_summary(results))
 

--- a/tests/unit/scripts/test_mirror_partial_validation_policy.py
+++ b/tests/unit/scripts/test_mirror_partial_validation_policy.py
@@ -1,0 +1,41 @@
+"""Trusted-mirror vs community partial-validation policy.
+
+The maintainer seed corpus includes ``summary.validation=partial`` cohorts.
+After #1573 the mirror path ran full community validation and rejected those
+bundles even when privacy was clean. The mirror workflow must pass
+``--allow-partial-validation``; community validate-submission must not.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+pytestmark = [pytest.mark.unit, pytest.mark.fast]
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+SYNC_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "sync-results-data-to-published.yml"
+COMMUNITY_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "validate-submission.yml"
+
+
+def test_mirror_workflow_allows_partial_validation() -> None:
+    text = SYNC_WORKFLOW.read_text(encoding="utf-8")
+    assert "--allow-partial-validation" in text
+    assert "partial" in text.lower()
+    # Privacy and inventory still gate the mirror path.
+    assert "validate_submission.py" in text
+    assert "generate_corpus_inventory.py --check" in text
+
+
+def test_community_validate_submission_does_not_allow_partial() -> None:
+    text = COMMUNITY_WORKFLOW.read_text(encoding="utf-8")
+    assert "--allow-partial-validation" not in text
+    # Community still requires the manifest for non-mirror heads.
+    assert "--require-manifest" in text
+
+
+def test_community_message_string_still_requires_passed() -> None:
+    bundle = (REPO_ROOT / "benchbox" / "validation" / "bundle.py").read_text(encoding="utf-8")
+    assert "must be 'passed' for public submissions" in bundle

--- a/tests/unit/scripts/test_validate_submission.py
+++ b/tests/unit/scripts/test_validate_submission.py
@@ -275,7 +275,7 @@ class TestValidateBundle:
         assert not vr.ok
         assert any("summary.validation is required" in e for e in vr.errors)
 
-    @pytest.mark.parametrize("status", ["not_run", "uncertain", "unknown"])
+    @pytest.mark.parametrize("status", ["not_run", "uncertain", "unknown", "partial"])
     def test_non_clean_public_validation_status_fails(self, status: str):
         data = _minimal_bundle()
         data["summary"]["validation"] = status
@@ -283,6 +283,22 @@ class TestValidateBundle:
         _validate_bundle(data, vr)
         assert not vr.ok
         assert any("summary.validation must be 'passed'" in e for e in vr.errors)
+
+    def test_partial_validation_allowed_only_when_flagged(self):
+        """Trusted mirror path may accept seed partials; community path may not."""
+        data = _minimal_bundle()
+        data["summary"]["validation"] = "partial"
+        community = ValidationResult("community")
+        _validate_bundle(data, community)
+        assert not community.ok
+        mirror = ValidationResult("mirror")
+        _validate_bundle(data, mirror, allow_partial_validation=True)
+        assert mirror.ok, mirror.errors
+        failed = ValidationResult("failed")
+        data_failed = _minimal_bundle()
+        data_failed["summary"]["validation"] = "failed"
+        _validate_bundle(data_failed, failed, allow_partial_validation=True)
+        assert not failed.ok
 
     def test_translation_fallback_fails_public_submission(self):
         data = _minimal_bundle()
@@ -812,6 +828,33 @@ class TestRequireManifestCli:
         bundle.write_text(json.dumps(_minimal_bundle()), encoding="utf-8")
         rc = main([str(bundle)])
         assert rc == 0
+
+
+class TestAllowPartialValidation:
+    def test_cli_community_default_rejects_partial(self, tmp_path: Path, capsys):
+        bundle = tmp_path / "partial.json"
+        data = _minimal_bundle()
+        data["summary"]["validation"] = "partial"
+        bundle.write_text(json.dumps(data), encoding="utf-8")
+        assert main([str(bundle)]) == 1
+        captured = capsys.readouterr()
+        assert "must be 'passed'" in captured.out or "must be 'passed'" in captured.err
+
+    def test_cli_allow_partial_accepts_seed_shaped_partial(self, tmp_path: Path, capsys):
+        bundle = tmp_path / "partial.json"
+        data = _minimal_bundle()
+        data["summary"]["validation"] = "partial"
+        bundle.write_text(json.dumps(data), encoding="utf-8")
+        assert main([str(bundle), "--allow-partial-validation"]) == 0
+
+    def test_allow_partial_still_rejects_private_path_leaks(self, tmp_path: Path, capsys):
+        """Privacy fail-closed is independent of the partial waiver."""
+        bundle = tmp_path / "leaky-partial.json"
+        data = _minimal_bundle()
+        data["summary"]["validation"] = "partial"
+        data["platform"]["config"] = {"working_dir": "/Users/alice/private"}
+        bundle.write_text(json.dumps(data), encoding="utf-8")
+        assert main([str(bundle), "--allow-partial-validation"]) == 1
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Community submissions still require summary.validation=passed. The
maintainer mirror path accepts partial cohorts with
--allow-partial-validation while privacy and inventory stay fail-closed.
