### PR TITLE
fix(results): filter all platform metadata export boundaries

### DIFF
--- a/benchbox/core/results/database.py
+++ b/benchbox/core/results/database.py
@@ -24,6 +24,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
+from benchbox.core.results.environment import build_platform_metadata_payload
 from benchbox.core.results.models import BenchmarkResults
 from benchbox.core.results.platform_options import sanitize_platform_options
 from benchbox.core.results.regression_policy import is_regression
@@ -353,7 +354,7 @@ class ResultDatabase:
             total_cost = result.cost_summary.get("total_cost")
 
         # Build metadata
-        metadata = {
+        metadata: dict[str, Any] = {
             "system_profile": result.system_profile,
             # ~/.benchbox/results.db outlives the run; sanitize so a
             # convention slip in an adapter's platform_info never persists a
@@ -362,6 +363,32 @@ class ResultDatabase:
             "tunings_applied": result.tunings_applied,
             "test_execution_type": result.test_execution_type,
         }
+        # Persist filtered platform metadata when the result carries explicit
+        # blocks so the local DB is not a silent egress channel for raw_config,
+        # raw_metadata, or the normalized deployment/cloud/compute/storage
+        # mappings. Same structural boundary as public/private payloads.
+        has_explicit_platform_meta = any(
+            getattr(result, name, None) is not None
+            for name in (
+                "platform_deployment",
+                "platform_cloud",
+                "platform_compute",
+                "platform_storage",
+                "platform_raw_config",
+                "platform_raw_metadata",
+            )
+        )
+        if has_explicit_platform_meta:
+            metadata["platform"] = build_platform_metadata_payload(
+                platform_info=result.platform_info,
+                platform_config=None,
+                deployment=getattr(result, "platform_deployment", None),
+                cloud=getattr(result, "platform_cloud", None),
+                compute=getattr(result, "platform_compute", None),
+                storage=getattr(result, "platform_storage", None),
+                raw_config=getattr(result, "platform_raw_config", None),
+                raw_metadata=getattr(result, "platform_raw_metadata", None),
+            )
 
         with self._connection() as conn:
             cursor = conn.cursor()

--- a/benchbox/core/results/environment.py
+++ b/benchbox/core/results/environment.py
@@ -257,6 +257,25 @@ def build_environment_payload(
     return _compact(payload)
 
 
+def _sanitize_metadata_block(
+    value: Any,
+    *,
+    default: Mapping[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Convert a metadata mapping (or dataclass) and filter credential-shaped keys.
+
+    Shared export boundary for raw_config, raw_metadata, and the normalized
+    deployment/cloud/compute/storage blocks. Non-secret tuning fields pass
+    through unchanged.
+    """
+    converted = _metadata_dict(value)
+    if not converted and default is not None:
+        converted = dict(default)
+    if not converted:
+        return {}
+    return sanitize_platform_options(converted)
+
+
 def build_platform_metadata_payload(
     *,
     platform_info: Mapping[str, Any] | None,
@@ -269,24 +288,28 @@ def build_platform_metadata_payload(
     raw_metadata: Mapping[str, Any] | None,
     sanitize_raw_config: bool = True,
 ) -> dict[str, Any]:
-    """Build normalized ``platform`` metadata blocks with conservative defaults."""
+    """Build normalized ``platform`` metadata blocks with conservative defaults.
+
+    Credential redaction is unconditional for every mapping this function
+    emits (raw_config, raw_metadata, and the normalized deployment/cloud/
+    compute/storage blocks). ``sanitize_raw_config`` remains a compatibility
+    argument for callers that supplied it, but never opts out of filtering.
+    """
+    _ = sanitize_raw_config  # compatibility only; boundary filtering is mandatory
     default_deployment = _default_deployment_metadata(platform_info or {}, platform_config or {})
     payload: dict[str, Any] = {
-        "deployment": _metadata_dict(deployment) or default_deployment.to_dict(),
-        "cloud": _metadata_dict(cloud) or PlatformCloudMetadata().to_dict(),
-        "compute": _metadata_dict(compute) or PlatformComputeMetadata().to_dict(),
-        "storage": _metadata_dict(storage) or PlatformStorageMetadata().to_dict(),
+        "deployment": _sanitize_metadata_block(deployment, default=default_deployment.to_dict()),
+        "cloud": _sanitize_metadata_block(cloud, default=PlatformCloudMetadata().to_dict()),
+        "compute": _sanitize_metadata_block(compute, default=PlatformComputeMetadata().to_dict()),
+        "storage": _sanitize_metadata_block(storage, default=PlatformStorageMetadata().to_dict()),
     }
     # ``raw_config`` may come from an adapter-specific hook rather than the
     # normalized platform config fallback. Keep this as the public export
     # boundary so every selected source receives the same structural filtering.
-    # Credential redaction is unconditional at this payload boundary. Keep
-    # ``sanitize_raw_config`` as a compatibility argument for callers that
-    # supplied it, but never let a private/internal export opt out of it.
-    raw_config_payload = sanitize_platform_options(_metadata_dict(raw_config))
+    raw_config_payload = _sanitize_metadata_block(raw_config)
     if raw_config_payload:
         payload["raw_config"] = raw_config_payload
-    raw_metadata_payload = _metadata_dict(raw_metadata)
+    raw_metadata_payload = _sanitize_metadata_block(raw_metadata)
     if raw_metadata_payload:
         payload["raw_metadata"] = raw_metadata_payload
     return _compact(payload)

--- a/benchbox/core/results/schema.py
+++ b/benchbox/core/results/schema.py
@@ -550,7 +550,8 @@ def _build_platform_section(
             # Credential redaction is a boundary invariant for every exported
             # result, including explicitly private/internal artifacts. The
             # flag still controls public anonymization elsewhere, but it must
-            # not turn a raw adapter config into a credential egress channel.
+            # not turn raw adapter config/metadata or normalized deployment/
+            # cloud/compute/storage blocks into a credential egress channel.
             sanitize_raw_config=True,
         )
     )

--- a/tests/unit/core/results/test_credential_egress_sentinel_invariant.py
+++ b/tests/unit/core/results/test_credential_egress_sentinel_invariant.py
@@ -174,3 +174,56 @@ def test_registered_adapter_result_payload_redacts_credential_sentinels(platform
     database_bytes = (tmp_path / "results.db").read_bytes()
     for sentinel in _CREDENTIAL_SENTINELS:
         assert sentinel.encode() not in database_bytes, f"{platform_name} results.db leaked {sentinel}"
+
+
+def test_platform_metadata_blocks_never_egress_distinct_sentinels(tmp_path: Path) -> None:
+    """raw_config, raw_metadata, and normalized mapping blocks share one boundary.
+
+    Distinct sentinels per source ensure a partial fix cannot silence the gate.
+    """
+    gates = {
+        "raw_config": "RAW_CONFIG_GATE",
+        "raw_metadata": "RAW_METADATA_GATE",
+        "deployment": "DEPLOYMENT_GATE",
+        "cloud": "CLOUD_GATE",
+        "compute": "COMPUTE_GATE",
+        "storage": "STORAGE_GATE",
+    }
+    result = BenchmarkResults(
+        benchmark_name="synthetic",
+        platform="synthetic",
+        scale_factor=1.0,
+        execution_id="metadata-blocks-gate",
+        timestamp=datetime.now(),
+        duration_seconds=0.1,
+        total_queries=0,
+        successful_queries=0,
+        failed_queries=0,
+        platform_info={"sort_key": "o_orderkey", "threads": 4},
+        platform_raw_config={"password": gates["raw_config"], "threads": 4},
+        platform_raw_metadata={"password": gates["raw_metadata"], "partition_key": "l_orderkey"},
+        platform_deployment={"token": gates["deployment"], "connection_mode": "embedded"},
+        platform_cloud={"access_key": gates["cloud"], "region": "us-east-1"},
+        platform_compute={"connection_string": gates["compute"], "warehouse": "BENCH_WH"},
+        platform_storage={"secret": gates["storage"], "bucket": "bench-bucket"},
+    )
+
+    public = json.dumps(build_result_payload(result), default=str)
+    private = (
+        ResultExporter(output_dir=tmp_path / "export", anonymize=False)
+        .export_result(result, formats=["json"])["json"]
+        .read_text(encoding="utf-8")
+    )
+    db_path = tmp_path / "results.db"
+    ResultDatabase(db_path=db_path).store_result(result)
+    database_bytes = db_path.read_bytes()
+
+    for source, sentinel in gates.items():
+        assert sentinel not in public, f"public payload leaked {source}={sentinel}"
+        assert sentinel not in private, f"private export leaked {source}={sentinel}"
+        assert sentinel.encode() not in database_bytes, f"results.db leaked {source}={sentinel}"
+
+    # Non-secret tuning must still be available to analysis consumers.
+    assert "o_orderkey" in public
+    assert "BENCH_WH" in private
+    assert b"bench-bucket" in database_bytes

--- a/tests/unit/core/results/test_database.py
+++ b/tests/unit/core/results/test_database.py
@@ -842,6 +842,48 @@ class TestSummaryStats:
         assert stats["unique_platforms"] == 0
 
 
+class TestPlatformMetadataCredentialBoundary:
+    """results.db must not persist credential-shaped platform metadata values."""
+
+    def test_store_result_filters_all_platform_metadata_sources(self, tmp_path):
+        gates = (
+            "RAW_CONFIG_GATE",
+            "RAW_METADATA_GATE",
+            "DEPLOYMENT_GATE",
+            "CLOUD_GATE",
+            "COMPUTE_GATE",
+            "STORAGE_GATE",
+        )
+        result = create_test_result(execution_id="platform-meta-db")
+        result.platform_raw_config = {"password": "RAW_CONFIG_GATE", "threads": 4, "sort_key": "o_orderkey"}
+        result.platform_raw_metadata = {"password": "RAW_METADATA_GATE", "partition_key": "l_orderkey"}
+        result.platform_deployment = {"token": "DEPLOYMENT_GATE", "connection_mode": "embedded"}
+        result.platform_cloud = {"access_key": "CLOUD_GATE", "region": "us-east-1"}
+        result.platform_compute = {"connection_string": "COMPUTE_GATE", "warehouse": "BENCH_WH"}
+        result.platform_storage = {"secret": "STORAGE_GATE", "bucket": "bench-bucket"}
+
+        db = ResultDatabase(tmp_path / "test.db")
+        db.store_result(result)
+        raw = (tmp_path / "test.db").read_bytes()
+        for gate in gates:
+            assert gate.encode() not in raw, f"results.db leaked {gate}"
+
+        stored = db.get_result("platform-meta-db")
+        assert stored is not None
+        platform = stored.metadata["platform"]
+        assert platform["raw_config"]["password"] == "<redacted>"
+        assert platform["raw_config"]["threads"] == 4
+        assert platform["raw_config"]["sort_key"] == "o_orderkey"
+        assert platform["raw_metadata"]["password"] == "<redacted>"
+        assert platform["raw_metadata"]["partition_key"] == "l_orderkey"
+        assert platform["deployment"]["token"] == "<redacted>"
+        assert platform["cloud"]["access_key"] == "<redacted>"
+        assert platform["compute"]["connection_string"] == "<redacted>"
+        assert platform["compute"]["warehouse"] == "BENCH_WH"
+        assert platform["storage"]["secret"] == "<redacted>"
+        assert platform["storage"]["bucket"] == "bench-bucket"
+
+
 class TestImportResults:
     """Tests for importing results from files."""
 

--- a/tests/unit/core/results/test_environment_anonymization.py
+++ b/tests/unit/core/results/test_environment_anonymization.py
@@ -228,3 +228,6 @@ def test_private_export_preserves_raw_platform_metadata_behind_explicit_option(t
     assert payload["platform"]["raw_config"]["username"] == "<redacted>"
     assert payload["platform"]["raw_config"]["password"] == "<redacted>"
     assert payload["platform"]["raw_config"]["access_token"] == "<redacted>"
+    # raw_metadata and normalized blocks share the same structural boundary:
+    # credentials never egress even when anonymize=False preserves identifiers.
+    assert "super-secret-password" not in json.dumps(payload.get("platform", {}).get("raw_metadata", {}))

--- a/tests/unit/core/results/test_platform_config_secret_filtering.py
+++ b/tests/unit/core/results/test_platform_config_secret_filtering.py
@@ -8,18 +8,68 @@ Copyright 2026 Joe Harris / BenchBox Project
 Licensed under the MIT License. See LICENSE file in the project root for details.
 """
 
+from __future__ import annotations
+
 import json
+from datetime import datetime
 
 import pytest
 
+from benchbox.core.results.database import ResultDatabase
 from benchbox.core.results.environment import build_platform_metadata_payload
+from benchbox.core.results.exporter import ResultExporter
+from benchbox.core.results.models import BenchmarkResults
 from benchbox.core.results.platform_options import REDACTED_VALUE
-from benchbox.core.results.schema import _extract_platform_config
+from benchbox.core.results.schema import _extract_platform_config, build_result_payload
 
 pytestmark = [
     pytest.mark.unit,
     pytest.mark.fast,
 ]
+
+# Distinct sentinels per source so a partial fix cannot silence the gate.
+_RAW_CONFIG_GATE = "RAW_CONFIG_GATE"
+_RAW_METADATA_GATE = "RAW_METADATA_GATE"
+_DEPLOYMENT_GATE = "DEPLOYMENT_GATE"
+_CLOUD_GATE = "CLOUD_GATE"
+_COMPUTE_GATE = "COMPUTE_GATE"
+_STORAGE_GATE = "STORAGE_GATE"
+_ALL_GATES = (
+    _RAW_CONFIG_GATE,
+    _RAW_METADATA_GATE,
+    _DEPLOYMENT_GATE,
+    _CLOUD_GATE,
+    _COMPUTE_GATE,
+    _STORAGE_GATE,
+)
+
+
+def _multi_source_result(*, execution_id: str = "multi-source-gate") -> BenchmarkResults:
+    return BenchmarkResults(
+        benchmark_name="synthetic",
+        platform="synthetic",
+        scale_factor=1.0,
+        execution_id=execution_id,
+        timestamp=datetime.now(),
+        duration_seconds=0.1,
+        total_queries=0,
+        successful_queries=0,
+        failed_queries=0,
+        platform_info={"sort_key": "o_orderkey", "threads": 4, "partition_key": "l_orderkey"},
+        platform_raw_config={
+            "password": _RAW_CONFIG_GATE,
+            "threads": 4,
+            "sort_key": "o_orderkey",
+        },
+        platform_raw_metadata={
+            "password": _RAW_METADATA_GATE,
+            "partition_key": "l_orderkey",
+        },
+        platform_deployment={"token": _DEPLOYMENT_GATE, "connection_mode": "embedded"},
+        platform_cloud={"access_key": _CLOUD_GATE, "region": "us-east-1"},
+        platform_compute={"connection_string": _COMPUTE_GATE, "warehouse": "BENCH_WH"},
+        platform_storage={"secret": _STORAGE_GATE, "bucket": "bench-bucket"},
+    )
 
 
 class TestExtractPlatformConfigFiltering:
@@ -36,6 +86,94 @@ class TestExtractPlatformConfigFiltering:
         out = _extract_platform_config({"configuration": {"memory_limit": "8GB", "threads": 4}})
         assert out["memory_limit"] == "8GB"
         assert out["threads"] == 4
+
+
+class TestPlatformMetadataBoundaryFiltering:
+    """raw_config, raw_metadata, and all four normalized mapping blocks."""
+
+    def test_all_sources_filtered_at_payload_builder(self):
+        payload = build_platform_metadata_payload(
+            platform_info={"sort_key": "o_orderkey", "threads": 4},
+            platform_config=None,
+            deployment={"token": _DEPLOYMENT_GATE, "connection_mode": "embedded"},
+            cloud={"access_key": _CLOUD_GATE, "region": "us-east-1"},
+            compute={"connection_string": _COMPUTE_GATE, "warehouse": "BENCH_WH"},
+            storage={"secret": _STORAGE_GATE, "bucket": "bench-bucket"},
+            raw_config={"password": _RAW_CONFIG_GATE, "threads": 4, "sort_key": "o_orderkey"},
+            raw_metadata={"password": _RAW_METADATA_GATE, "partition_key": "l_orderkey"},
+        )
+        serialized = json.dumps(payload, default=str)
+        for gate in _ALL_GATES:
+            assert gate not in serialized, f"builder leaked {gate}"
+
+        assert payload["raw_config"]["password"] == REDACTED_VALUE
+        assert payload["raw_config"]["threads"] == 4
+        assert payload["raw_config"]["sort_key"] == "o_orderkey"
+        assert payload["raw_metadata"]["password"] == REDACTED_VALUE
+        assert payload["raw_metadata"]["partition_key"] == "l_orderkey"
+        assert payload["deployment"]["token"] == REDACTED_VALUE
+        assert payload["deployment"]["connection_mode"] == "embedded"
+        assert payload["cloud"]["access_key"] == REDACTED_VALUE
+        assert payload["cloud"]["region"] == "us-east-1"
+        assert payload["compute"]["connection_string"] == REDACTED_VALUE
+        assert payload["compute"]["warehouse"] == "BENCH_WH"
+        assert payload["storage"]["secret"] == REDACTED_VALUE
+        assert payload["storage"]["bucket"] == "bench-bucket"
+
+    def test_sanitize_flag_cannot_disable_any_block(self):
+        payload = build_platform_metadata_payload(
+            platform_info=None,
+            platform_config=None,
+            deployment={"token": _DEPLOYMENT_GATE},
+            cloud={"access_key": _CLOUD_GATE},
+            compute={"connection_string": _COMPUTE_GATE},
+            storage={"secret": _STORAGE_GATE},
+            raw_config={"password": _RAW_CONFIG_GATE},
+            raw_metadata={"password": _RAW_METADATA_GATE},
+            sanitize_raw_config=False,
+        )
+        serialized = json.dumps(payload, default=str)
+        for gate in _ALL_GATES:
+            assert gate not in serialized, f"opt-out path leaked {gate}"
+
+    def test_public_result_payload_redacts_all_sources(self):
+        text = json.dumps(build_result_payload(_multi_source_result()), default=str)
+        for gate in _ALL_GATES:
+            assert gate not in text, f"public payload leaked {gate}"
+        # Non-secret tuning survives into platform.config / platform_info path.
+        assert "o_orderkey" in text
+        assert "threads" in text
+
+    def test_private_export_redacts_all_sources(self, tmp_path):
+        exporter = ResultExporter(output_dir=tmp_path / "export", anonymize=False)
+        exported = exporter.export_result(_multi_source_result(execution_id="private-export"), formats=["json"])
+        text = exported["json"].read_text(encoding="utf-8")
+        for gate in _ALL_GATES:
+            assert gate not in text, f"private export leaked {gate}"
+        assert "BENCH_WH" in text
+        assert "bench-bucket" in text
+
+    def test_results_db_never_persists_source_sentinels(self, tmp_path):
+        db = ResultDatabase(db_path=tmp_path / "results.db")
+        db.store_result(_multi_source_result(execution_id="db-multi-source"))
+        raw = (tmp_path / "results.db").read_bytes()
+        for gate in _ALL_GATES:
+            assert gate.encode() not in raw, f"results.db leaked {gate}"
+
+        stored = db.get_result("db-multi-source")
+        assert stored is not None
+        platform = stored.metadata.get("platform") or {}
+        assert platform.get("raw_config", {}).get("password") == REDACTED_VALUE
+        assert platform.get("raw_metadata", {}).get("password") == REDACTED_VALUE
+        assert platform.get("deployment", {}).get("token") == REDACTED_VALUE
+        assert platform.get("cloud", {}).get("access_key") == REDACTED_VALUE
+        assert platform.get("compute", {}).get("connection_string") == REDACTED_VALUE
+        assert platform.get("storage", {}).get("secret") == REDACTED_VALUE
+        # Non-secret fields preserved for analysis consumers.
+        assert platform.get("raw_config", {}).get("sort_key") == "o_orderkey"
+        assert platform.get("raw_config", {}).get("threads") == 4
+        assert platform.get("compute", {}).get("warehouse") == "BENCH_WH"
+        assert platform.get("storage", {}).get("bucket") == "bench-bucket"
 
 
 class TestResultsDbMetadataFiltering:
@@ -71,11 +209,6 @@ class TestResultsDbMetadataFiltering:
         assert payload["raw_config"]["threads"] == 4
 
     def test_platform_info_secret_never_reaches_metadata_json(self, tmp_path):
-        from datetime import datetime
-
-        from benchbox.core.results.database import ResultDatabase
-        from benchbox.core.results.models import BenchmarkResults
-
         result = BenchmarkResults(
             benchmark_name="tpch",
             platform="duckdb",

--- a/tests/unit/core/results/test_schema_policy.py
+++ b/tests/unit/core/results/test_schema_policy.py
@@ -91,3 +91,43 @@ def test_normalizer_policy_names_fallback_reason_for_unknown_v2() -> None:
     assert decision.accepted
     assert decision.normalized_version == LEGACY_NORMALIZED_SCHEMA_VERSION
     assert decision.reason == "legacy-fallback-unknown-v2"
+
+
+def test_producer_payload_boundary_redacts_platform_metadata_sentinels() -> None:
+    """Producer schema path must apply the multi-source credential boundary."""
+    import json
+    from datetime import datetime
+
+    from benchbox.core.results.models import BenchmarkResults
+    from benchbox.core.results.schema import build_result_payload
+
+    gates = (
+        "RAW_CONFIG_GATE",
+        "RAW_METADATA_GATE",
+        "DEPLOYMENT_GATE",
+        "CLOUD_GATE",
+        "COMPUTE_GATE",
+        "STORAGE_GATE",
+    )
+    result = BenchmarkResults(
+        benchmark_name="synthetic",
+        platform="synthetic",
+        scale_factor=1.0,
+        execution_id="schema-policy-gate",
+        timestamp=datetime.now(),
+        duration_seconds=0.1,
+        total_queries=0,
+        successful_queries=0,
+        failed_queries=0,
+        platform_info={"sort_key": "o_orderkey", "threads": 4},
+        platform_raw_config={"password": "RAW_CONFIG_GATE"},
+        platform_raw_metadata={"password": "RAW_METADATA_GATE"},
+        platform_deployment={"token": "DEPLOYMENT_GATE"},
+        platform_cloud={"access_key": "CLOUD_GATE"},
+        platform_compute={"connection_string": "COMPUTE_GATE"},
+        platform_storage={"secret": "STORAGE_GATE"},
+    )
+    text = json.dumps(build_result_payload(result), default=str)
+    for gate in gates:
+        assert gate not in text, f"producer payload leaked {gate}"
+    assert "o_orderkey" in text

--- a/tests/unit/core/results/test_schema_timing_contract.py
+++ b/tests/unit/core/results/test_schema_timing_contract.py
@@ -52,6 +52,44 @@ def _result_with_queries(query_results: list[dict[str, Any]], execution_id: str 
     )
 
 
+def test_build_result_payload_redacts_platform_metadata_credential_sentinels() -> None:
+    """Timing payload construction must not bypass the platform metadata boundary."""
+    import json
+
+    from benchbox.core.results.models import BenchmarkResults
+
+    gates = (
+        "RAW_CONFIG_GATE",
+        "RAW_METADATA_GATE",
+        "DEPLOYMENT_GATE",
+        "CLOUD_GATE",
+        "COMPUTE_GATE",
+        "STORAGE_GATE",
+    )
+    result = BenchmarkResults(
+        benchmark_name="synthetic",
+        platform="synthetic",
+        scale_factor=1.0,
+        execution_id="timing-meta-gate",
+        timestamp=datetime(2026, 2, 12),
+        duration_seconds=0.1,
+        total_queries=0,
+        successful_queries=0,
+        failed_queries=0,
+        platform_info={"sort_key": "o_orderkey", "threads": 4},
+        platform_raw_config={"password": "RAW_CONFIG_GATE", "threads": 4},
+        platform_raw_metadata={"password": "RAW_METADATA_GATE"},
+        platform_deployment={"token": "DEPLOYMENT_GATE"},
+        platform_cloud={"access_key": "CLOUD_GATE"},
+        platform_compute={"connection_string": "COMPUTE_GATE"},
+        platform_storage={"secret": "STORAGE_GATE"},
+    )
+    text = json.dumps(build_result_payload(result), default=str)
+    for gate in gates:
+        assert gate not in text, f"timing payload path leaked {gate}"
+    assert "o_orderkey" in text
+
+
 def test_build_result_payload_prefers_execution_time_seconds() -> None:
     result = _result_with_queries(
         [


### PR DESCRIPTION
## Summary

Close remaining platform-metadata credential egress after #1468.

`build_platform_metadata_payload` already structurally filtered `raw_config`, but `raw_metadata` and the normalized `deployment` / `cloud` / `compute` / `storage` blocks were copied unsanitized into public payloads, private exports, and (when present) results.db. Credential-shaped keys in those mappings could therefore survive every export boundary.

## Changes

- **`environment.py`**: shared `_sanitize_metadata_block` applies `sanitize_platform_options` to every raw and normalized platform mapping at the payload boundary.
- **`database.py`**: when a result carries explicit platform metadata blocks, store a filtered snapshot under `metadata["platform"]` via the same builder (no silent local-DB egress channel).
- **`schema.py`**: comment only — producer path already routes through the builder.
- **Tests**: distinct multi-source sentinels (RAW_CONFIG / RAW_METADATA / DEPLOYMENT / CLOUD / COMPUTE / STORAGE) across public payload, private export (`anonymize=False`), and ResultDatabase; non-secret tuning fields preserved.

## Verification

- Unfixed-tree gate (seq 1): **pass** after fix
- Non-secret preservation (seq 2): **pass**
- `tests/unit/core/results/` fast: **937 passed**, 4 skipped
- Targeted multi-source files: **49 passed**
- `make ci-lint`: **pass** (full `pr-preflight` fast lane hung at ~95% on Ray workers in this environment; scoped results suite used for local proof)

## Scope

Only the paths listed for `credential-egress-platform-metadata-boundary-v3`. Does not touch `platform_options.py` / `anonymization.py` / MCP.
