### PR TITLE
fix(results): split submit schema_violation from bundle load errors

### DIFF
--- a/_project/specs/uat-framework.md
+++ b/_project/specs/uat-framework.md
@@ -128,7 +128,7 @@ tests/uat/
 |---|---|---|---|
 | `__init__.py` | UAT package marker and documentation string | — | 6 |
 | `matrix.py` | Registry-driven benchmark enumeration, platform grouping, compose-derived TCP reachability probe (connection facts now owned by `docker_assets`) | 250 | 515 |
-| `runner.py` | Build `benchbox run` argv per cell; capture stdout+stderr to per-run log; extract result-JSON path; submit classification via shared `benchbox.core.results.submit_classification` | 120 | 353 |
+| `runner.py` | Build `benchbox run` argv per cell; capture stdout+stderr to per-run log; extract result-JSON path; submit classification via shared `benchbox.core.results.submit_classification` | 120 | 354 |
 | `config.py` | Load YAML, validate against schema (Section 3), expose typed dataclass access | 180 | 751 |
 | `_cli.py` | UAT CLI entrypoint: argument parsing, sweep/execute/validate/report/package subcommands, output wiring | — | 806 |
 | `timeouts.py` | Signal-based timeout (POSIX process-group kill ladder) | 80 | 123 |
@@ -176,7 +176,7 @@ remain hand-tracked.
 **Per-bucket production LOC** (auto-generated -- run the script to refresh):
 
 - plumbing (orchestrator/config/`_cli`): 2,463
-- core exercise (execute/matrix/runner/enumerate/cleanup/ladder): 2,365
+- core exercise (execute/matrix/runner/enumerate/cleanup/ladder): 2,366
 - preflight/compat/timeouts: 1,008
 - Docker lifecycle (default-OFF, incl. `container_cleanup.py`): 1,743
 - chartered evidence artifacts (validate/report/package/cells_io/gate_summary): 1,684
@@ -185,7 +185,7 @@ remain hand-tracked.
 - artifact hygiene: 315
 - package init markers: 23
 
-**Total: 10,304 production LOC across 26 modules.**
+**Total: 10,305 production LOC across 26 modules.**
 
 <!-- UAT-LOC-SUMMARY:END -->
 

--- a/benchbox/core/results/submit_classification.py
+++ b/benchbox/core/results/submit_classification.py
@@ -34,12 +34,19 @@ from benchbox.validation.bundle import CLI_REFUSED_COMPLIANCE_CLASSES
 
 
 class SubmitTerminalState(str, Enum):
-    """Terminal submit verdict shared by the CLI and UAT surfaces."""
+    """Terminal submit verdict shared by the CLI and UAT surfaces.
+
+    ``schema_violation`` is reserved for a *successfully loaded* result that
+    fails clean-pass integrity (failed validation claim, translation fallback,
+    …). Unreadable or unparseable files use ``bundle_load_error`` so operators
+    can distinguish "could not load the artifact" from "loaded but not clean".
+    """
 
     submittable = "submittable"
     unofficial = "unofficial"
     query_failure = "query_failure"
     schema_violation = "schema_violation"
+    bundle_load_error = "bundle_load_error"
     unvalidated = "unvalidated"
     missing_manifest = "missing_manifest"
 
@@ -69,9 +76,10 @@ def classify_loaded_result(result: Any) -> SubmitTerminalState:
 def classify_result_path(result_json: Path | str | None) -> SubmitTerminalState:
     """Classify a result-file path, including missing-file and load failures.
 
-    A missing path/file is ``missing_manifest``; an unreadable or
-    schema-invalid file is ``schema_violation``. A loadable result is then
-    routed through :func:`classify_loaded_result`.
+    A missing path/file is ``missing_manifest``; an unreadable or unparseable
+    file is ``bundle_load_error``. A loadable result is then routed through
+    :func:`classify_loaded_result` (which may still return ``schema_violation``
+    for integrity problems on a successfully loaded payload).
     """
     if result_json is None:
         return SubmitTerminalState.missing_manifest
@@ -82,6 +90,6 @@ def classify_result_path(result_json: Path | str | None) -> SubmitTerminalState:
         result, _raw = load_result_file(path)
     except FileNotFoundError:
         return SubmitTerminalState.missing_manifest
-    except (json.JSONDecodeError, OSError, ResultLoadError, UnsupportedSchemaError):
-        return SubmitTerminalState.schema_violation
+    except (json.JSONDecodeError, UnicodeDecodeError, OSError, ResultLoadError, UnsupportedSchemaError):
+        return SubmitTerminalState.bundle_load_error
     return classify_loaded_result(result)

--- a/tests/uat/runner.py
+++ b/tests/uat/runner.py
@@ -87,6 +87,7 @@ def submit_state_is_cell_failure(state: SubmitTerminalState | str) -> bool:
     return normalized in {
         SubmitTerminalState.query_failure.value,
         SubmitTerminalState.schema_violation.value,
+        SubmitTerminalState.bundle_load_error.value,
         SubmitTerminalState.missing_manifest.value,
     }
 

--- a/tests/uat/test_package.py
+++ b/tests/uat/test_package.py
@@ -199,6 +199,25 @@ def test_package_counts_schema_violation_as_failure(tmp_path: Path):
     assert any("schema_violation" in w for w in warnings)
 
 
+def test_package_counts_bundle_load_error_as_failure(tmp_path: Path):
+    cfg = validate_config({"name": "x", "package": {"submit_terminal_state": "local-stage"}})
+    bad = tmp_path / "malformed.json"
+    bad.write_text("{not valid json", encoding="utf-8")
+    runner = _fake_runner_factory([])
+    warnings: list[str] = []
+    result = package.run_package(
+        cfg,
+        result_paths=[bad],
+        submissions_dir=tmp_path / "subs",
+        runner=runner,
+        warn=warnings.append,
+        classify_results=True,
+    )
+    assert result.failure_count == 1
+    assert result.invocations == ()
+    assert any("bundle_load_error" in w for w in warnings)
+
+
 @pytest.mark.parametrize("state", sorted(package.PR_STUB_TERMINAL_STATES))
 def test_package_warns_for_pr_stub_states(tmp_path: Path, state: str):
     cfg = validate_config({"name": "x", "package": {"submit_terminal_state": state}})

--- a/tests/uat/test_runner.py
+++ b/tests/uat/test_runner.py
@@ -494,6 +494,7 @@ def test_classify_for_submit_vocabulary_and_clean_result(tmp_path: Path):
         "unofficial",
         "query_failure",
         "schema_violation",
+        "bundle_load_error",
         "unvalidated",
         "missing_manifest",
     }
@@ -504,6 +505,7 @@ def test_submit_state_is_cell_failure_excludes_unvalidated() -> None:
     assert not runner.submit_state_is_cell_failure("unvalidated")
     assert not runner.submit_state_is_cell_failure(runner.SubmitTerminalState.unvalidated)
     assert runner.submit_state_is_cell_failure("schema_violation")
+    assert runner.submit_state_is_cell_failure("bundle_load_error")
     assert runner.submit_state_is_cell_failure("query_failure")
     assert runner.submit_state_is_cell_failure("missing_manifest")
 

--- a/tests/unit/core/results/test_submit_classifier_contract.py
+++ b/tests/unit/core/results/test_submit_classifier_contract.py
@@ -149,8 +149,20 @@ def test_submit_classifier_contract_path_only_states(tmp_path: Path):
 
     malformed = tmp_path / "malformed.json"
     malformed.write_text("{not valid json", encoding="utf-8")
-    assert classify_result_path(malformed) is SubmitTerminalState.schema_violation
-    assert runner.classify_for_submit(malformed) is runner.SubmitTerminalState.schema_violation
+    # Load/parse failures are bundle_load_error, not schema_violation (integrity).
+    assert classify_result_path(malformed) is SubmitTerminalState.bundle_load_error
+    assert runner.classify_for_submit(malformed) is runner.SubmitTerminalState.bundle_load_error
+
+
+def test_submit_classifier_contract_load_error_distinct_from_integrity(tmp_path: Path):
+    """Loaded integrity failures stay schema_violation; unreadable files are load errors."""
+    integrity = tmp_path / "integrity.json"
+    _write_result_json(integrity, failed=0, validation="failed")
+    assert classify_result_path(integrity) is SubmitTerminalState.schema_violation
+
+    unreadable = tmp_path / "unreadable.json"
+    unreadable.write_bytes(b"\xff\xfe not json")
+    assert classify_result_path(unreadable) is SubmitTerminalState.bundle_load_error
 
 
 def test_submit_classifier_contract_cli_refusal_tracks_state(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):


### PR DESCRIPTION
Path-level unreadable/unparseable artifacts become bundle_load_error.
schema_violation remains for loaded results that fail clean-pass integrity.
