### PR TITLE
fix(ci): bound develop-post-merge push-drop with sweep + gap detector

### DIFF
--- a/.github/workflows/develop-post-merge-gap-detector.yml
+++ b/.github/workflows/develop-post-merge-gap-detector.yml
@@ -1,0 +1,78 @@
+name: Develop post-merge gap detector
+
+# Instrumentation for the silent develop-post-merge push-drop class.
+#
+# develop-post-merge.yml is push-triggered on develop. GitHub has dropped push
+# delivery for consecutive develop merges (2026-08-03 corpus-mirror gap;
+# 2026-08-04 six consecutive merges with no post-merge run). The hourly
+# schedule on develop-post-merge.yml re-gates the *tip* so develop is not left
+# un-gated; this workflow records whether each recent develop SHA ever got a
+# post-merge run at all, and fails when gaps remain so the class stays visible
+# until the lookback window advances past it.
+#
+# Read-only. No write permissions. Does not open PRs, re-run gates, or mutate
+# repository state. Manual recovery for tip coverage is still
+# `gh workflow run develop-post-merge.yml` (or wait for the next hourly sweep).
+#
+# See docs/operations/develop-post-merge-gaps.md.
+
+on:
+  schedule:
+    # Daily, offset from other canaries. Instrumentation does not need hourly
+    # cadence; the sweep in develop-post-merge.yml already bounds tip exposure.
+    - cron: "47 7 * * *"
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+  # actions:read is required to list workflow runs via gh/api. The main
+  # develop-post-merge workflow already grants actions:read on its metrics /
+  # auto-revert jobs; this is not a new capability class for the repo.
+  actions: read
+
+concurrency:
+  group: develop-post-merge-gap-detector
+  cancel-in-progress: false
+
+jobs:
+  detect-gaps:
+    name: Detect missing develop-post-merge runs
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out develop
+        uses: actions/checkout@v4
+        with:
+          ref: develop
+          # Need enough history for the lookback window.
+          fetch-depth: 0
+
+      - name: Fetch origin/develop tip
+        run: git fetch --no-tags origin develop
+
+      - name: Run gap detector
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          # Capture JSON even when the detector exits 1 (gaps present) so the
+          # always()-run upload below still has a report artifact.
+          set +e
+          python3 scripts/detect_develop_post_merge_gaps.py \
+            --live \
+            --branch origin/develop \
+            --commit-limit 20 \
+            --run-limit 100 \
+            --json > gap-report.json
+          rc=$?
+          set -e
+          cat gap-report.json
+          exit "${rc}"
+
+      - name: Upload gap report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: develop-post-merge-gap-report
+          path: gap-report.json
+          retention-days: 30
+          if-no-files-found: ignore

--- a/.github/workflows/develop-post-merge-gap-detector.yml
+++ b/.github/workflows/develop-post-merge-gap-detector.yml
@@ -57,11 +57,15 @@ jobs:
           # Capture JSON even when the detector exits 1 (gaps present) so the
           # always()-run upload below still has a report artifact.
           set +e
+          # --run-limit is a hard row cap while paginating unique headShas
+          # (commit-limit + unique-margin). Do not pass a shallow fixed limit:
+          # schedule tip floods would self-poison the window.
           python3 scripts/detect_develop_post_merge_gaps.py \
             --live \
             --branch origin/develop \
             --commit-limit 20 \
-            --run-limit 100 \
+            --unique-margin 10 \
+            --run-limit 1000 \
             --json > gap-report.json
           rc=$?
           set -e

--- a/.github/workflows/develop-post-merge.yml
+++ b/.github/workflows/develop-post-merge.yml
@@ -8,9 +8,13 @@ name: Develop post-merge
 # Push is the primary trigger. GitHub has been observed to drop push delivery
 # for consecutive develop merges (see docs/operations/develop-post-merge-gaps.md
 # and the 2026-08-03 corpus-mirror gap), so a scheduled sweep is additive: it
-# re-runs the same gates against the current develop tip within a bounded
-# window when a per-push run was never created. It is not a replacement for
-# push, and it does not paper over the gap with extra event types.
+# re-runs the lightweight tip gates within a bounded window when a per-push
+# run was never created. It is not a replacement for push, and it does not
+# paper over the gap with extra event types.
+#
+# Schedule path is gates-only and slim: lint + fast-test + explorer-tokens.
+# medium-test (~40 min) and all mutation jobs (auto-revert, green-run-cleanup,
+# close-orphaned-prs) stay on push / workflow_dispatch only.
 
 on:
   push:
@@ -28,10 +32,11 @@ permissions:
 concurrency:
   # Push (and manual dispatch) stay SHA-keyed so concurrent merges do not
   # cancel each other. Schedule uses a fixed group so a sweep never cancels
-  # — and is never cancelled by — a push-triggered run for the same tip, and
-  # successive sweeps serialize instead of stacking.
+  # — and is never cancelled by — a push-triggered run for the same tip.
+  # cancel-in-progress is true only for schedule so a newer sweep supersedes
+  # a still-running older one; push runs never cancel each other.
   group: ${{ github.event_name == 'schedule' && 'develop-post-merge-schedule' || format('develop-post-merge-{0}', github.sha) }}
-  cancel-in-progress: false
+  cancel-in-progress: ${{ github.event_name == 'schedule' }}
 
 jobs:
   lint:
@@ -252,6 +257,12 @@ jobs:
     # eventual develop tip has a semantic conflict with another PR merged in
     # between (see the TODO description for the #1093/#1095/#1100 incident
     # this closes half of).
+    #
+    # SLIM SCHEDULE: medium-test is intentionally omitted on the hourly
+    # schedule (push + workflow_dispatch only). The ~40 min tier would
+    # otherwise cost ~24 full medium runs/day even when tip is already
+    # push-covered; lint/fast-test/explorer-tokens still bound tip exposure.
+    if: ${{ github.event_name != 'schedule' }}
     runs-on: ubuntu-latest
     timeout-minutes: 40
     steps:
@@ -323,6 +334,9 @@ jobs:
     # its original (un-squashed) branch tip via the GraphQL API. Any other
     # open PR whose head commit is a git ancestor of that tip has all of its
     # content already on develop and can be closed safely.
+    #
+    # Schedule path is gates-only: mutation jobs never run on schedule.
+    if: ${{ github.event_name != 'schedule' }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -437,7 +451,9 @@ jobs:
     # dispositioned failures were fixed (#977, #994), so a medium-test failure
     # now opens a (reviewable) revert PR, same as lint/fast-test/explorer-tokens.
     needs: [lint, fast-test, explorer-tokens, medium-test]
-    if: ${{ always() && (needs.lint.result == 'failure' || needs.fast-test.result == 'failure' || needs.explorer-tokens.result == 'failure' || needs.medium-test.result == 'failure') }}
+    # Schedule path is gates-only: never open revert PRs / issues from a sweep.
+    # event_name must lead so always() cannot re-enable mutation on schedule.
+    if: ${{ github.event_name != 'schedule' && always() && (needs.lint.result == 'failure' || needs.fast-test.result == 'failure' || needs.explorer-tokens.result == 'failure' || needs.medium-test.result == 'failure') }}
     outputs:
       auto-revert-pr-opened-at: ${{ steps.open-revert.outputs.auto-revert-pr-opened-at }}
       auto-revert-pr-url: ${{ steps.open-revert.outputs.auto-revert-pr-url }}
@@ -860,7 +876,9 @@ jobs:
     # it tracked is resolved, so clear it instead of leaving it for a human
     # to notice and close by hand.
     needs: [lint, fast-test, explorer-tokens, medium-test]
-    if: ${{ always() && needs.lint.result == 'success' && needs.fast-test.result == 'success' && needs.explorer-tokens.result == 'success' && needs.medium-test.result == 'success' }}
+    # Schedule path is gates-only: never close PRs/issues from a sweep.
+    # event_name must lead so always() cannot re-enable mutation on schedule.
+    if: ${{ github.event_name != 'schedule' && always() && needs.lint.result == 'success' && needs.fast-test.result == 'success' && needs.explorer-tokens.result == 'success' && needs.medium-test.result == 'success' }}
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/develop-post-merge.yml
+++ b/.github/workflows/develop-post-merge.yml
@@ -4,16 +4,33 @@ name: Develop post-merge
 # run the same lightweight local gates against the actual develop tip. This is
 # intentionally narrower than test.yml's full PR matrix so it does not turn
 # every squash merge into the heavyweight optional suite.
+#
+# Push is the primary trigger. GitHub has been observed to drop push delivery
+# for consecutive develop merges (see docs/operations/develop-post-merge-gaps.md
+# and the 2026-08-03 corpus-mirror gap), so a scheduled sweep is additive: it
+# re-runs the same gates against the current develop tip within a bounded
+# window when a per-push run was never created. It is not a replacement for
+# push, and it does not paper over the gap with extra event types.
 
 on:
   push:
     branches: [develop]
+  # Bound silent push-drop exposure. Hourly is enough to re-gate tip without
+  # waiting for the next real merge; the gap detector (sibling workflow)
+  # instruments which exact SHAs still lack a per-push run.
+  schedule:
+    - cron: "17 * * * *"
+  workflow_dispatch: {}
 
 permissions:
   contents: read
 
 concurrency:
-  group: develop-post-merge-${{ github.sha }}
+  # Push (and manual dispatch) stay SHA-keyed so concurrent merges do not
+  # cancel each other. Schedule uses a fixed group so a sweep never cancels
+  # — and is never cancelled by — a push-triggered run for the same tip, and
+  # successive sweeps serialize instead of stacking.
+  group: ${{ github.event_name == 'schedule' && 'develop-post-merge-schedule' || format('develop-post-merge-{0}', github.sha) }}
   cancel-in-progress: false
 
 jobs:
@@ -26,7 +43,12 @@ jobs:
       cancel-in-progress: false
     runs-on: ubuntu-latest
     steps:
+      # Default branch is develop, so schedule/dispatch already resolve to the
+      # tip workflow + tip SHA. Pin ref explicitly so a future default-branch
+      # rename cannot silently re-target this sweep.
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event_name == 'schedule' && 'develop' || github.sha }}
 
       - name: Set up Python
         uses: actions/setup-python@v5
@@ -94,6 +116,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event_name == 'schedule' && 'develop' || github.sha }}
 
       - name: Set up Python
         uses: actions/setup-python@v5
@@ -159,6 +183,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event_name == 'schedule' && 'develop' || github.sha }}
 
       - name: Run explorer token scan
         id: token-scan
@@ -230,6 +256,8 @@ jobs:
     timeout-minutes: 40
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event_name == 'schedule' && 'develop' || github.sha }}
 
       - name: Set up Python
         uses: actions/setup-python@v5
@@ -305,6 +333,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
+          ref: ${{ github.event_name == 'schedule' && 'develop' || github.sha }}
           fetch-depth: 0
 
       - name: Close PRs whose branches are ancestors of the merged PR
@@ -428,6 +457,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
+          ref: ${{ github.event_name == 'schedule' && 'develop' || github.sha }}
           fetch-depth: 0
 
       - name: Download current run signature artifacts
@@ -842,6 +872,8 @@ jobs:
       RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event_name == 'schedule' && 'develop' || github.sha }}
 
       - name: Close stale auto-revert PRs and develop-red incidents
         shell: bash

--- a/docs/operations/develop-post-merge-gaps.md
+++ b/docs/operations/develop-post-merge-gaps.md
@@ -45,23 +45,36 @@ Two additive pieces. Neither replaces per-push runs.
 - `schedule: "17 * * * *"` (hourly, minute offset to spread load)
 - `workflow_dispatch` (manual recovery)
 
-On schedule it checks out the current `develop` tip and runs the **same**
-gate jobs. Concurrency is split deliberately:
+**Schedule path is slim and gates-only:**
 
-| Event | Concurrency group | Why |
+| Job | `push` / `workflow_dispatch` | `schedule` |
 | --- | --- | --- |
-| `push` / `workflow_dispatch` | `develop-post-merge-${{ github.sha }}` | Concurrent merges must not cancel each other. |
-| `schedule` | `develop-post-merge-schedule` (fixed) | A sweep must not cancel a push run for the same tip, and successive sweeps serialize. |
+| lint, fast-test, explorer-tokens | yes | yes |
+| medium-test (~40 min) | yes | **no** |
+| close-orphaned-prs, auto-revert-on-failure, green-run-cleanup | yes | **no** (mutation) |
 
-`cancel-in-progress` stays `false` in both cases.
+Medium-test stays on the real merge path so a squash race still trips
+auto-revert; the hourly sweep deliberately omits it to avoid ~24 full
+medium runs/day when tip is already push-covered. Schedule also never
+opens revert PRs, closes orphaned PRs, or cleans green-run issues — those
+remain push/dispatch only.
 
-The sweep covers **tip only**. Intermediate SHAs whose push events were
-dropped still will not show a per-SHA run; they age out of lookback windows.
-Safety property restored: develop tip is re-gated within about an hour even
-when push delivery fails.
+Concurrency:
+
+| Event | Concurrency group | `cancel-in-progress` |
+| --- | --- | --- |
+| `push` / `workflow_dispatch` | `develop-post-merge-${{ github.sha }}` | `false` (concurrent merges must not cancel each other) |
+| `schedule` | `develop-post-merge-schedule` (fixed) | `true` (newer sweep supersedes an older still-running one; never shares a group with push) |
+
+**Success criterion for the sweep:** develop **tip** is re-gated by the
+slim gates within about an hour of a silent push-drop. That is the safety
+property. It is **not** a claim that every intermediate dropped SHA gets
+its own run, and it is **not** a claim that the exact-SHA verification
+ladder stays green after an incident.
 
 Permissions are unchanged: workflow-level `contents: read`, with the same
-job-level escalations auto-revert / orphan-close already used.
+job-level escalations auto-revert / orphan-close already used on the
+push path only.
 
 ### 2. Gap detector (instrumentation)
 
@@ -71,7 +84,7 @@ job-level escalations auto-revert / orphan-close already used.
 
 ```bash
 python3 scripts/detect_develop_post_merge_gaps.py \
-  --live --branch origin/develop --commit-limit 20 --run-limit 100
+  --live --branch origin/develop --commit-limit 20
 ```
 
 The script compares the last N develop commits to recent
@@ -80,50 +93,60 @@ is a gap: GitHub never started post-merge for that push. The job fails and
 emits `::error` annotations so the class stays visible until the SHAs age
 out of the lookback — it does **not** open PRs or re-run gates.
 
+Live mode paginates the run list until it has enough **unique** headShas
+(`commit_limit + margin`, default margin 10) or hits a hard row cap
+(default 1000). A fixed shallow `--limit` is not safe: after many hourly
+schedule runs for the same tip, the most-recent N rows can all share one
+`headSha` and would otherwise hide older push-covered commits deeper in
+history (self-poisoning).
+
 A tip that was only covered by the hourly sweep (event=`schedule`) still
 counts as covered for that tip SHA. Intermediate dropped SHAs remain
 uncovered by design: that is the instrumentation of the push-drop class.
 
 ## Verification ladder
 
-Exact-SHA coverage for the last 10 develop commits:
+Exact-SHA coverage for the last 10 develop commits (diagnostic, not a
+post-incident green promise):
 
 ```bash
 bash -c '
   shas=$(git log --format=%H origin/develop -10)
-  runs=$(gh run list --workflow develop-post-merge.yml --limit 60 --json headSha --jq .[].headSha)
+  runs=$(gh run list --workflow develop-post-merge.yml --limit 100 --json headSha --jq .[].headSha)
   for s in $shas; do
     echo "$runs" | grep -q "$s" || exit 1
   done
 '
 ```
 
-- Exit `0`: every recent develop push has a post-merge run for its exact SHA
-  (or a schedule/dispatch run was recorded against that SHA as tip).
-- Exit `1`: at least one recent SHA has no run. That is the gap class. After
-  a drop episode this can stay non-zero until those SHAs fall out of the
-  `-10` window even if tip is currently green via the sweep.
+How to read the result:
 
-Offline / scripted form of the same check:
+| Exit | Meaning |
+| --- | --- |
+| `0` | Every looked-up develop SHA currently has at least one post-merge run (push, schedule, or dispatch) whose `headSha` matches. Quiet periods with healthy push delivery look like this. |
+| `1` | At least one recent SHA has no run. **Expected after a real push-drop episode**, and can remain non-zero until those intermediate SHAs age out of the lookback — even when tip is green via the hourly sweep. Do not treat this as "the sweep is broken." |
 
-```bash
-git log --format=%H origin/develop -20 > /tmp/commits.txt
-gh run list --workflow develop-post-merge.yml --limit 100 --json headSha \
-  --jq '.[].headSha' > /tmp/runs.txt
-python3 scripts/detect_develop_post_merge_gaps.py \
-  --commits-file /tmp/commits.txt --runs-file /tmp/runs.txt --json
-```
-
-Live form used by CI:
+Preferred scripted form (paginates unique headShas; same honesty rules):
 
 ```bash
 python3 scripts/detect_develop_post_merge_gaps.py --live --json
 ```
 
+Offline form (no pagination; you supply both lists):
+
+```bash
+git log --format=%H origin/develop -20 > /tmp/commits.txt
+gh run list --workflow develop-post-merge.yml --limit 200 --json headSha \
+  --jq '.[].headSha' > /tmp/runs.txt
+python3 scripts/detect_develop_post_merge_gaps.py \
+  --commits-file /tmp/commits.txt --runs-file /tmp/runs.txt --json
+```
+
 ## Manual recovery
 
 If tip has no recent post-merge run and you do not want to wait for the
-hourly sweep:
+hourly sweep (full push-equivalent path including medium-test and mutation
+jobs when tip is red/green as usual):
 
 ```bash
 gh workflow run develop-post-merge.yml --ref develop
@@ -143,7 +166,14 @@ gh workflow run develop-post-merge-gap-detector.yml --ref develop
   related event.
 - **No replacement of the push trigger.** Push remains primary; schedule is
   additive.
+- **No full medium-test on every hourly sweep.** Cost decision: slim
+  schedule (lint + fast-test + explorer-tokens) bounds tip exposure without
+  ~24× medium-tier runner hours/day.
+- **No mutation jobs on schedule.** Auto-revert / orphan-close / green-run
+  cleanup stay push + dispatch only so a sweep cannot open or close GitHub
+  objects without a real merge event.
 - **No new permission classes** beyond what develop-post-merge already uses
   (`actions: read` already appears on metrics / auto-revert jobs).
 - **No claim that intermediate dropped SHAs are "covered" by a later tip
-  sweep.** Tip safety and per-SHA instrumentation are separate signals.
+  sweep, or that the every-SHA ladder stays green post-incident.** Tip
+  safety (≤~1h re-gate) and per-SHA instrumentation are separate signals.

--- a/docs/operations/develop-post-merge-gaps.md
+++ b/docs/operations/develop-post-merge-gaps.md
@@ -1,0 +1,149 @@
+<!-- Copyright 2026 Joe Harris / BenchBox Project. Licensed under the MIT License. -->
+
+# Develop post-merge push gaps
+
+```{tags} contributor, operations, ci
+```
+
+## What failed
+
+`Develop post-merge` (`.github/workflows/develop-post-merge.yml`) is the
+safety net that re-runs lint, fast-test, explorer-tokens, and medium-test
+against the actual `develop` tip after a merge. Its primary trigger is:
+
+```yaml
+on:
+  push:
+    branches: [develop]
+```
+
+There is no path filter. In principle every develop push should produce a
+run for that exact SHA. In practice GitHub has **dropped push delivery** for
+consecutive develop merges:
+
+| When | Signal |
+| --- | --- |
+| 2026-08-03 | Three consecutive develop merges got **no** push workflows at all — not even develop-post-merge — which left the `published-results` corpus mirror stale (see the header comment on `corpus-drift-check.yml`). |
+| 2026-08-04 | Six consecutive develop merges produced **no** develop-post-merge run for their SHAs. |
+
+The mechanism (GitHub delivery drop vs concurrency edge vs API lag) is not
+fully proven. What is proven is the **observable gap**: `git log
+origin/develop` SHAs with no matching `gh run list --workflow
+develop-post-merge.yml` `headSha`.
+
+That is a silent failure mode. Push-only guards share it. Every workflow
+that only fires on `push` to develop can miss the same window.
+
+## What we do about it
+
+Two additive pieces. Neither replaces per-push runs.
+
+### 1. Scheduled sweep (coverage)
+
+`develop-post-merge.yml` also runs on:
+
+- `schedule: "17 * * * *"` (hourly, minute offset to spread load)
+- `workflow_dispatch` (manual recovery)
+
+On schedule it checks out the current `develop` tip and runs the **same**
+gate jobs. Concurrency is split deliberately:
+
+| Event | Concurrency group | Why |
+| --- | --- | --- |
+| `push` / `workflow_dispatch` | `develop-post-merge-${{ github.sha }}` | Concurrent merges must not cancel each other. |
+| `schedule` | `develop-post-merge-schedule` (fixed) | A sweep must not cancel a push run for the same tip, and successive sweeps serialize. |
+
+`cancel-in-progress` stays `false` in both cases.
+
+The sweep covers **tip only**. Intermediate SHAs whose push events were
+dropped still will not show a per-SHA run; they age out of lookback windows.
+Safety property restored: develop tip is re-gated within about an hour even
+when push delivery fails.
+
+Permissions are unchanged: workflow-level `contents: read`, with the same
+job-level escalations auto-revert / orphan-close already used.
+
+### 2. Gap detector (instrumentation)
+
+`.github/workflows/develop-post-merge-gap-detector.yml` runs daily
+(`47 7 * * *`) and on `workflow_dispatch`. It is read-only
+(`contents: read`, `actions: read`) and calls:
+
+```bash
+python3 scripts/detect_develop_post_merge_gaps.py \
+  --live --branch origin/develop --commit-limit 20 --run-limit 100
+```
+
+The script compares the last N develop commits to recent
+`develop-post-merge` run `headSha`s. Any commit with **no** run (any status)
+is a gap: GitHub never started post-merge for that push. The job fails and
+emits `::error` annotations so the class stays visible until the SHAs age
+out of the lookback — it does **not** open PRs or re-run gates.
+
+A tip that was only covered by the hourly sweep (event=`schedule`) still
+counts as covered for that tip SHA. Intermediate dropped SHAs remain
+uncovered by design: that is the instrumentation of the push-drop class.
+
+## Verification ladder
+
+Exact-SHA coverage for the last 10 develop commits:
+
+```bash
+bash -c '
+  shas=$(git log --format=%H origin/develop -10)
+  runs=$(gh run list --workflow develop-post-merge.yml --limit 60 --json headSha --jq .[].headSha)
+  for s in $shas; do
+    echo "$runs" | grep -q "$s" || exit 1
+  done
+'
+```
+
+- Exit `0`: every recent develop push has a post-merge run for its exact SHA
+  (or a schedule/dispatch run was recorded against that SHA as tip).
+- Exit `1`: at least one recent SHA has no run. That is the gap class. After
+  a drop episode this can stay non-zero until those SHAs fall out of the
+  `-10` window even if tip is currently green via the sweep.
+
+Offline / scripted form of the same check:
+
+```bash
+git log --format=%H origin/develop -20 > /tmp/commits.txt
+gh run list --workflow develop-post-merge.yml --limit 100 --json headSha \
+  --jq '.[].headSha' > /tmp/runs.txt
+python3 scripts/detect_develop_post_merge_gaps.py \
+  --commits-file /tmp/commits.txt --runs-file /tmp/runs.txt --json
+```
+
+Live form used by CI:
+
+```bash
+python3 scripts/detect_develop_post_merge_gaps.py --live --json
+```
+
+## Manual recovery
+
+If tip has no recent post-merge run and you do not want to wait for the
+hourly sweep:
+
+```bash
+gh workflow run develop-post-merge.yml --ref develop
+```
+
+To re-check the gap class without waiting for the daily detector:
+
+```bash
+gh workflow run develop-post-merge-gap-detector.yml --ref develop
+```
+
+## What we deliberately did not do
+
+- **No extra push-adjacent spam** (`pull_request`, `workflow_run`,
+  `repository_dispatch`, etc.) to force more events. That papers over the
+  class without bounding tip exposure cleanly and burns runners on every
+  related event.
+- **No replacement of the push trigger.** Push remains primary; schedule is
+  additive.
+- **No new permission classes** beyond what develop-post-merge already uses
+  (`actions: read` already appears on metrics / auto-revert jobs).
+- **No claim that intermediate dropped SHAs are "covered" by a later tip
+  sweep.** Tip safety and per-SHA instrumentation are separate signals.

--- a/scripts/detect_develop_post_merge_gaps.py
+++ b/scripts/detect_develop_post_merge_gaps.py
@@ -1,0 +1,265 @@
+#!/usr/bin/env python3
+"""Detect develop commits that never got a develop-post-merge workflow run.
+
+GitHub has been observed to drop push delivery for consecutive develop merges
+(see docs/operations/develop-post-merge-gaps.md). When that happens, the
+push-triggered ``develop-post-merge.yml`` workflow never starts for those
+SHAs, so develop tip can sit un-gated until the next successful delivery or
+the scheduled sweep.
+
+This script is the instrumentation half of the fix:
+
+- given recent develop commit SHAs and recent ``develop-post-merge`` run
+  head SHAs, report which commits lack any run (any status/conclusion);
+- exit non-zero when gaps remain so a scheduled/canary workflow can fail
+  loudly instead of silently.
+
+It does **not** open PRs, re-run gates, or mutate repository state. The
+scheduled sweep in ``develop-post-merge.yml`` is the coverage half: it re-runs
+the same gates against the current tip within a bounded window.
+
+Usage:
+    # Offline / unit-testable pure check (stdin or flags):
+    python scripts/detect_develop_post_merge_gaps.py \\
+        --commits-file commits.txt --runs-file runs.txt
+
+    # Live check against origin/develop + GitHub Actions API via gh:
+    python scripts/detect_develop_post_merge_gaps.py --live
+
+Exit codes:
+    0 - every looked-up SHA has at least one develop-post-merge run
+    1 - one or more SHAs lack a run (gap class still present)
+    2 - usage / I/O error
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+DEFAULT_COMMIT_LIMIT = 20
+DEFAULT_RUN_LIMIT = 100
+WORKFLOW_FILE = "develop-post-merge.yml"
+
+
+# ---------------------------------------------------------------------------
+# Pure logic (unit-tested; no git/network)
+# ---------------------------------------------------------------------------
+def normalize_sha(value: str) -> str:
+    """Lowercase full/short SHA; reject empty tokens."""
+    sha = value.strip().lower()
+    if not sha:
+        raise ValueError("empty SHA")
+    return sha
+
+
+def parse_sha_lines(text: str) -> list[str]:
+    """Parse one SHA per line; ignore blanks and # comments."""
+    out: list[str] = []
+    for raw in text.splitlines():
+        line = raw.split("#", 1)[0].strip()
+        if not line:
+            continue
+        # Allow "sha message..." lines from `git log --format=%H %s`.
+        token = line.split()[0]
+        out.append(normalize_sha(token))
+    return out
+
+
+def find_uncovered(commit_shas: list[str], run_head_shas: set[str]) -> list[str]:
+    """Return commit SHAs (in order) that have no matching run headSha.
+
+    Matching is prefix-aware so a short run headSha can cover a full commit
+    SHA and vice versa (gh sometimes returns full SHAs; tests may use shorts).
+    """
+    normalized_runs = {normalize_sha(s) for s in run_head_shas}
+    uncovered: list[str] = []
+    for commit in commit_shas:
+        c = normalize_sha(commit)
+        if any(c == r or c.startswith(r) or r.startswith(c) for r in normalized_runs):
+            continue
+        uncovered.append(c)
+    return uncovered
+
+
+def format_report(
+    commit_shas: list[str],
+    uncovered: list[str],
+    *,
+    commit_limit: int,
+    run_count: int,
+) -> str:
+    """Human-readable summary for logs / job annotations."""
+    lines = [
+        "develop-post-merge gap detector",
+        f"  commits checked: {len(commit_shas)} (limit {commit_limit})",
+        f"  run headShas supplied: {run_count}",
+        f"  uncovered: {len(uncovered)}",
+    ]
+    if uncovered:
+        lines.append("  missing develop-post-merge run for:")
+        for sha in uncovered:
+            lines.append(f"    - {sha}")
+        lines.append(
+            "  A missing SHA means GitHub never delivered (or never recorded) a "
+            "push-triggered develop-post-merge run for that commit. The hourly "
+            "schedule on develop-post-merge.yml re-gates the *tip* only; this "
+            "detector keeps intermediate push-drop SHAs visible until they age "
+            "out of the lookback window. See docs/operations/develop-post-merge-gaps.md."
+        )
+    else:
+        lines.append("  all checked develop commits have at least one post-merge run.")
+    return "\n".join(lines) + "\n"
+
+
+# ---------------------------------------------------------------------------
+# Live I/O (git + gh)
+# ---------------------------------------------------------------------------
+def _run(cmd: list[str]) -> str:
+    try:
+        completed = subprocess.run(
+            cmd,
+            check=True,
+            text=True,
+            capture_output=True,
+        )
+    except FileNotFoundError as exc:
+        raise RuntimeError(f"required executable not found: {cmd[0]}") from exc
+    except subprocess.CalledProcessError as exc:
+        stderr = (exc.stderr or "").strip()
+        raise RuntimeError(f"command failed ({exc.returncode}): {' '.join(cmd)}\n{stderr}") from exc
+    return completed.stdout
+
+
+def live_commit_shas(limit: int, branch: str = "origin/develop") -> list[str]:
+    out = _run(["git", "log", "--format=%H", f"-{limit}", branch])
+    return parse_sha_lines(out)
+
+
+def live_run_head_shas(limit: int, workflow: str = WORKFLOW_FILE) -> set[str]:
+    """List recent workflow run headShas via the gh CLI.
+
+    Includes every status/conclusion: a queued or failed run still proves the
+    push was not silently dropped. Only a total absence of runs for a SHA is
+    a gap.
+    """
+    raw = _run(
+        [
+            "gh",
+            "run",
+            "list",
+            f"--workflow={workflow}",
+            f"--limit={limit}",
+            "--json",
+            "headSha",
+        ]
+    )
+    try:
+        rows = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        raise RuntimeError(f"gh run list returned non-JSON: {exc}") from exc
+    if not isinstance(rows, list):
+        raise RuntimeError("gh run list JSON was not a list")
+    shas: set[str] = set()
+    for row in rows:
+        if not isinstance(row, dict):
+            continue
+        head = row.get("headSha")
+        if isinstance(head, str) and head.strip():
+            shas.add(normalize_sha(head))
+    return shas
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--live",
+        action="store_true",
+        help="Read origin/develop commits and gh run list (requires git + gh).",
+    )
+    parser.add_argument(
+        "--commits-file",
+        type=Path,
+        help="File of develop commit SHAs (one per line). Required unless --live.",
+    )
+    parser.add_argument(
+        "--runs-file",
+        type=Path,
+        help="File of develop-post-merge run headShas (one per line). Required unless --live.",
+    )
+    parser.add_argument(
+        "--commit-limit",
+        type=int,
+        default=DEFAULT_COMMIT_LIMIT,
+        help=f"How many recent develop commits to check (live mode). Default {DEFAULT_COMMIT_LIMIT}.",
+    )
+    parser.add_argument(
+        "--run-limit",
+        type=int,
+        default=DEFAULT_RUN_LIMIT,
+        help=f"How many recent workflow runs to load (live mode). Default {DEFAULT_RUN_LIMIT}.",
+    )
+    parser.add_argument(
+        "--branch",
+        default="origin/develop",
+        help="git rev-list/log target for --live (default origin/develop).",
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Emit machine-readable JSON on stdout (human report still goes to stderr).",
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+
+    try:
+        if args.live:
+            if args.commit_limit < 1 or args.run_limit < 1:
+                raise RuntimeError("--commit-limit and --run-limit must be >= 1")
+            commit_shas = live_commit_shas(args.commit_limit, branch=args.branch)
+            run_shas = live_run_head_shas(args.run_limit)
+        else:
+            if args.commits_file is None or args.runs_file is None:
+                parser.error("provide --live, or both --commits-file and --runs-file")
+            commit_shas = parse_sha_lines(args.commits_file.read_text(encoding="utf-8"))
+            run_shas = set(parse_sha_lines(args.runs_file.read_text(encoding="utf-8")))
+    except (OSError, RuntimeError, ValueError) as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 2
+
+    uncovered = find_uncovered(commit_shas, run_shas)
+    report = format_report(
+        commit_shas,
+        uncovered,
+        commit_limit=args.commit_limit if args.live else len(commit_shas),
+        run_count=len(run_shas),
+    )
+    # Human report on stderr so --json stdout stays pure.
+    sys.stderr.write(report)
+    if uncovered:
+        for sha in uncovered:
+            # GitHub Actions annotation when running in CI.
+            print(f"::error title=develop-post-merge gap::No develop-post-merge run for {sha}", file=sys.stderr)
+
+    if args.json:
+        payload = {
+            "commits_checked": commit_shas,
+            "run_head_shas": sorted(run_shas),
+            "uncovered": uncovered,
+            "ok": not uncovered,
+        }
+        json.dump(payload, sys.stdout, indent=2, sort_keys=True)
+        sys.stdout.write("\n")
+
+    return 1 if uncovered else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/detect_develop_post_merge_gaps.py
+++ b/scripts/detect_develop_post_merge_gaps.py
@@ -15,11 +15,17 @@ This script is the instrumentation half of the fix:
   loudly instead of silently.
 
 It does **not** open PRs, re-run gates, or mutate repository state. The
-scheduled sweep in ``develop-post-merge.yml`` is the coverage half: it re-runs
-the same gates against the current tip within a bounded window.
+scheduled sweep in ``develop-post-merge.yml`` is the coverage half: it
+re-gates the current tip (slim gates on schedule) within a bounded window.
+
+Live mode paginates the run list until it has enough **unique** headShas to
+cover the commit lookback (plus margin). A fixed shallow limit is not safe:
+after the hourly schedule lands, the most-recent N runs can all share the
+same tip SHA and would otherwise "poison" the window so older push-covered
+commits look uncovered.
 
 Usage:
-    # Offline / unit-testable pure check (stdin or flags):
+    # Offline / unit-testable pure check:
     python scripts/detect_develop_post_merge_gaps.py \\
         --commits-file commits.txt --runs-file runs.txt
 
@@ -38,11 +44,16 @@ import argparse
 import json
 import subprocess
 import sys
+from collections.abc import Callable, Iterable, Sequence
 from pathlib import Path
 
 DEFAULT_COMMIT_LIMIT = 20
-DEFAULT_RUN_LIMIT = 100
+DEFAULT_UNIQUE_MARGIN = 10
+DEFAULT_PAGE_SIZE = 100
+DEFAULT_MAX_RUN_ROWS = 1000
 WORKFLOW_FILE = "develop-post-merge.yml"
+
+ListRunsFn = Callable[[int], list[dict]]
 
 
 # ---------------------------------------------------------------------------
@@ -67,6 +78,41 @@ def parse_sha_lines(text: str) -> list[str]:
         token = line.split()[0]
         out.append(normalize_sha(token))
     return out
+
+
+def extract_head_shas(rows: Sequence[object]) -> set[str]:
+    """Collect headSha values from a gh/api run-list payload."""
+    shas: set[str] = set()
+    for row in rows:
+        if not isinstance(row, dict):
+            continue
+        head = row.get("headSha")
+        if isinstance(head, str) and head.strip():
+            shas.add(normalize_sha(head))
+    return shas
+
+
+def accumulate_unique_head_shas(
+    pages: Iterable[Sequence[object]],
+    *,
+    min_unique: int,
+) -> set[str]:
+    """Fold run-list pages into a unique headSha set until ``min_unique`` or exhausted.
+
+    Stops early once enough distinct headShas are collected so a flood of
+    schedule runs for the same tip cannot hide older push-covered SHAs that
+    sit deeper in the run history.
+    """
+    if min_unique < 1:
+        raise ValueError("min_unique must be >= 1")
+    unique: set[str] = set()
+    for page in pages:
+        if not page:
+            break
+        unique |= extract_head_shas(page)
+        if len(unique) >= min_unique:
+            break
+    return unique
 
 
 def find_uncovered(commit_shas: list[str], run_head_shas: set[str]) -> list[str]:
@@ -96,7 +142,7 @@ def format_report(
     lines = [
         "develop-post-merge gap detector",
         f"  commits checked: {len(commit_shas)} (limit {commit_limit})",
-        f"  run headShas supplied: {run_count}",
+        f"  unique run headShas supplied: {run_count}",
         f"  uncovered: {len(uncovered)}",
     ]
     if uncovered:
@@ -105,8 +151,8 @@ def format_report(
             lines.append(f"    - {sha}")
         lines.append(
             "  A missing SHA means GitHub never delivered (or never recorded) a "
-            "push-triggered develop-post-merge run for that commit. The hourly "
-            "schedule on develop-post-merge.yml re-gates the *tip* only; this "
+            "develop-post-merge run for that commit. The hourly schedule on "
+            "develop-post-merge.yml re-gates the *tip* only (slim gates); this "
             "detector keeps intermediate push-drop SHAs visible until they age "
             "out of the lookback window. See docs/operations/develop-post-merge-gaps.md."
         )
@@ -139,13 +185,8 @@ def live_commit_shas(limit: int, branch: str = "origin/develop") -> list[str]:
     return parse_sha_lines(out)
 
 
-def live_run_head_shas(limit: int, workflow: str = WORKFLOW_FILE) -> set[str]:
-    """List recent workflow run headShas via the gh CLI.
-
-    Includes every status/conclusion: a queued or failed run still proves the
-    push was not silently dropped. Only a total absence of runs for a SHA is
-    a gap.
-    """
+def _gh_run_list(limit: int, workflow: str = WORKFLOW_FILE) -> list[dict]:
+    """Fetch the most recent ``limit`` runs as a list of dicts via gh."""
     raw = _run(
         [
             "gh",
@@ -154,7 +195,7 @@ def live_run_head_shas(limit: int, workflow: str = WORKFLOW_FILE) -> set[str]:
             f"--workflow={workflow}",
             f"--limit={limit}",
             "--json",
-            "headSha",
+            "headSha,event,databaseId",
         ]
     )
     try:
@@ -163,14 +204,74 @@ def live_run_head_shas(limit: int, workflow: str = WORKFLOW_FILE) -> set[str]:
         raise RuntimeError(f"gh run list returned non-JSON: {exc}") from exc
     if not isinstance(rows, list):
         raise RuntimeError("gh run list JSON was not a list")
-    shas: set[str] = set()
-    for row in rows:
-        if not isinstance(row, dict):
-            continue
-        head = row.get("headSha")
-        if isinstance(head, str) and head.strip():
-            shas.add(normalize_sha(head))
-    return shas
+    return [row for row in rows if isinstance(row, dict)]
+
+
+def iter_growing_run_pages(
+    list_runs: ListRunsFn,
+    *,
+    page_size: int,
+    max_rows: int,
+) -> Iterable[list[dict]]:
+    """Yield successive run-list windows with a growing ``--limit``.
+
+    ``gh run list`` has no offset; each call returns the most recent N runs.
+    We grow N by page_size and yield only the *new* tail each time so
+    ``accumulate_unique_head_shas`` sees each run once while still being able
+    to dig past a tip-SHA flood.
+    """
+    if page_size < 1 or max_rows < 1:
+        raise ValueError("page_size and max_rows must be >= 1")
+    seen_ids: set[object] = set()
+    limit = min(page_size, max_rows)
+    while True:
+        rows = list_runs(limit)
+        fresh = []
+        for row in rows:
+            # Prefer stable run id when present; fall back to object identity.
+            rid = row.get("databaseId", row.get("id"))
+            key: object = rid if rid is not None else id(row)
+            if key in seen_ids:
+                continue
+            seen_ids.add(key)
+            fresh.append(row)
+        yield fresh
+        if len(rows) < limit:
+            # API returned fewer than requested: no more history.
+            break
+        if limit >= max_rows:
+            break
+        limit = min(limit + page_size, max_rows)
+
+
+def live_run_head_shas(
+    *,
+    min_unique: int,
+    page_size: int = DEFAULT_PAGE_SIZE,
+    max_rows: int = DEFAULT_MAX_RUN_ROWS,
+    workflow: str = WORKFLOW_FILE,
+    list_runs: ListRunsFn | None = None,
+) -> set[str]:
+    """Collect unique run headShas until ``min_unique`` or history is exhausted.
+
+    Includes every status/conclusion: a queued or failed run still proves the
+    push (or schedule/dispatch) was not silently dropped for that SHA. Only a
+    total absence of runs for a SHA is a gap.
+
+    Pagination is unique-set driven: after many hourly schedule runs for the
+    same tip, a fixed shallow ``--limit`` would return only that tip SHA and
+    false-gap older commits that still have push runs deeper in history.
+    """
+    if min_unique < 1:
+        raise ValueError("min_unique must be >= 1")
+
+    def _list(limit: int) -> list[dict]:
+        if list_runs is not None:
+            return list_runs(limit)
+        return _gh_run_list(limit, workflow=workflow)
+
+    pages = iter_growing_run_pages(_list, page_size=page_size, max_rows=max_rows)
+    return accumulate_unique_head_shas(pages, min_unique=min_unique)
 
 
 def build_parser() -> argparse.ArgumentParser:
@@ -197,10 +298,22 @@ def build_parser() -> argparse.ArgumentParser:
         help=f"How many recent develop commits to check (live mode). Default {DEFAULT_COMMIT_LIMIT}.",
     )
     parser.add_argument(
+        "--unique-margin",
+        type=int,
+        default=DEFAULT_UNIQUE_MARGIN,
+        help=(
+            "Extra unique headShas to collect beyond --commit-limit before "
+            f"stopping pagination (live mode). Default {DEFAULT_UNIQUE_MARGIN}."
+        ),
+    )
+    parser.add_argument(
         "--run-limit",
         type=int,
-        default=DEFAULT_RUN_LIMIT,
-        help=f"How many recent workflow runs to load (live mode). Default {DEFAULT_RUN_LIMIT}.",
+        default=DEFAULT_MAX_RUN_ROWS,
+        help=(
+            "Hard cap on how many recent workflow runs to fetch while "
+            f"paginating (live mode). Default {DEFAULT_MAX_RUN_ROWS}."
+        ),
     )
     parser.add_argument(
         "--branch",
@@ -223,8 +336,14 @@ def main(argv: list[str] | None = None) -> int:
         if args.live:
             if args.commit_limit < 1 or args.run_limit < 1:
                 raise RuntimeError("--commit-limit and --run-limit must be >= 1")
+            if args.unique_margin < 0:
+                raise RuntimeError("--unique-margin must be >= 0")
             commit_shas = live_commit_shas(args.commit_limit, branch=args.branch)
-            run_shas = live_run_head_shas(args.run_limit)
+            min_unique = args.commit_limit + args.unique_margin
+            run_shas = live_run_head_shas(
+                min_unique=min_unique,
+                max_rows=args.run_limit,
+            )
         else:
             if args.commits_file is None or args.runs_file is None:
                 parser.error("provide --live, or both --commits-file and --runs-file")

--- a/tests/unit/workflows/test_develop_post_merge_gaps.py
+++ b/tests/unit/workflows/test_develop_post_merge_gaps.py
@@ -1,0 +1,198 @@
+"""Contracts for develop-post-merge push-drop sweep + gap instrumentation.
+
+Pins:
+
+1. develop-post-merge.yml keeps the push trigger and adds an additive schedule
+   with a fixed concurrency group that will not cancel SHA-keyed push runs.
+2. develop-post-merge-gap-detector.yml exists as a cheap read-only canary.
+3. Pure gap-classification logic in scripts/detect_develop_post_merge_gaps.py.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+import yaml
+
+pytestmark = [pytest.mark.unit, pytest.mark.fast]
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+POST_MERGE = REPO_ROOT / ".github" / "workflows" / "develop-post-merge.yml"
+GAP_DETECTOR = REPO_ROOT / ".github" / "workflows" / "develop-post-merge-gap-detector.yml"
+SCRIPT = REPO_ROOT / "scripts" / "detect_develop_post_merge_gaps.py"
+
+
+def _load_script():
+    spec = importlib.util.spec_from_file_location("_detect_post_merge_gaps", SCRIPT)
+    assert spec is not None and spec.loader is not None
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+mod = _load_script()
+
+
+def _load_workflow(path: Path) -> dict:
+    document = yaml.safe_load(path.read_text(encoding="utf-8"))
+    assert isinstance(document, dict)
+    return document
+
+
+# ---------------------------------------------------------------------------
+# develop-post-merge.yml contracts
+# ---------------------------------------------------------------------------
+def test_post_merge_keeps_push_and_adds_schedule() -> None:
+    workflow = _load_workflow(POST_MERGE)
+    # PyYAML 1.1 treats the key `on` as boolean True.
+    on = workflow[True]
+    assert "push" in on
+    assert on["push"]["branches"] == ["develop"]
+    assert "schedule" in on
+    crons = [entry["cron"] for entry in on["schedule"]]
+    assert crons, "expected at least one schedule cron"
+    assert "workflow_dispatch" in on
+
+
+def test_post_merge_schedule_uses_fixed_concurrency_group() -> None:
+    """Schedule must not share the SHA-keyed group used by push runs.
+
+    A fixed schedule group with cancel-in-progress false means a sweep cannot
+    cancel (or be cancelled by) a concurrent push-triggered run for the tip.
+    """
+    text = POST_MERGE.read_text(encoding="utf-8")
+    assert "develop-post-merge-schedule" in text
+    assert "github.event_name == 'schedule'" in text
+    assert "cancel-in-progress: false" in text
+    # Push path still SHA-keyed (format or legacy literal both acceptable as
+    # long as schedule is the fixed branch of the expression).
+    assert "develop-post-merge-" in text
+
+
+def test_post_merge_workflow_permissions_stay_contents_read() -> None:
+    """No new workflow-level permission classes beyond today's baseline."""
+    workflow = _load_workflow(POST_MERGE)
+    assert workflow.get("permissions") == {"contents": "read"}
+
+
+def test_post_merge_gate_jobs_still_present() -> None:
+    workflow = _load_workflow(POST_MERGE)
+    jobs = workflow["jobs"]
+    for name in ("lint", "fast-test", "explorer-tokens", "medium-test"):
+        assert name in jobs, f"missing gate job {name}"
+
+
+def test_post_merge_schedule_checkouts_pin_develop() -> None:
+    """Schedule must not silently re-target if the default branch ever moves."""
+    text = POST_MERGE.read_text(encoding="utf-8")
+    assert "github.event_name == 'schedule' && 'develop' || github.sha" in text
+
+
+# ---------------------------------------------------------------------------
+# gap detector workflow contracts
+# ---------------------------------------------------------------------------
+def test_gap_detector_workflow_is_read_only_scheduled_canary() -> None:
+    workflow = _load_workflow(GAP_DETECTOR)
+    # PyYAML 1.1 treats the key `on` as boolean True.
+    on = workflow[True]
+    assert "schedule" in on
+    assert "workflow_dispatch" in on
+    assert "push" not in on  # instrumentation, not another push-spam path
+
+    perms = workflow.get("permissions") or {}
+    assert perms.get("contents") == "read"
+    assert perms.get("actions") == "read"
+    # No write surfaces.
+    for key in ("pull-requests", "issues", "contents"):
+        if key == "contents":
+            assert perms[key] == "read"
+        else:
+            assert key not in perms or perms[key] == "read"
+
+    jobs = workflow["jobs"]
+    assert len(jobs) == 1
+    detect = next(iter(jobs.values()))
+    steps_text = yaml.dump(detect.get("steps") or [])
+    assert "detect_develop_post_merge_gaps.py" in steps_text
+
+
+def test_gap_detector_concurrency_does_not_cancel_in_progress() -> None:
+    workflow = _load_workflow(GAP_DETECTOR)
+    concurrency = workflow.get("concurrency") or {}
+    assert concurrency.get("cancel-in-progress") is False
+    assert concurrency.get("group") == "develop-post-merge-gap-detector"
+
+
+# ---------------------------------------------------------------------------
+# Pure script logic
+# ---------------------------------------------------------------------------
+def test_parse_sha_lines_ignores_comments_and_messages() -> None:
+    text = """
+    # header
+    abcdef0123456789 deadbeef comment ignored as message
+    \t
+    1111111111111111
+    """
+    assert mod.parse_sha_lines(text) == [
+        "abcdef0123456789",
+        "1111111111111111",
+    ]
+
+
+def test_find_uncovered_reports_missing_in_order() -> None:
+    commits = ["aaa", "bbb", "ccc", "ddd"]
+    runs = {"aaa", "ccc"}
+    assert mod.find_uncovered(commits, runs) == ["bbb", "ddd"]
+
+
+def test_find_uncovered_is_prefix_aware() -> None:
+    full = "abcdef0123456789abcdef0123456789abcdef01"
+    assert mod.find_uncovered([full], {"abcdef01"}) == []
+    assert mod.find_uncovered(["abcdef01"], {full}) == []
+    assert mod.find_uncovered([full], {"deadbeef"}) == [full]
+
+
+def test_find_uncovered_empty_when_fully_covered() -> None:
+    commits = ["a" * 40, "b" * 40]
+    assert mod.find_uncovered(commits, set(commits)) == []
+
+
+def test_format_report_mentions_uncovered_shas() -> None:
+    report = mod.format_report(["a", "b"], ["b"], commit_limit=2, run_count=1)
+    assert "uncovered: 1" in report
+    assert "b" in report
+    assert "develop-post-merge" in report
+
+
+def test_cli_exits_one_on_gap(tmp_path: Path) -> None:
+    commits = tmp_path / "commits.txt"
+    runs = tmp_path / "runs.txt"
+    commits.write_text("aaa\nbbb\n", encoding="utf-8")
+    runs.write_text("aaa\n", encoding="utf-8")
+    completed = subprocess.run(
+        [sys.executable, str(SCRIPT), "--commits-file", str(commits), "--runs-file", str(runs)],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    assert completed.returncode == 1
+    assert "bbb" in completed.stderr
+
+
+def test_cli_exits_zero_when_covered(tmp_path: Path) -> None:
+    commits = tmp_path / "commits.txt"
+    runs = tmp_path / "runs.txt"
+    commits.write_text("aaa\nbbb\n", encoding="utf-8")
+    runs.write_text("aaa\nbbb\n", encoding="utf-8")
+    completed = subprocess.run(
+        [sys.executable, str(SCRIPT), "--commits-file", str(commits), "--runs-file", str(runs), "--json"],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    assert completed.returncode == 0
+    assert '"ok": true' in completed.stdout

--- a/tests/unit/workflows/test_develop_post_merge_gaps.py
+++ b/tests/unit/workflows/test_develop_post_merge_gaps.py
@@ -4,13 +4,17 @@ Pins:
 
 1. develop-post-merge.yml keeps the push trigger and adds an additive schedule
    with a fixed concurrency group that will not cancel SHA-keyed push runs.
-2. develop-post-merge-gap-detector.yml exists as a cheap read-only canary.
-3. Pure gap-classification logic in scripts/detect_develop_post_merge_gaps.py.
+2. Mutation jobs and medium-test are excluded from schedule.
+3. Every checkout pins develop on schedule.
+4. develop-post-merge-gap-detector.yml exists as a cheap read-only canary.
+5. Pure gap-classification + unique-headSha pagination logic in
+   scripts/detect_develop_post_merge_gaps.py.
 """
 
 from __future__ import annotations
 
 import importlib.util
+import re
 import subprocess
 import sys
 from pathlib import Path
@@ -24,6 +28,14 @@ REPO_ROOT = Path(__file__).resolve().parents[3]
 POST_MERGE = REPO_ROOT / ".github" / "workflows" / "develop-post-merge.yml"
 GAP_DETECTOR = REPO_ROOT / ".github" / "workflows" / "develop-post-merge-gap-detector.yml"
 SCRIPT = REPO_ROOT / "scripts" / "detect_develop_post_merge_gaps.py"
+
+MUTATION_JOBS = (
+    "auto-revert-on-failure",
+    "green-run-cleanup",
+    "close-orphaned-prs",
+)
+CHECKOUT_PIN = "github.event_name == 'schedule' && 'develop' || github.sha"
+SCHEDULE_EXCLUSION = "github.event_name != 'schedule'"
 
 
 def _load_script():
@@ -59,17 +71,12 @@ def test_post_merge_keeps_push_and_adds_schedule() -> None:
 
 
 def test_post_merge_schedule_uses_fixed_concurrency_group() -> None:
-    """Schedule must not share the SHA-keyed group used by push runs.
-
-    A fixed schedule group with cancel-in-progress false means a sweep cannot
-    cancel (or be cancelled by) a concurrent push-triggered run for the tip.
-    """
+    """Schedule must not share the SHA-keyed group used by push runs."""
     text = POST_MERGE.read_text(encoding="utf-8")
     assert "develop-post-merge-schedule" in text
     assert "github.event_name == 'schedule'" in text
-    assert "cancel-in-progress: false" in text
-    # Push path still SHA-keyed (format or legacy literal both acceptable as
-    # long as schedule is the fixed branch of the expression).
+    # Push path never cancels in progress; schedule may supersede itself.
+    assert "cancel-in-progress: ${{ github.event_name == 'schedule' }}" in text
     assert "develop-post-merge-" in text
 
 
@@ -87,9 +94,59 @@ def test_post_merge_gate_jobs_still_present() -> None:
 
 
 def test_post_merge_schedule_checkouts_pin_develop() -> None:
-    """Schedule must not silently re-target if the default branch ever moves."""
+    """Every checkout must pin develop on schedule (count match)."""
     text = POST_MERGE.read_text(encoding="utf-8")
-    assert "github.event_name == 'schedule' && 'develop' || github.sha" in text
+    checkout_count = len(re.findall(r"uses:\s*actions/checkout@v4", text))
+    pin_count = text.count(CHECKOUT_PIN)
+    assert checkout_count >= 1
+    assert pin_count == checkout_count, (
+        f"expected every checkout to pin develop on schedule; "
+        f"found {checkout_count} checkouts but {pin_count} pin expressions"
+    )
+
+
+def test_mutation_jobs_exclude_schedule() -> None:
+    """auto-revert / green-run-cleanup / close-orphaned must not run on schedule."""
+    workflow = _load_workflow(POST_MERGE)
+    jobs = workflow["jobs"]
+    for name in MUTATION_JOBS:
+        assert name in jobs, f"missing mutation job {name}"
+        job_if = str(jobs[name].get("if", ""))
+        assert SCHEDULE_EXCLUSION in job_if, f"{name} must gate on {SCHEDULE_EXCLUSION!r}; got if={job_if!r}"
+
+
+def test_mutation_jobs_preserve_push_path_conditions() -> None:
+    """Push-path behavior must not be weakened when adding schedule exclusion."""
+    workflow = _load_workflow(POST_MERGE)
+    jobs = workflow["jobs"]
+
+    auto = str(jobs["auto-revert-on-failure"]["if"])
+    assert "always()" in auto
+    assert "needs.lint.result == 'failure'" in auto
+    assert "needs.medium-test.result == 'failure'" in auto
+    # event_name leads so always() cannot re-enable the job on schedule.
+    assert auto.index(SCHEDULE_EXCLUSION) < auto.index("always()")
+
+    green = str(jobs["green-run-cleanup"]["if"])
+    assert "always()" in green
+    assert "needs.lint.result == 'success'" in green
+    assert "needs.medium-test.result == 'success'" in green
+    assert green.index(SCHEDULE_EXCLUSION) < green.index("always()")
+
+    # close-orphaned had no prior if; exclusion alone is the gate.
+    close = str(jobs["close-orphaned-prs"]["if"])
+    assert SCHEDULE_EXCLUSION in close
+
+
+def test_medium_test_is_slim_schedule_omitted() -> None:
+    """Cost decision: medium-test runs on push/dispatch only, not schedule."""
+    workflow = _load_workflow(POST_MERGE)
+    medium_if = str(workflow["jobs"]["medium-test"].get("if", ""))
+    assert SCHEDULE_EXCLUSION in medium_if
+    # Slim gates remain unconditional (no schedule exclusion).
+    for name in ("lint", "fast-test", "explorer-tokens"):
+        job_if = workflow["jobs"][name].get("if")
+        assert job_if is None or SCHEDULE_EXCLUSION not in str(job_if)
 
 
 # ---------------------------------------------------------------------------
@@ -166,6 +223,66 @@ def test_format_report_mentions_uncovered_shas() -> None:
     assert "uncovered: 1" in report
     assert "b" in report
     assert "develop-post-merge" in report
+
+
+def test_accumulate_unique_head_shas_stops_at_min_unique() -> None:
+    pages = [
+        [{"headSha": "aaa", "databaseId": 1}, {"headSha": "aaa", "databaseId": 2}],
+        [{"headSha": "bbb", "databaseId": 3}],
+        [{"headSha": "ccc", "databaseId": 4}],  # should not be needed
+    ]
+    got = mod.accumulate_unique_head_shas(pages, min_unique=2)
+    assert got == {"aaa", "bbb"}
+
+
+def test_live_run_head_shas_paginates_past_tip_flood() -> None:
+    """100 schedule runs for tip must not hide older push-covered SHAs."""
+    tip = "t" * 40
+    older = [f"{i:040x}" for i in range(1, 6)]  # five distinct older SHAs
+
+    # First 100 rows are all tip (schedule self-poisoning shape).
+    # Deeper rows carry the older push headShas.
+    def list_runs(limit: int) -> list[dict]:
+        rows: list[dict] = []
+        for i in range(100):
+            rows.append({"headSha": tip, "databaseId": i + 1, "event": "schedule"})
+        for i, sha in enumerate(older):
+            rows.append({"headSha": sha, "databaseId": 200 + i, "event": "push"})
+        return rows[:limit]
+
+    unique = mod.live_run_head_shas(
+        min_unique=1 + len(older),  # tip + all older
+        page_size=100,
+        max_rows=200,
+        list_runs=list_runs,
+    )
+    assert tip in unique
+    for sha in older:
+        assert sha in unique, f"older push SHA {sha} must survive tip flood"
+    # And find_uncovered must not false-gap those older commits.
+    commits = [tip, *older]
+    assert mod.find_uncovered(commits, unique) == []
+
+
+def test_live_run_head_shas_still_reports_true_gaps() -> None:
+    tip = "a" * 40
+    covered = "b" * 40
+    missing = "c" * 40
+
+    def list_runs(limit: int) -> list[dict]:
+        rows = [
+            {"headSha": tip, "databaseId": 1},
+            {"headSha": covered, "databaseId": 2},
+        ]
+        return rows[:limit]
+
+    unique = mod.live_run_head_shas(
+        min_unique=20,
+        page_size=10,
+        max_rows=50,
+        list_runs=list_runs,
+    )
+    assert mod.find_uncovered([tip, covered, missing], unique) == [missing]
 
 
 def test_cli_exits_one_on_gap(tmp_path: Path) -> None:

--- a/tests/unit/workflows/test_develop_post_merge_metrics.py
+++ b/tests/unit/workflows/test_develop_post_merge_metrics.py
@@ -245,7 +245,12 @@ def test_close_orphaned_prs_waits_for_post_merge_validation_success() -> None:
     )
     close_orphaned_prs = workflow_yaml["jobs"]["close-orphaned-prs"]
     assert close_orphaned_prs["needs"] == ["lint", "fast-test", "explorer-tokens", "medium-test"]
-    assert close_orphaned_prs.get("if") is None
+    # Schedule exclusion is allowed (gates-only sweep); push path must still
+    # wait on all four gates and must not run mutation work on schedule.
+    job_if = close_orphaned_prs.get("if")
+    assert job_if is None or "github.event_name != 'schedule'" in str(job_if)
+    # Must not use always() here: a skipped/failed gate must skip close.
+    assert "always()" not in str(job_if or "")
 
 
 def test_post_merge_explorer_tokens_job_runs_unconditionally() -> None:


### PR DESCRIPTION
GitHub has dropped push delivery for consecutive develop merges, so
develop-post-merge never started for those SHAs and tip sat un-gated.
Keep the push trigger, add an hourly scheduled sweep of the same gates
against develop tip (fixed concurrency group so sweeps never cancel
push runs), and a read-only daily gap detector that fails when recent
develop SHAs lack any post-merge run.
