### PR TITLE
fix(results): drop alias spellings of unread identifier fields

### DIFF
--- a/benchbox/core/results/anonymization_specs.yaml
+++ b/benchbox/core/results/anonymization_specs.yaml
@@ -10,12 +10,23 @@
 # default salt. Compact forms match ``_compact_key`` (lowercase, non-alnum
 # stripped). Retained identifiers (endpoint, database_name, submission_path)
 # stay under identifier_keys / path / endpoint rules below.
+#
+# Alias rows cover alternate spellings of the six unread drop fields so a
+# producer using workdir/datadir/pythonexecutable cannot reintroduce empty-salt
+# path_/host_ tokens. host/hostname/server are intentionally NOT dropped: they
+# are broader than engine_host and may carry non-local endpoints still hashed.
 public_drop_keys:
 - machineid
 - workingdir
+- workdir
+- workingdirectory
+- workingroot
 - driverruntimepythonexecutable
+- pythonexecutable
 - databasepath
 - datapath
+- datadir
+- datadirectory
 - enginehost
 identifier_keys:
   account: account

--- a/docs/development/adr/adr-published-identifier-field-set.md
+++ b/docs/development/adr/adr-published-identifier-field-set.md
@@ -50,7 +50,11 @@ implemented. Nothing correlates by machine today.
 ## Decision
 
 **Do not publish the six fields that have no consumer.** Remove them at the
-publication boundary rather than pseudonymising them.
+publication boundary rather than pseudonymising them. Also omit compact-form
+**aliases** of those fields (`workdir`, `workingdirectory`, `workingroot`,
+`datadir`, `datadirectory`, `pythonexecutable`) so alternate spellings cannot
+reintroduce empty-salt path tokens. `host` / `hostname` / `server` stay hashed
+rather than dropped: they are broader than `engine_host`.
 
 For the three that do have a consumer, keep publishing a pseudonym. The
 retained-field salt decision is recorded below (closed 2026-08-05).

--- a/tests/unit/core/results/test_anonymization.py
+++ b/tests/unit/core/results/test_anonymization.py
@@ -1005,6 +1005,42 @@ class TestPublicUnreadIdentifierDrop:
         assert out["environment"]["client_host"]["hostname"].startswith("host_")
         assert out["environment"]["platform_runtime"]["runtime_type"] == "local"
 
+    def test_alias_drop_keys_of_unread_identifiers_are_omitted(self):
+        """Aliases of the six unread fields must drop, not mint path_ tokens."""
+        payload = {
+            "platform": {
+                "config": {
+                    "workdir": "/Users/alice/project",
+                    "working_directory": "/Users/alice/project",
+                    "working_root": "/Users/alice/project",
+                    "data_dir": "/Users/alice/data",
+                    "data_directory": "/Users/alice/data",
+                    "python_executable": "/Users/alice/.venv/bin/python",
+                    "endpoint": "https://example.invalid/warehouse",
+                    "database_name": "analytics",
+                }
+            },
+            "metadata": {"submission_path": "PR-based"},
+        }
+        out = AnonymizationManager().anonymize_result_payload(payload)
+        cfg = out["platform"]["config"]
+        for key in (
+            "workdir",
+            "working_directory",
+            "working_root",
+            "data_dir",
+            "data_directory",
+            "python_executable",
+        ):
+            assert key not in cfg, f"alias drop key still present: {key}"
+        assert "alice" not in json.dumps(out)
+        # Retained consumers still publish under canonical keys.
+        assert _is_public_pseudonym(cfg["endpoint"], "endpoint")
+        assert _is_public_pseudonym(cfg["database_name"], "database")
+        assert out["metadata"]["submission_path"] == "PR-based" or _is_public_pseudonym(
+            out["metadata"]["submission_path"], "path"
+        )
+
     def test_empty_client_host_omitted_after_machine_id_drop(self):
         """client_host that only held machine_id must not publish as {}."""
         out = AnonymizationManager().anonymize_result_payload(


### PR DESCRIPTION
Omit workdir/datadir/pythonexecutable-style aliases at the public
boundary so empty-salt path tokens cannot reappear under alternate keys.
