### PR TITLE
fix(corpus): gate published-results mirror on publication fixed point

### DIFF
--- a/.github/workflows/sync-results-data-to-published.yml
+++ b/.github/workflows/sync-results-data-to-published.yml
@@ -9,6 +9,18 @@ name: Sync results-data to published-results
 # workflow keeps it in sync with develop's authoritative `results-data/`
 # without forcing maintainers to mirror by hand.
 #
+# Publication fixed-point precondition: develop's corpus must already be at
+# the publication fixed point before any mirror branch is built or PR opened.
+# The gate below is the same check as
+# tests/unit/scripts/test_corpus_privacy_invariant.py::test_rederived_corpus_publishes_byte_identically_to_what_is_stored
+# (AnonymizationManager + canonical_json_bytes over primary bundles). If
+# re-anonymizing would rewrite stored bytes, this workflow fails loudly and
+# does not open a mirror that would re-publish rewriteable content. When
+# re-derivation is in flight on develop, the mirror waits on that fixed point
+# automatically; once the precondition holds, the mirror runs unattended
+# again. The gate runs on the content being mirrored (develop @ GITHUB_SHA),
+# not on published-results.
+#
 # The mirror PR is intentionally a draft — it never auto-merges. Maintainers
 # review and flip ready when the develop-side change is ready to be visible
 # on the public corpus branch. Validator changes mirror both the thin
@@ -115,6 +127,83 @@ jobs:
             echo "diff_count=${#DIFFED[@]}"
           } >> "$GITHUB_OUTPUT"
 
+      # Fixed-point gate: refuse to build or open a mirror when develop's
+      # results-data would be rewritten by a second anonymization pass. Same
+      # logic as test_rederived_corpus_publishes_byte_identically_to_what_is_stored
+      # in tests/unit/scripts/test_corpus_privacy_invariant.py. Runs on the
+      # develop checkout (content being mirrored) before any mirror branch is
+      # created. uv/Python are installed here so the gate can import
+      # AnonymizationManager; later validate steps reuse the same toolchain.
+      - name: Install uv
+        if: steps.drift.outputs.has_drift == 'true'
+        uses: astral-sh/setup-uv@v4
+
+      - name: Set up Python
+        if: steps.drift.outputs.has_drift == 'true'
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Gate corpus publication fixed point
+        if: steps.drift.outputs.has_drift == 'true'
+        run: |
+          set -euo pipefail
+          # Inline equivalent of
+          # test_rederived_corpus_publishes_byte_identically_to_what_is_stored.
+          # Uses AnonymizationManager directly so this stays a corpus-domain
+          # gate rather than develop's full test matrix.
+          # Fails loud: a skipped/refused mirror must not look like success.
+          uv run -- python - <<'PY'
+          from __future__ import annotations
+
+          import json
+          import sys
+          from pathlib import Path
+
+          from benchbox.core.results.anonymization import AnonymizationManager
+          from benchbox.core.results.canonical_json import canonical_json_bytes
+
+          RESULTS_DATA = Path("results-data")
+          COMPANION_SUFFIXES = (".manifest.json", ".plans.json", ".tuning.json", ".applied.json")
+          MIGRATION_MANIFEST = "path-privacy-migration.manifest.json"
+
+          manager = AnonymizationManager()
+          drifted: list[str] = []
+          scanned = 0
+
+          for path in sorted((RESULTS_DATA / "bundles").rglob("*.json")):
+              if path.name.endswith(COMPANION_SUFFIXES) or path.name == MIGRATION_MANIFEST:
+                  continue
+              stored = path.read_bytes()
+              payload = json.loads(stored.decode("utf-8"))
+              if not isinstance(payload, dict):
+                  continue
+              scanned += 1
+              if canonical_json_bytes(manager.anonymize_result_payload(payload)) != stored:
+                  drifted.append(str(path))
+
+          if not scanned:
+              print(
+                  "::error::No primary bundles scanned — publication fixed-point gate would be vacuous.",
+                  file=sys.stderr,
+              )
+              raise SystemExit(1)
+
+          if drifted:
+              print(
+                  f"::error::Corpus is not at the publication fixed point "
+                  f"({len(drifted)} bundle(s) would be rewritten by re-anonymization). "
+                  f"Refusing to open a mirror that would rewrite published bytes. "
+                  f"Same check as test_rederived_corpus_publishes_byte_identically_to_what_is_stored.",
+                  file=sys.stderr,
+              )
+              for rel in drifted[:20]:
+                  print(f"  {rel}", file=sys.stderr)
+              raise SystemExit(1)
+
+          print(f"Publication fixed point OK ({scanned} primary bundles).")
+          PY
+
       - name: Build mirror branch
         if: steps.drift.outputs.has_drift == 'true'
         id: build
@@ -212,23 +301,15 @@ jobs:
       # lint/type/pytest matrix here would gate corpus content on checks that have
       # nothing to do with it (rejected by the ADR for the same reason it rejected
       # routing submissions through develop directly). The two checks that ARE
-      # domain-appropriate are exactly the ones `validate-submission.yml` already
-      # runs for a human-authored submission PR: does each changed bundle pass
-      # schema/hash/privacy validation, and is the generated inventory still
-      # current. Run precisely those two, reusing the identical vendored scripts
-      # and the identical `--no-project --python 3.11` invocation convention
-      # documented in `adr-published-results-slim-corpus-branch.md`, so the mirror
-      # PR is judged by the same bar a contributor PR would be.
-      - name: Install uv
-        if: steps.drift.outputs.has_drift == 'true' && steps.build.outputs.has_changes == 'true'
-        uses: astral-sh/setup-uv@v4
-
-      - name: Set up Python
-        if: steps.drift.outputs.has_drift == 'true' && steps.build.outputs.has_changes == 'true'
-        uses: actions/setup-python@v5
-        with:
-          python-version: "3.11"
-
+      # domain-appropriate after the publication fixed-point gate above are exactly
+      # the ones `validate-submission.yml` already runs for a human-authored
+      # submission PR: does each changed bundle pass schema/hash/privacy
+      # validation, and is the generated inventory still current. Run precisely
+      # those two, reusing the identical vendored scripts and the identical
+      # `--no-project --python 3.11` invocation convention documented in
+      # `adr-published-results-slim-corpus-branch.md`, so the mirror PR is judged
+      # by the same bar a contributor PR would be. uv/Python were installed
+      # earlier for the fixed-point gate and are reused here.
       - name: Validate mirrored corpus content
         # The working tree right now (after `git switch --force-create` and the
         # path-level checkouts above) IS the exact content the PR will present as

--- a/docs/operations/results-phase-2-runbook.md
+++ b/docs/operations/results-phase-2-runbook.md
@@ -32,6 +32,18 @@ validators, plus `corpus-inventory.json`) and opens a **draft** PR against
 auto-merges — a maintainer reviews and flips it ready when the develop-side
 change is ready to surface on the public corpus branch.
 
+**Publication fixed-point gate.** Before building a mirror branch or opening
+a PR, the sync workflow runs the same check as
+`tests/unit/scripts/test_corpus_privacy_invariant.py::test_rederived_corpus_publishes_byte_identically_to_what_is_stored`
+against the develop content at `GITHUB_SHA` (the bytes about to be mirrored).
+If re-anonymization would rewrite any primary bundle, the run fails loudly and
+does **not** open a mirror. That keeps `published-results` from receiving a
+corpus that Explorer publication would immediately rewrite, and sequences any
+in-flight re-derivation automatically: the mirror waits until develop is at
+the fixed point, then proceeds unattended. A red sync run with drift still
+present is the expected signal while re-derivation is open — not a stuck
+manual gate.
+
 If the workflow's heuristics ever miss a path (or a one-off mirror is
 needed outside the trigger conditions), trigger it manually via
 `workflow_dispatch` from the Actions tab.

--- a/tests/unit/test_sync_results_workflow.py
+++ b/tests/unit/test_sync_results_workflow.py
@@ -1,11 +1,16 @@
 from pathlib import Path
 
 import pytest
+import yaml
 
 pytestmark = [pytest.mark.unit, pytest.mark.fast]
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 WORKFLOW_PATH = REPO_ROOT / ".github" / "workflows" / "sync-results-data-to-published.yml"
+
+FIXED_POINT_GATE_STEP = "Gate corpus publication fixed point"
+BUILD_MIRROR_STEP = "Build mirror branch"
+FIXED_POINT_TEST_FRAGMENT = "rederived_corpus_publishes_byte_identically"
 
 
 def test_sync_results_workflow_sources_triggering_commit() -> None:
@@ -16,3 +21,41 @@ def test_sync_results_workflow_sources_triggering_commit() -> None:
     assert 'SOURCE_REF="${GITHUB_SHA}"' in workflow
     assert 'git checkout "${SOURCE_REF}" -- "${path}"' in workflow
     assert "origin/develop" not in workflow
+
+
+def test_sync_workflow_references_publication_fixed_point_gate() -> None:
+    """The mirror must refuse a corpus that re-anonymization would rewrite.
+
+    Pins the workflow to the same fixed-point invariant as
+    ``test_rederived_corpus_publishes_byte_identically_to_what_is_stored`` so a
+    future edit cannot drop the gate while leaving the unit suite green.
+    """
+    workflow = WORKFLOW_PATH.read_text(encoding="utf-8")
+    assert FIXED_POINT_TEST_FRAGMENT in workflow, (
+        "sync workflow does not reference the publication fixed-point gate "
+        f"({FIXED_POINT_TEST_FRAGMENT}); a non-fixed-point corpus could still be mirrored"
+    )
+    assert "AnonymizationManager" in workflow
+    assert "canonical_json_bytes" in workflow
+    assert "publication fixed point" in workflow.lower() or "not at the publication fixed point" in workflow
+
+
+def test_sync_workflow_fixed_point_gate_runs_before_mirror_build() -> None:
+    """Gate must run on develop content before any mirror branch is built.
+
+    Building first would push rewriteable bytes; the gate is a precondition for
+    opening a public mirror, not a post-hoc status on an already-opened PR.
+    """
+    steps = yaml.safe_load(WORKFLOW_PATH.read_text(encoding="utf-8"))["jobs"]["mirror"]["steps"]
+    names = [step.get("name") for step in steps]
+    assert FIXED_POINT_GATE_STEP in names, f"missing step {FIXED_POINT_GATE_STEP!r}"
+    assert BUILD_MIRROR_STEP in names, f"missing step {BUILD_MIRROR_STEP!r}"
+    assert names.index(FIXED_POINT_GATE_STEP) < names.index(BUILD_MIRROR_STEP), (
+        "publication fixed-point gate runs after Build mirror branch; "
+        "the mirror could be built from a corpus that publishing would rewrite"
+    )
+
+    gate = next(step for step in steps if step.get("name") == FIXED_POINT_GATE_STEP)
+    run = gate.get("run", "")
+    assert "Refusing to open a mirror" in run or "not at the publication fixed point" in run
+    assert "SystemExit(1)" in run or "raise SystemExit" in run


### PR DESCRIPTION
Refuse to build or open a results-data mirror when develop's corpus is not
already at the publication fixed point (re-anonymize would rewrite bytes).

The sync workflow now runs the same check as
test_rederived_corpus_publishes_byte_identically_to_what_is_stored against
develop@GITHUB_SHA before Build mirror branch. Failure is loud and does not
look like a successful no-op. When re-derivation is in flight the mirror waits
on that precondition; once it holds, mirroring proceeds unattended again.
