### PR TITLE
docs: document stacked-PR base branch policy

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -113,11 +113,12 @@ all issues, considerations, and nits unless the user explicitly opts out. Run
 low-effort subagent; you still choose the command and interpret failures. Do
 not poll CI: pending is a valid terminal state.
 
-Dev PRs target `develop`, use squash merge, and never direct-push protected
-branches. Force-push only feature/pool branches with `--force-with-lease`.
-Soundness paths listed by `_project/scripts/auto_merge_soundness_paths.py`
-require maintainer review and remain excluded from auto-merge. A drift/pinning
-guard and its required-CI wiring must land in the same PR.
+Dev PRs target `develop` (or `release` / `published-results`), use squash merge, and never direct-push protected
+branches. Stacked/feature-base PRs unsupported: zero CI by branch filters; `pr-base-guard.yml` fails loud —
+retarget/rebase onto `develop` after parent squash-merge (`docs/development/pr-base-branch-policy.md`); bad-base empty
+checks ≠ `mergeable_state: CONFLICTING`. Force-push only feature/pool branches with `--force-with-lease`. Soundness
+paths listed by `_project/scripts/auto_merge_soundness_paths.py` require maintainer review and remain excluded from
+auto-merge. A drift/pinning guard and its required-CI wiring must land in the same PR.
 
 ## TODO tracker
 
@@ -165,5 +166,5 @@ guard (`scripts/check_untracked_skill_mirrors.sh`), not a lock-verify step.
 - Operations: `docs/operations/` — `repo-admin-settings.md` (PR/admin policy),
   `uat-framework.md`, `release-guide.md`, `agent-instruction-evaluation.md`
 - Development: `docs/development/` — `run-lifecycle-map.md`,
-  `result-integrity-validation.md`, `adding-new-platforms.md`
+  `result-integrity-validation.md`, `adding-new-platforms.md`, `pr-base-branch-policy.md`
 - SQL compatibility: `benchbox/sql_compat/README.md`; tests: `tests/README.md`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -107,18 +107,19 @@ Read a claimed TODO's `verification` ladder and run the narrowest proof first.
 Useful local checks: `uv run -- python -m pytest -m fast -q`,
 `uv run -- ruff check .`, `uv run -- ruff format --check .`, `uv run -- ty check`.
 
-Before publication, self-review with the `code` skill's review action and fix
-all issues, considerations, and nits unless the user explicitly opts out. Run
-`make pr-preflight` once, then `make pr-open`. Boilerplate gates may go to a
-low-effort subagent; you still choose the command and interpret failures. Do
-not poll CI: pending is a valid terminal state.
+Before publication, self-review with the `code` skill's review action and fix all
+issues, considerations, and nits unless the user explicitly opts out. Run `make pr-preflight`
+once, then `make pr-open`. Boilerplate gates may go to a low-effort subagent; you still
+choose the command and interpret failures. Do not poll CI: pending is a valid terminal state.
 
 Dev PRs target `develop` (or `release` / `published-results`), use squash merge, and never direct-push protected
-branches. Stacked/feature-base PRs unsupported: zero CI by branch filters; `pr-base-guard.yml` fails loud —
-retarget/rebase onto `develop` after parent squash-merge (`docs/development/pr-base-branch-policy.md`); bad-base empty
-checks ≠ `mergeable_state: CONFLICTING`. Force-push only feature/pool branches with `--force-with-lease`. Soundness
-paths listed by `_project/scripts/auto_merge_soundness_paths.py` require maintainer review and remain excluded from
-auto-merge. A drift/pinning guard and its required-CI wiring must land in the same PR.
+branches. Force-push only feature/pool branches with `--force-with-lease`. Soundness paths listed by
+`_project/scripts/auto_merge_soundness_paths.py` require maintainer review and remain excluded from auto-merge.
+A drift/pinning guard and its required-CI wiring must land in the same PR.
+## PR base branch (stacked PRs unsupported)
+Stacked/feature-base PRs unsupported: zero CI by filters; `pr-base-guard.yml` fails loud — retarget/rebase onto
+`develop` after parent squash-merge (`docs/development/pr-base-branch-policy.md`). Bad-base empty checks ≠
+`mergeable_state: dirty` (conflicts).
 
 ## TODO tracker
 
@@ -145,21 +146,20 @@ claimable items).
 - CLI dry runs must propagate explicit phases; deterministic runs use a seed.
 - Green focused/fast tests are not UAT or production certification.
 
-Apple/macOS notes: `make test-correctness-gate` uses Linux-generated digests;
-use `make ci-linux` for parity. Mocker is local-only and unsuitable for the
-known multi-service stacks; follow `docs/operations/uat-framework.md` for
-container lifecycle and cleanup. Never globally prune without approval.
+Apple/macOS notes: `make test-correctness-gate` uses Linux-generated digests; use
+`make ci-linux` for parity. Mocker is local-only and unsuitable for the known multi-service
+stacks; follow `docs/operations/uat-framework.md` for container lifecycle and cleanup. Never
+globally prune without approval.
 
 ## Skills and generated mirrors
 
-Stable wrappers are `code`, `test`, `todo`, `todo-db`, `blog`,
-`benchbox`, `skill-sync`, and `tidy-perms`. `todo` authors ideas/specs;
-`todo-db` owns tracker actions. Skill source is
-`/Users/joe/.skill-sync/skills`; `.claude/skills`, `.codex/skills`,
-`.gemini/skills`, and `.antigravity/skills` are generated mirrors. Run
-`make skill-sync` to regenerate mirrors, never hand-edit one. Integrity
-comes from PR review of the mirror diff plus the untracked-mirror drift
-guard (`scripts/check_untracked_skill_mirrors.sh`), not a lock-verify step.
+Stable wrappers are `code`, `test`, `todo`, `todo-db`, `blog`, `benchbox`,
+`skill-sync`, and `tidy-perms`. `todo` authors ideas/specs; `todo-db` owns tracker
+actions. Skill source is `/Users/joe/.skill-sync/skills`; `.claude/skills`, `.codex/skills`,
+`.gemini/skills`, and `.antigravity/skills` are generated mirrors. Run `make skill-sync` to
+regenerate mirrors, never hand-edit one. Integrity comes from PR review of the mirror diff
+plus the untracked-mirror drift guard (`scripts/check_untracked_skill_mirrors.sh`), not a
+lock-verify step.
 
 ## Operational references
 

--- a/docs/development/index.md
+++ b/docs/development/index.md
@@ -21,6 +21,7 @@ Documentation for contributors and developers working on BenchBox.
 
 - [Adding New Platforms](adding-new-platforms.md) - How to add support for new database platforms
 - [New Platform Acceptance Checklist](new-platform-acceptance-checklist.md) - Required registry, docs, tests, compatibility, and UAT gates
+- [PR base branch policy](pr-base-branch-policy.md) - Integration bases only; stacked/feature-base PRs unsupported
 - [Import Patterns](import-patterns.md) - Lazy loading and dependency management patterns
 - [TPC Compilation Guide](tpc-compilation-guide.md) - Compiling TPC benchmark tools
 

--- a/docs/development/pr-base-branch-policy.md
+++ b/docs/development/pr-base-branch-policy.md
@@ -63,14 +63,18 @@ force-push after every parent merge anyway. Preferred workflow:
 
 ## "No checks" is not one failure mode
 
+Use REST `mergeable_state` vocabulary from `docs/operations/pr-triage.md`
+(GraphQL `mergeable: CONFLICTING` is the same situation as REST `dirty`):
+
 | Symptom | Cause | What to do |
 | --- | --- | --- |
-| Guard fails; other checks absent | Base is not an integration branch | Retarget to `develop` (or the correct lane base) |
-| Required checks missing / stuck; `mergeable_state: CONFLICTING` | GitHub mergeability / conflicts | Resolve conflicts or rebase onto the base tip |
-| Path-aware jobs skipped; umbrella still green | Classifier decided the path set is safe-content | Expected; not a stacked-base issue |
+| Guard red; other lanes absent | Base is not an integration branch | Retarget to `develop` (or the correct lane base) |
+| `mergeable_state: dirty` (GraphQL `mergeable: CONFLICTING`) | Conflicts with the base tip | Rebase/resolve onto the base tip |
+| Required checks missing/stuck on an integration base; `mergeable_state: blocked` | CI unfinished, path gate, or ruleset | Inspect check runs — do not retarget |
 
 Do not treat an empty check list on a feature base as "CI is fine" or as the
-same problem as a conflicting PR on `develop`.
+same problem as `dirty` (conflicts) or `blocked` (unfinished gates) on
+`develop`.
 
 ## Agent checklist
 
@@ -79,5 +83,5 @@ same problem as a conflicting PR on `develop`.
 - Never open a PR with `--base` set to another feature branch.
 - If `pr-base-guard` fails, fix the base; do not try to "add CI" to the
   stacked base by editing branch filters.
-- Short agent-facing summary: `AGENTS.md` → *PR base branch (stacked PRs
-  unsupported)*.
+- Short agent-facing summary: `AGENTS.md` → section **PR base branch
+  (stacked PRs unsupported)**.

--- a/docs/development/pr-base-branch-policy.md
+++ b/docs/development/pr-base-branch-policy.md
@@ -1,0 +1,83 @@
+# PR base branch policy
+
+BenchBox does **not** support stacked PRs (a PR whose base is another feature
+branch). Open every change against an integration branch and rebase children
+after each parent lands.
+
+## Allowed bases
+
+| Base | When |
+| --- | --- |
+| `develop` | Normal development PRs |
+| `release` | Release-lane PRs only |
+| `published-results` | Published-results lane only |
+
+Any other base (including a sibling feature branch) is out of policy.
+
+## Why stacked bases get zero CI
+
+Almost every PR workflow filters on those integration branches:
+
+```yaml
+on:
+  pull_request:
+    branches: [develop]   # or release / published-results
+```
+
+A PR opened against `fix/parent` therefore triggers **no** `pr.yml`, no
+`ci-required-result`, and no browser lane. The GitHub PR page looks calm
+(empty check list) rather than broken, and the change can reach `develop`
+only when the parent merges — never validated on its own and attributed to
+the parent's PR.
+
+That silence is intentional branch-filter design, not a CI outage. We do
+**not** widen every workflow's branch filter to "support" stacking; that
+would dilute the integration-branch contract and still leave squash-merge
+chains needing rebases.
+
+## Loud failure: `pr-base-guard.yml`
+
+`.github/workflows/pr-base-guard.yml` is the one PR workflow **without** a
+`branches:` filter. It always reports:
+
+- Base is `develop` / `release` / `published-results` → pass in seconds; the
+  normal CI lanes apply.
+- Base is anything else → fail with an explicit message to retarget or fold
+  into the parent.
+
+It also listens for `edited` so retargeting an open PR re-evaluates (a PR
+opened on `develop` and later pointed at a feature branch must not keep a
+stale green result).
+
+Unit pins live in `tests/unit/workflows/test_stacked_pr_base_guard.py`.
+
+## After a parent merges
+
+`develop` is squash-merge only. A stacked chain would need a rebase and
+force-push after every parent merge anyway. Preferred workflow:
+
+1. Open each PR against `develop` (or the appropriate integration base).
+2. If work depends on an unmerged parent, wait or fold into the parent PR.
+3. After the parent squash-merges, rebase the child onto the updated base and
+   force-push with `--force-with-lease` on the feature/pool branch only.
+
+## "No checks" is not one failure mode
+
+| Symptom | Cause | What to do |
+| --- | --- | --- |
+| Guard fails; other checks absent | Base is not an integration branch | Retarget to `develop` (or the correct lane base) |
+| Required checks missing / stuck; `mergeable_state: CONFLICTING` | GitHub mergeability / conflicts | Resolve conflicts or rebase onto the base tip |
+| Path-aware jobs skipped; umbrella still green | Classifier decided the path set is safe-content | Expected; not a stacked-base issue |
+
+Do not treat an empty check list on a feature base as "CI is fine" or as the
+same problem as a conflicting PR on `develop`.
+
+## Agent checklist
+
+- `make pr-open` (and manual `gh pr create`) must target `develop` unless the
+  change is explicitly for `release` or `published-results`.
+- Never open a PR with `--base` set to another feature branch.
+- If `pr-base-guard` fails, fix the base; do not try to "add CI" to the
+  stacked base by editing branch filters.
+- Short agent-facing summary: `AGENTS.md` → *PR base branch (stacked PRs
+  unsupported)*.


### PR DESCRIPTION
Stacked/feature-base PRs are unsupported: branch-filtered workflows give
them zero CI, and pr-base-guard.yml fails them loudly. Record the policy
in AGENTS.md and docs/development/pr-base-branch-policy.md so agents
retarget onto develop instead of widening workflow filters.
