### PR TITLE
docs(ops): honest pypi env gate pin (bypass, no canary)

### DIFF
--- a/docs/operations/repo-admin-settings.md
+++ b/docs/operations/repo-admin-settings.md
@@ -366,20 +366,23 @@ future regression (ruleset deleted, made inactive, ref narrowed, creation rule
 dropped, or bypass emptied) becomes a blocking drift finding instead of a
 warning.
 
-### `pypi` environment required-reviewers gate (enforced)
+### `pypi` environment required-reviewers gate (configured; observed 2026-08-05)
 
 `release.yml`'s `publish` job already scopes the real-PyPI publish to the
 GitHub `environment: pypi` (and `test-pypi` for the test-PyPI path), which
 is the correct native mechanism for a required-reviewers/human-approval
 gate on publish. The workflow file alone does not prove the `pypi`
 environment has `required_reviewers` configured on the repo side — only a
-live environments API read does.
+live environments API read does. GitHub enforces the gate at deployment time
+when it is configured; unlike the tag-creation ruleset, there is no automated
+environment-drift canary in `release-canary.yml` / `ruleset_drift_check.py` —
+honesty of this section rests on the dated pin below and manual re-verify.
 
 Verify:
 
 ```bash
 gh api repos/joeharris76/BenchBox/environments/pypi \
-  --jq '{name, protection_rules: [.protection_rules[] | {type, reviewers: [.reviewers[]?.reviewer.login]}]}'
+  --jq '{name, can_admins_bypass, protection_rules: [.protection_rules[] | {type, prevent_self_review, reviewers: [.reviewers[]?.reviewer.login]}]}'
 ```
 
 Live verification on 2026-08-05 (command above) shows the `pypi` environment
@@ -388,16 +391,19 @@ already carries a required-reviewers gate:
 ```text
 # pypi environment live state
 # checked: 2026-08-05  by: joeharris76 (admin)
-# command: gh api repos/joeharris76/BenchBox/environments/pypi --jq '{name, protection_rules: [.protection_rules[] | {type, reviewers: [.reviewers[]?.reviewer.login]}]}'
-# observed: {"name":"pypi","protection_rules":[{"reviewers":["joeharris76"],"type":"required_reviewers"}]}
+# command: gh api repos/joeharris76/BenchBox/environments/pypi --jq '{name, can_admins_bypass, protection_rules: [.protection_rules[] | {type, prevent_self_review, reviewers: [.reviewers[]?.reviewer.login]}]}'
+# observed: {"name":"pypi","can_admins_bypass":true,"protection_rules":[{"reviewers":["joeharris76"],"type":"required_reviewers","prevent_self_review":false}]}
 # type: required_reviewers  reviewer login(s): joeharris76  (User id 57046)
-# prevent_self_review: false  wait_timer: null  deployment_branch_policy: null
+# can_admins_bypass: true  prevent_self_review: false  wait_timer: null  deployment_branch_policy: null
 ```
 
-No admin mutation required for this gate — it is already configured. A future
-regression (rule removed, reviewers emptied, or environment deleted) would be
-caught by re-running the verify command above and comparing to this dated
-record.
+No admin mutation required for this gate — it is already configured. The
+`can_admins_bypass: true` + `prevent_self_review: false` pair is the accepted
+single-admin / self-review posture for this repo (one maintainer is both the
+required reviewer and an admin who can still approve or bypass their own
+deployment). Detect drift manually: re-run the verify command above and
+compare to this dated record (rule removed, reviewers emptied, environment
+deleted, or bypass/self-review flags flipped).
 
 `test-pypi` intentionally has no protection rules (lower friction for dry-run
 publish paths). Observed on 2026-08-05:


### PR DESCRIPTION
Soften the pypi required-reviewers section title from (enforced) to
(configured; observed 2026-08-05): GitHub enforces at deploy time, but
unlike the tag ruleset there is no automated environment-drift canary.

Pin can_admins_bypass: true with the accepted single-admin /
prevent_self_review: false posture, and reword drift detection as manual
re-verify against the dated pin.
