### PR TITLE
fix(results): drop residual local-path keys at public anonymization boundary

### DIFF
--- a/benchbox/core/results/anonymization_specs.yaml
+++ b/benchbox/core/results/anonymization_specs.yaml
@@ -13,8 +13,14 @@
 #
 # Alias rows cover alternate spellings of the six unread drop fields so a
 # producer using workdir/datadir/pythonexecutable cannot reintroduce empty-salt
-# path_/host_ tokens. host/hostname/server are intentionally NOT dropped: they
-# are broader than engine_host and may carry non-local endpoints still hashed.
+# path_/host_ tokens. Residual pure-local filesystem keys (output*/result*/
+# log*/filepath/path/sourceroot/credentialfile) are also dropped: no Explorer
+# or pipeline consumer, empty-salt confirmation oracle only.
+#
+# KEEP HASH (do not add here): sslrootcert (libpq privacy hash); s3stagingurl /
+# staginglocation / stagingurl / httppath (may embed account/tenant); host /
+# hostname / server (broader than engine_host, may be remote); retained
+# consumers endpoint / database_name / submission_path.
 public_drop_keys:
 - machineid
 - workingdir
@@ -28,6 +34,19 @@ public_drop_keys:
 - datadir
 - datadirectory
 - enginehost
+# Residual local-path keys (compact forms): omit rather than path_ tokens.
+- outputdir
+- outputdirectory
+- outputpath
+- outputlocation
+- resultdir
+- resultpath
+- logpath
+- logfile
+- filepath
+- path
+- sourceroot
+- credentialfile
 identifier_keys:
   account: account
   accountid: account

--- a/docs/development/adr/adr-published-identifier-field-set.md
+++ b/docs/development/adr/adr-published-identifier-field-set.md
@@ -1,8 +1,8 @@
 # ADR: Drop unread identifier fields from the published corpus
 
 - Status: Accepted (implemented at the public anonymization boundary;
-  retained-field salt closed 2026-08-05)
-- Date: 2026-08-04; salt amendment 2026-08-05
+  retained-field salt closed 2026-08-05; residual local-path drop 2026-08-05)
+- Date: 2026-08-04; salt amendment 2026-08-05; residual path/host keys 2026-08-05
 - Supersedes nothing. Constrains `benchbox/core/results/anonymization.py` and
   any future re-derivation of `results-data/`.
 
@@ -58,6 +58,31 @@ rather than dropped: they are broader than `engine_host`.
 
 For the three that do have a consumer, keep publishing a pseudonym. The
 retained-field salt decision is recorded below (closed 2026-08-05).
+
+## Residual path/host keys (2026-08-05)
+
+After the six-field drop and alias rows, several **pure local filesystem**
+keys could still mint empty-salt `path_` tokens under `path_keys` / suffix
+rules, with no Explorer or publication-pipeline consumer. Treat them like the
+other unread local identifiers: **drop**, do not hash.
+
+| compact key class | policy | rationale |
+|---|---|---|
+| `outputdir`, `outputdirectory`, `outputpath`, `outputlocation` | **drop** | Local run output location; no public reader |
+| `resultdir`, `resultpath` | **drop** | Local results location; no public reader |
+| `logpath`, `logfile` | **drop** | Local log location; no public reader |
+| `filepath`, `path` | **drop** | Exact key name only (compact); not `submission_path` / `*_path` retained consumers |
+| `sourceroot` | **drop** | Local source tree root; no public reader |
+| `credentialfile` | **drop** | Local credential path; omit entirely (stronger than redact-in-place) |
+| `datadir` / `datadirectory` / `workdir` family | **drop** | Already covered by unread-field aliases |
+| `sslrootcert` | **keep hash** | libpq spelling; intentional privacy hash for cert path material |
+| `s3stagingurl`, `staginglocation`, `stagingurl`, `httppath` | **keep hash** | May embed account/tenant; not pure local FS |
+| `host`, `hostname`, `server` | **keep hash** | Broader than `engine_host`; may be remote endpoints |
+| `endpoint`, `database_name`, `submission_path` | **keep hash** | Retained consumers (see field-set table above) |
+
+Corpus inventory (tip `results-data/` JSON): none of the newly dropped compact
+keys appear as object keys, so **no full re-derive** is required for this
+amendment. Fixed-point / privacy gates remain the regression bar.
 
 ## Retained-field salt decision (2026-08-05)
 
@@ -138,6 +163,9 @@ bundles are the product.
 - Retained-field salt decision (2026-08-05): empty OSS default; residual
   confirmation oracle documented; operator-configured non-empty salt recommended
   for community-facing publishes; publication fixed point from #1512 preserved.
+- Residual local-path keys (2026-08-05): additional pure-FS compact keys dropped
+  at the public boundary; remote-ish path/host keys remain hashed; no corpus
+  re-derive when tip bundles lack those keys.
 
 ## What this does not change
 

--- a/tests/fixtures/golden/results/environment_capture_schema_cases.json
+++ b/tests/fixtures/golden/results/environment_capture_schema_cases.json
@@ -278,11 +278,13 @@
           "prefix/",
           "athena_private"
         ],
+        "absent_keys": [
+          "output_location"
+        ],
         "prefixes": {
           "platform.cloud.account": "account_",
           "platform.compute.workgroup": "workgroup_",
-          "platform.storage.bucket": "bucket_",
-          "platform.raw_config.output_location": "path_"
+          "platform.storage.bucket": "bucket_"
         }
       }
     },

--- a/tests/unit/core/results/test_anonymization.py
+++ b/tests/unit/core/results/test_anonymization.py
@@ -633,7 +633,8 @@ class TestPublicPayloadCredentialAliases:
         assert out["passwd"] == PUBLIC_REDACTED_VALUE
         assert out["pwd"] == PUBLIC_REDACTED_VALUE
         assert out["pat"] == PUBLIC_REDACTED_VALUE
-        assert out["path"].startswith("path_")
+        # Exact key ``path`` is a residual local-FS drop key (no public consumer).
+        assert "path" not in out
         assert out["sort_key"] == "o_orderkey"
 
 
@@ -1040,6 +1041,70 @@ class TestPublicUnreadIdentifierDrop:
         assert out["metadata"]["submission_path"] == "PR-based" or _is_public_pseudonym(
             out["metadata"]["submission_path"], "path"
         )
+
+    def test_residual_local_path_keys_are_dropped_not_hashed(self):
+        """Pure local-FS residual keys omit rather than mint empty-salt path_ tokens."""
+        payload = {
+            "platform": {
+                "config": {
+                    "output_dir": "/Users/alice/out",
+                    "output_directory": "/Users/alice/out",
+                    "output_path": "/Users/alice/out/run.json",
+                    "output_location": "/Users/alice/out",
+                    "result_dir": "/Users/alice/results",
+                    "result_path": "/Users/alice/results/run.json",
+                    "log_path": "/Users/alice/logs/run.log",
+                    "log_file": "/Users/alice/logs/run.log",
+                    "file_path": "/Users/alice/data/file.parquet",
+                    "path": "/Users/alice/scratch",
+                    "source_root": "/Users/alice/src",
+                    "credential_file": "/Users/alice/.aws/credentials",
+                    # KEEP HASH / retained consumers
+                    "sslrootcert": "/Users/alice/certs/root.pem",
+                    "s3_staging_url": "s3://tenant-bucket/staging/",
+                    "staging_location": "s3://tenant-bucket/staging/",
+                    "staging_url": "s3://tenant-bucket/staging/",
+                    "http_path": "/sql/1.0/warehouses/abc",
+                    "host": "db.example.internal",
+                    "hostname": "db.example.internal",
+                    "server": "db.example.internal",
+                    "endpoint": "https://example.invalid/warehouse",
+                    "database_name": "analytics",
+                }
+            },
+            "metadata": {"submission_path": "/Users/alice/submission.json"},
+        }
+        out = AnonymizationManager().anonymize_result_payload(payload)
+        cfg = out["platform"]["config"]
+        for key in (
+            "output_dir",
+            "output_directory",
+            "output_path",
+            "output_location",
+            "result_dir",
+            "result_path",
+            "log_path",
+            "log_file",
+            "file_path",
+            "path",
+            "source_root",
+            "credential_file",
+        ):
+            assert key not in cfg, f"residual local path key still present: {key}"
+        serialized = json.dumps(out, default=str)
+        assert "alice" not in serialized
+        # Remote-ish / intentional privacy hashes remain published as pseudonyms.
+        assert _is_public_pseudonym(cfg["sslrootcert"], "path")
+        assert _is_public_pseudonym(cfg["s3_staging_url"], "endpoint")  # *url suffix
+        assert _is_public_pseudonym(cfg["staging_location"], "path")
+        assert _is_public_pseudonym(cfg["staging_url"], "endpoint")
+        assert _is_public_pseudonym(cfg["http_path"], "path")
+        assert cfg["host"].startswith("host_")
+        assert cfg["hostname"].startswith("host_")
+        assert cfg["server"].startswith("host_")
+        assert _is_public_pseudonym(cfg["endpoint"], "endpoint")
+        assert _is_public_pseudonym(cfg["database_name"], "database")
+        assert _is_public_pseudonym(out["metadata"]["submission_path"], "path")
 
     def test_empty_client_host_omitted_after_machine_id_drop(self):
         """client_host that only held machine_id must not publish as {}."""

--- a/tests/unit/core/results/test_environment_anonymization.py
+++ b/tests/unit/core/results/test_environment_anonymization.py
@@ -179,7 +179,8 @@ def test_anonymized_json_export_hashes_infrastructure_identifiers_and_redacts_se
     assert payload["platform"]["storage"]["prefix"].startswith("prefix_")
     assert payload["platform"]["raw_config"]["password"] == "<redacted>"
     assert payload["platform"]["raw_config"]["access_token"] == "<redacted>"
-    assert payload["platform"]["raw_config"]["credential_file"] == "<redacted>"
+    # Residual local-path drop: credential_file is omitted, not redacted-in-place.
+    assert "credential_file" not in payload["platform"]["raw_config"]
     assert payload["platform"]["raw_config"]["connection_string"] == "<redacted>"
     assert payload["config"]["platform_options"]["client_secret"] == "<redacted>"
 


### PR DESCRIPTION
## Summary

Drop pure local-filesystem residual keys at the public anonymization boundary so they no longer mint empty-salt `path_` confirmation-oracle tokens. Keep hashing remote-ish path/host keys and retained consumers.

## Decision

| Class | Policy |
|---|---|
| `outputdir` / `outputdirectory` / `outputpath` / `outputlocation` | **drop** |
| `resultdir` / `resultpath` | **drop** |
| `logpath` / `logfile` | **drop** |
| `filepath` / `path` (exact key only) | **drop** |
| `sourceroot` / `credentialfile` | **drop** |
| `sslrootcert` | keep hash |
| `s3stagingurl` / `staginglocation` / `stagingurl` / `httppath` | keep hash |
| `host` / `hostname` / `server` | keep hash |
| `endpoint` / `database_name` / `submission_path` | keep hash (retained consumers) |

## Changes

- Expand `public_drop_keys` in `anonymization_specs.yaml` (compact forms)
- ADR residual path/host table in `adr-published-identifier-field-set.md`
- Unit coverage for drops + keep-hash; environment export omits `credential_file`
- Golden public-export case for Athena: `output_location` is now absent (not `path_`)

## Corpus

Tip `results-data/` inventory: none of the newly dropped compact keys appear as object keys across 203 primary bundles. Fixed-point re-anonymize: 0 changes. **No re-derive.**

## Verification

- `uv run -- python -m pytest tests/unit/core/results/test_anonymization.py tests/unit/core/results/test_environment_anonymization.py tests/unit/core/results/test_environment_schema_compatibility.py -n 0 -q` → green
- `make pr-preflight-fast-tests` → 27244 passed, 19 skipped
- `todo check-scope --base origin/develop` → scope OK (5 files)

## TODO

`residual-path-host-keys-empty-salt-drop-or-hash-policy`
