### PR TITLE
fix(mcp): scrub dsn/connection_string/private_key/sas/pat assignments

### DIFF
--- a/benchbox/mcp/errors.py
+++ b/benchbox/mcp/errors.py
@@ -44,15 +44,20 @@ _SECRET_SAS_ASSIGNMENT_RE = re.compile(
     flags=re.IGNORECASE,
 )
 # Unquoted PEM / multi-line private keys span whitespace; the generic arm only
-# takes the first token and leaves base64 body lines intact.
+# takes the first token and leaves base64 body lines intact. Truncated PEM
+# (BEGIN without END) and CRLF-separated base64 continuations must still mask.
 _SECRET_PRIVATE_KEY_KEY_PATTERN = r"private[_-]?key[a-z0-9_-]*"
+# Body lines are base64-ish; allow ``_`` so truncated PEM / test sentinels are
+# not split mid-token (which re-exposes the remainder after the first mask).
+_SECRET_PRIVATE_KEY_BODY_LINE = r"[A-Za-z0-9+/=_]+"
 _SECRET_PRIVATE_KEY_ASSIGNMENT_RE = re.compile(
     rf"(({_SECRET_PRIVATE_KEY_KEY_PATTERN})\s*=\s*)"
     r"(?:"
     r"'[^']*'"
     r"|\"[^\"]*\""
     r"|-----BEGIN[^\n]*-----[\s\S]*?-----END[^\n]*-----"
-    r"|[^\s,;'\")]+(?:\n[A-Za-z0-9+/=]+)*"
+    rf"|-----BEGIN[^\n]*-----(?:\r?\n{_SECRET_PRIVATE_KEY_BODY_LINE})*"
+    rf"|[^\s,;'\")]+(?:\r?\n{_SECRET_PRIVATE_KEY_BODY_LINE})*"
     r")",
     flags=re.IGNORECASE,
 )

--- a/benchbox/mcp/errors.py
+++ b/benchbox/mcp/errors.py
@@ -35,6 +35,27 @@ _SECRET_ASSIGNMENT_RE = re.compile(
     r"(?:'[^']*'|\"[^\"]*\"|[^&\s,;'\")]+)",
     flags=re.IGNORECASE,
 )
+# Azure SAS tokens are query-string shaped (sv=...&sig=...); the generic value
+# arm stops at ``&`` and would leave signature segments in the clear.
+_SECRET_SAS_KEY_PATTERN = r"(?:storage[_-]?sas(?:[_-]?token)?|sas)[a-z0-9_-]*"
+_SECRET_SAS_ASSIGNMENT_RE = re.compile(
+    rf"(({_SECRET_SAS_KEY_PATTERN})\s*=\s*)"
+    r"(?:'[^']*'|\"[^\"]*\"|[^\s,;'\")]+)",
+    flags=re.IGNORECASE,
+)
+# Unquoted PEM / multi-line private keys span whitespace; the generic arm only
+# takes the first token and leaves base64 body lines intact.
+_SECRET_PRIVATE_KEY_KEY_PATTERN = r"private[_-]?key[a-z0-9_-]*"
+_SECRET_PRIVATE_KEY_ASSIGNMENT_RE = re.compile(
+    rf"(({_SECRET_PRIVATE_KEY_KEY_PATTERN})\s*=\s*)"
+    r"(?:"
+    r"'[^']*'"
+    r"|\"[^\"]*\""
+    r"|-----BEGIN[^\n]*-----[\s\S]*?-----END[^\n]*-----"
+    r"|[^\s,;'\")]+(?:\n[A-Za-z0-9+/=]+)*"
+    r")",
+    flags=re.IGNORECASE,
+)
 _SECRET_QUOTED_ASSIGNMENT_RE = re.compile(
     rf"""(?P<prefix>["']{_SECRET_KEY_PATTERN}["']\s*:\s*)(?P<quote>["'])(?P<value>(?:\\.|(?!(?P=quote)).)*(?P=quote))""",
     flags=re.IGNORECASE,
@@ -102,6 +123,10 @@ def scrub_secret_material(text: str) -> str:
         return f"{match.group('prefix')}****"
 
     scrubbed = _SECRET_QUOTED_ASSIGNMENT_RE.sub(replace_quoted, text)
+    # Specialized arms before the generic assignment so multi-param SAS and
+    # multi-line private keys are not truncated at ``&`` / first whitespace.
+    scrubbed = _SECRET_PRIVATE_KEY_ASSIGNMENT_RE.sub(r"\1****", scrubbed)
+    scrubbed = _SECRET_SAS_ASSIGNMENT_RE.sub(r"\1****", scrubbed)
     scrubbed = _SECRET_ASSIGNMENT_RE.sub(r"\1****", scrubbed)
     scrubbed = _SECRET_COLON_ASSIGNMENT_RE.sub(replace_colon, scrubbed)
     scrubbed = _SECRET_PROSE_CONNECTOR_RE.sub(replace_prose, scrubbed)

--- a/benchbox/mcp/errors.py
+++ b/benchbox/mcp/errors.py
@@ -23,9 +23,12 @@ from typing import Any
 # embedded in a value.
 # Keep the key vocabulary in one pattern so JSON, assignment, and prose forms
 # cannot drift apart.
+# Expandable keys accept common suffixes (e.g. motherduck_token). Short exact
+# keys (pat) must not expand into longer non-secret words such as "path".
 _SECRET_KEY_PATTERN = (
-    r"(?:password|passwd|pwd|token|secret|api[_-]?key|access[_-]?key|account[_-]?key|"
-    r"key[_-]?id|credential)[a-z0-9_-]*"
+    r"(?:(?:password|passwd|pwd|token|secret|api[_-]?key|access[_-]?key|account[_-]?key|"
+    r"key[_-]?id|credential|dsn|connection[_-]?string|private[_-]?key|sas)[a-z0-9_-]*|"
+    r"pat)"
 )
 _SECRET_ASSIGNMENT_RE = re.compile(
     rf"(({_SECRET_KEY_PATTERN})\s*=\s*)"

--- a/tests/unit/mcp/test_errors.py
+++ b/tests/unit/mcp/test_errors.py
@@ -351,6 +351,50 @@ class TestExceptionSecretScrubbing:
         result = make_execution_error("failed", exception=Exception("table lineitem not found"))
         assert result["details"]["exception_message"] == "table lineitem not found"
 
+    @pytest.mark.parametrize(
+        ("text", "sentinel"),
+        [
+            ("dsn=DSN_GATE", "DSN_GATE"),
+            ("DSN=DSN_GATE", "DSN_GATE"),
+            ("dsn='DSN_GATE'", "DSN_GATE"),
+            ('dsn="DSN_GATE"', "DSN_GATE"),
+            ("connection_string=CONNECTION_GATE", "CONNECTION_GATE"),
+            ("CONNECTION_STRING=CONNECTION_GATE", "CONNECTION_GATE"),
+            ("connection-string=CONNECTION_GATE", "CONNECTION_GATE"),
+            ("private_key=PRIVATE_GATE", "PRIVATE_GATE"),
+            ("Private_Key=PRIVATE_GATE", "PRIVATE_GATE"),
+            ("private-key=PRIVATE_GATE", "PRIVATE_GATE"),
+            ("sas=SAS_GATE", "SAS_GATE"),
+            ("SAS=SAS_GATE", "SAS_GATE"),
+            ("pat=PAT_GATE", "PAT_GATE"),
+            ("PAT=PAT_GATE", "PAT_GATE"),
+            ("password=EXISTING_SECRET", "EXISTING_SECRET"),
+        ],
+    )
+    def test_credential_assignment_vocabulary_is_scrubbed(self, text: str, sentinel: str) -> None:
+        """Assignment forms for the remaining credential vocabulary must not leak."""
+        result = make_execution_error(text, exception=Exception(text))
+        blob = str(result)
+        assert sentinel not in blob
+        assert sentinel not in result["message"]
+        assert sentinel not in result["details"]["exception_message"]
+        assert "****" in result["message"]
+        assert "****" in result["details"]["exception_message"]
+
+    def test_pat_does_not_match_path_assignment(self) -> None:
+        """Exact-key ``pat`` must not expand into non-secret ``path``."""
+        text = "path=/var/tmp/data failed to open"
+        result = make_execution_error(text, exception=Exception(text))
+        assert result["details"]["exception_message"] == text
+        assert result["message"] == text
+
+    def test_combined_credential_assignment_vocabulary_is_scrubbed(self) -> None:
+        text = "dsn=DSN_GATE private_key=PK_GATE sas=SAS_GATE pat=PAT_GATE connection_string=CS_GATE"
+        result = make_execution_error(text, exception=Exception(text))
+        blob = str(result)
+        for sentinel in ("DSN_GATE", "PK_GATE", "SAS_GATE", "PAT_GATE", "CS_GATE"):
+            assert sentinel not in blob
+
 
 class TestMakeExecutionError:
     """Tests for make_execution_error helper function."""

--- a/tests/unit/mcp/test_errors.py
+++ b/tests/unit/mcp/test_errors.py
@@ -443,6 +443,29 @@ class TestExceptionSecretScrubbing:
         assert "continuedBase64Line" not in blob
         assert "private_key=****" in result["details"]["exception_message"]
 
+    def test_truncated_pem_without_end_is_scrubbed(self) -> None:
+        """BEGIN without END must still mask following base64 body lines."""
+        pem_label = " ".join(("RSA", "PRIVATE", "KEY"))
+        begin = f"-----BEGIN {pem_label}-----"
+        body = "MIIE_GATE_BLOB"
+        text = f"private_key={begin}\n{body}\nmoreBase64Body=="
+        result = make_execution_error(text, exception=Exception(text))
+        blob = str(result)
+        assert body not in blob
+        assert "moreBase64Body" not in blob
+        assert begin not in blob
+        assert "private_key=****" in result["details"]["exception_message"]
+
+    def test_crlf_private_key_base64_continuation_is_scrubbed(self) -> None:
+        """Windows-style CRLF continuations must not leave base64 lines."""
+        body = "MIIE_GATE_BLOB"
+        text = f"private_key={body}\r\ncontinuedBase64Line\r\nnot_part_of_key=1"
+        result = make_execution_error(text, exception=Exception(text))
+        blob = str(result)
+        assert body not in blob
+        assert "continuedBase64Line" not in blob
+        assert "private_key=****" in result["details"]["exception_message"]
+
 
 class TestMakeExecutionError:
     """Tests for make_execution_error helper function."""

--- a/tests/unit/mcp/test_errors.py
+++ b/tests/unit/mcp/test_errors.py
@@ -395,6 +395,54 @@ class TestExceptionSecretScrubbing:
         for sentinel in ("DSN_GATE", "PK_GATE", "SAS_GATE", "PAT_GATE", "CS_GATE"):
             assert sentinel not in blob
 
+    @pytest.mark.parametrize(
+        "text",
+        [
+            "sas=sv=2020-08-04&sig=SIG_GATE",
+            "SAS=sv=2020-08-04&ss=b&srt=sco&sig=SIG_GATE",
+            "storage_sas_token=sv=2020-08-04&sig=SIG_GATE",
+            "storage-sas-token=sv=2020-08-04&sig=SIG_GATE",
+        ],
+    )
+    def test_sas_querystring_assignment_masks_ampersand_segments(self, text: str) -> None:
+        """SAS values are query-string shaped; ``&sig=...`` must not survive."""
+        result = make_execution_error(text, exception=Exception(text))
+        blob = str(result)
+        assert "SIG_GATE" not in blob
+        assert "sv=2020-08-04" not in blob
+        assert "****" in result["message"]
+        assert "****" in result["details"]["exception_message"]
+
+    def test_unquoted_multiline_private_key_pem_is_scrubbed(self) -> None:
+        """Unquoted PEM must not leave base64 body lines in MCP error egress.
+
+        PEM armor labels are assembled at runtime so static secret scanners do
+        not treat the test fixture as a real key material sample.
+        """
+        pem_label = " ".join(("RSA", "PRIVATE", "KEY"))
+        begin = f"-----BEGIN {pem_label}-----"
+        end = f"-----END {pem_label}-----"
+        body = "MIIE_GATE_BLOB"
+        text = f"load failed private_key={begin}\n{body}\nmoreBase64Body==\n{end} after"
+        result = make_execution_error(text, exception=Exception(text))
+        blob = str(result)
+        assert body not in blob
+        assert "moreBase64Body" not in blob
+        assert begin not in blob
+        assert "private_key=****" in result["message"]
+        assert "private_key=****" in result["details"]["exception_message"]
+        # Trailing diagnostic prose after the PEM block remains.
+        assert "after" in result["message"]
+
+    def test_unquoted_multiline_private_key_base64_continuation_is_scrubbed(self) -> None:
+        body = "MIIE_GATE_BLOB"
+        text = f"private_key={body}\ncontinuedBase64Line\nnot_part_of_key=1"
+        result = make_execution_error(text, exception=Exception(text))
+        blob = str(result)
+        assert body not in blob
+        assert "continuedBase64Line" not in blob
+        assert "private_key=****" in result["details"]["exception_message"]
+
 
 class TestMakeExecutionError:
     """Tests for make_execution_error helper function."""


### PR DESCRIPTION
## Summary

Extend MCP exception-text scrubbing so remaining credential assignment forms no longer leak through `make_execution_error` / `scrub_secret_material`:

- `dsn=`
- `connection_string=` / `connection-string=`
- `private_key=` / `private-key=`
- `sas=`
- `pat=` (exact key only — must not match `path=`)

### Approach

`_SECRET_KEY_PATTERN` now includes the expandable keys (`dsn`, `connection[_-]?string`, `private[_-]?key`, `sas`) alongside the existing password/token vocabulary, and treats `pat` as an exact alternative so it cannot expand into `path`.

Proof is behavioral (public entry points), not regex-source inspection.

### Tests

Table-driven unit coverage for casing/quoting variants, combined multi-key leakage, password regression, and path non-match — all driven through `make_execution_error`.

## Verification

- `todo verify` rungs 1–2: pass
- `uv run -- python -m pytest tests/unit/mcp/test_errors.py -q`: 59 passed
- Behavioral gates for dsn/connection_string/private_key/sas/pat + password regression: pass
- `make ci-lint`: pass
- Full local `make pr-preflight` fast suite: blocked by concurrent hung xdist run at ~95% (chdb native wait; reproduced independently). CI is the authoritative full-suite gate.

## Scope

Only modifies the two allowed paths. Does not touch analytics/benchmark tools, results, or todo_db.
