### PR TITLE
chore(skills): pin skill-sync-skills for wrapper update capability

### DIFF
--- a/.claude/skills/todo-db/SKILL.md
+++ b/.claude/skills/todo-db/SKILL.md
@@ -42,8 +42,8 @@ the alert. Auto-remint is only for todo-db >= 0.3 wrappers. Global `--db` /
 Banner is stderr-only and zero-suppressed, so stdout stays machine-readable.
 
 Standalone-only actions are declared in the skill sidecar as
-`standalone_only_commands` (currently none for this wrapper); rule 4 applies
-when a future verb is declared.
+`standalone_only_commands` (currently none for the BenchBox wrapper once it
+exposes `update`); rule 4 applies when a future verb is declared.
 
 ## Rules
 

--- a/.claude/skills/todo-db/references/prioritize.md
+++ b/.claude/skills/todo-db/references/prioritize.md
@@ -132,9 +132,9 @@ DB.
 Only when the user explicitly asks to apply the ranking (e.g. "write these
 priorities back", "update priorities to match"):
 
-1. Confirm the resolved command supports `update` (standalone todo-db
-   >= 0.3). If the project wrapper lacks it, report the capability gap per
-   SKILL.md rule 4 — do not drop+recreate to change priority.
+1. Confirm the resolved command supports `update` (`todo update --help`
+   exits 0). If it does not, report the capability gap — do not drop+recreate
+   to change priority.
 2. Update only items whose recommended band differs from stored priority.
 3. Record a one-line reason per update. Prefer band moves
    (`medium` → `high`) over inventing fractional ranks the schema cannot

--- a/.claude/skills/todo-db/references/queries.md
+++ b/.claude/skills/todo-db/references/queries.md
@@ -3,16 +3,14 @@
 - Create: `todo create --title ... --worktree ... --priority ...`, or
   `--from -` with JSON. Code items need scope, must-preserve, anti-pattern,
   and verification guardrails.
-- Update — standalone-only (todo-db >= 0.3.0; legacy project wrappers do not
-  implement it, so SKILL.md rule 4 applies — report the gap and stop rather
-  than invoking the wrapper): `todo update <id>` corrects items after
-  creation — `--title/--description/--priority/--worktree`, `--add-work`,
-  `--edit-work` (pending units only; done units carry evidence and are
-  immutable), `--add-verify`, `--drop-verify SEQ --reason ...`. Every update
-  is one chained audit event with from/to diffs; edits to done/dropped items
-  require `--reason`. Id, state, and identity are immutable — state moves
-  only through lifecycle verbs. Prefer `update` over drop-and-recreate: it
-  preserves history and links.
+- Update: `todo update <id>` corrects items after creation —
+  `--title/--description/--priority/--worktree`, `--add-work`, `--edit-work`
+  (pending units only; done units carry evidence and are immutable),
+  `--add-verify`, `--drop-verify SEQ --reason ...`. Every update is one chained
+  audit event with from/to diffs; edits to done/dropped items require
+  `--reason`. Id, state, and identity are immutable — state moves only through
+  lifecycle verbs. Prefer `update` over drop-and-recreate: it preserves history
+  and links. (Exposed on the BenchBox project wrapper; not standalone-only.)
 - Inspect: `todo list [filters]`, `todo show <id> [--json]`, `todo stats`,
   `todo deps <id>`, and `todo export`.
 - Rank / group open work (skill-only, read-only by default): follow

--- a/skill-sync.lock
+++ b/skill-sync.lock
@@ -1,16 +1,16 @@
 {
   "version": 1,
-  "lockedAt": "2026-08-05T21:03:55.418Z",
+  "lockedAt": "2026-08-05T23:53:01.556Z",
   "skills": {
     "blog": {
       "source": {
         "type": "git",
         "name": "canonical",
         "url": "https://github.com/joeharris76/skill-sync-skills.git",
-        "ref": "88844f58c45bee86c095fb5d8314635fba3a6398",
+        "ref": "76ef27b0e5567e14e130b60251c9e03f8fbefbdf",
         "subdir": "skills",
-        "revision": "88844f58c45bee86c095fb5d8314635fba3a6398",
-        "fetchedAt": "2026-08-05T21:03:48.646Z"
+        "revision": "76ef27b0e5567e14e130b60251c9e03f8fbefbdf",
+        "fetchedAt": "2026-08-05T23:52:45.752Z"
       },
       "installMode": "mirror",
       "files": {
@@ -61,10 +61,10 @@
         "type": "git",
         "name": "canonical",
         "url": "https://github.com/joeharris76/skill-sync-skills.git",
-        "ref": "88844f58c45bee86c095fb5d8314635fba3a6398",
+        "ref": "76ef27b0e5567e14e130b60251c9e03f8fbefbdf",
         "subdir": "skills",
-        "revision": "88844f58c45bee86c095fb5d8314635fba3a6398",
-        "fetchedAt": "2026-08-05T21:03:49.259Z"
+        "revision": "76ef27b0e5567e14e130b60251c9e03f8fbefbdf",
+        "fetchedAt": "2026-08-05T23:52:46.466Z"
       },
       "installMode": "mirror",
       "files": {
@@ -111,10 +111,10 @@
         "type": "git",
         "name": "canonical",
         "url": "https://github.com/joeharris76/skill-sync-skills.git",
-        "ref": "88844f58c45bee86c095fb5d8314635fba3a6398",
+        "ref": "76ef27b0e5567e14e130b60251c9e03f8fbefbdf",
         "subdir": "skills",
-        "revision": "88844f58c45bee86c095fb5d8314635fba3a6398",
-        "fetchedAt": "2026-08-05T21:03:49.902Z"
+        "revision": "76ef27b0e5567e14e130b60251c9e03f8fbefbdf",
+        "fetchedAt": "2026-08-05T23:52:47.121Z"
       },
       "installMode": "mirror",
       "files": {
@@ -157,10 +157,10 @@
         "type": "git",
         "name": "canonical",
         "url": "https://github.com/joeharris76/skill-sync-skills.git",
-        "ref": "88844f58c45bee86c095fb5d8314635fba3a6398",
+        "ref": "76ef27b0e5567e14e130b60251c9e03f8fbefbdf",
         "subdir": "skills",
-        "revision": "88844f58c45bee86c095fb5d8314635fba3a6398",
-        "fetchedAt": "2026-08-05T21:03:51.128Z"
+        "revision": "76ef27b0e5567e14e130b60251c9e03f8fbefbdf",
+        "fetchedAt": "2026-08-05T23:52:49.366Z"
       },
       "installMode": "mirror",
       "files": {
@@ -187,10 +187,10 @@
         "type": "git",
         "name": "canonical",
         "url": "https://github.com/joeharris76/skill-sync-skills.git",
-        "ref": "88844f58c45bee86c095fb5d8314635fba3a6398",
+        "ref": "76ef27b0e5567e14e130b60251c9e03f8fbefbdf",
         "subdir": "skills",
-        "revision": "88844f58c45bee86c095fb5d8314635fba3a6398",
-        "fetchedAt": "2026-08-05T21:03:52.320Z"
+        "revision": "76ef27b0e5567e14e130b60251c9e03f8fbefbdf",
+        "fetchedAt": "2026-08-05T23:52:51.891Z"
       },
       "installMode": "mirror",
       "files": {
@@ -245,10 +245,10 @@
         "type": "git",
         "name": "canonical",
         "url": "https://github.com/joeharris76/skill-sync-skills.git",
-        "ref": "88844f58c45bee86c095fb5d8314635fba3a6398",
+        "ref": "76ef27b0e5567e14e130b60251c9e03f8fbefbdf",
         "subdir": "skills",
-        "revision": "88844f58c45bee86c095fb5d8314635fba3a6398",
-        "fetchedAt": "2026-08-05T21:03:55.356Z"
+        "revision": "76ef27b0e5567e14e130b60251c9e03f8fbefbdf",
+        "fetchedAt": "2026-08-05T23:52:57.464Z"
       },
       "installMode": "mirror",
       "files": {
@@ -279,10 +279,10 @@
         "type": "git",
         "name": "canonical",
         "url": "https://github.com/joeharris76/skill-sync-skills.git",
-        "ref": "88844f58c45bee86c095fb5d8314635fba3a6398",
+        "ref": "76ef27b0e5567e14e130b60251c9e03f8fbefbdf",
         "subdir": "skills",
-        "revision": "88844f58c45bee86c095fb5d8314635fba3a6398",
-        "fetchedAt": "2026-08-05T21:03:54.725Z"
+        "revision": "76ef27b0e5567e14e130b60251c9e03f8fbefbdf",
+        "fetchedAt": "2026-08-05T23:52:56.498Z"
       },
       "installMode": "mirror",
       "files": {
@@ -305,10 +305,10 @@
         "type": "git",
         "name": "canonical",
         "url": "https://github.com/joeharris76/skill-sync-skills.git",
-        "ref": "88844f58c45bee86c095fb5d8314635fba3a6398",
+        "ref": "76ef27b0e5567e14e130b60251c9e03f8fbefbdf",
         "subdir": "skills",
-        "revision": "88844f58c45bee86c095fb5d8314635fba3a6398",
-        "fetchedAt": "2026-08-05T21:03:52.923Z"
+        "revision": "76ef27b0e5567e14e130b60251c9e03f8fbefbdf",
+        "fetchedAt": "2026-08-05T23:52:52.965Z"
       },
       "installMode": "mirror",
       "files": {
@@ -327,10 +327,10 @@
         "type": "git",
         "name": "canonical",
         "url": "https://github.com/joeharris76/skill-sync-skills.git",
-        "ref": "88844f58c45bee86c095fb5d8314635fba3a6398",
+        "ref": "76ef27b0e5567e14e130b60251c9e03f8fbefbdf",
         "subdir": "skills",
-        "revision": "88844f58c45bee86c095fb5d8314635fba3a6398",
-        "fetchedAt": "2026-08-05T21:03:51.734Z"
+        "revision": "76ef27b0e5567e14e130b60251c9e03f8fbefbdf",
+        "fetchedAt": "2026-08-05T23:52:50.534Z"
       },
       "installMode": "mirror",
       "files": {
@@ -347,24 +347,24 @@
           "size": 1777
         },
         "references/prioritize.md": {
-          "sha256": "3b12c55ceea10db384887ee1378d8ec3e0f5344f02f7d577a0f668fe537d7a53",
-          "size": 7014
+          "sha256": "8924375eb6ff92dbbefc94473bd7df0e4246c0608bbf8abd2961508f01cd94f7",
+          "size": 6980
         },
         "references/queries.md": {
-          "sha256": "b98ffc1201fa9cd82f3047f4799cdc85d7116a74527c0bef26de6c6ceb9c5702",
-          "size": 1332
+          "sha256": "cc115cd912588f0c719c9a841b10174a2904375287ce3887edbb0a3b3346e7c2",
+          "size": 1219
         },
         "references/review.md": {
           "sha256": "716b75c1d896f01219d0d10a00192732d61f471d7f1ea5cbdb837f0a22339013",
           "size": 318
         },
         "SKILL.md": {
-          "sha256": "77c5283bc70577c1b6aa858cf177bc74119c589b5424ae71325441b9bc3f114c",
-          "size": 3118
+          "sha256": "6a90a828bbc122d9bcd4e39feccc90d0d5adef48ee02e18eaac8b0d2f952b9d6",
+          "size": 3169
         },
         "skill.yaml": {
-          "sha256": "e17f6df4c3c3e20399dca7b80f2b0be290cc1f921721f680d44c5a309ae5f7d0",
-          "size": 444
+          "sha256": "dabb671a004d7be8e23058695385b853508416ac7b4e2a66ffaeaffd74a64519",
+          "size": 427
         }
       }
     },
@@ -373,10 +373,10 @@
         "type": "git",
         "name": "canonical",
         "url": "https://github.com/joeharris76/skill-sync-skills.git",
-        "ref": "88844f58c45bee86c095fb5d8314635fba3a6398",
+        "ref": "76ef27b0e5567e14e130b60251c9e03f8fbefbdf",
         "subdir": "skills",
-        "revision": "88844f58c45bee86c095fb5d8314635fba3a6398",
-        "fetchedAt": "2026-08-05T21:03:50.523Z"
+        "revision": "76ef27b0e5567e14e130b60251c9e03f8fbefbdf",
+        "fetchedAt": "2026-08-05T23:52:47.964Z"
       },
       "installMode": "mirror",
       "files": {
@@ -415,10 +415,10 @@
         "type": "git",
         "name": "canonical",
         "url": "https://github.com/joeharris76/skill-sync-skills.git",
-        "ref": "88844f58c45bee86c095fb5d8314635fba3a6398",
+        "ref": "76ef27b0e5567e14e130b60251c9e03f8fbefbdf",
         "subdir": "skills",
-        "revision": "88844f58c45bee86c095fb5d8314635fba3a6398",
-        "fetchedAt": "2026-08-05T21:03:53.530Z"
+        "revision": "76ef27b0e5567e14e130b60251c9e03f8fbefbdf",
+        "fetchedAt": "2026-08-05T23:52:54.155Z"
       },
       "installMode": "mirror",
       "files": {
@@ -437,10 +437,10 @@
         "type": "git",
         "name": "canonical",
         "url": "https://github.com/joeharris76/skill-sync-skills.git",
-        "ref": "88844f58c45bee86c095fb5d8314635fba3a6398",
+        "ref": "76ef27b0e5567e14e130b60251c9e03f8fbefbdf",
         "subdir": "skills",
-        "revision": "88844f58c45bee86c095fb5d8314635fba3a6398",
-        "fetchedAt": "2026-08-05T21:03:54.125Z"
+        "revision": "76ef27b0e5567e14e130b60251c9e03f8fbefbdf",
+        "fetchedAt": "2026-08-05T23:52:55.375Z"
       },
       "installMode": "mirror",
       "files": {

--- a/skill-sync.yaml
+++ b/skill-sync.yaml
@@ -3,7 +3,7 @@ sources:
   - name: canonical
     type: git
     url: https://github.com/joeharris76/skill-sync-skills.git
-    ref: 88844f58c45bee86c095fb5d8314635fba3a6398
+    ref: 76ef27b0e5567e14e130b60251c9e03f8fbefbdf
     subdir: skills
 skills:
   - blog


### PR DESCRIPTION
## Summary

Completes `wrapper-update-verb-capability-declaration-handoff`:

1. Canonical skill-sync-skills already merged (`76ef27b0`) dropping `update` from `standalone_only_commands` and fixing skill prose/references
2. This PR bumps `skill-sync.yaml` / `skill-sync.lock` to that revision and resyncs mirrors

Mirror-only half of this work was already on develop via #1581; the pin closes the re-break path.

## Test plan
- [x] `.claude/skills/todo-db/skill.yaml` has `standalone_only_commands: {}`
- [x] skill-sync force sync from new pin succeeds
- [ ] CI green
