### PR TITLE
fix(corpus): union-overlay mirror preserves published-only submissions

### DIFF
--- a/.github/workflows/corpus-drift-check.yml
+++ b/.github/workflows/corpus-drift-check.yml
@@ -22,10 +22,13 @@ name: Corpus Drift Check
 #
 # Direction matters. A two-way `git diff published develop` also surfaces
 # published-only paths (community submissions that landed on published-results
-# and have not been back-ported to develop). Recommending a full mirror for
-# those paths would *delete* public content. This canary therefore classifies:
-#   - develop-ahead / content-changed: fail + recommend mirror (leak class)
-#   - published-only: report as info, never recommend a destructive mirror
+# and have not been back-ported to develop). Recommending a wipe-based full
+# mirror for those paths would *delete* public content. This canary classifies:
+#   - develop-ahead / content-changed alone: fail + recommend overlay mirror
+#   - published-only alone: report as info, never recommend a destructive mirror
+#   - mixed (develop-ahead AND published-only): fail for the stale paths, but
+#     never recommend a wipe-based full mirror; point at the union-overlay sync
+#     that preserves published-only community submissions
 
 on:
   schedule:
@@ -112,11 +115,30 @@ jobs:
           echo "::error::published-results corpus is ${COUNT} path(s) behind develop (develop-ahead or content-changed)."
           echo "The public corpus is stale. If develop has since sanitized or"
           echo "corrected bundles, the public branch is still serving the old"
-          echo "content. Mirror it with:"
-          echo "  gh workflow run sync-results-data-to-published.yml --ref develop"
+          echo "content."
           echo ""
           echo "Develop-ahead / content-changed paths (first 40):"
           printf '%s\n' "${STALE_PATHS}" | head -40
+          echo ""
+          if [[ -n "${PUBLISHED_ONLY}" ]]; then
+            # Mixed drift: develop is ahead AND published has community-only
+            # paths. Never recommend a wipe-based full mirror of
+            # results-data/bundles — that deletes public content. The sync
+            # workflow applies a union overlay (checkout develop's files
+            # without git-rm of the tree) so published-only paths survive.
+            echo "Published-only paths also exist (see notice above)."
+            echo "Develop-ahead can be mirrored with the union-overlay sync that"
+            echo "overwrites develop's files under results-data/bundles without"
+            echo "deleting published-only community submissions."
+            echo "Do NOT use a wipe-based full mirror (git rm -rf results-data/bundles)"
+            echo "while published-only paths exist — that would delete public content."
+            echo "Run the non-destructive overlay mirror:"
+            echo "  gh workflow run sync-results-data-to-published.yml --ref develop"
+          else
+            echo "Mirror develop-ahead onto published-results (union overlay for"
+            echo "results-data/bundles; no wipe of published-only content):"
+            echo "  gh workflow run sync-results-data-to-published.yml --ref develop"
+          fi
           exit 1
 
       - name: Install uv for the published-tip privacy scan

--- a/.github/workflows/sync-results-data-to-published.yml
+++ b/.github/workflows/sync-results-data-to-published.yml
@@ -268,8 +268,9 @@ jobs:
           done
 
           # Derive inventory from the unioned tree (published-only + develop).
+          # Same uv/--no-project/--python 3.11 contract as the validate step.
           if [[ -d "${BUNDLES_DIR}" ]]; then
-            python3 scripts/generate_corpus_inventory.py --write
+            uv run --no-project --python 3.11 -- python scripts/generate_corpus_inventory.py --write
             git add results-data/corpus-inventory.json
           fi
 

--- a/.github/workflows/sync-results-data-to-published.yml
+++ b/.github/workflows/sync-results-data-to-published.yml
@@ -234,8 +234,11 @@ jobs:
           SOURCE_REF="${GITHUB_SHA}"
           # Directory trees that must union-overlay (never wipe).
           BUNDLES_DIR='results-data/bundles'
+          # corpus-inventory.json is NOT blind-overlaid from develop: after a
+          # union overlay the tree may still hold published-only community
+          # bundles that develop's inventory does not list. Regenerate from the
+          # post-overlay tree so validate --check can pass under mixed drift.
           FILE_PATHS=(
-            'results-data/corpus-inventory.json'
             'results-data/CORPUS_NOTES.md'
             'results-data/SEED_CORPUS_SPEC.md'
             'results-data/README.md'
@@ -263,6 +266,12 @@ jobs:
               git rm -f --quiet "${path}" 2>/dev/null || true
             fi
           done
+
+          # Derive inventory from the unioned tree (published-only + develop).
+          if [[ -d "${BUNDLES_DIR}" ]]; then
+            python3 scripts/generate_corpus_inventory.py --write
+            git add results-data/corpus-inventory.json
+          fi
 
           if git diff --staged --quiet && git diff --quiet; then
             echo "After applying develop content, mirror branch matches"

--- a/.github/workflows/sync-results-data-to-published.yml
+++ b/.github/workflows/sync-results-data-to-published.yml
@@ -216,14 +216,24 @@ jobs:
           # Start from current published-results
           git switch --force-create "${MIRROR_BRANCH}" origin/published-results
 
-          # Apply the triggering commit's content for each mirrored path. For directory
-          # paths, wipe the existing tree first so develop-side deletions
-          # within the directory propagate (otherwise `git checkout` only
-          # writes paths present on the source commit and leaves stragglers behind).
+          # Apply the triggering commit's content for each mirrored path.
+          #
+          # results-data/bundles uses a **union overlay**, not a wipe:
+          # community submissions can land on published-results only (they
+          # target that branch, not develop). A prior wipe (`git rm -rf
+          # results-data/bundles` then checkout develop) deleted those
+          # published-only paths whenever develop was also ahead. Overlay
+          # instead:
+          #   - checkout develop's version of every path that exists on develop
+          #     (overwrites shared / develop-ahead files)
+          #   - leave paths that exist only on published-results intact
+          # Develop-side deletions inside bundles therefore do NOT auto-
+          # propagate; that is intentional — never delete public community
+          # content from an automated mirror. FILE_PATHS still use per-path
+          # apply (including removal when missing on the source commit).
           SOURCE_REF="${GITHUB_SHA}"
-          DIRECTORY_PATHS=(
-            'results-data/bundles'
-          )
+          # Directory trees that must union-overlay (never wipe).
+          BUNDLES_DIR='results-data/bundles'
           FILE_PATHS=(
             'results-data/corpus-inventory.json'
             'results-data/CORPUS_NOTES.md'
@@ -235,17 +245,15 @@ jobs:
             'scripts/generate_corpus_inventory.py'
           )
 
-          for path in "${DIRECTORY_PATHS[@]}"; do
-            if git cat-file -e "${SOURCE_REF}:${path}" 2>/dev/null; then
-              # Wipe the directory's existing tree so file-level deletions
-              # on the source commit propagate to the mirror.
-              git rm -rf --quiet "${path}" 2>/dev/null || true
-              git checkout "${SOURCE_REF}" -- "${path}"
-            else
-              # Whole directory removed on the source commit — mirror the removal.
-              git rm -rf --quiet "${path}" 2>/dev/null || true
-            fi
-          done
+          if git cat-file -e "${SOURCE_REF}:${BUNDLES_DIR}" 2>/dev/null; then
+            # Union overlay: checkout develop tree without removing published-only.
+            # Do NOT `git rm -rf` the directory first.
+            git checkout "${SOURCE_REF}" -- "${BUNDLES_DIR}"
+          else
+            # Source has no bundles tree — leave published intact rather than
+            # wipe community submissions. Report so the PR review can decide.
+            echo "Source commit has no ${BUNDLES_DIR}; leaving published tree intact (union overlay)."
+          fi
 
           for path in "${FILE_PATHS[@]}"; do
             if git cat-file -e "${SOURCE_REF}:${path}" 2>/dev/null; then

--- a/docs/operations/results-phase-2-runbook.md
+++ b/docs/operations/results-phase-2-runbook.md
@@ -51,14 +51,39 @@ back-ported) are left intact. A previous wipe-then-checkout strategy deleted
 those published-only submissions whenever develop was also ahead.
 Develop-side *path deletions* do not auto-propagate (a deleted seed path that
 still exists only on published-results becomes published-only and is kept).
-Remove those manually via a reviewed PR against `published-results` when the
-deletion is intentional privacy remediation. After overlay, the workflow
-regenerates `corpus-inventory.json` from the unioned tree so community-only
-paths remain inventory-listed. Other allowlist files (docs, validators) still
-use per-path checkout / removal. The scheduled
+After overlay, the workflow regenerates `corpus-inventory.json` from the
+unioned tree so community-only paths remain inventory-listed. Other allowlist
+files (docs, validators) still use per-path checkout / removal. The scheduled
 [`corpus-drift-check.yml`](../../.github/workflows/corpus-drift-check.yml)
 canary classifies develop-ahead vs published-only and never recommends a
 wipe-based full mirror while published-only paths exist.
+
+#### Public deletion / privacy takedown (intentional path removal)
+
+The union overlay **intentionally does not** propagate develop-side deletions
+inside `results-data/bundles/`. If a path is removed on `develop` but still
+exists only on `published-results`, it becomes **published-only** and is kept
+on the next mirror. That protects community submissions the automated sync
+must never wipe.
+
+When a maintainer must remove a path from the public corpus (privacy
+remediation, takedown, mistaken publish):
+
+1. **Do not** reintroduce a wipe-then-checkout of `results-data/bundles/` on
+   the sync workflow, and **do not** run a full-tree wipe of published bundles
+   while any published-only paths should survive. A full wipe would delete
+   every community submission that is not on develop.
+2. Open a **manual PR against `published-results`** that deletes only the
+   intended path(s) under `results-data/bundles/` (and any related docs if
+   needed).
+3. Regenerate inventory on that branch:
+   `uv run -- python scripts/generate_corpus_inventory.py --write`, then
+   stage `results-data/corpus-inventory.json` with the path removals.
+4. Merge after review. Leave develop in sync if the same path still exists
+   there (delete on develop in a separate PR if the seed/corpus copy must go
+   too); the next develop→published mirror will not resurrect a path that is
+   already gone from both trees, and will not re-delete other published-only
+   paths.
 
 If the workflow's heuristics ever miss a path (or a one-off mirror is
 needed outside the trigger conditions), trigger it manually via

--- a/docs/operations/results-phase-2-runbook.md
+++ b/docs/operations/results-phase-2-runbook.md
@@ -44,6 +44,19 @@ the fixed point, then proceeds unattended. A red sync run with drift still
 present is the expected signal while re-derivation is open — not a stuck
 manual gate.
 
+For `results-data/bundles/`, the apply is a **union overlay**, not a wipe:
+develop's files overwrite matching paths on `published-results`, and paths
+that exist only on `published-results` (community submissions not
+back-ported) are left intact. A previous wipe-then-checkout strategy deleted
+those published-only submissions whenever develop was also ahead.
+Develop-side *path deletions* do not auto-propagate; remove them manually via
+a reviewed PR against `published-results` when intentional. After overlay, the
+workflow regenerates `corpus-inventory.json` from the unioned tree so
+community-only paths remain inventory-listed. The scheduled
+[`corpus-drift-check.yml`](../../.github/workflows/corpus-drift-check.yml)
+canary classifies develop-ahead vs published-only and never recommends a
+wipe-based full mirror while published-only paths exist.
+
 If the workflow's heuristics ever miss a path (or a one-off mirror is
 needed outside the trigger conditions), trigger it manually via
 `workflow_dispatch` from the Actions tab.

--- a/docs/operations/results-phase-2-runbook.md
+++ b/docs/operations/results-phase-2-runbook.md
@@ -49,10 +49,13 @@ develop's files overwrite matching paths on `published-results`, and paths
 that exist only on `published-results` (community submissions not
 back-ported) are left intact. A previous wipe-then-checkout strategy deleted
 those published-only submissions whenever develop was also ahead.
-Develop-side *path deletions* do not auto-propagate; remove them manually via
-a reviewed PR against `published-results` when intentional. After overlay, the
-workflow regenerates `corpus-inventory.json` from the unioned tree so
-community-only paths remain inventory-listed. The scheduled
+Develop-side *path deletions* do not auto-propagate (a deleted seed path that
+still exists only on published-results becomes published-only and is kept).
+Remove those manually via a reviewed PR against `published-results` when the
+deletion is intentional privacy remediation. After overlay, the workflow
+regenerates `corpus-inventory.json` from the unioned tree so community-only
+paths remain inventory-listed. Other allowlist files (docs, validators) still
+use per-path checkout / removal. The scheduled
 [`corpus-drift-check.yml`](../../.github/workflows/corpus-drift-check.yml)
 canary classifies develop-ahead vs published-only and never recommends a
 wipe-based full mirror while published-only paths exist.

--- a/tests/unit/scripts/test_corpus_drift_canary.py
+++ b/tests/unit/scripts/test_corpus_drift_canary.py
@@ -4,8 +4,9 @@ The scheduled workflow `.github/workflows/corpus-drift-check.yml` must:
 
 1. Fail when develop is ahead of published-results on mirrored corpus paths
    (the leak class that motivated the canary).
-2. Report published-only paths without recommending a full mirror that would
-   delete community submissions.
+2. Report published-only paths without recommending a wipe-based full mirror that
+   would delete community submissions — including when develop-ahead is *also*
+   non-empty (mixed drift).
 3. Never use a direction-blind ``git diff FETCH_HEAD HEAD`` classification.
 4. Include a scheduled privacy scan of the published tip itself.
 
@@ -100,10 +101,50 @@ def classify_corpus_drift(repo: Path, published_ref: str, develop_ref: str) -> d
     }
 
 
+def canary_recommendation_policy(
+    *,
+    stale: list[str],
+    published_only: list[str],
+) -> dict[str, bool | str]:
+    """Mirror the canary's recommendation gate for unit tests.
+
+    When published-only is non-empty, never emit a wipe-based full-mirror
+    recommendation. Mixed drift still fails for stale paths but points at the
+    union-overlay (non-destructive) sync.
+    """
+    if not stale:
+        return {
+            "fail": False,
+            "recommend_wipe_full_mirror": False,
+            "recommend_overlay_mirror": False,
+            "message_kind": "in_sync_or_published_only_info",
+        }
+    if published_only:
+        return {
+            "fail": True,
+            "recommend_wipe_full_mirror": False,
+            "recommend_overlay_mirror": True,
+            "message_kind": "mixed_overlay_only",
+        }
+    return {
+        "fail": True,
+        "recommend_wipe_full_mirror": False,
+        "recommend_overlay_mirror": True,
+        "message_kind": "develop_ahead_overlay",
+    }
+
+
 def _workflow_run_scripts() -> list[str]:
     workflow = yaml.safe_load(WORKFLOW_PATH.read_text(encoding="utf-8"))
     steps = workflow["jobs"]["corpus-drift"]["steps"]
     return [step.get("run", "") for step in steps if step.get("run")]
+
+
+def _compare_step_script() -> str:
+    for script in _workflow_run_scripts():
+        if "PUBLISHED_ONLY" in script and "STALE_PATHS" in script:
+            return script
+    raise AssertionError("corpus-drift-check.yml has no directional compare step")
 
 
 def test_workflow_is_scheduled_and_report_only() -> None:
@@ -164,6 +205,41 @@ def test_classifier_separates_published_only_from_develop_ahead(tmp_path: Path) 
     assert "results-data/bundles/shared.json" in result["stale"]
 
 
+def test_classifier_mixed_develop_ahead_and_published_only(tmp_path: Path) -> None:
+    """Mixed fixture: both sides of drift present at once (the canary gate case)."""
+    repo = tmp_path / "mixed"
+    _init_repo(repo)
+
+    published_files = {
+        "results-data/corpus-inventory.json": '{"version": 1}\n',
+        "results-data/bundles/shared.json": '{"id": "shared-v1"}\n',
+        "results-data/bundles/community_a.json": '{"id": "a"}\n',
+        "results-data/bundles/community_b.json": '{"id": "b"}\n',
+    }
+    published_sha = _commit_tree(repo, published_files, "published with community")
+    develop_files = {
+        "results-data/corpus-inventory.json": '{"version": 2}\n',
+        "results-data/bundles/shared.json": '{"id": "shared-v2"}\n',
+        "results-data/bundles/seed_new.json": '{"id": "seed"}\n',
+    }
+    develop_sha = _commit_tree(repo, develop_files, "develop with seed + sanitization")
+
+    result = classify_corpus_drift(repo, published_sha, develop_sha)
+    assert result["published_only"]  # community_a, community_b
+    assert result["stale"]  # shared content-changed + seed_new + inventory
+    assert "results-data/bundles/community_a.json" in result["published_only"]
+    assert "results-data/bundles/seed_new.json" in result["develop_ahead"]
+
+    policy = canary_recommendation_policy(
+        stale=result["stale"],
+        published_only=result["published_only"],
+    )
+    assert policy["fail"] is True
+    assert policy["recommend_wipe_full_mirror"] is False
+    assert policy["recommend_overlay_mirror"] is True
+    assert policy["message_kind"] == "mixed_overlay_only"
+
+
 def test_classifier_in_sync_when_trees_match(tmp_path: Path) -> None:
     repo = tmp_path / "corpus"
     _init_repo(repo)
@@ -178,10 +254,31 @@ def test_classifier_in_sync_when_trees_match(tmp_path: Path) -> None:
 
 
 def test_mirror_recommendation_only_for_stale_not_published_only() -> None:
-    """Document the canary policy: only stale paths get the mirror recipe."""
+    """Document the canary policy: only stale paths get a mirror recipe."""
     scripts = "\n".join(_workflow_run_scripts())
     # The destructive warning is tied to the published-only branch.
     published_only_block = scripts.split("published-only")[1].split("Develop-ahead")[0]
     assert "Do NOT run a full mirror" in published_only_block
-    # The mirror recipe appears in the stale/error path, not as the only advice.
+    # Overlay / non-destructive recipe appears for develop-ahead remediation.
     assert "gh workflow run sync-results-data-to-published.yml --ref develop" in scripts
+    assert "union-overlay" in scripts or "union overlay" in scripts.lower()
+
+
+def test_canary_mixed_drift_does_not_recommend_wipe_based_full_mirror() -> None:
+    """When published-only is non-empty, never recommend a wipe-based full mirror.
+
+    The compare step must gate on PUBLISHED_ONLY and require wipe prohibition
+    language in the mixed branch, even though develop-ahead is also non-empty.
+    """
+    script = _compare_step_script()
+    assert 'if [[ -n "${PUBLISHED_ONLY}" ]]; then' in script
+    # Mixed branch sits under the stale-paths failure path.
+    stale_section = script.split('if [[ -z "${STALE_PATHS}" ]]')[1]
+    assert "wipe-based full mirror" in stale_section
+    assert "Do NOT use a wipe-based full mirror" in stale_section
+    assert "git rm -rf results-data/bundles" in stale_section
+    # Must not present the old bare "Mirror it with:" wipe-implying recipe alone.
+    assert "Mirror it with:" not in script
+    # Overlay language is required so operators know the safe apply mode.
+    assert "union-overlay" in stale_section or "union overlay" in stale_section.lower()
+    assert "non-destructive" in stale_section or "without" in stale_section

--- a/tests/unit/test_sync_results_workflow.py
+++ b/tests/unit/test_sync_results_workflow.py
@@ -196,10 +196,16 @@ def test_union_overlay_preserves_published_only_when_develop_ahead(tmp_path: Pat
     community_body = (repo / f"{BUNDLES_DIR}/community_only.json").read_text(encoding="utf-8")
     assert "community" in community_body
 
+
 def test_build_mirror_regenerates_inventory_after_union_overlay() -> None:
     """Inventory must be derived from the unioned tree, not blind-overlaid from develop."""
     workflow = WORKFLOW_PATH.read_text(encoding="utf-8")
+    # Build step must regenerate, not only checkout develop inventory.
     assert "generate_corpus_inventory.py --write" in workflow
     build = workflow.split("name: Build mirror branch", 1)[1].split("name: ", 1)[0]
     assert "generate_corpus_inventory.py --write" in build
-
+    # Inventory is not in the blind FILE_PATHS overlay list (regenerated instead).
+    assert (
+        "corpus-inventory.json" not in build.split("FILE_PATHS=", 1)[1].split(")", 1)[0]
+        or "generate_corpus_inventory.py --write" in build
+    )

--- a/tests/unit/test_sync_results_workflow.py
+++ b/tests/unit/test_sync_results_workflow.py
@@ -55,6 +55,7 @@ def _build_step_run() -> str:
             return run
     raise AssertionError("sync workflow has no Build mirror branch step")
 
+
 FIXED_POINT_GATE_STEP = "Gate corpus publication fixed point"
 BUILD_MIRROR_STEP = "Build mirror branch"
 FIXED_POINT_TEST_FRAGMENT = "rederived_corpus_publishes_byte_identically"
@@ -106,6 +107,8 @@ def test_sync_workflow_fixed_point_gate_runs_before_mirror_build() -> None:
     run = gate.get("run", "")
     assert "Refusing to open a mirror" in run or "not at the publication fixed point" in run
     assert "SystemExit(1)" in run or "raise SystemExit" in run
+
+
 def test_sync_workflow_does_not_wipe_bundles_directory() -> None:
     """The apply path must not ``git rm -rf`` results-data/bundles (union overlay)."""
     run = _build_step_run()

--- a/tests/unit/test_sync_results_workflow.py
+++ b/tests/unit/test_sync_results_workflow.py
@@ -1,3 +1,13 @@
+"""Static + behavioral pins for the develop → published-results corpus mirror.
+
+The Build mirror step must apply a **union overlay** for ``results-data/bundles``:
+checkout develop's tree without ``git rm -rf`` of the directory, so published-only
+community submissions survive when develop is also ahead.
+"""
+
+from __future__ import annotations
+
+import subprocess
 from pathlib import Path
 
 import pytest
@@ -7,6 +17,43 @@ pytestmark = [pytest.mark.unit, pytest.mark.fast]
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 WORKFLOW_PATH = REPO_ROOT / ".github" / "workflows" / "sync-results-data-to-published.yml"
+BUNDLES_DIR = "results-data/bundles"
+
+
+def _run(cmd: list[str], *, cwd: Path) -> str:
+    return subprocess.check_output(cmd, cwd=cwd, text=True).strip()
+
+
+def _init_repo(root: Path) -> None:
+    root.mkdir(parents=True, exist_ok=True)
+    _run(["git", "init", "-b", "main"], cwd=root)
+    _run(["git", "config", "user.email", "mirror@example.com"], cwd=root)
+    _run(["git", "config", "user.name", "Mirror Test"], cwd=root)
+
+
+def _commit_files(root: Path, files: dict[str, str], message: str) -> str:
+    for rel, content in files.items():
+        path = root / rel
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(content, encoding="utf-8")
+        _run(["git", "add", rel], cwd=root)
+    _run(["git", "commit", "--allow-empty", "-m", message], cwd=root)
+    return _run(["git", "rev-parse", "HEAD"], cwd=root)
+
+
+def _tracked_under(root: Path, prefix: str, ref: str = "HEAD") -> set[str]:
+    raw = _run(["git", "ls-tree", "-r", "--name-only", ref, prefix], cwd=root)
+    return {line for line in raw.splitlines() if line}
+
+
+def _build_step_run() -> str:
+    workflow = yaml.safe_load(WORKFLOW_PATH.read_text(encoding="utf-8"))
+    for step in workflow["jobs"]["mirror"]["steps"]:
+        if step.get("name") == "Build mirror branch":
+            run = step.get("run", "")
+            assert run, "Build mirror branch step has empty run body"
+            return run
+    raise AssertionError("sync workflow has no Build mirror branch step")
 
 FIXED_POINT_GATE_STEP = "Gate corpus publication fixed point"
 BUILD_MIRROR_STEP = "Build mirror branch"
@@ -59,3 +106,100 @@ def test_sync_workflow_fixed_point_gate_runs_before_mirror_build() -> None:
     run = gate.get("run", "")
     assert "Refusing to open a mirror" in run or "not at the publication fixed point" in run
     assert "SystemExit(1)" in run or "raise SystemExit" in run
+def test_sync_workflow_does_not_wipe_bundles_directory() -> None:
+    """The apply path must not ``git rm -rf`` results-data/bundles (union overlay)."""
+    run = _build_step_run()
+    assert "union overlay" in run.lower() or "Union overlay" in run
+    # Executable lines only: comments may still *describe* the old wipe defect.
+    executable = "\n".join(line for line in run.splitlines() if line.strip() and not line.lstrip().startswith("#"))
+    assert "git rm -rf" not in executable
+    assert 'git checkout "${SOURCE_REF}" -- "${BUNDLES_DIR}"' in executable
+    assert "BUNDLES_DIR=" in executable or "BUNDLES_DIR='" in executable or 'BUNDLES_DIR="' in executable
+    # Explicit non-wipe guard language for published-only.
+    assert "published-only" in run
+
+
+def test_wipe_then_checkout_deletes_published_only_when_develop_ahead(tmp_path: Path) -> None:
+    """w0 evidence: the old wipe strategy deletes community-only paths under mixed drift.
+
+    published has shared + community_only; develop has shared (updated) + develop_only.
+    ``git rm -rf bundles`` then checkout develop removes community_only.
+    """
+    repo = tmp_path / "wipe-proof"
+    _init_repo(repo)
+
+    published = {
+        f"{BUNDLES_DIR}/shared.json": '{"id": "shared-v1"}\n',
+        f"{BUNDLES_DIR}/community_only.json": '{"id": "community"}\n',
+        "results-data/corpus-inventory.json": '{"version": 1}\n',
+    }
+    pub_sha = _commit_files(repo, published, "published tip")
+    _run(["git", "branch", "published-results", pub_sha], cwd=repo)
+
+    # Orphan-style develop tip on same repo: replace bundles with develop tree.
+    _run(["git", "rm", "-rf", "--quiet", BUNDLES_DIR], cwd=repo)
+    develop = {
+        f"{BUNDLES_DIR}/shared.json": '{"id": "shared-v2-sanitized"}\n',
+        f"{BUNDLES_DIR}/develop_only.json": '{"id": "new-on-develop"}\n',
+        "results-data/corpus-inventory.json": '{"version": 1}\n',
+    }
+    dev_sha = _commit_files(repo, develop, "develop tip")
+
+    # Reproduce the old wipe-based mirror apply starting from published.
+    _run(["git", "switch", "--force-create", "mirror-wipe", "published-results"], cwd=repo)
+    _run(["git", "rm", "-rf", "--quiet", BUNDLES_DIR], cwd=repo)
+    _run(["git", "checkout", dev_sha, "--", BUNDLES_DIR], cwd=repo)
+    _run(["git", "add", "-A"], cwd=repo)
+    _run(["git", "commit", "-m", "wipe mirror"], cwd=repo)
+
+    tracked = _tracked_under(repo, BUNDLES_DIR)
+    assert f"{BUNDLES_DIR}/shared.json" in tracked
+    assert f"{BUNDLES_DIR}/develop_only.json" in tracked
+    assert f"{BUNDLES_DIR}/community_only.json" not in tracked, (
+        "wipe-then-checkout deleted published-only community_only.json — the defect this TODO fixes"
+    )
+
+
+def test_union_overlay_preserves_published_only_when_develop_ahead(tmp_path: Path) -> None:
+    """Union overlay: checkout develop's bundles without wipe; published-only survives."""
+    repo = tmp_path / "overlay"
+    _init_repo(repo)
+
+    published = {
+        f"{BUNDLES_DIR}/shared.json": '{"id": "shared-v1"}\n',
+        f"{BUNDLES_DIR}/community_only.json": '{"id": "community"}\n',
+        "results-data/corpus-inventory.json": '{"version": 1}\n',
+    }
+    pub_sha = _commit_files(repo, published, "published tip")
+    _run(["git", "branch", "published-results", pub_sha], cwd=repo)
+
+    _run(["git", "rm", "-rf", "--quiet", BUNDLES_DIR], cwd=repo)
+    develop = {
+        f"{BUNDLES_DIR}/shared.json": '{"id": "shared-v2-sanitized"}\n',
+        f"{BUNDLES_DIR}/develop_only.json": '{"id": "new-on-develop"}\n',
+        "results-data/corpus-inventory.json": '{"version": 1}\n',
+    }
+    dev_sha = _commit_files(repo, develop, "develop tip")
+
+    # New union-overlay apply (matches sync workflow Build mirror step).
+    _run(["git", "switch", "--force-create", "mirror-overlay", "published-results"], cwd=repo)
+    _run(["git", "checkout", dev_sha, "--", BUNDLES_DIR], cwd=repo)
+    _run(["git", "add", "-A"], cwd=repo)
+    _run(["git", "commit", "-m", "overlay mirror"], cwd=repo)
+
+    tracked = _tracked_under(repo, BUNDLES_DIR)
+    assert f"{BUNDLES_DIR}/community_only.json" in tracked
+    assert f"{BUNDLES_DIR}/develop_only.json" in tracked
+    assert f"{BUNDLES_DIR}/shared.json" in tracked
+    shared_body = (repo / f"{BUNDLES_DIR}/shared.json").read_text(encoding="utf-8")
+    assert "shared-v2-sanitized" in shared_body
+    community_body = (repo / f"{BUNDLES_DIR}/community_only.json").read_text(encoding="utf-8")
+    assert "community" in community_body
+
+def test_build_mirror_regenerates_inventory_after_union_overlay() -> None:
+    """Inventory must be derived from the unioned tree, not blind-overlaid from develop."""
+    workflow = WORKFLOW_PATH.read_text(encoding="utf-8")
+    assert "generate_corpus_inventory.py --write" in workflow
+    build = workflow.split("name: Build mirror branch", 1)[1].split("name: ", 1)[0]
+    assert "generate_corpus_inventory.py --write" in build
+

--- a/tests/unit/test_sync_results_workflow.py
+++ b/tests/unit/test_sync_results_workflow.py
@@ -207,8 +207,8 @@ def test_build_mirror_regenerates_inventory_after_union_overlay() -> None:
     assert "generate_corpus_inventory.py --write" in workflow
     build = workflow.split("name: Build mirror branch", 1)[1].split("name: ", 1)[0]
     assert "generate_corpus_inventory.py --write" in build
-    # Inventory is not in the blind FILE_PATHS overlay list (regenerated instead).
-    assert (
-        "corpus-inventory.json" not in build.split("FILE_PATHS=", 1)[1].split(")", 1)[0]
-        or "generate_corpus_inventory.py --write" in build
-    )
+    # Inventory artifact must not be blind-overlaid from develop (regenerated
+    # from the unioned tree instead). Assert against the FILE_PATHS block only.
+    assert "FILE_PATHS=" in build
+    file_paths_block = build.split("FILE_PATHS=", 1)[1].split(")", 1)[0]
+    assert "corpus-inventory.json" not in file_paths_block


### PR DESCRIPTION
The develop→published-results sync wiped results-data/bundles before
checking out develop, which deleted community submissions that exist only
on published-results whenever develop was also ahead.

Apply a union overlay for bundles instead: checkout develop's files without
git rm -rf of the tree so published-only paths survive. Gate the corpus
drift canary so mixed develop-ahead + published-only never recommends a
wipe-based full mirror.
