### PR TITLE
fix(todo-db): surface turso auto-provision mint failures

### DIFF
--- a/_project/scripts/todo_db.py
+++ b/_project/scripts/todo_db.py
@@ -532,7 +532,7 @@ def _turso_db_name() -> str:
     return os.environ.get("TODO_DB_TURSO_DB") or "benchbox-todo"
 
 
-def _try_turso_auto_provision() -> tuple[str, str] | None:
+def _try_turso_auto_provision() -> tuple[tuple[str, str] | None, str | None]:
     """Mint a short-lived hosted backend via the maintainer's logged-in turso CLI.
 
     Only called from `_resolve_backend` when no explicit backend is configured
@@ -544,13 +544,21 @@ def _try_turso_auto_provision() -> tuple[str, str] | None:
     day-granularity expirations or ``never``; sub-day values like ``30m``
     are rejected).
 
-    Returns ``(url, token)`` on success, ``None`` on ANY failure -- turso not
-    on PATH, not logged in, a nonzero exit, or empty output -- so the caller
-    falls through to the existing implicit-local-fallback behavior. Neither
-    the URL nor the token is ever printed or logged here.
+    Returns a structured ``(credentials, failure_reason)`` pair:
+
+    * turso absent: ``(None, None)`` -- skipped, no special warning
+    * success: ``((url, token), None)``
+    * failure while turso is present: ``(None, reason)`` where ``reason`` is a
+      short class only (``db-show-failed``, ``db-show-empty``,
+      ``token-create-failed``, ``token-empty``, ``turso-error``). Never
+      includes stderr content that might hold secrets.
+
+    The caller falls through to the existing implicit-local-fallback on any
+    non-success result. Neither the URL nor the token is ever printed or
+    logged here.
     """
     if not shutil.which("turso"):
-        return None
+        return None, None
     name = _turso_db_name()
     try:
         show = subprocess.run(
@@ -561,10 +569,10 @@ def _try_turso_auto_provision() -> tuple[str, str] | None:
             timeout=15,
         )
         if show.returncode != 0:
-            return None
+            return None, "db-show-failed"
         url = show.stdout.strip()
         if not url:
-            return None
+            return None, "db-show-empty"
         tokens = subprocess.run(
             ["turso", "db", "tokens", "create", name, "--expiration", "1d"],
             capture_output=True,
@@ -573,32 +581,42 @@ def _try_turso_auto_provision() -> tuple[str, str] | None:
             timeout=15,
         )
         if tokens.returncode != 0:
-            return None
+            return None, "token-create-failed"
         token = tokens.stdout.strip()
         if not token:
-            return None
-        return url, token
+            return None, "token-empty"
+        return (url, token), None
     except (OSError, subprocess.SubprocessError):
-        return None
+        return None, "turso-error"
 
 
-def _resolve_backend(explicit: str | None) -> tuple[Path | str, bool, bool]:
-    """Return ``(backend, implicit_default_local, auto_provisioned)``.
+def _resolve_backend(explicit: str | None) -> tuple[Path | str, bool, bool, str | None]:
+    """Return ``(backend, implicit_default_local, auto_provisioned, provision_failure)``.
 
     CLI precedence: --db > TODO_DB_PATH > TODO_DB_URL > turso auto-provisioning
     > local fallback. Auto-provisioning is attempted ONLY when none of the
     three explicit knobs are set, so explicit config always outranks it and
     hermetic tests pinning TODO_DB_PATH never invoke it.
+
+    ``provision_failure`` is a short reason class when turso was on PATH but
+    minting failed (so the operator gets a distinct WARN instead of silent
+    fallthrough); it is ``None`` when auto-provision was skipped, succeeded,
+    or never considered (explicit backend).
     """
     if explicit:
-        return (_normalize_url(explicit) if _is_hosted_url(explicit) else Path(explicit)), False, False
+        return (
+            (_normalize_url(explicit) if _is_hosted_url(explicit) else Path(explicit)),
+            False,
+            False,
+            None,
+        )
     env_path = os.environ.get("TODO_DB_PATH")
     if env_path:
-        return Path(env_path), False, False
+        return Path(env_path), False, False, None
     env_url = os.environ.get("TODO_DB_URL")
     if env_url:
-        return _normalize_url(env_url), False, False
-    provisioned = _try_turso_auto_provision()
+        return _normalize_url(env_url), False, False, None
+    provisioned, provision_failure = _try_turso_auto_provision()
     if provisioned:
         url, token = provisioned
         # Use the hosted backend exactly as if TODO_DB_URL/TODO_DB_AUTH_TOKEN
@@ -607,8 +625,8 @@ def _resolve_backend(explicit: str | None) -> tuple[Path | str, bool, bool]:
         # etc.) works unchanged.
         os.environ["TODO_DB_URL"] = url
         os.environ["TODO_DB_AUTH_TOKEN"] = token
-        return _normalize_url(url), False, True
-    return git_main_root() / ".todo-db" / "todo.sqlite", True, False
+        return _normalize_url(url), False, True, None
+    return git_main_root() / ".todo-db" / "todo.sqlite", True, False, provision_failure
 
 
 def resolve_backend(explicit: str | None) -> Path | str:
@@ -1398,7 +1416,13 @@ def _premigrate_freeze_refusal(backend: Path | str, actor: str) -> int | None:
     return 2
 
 
-def _report_backend(backend: Path | str, *, implicit_default_local: bool, auto_provisioned: bool = False) -> None:
+def _report_backend(
+    backend: Path | str,
+    *,
+    implicit_default_local: bool,
+    auto_provisioned: bool = False,
+    provision_failure: str | None = None,
+) -> None:
     if isinstance(backend, Path):
         print(f"todo backend: local ({backend})", file=sys.stderr)
         if implicit_default_local:
@@ -1407,6 +1431,12 @@ def _report_backend(backend: Path | str, *, implicit_default_local: bool, auto_p
                 "set --db, TODO_DB_PATH, or TODO_DB_URL explicitly.",
                 file=sys.stderr,
             )
+            if provision_failure:
+                # Reason class only -- never stderr content (may hold secrets).
+                print(
+                    f"WARNING: turso auto-provision failed ({provision_failure}); using local fallback",
+                    file=sys.stderr,
+                )
         return
     # Never print the hosted URL or token: the backend kind is enough.
     if auto_provisioned:
@@ -1479,6 +1509,7 @@ def run_doctor(
     *,
     implicit_default_local: bool,
     auto_provisioned: bool = False,
+    provision_failure: str | None = None,
     as_json: bool = False,
 ) -> int:
     """Side-effect-free health check over config, identity, reachability, and auth.
@@ -1526,6 +1557,13 @@ def run_doctor(
         )
     record("backend", "OK", backend_detail)
     record("identity", identity_status, identity_detail)
+
+    # 1b. Auto-provision mint failure. WARN only (exit 0 still allowed): turso
+    # was on PATH and mint was attempted, but it failed, so the operator can
+    # see why they landed on the local fallback. Reason class only -- never
+    # stderr content that might hold secrets.
+    if provision_failure:
+        record("turso-provision", "WARN", f"auto-provision failed ({provision_failure})")
 
     # 2. Auth. Only hosted needs a token; checked before reachability so a missing
     # token reports as auth rather than as a confusing connection error.
@@ -1592,7 +1630,7 @@ def run_doctor(
         print(json.dumps({"exit_code": exit_code, "checks": checks}, indent=2, sort_keys=True))
     else:
         for entry in checks:
-            print(f"{entry['status']:<4} {entry['check']:<11} {entry['detail']}")
+            print(f"{entry['status']:<4} {entry['check']:<15} {entry['detail']}")
         if exit_code == DOCTOR_EXIT_AUTH:
             # stdout is block-buffered when redirected while stderr is not, so the
             # remediation would otherwise print ABOVE the checks it refers to.
@@ -1613,6 +1651,7 @@ def _preconnect_command(
     *,
     implicit_default_local: bool,
     auto_provisioned: bool = False,
+    provision_failure: str | None = None,
 ) -> int | None:
     """Handle the commands that must run BEFORE `connect_backend`, else ``None``.
 
@@ -1631,12 +1670,19 @@ def _preconnect_command(
             backend,
             implicit_default_local=implicit_default_local,
             auto_provisioned=auto_provisioned,
+            provision_failure=provision_failure,
             as_json=args.as_json,
         )
 
     if implicit_default_local and _command_mutates_tracker(args):
+        provision_note = (
+            f" (turso auto-provision was attempted but failed: {provision_failure})"
+            if provision_failure
+            else ""
+        )
         print(
-            "error: refusing to write through the implicit local fallback; "
+            "error: refusing to write through the implicit local fallback"
+            f"{provision_note}; "
             "select a backend with --db, TODO_DB_PATH, or TODO_DB_URL, or log in with "
             "`turso auth login` so this can auto-provision a hosted backend",
             file=sys.stderr,
@@ -4370,14 +4416,20 @@ def main(argv: list[str] | None = None) -> int:
             print(f"error: {exc}", file=sys.stderr)
             return 2
 
-    backend, implicit_default_local, auto_provisioned = _resolve_backend(args.db)
-    _report_backend(backend, implicit_default_local=implicit_default_local, auto_provisioned=auto_provisioned)
+    backend, implicit_default_local, auto_provisioned, provision_failure = _resolve_backend(args.db)
+    _report_backend(
+        backend,
+        implicit_default_local=implicit_default_local,
+        auto_provisioned=auto_provisioned,
+        provision_failure=provision_failure,
+    )
     early = _preconnect_command(
         args,
         actor,
         backend,
         implicit_default_local=implicit_default_local,
         auto_provisioned=auto_provisioned,
+        provision_failure=provision_failure,
     )
     if early is not None:
         return early

--- a/_project/specs/todo-db-tracker.md
+++ b/_project/specs/todo-db-tracker.md
@@ -841,8 +841,12 @@ TODO tree from an untrusted source would plant shell commands; do not.
     backend transparently, falling back to the local implicit DB (with a
     refusal-on-write pointing at `turso auth login` /
     `TODO_DB_URL`+`TODO_DB_AUTH_TOKEN` / `--db`/`TODO_DB_PATH`) if turso is
-    absent, not logged in, or the mint fails. This closes the former open
-    provisioning item without requiring the two variables in local `.env`.
+    absent, not logged in, or the mint fails. When turso is on PATH but mint
+    fails, a short reason class (`db-show-failed`, `token-create-failed`,
+    etc. — never stderr/URL/token) is surfaced via stderr WARN, the doctor
+    `turso-provision` check, and the write-refusal message, so the fallthrough
+    is not silent. This closes the former open provisioning item without
+    requiring the two variables in local `.env`.
 - **G2 — CLI MVP:** schema DDL + `create/show/claim/start/done/defer/
   promote/dismiss/complete/ready/list/stats/export` + tests. No repo changes
   to the YAML system yet.

--- a/tests/unit/scripts/test_todo_db_doctor.py
+++ b/tests/unit/scripts/test_todo_db_doctor.py
@@ -226,6 +226,6 @@ def test_implicit_local_fallback_is_warned_not_failed(monkeypatch, tmp_path, cap
     db = tmp_path / "fallback.sqlite"
     assert todo_db.main(["--db", str(db), "init"]) == 0
 
-    monkeypatch.setattr(todo_db, "_resolve_backend", lambda _explicit: (db, True, False))
+    monkeypatch.setattr(todo_db, "_resolve_backend", lambda _explicit: (db, True, False, None))
     assert todo_db.main(["doctor"]) == todo_db.DOCTOR_EXIT_OK
     assert "WARN identity" in capsys.readouterr().out

--- a/tests/unit/scripts/test_todo_db_turso_autoprovision.py
+++ b/tests/unit/scripts/test_todo_db_turso_autoprovision.py
@@ -11,6 +11,8 @@ back to the local scratch database (see `_try_turso_auto_provision` and
   - any failure (turso absent, mint failure) falls through to the existing
     local-fallback behavior, whose write-refusal error now names `turso auth
     login` alongside the existing remediations;
+  - when turso is on PATH but mint fails, a distinct provision_failure reason
+    class is surfaced (WARN / doctor check / write-refusal) without secrets;
   - auto-provisioning is never attempted when an explicit backend
     (--db/TODO_DB_PATH/TODO_DB_URL) is configured;
   - the minted token and URL are never printed, including through `doctor`.
@@ -83,11 +85,12 @@ class TestAutoProvisionSuccess:
         fake_run, calls = _make_fake_turso_run()
         monkeypatch.setattr(todo_db.subprocess, "run", fake_run)
 
-        backend, implicit_default_local, auto_provisioned = todo_db._resolve_backend(None)
+        backend, implicit_default_local, auto_provisioned, provision_failure = todo_db._resolve_backend(None)
 
         assert backend == _URL
         assert implicit_default_local is False
         assert auto_provisioned is True
+        assert provision_failure is None
         # Downstream readers (_auth_token(), connect_hosted(), ...) all key off
         # these two env vars -- auto-provisioning must behave exactly as if
         # they had been set explicitly.
@@ -103,10 +106,11 @@ class TestAutoProvisionSuccess:
         fake_run, calls = _make_fake_turso_run(db_name="my-custom-db")
         monkeypatch.setattr(todo_db.subprocess, "run", fake_run)
 
-        backend, _implicit, auto_provisioned = todo_db._resolve_backend(None)
+        backend, _implicit, auto_provisioned, provision_failure = todo_db._resolve_backend(None)
 
         assert backend == _URL
         assert auto_provisioned is True
+        assert provision_failure is None
         assert ["turso", "db", "show", "my-custom-db", "--url"] in calls
 
     def test_report_backend_names_auto_provisioning(self, capsys):
@@ -125,29 +129,70 @@ class TestAutoProvisionFailureFallsThrough:
         # autouse fixture; this is asserted explicitly here too.
         assert todo_db.shutil.which("turso") is None
 
-        backend, implicit_default_local, auto_provisioned = todo_db._resolve_backend(None)
+        backend, implicit_default_local, auto_provisioned, provision_failure = todo_db._resolve_backend(None)
 
         assert isinstance(backend, Path)
         assert implicit_default_local is True
         assert auto_provisioned is False
+        # turso absent is a silent skip -- no provision_failure reason class.
+        assert provision_failure is None
 
     def test_turso_present_but_show_fails_falls_through(self, monkeypatch, tmp_path):
         _clear_backend_env(monkeypatch)
         monkeypatch.setattr(todo_db, "git_main_root", lambda: tmp_path)
         monkeypatch.setattr(todo_db.shutil, "which", lambda name: "/usr/bin/turso" if name == "turso" else None)
+        real_run = todo_db.subprocess.run
 
         def fake_run(cmd, *args, **kwargs):
             if cmd[:1] == ["turso"]:
                 return SimpleNamespace(returncode=1, stdout="", stderr="not logged in")
-            return todo_db.subprocess.run(cmd, *args, **kwargs)
+            return real_run(cmd, *args, **kwargs)
 
         monkeypatch.setattr(todo_db.subprocess, "run", fake_run)
 
-        backend, implicit_default_local, auto_provisioned = todo_db._resolve_backend(None)
+        backend, implicit_default_local, auto_provisioned, provision_failure = todo_db._resolve_backend(None)
 
         assert isinstance(backend, Path)
         assert implicit_default_local is True
         assert auto_provisioned is False
+        assert provision_failure == "db-show-failed"
+
+    def test_turso_present_but_token_create_fails_falls_through(self, monkeypatch, tmp_path):
+        _clear_backend_env(monkeypatch)
+        monkeypatch.setattr(todo_db, "git_main_root", lambda: tmp_path)
+        monkeypatch.setattr(todo_db.shutil, "which", lambda name: "/usr/bin/turso" if name == "turso" else None)
+        real_run = todo_db.subprocess.run
+
+        def fake_run(cmd, *args, **kwargs):
+            if cmd[:1] == ["turso"]:
+                if cmd[1:3] == ["db", "show"]:
+                    return SimpleNamespace(returncode=0, stdout=f"{_URL}\n", stderr="")
+                if cmd[1:4] == ["db", "tokens", "create"]:
+                    return SimpleNamespace(returncode=1, stdout="", stderr="permission denied: secret-xyz")
+                return SimpleNamespace(returncode=1, stdout="", stderr="unexpected")
+            return real_run(cmd, *args, **kwargs)
+
+        monkeypatch.setattr(todo_db.subprocess, "run", fake_run)
+
+        backend, implicit_default_local, auto_provisioned, provision_failure = todo_db._resolve_backend(None)
+
+        assert isinstance(backend, Path)
+        assert implicit_default_local is True
+        assert auto_provisioned is False
+        assert provision_failure == "token-create-failed"
+
+    def test_report_backend_surfaces_provision_failure_class(self, tmp_path, capsys):
+        todo_db._report_backend(
+            tmp_path / "todo.sqlite",
+            implicit_default_local=True,
+            auto_provisioned=False,
+            provision_failure="token-create-failed",
+        )
+        err = capsys.readouterr().err
+        assert "WARNING: turso auto-provision failed (token-create-failed); using local fallback" in err
+        assert _URL not in err
+        assert _TOKEN not in err
+        assert "secret" not in err
 
     def test_write_refusal_error_names_turso_auth_login_remediation(self, monkeypatch, tmp_path, capsys):
         _clear_backend_env(monkeypatch)
@@ -163,6 +208,29 @@ class TestAutoProvisionFailureFallsThrough:
         assert "TODO_DB_PATH" in err
         assert not (tmp_path / ".todo-db" / "todo.sqlite").exists()
 
+    def test_write_refusal_mentions_provision_failure_class(self, monkeypatch, tmp_path, capsys):
+        _clear_backend_env(monkeypatch)
+        monkeypatch.setattr(todo_db, "git_main_root", lambda: tmp_path)
+        monkeypatch.setattr(todo_db.shutil, "which", lambda name: "/usr/bin/turso" if name == "turso" else None)
+        real_run = todo_db.subprocess.run
+
+        def fake_run(cmd, *args, **kwargs):
+            if cmd[:1] == ["turso"]:
+                return SimpleNamespace(returncode=1, stdout="", stderr="not logged in: token-sekrit")
+            return real_run(cmd, *args, **kwargs)
+
+        monkeypatch.setattr(todo_db.subprocess, "run", fake_run)
+
+        rc = todo_db.main(["claim", "missing-item"])
+
+        assert rc == 2
+        err = capsys.readouterr().err
+        assert "refusing to write through the implicit local fallback" in err
+        assert "turso auto-provision was attempted but failed: db-show-failed" in err
+        assert "token-sekrit" not in err
+        assert _TOKEN not in err
+        assert _URL not in err
+
 
 class TestAutoProvisionNeverInvokedWithExplicitBackend:
     def test_explicit_flag_skips_auto_provision(self, monkeypatch, tmp_path):
@@ -173,11 +241,14 @@ class TestAutoProvisionNeverInvokedWithExplicitBackend:
 
         monkeypatch.setattr(todo_db, "_try_turso_auto_provision", boom)
 
-        backend, implicit_default_local, auto_provisioned = todo_db._resolve_backend(str(tmp_path / "todo.sqlite"))
+        backend, implicit_default_local, auto_provisioned, provision_failure = todo_db._resolve_backend(
+            str(tmp_path / "todo.sqlite")
+        )
 
         assert isinstance(backend, Path)
         assert implicit_default_local is False
         assert auto_provisioned is False
+        assert provision_failure is None
 
     def test_env_todo_db_path_skips_auto_provision(self, monkeypatch, tmp_path):
         monkeypatch.setenv("TODO_DB_PATH", str(tmp_path / "todo.sqlite"))
@@ -188,11 +259,12 @@ class TestAutoProvisionNeverInvokedWithExplicitBackend:
 
         monkeypatch.setattr(todo_db, "_try_turso_auto_provision", boom)
 
-        backend, implicit_default_local, auto_provisioned = todo_db._resolve_backend(None)
+        backend, implicit_default_local, auto_provisioned, provision_failure = todo_db._resolve_backend(None)
 
         assert isinstance(backend, Path)
         assert implicit_default_local is False
         assert auto_provisioned is False
+        assert provision_failure is None
 
     def test_env_todo_db_url_skips_auto_provision(self, monkeypatch):
         monkeypatch.delenv("TODO_DB_PATH", raising=False)
@@ -204,11 +276,12 @@ class TestAutoProvisionNeverInvokedWithExplicitBackend:
 
         monkeypatch.setattr(todo_db, "_try_turso_auto_provision", boom)
 
-        backend, implicit_default_local, auto_provisioned = todo_db._resolve_backend(None)
+        backend, implicit_default_local, auto_provisioned, provision_failure = todo_db._resolve_backend(None)
 
         assert backend == "libsql://explicit-env.turso.io"
         assert implicit_default_local is False
         assert auto_provisioned is False
+        assert provision_failure is None
 
 
 class TestDoctorRedactsAutoProvisionedSecrets:
@@ -248,3 +321,38 @@ class TestDoctorRedactsAutoProvisionedSecrets:
         combined = "".join(capsys.readouterr())
         assert _TOKEN not in combined
         assert _URL not in combined
+
+    def test_doctor_surfaces_provision_failure_class_without_secrets(self, monkeypatch, tmp_path, capsys):
+        _clear_backend_env(monkeypatch)
+        monkeypatch.setattr(todo_db, "git_main_root", lambda: tmp_path)
+        monkeypatch.setattr(todo_db.shutil, "which", lambda name: "/usr/bin/turso" if name == "turso" else None)
+        real_run = todo_db.subprocess.run
+
+        def fake_run(cmd, *args, **kwargs):
+            if cmd[:1] == ["turso"]:
+                if cmd[1:3] == ["db", "show"]:
+                    return SimpleNamespace(returncode=0, stdout=f"{_URL}\n", stderr="")
+                if cmd[1:4] == ["db", "tokens", "create"]:
+                    return SimpleNamespace(returncode=1, stdout="", stderr=f"denied token={_TOKEN}")
+                return SimpleNamespace(returncode=1, stdout="", stderr="unexpected")
+            return real_run(cmd, *args, **kwargs)
+
+        monkeypatch.setattr(todo_db.subprocess, "run", fake_run)
+        # Local fallback needs a usable DB so doctor exit is OK (WARN only).
+        (tmp_path / ".todo-db").mkdir(parents=True, exist_ok=True)
+        db = tmp_path / ".todo-db" / "todo.sqlite"
+        assert todo_db.main(["--db", str(db), "init"]) == 0
+        # Clear env again after init (init may leave nothing, but be safe).
+        _clear_backend_env(monkeypatch)
+
+        rc = todo_db.main(["doctor"])
+
+        assert rc == todo_db.DOCTOR_EXIT_OK
+        captured = capsys.readouterr()
+        combined = captured.out + captured.err
+        assert "turso-provision" in combined
+        assert "token-create-failed" in combined
+        assert "WARN" in combined
+        assert _TOKEN not in combined
+        assert _URL not in combined
+        assert "denied token=" not in combined


### PR DESCRIPTION
## Summary

When `turso` is on PATH and auto-provision minting fails, surface a short reason class instead of falling through to the local fallback with no signal.

- `_try_turso_auto_provision` returns `(credentials|None, reason|None)` with classes: `db-show-failed`, `db-show-empty`, `token-create-failed`, `token-empty`, `turso-error`
- Turso absent remains silent `(None, None)`
- `doctor` records `turso-provision` WARN; backend stderr and write-refusal name the class
- Tokens/URLs never printed

Closes `todo-db-auto-provision-mint-failure-visibility`.

## Test plan
- [x] `uv run -- python -m pytest tests/unit/scripts/test_todo_db_turso_autoprovision.py tests/unit/scripts/test_todo_db_doctor.py -q` (31 passed)
- [ ] CI green
