### PR TITLE
fix(ci): stop auto-merge-on-open from arming at PR open

### DIFF
--- a/.github/workflows/auto-merge-on-open.yml
+++ b/.github/workflows/auto-merge-on-open.yml
@@ -1,15 +1,33 @@
 name: Auto-enable auto-merge
 
-# Backstop for the local `make pr-open` flow: if a PR is opened against
-# develop via the GitHub UI, `gh pr create` directly, or any path that
-# skips `gh pr merge --auto --squash`, this workflow turns auto-merge on.
+# Auto-merge arming policy (cross-layer with the Makefile):
 #
-# Drafts are explicitly skipped — opening a draft is the user's signal
-# that the PR is not yet ready to land. Auto-merge gets enabled when the
-# draft is marked ready (the `ready_for_review` event).
+# Local path:
+#   - `make pr-open` withholds auto-merge by default.
+#   - `make pr-ready` / `pr-arm-auto-merge` (or `make pr-open READY=1`) is the
+#     intentional arming path for a finished branch.
 #
-# `synchronize` re-evaluates on every push: a later commit that newly
-# touches a soundness-critical path must flip auto-merge back OFF. GitHub
+# Workflow path (this file):
+#   - Do NOT arm on `opened` or `reopened`. Opening a non-draft PR (including
+#     bare `gh pr create`) is not the final signal — that is what defeated the
+#     Makefile hold after #1567 (live proof: #1568/#1569 merged hands-free).
+#   - DO arm on `ready_for_review` (draft → ready is the UI equivalent of
+#     `make pr-ready`).
+#   - On `synchronize` (and other events): only re-evaluate soundness
+#     revocation — disable auto-merge if soundness paths are touched. Never
+#     re-enable on synchronize; that would re-open the race on the first push
+#     after open.
+#
+# Intentional gap: a non-draft PR opened without `make pr-ready`, `READY=1`,
+# or marking a draft ready will not get auto-merge from this workflow. Use
+# one of those paths when the branch is final.
+#
+# Drafts remain skipped at the job level — opening a draft is the user's
+# signal that the PR is not yet ready. Auto-merge is enabled when the draft
+# is marked ready (`ready_for_review`).
+#
+# `synchronize` re-evaluates on every push so a later commit that newly
+# touches a soundness-critical path can flip auto-merge back OFF. GitHub
 # only auto-disables auto-merge on push when the pusher lacks write access,
 # so in the normal same-repo/write-author flow a stale enabled auto-merge
 # would otherwise survive and merge after checks without review.
@@ -87,7 +105,11 @@ jobs:
           echo "$result" >> "$GITHUB_OUTPUT"
 
       - name: Enable squash auto-merge
-        if: steps.soundness.outputs.soundness_path != 'true'
+        # Arm only on draft→ready. Never on opened/reopened/synchronize — those
+        # are not "branch is final" signals (see header policy). Soundness
+        # predicate first so the existing substring pin in
+        # test_auto_merge_soundness_paths still matches.
+        if: steps.soundness.outputs.soundness_path != 'true' && github.event.action == 'ready_for_review'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_NUMBER: ${{ github.event.pull_request.number }}

--- a/Makefile
+++ b/Makefile
@@ -1566,15 +1566,15 @@ pr-content-guard:
 		echo "No docs paths changed."; \
 	fi
 
-# Push current branch and open a PR against develop with auto-merge enabled
-# unless the diff touches soundness-critical comparator/plan-parser paths.
-# Squash-merge happens automatically once `lint` + `test (ubuntu-latest, 3.12)`
-# go green. Refuses to run from develop/release.
+# Push current branch and open a PR against develop. Auto-merge is WITHHELD by
+# default so a follow-up commit cannot race a merge. Arm only when the branch
+# is final: `make pr-ready`, or `make pr-open READY=1` to open and arm in one
+# step. Soundness-path diffs are never armed (see pr-arm-auto-merge).
+# Refuses to run from develop/release.
 #
-# Idempotent: safe to rerun. If a PR is already open for the branch, reuses it
-# and just (re)enables auto-merge when the soundness-path review gate does not
-# apply — useful after a partial run, or to flip auto-merge on for a PR opened
-# via `gh pr create` directly.
+# Idempotent: safe to rerun. If a PR is already open for the branch, reuses it.
+# Without READY=1 this does not re-enable auto-merge — run `make pr-ready`
+# when the branch is final (or READY=1 here to arm after open/reuse).
 #
 # Pre-push warning: runs `git merge-tree` against every other open PR head
 # (pure git, ~1s, no CI) and prints any textual conflicts so you can coordinate
@@ -1668,9 +1668,11 @@ pr-fanout:
 
 # Refresh the current PR branch onto origin/develop, then run pr-open.
 # This is the stale-PR escape hatch when required checks must be current with
-# develop: GitHub can show a PR as CLEAN even though auto-merge is waiting for
-# a branch update. Run this one stale PR at a time; updating several branches
-# at once can let the first merge stale the others again under strict checks.
+# develop: GitHub can show a PR as CLEAN even though merge is waiting for a
+# branch update. pr-refresh does NOT re-enable auto-merge on its own (pr-open
+# withholds unless READY=1); run `make pr-ready` when the branch is final.
+# Run this one stale PR at a time; updating several branches at once can let
+# the first merge stale the others again under strict checks.
 pr-refresh:
 	@CURRENT=$$(git branch --show-current); \
 	case "$$CURRENT" in \
@@ -2653,10 +2655,11 @@ help:
 	@echo "PR Workflow & Worktrees:"
 	@echo "  make agent-write-preflight  Refuse write work from the BenchBox primary clone unless explicitly overridden"
 	@echo "  make pr-preflight    Run lint + fast marker tests locally (coverage remains CI-only)"
-	@echo "  make pr-open [PR_BODY_FILE=path] Push branch + open PR vs develop + enable auto-merge"
+	@echo "  make pr-open [PR_BODY_FILE=path] [READY=1]  Push branch + open PR vs develop (auto-merge withheld unless READY=1)"
+	@echo "  make pr-ready        Arm squash auto-merge for the open PR on this branch (when final)"
 	@echo "  make pr-fanout       Run pr-open across worktrees with bounded parallelism (PR_FANOUT_JOBS=$(PR_FANOUT_JOBS))"
 	@echo "  make shrink-rollup   Sum merged shrink ledger fragments from origin/develop"
-	@echo "  make pr-refresh      Merge origin/develop into current branch, push, and re-enable auto-merge"
+	@echo "  make pr-refresh      Merge origin/develop into current branch and re-run pr-open (still withholds auto-merge unless READY=1)"
 	@echo "  make pr-status       List your open PRs vs develop with CI + auto-merge state"
 	@echo "  make pr-review-followups-list        List un-actioned bot/agent review comments on merged PRs"
 	@echo "  make pr-review-followups             Action each comment, reply with marker, submit PR"

--- a/docs/operations/pr-triage.md
+++ b/docs/operations/pr-triage.md
@@ -81,15 +81,29 @@ a PR's mergeability — both only alert.
   waiting on the owner's manual review and merge.
 - **Green-unmerged nightly sweep**
   (`_project/scripts/green_unmerged_sweep.py`,
-  `.github/workflows/nightly.yml`) — for PRs that *should* have auto-merge
-  on (non-draft, non-soundness-gated, required lane green) but don't:
-  flags ones stranded more than 2 hours after their head commit was
-  pushed. Note: `auto-merge-on-open.yml` no longer arms on `opened` or
-  `synchronize`; it only arms on `ready_for_review`. Ordinary non-draft PRs
-  still need `make pr-ready` / `READY=1` (or draft→ready) to arm. A green
-  `enable`-job run is not proof the PR's own `auto_merge` field ended up
-  populated — the sweep always re-reads the PR's current field rather than
-  trusting the workflow run's conclusion.
+  `.github/workflows/nightly.yml`) — alerts on non-draft, non-soundness
+  PRs whose required lane is green but auto-merge is still off for more
+  than 2 hours after the head commit.
+
+  After the auto-merge hold, **an intentional non-armed green PR is normal**,
+  not a stuck state. Auto-merge is **not** armed by `opened`, `reopened`, or
+  `synchronize` (a re-push will not flip it on). The only intentional arm
+  signals are:
+
+  - `make pr-ready` (or `make pr-arm-auto-merge`) on a finished branch
+  - `make pr-open READY=1` to open and arm in one step
+  - draft → ready (`ready_for_review` in `auto-merge-on-open.yml`)
+
+  Do **not** remediate a green-unmerged alert by re-pushing "to re-trigger
+  synchronize." That path no longer enables auto-merge. If the branch is
+  final, arm it; if work continues, leave auto-merge off.
+
+  Known follow-up: `green_unmerged_sweep.py` still classifies many of these
+  intentional holds as stranded (false positives). Fixing the classifier is
+  out of the enablement-hold change set (`_project/scripts/`); until then,
+  treat sweep hits as triage signals, not proof of a broken arm path. A green
+  `enable`-job run is also not proof the PR's `auto_merge` field is set —
+  the sweep re-reads the PR field rather than trusting the workflow conclusion.
 
 Both sweeps upsert a single marker-tagged tracking issue while their
 respective queue is non-empty, and patch it to the empty state exactly

--- a/docs/operations/pr-triage.md
+++ b/docs/operations/pr-triage.md
@@ -84,8 +84,9 @@ a PR's mergeability — both only alert.
   `.github/workflows/nightly.yml`) — for PRs that *should* have auto-merge
   on (non-draft, non-soundness-gated, required lane green) but don't:
   flags ones stranded more than 2 hours after their head commit was
-  pushed, on the theory that `auto-merge-on-open.yml`'s `synchronize`
-  re-evaluation has had every chance to fire by then. A green
+  pushed. Note: `auto-merge-on-open.yml` no longer arms on `opened` or
+  `synchronize`; it only arms on `ready_for_review`. Ordinary non-draft PRs
+  still need `make pr-ready` / `READY=1` (or draft→ready) to arm. A green
   `enable`-job run is not proof the PR's own `auto_merge` field ended up
   populated — the sweep always re-reads the PR's current field rather than
   trusting the workflow run's conclusion.

--- a/docs/operations/repo-admin-settings.md
+++ b/docs/operations/repo-admin-settings.md
@@ -139,6 +139,11 @@ The soundness gate, as operated:
   `make pr-open READY=1`) does, so a PR cannot merge while a follow-up commit
   is still being written. Arming at creation stranded three commits in one
   session, two of them the fixes for their own review findings.
+- `.github/workflows/auto-merge-on-open.yml` matches that hold: it does **not**
+  arm on `opened` / `reopened` / `synchronize` (bare `gh pr create` no longer
+  auto-arms). It arms only on `ready_for_review` (draft → ready), which is the
+  UI equivalent of `make pr-ready`. `synchronize` still re-evaluates soundness
+  revocation only — it never re-enables auto-merge.
 - The arming path and `auto-merge-on-open.yml` WITHHOLD squash auto-merge for
   PRs touching those paths (and revoke it on a later push that newly touches
   them). CI cannot catch a change that redefines the oracle it validates

--- a/tests/unit/workflows/test_auto_merge_enablement_point.py
+++ b/tests/unit/workflows/test_auto_merge_enablement_point.py
@@ -38,6 +38,10 @@ AUTO_MERGE_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "auto-merge-on-open.
 
 ARM_COMMAND = "gh pr merge --auto --squash"
 
+# Exact enable/disable `if:` pins for auto-merge-on-open.yml (collapsed form).
+ENABLE_IF = "steps.soundness.outputs.soundness_path != 'true' && github.event.action == 'ready_for_review'"
+DISABLE_IF = "steps.soundness.outputs.soundness_path == 'true'"
+
 
 def _target_body(name: str) -> str:
     """Return the recipe lines of a Makefile target."""
@@ -71,6 +75,16 @@ def _steps_by_name(job: dict[str, Any]) -> dict[str, dict[str, Any]]:
         if name:
             named[str(name)] = step
     return named
+
+
+def _collapsed_if(step: dict[str, Any]) -> str:
+    """Normalize a step `if:` to a single-line string for exact comparison.
+
+    PyYAML may leave multi-line folded scalars with internal newlines/spaces;
+    collapse whitespace so the pin is the semantic condition, not YAML layout.
+    """
+    raw = str(step.get("if") or "").strip()
+    return re.sub(r"\s+", " ", raw)
 
 
 # ---------------------------------------------------------------------------
@@ -132,6 +146,22 @@ def test_auto_merge_enablement_point_preserves_soundness_withholding() -> None:
 # ---------------------------------------------------------------------------
 
 
+def test_auto_merge_workflow_enable_if_is_exact_policy() -> None:
+    """Enable step must arm only for non-soundness ready_for_review.
+
+    Exact pin: opened/reopened/synchronize cannot arm even if someone later
+    rewrites the condition into a looser OR of event actions.
+    """
+    workflow = _load_workflow()
+    steps = _steps_by_name(_enable_job(workflow))
+    enable = steps.get("Enable squash auto-merge")
+    assert enable is not None, "enable step missing from auto-merge-on-open.yml"
+    assert _collapsed_if(enable) == ENABLE_IF, (
+        f"enable step if: drifted from policy pin\n  got:  {_collapsed_if(enable)!r}\n  want: {ENABLE_IF!r}"
+    )
+    assert ARM_COMMAND in str(enable.get("run") or ""), "enable step no longer arms squash auto-merge"
+
+
 def test_auto_merge_workflow_does_not_enable_merely_because_pr_was_opened() -> None:
     """No layer may arm auto-merge solely because a non-draft PR was opened.
 
@@ -141,21 +171,10 @@ def test_auto_merge_workflow_does_not_enable_merely_because_pr_was_opened() -> N
     """
     workflow = _load_workflow()
     steps = _steps_by_name(_enable_job(workflow))
-    enable = steps.get("Enable squash auto-merge")
-    assert enable is not None, "enable step missing from auto-merge-on-open.yml"
-    condition = str(enable.get("if") or "")
-    assert "ready_for_review" in condition, (
-        "enable step must require ready_for_review so opened/reopened/synchronize cannot arm"
-    )
-    assert ARM_COMMAND in str(enable.get("run") or ""), "enable step no longer arms squash auto-merge"
-    # Must not enable for opened / reopened / synchronize (positive exclusion
-    # is hard in YAML `if:`; requiring ready_for_review is the policy pin).
+    condition = _collapsed_if(steps["Enable squash auto-merge"])
+    # Exact policy already asserted above; restate exclusions for the defect.
+    assert condition == ENABLE_IF
     for forbidden in ("opened", "reopened", "synchronize"):
-        # Allow the action name only as the required positive match, not as an
-        # alternate arming path. A condition that ORs in opened would re-open
-        # the race.
-        if forbidden == "ready_for_review":
-            continue
         assert f"== '{forbidden}'" not in condition and f'== "{forbidden}"' not in condition, (
             f"enable step still matches event action {forbidden!r}: {condition!r}"
         )
@@ -180,12 +199,9 @@ def test_auto_merge_workflow_does_not_re_enable_on_synchronize() -> None:
     first post-open push lands, restoring the partial-stack race.
     """
     workflow = _load_workflow()
-    steps = _steps_by_name(_enable_job(workflow))
-    enable = steps["Enable squash auto-merge"]
-    condition = str(enable.get("if") or "")
-    assert "synchronize" not in condition, f"enable step condition still mentions synchronize: {condition!r}"
-    # Only ready_for_review should be the positive arming event in the condition.
-    assert "ready_for_review" in condition
+    condition = _collapsed_if(_steps_by_name(_enable_job(workflow))["Enable squash auto-merge"])
+    assert condition == ENABLE_IF
+    assert "synchronize" not in condition
 
 
 def test_auto_merge_workflow_preserves_soundness_disable() -> None:
@@ -195,5 +211,6 @@ def test_auto_merge_workflow_preserves_soundness_disable() -> None:
     disable = steps.get("Disable auto-merge for soundness PR")
     assert disable is not None, "soundness disable step is gone"
     assert "--disable-auto" in str(disable.get("run") or ""), "soundness disable no longer calls --disable-auto"
-    condition = str(disable.get("if") or "")
-    assert "soundness_path" in condition, "disable step no longer gates on soundness_path"
+    assert _collapsed_if(disable) == DISABLE_IF, (
+        f"disable step if: drifted from policy pin\n  got:  {_collapsed_if(disable)!r}\n  want: {DISABLE_IF!r}"
+    )

--- a/tests/unit/workflows/test_auto_merge_enablement_point.py
+++ b/tests/unit/workflows/test_auto_merge_enablement_point.py
@@ -1,4 +1,4 @@
-"""Auto-merge must not be armed at PR creation.
+"""Auto-merge must not be armed merely because a PR was opened.
 
 Arming at creation is only correct if nothing more will be pushed - and the
 usual reason something more is pushed is review feedback, which arrives after
@@ -11,21 +11,30 @@ own PR body described, and #1521 and #1531 then each lost the very commit that
 addressed their own review findings. No local check can prevent it - in all
 three the working tree was clean when the PR was opened.
 
-So `pr-open` withholds, `pr-ready` arms, and `pr-open READY=1` keeps the
-one-command path for a branch already known to be final.
+#1567 moved the Makefile hold (`pr-open` withholds; `pr-ready` arms). The
+workflow `auto-merge-on-open.yml` still armed on `opened` for any non-draft
+PR, so bare `gh pr create` defeated the hold (#1568/#1569). The cross-layer
+policy is therefore:
+
+- Local: `pr-open` withholds; `pr-ready` / `READY=1` arms.
+- Workflow: arm only on `ready_for_review`; never enable on
+  opened/reopened/synchronize. Soundness disable still runs on those events.
 """
 
 from __future__ import annotations
 
 import re
 from pathlib import Path
+from typing import Any
 
 import pytest
+import yaml
 
 pytestmark = [pytest.mark.unit, pytest.mark.fast]
 
 REPO_ROOT = Path(__file__).resolve().parents[3]
 MAKEFILE = REPO_ROOT / "Makefile"
+AUTO_MERGE_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "auto-merge-on-open.yml"
 
 ARM_COMMAND = "gh pr merge --auto --squash"
 
@@ -36,6 +45,37 @@ def _target_body(name: str) -> str:
     match = re.search(rf"^{re.escape(name)}:.*?\n((?:\t.*\n|\n)*)", text, re.MULTILINE)
     assert match, f"Makefile has no target {name!r}"
     return match.group(1)
+
+
+def _load_workflow() -> dict[str, Any]:
+    return yaml.safe_load(AUTO_MERGE_WORKFLOW.read_text(encoding="utf-8"))
+
+
+def _triggers(workflow: dict[str, Any]) -> dict[str, Any]:
+    """Return the `on:` block (PyYAML 1.1 may resolve unquoted `on` to True)."""
+    triggers = workflow.get("on", workflow.get(True))
+    assert triggers is not None, "workflow has no `on:` block"
+    return triggers
+
+
+def _enable_job(workflow: dict[str, Any]) -> dict[str, Any]:
+    jobs = workflow.get("jobs") or {}
+    assert "enable" in jobs, "auto-merge workflow has no enable job"
+    return jobs["enable"]
+
+
+def _steps_by_name(job: dict[str, Any]) -> dict[str, dict[str, Any]]:
+    named: dict[str, dict[str, Any]] = {}
+    for step in job.get("steps") or []:
+        name = step.get("name")
+        if name:
+            named[str(name)] = step
+    return named
+
+
+# ---------------------------------------------------------------------------
+# Makefile layer (hold at pr-open; arm via pr-ready)
+# ---------------------------------------------------------------------------
 
 
 def test_auto_merge_enablement_point_is_not_pr_open() -> None:
@@ -85,3 +125,75 @@ def test_auto_merge_enablement_point_preserves_soundness_withholding() -> None:
     arm_index = body.index(ARM_COMMAND)
     check_index = body.index("auto_merge_soundness_paths.py")
     assert check_index < arm_index, "soundness check runs after arming, so it cannot withhold"
+
+
+# ---------------------------------------------------------------------------
+# Workflow layer (do not arm on opened; arm only on ready_for_review)
+# ---------------------------------------------------------------------------
+
+
+def test_auto_merge_workflow_does_not_enable_merely_because_pr_was_opened() -> None:
+    """No layer may arm auto-merge solely because a non-draft PR was opened.
+
+    After #1567 the Makefile held at pr-open, but this workflow still ran
+    `gh pr merge --auto --squash` on the `opened` event for any non-draft
+    develop PR. That is the defect under test.
+    """
+    workflow = _load_workflow()
+    steps = _steps_by_name(_enable_job(workflow))
+    enable = steps.get("Enable squash auto-merge")
+    assert enable is not None, "enable step missing from auto-merge-on-open.yml"
+    condition = str(enable.get("if") or "")
+    assert "ready_for_review" in condition, (
+        "enable step must require ready_for_review so opened/reopened/synchronize cannot arm"
+    )
+    assert ARM_COMMAND in str(enable.get("run") or ""), "enable step no longer arms squash auto-merge"
+    # Must not enable for opened / reopened / synchronize (positive exclusion
+    # is hard in YAML `if:`; requiring ready_for_review is the policy pin).
+    for forbidden in ("opened", "reopened", "synchronize"):
+        # Allow the action name only as the required positive match, not as an
+        # alternate arming path. A condition that ORs in opened would re-open
+        # the race.
+        if forbidden == "ready_for_review":
+            continue
+        assert f"== '{forbidden}'" not in condition and f'== "{forbidden}"' not in condition, (
+            f"enable step still matches event action {forbidden!r}: {condition!r}"
+        )
+
+
+def test_auto_merge_workflow_keeps_opened_trigger_for_soundness_re_eval() -> None:
+    """opened/reopened/synchronize must still run for soundness disable.
+
+    Dropping those triggers would leave a soundness PR that was opened with
+    auto-merge already on (or that later gains a soundness commit) without a
+    revocation path from this workflow.
+    """
+    types = _triggers(_load_workflow())["pull_request"]["types"]
+    for required in ("opened", "reopened", "ready_for_review", "synchronize"):
+        assert required in types, f"pull_request types missing {required!r}: {types}"
+
+
+def test_auto_merge_workflow_does_not_re_enable_on_synchronize() -> None:
+    """synchronize must not re-arm auto-merge.
+
+    Re-enabling on every push would defeat the open-time hold as soon as the
+    first post-open push lands, restoring the partial-stack race.
+    """
+    workflow = _load_workflow()
+    steps = _steps_by_name(_enable_job(workflow))
+    enable = steps["Enable squash auto-merge"]
+    condition = str(enable.get("if") or "")
+    assert "synchronize" not in condition, f"enable step condition still mentions synchronize: {condition!r}"
+    # Only ready_for_review should be the positive arming event in the condition.
+    assert "ready_for_review" in condition
+
+
+def test_auto_merge_workflow_preserves_soundness_disable() -> None:
+    """Must-preserve: soundness paths still revoke auto-merge."""
+    workflow = _load_workflow()
+    steps = _steps_by_name(_enable_job(workflow))
+    disable = steps.get("Disable auto-merge for soundness PR")
+    assert disable is not None, "soundness disable step is gone"
+    assert "--disable-auto" in str(disable.get("run") or ""), "soundness disable no longer calls --disable-auto"
+    condition = str(disable.get("if") or "")
+    assert "soundness_path" in condition, "disable step no longer gates on soundness_path"

--- a/tests/unit/workflows/test_auto_merge_partial_stack_race.py
+++ b/tests/unit/workflows/test_auto_merge_partial_stack_race.py
@@ -1,20 +1,21 @@
 """Guards against auto-merge landing a PR before its later commits are pushed.
 
-`make pr-open` enables squash auto-merge at PR creation. When work continues on
-the branch afterwards, the PR can satisfy its checks and merge while a later
-commit is still being written, so develop receives a partial change and the
-remaining commit is orphaned: the branch is merged, the PR is closed, and
-nothing reports that part of the work never landed.
+Auto-merge is no longer armed at bare PR creation (`make pr-open` withholds;
+`auto-merge-on-open.yml` arms only on `ready_for_review`). The partial-stack
+race remains when a branch is marked final too early (`make pr-ready` /
+`READY=1` / draft→ready) and more commits follow: the PR can satisfy its
+checks and merge while a later commit is still being written, so develop
+receives a partial change and the remainder is orphaned on a closed branch.
 
 This is not hypothetical. PR #1503 merged carrying only its first commit; the
 `Results Explorer browser gate` job that its own PR body described never landed,
 and the orphan (b5c56ea9) was found by hand. The detector's own header records
 three earlier occurrences in the same remediation.
 
-`auto-merge-on-open.yml` cannot prevent it: it reacts to `synchronize`, and in
-this race there is no later push to react to *until after* the merge has already
-happened. So the guard is detection, and detection is only useful if it runs
-close to the event - hence the trigger assertions below.
+`auto-merge-on-open.yml` cannot prevent it: once auto-merge is armed, the race
+has no later push to react to *until after* the merge has already happened.
+So the guard is detection, and detection is only useful if it runs close to
+the event - hence the trigger assertions below.
 """
 
 from __future__ import annotations


### PR DESCRIPTION
After #1567, make pr-open withheld auto-merge until pr-ready/READY=1, but
auto-merge-on-open.yml still armed on the opened event for any non-draft
develop PR. Bare gh pr create therefore defeated the hold (#1568/#1569).

Policy (cross-layer):
- Arm only on ready_for_review (draft→ready UI path) or make pr-ready.
- Never enable on opened/reopened/synchronize.
- synchronize still revokes auto-merge for soundness-path diffs.

Pin the policy in unit tests across Makefile and workflow layers.
