### PR TITLE
fix(results): scrub URI query/fragment credentials with username precision

### DIFF
--- a/benchbox/core/results/platform_options.py
+++ b/benchbox/core/results/platform_options.py
@@ -30,6 +30,15 @@ _URI_USERINFO_RE = re.compile(
     flags=re.IGNORECASE,
 )
 
+# Query and fragment parameters. Separators cover the first query ("?"), later
+# query pairs ("&"), the fragment start ("#"), and fragment pairs ("&" after
+# "#"). Credential-named params (access_token, sslpassword, password, ...) are
+# masked; ordinary params (x=1, region=...) are left intact. Name matching
+# reuses is_secret_option_key so key-level and URI-component rules stay aligned.
+_URI_QUERY_OR_FRAGMENT_PARAM_RE = re.compile(
+    r"(?P<sep>[?&#])(?P<name>[^=?#&]+)=(?P<value>[^?#&]*)",
+)
+
 
 def _normalize_secret_key(key: str) -> str:
     """Lowercase ``key`` and strip non-alphanumerics so ``sessionToken``,
@@ -92,15 +101,37 @@ def _is_username_key(key: str) -> bool:
 
 
 def _redact_uri_userinfo_match(match: re.Match[str]) -> str:
-    """Redact one URI's userinfo, preserving Azure storage container authorities."""
+    """Redact credential-bearing userinfo; keep username-only and Azure authorities.
+
+    Userinfo with a password uses ``user:password`` form (colon present). A bare
+    username (``https://public-user@host/path``) is identity, not a secret, and
+    must survive export so provenance is not replaced with a generic mask.
+    """
     if match.group("scheme").lower() in _AUTHORITY_USERINFO_SCHEMES:
+        return match.group(0)
+    userinfo = match.group("userinfo")
+    # Colon marks a password component (including empty password ``user:``).
+    if ":" not in userinfo:
         return match.group(0)
     return f"{match.group('scheme')}{match.group('sep')}****@"
 
 
-def _scrub_uri_userinfo(value: str) -> str:
-    """Replace credential-bearing URI userinfo without changing ordinary values."""
-    return _URI_USERINFO_RE.sub(_redact_uri_userinfo_match, value)
+def _redact_uri_query_or_fragment_param(match: re.Match[str]) -> str:
+    """Mask one query/fragment parameter value when its name is credential-like."""
+    if is_secret_option_key(match.group("name")):
+        return f"{match.group('sep')}{match.group('name')}=****"
+    return match.group(0)
+
+
+def _scrub_uri_credentials(value: str) -> str:
+    """Scrub URI userinfo passwords and credential-named query/fragment params.
+
+    Component-aware: ordinary hosts, paths, ports, non-secret query params, and
+    username-only userinfo are preserved. Does not stack independent broken
+    matchers — one pass for userinfo precision, one for query/fragment names.
+    """
+    scrubbed = _URI_USERINFO_RE.sub(_redact_uri_userinfo_match, value)
+    return _URI_QUERY_OR_FRAGMENT_PARAM_RE.sub(_redact_uri_query_or_fragment_param, scrubbed)
 
 
 _INTERNAL_OPTION_KEYS = {
@@ -222,7 +253,7 @@ def _iter_public_options(options: Mapping[str, Any] | None):
 
 def _sanitize_option_value(value: Any, *, exclude_internal: bool = False, redact_usernames: bool = True) -> Any:
     if isinstance(value, str):
-        return _scrub_uri_userinfo(value)
+        return _scrub_uri_credentials(value)
     if isinstance(value, Mapping):
         return sanitize_platform_options(
             value,

--- a/tests/unit/core/results/test_platform_options_capture.py
+++ b/tests/unit/core/results/test_platform_options_capture.py
@@ -261,6 +261,74 @@ def test_uri_userinfo_credentials_are_redacted_without_touching_public_values() 
     assert sanitized["sort_key"] == "o_orderkey"
 
 
+def test_uri_username_only_identity_is_preserved() -> None:
+    """Username-only userinfo is identity, not a secret — do not replace with ****.
+
+    Successor of the query-credential scrub TODO: earlier userinfo redaction
+    treated every authority userinfo as credential-bearing and over-redacted
+    ``https://public-user@host/path`` in exported platform options.
+    """
+    from benchbox.core.results.platform_options import sanitize_platform_options
+
+    sanitized = sanitize_platform_options(
+        {
+            "username_only": "https://public-user@example.invalid/export",
+            # Key must not itself be secret-named; this tests value-level URI scrub.
+            "export_url": "https://public-user:URI_USERINFO_GATE@example.invalid/export",
+        }
+    )
+
+    assert sanitized["username_only"] == "https://public-user@example.invalid/export"
+    assert "public-user" in sanitized["username_only"]
+    assert sanitized["export_url"] == "https://****@example.invalid/export"
+    assert "URI_USERINFO_GATE" not in sanitized["export_url"]
+
+
+def test_uri_query_and_fragment_credential_params_are_scrubbed() -> None:
+    """Credential-named query/fragment params must not reach serialized payloads.
+
+    Structural key filtering already redacts options named ``access_token``;
+    this covers the same names embedded as URI components on non-secret keys
+    (export URLs, connection URIs with sslpassword, OAuth-style fragments).
+    Ordinary params such as ``x=1`` stay intact for downstream routing.
+    """
+    import json
+
+    from benchbox.core.results.platform_options import sanitize_platform_options
+
+    values = {
+        "query": "https://example.invalid/export?access_token=URI_QUERY_GATE&x=1",
+        "ssl": "postgresql://host.example/db?sslpassword=URI_SSL_GATE&application_name=bb",
+        "fragment": "https://example.invalid/export#access_token=URI_FRAG_GATE&section=results",
+        # Non-secret option key: credential lives only in the URI query component.
+        "endpoint": "https://example.invalid/x?password=URI_PW_GATE&region=us-east-1",
+        "combined": "postgresql://u:URI_USERINFO_GATE@example.invalid/db?sslpassword=URI_SSL2_GATE&x=1",
+        "ordinary": "https://example.invalid/export?x=1&region=us-east-1",
+    }
+    sanitized = sanitize_platform_options(values)
+    out = json.dumps(sanitized)
+
+    for sentinel in (
+        "URI_QUERY_GATE",
+        "URI_SSL_GATE",
+        "URI_FRAG_GATE",
+        "URI_PW_GATE",
+        "URI_USERINFO_GATE",
+        "URI_SSL2_GATE",
+    ):
+        assert sentinel not in out, out
+
+    assert sanitized["query"] == "https://example.invalid/export?access_token=****&x=1"
+    assert sanitized["ssl"] == "postgresql://host.example/db?sslpassword=****&application_name=bb"
+    assert sanitized["fragment"] == "https://example.invalid/export#access_token=****&section=results"
+    assert sanitized["endpoint"] == "https://example.invalid/x?password=****&region=us-east-1"
+    assert sanitized["combined"] == "postgresql://****@example.invalid/db?sslpassword=****&x=1"
+    assert sanitized["ordinary"] == "https://example.invalid/export?x=1&region=us-east-1"
+    assert "x=1" in out
+    assert "application_name=bb" in out
+    assert "region=us-east-1" in out
+
+
 def test_uri_userinfo_redaction_consumes_an_unescaped_at_in_the_password() -> None:
     """Review follow-up: a password may legally contain an unescaped '@'.
 


### PR DESCRIPTION
## Summary

Scrub credential-bearing URI **query and fragment** parameters in platform options, and keep **username-only** userinfo identity (do not replace non-secret usernames with `****`).

Structural key filtering already redacts options named `access_token` / `password` / `dsn`, but credentials still leaked when those names appeared as URI components on ordinary option keys (export URLs, connection URIs with `sslpassword`, OAuth-style fragments). Username-only authorities were also over-redacted.

## Changes

- `benchbox/core/results/platform_options.py`
  - Userinfo: redact only when a password component is present (`:` in userinfo); preserve username-only and Azure container authorities
  - Query/fragment: mask values of credential-named params via existing `is_secret_option_key` alignment (`access_token`, `sslpassword`, `password`, …)
  - Preserve ordinary hosts, paths, ports, and non-secret params (`x=1`, `application_name`, …)
- Tests covering username-only precision, query/fragment sentinels, and combined userinfo+query cases

## Verification

- TODO rungs 1–2 pass (query/userinfo/ssl sentinels absent; `public-user` and `x=1` preserved; ordinary URLs unchanged)
- `pytest tests/unit/core/results/test_platform_options_capture.py` — 68 passed
- `ruff` / `ty` clean on touched files
- Full `pr-preflight` fast suite hung at ~95% under multi-agent load after `ci-lint` passed; CI will re-run the suite

## Scope

Only:
- `benchbox/core/results/platform_options.py`
- `tests/unit/core/results/test_platform_options_capture.py`

Does not touch `environment.py`, `anonymization.py`, `schema.py`, or `todo_db.py`.
