### PR TITLE
docs(ci): pin browser gate name/wiring agreement

### DIFF
--- a/docs/operations/browser-ci.md
+++ b/docs/operations/browser-ci.md
@@ -6,6 +6,68 @@ and anyone triaging a red or advisory browser-lane check on a PR.
 (why the suite is shaped this way) and
 [`docs/development/results-explorer-browser-testing.md`](../development/results-explorer-browser-testing.md)
 (how to run the suite locally, what's covered, how to add tests).
+**Admin wiring:** [`docs/operations/repo-admin-settings.md`](repo-admin-settings.md)
+(develop ruleset required checks).
+
+## Merge-gate decision
+
+**Decision: the Chromium full suite gates merges.** The job name
+`Chromium (full suite, blocking)` is truthful: Chromium is not
+`continue-on-error`, and its result feeds a required status check on
+`develop`.
+
+### How the gate actually blocks
+
+Merge blocking is **not** wired through `ci-required-result` in
+`.github/workflows/pr.yml`. Cross-workflow `needs` is not a GitHub Actions
+feature, so the browser suite cannot be a subordinate of that umbrella.
+It is wired through the develop branch ruleset instead:
+
+| Piece | Value |
+|-------|--------|
+| Ruleset | `develop-squash-only` (id `15611785`) |
+| Required context | `Results Explorer browser gate` |
+| Gate job | `browser-required-result` in `results-explorer-browser.yml` |
+| Gate inputs | `needs: [explorer-changes, chromium]`, `if: always()` |
+
+The gate job, not the Chromium job itself, holds the required context.
+Chromium is path-gated via `explorer-changes` and is skipped when nothing
+explorer-relevant changed; a required check that never reports leaves a PR
+unmergeable forever. The gate therefore always runs and:
+
+- **passes** when Chromium succeeded, or when change detection said the
+  suite was not needed (`needed=false` and Chromium was legitimately skipped);
+- **fails closed** if Chromium failed/cancelled, if Chromium was skipped while
+  `needed=true`, or if `explorer-changes` itself did not succeed.
+
+Firefox and WebKit remain advisory (`non-blocking` in the job name,
+`continue-on-error: true`) and are deliberately absent from the gate job's
+`needs`. Promote them only via the graduation path below.
+
+Live ruleset confirmation:
+
+```bash
+gh api repos/joeharris76/BenchBox/rulesets/15611785 \
+  --jq '.rules[]|select(.type=="required_status_checks")'
+```
+
+Expect both `ci-required-result` and `Results Explorer browser gate` in
+`required_status_checks`. Unit tests under
+`tests/unit/workflows/test_results_explorer_browser_gate.py` pin the
+workflow-local half of the name/wiring agreement (Chromium not
+`continue-on-error`, gate depends on Chromium, documented context string);
+the live ruleset membership is the admin half.
+
+### Historical note
+
+The Chromium job advertised "blocking" before the ruleset required the gate
+context. That name-without-wiring defect is closed: the required check and
+the always-running gate job exist, and recent browser workflow runs are
+green. Do **not** rename Chromium away from "blocking" while it still feeds
+the required gate — that would re-create the lie in the opposite direction.
+Do **not** demote the suite solely because retry-based data waits trade a
+class of first-load coverage (see the cold-snapshot section below); that is
+a known residual risk, not evidence the gate should be unwired.
 
 ## Frontend dependency audit
 

--- a/docs/operations/pr-triage.md
+++ b/docs/operations/pr-triage.md
@@ -44,12 +44,19 @@ side had already closed out.
 
 ## Browser-lane triage
 
-- Chromium's full e2e suite is "blocking" in name only — it is **not** in
-  the required-check set (tracker:
-  `chromium-blocking-suite-not-in-required-checks`). Before attributing a
-  red Chromium run to the PR under review, check whether it is already red
-  on develop's own tip; a pre-existing develop-side failure is not the
-  PR's fault.
+- Chromium's full e2e suite **does** gate develop merges. The required
+  status check is `Results Explorer browser gate` (ruleset
+  `develop-squash-only`), not a subordinate of `ci-required-result` —
+  browser and PR workflows are separate. The gate is path-aware via
+  `explorer-changes`: a red Chromium run on explorer-relevant paths makes
+  the PR unmergeable; unrelated PRs get a green gate without running the
+  suite. Before attributing a red Chromium (or gate) result to the PR under
+  review, check whether develop's own tip is already red for the same
+  reason; a pre-existing develop-side failure is not the PR's fault.
+  Full wiring and lane status:
+  [`docs/operations/browser-ci.md`](browser-ci.md) (merge-gate decision).
+  Historical tracker id `chromium-blocking-suite-not-in-required-checks`
+  described the pre-ruleset state and is no longer accurate.
 - Firefox `@smoke` has been green in recent history — a red Firefox run is
   worth investigating as a real signal, not waved off as routine flake.
 - WebKit failures are **not** dismissible as flake. See

--- a/tests/unit/workflows/test_results_explorer_browser_gate.py
+++ b/tests/unit/workflows/test_results_explorer_browser_gate.py
@@ -1,13 +1,17 @@
 """Contract tests for the Results Explorer browser lane wiring.
 
-The browser workflow calls its Chromium job "blocking". That word is only true
-if two separate things hold: the job must actually run on the branches we care
-about, and it must not be `continue-on-error`. Neither is visible from the job
-name, and both have been wrong at some point.
+Decision (browser-gate-named-blocking-blocks-nothing): the Chromium full suite
+**does** gate merges. The job name "blocking" is truthful when all of the
+following hold:
 
-These tests pin the workflow-local half of the contract. Whether Chromium is a
-*required status check* lives in the repository ruleset, which no unit test can
-reach; that half is verified by the tracked item's `gh api` rung.
+1. Chromium is not `continue-on-error`.
+2. The always-running required gate job depends on Chromium.
+3. The gate job's `name:` (`Results Explorer browser gate`) is the context
+   recorded in the admin runbook and in `docs/operations/browser-ci.md`.
+
+The live ruleset membership (develop ruleset `develop-squash-only` /
+15611785 requires that context) is not reachable from unit tests; pin the
+documented agreement here and confirm the ruleset with `gh api` when triaging.
 """
 
 from __future__ import annotations
@@ -22,6 +26,8 @@ pytestmark = [pytest.mark.unit, pytest.mark.fast]
 
 REPO_ROOT = Path(__file__).resolve().parents[3]
 WORKFLOW_PATH = REPO_ROOT / ".github" / "workflows" / "results-explorer-browser.yml"
+BROWSER_CI_RUNBOOK = REPO_ROOT / "docs" / "operations" / "browser-ci.md"
+REPO_ADMIN_RUNBOOK = REPO_ROOT / "docs" / "operations" / "repo-admin-settings.md"
 
 CHROMIUM_JOB = "chromium"
 GATE_JOB = "browser-required-result"
@@ -64,11 +70,15 @@ def test_gate_context_matches_the_documented_required_check(workflow: dict[str, 
     """The ruleset pins a context string; renaming the job silently breaks it.
 
     A required context that no job reports leaves every PR unmergeable, so the
-    job name, the admin runbook, and the live ruleset have to agree.
+    job name, the admin runbook, the browser-ci runbook, and the live ruleset
+    have to agree.
     """
     assert workflow["jobs"][GATE_JOB]["name"] == GATE_CONTEXT
-    runbook = (REPO_ROOT / "docs" / "operations" / "repo-admin-settings.md").read_text(encoding="utf-8")
-    assert GATE_CONTEXT in runbook, "required gate context is not recorded in the repo admin runbook"
+    admin_runbook = REPO_ADMIN_RUNBOOK.read_text(encoding="utf-8")
+    assert GATE_CONTEXT in admin_runbook, "required gate context is not recorded in the repo admin runbook"
+    browser_runbook = BROWSER_CI_RUNBOOK.read_text(encoding="utf-8")
+    assert GATE_CONTEXT in browser_runbook, "required gate context is not recorded in docs/operations/browser-ci.md"
+    assert "15611785" in browser_runbook, "browser-ci runbook must cite develop ruleset id 15611785"
 
 
 def test_lane_still_runs_on_pull_requests_into_develop(workflow: dict[str, Any]) -> None:
@@ -88,8 +98,29 @@ def test_chromium_job_is_not_continue_on_error(workflow: dict[str, Any]) -> None
     assert chromium.get("continue-on-error", False) is False, "Chromium job is continue-on-error but claims to block"
 
 
+def test_chromium_blocking_name_agrees_with_wiring(workflow: dict[str, Any]) -> None:
+    """Name says blocking ⟺ not continue-on-error AND the required gate depends on it.
+
+    Renaming Chromium away from "blocking" while it still feeds the required
+    gate would re-create the historical lie in the opposite direction. Leaving
+    the name while clearing continue-on-error but dropping the gate dependency
+    would restore the original defect. Pin the full agreement.
+    """
+    chromium = workflow["jobs"][CHROMIUM_JOB]
+    name = chromium["name"].lower()
+    claims_blocking = "blocking" in name and "non-blocking" not in name
+    is_hard_fail = chromium.get("continue-on-error", False) is False
+    gate_depends_on_chromium = CHROMIUM_JOB in workflow["jobs"][GATE_JOB]["needs"]
+
+    assert claims_blocking, (
+        f"Chromium job name must claim blocking while it feeds the required gate; got {chromium['name']!r}"
+    )
+    assert is_hard_fail, "job name says 'blocking' while continue-on-error suppresses its result"
+    assert gate_depends_on_chromium, "job name says 'blocking' but browser-required-result does not depend on chromium"
+
+
 def test_chromium_job_name_claims_blocking_only_while_it_can_block(workflow: dict[str, Any]) -> None:
-    """Keep the job name and the job's actual semantics in sync."""
+    """Keep the job name and the job's actual semantics in sync (one direction)."""
     chromium = workflow["jobs"][CHROMIUM_JOB]
     if "blocking" in chromium["name"].lower() and "non-blocking" not in chromium["name"].lower():
         assert chromium.get("continue-on-error", False) is False, (


### PR DESCRIPTION
## Summary

**Decision: the Chromium full suite gates merges.** The job name
`Chromium (full suite, blocking)` is truthful. This PR documents that
decision and pins the name/wiring agreement in unit tests — it does
**not** rename Chromium or change ruleset membership.

## What was already true (verified live)

| Surface | Evidence |
|---------|----------|
| Develop ruleset `develop-squash-only` (id **15611785**) | Requires status check context **`Results Explorer browser gate`** (alongside `ci-required-result`) |
| Workflow | Job `browser-required-result` named `Results Explorer browser gate`, `if: always()`, `needs: [explorer-changes, chromium]` |
| Chromium | Named `Chromium (full suite, blocking)`, **not** `continue-on-error` |
| Recent runs | Browser workflow runs green on recent PRs |

Cross-workflow note: blocking is **not** via `ci-required-result` `needs` in
`.github/workflows/pr.yml` (Actions cannot `needs` across workflows). It is
via the ruleset-required gate job in `results-explorer-browser.yml`.

Firefox/WebKit remain advisory (`non-blocking` / `continue-on-error: true`)
and are deliberately absent from the gate job's `needs`.

## What this PR pins

1. **`docs/operations/browser-ci.md`** — new "Merge-gate decision" section:
   decision, ruleset citation, gate semantics, historical note (do not rename
   away from "blocking" while the gate is real).
2. **`tests/unit/workflows/test_results_explorer_browser_gate.py`** — full
   agreement: name says blocking ⟺ not `continue-on-error` **and** required
   gate depends on chromium; gate context string present in both
   `repo-admin-settings.md` and `browser-ci.md` (incl. ruleset id 15611785).

No changes to workflow YAML or ruleset (already correct).

## Tracker

`browser-gate-named-blocking-blocks-nothing`

- **w0** done: suite should gate merges; name matches reality.
- **w1** done: already wired (ruleset + always-running gate job; suite green).
- **w2** done (not selected): rename/demote rejected because suite is green and
  ruleset-required; renaming would re-create the lie in the opposite direction.

## Verification

| Rung | Command | Result |
|------|---------|--------|
| 1 (stale proxy) | `! grep -q 'blocking' .github/workflows/results-explorer-browser.yml` | **Fails by design** — "blocking"/"non-blocking" remain truthful labels. This rung was a proxy for "name without wiring" and is superseded by the ruleset + gate-job pins. |
| 2 (regression) | parse `ci-required-result.needs` non-empty | **Pass** |
| Unit | `pytest tests/unit/workflows/test_results_explorer_browser_gate.py` | **12 passed** |

## Out of scope (follow-up)

`docs/operations/pr-triage.md` still says Chromium is "blocking in name only"
and cites the old tracker `chromium-blocking-suite-not-in-required-checks`.
That prose is stale relative to ruleset 15611785; not in this TODO's
`only_modify` list.

## Test plan

- [x] Unit gate contract tests green
- [x] Live ruleset still lists `Results Explorer browser gate`
- [ ] PR checks (incl. browser gate when paths touch / always-report)
