### PR TITLE
fix(todo-db): discover hosted URL from tracked .todo-db/config.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -194,8 +194,11 @@ _project/DONE/_indexes/
 # Local-SQLite TODO tracker spike (see _project/specs/todo-db-tracker.md):
 # per-clone operational state (DBs / replica) stays ignored; credential-free
 # backend config.json is tracked so clones discover the hosted URL.
-.todo-db/*
-!.todo-db/config.json
+.todo-db/*.db
+.todo-db/*.sqlite
+.todo-db/*.sqlite-*
+.todo-db/replica*
+.todo-db/export/
 _project/blind-spots/_indexes/
 
 # Ephemeral review/audit evidence. Commit durable markdown summaries instead.

--- a/.gitignore
+++ b/.gitignore
@@ -192,8 +192,10 @@ _project/TODO/_indexes/
 _project/DONE/_indexes/
 
 # Local-SQLite TODO tracker spike (see _project/specs/todo-db-tracker.md):
-# per-clone operational state, never committed.
-.todo-db/
+# per-clone operational state (DBs / replica) stays ignored; credential-free
+# backend config.json is tracked so clones discover the hosted URL.
+.todo-db/*
+!.todo-db/config.json
 _project/blind-spots/_indexes/
 
 # Ephemeral review/audit evidence. Commit durable markdown summaries instead.

--- a/.todo-db/config.json
+++ b/.todo-db/config.json
@@ -1,0 +1,3 @@
+{
+  "url": "libsql://benchbox-todo-joeharris76.aws-us-east-1.turso.io"
+}

--- a/_project/decisions/single-repo-migration.md
+++ b/_project/decisions/single-repo-migration.md
@@ -380,3 +380,5 @@ released `main` so operators discover the production URL without silent
 local fallback.
 
 - **`main` only** (extension to A3): `.todo-db/`.
+
+This amendment is authoritative for the release-curation guard.

--- a/_project/decisions/single-repo-migration.md
+++ b/_project/decisions/single-repo-migration.md
@@ -370,3 +370,13 @@ and `tests/unit/test_release_infrastructure.py`:
 
 With gap 1 (history alignment via `-s ours`) folded into `release-cut` by #1089,
 both gaps this release exposed are now closed in the target itself.
+
+## Amendment 2026-08-05 — .todo-db config to main-only allowlist
+
+Adding `.todo-db/` as a top-level tracked path: credential-free
+`.todo-db/config.json` binds clones to the hosted tracker URL. Operational
+DB/replica files stay gitignored. The directory ships on both `develop` and
+released `main` so operators discover the production URL without silent
+local fallback.
+
+- **`main` only** (extension to A3): `.todo-db/`.

--- a/_project/scripts/todo_db.py
+++ b/_project/scripts/todo_db.py
@@ -16,8 +16,12 @@ Backend selection (first match wins):
                             replica at <git root>/.todo-db/replica.db
                             (override: TODO_DB_REPLICA); plaintext
                             http:// is refused
-- turso auto-provision      when none of the above are set and a logged-in
-                            `turso` CLI can mint a short-lived token
+- .todo-db/config.json      credential-free hosted URL discovery at the git
+                            main root (``{"url": "libsql://..."}`` only;
+                            token still comes from TODO_DB_AUTH_TOKEN or a
+                            later connect/auth failure path)
+- turso auto-provision      when none of the above yield a backend and a
+                            logged-in `turso` CLI can mint a short-lived token
 - default                   <git main root>/.todo-db/todo.sqlite (gitignored)
 
 Hosted mode keeps the exact write-transaction discipline of local mode:
@@ -532,15 +536,65 @@ def _turso_db_name() -> str:
     return os.environ.get("TODO_DB_TURSO_DB") or "benchbox-todo"
 
 
+def _todo_db_config_path() -> Path:
+    """Credential-free backend config at the shared main-root tracker dir."""
+    return git_main_root() / ".todo-db" / "config.json"
+
+
+def _load_config_url() -> str | None:
+    """Load a hosted URL from ``.todo-db/config.json`` if present and valid.
+
+    Shape (tracked, credential-free)::
+
+        {"url": "libsql://benchbox-todo-....turso.io"}
+
+    Tokens must NEVER appear in this file. A missing file returns ``None``
+    so resolution falls through to auto-provision / local fallback. A present
+    but unreadable or invalid file raises ``TodoError`` so a bad commit does
+    not silently demote the clone to the implicit local scratch DB.
+    """
+    path = _todo_db_config_path()
+    try:
+        if not path.is_file():
+            return None
+        raw_text = path.read_text(encoding="utf-8")
+    except OSError as exc:
+        raise TodoError(f"cannot read todo backend config {path}: {exc}") from exc
+    try:
+        data = json.loads(raw_text)
+    except json.JSONDecodeError as exc:
+        raise TodoError(f"todo backend config {path} is not valid JSON: {exc}") from exc
+    if not isinstance(data, dict):
+        raise TodoError(f"todo backend config {path} must be a JSON object")
+    # Reject accidental credential commits loudly (never load or echo them).
+    for forbidden in ("auth_token", "token", "TODO_DB_AUTH_TOKEN"):
+        if forbidden in data:
+            raise TodoError(
+                f"todo backend config {path} must not contain credentials "
+                f"(found key {forbidden!r}); URL only, token via TODO_DB_AUTH_TOKEN"
+            )
+    raw = data.get("url")
+    if raw is None:
+        return None
+    if not isinstance(raw, str) or not raw.strip():
+        raise TodoError(f"todo backend config {path}: 'url' must be a non-empty string")
+    url = _normalize_url(raw)
+    if not _is_hosted_url(url):
+        raise TodoError(
+            f"todo backend config {path}: 'url' must be a libsql:// or https:// hosted URL, got {url!r}"
+        )
+    return _require_secure_url(url)
+
+
 def _try_turso_auto_provision() -> tuple[tuple[str, str] | None, str | None]:
     """Mint a short-lived hosted backend via the maintainer's logged-in turso CLI.
 
-    Only called from `_resolve_backend` when no explicit backend is configured
-    at all (--db absent, TODO_DB_PATH unset, TODO_DB_URL unset) -- this is the
-    sanctioned local pattern documented in
-    _project/specs/todo-db-tracker.md ("Local auth provisioning"): mint a URL
-    with `turso db show <name> --url` and a token with
-    `turso db tokens create <name> --expiration 1d` (Turso CLI accepts
+    Only called from `_resolve_backend` when no backend URL/path is configured
+    at all (--db absent, TODO_DB_PATH unset, TODO_DB_URL unset, no
+    `.todo-db/config.json` URL) -- this is the sanctioned local pattern
+    documented in _project/specs/todo-db-tracker.md ("Local auth
+    provisioning"): mint a URL with `turso db show <name> --url` and a token
+    with `turso db tokens create <name> --expiration 1d` (Turso CLI accepts
     day-granularity expirations or ``never``; sub-day values like ``30m``
     are rejected).
 
@@ -593,15 +647,19 @@ def _try_turso_auto_provision() -> tuple[tuple[str, str] | None, str | None]:
 def _resolve_backend(explicit: str | None) -> tuple[Path | str, bool, bool, str | None]:
     """Return ``(backend, implicit_default_local, auto_provisioned, provision_failure)``.
 
-    CLI precedence: --db > TODO_DB_PATH > TODO_DB_URL > turso auto-provisioning
-    > local fallback. Auto-provisioning is attempted ONLY when none of the
-    three explicit knobs are set, so explicit config always outranks it and
-    hermetic tests pinning TODO_DB_PATH never invoke it.
+    CLI precedence: --db > TODO_DB_PATH > TODO_DB_URL > ``.todo-db/config.json``
+    URL discovery > turso auto-provisioning > local fallback.
+
+    Config-discovered and env URLs are "selected" backends (not
+    ``implicit_default_local``), so mutating commands proceed to connect and
+    fail on missing auth rather than the implicit-local write refusal.
+    Auto-provisioning runs ONLY when no path/URL was selected by any earlier
+    step, so hermetic tests pinning TODO_DB_PATH never invoke it.
 
     ``provision_failure`` is a short reason class when turso was on PATH but
     minting failed (so the operator gets a distinct WARN instead of silent
     fallthrough); it is ``None`` when auto-provision was skipped, succeeded,
-    or never considered (explicit backend).
+    or never considered (explicit backend or config URL).
     """
     if explicit:
         return (
@@ -616,6 +674,13 @@ def _resolve_backend(explicit: str | None) -> tuple[Path | str, bool, bool, str 
     env_url = os.environ.get("TODO_DB_URL")
     if env_url:
         return _normalize_url(env_url), False, False, None
+    config_url = _load_config_url()
+    if config_url:
+        # Selected hosted backend (same class as TODO_DB_URL). Token still
+        # comes from TODO_DB_AUTH_TOKEN; missing token surfaces through the
+        # existing connect/auth failure paths. Do not auto-mint here --
+        # full auto-provision (URL+token) only runs when no URL is known.
+        return config_url, False, False, None
     provisioned, provision_failure = _try_turso_auto_provision()
     if provisioned:
         url, token = provisioned
@@ -630,7 +695,7 @@ def _resolve_backend(explicit: str | None) -> tuple[Path | str, bool, bool, str 
 
 
 def resolve_backend(explicit: str | None) -> Path | str:
-    """Pick the backend: --db > TODO_DB_PATH > TODO_DB_URL > auto-provision > local fallback."""
+    """Pick the backend: --db > TODO_DB_PATH > TODO_DB_URL > config.json > auto-provision > local fallback."""
     return _resolve_backend(explicit)[0]
 
 
@@ -1428,7 +1493,8 @@ def _report_backend(
         if implicit_default_local:
             print(
                 "WARNING: LOCAL FALLBACK DB - NOT the production tracker; "
-                "set --db, TODO_DB_PATH, or TODO_DB_URL explicitly.",
+                "set --db, TODO_DB_PATH, or TODO_DB_URL, ensure "
+                ".todo-db/config.json is present, or log in with `turso auth login`.",
                 file=sys.stderr,
             )
             if provision_failure:
@@ -1550,7 +1616,7 @@ def run_doctor(
             (
                 "WARN",
                 "implicit local fallback -- NOT the production tracker; "
-                "set --db, TODO_DB_PATH, or TODO_DB_URL",
+                "set --db, TODO_DB_PATH, TODO_DB_URL, or .todo-db/config.json",
             )
             if implicit_default_local
             else ("OK", "backend selected explicitly")
@@ -1683,8 +1749,9 @@ def _preconnect_command(
         print(
             "error: refusing to write through the implicit local fallback"
             f"{provision_note}; "
-            "select a backend with --db, TODO_DB_PATH, or TODO_DB_URL, or log in with "
-            "`turso auth login` so this can auto-provision a hosted backend",
+            "select a backend with --db, TODO_DB_PATH, TODO_DB_URL, or "
+            ".todo-db/config.json, or log in with `turso auth login` so this "
+            "can auto-provision a hosted backend",
             file=sys.stderr,
         )
         return 2
@@ -4188,7 +4255,7 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument(
         "--db",
         help="database path, or libsql://... / https://... URL for the hosted backend"
-        " (default: <git main root>/.todo-db/todo.sqlite, or TODO_DB_URL when set)",
+        " (default: TODO_DB_PATH / TODO_DB_URL / .todo-db/config.json / auto-provision / local)",
     )
     parser.add_argument("--actor", help="override actor identity for the audit log")
     sub = parser.add_subparsers(dest="command", required=True)
@@ -4416,7 +4483,12 @@ def main(argv: list[str] | None = None) -> int:
             print(f"error: {exc}", file=sys.stderr)
             return 2
 
-    backend, implicit_default_local, auto_provisioned, provision_failure = _resolve_backend(args.db)
+    try:
+        backend, implicit_default_local, auto_provisioned, provision_failure = _resolve_backend(args.db)
+    except TodoError as exc:
+        # Corrupt/credential-bearing config.json and similar resolution errors.
+        print(f"error: {exc}", file=sys.stderr)
+        return 2
     _report_backend(
         backend,
         implicit_default_local=implicit_default_local,

--- a/_project/specs/todo-db-tracker.md
+++ b/_project/specs/todo-db-tracker.md
@@ -345,10 +345,12 @@ To evaluate the design without provisioning a hosted service, the full G2
 scope was built as a spike against a **local SQLite file**:
 `_project/scripts/todo_db.py` (schema v1 + complete CLI) with
 `tests/unit/scripts/test_todo_db.py` (41 tests covering every enforced
-invariant). Database path: `<git root>/.todo-db/todo.sqlite` (gitignored);
-override with `--db` / `TODO_DB_PATH`. The implicit path is visibly a local
-fallback: reads emit an unmistakable stderr warning, while writes exit 2 until
-the operator explicitly selects `--db`, `TODO_DB_PATH`, or `TODO_DB_URL`.
+invariant). Database path: `<git root>/.todo-db/todo.sqlite` (gitignored operational
+state under `.todo-db/*`; credential-free `.todo-db/config.json` is tracked);
+override with `--db` / `TODO_DB_PATH` / `TODO_DB_URL` / config URL. The
+implicit path is visibly a local fallback: reads emit an unmistakable stderr
+warning, while writes exit 2 until a backend is selected (`--db`,
+`TODO_DB_PATH`, `TODO_DB_URL`, config discovery, or turso auto-provision).
 `init` remains available for fresh-clone bootstrap. Every invocation reports
 `local (<path>)` or `hosted` on stderr; hosted URLs and tokens are never
 printed.
@@ -562,9 +564,14 @@ With G1 closed, `connect()` grew a second mode (PR #1219; hardened in
 PR #1222). Backend
 selection, first match wins: `--db` (a `libsql://`/`https://` value selects
 hosted) → `TODO_DB_PATH` (local file) → `TODO_DB_URL` (hosted; requires
-`TODO_DB_AUTH_TOKEN`) → default local path. `TODO_DB_PATH` deliberately
-outranks `TODO_DB_URL` so a test or tool that pins a local file can never be
-silently redirected at the shared database.
+`TODO_DB_AUTH_TOKEN`) → `.todo-db/config.json` URL discovery (credential-free
+hosted URL only; see "Session binding & token minting" below) → turso
+auto-provision (URL+token mint when a logged-in CLI is available) → default
+local path. `TODO_DB_PATH` deliberately outranks `TODO_DB_URL` so a test or
+tool that pins a local file can never be silently redirected at the shared
+database. A config-discovered URL is a *selected* hosted backend (not the
+implicit local fallback): mutating commands proceed to connect and surface
+auth failures rather than the implicit-local write refusal.
 
 The default-local final branch is a diagnostic/bootstrap seam, not a silent
 production substitute. Implicit reads remain available with a loud
@@ -572,6 +579,42 @@ production substitute. Implicit reads remain available with a loud
 writes fail before opening the database. Explicit local pins are warning-free,
 and hosted invocations identify only the backend kind so the DSN remains
 secret. `init` and non-mutating dry-runs are the deliberate exceptions.
+
+### Session binding & token minting
+
+Clones discover the production tracker without embedding secrets:
+
+1. **URL (non-secret, tracked).** `<git main root>/.todo-db/config.json`
+   holds only `{"url": "libsql://..."}`. The file is deliberately *not*
+   gitignored (see `.gitignore`: `.todo-db/*` with `!.todo-db/config.json`);
+   local DBs and the per-worktree `replica.db` remain ignored. Never put
+   tokens, cookies, or other credentials in this file — the loader refuses
+   known credential keys.
+2. **Token (secret, session-scoped).** Auth remains
+   `TODO_DB_AUTH_TOKEN` in the process environment. Mint a short-lived token
+   from a logged-in maintainer shell:
+
+   ```bash
+   turso auth login   # once per machine / when the CLI session expires
+   export TODO_DB_AUTH_TOKEN=$(turso db tokens create benchbox-todo --expiration 1d)
+   ```
+
+   Turso CLI accepts day-granularity expirations or `never`; sub-day values
+   like `30m` are rejected. Prefer 1d session tokens over long-lived ones.
+3. **Auto-provision (no config, no env).** When no `--db` / `TODO_DB_PATH` /
+   `TODO_DB_URL` / config URL is set and `turso` is on PATH and logged in,
+   `_try_turso_auto_provision` mints both URL and a 1d token in-process
+   (never written to disk or printed) and selects the hosted backend as
+   auto-provisioned. This is the zero-config path for a logged-in operator
+   on a machine that has not yet pulled `config.json`.
+4. **Precedence reminder.** Config supplies the URL the way `TODO_DB_URL`
+   would; it does **not** mint a token. A selected hosted backend with a
+   missing token fails at connect / `doctor` auth (exit 4), never by silently
+   writing to a local scratch DB.
+
+Credentials never land in the repo, in stderr backend banners, or in
+`doctor` output. Hosted reports only `todo backend: hosted` (or
+`hosted (auto-provisioned via turso CLI)`).
 
 Hosted mode uses the `libsql` Python client (0.1.11) with a **per-worktree
 embedded replica** at `<git root>/.todo-db/replica.db` (override:
@@ -833,20 +876,24 @@ TODO tree from an untrusted source would plant shell commands; do not.
     (`turso db tokens create benchbox-todo`), never stored or echoed.
     **Local auto-provisioning now exists** (`_project/scripts/todo_db.py`,
     `_resolve_backend`/`_try_turso_auto_provision`): when none of --db,
-    `TODO_DB_PATH`, or `TODO_DB_URL` is set, the CLI shells out to the
-    logged-in `turso` CLI itself (`turso db show <name> --url` +
-    `turso db tokens create <name> --expiration 1d` (Turso CLI requires
-    day granularity or ``never``; sub-day values are rejected), db name from
-    `TODO_DB_TURSO_DB`, default `benchbox-todo`) and uses the hosted
-    backend transparently, falling back to the local implicit DB (with a
-    refusal-on-write pointing at `turso auth login` /
-    `TODO_DB_URL`+`TODO_DB_AUTH_TOKEN` / `--db`/`TODO_DB_PATH`) if turso is
-    absent, not logged in, or the mint fails. When turso is on PATH but mint
-    fails, a short reason class (`db-show-failed`, `token-create-failed`,
-    etc. — never stderr/URL/token) is surfaced via stderr WARN, the doctor
-    `turso-provision` check, and the write-refusal message, so the fallthrough
-    is not silent. This closes the former open provisioning item without
-    requiring the two variables in local `.env`.
+    `TODO_DB_PATH`, `TODO_DB_URL`, or a `.todo-db/config.json` URL is set,
+    the CLI shells out to the logged-in `turso` CLI itself
+    (`turso db show <name> --url` + `turso db tokens create <name>
+    --expiration 1d` (Turso CLI requires day granularity or ``never``;
+    sub-day values are rejected), db name from `TODO_DB_TURSO_DB`, default
+    `benchbox-todo`) and uses the hosted backend transparently, falling
+    back to the local implicit DB (with a refusal-on-write pointing at
+    `turso auth login` / `TODO_DB_URL`+`TODO_DB_AUTH_TOKEN` /
+    `--db`/`TODO_DB_PATH`/config) if turso is absent, not logged in, or the
+    mint fails. When turso is on PATH but mint fails, a short reason class
+    (`db-show-failed`, `token-create-failed`, etc. — never stderr/URL/token)
+    is surfaced via stderr WARN, the doctor `turso-provision` check, and the
+    write-refusal message, so the fallthrough is not silent. Tracked
+    credential-free config discovery (`.todo-db/config.json` with URL only)
+    is the clone-default path for selecting the production hosted URL;
+    session tokens still mint as above or via `TODO_DB_AUTH_TOKEN`. This
+    closes the former open provisioning item without requiring the two
+    variables in local `.env`.
 - **G2 — CLI MVP:** schema DDL + `create/show/claim/start/done/defer/
   promote/dismiss/complete/ready/list/stats/export` + tests. No repo changes
   to the YAML system yet.

--- a/tests/unit/scripts/test_todo_db.py
+++ b/tests/unit/scripts/test_todo_db.py
@@ -906,3 +906,134 @@ class TestCheckScopeReportsWhatItActuallyChecked:
         """--strict only affects the no-rules case."""
         _mk(conn, scope=[("only_modify", "benchbox/core/*")])
         assert self._run(conn, monkeypatch, "sample-item", ["benchbox/cli/x.py"], strict=True) == 1
+
+
+class TestConfigDiscovery:
+    """Credential-free `.todo-db/config.json` URL discovery (selected hosted)."""
+
+    _CONFIG_URL = "libsql://benchbox-todo-from-config.turso.io"
+
+    def _clear_backend_env(self, monkeypatch):
+        monkeypatch.delenv("TODO_DB_PATH", raising=False)
+        monkeypatch.delenv("TODO_DB_URL", raising=False)
+        monkeypatch.delenv("TODO_DB_AUTH_TOKEN", raising=False)
+
+    def _write_config(self, root: Path, payload: dict | str) -> Path:
+        cfg_dir = root / ".todo-db"
+        cfg_dir.mkdir(parents=True, exist_ok=True)
+        path = cfg_dir / "config.json"
+        if isinstance(payload, str):
+            path.write_text(payload, encoding="utf-8")
+        else:
+            path.write_text(json.dumps(payload), encoding="utf-8")
+        return path
+
+    def test_config_url_selects_hosted_not_implicit_local(self, monkeypatch, tmp_path):
+        self._clear_backend_env(monkeypatch)
+        monkeypatch.setattr(todo_db, "git_main_root", lambda: tmp_path)
+        self._write_config(tmp_path, {"url": self._CONFIG_URL})
+
+        backend, implicit_default_local, auto_provisioned, provision_failure = todo_db._resolve_backend(None)
+
+        assert backend == self._CONFIG_URL
+        assert implicit_default_local is False
+        assert auto_provisioned is False
+        assert provision_failure is None
+
+    def test_config_url_outranks_auto_provision(self, monkeypatch, tmp_path):
+        self._clear_backend_env(monkeypatch)
+        monkeypatch.setattr(todo_db, "git_main_root", lambda: tmp_path)
+        self._write_config(tmp_path, {"url": self._CONFIG_URL})
+
+        def boom(*_args, **_kwargs):
+            raise AssertionError("auto-provisioning must not run when config.json supplies a URL")
+
+        monkeypatch.setattr(todo_db, "_try_turso_auto_provision", boom)
+
+        backend, implicit, auto, provision_failure = todo_db._resolve_backend(None)
+        assert backend == self._CONFIG_URL
+        assert implicit is False
+        assert auto is False
+        assert provision_failure is None
+
+    def test_env_url_outranks_config(self, monkeypatch, tmp_path):
+        monkeypatch.delenv("TODO_DB_PATH", raising=False)
+        monkeypatch.setenv("TODO_DB_URL", "libsql://from-env.turso.io")
+        monkeypatch.setattr(todo_db, "git_main_root", lambda: tmp_path)
+        self._write_config(tmp_path, {"url": self._CONFIG_URL})
+
+        backend, implicit, auto, provision_failure = todo_db._resolve_backend(None)
+        assert backend == "libsql://from-env.turso.io"
+        assert implicit is False
+        assert auto is False
+        assert provision_failure is None
+
+    def test_env_path_outranks_config(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("TODO_DB_PATH", str(tmp_path / "pin.sqlite"))
+        monkeypatch.delenv("TODO_DB_URL", raising=False)
+        monkeypatch.setattr(todo_db, "git_main_root", lambda: tmp_path)
+        self._write_config(tmp_path, {"url": self._CONFIG_URL})
+
+        backend, implicit, auto, provision_failure = todo_db._resolve_backend(None)
+        assert backend == Path(tmp_path / "pin.sqlite")
+        assert implicit is False
+        assert auto is False
+        assert provision_failure is None
+
+    def test_missing_config_falls_through_to_local(self, monkeypatch, tmp_path):
+        self._clear_backend_env(monkeypatch)
+        monkeypatch.setattr(todo_db, "git_main_root", lambda: tmp_path)
+        monkeypatch.setattr(todo_db, "_try_turso_auto_provision", lambda: (None, None))
+
+        backend, implicit, auto, provision_failure = todo_db._resolve_backend(None)
+        assert backend == tmp_path / ".todo-db" / "todo.sqlite"
+        assert implicit is True
+        assert auto is False
+        assert provision_failure is None
+
+    def test_config_with_token_key_is_rejected(self, monkeypatch, tmp_path):
+        self._clear_backend_env(monkeypatch)
+        monkeypatch.setattr(todo_db, "git_main_root", lambda: tmp_path)
+        self._write_config(tmp_path, {"url": self._CONFIG_URL, "auth_token": "sekrit"})
+
+        with pytest.raises(todo_db.TodoError, match="must not contain credentials"):
+            todo_db._resolve_backend(None)
+
+    def test_config_http_url_is_rejected(self, monkeypatch, tmp_path):
+        self._clear_backend_env(monkeypatch)
+        monkeypatch.setattr(todo_db, "git_main_root", lambda: tmp_path)
+        self._write_config(tmp_path, {"url": "http://insecure.example/db"})
+
+        with pytest.raises(todo_db.TodoError, match="plaintext http"):
+            todo_db._resolve_backend(None)
+
+    def test_report_backend_never_echoes_config_url(self, monkeypatch, tmp_path, capsys):
+        self._clear_backend_env(monkeypatch)
+        monkeypatch.setattr(todo_db, "git_main_root", lambda: tmp_path)
+        self._write_config(tmp_path, {"url": self._CONFIG_URL})
+
+        backend, implicit, auto, provision_failure = todo_db._resolve_backend(None)
+        todo_db._report_backend(
+            backend,
+            implicit_default_local=implicit,
+            auto_provisioned=auto,
+            provision_failure=provision_failure,
+        )
+        err = capsys.readouterr().err
+        assert "todo backend: hosted" in err
+        assert self._CONFIG_URL not in err
+        assert "LOCAL FALLBACK" not in err
+
+    def test_mutating_via_config_is_not_implicit_local_refusal(self, monkeypatch, tmp_path, capsys):
+        """Config-selected hosted must reach connect/auth, not the local write fence."""
+        self._clear_backend_env(monkeypatch)
+        monkeypatch.setattr(todo_db, "git_main_root", lambda: tmp_path)
+        self._write_config(tmp_path, {"url": self._CONFIG_URL})
+
+        rc = todo_db.main(["claim", "missing-item"])
+        err = capsys.readouterr().err
+        assert rc == 2
+        assert "refusing to write through the implicit local fallback" not in err
+        # Missing token is the expected hard-error path for a selected hosted backend.
+        assert "TODO_DB_AUTH_TOKEN" in err
+        assert self._CONFIG_URL not in err

--- a/tests/unit/scripts/test_todo_db_doctor.py
+++ b/tests/unit/scripts/test_todo_db_doctor.py
@@ -229,3 +229,46 @@ def test_implicit_local_fallback_is_warned_not_failed(monkeypatch, tmp_path, cap
     monkeypatch.setattr(todo_db, "_resolve_backend", lambda _explicit: (db, True, False, None))
     assert todo_db.main(["doctor"]) == todo_db.DOCTOR_EXIT_OK
     assert "WARN identity" in capsys.readouterr().out
+
+
+def test_config_discovered_url_is_selected_not_implicit(monkeypatch, tmp_path, capsys):
+    """Tracked config.json selects hosted; doctor treats it as explicit identity."""
+    monkeypatch.delenv("TODO_DB_PATH", raising=False)
+    monkeypatch.delenv("TODO_DB_URL", raising=False)
+    monkeypatch.delenv("TODO_DB_AUTH_TOKEN", raising=False)
+    monkeypatch.setattr(todo_db, "git_main_root", lambda: tmp_path)
+    cfg = tmp_path / ".todo-db"
+    cfg.mkdir()
+    (cfg / "config.json").write_text(json.dumps({"url": _HOSTED_URL}), encoding="utf-8")
+
+    rc = todo_db.main(["doctor"])
+    captured = capsys.readouterr()
+    combined = captured.out + captured.err
+
+    assert rc == todo_db.DOCTOR_EXIT_AUTH  # hosted selected, token missing
+    assert "WARN identity" not in captured.out
+    assert "backend selected explicitly" in captured.out or "OK   identity" in captured.out
+    assert "TODO_DB_AUTH_TOKEN is not set" in captured.out
+    assert _HOSTED_URL not in combined
+    assert _SECRET not in combined
+
+
+def test_doctor_config_path_never_leaks_url_on_connect_failure(monkeypatch, tmp_path, capsys):
+    monkeypatch.delenv("TODO_DB_PATH", raising=False)
+    monkeypatch.delenv("TODO_DB_URL", raising=False)
+    monkeypatch.setenv("TODO_DB_AUTH_TOKEN", _SECRET)
+    monkeypatch.setattr(todo_db, "git_main_root", lambda: tmp_path)
+    cfg = tmp_path / ".todo-db"
+    cfg.mkdir()
+    (cfg / "config.json").write_text(json.dumps({"url": _HOSTED_URL}), encoding="utf-8")
+
+    def boom(*_args, **_kwargs):
+        raise RuntimeError(f"connect failed for {_HOSTED_URL} using {_SECRET}")
+
+    monkeypatch.setattr(todo_db, "connect_backend", boom)
+
+    rc = todo_db.main(["doctor"])
+    combined = "".join(capsys.readouterr())
+    assert rc in (todo_db.DOCTOR_EXIT_FAIL, todo_db.DOCTOR_EXIT_AUTH)
+    assert _HOSTED_URL not in combined
+    assert _SECRET not in combined

--- a/tests/unit/scripts/test_todo_db_hosted.py
+++ b/tests/unit/scripts/test_todo_db_hosted.py
@@ -234,10 +234,26 @@ class TestBackendResolution:
         assert todo_db.resolve_backend(HOSTED_URL) == HOSTED_URL
         assert todo_db.resolve_backend("https://example-db.turso.io") == ("https://example-db.turso.io")
 
-    def test_no_env_defaults_to_local_path(self, monkeypatch):
+    def test_no_env_defaults_to_local_path(self, monkeypatch, tmp_path):
         monkeypatch.delenv("TODO_DB_URL", raising=False)
         monkeypatch.delenv("TODO_DB_PATH", raising=False)
+        # Empty main root (no tracked config.json) so resolution reaches local fallback.
+        monkeypatch.setattr(todo_db, "git_main_root", lambda: tmp_path)
+        monkeypatch.setattr(todo_db, "_try_turso_auto_provision", lambda: (None, None))
         assert isinstance(todo_db.resolve_backend(None), Path)
+
+    def test_config_json_selects_hosted_without_env(self, monkeypatch, tmp_path):
+        monkeypatch.delenv("TODO_DB_URL", raising=False)
+        monkeypatch.delenv("TODO_DB_PATH", raising=False)
+        monkeypatch.setattr(todo_db, "git_main_root", lambda: tmp_path)
+        cfg = tmp_path / ".todo-db"
+        cfg.mkdir()
+        (cfg / "config.json").write_text(json.dumps({"url": HOSTED_URL}), encoding="utf-8")
+
+        backend, implicit, auto, provision_failure = todo_db._resolve_backend(None)
+        assert backend == HOSTED_URL
+        assert implicit is False
+        assert auto is False
 
     def test_implicit_local_read_is_loud_but_allowed(self, monkeypatch, tmp_path, capsys):
         monkeypatch.delenv("TODO_DB_URL", raising=False)

--- a/tests/unit/scripts/test_todo_db_turso_autoprovision.py
+++ b/tests/unit/scripts/test_todo_db_turso_autoprovision.py
@@ -1,11 +1,12 @@
 """Tests for turso auto-provisioning of the hosted backend.
 
 `_project/scripts/todo_db.py` resolves its backend with precedence
---db > TODO_DB_PATH > TODO_DB_URL > implicit local fallback. When none of the
-three explicit knobs are set, it now attempts to auto-provision a hosted
-backend via the maintainer's already-logged-in `turso` CLI before falling
-back to the local scratch database (see `_try_turso_auto_provision` and
-`_resolve_backend`). These tests pin:
+--db > TODO_DB_PATH > TODO_DB_URL > .todo-db/config.json > turso
+auto-provision > implicit local fallback. When none of the path/URL knobs
+(including credential-free config discovery) yield a backend, it attempts to
+auto-provision a hosted backend via the maintainer's already-logged-in
+`turso` CLI before falling back to the local scratch database (see
+`_try_turso_auto_provision` and `_resolve_backend`). These tests pin:
 
   - success mints a URL + token and selects the hosted backend transparently;
   - any failure (turso absent, mint failure) falls through to the existing
@@ -14,8 +15,11 @@ back to the local scratch database (see `_try_turso_auto_provision` and
   - when turso is on PATH but mint fails, a distinct provision_failure reason
     class is surfaced (WARN / doctor check / write-refusal) without secrets;
   - auto-provisioning is never attempted when an explicit backend
-    (--db/TODO_DB_PATH/TODO_DB_URL) is configured;
+    (--db/TODO_DB_PATH/TODO_DB_URL) or config.json URL is configured;
   - the minted token and URL are never printed, including through `doctor`.
+
+Hermetic note: success paths pin `git_main_root` to an empty tmp dir so a
+tracked repo `config.json` cannot short-circuit auto-provision.
 
 The repo-wide `conftest.py` autouse fixture forces `shutil.which("turso")` to
 report absent by default, so these tests must explicitly opt back in via
@@ -79,8 +83,10 @@ def _clear_backend_env(monkeypatch):
 
 
 class TestAutoProvisionSuccess:
-    def test_success_selects_hosted_backend_and_propagates_env(self, monkeypatch):
+    def test_success_selects_hosted_backend_and_propagates_env(self, monkeypatch, tmp_path):
         _clear_backend_env(monkeypatch)
+        # Empty main root: no config.json short-circuiting auto-provision.
+        monkeypatch.setattr(todo_db, "git_main_root", lambda: tmp_path)
         monkeypatch.setattr(todo_db.shutil, "which", lambda name: "/usr/bin/turso" if name == "turso" else None)
         fake_run, calls = _make_fake_turso_run()
         monkeypatch.setattr(todo_db.subprocess, "run", fake_run)
@@ -99,8 +105,9 @@ class TestAutoProvisionSuccess:
         assert ["turso", "db", "show", "benchbox-todo", "--url"] in calls
         assert ["turso", "db", "tokens", "create", "benchbox-todo", "--expiration", "1d"] in calls
 
-    def test_custom_db_name_from_env(self, monkeypatch):
+    def test_custom_db_name_from_env(self, monkeypatch, tmp_path):
         _clear_backend_env(monkeypatch)
+        monkeypatch.setattr(todo_db, "git_main_root", lambda: tmp_path)
         monkeypatch.setenv("TODO_DB_TURSO_DB", "my-custom-db")
         monkeypatch.setattr(todo_db.shutil, "which", lambda name: "/usr/bin/turso" if name == "turso" else None)
         fake_run, calls = _make_fake_turso_run(db_name="my-custom-db")
@@ -285,8 +292,9 @@ class TestAutoProvisionNeverInvokedWithExplicitBackend:
 
 
 class TestDoctorRedactsAutoProvisionedSecrets:
-    def test_doctor_never_prints_the_auto_provisioned_url_or_token(self, monkeypatch, capsys):
+    def test_doctor_never_prints_the_auto_provisioned_url_or_token(self, monkeypatch, tmp_path, capsys):
         _clear_backend_env(monkeypatch)
+        monkeypatch.setattr(todo_db, "git_main_root", lambda: tmp_path)
         monkeypatch.setattr(todo_db.shutil, "which", lambda name: "/usr/bin/turso" if name == "turso" else None)
         fake_run, _calls = _make_fake_turso_run()
         monkeypatch.setattr(todo_db.subprocess, "run", fake_run)
@@ -305,8 +313,9 @@ class TestDoctorRedactsAutoProvisionedSecrets:
         assert _URL not in combined
         assert "auto-provisioned" in combined
 
-    def test_doctor_json_never_prints_the_auto_provisioned_url_or_token(self, monkeypatch, capsys):
+    def test_doctor_json_never_prints_the_auto_provisioned_url_or_token(self, monkeypatch, tmp_path, capsys):
         _clear_backend_env(monkeypatch)
+        monkeypatch.setattr(todo_db, "git_main_root", lambda: tmp_path)
         monkeypatch.setattr(todo_db.shutil, "which", lambda name: "/usr/bin/turso" if name == "turso" else None)
         fake_run, _calls = _make_fake_turso_run()
         monkeypatch.setattr(todo_db.subprocess, "run", fake_run)


### PR DESCRIPTION
## Summary

Clones discover the production tracker URL from a tracked, credential-free `.todo-db/config.json` instead of silently writing to a local scratch DB.

- Precedence: `--db` > `TODO_DB_PATH` > `TODO_DB_URL` > **config.json** > turso auto-provision > local fallback
- Config is URL-only; token keys are rejected
- Mutating via config reaches hosted auth (not the implicit-local write fence)
- Stacked on mint-failure visibility for shared resolve path

Closes `todo-wrapper-silently-falls-back-to-local-database-20260805`.

## Test plan
- [x] Config discovery + doctor + autoprovision + hosted resolution tests (42 passed)
- [x] config.json not carrying tokens; DBs still gitignored
- [ ] CI green
