### PR TITLE
fix(todo-db): resolve shim ROOT from script path, not cwd git root

### DIFF
--- a/_project/scripts/todo
+++ b/_project/scripts/todo
@@ -6,5 +6,8 @@ set -euo pipefail
 # Keep this declaration synchronized with todo_db.SCHEMA_VERSION. The required
 # schema-migration inventory gate rejects a wrapper/CLI mismatch before merge.
 TODO_SCHEMA_VERSION=5
-ROOT="$(git rev-parse --show-toplevel)"
+# Resolve the tree that owns this shim, not cwd's git toplevel. An absolute
+# path to another clone's shim must still run that clone's todo_db.py.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
 exec uv run --project "$ROOT/_project/scripts" -- python "$ROOT/_project/scripts/todo_db.py" "$@"

--- a/_project/specs/todo-db-tracker.md
+++ b/_project/specs/todo-db-tracker.md
@@ -411,8 +411,11 @@ historical archive deferrals).
 **Thin wrapper + UAT (2026-07-18, third round).** The wrapper was built
 TDD-first: `tests/unit/scripts/test_todo_wrapper.py` pins the contract
 (10 tests written red), then the implementation turned them green —
-`_project/scripts/todo` (7-line shim, works from any cwd, propagates gate
-exit codes) and `.claude/skills/todo-db/SKILL.md` (the thin skill). The
+`_project/scripts/todo` (shim resolves ROOT from its own path via
+`BASH_SOURCE`, not cwd/`git rev-parse --show-toplevel`, so an absolute
+path to another clone's shim still runs that clone's `todo_db.py`;
+propagates gate exit codes) and `.claude/skills/todo-db/SKILL.md` (the
+thin skill). The
 contract tests enforce thinness structurally: ≤40 non-empty body lines,
 every referenced `todo <cmd>` must exist in the CLI's handler table, the
 mandatory workflow verbs must be present, and schema/validation vocabulary

--- a/tests/unit/scripts/test_todo_wrapper.py
+++ b/tests/unit/scripts/test_todo_wrapper.py
@@ -105,6 +105,23 @@ class TestShim:
         stats = json.loads(result.stdout)
         assert stats["items_by_state"] == {}
 
+    def test_shim_resolves_code_from_own_location_not_cwd_git_root(self):
+        # Absolute path to this tree's shim, cwd outside any repo: must still
+        # load this tree's todo_db.py (not fail or bind to another clone).
+        assert SHIM_PATH.is_absolute()
+        result = subprocess.run(
+            [str(SHIM_PATH), "update", "--help"],
+            capture_output=True,
+            text=True,
+            cwd="/tmp",
+            env={"PATH": os.environ["PATH"], "HOME": str(Path.home())},
+            check=False,
+            timeout=120,
+        )
+        combined = result.stdout + result.stderr
+        assert result.returncode == 0, combined
+        assert "update" in combined
+
     def test_shim_propagates_gate_exit_codes(self, tmp_path):
         db = tmp_path / "wrapper.sqlite"
         create = _run_shim(

--- a/tests/unit/scripts/test_todo_wrapper.py
+++ b/tests/unit/scripts/test_todo_wrapper.py
@@ -105,10 +105,25 @@ class TestShim:
         stats = json.loads(result.stdout)
         assert stats["items_by_state"] == {}
 
-    def test_shim_resolves_code_from_own_location_not_cwd_git_root(self):
-        # Absolute path to this tree's shim, cwd outside any repo: must still
-        # load this tree's todo_db.py (not fail or bind to another clone).
+    def test_shim_resolves_code_from_own_location_not_cwd_git_root(self, tmp_path):
+        # Absolute path to THIS tree's shim must win even when cwd is another
+        # git root with a decoy _project/scripts/todo_db.py (the lagging-primary
+        # / wrong-clone failure mode).
         assert SHIM_PATH.is_absolute()
+        decoy = tmp_path / "other-clone"
+        scripts = decoy / "_project" / "scripts"
+        scripts.mkdir(parents=True)
+        (decoy / ".git").mkdir()
+        decoy_marker = "DECOY_TODO_DB_MARKER_NOT_FROM_REAL_TREE"
+        (scripts / "todo_db.py").write_text(
+            f"import sys\nprint({decoy_marker!r})\nsys.exit(97)\n",
+            encoding="utf-8",
+        )
+        (scripts / "pyproject.toml").write_text(
+            '[project]\nname = "decoy"\nversion = "0"\nrequires-python = ">=3.10"\n',
+            encoding="utf-8",
+        )
+        # Foreign non-git cwd smoke
         result = subprocess.run(
             [str(SHIM_PATH), "update", "--help"],
             capture_output=True,
@@ -121,6 +136,22 @@ class TestShim:
         combined = result.stdout + result.stderr
         assert result.returncode == 0, combined
         assert "update" in combined
+        assert decoy_marker not in combined
+        # Foreign git root with decoy scripts must not execute the decoy
+        result2 = subprocess.run(
+            [str(SHIM_PATH), "update", "--help"],
+            capture_output=True,
+            text=True,
+            cwd=str(decoy),
+            env={"PATH": os.environ["PATH"], "HOME": str(Path.home())},
+            check=False,
+            timeout=120,
+        )
+        combined2 = result2.stdout + result2.stderr
+        assert result2.returncode == 0, combined2
+        assert "update" in combined2
+        assert decoy_marker not in combined2
+        assert result2.returncode != 97
 
     def test_shim_propagates_gate_exit_codes(self, tmp_path):
         db = tmp_path / "wrapper.sqlite"


### PR DESCRIPTION
## Summary

The `todo` shim now resolves `ROOT` from its own script path (`BASH_SOURCE`), not `git rev-parse --show-toplevel` from cwd. Absolute invocations from a foreign cwd (e.g. lagging primary clone) run the intended tree's `todo_db.py`.

Closes `todo-shim-resolves-code-via-cwd-git-toplevel`.

## Test plan
- [x] `uv run -- python -m pytest tests/unit/scripts/test_todo_wrapper.py -q -n 0` (15 passed)
- [x] Absolute shim + `cwd=/tmp` → `update --help` exit 0
- [ ] CI green
