### PR TITLE
docs(results): record public_result_id permanence and minted format

### DIFF
--- a/docs/development/adr/README.md
+++ b/docs/development/adr/README.md
@@ -9,3 +9,4 @@ Architecture Decision Records
 - [ADR: published-results as a Slim Corpus-Only Branch](adr-published-results-slim-corpus-branch.md)
 - [ADR: DuckLake Maturity, Publishability, Review Path, and Compaction Bias](adr-ducklake-maturity-and-publishability.md)
 - [ADR: One Engine, Scoped Surfaces — CLI and MCP over a Shared Core](adr-one-engine-scoped-surfaces.md)
+- [ADR: `public_result_id` permanence attaches at publication](adr-public-result-id-permanence.md)

--- a/docs/development/adr/adr-public-result-id-permanence.md
+++ b/docs/development/adr/adr-public-result-id-permanence.md
@@ -1,0 +1,179 @@
+# ADR: `public_result_id` permanence attaches at publication
+
+- Status: Accepted
+- Date: 2026-08-05
+- Supersedes the informal format and collision rules previously stated in
+  `docs/reference/hosted-results-contract.md` §1.1 (and the Phase 1 line in
+  `docs/development/benchbox-results-platform-strategy.md` Result Identity).
+- Constrains: explorer publication pipeline
+  (`_project/scripts/explorer_pipeline/`), hosted results contract,
+  and any future alias/redirect surface for public result URLs.
+
+## Context
+
+`docs/reference/hosted-results-contract.md` documented `public_result_id` as
+permanent once minted, with format:
+
+```text
+{benchmark}-{platform}-sf{scale_factor}-{date}
+```
+
+and collisions resolved by appending `-{n}`. That is not what the pipeline
+mints.
+
+What is actually minted (see
+`BundleTransformer.result_id_from_bundle` in
+`_project/scripts/explorer_pipeline/transformer.py`):
+
+```text
+{benchmark}-{platform}-sf{scale_factor}-{yyyymmdd}-{sha8}
+```
+
+where:
+
+| Segment | Source |
+|---|---|
+| `benchmark` | published bundle `benchmark.id` |
+| `platform` | published bundle `platform.name`, lowercased, spaces → `-` |
+| `scale_factor` | published bundle `benchmark.scale_factor` (stringified as in Python `f"{value}"`) |
+| `yyyymmdd` | first 10 chars of `run.timestamp`, hyphens stripped |
+| `sha8` | first 8 hex chars of `sha256(published_bytes)` |
+
+**Published bytes** means the anonymized, canonical-JSON bytes that land under
+`bundles/{result_id}.json` — not the raw source bundle. The pipeline derives
+the id only after `_public_bundle_data` / `canonical_json_bytes`
+(`pipeline.py`); that order is pinned by
+`tests/unit/scripts/explorer_pipeline/test_result_id_contract.py`.
+
+Because the id is content-addressed over published bytes:
+
+- every re-derivation of the corpus that changes published content (for
+  example anonymization field-set or salt changes) rotates every id;
+- identical published content re-derives the same id (idempotent republish);
+- two distinct published payloads that collide on the 32-bit `sha8` prefix
+  are a hard failure (`DuplicateResultIdError`), not a silent `-{n}` rename.
+
+There is no deployed public Explorer that has advertised the documented
+(wrong) format. Corpus rotations such as #1537 changed ids in git and CI
+artifacts only. External bookmarks of `/results/r/{public_result_id}` do not
+yet exist as a product surface.
+
+The open questions that remain are when permanence freezes relative to
+corpus motion, whether the written contract must match the mint, and whether
+an alias/redirect table is required before first public deploy.
+
+## Decision
+
+### 1. Permanence attaches at publication
+
+**A `public_result_id` is permanent for a given set of published bytes once
+those bytes are part of a public Explorer corpus that consumers may link
+to.** It is a content-addressed id of the published artifact, not a
+stable label for an ephemeral local run, a private bundle path, or a
+pre-anonymization capture.
+
+Consequences:
+
+- Local run ids, capture filenames, and private machine paths never become
+  the public id.
+- Re-deriving the same published bytes yields the same id (content
+  address).
+- Deliberately changing published bytes (privacy fix, schema projection,
+  field-set drop) is allowed to change ids **until the first public deploy
+  that treats Explorer URLs as a consumer contract**. After that deploy,
+  any further rotation must either preserve ids for unchanged published
+  bytes (the normal content-address path) or ship an explicit
+  alias/redirect map for ids that change.
+- Permanent does **not** mean "immune to content change." It means "the same
+  published bytes always map to the same id, and once that id is live in
+  the public product, links keep resolving."
+
+### 2. Document the actual minted format (including `sha8`)
+
+The authoritative format is:
+
+```text
+{benchmark}-{platform}-sf{scale_factor}-{yyyymmdd}-{sha8}
+```
+
+Example: `tpch-duckdb-sf1.0-20260315-a1b2c3d4`
+
+Collision handling in the publication pipeline (Phase 1 static corpus):
+
+| Case | Behavior |
+|---|---|
+| Same `result_id`, identical published digest | Skip as redundant; publish once |
+| Same `result_id`, differing published digest | Fail closed with `DuplicateResultIdError` |
+
+The older contract claim that the minting service appends `-{n}` is
+**rejected** for the Phase 1 pipeline. Content addressing already
+separates distinct payloads in the common case; a 32-bit prefix collision
+is treated as a build error so evidence is not silently dropped or
+renamed under a non-content-addressed suffix. A Phase 3 concurrent mint
+service may need a different concurrency story, but it must not invent a
+format that diverges from this slug without a new ADR.
+
+`public_result_id` in the hosted contract and `result_id` in the explorer
+pipeline refer to the same slug today.
+
+### 3. Alias / redirect before first public deploy: not needed
+
+**No alias or redirect mechanism is required before the first public
+Explorer deploy.**
+
+Rationale:
+
+1. The format mismatch lived in documentation only. Minted ids have always
+   included `sha8` in code and unit tests.
+2. No public product surface has served `/results/r/{id}` under either the
+   wrong or the right format as a stable external contract.
+3. Prior corpus-wide id rotations (#1537 and related privacy work) therefore
+   had zero external link breakage cost.
+4. Building redirect tables now would invent infrastructure for a consumer
+   that does not exist yet.
+
+**Trigger for revisiting:** the first release that publishes Explorer result
+detail URLs as a documented, linkable public surface. After that point,
+any id-changing re-derivation of already-public published bytes needs an
+alias/redirect (or an explicit deprecation notice), decided in a follow-up
+ADR or ops runbook change — not assumed free.
+
+## Alternatives rejected
+
+| Alternative | Why rejected |
+|---|---|
+| Permanence attaches at local run / commit of private capture | Private bytes and paths are not the public artifact; hashing them would fingerprint non-public content and diverge from downloadable bundles |
+| Keep format without `sha8` and resolve collisions with `-{n}` | Diverges from implemented mint; sequential suffixes are not content-addressed and break deterministic re-derivation |
+| Freeze ids independently of content (assign once, never recompute) | Loses verifiability ("anyone holding the published bundle can recompute the id") and forces a registry service before Phase 1 needs one |
+| Ship alias/redirect tables now for pre-deploy rotations | No external links to protect; cost without benefit |
+
+## Consequences
+
+- `docs/reference/hosted-results-contract.md` must describe the `sha8`
+  format and fail-closed / skip-identical collision rules.
+- Explorer pipeline code remains the mint authority; docs follow code.
+- Content-addressed permanence is preserved (must-preserve for this TODO).
+- First public deploy becomes the freeze line for external link stability;
+  ops should treat post-deploy id rotations as a compatibility event.
+- Strategy doc identity table remains non-authoritative relative to this
+  ADR and the hosted contract (out of scope for the immediate contract fix;
+  update when that doc is next edited for identity).
+
+## Prior art
+
+| Path | Role | Decision |
+|---|---|---|
+| `_project/scripts/explorer_pipeline/transformer.py` (`result_id_from_bundle`, `_sha256_prefix`) | Mint implementation | Extend docs to match; no code change |
+| `_project/scripts/explorer_pipeline/pipeline.py` (id after `public_raw`, `DuplicateResultIdError`) | Publication boundary and collision policy | Keep; document |
+| `tests/unit/scripts/explorer_pipeline/test_result_id_contract.py` | Pins hash-of-published-bytes | Keep |
+| `tests/unit/scripts/explorer_pipeline/test_transformer.py` (`TestResultIdFromBundle`) | Pins format including 8-hex suffix | Keep |
+| `docs/reference/hosted-results-contract.md` §1.1 | Public contract (was wrong) | Correct |
+| `docs/development/adr/adr-published-identifier-field-set.md` | What fields enter published bytes | Orthogonal; field-set changes still rotate ids pre-deploy |
+
+## Work units
+
+| Unit | Outcome |
+|---|---|
+| w0 | This ADR |
+| w1 | Contract format + collision text aligned with mint |
+| w2 | Alias/redirect = not needed until first public deploy (this section) |

--- a/docs/reference/hosted-results-contract.md
+++ b/docs/reference/hosted-results-contract.md
@@ -65,20 +65,29 @@ idempotent with respect to content.
 #### `public_result_id`
 
 A stable, human-readable permalink slug that identifies a result in the public
-corpus.
+corpus. In the explorer publication pipeline this is the same value as
+`result_id` on manifest entries and published bundle filenames.
 
 | Property | Value |
 |---|---|
-| Format | `{benchmark}-{platform}-sf{scale_factor}-{date}` (e.g., `tpch-duckdb-sf1-20260315`) |
-| Stability | Permanent once minted. Never reused for a different result. |
-| Uniqueness | Unique within the public corpus. Conflicts are resolved by the minting service (not the submitter) appending `-{n}`, where `n` starts at 2 and increments monotonically (e.g., `-2`, `-3`). |
-| Minting | Phase 1: on commit to `results-data/`. Phase 2+: after validation passes. |
+| Format | `{benchmark}-{platform}-sf{scale_factor}-{yyyymmdd}-{sha8}` (e.g., `tpch-duckdb-sf1.0-20260315-a1b2c3d4`) |
+| `sha8` | First 8 hex characters of `sha256(published_bundle_bytes)`. Published bytes are the anonymized, canonical-JSON payload written to `bundles/{public_result_id}.json` — not the raw private capture. |
+| Stability | Permanent once minted for a given set of published bytes. Same published bytes always re-derive the same id. Permanence attaches at **publication** (content address of public artifact), not at local run capture. See `docs/development/adr/adr-public-result-id-permanence.md`. |
+| Uniqueness | Unique within the public corpus. Identical published digests under the same id are idempotent (publish once). Distinct published content that collides on the same id fails the build closed (`DuplicateResultIdError`); the Phase 1 pipeline does **not** append `-{n}`. |
+| Minting | Phase 1: by the explorer static pipeline when projecting `results-data/` into the public corpus. Phase 2+: after validation passes, using the same format over the published payload. |
 | Phase introduced | Phase 1 |
-| Used for | Stable URLs (`/results/r/{public_result_id}`), manifest index, compare links |
+| Used for | Stable URLs (`/results/r/{public_result_id}`), manifest index, compare links, `bundles/{public_result_id}.json` |
 
 The `public_result_id` is the only identifier that is stable across all phases
 and safe to use in external links. CLI tools and frontend must use this identifier
 for any URL or reference intended to be shared or bookmarked.
+
+**Pre-deploy alias note:** Before the first public Explorer deploy, no
+alias/redirect table is required for format or corpus rotations (documentation
+previously omitted `sha8`, but code has always minted it; no external product
+links used the wrong format). After first public deploy, any id-changing
+re-derivation of already-public published bytes needs an explicit
+compatibility mechanism — see the ADR.
 
 #### Identifier Summary
 
@@ -721,8 +730,11 @@ The frontend enforces cohort rules before rendering:
 The following questions are explicitly deferred to Phase 3 design and are not
 resolved by this contract:
 
-- **`public_result_id` collision resolution:** Algorithm and concurrency strategy
-  when two submissions produce the same deterministic ID.
+- **`public_result_id` collision resolution (Phase 3 only):** Concurrent mint
+  strategy when two API submissions race to the same content-addressed id.
+  Phase 1 static publication already fails closed on distinct content and
+  skips identical content (see §1.1 and
+  `docs/development/adr/adr-public-result-id-permanence.md`).
 - **Idempotency semantics:** Re-submitting a bundle that is already in
   `pending` or `validated` state - return `200 OK` or `409 Conflict`?
 - **Cross-visibility cohort comparisons:** Whether results in different


### PR DESCRIPTION
Align the hosted results contract with what the explorer pipeline mints:
content-addressed `{benchmark}-{platform}-sf{scale}-{yyyymmdd}-{sha8}`
over published bytes. Permanence attaches at publication; no alias table
is needed before the first public Explorer deploy.
