### PR TITLE
fix(results): anonymize nested tuning companion constraint shapes

### DIFF
--- a/benchbox/core/results/anonymization.py
+++ b/benchbox/core/results/anonymization.py
@@ -404,7 +404,10 @@ class AnonymizationManager:
         if constraints is not None or table_tunings is not None:
             anonymized_requested = anonymized.setdefault("requested", {})
             if isinstance(anonymized_requested, dict):
-                if isinstance(constraints, dict):
+                # Non-dict companions (list-of-constraint-dicts) are untrusted
+                # shapes too; route every non-None value through the recursive
+                # constraint walker rather than only dict payloads.
+                if constraints is not None:
                     anonymized_requested["constraints"] = self._anonymize_tuning_constraints(constraints)
                 if table_tunings is not None:
                     anonymized_requested["table_tunings"] = self._anonymize_tuning_table_tunings(table_tunings)
@@ -418,8 +421,44 @@ class AnonymizationManager:
         reference = value.rpartition(":")[0] if ":" in value else value
         return bool(reference) and all(part not in {"", ".", ".."} for part in reference.split("/"))
 
+    # Identifier-bearing companion keys. Scalar keys hash the value (including
+    # slash-delimited compounds such as ``orders/o_orderkey`` as one token so
+    # neither segment survives). Collection keys hash list/dict containers while
+    # recursing into nested dict entries so list-of-dicts FK shapes do not leak.
+    _CONSTRAINT_TABLE_SCALAR_KEYS = frozenset(
+        {
+            "table",
+            "table_name",
+            "referenced_table",
+            "referenced_table_name",
+            "local_table",
+            "references_table",
+        }
+    )
+    _CONSTRAINT_COLUMN_SCALAR_KEYS = frozenset(
+        {
+            "column",
+            "column_name",
+            "name",
+            "referenced_column",
+            "referenced_column_name",
+            "references_column",
+            "local_column",
+        }
+    )
+    _CONSTRAINT_TABLE_COLLECTION_KEYS = frozenset({"tables", "table_names", "referenced_tables"})
+    _CONSTRAINT_COLUMN_COLLECTION_KEYS = frozenset(
+        {"columns", "column_names", "referenced_columns", "referenced_column_names"}
+    )
+
     def _anonymize_tuning_constraints(self, value: Any) -> Any:
-        """Anonymize table/column identifiers nested in constraint settings."""
+        """Anonymize table/column identifiers nested in constraint settings.
+
+        Walks dict/list/tuple companions recursively. Only identifier-bearing
+        keys (table/column scalars and collections, including TPC-DI-style
+        ``local_table`` / ``references_table``) are pseudonymized; enabled
+        flags, actions, and unrelated tuning values pass through.
+        """
         if isinstance(value, dict):
             anonymized: dict[str, Any] = {}
             for key, child in value.items():
@@ -427,19 +466,13 @@ class AnonymizationManager:
                 # rather than KeyErroring when the scalar walk drops the key.
                 if _compact_key(str(key)) in _PUBLIC_DROP_KEYS:
                     continue
-                if key in {"table", "table_name", "referenced_table", "referenced_table_name"}:
-                    anonymized[key] = self._hash_public_identifier(str(child), "table")
-                elif key in {
-                    "column",
-                    "column_name",
-                    "name",
-                    "referenced_column",
-                    "referenced_column_name",
-                }:
-                    anonymized[key] = self._hash_public_identifier(str(child), "column")
-                elif key in {"tables", "table_names", "referenced_tables"}:
+                if key in self._CONSTRAINT_TABLE_SCALAR_KEYS:
+                    anonymized[key] = self._anonymize_constraint_identifier_value(child, "table")
+                elif key in self._CONSTRAINT_COLUMN_SCALAR_KEYS:
+                    anonymized[key] = self._anonymize_constraint_identifier_value(child, "column")
+                elif key in self._CONSTRAINT_TABLE_COLLECTION_KEYS:
                     anonymized[key] = self._anonymize_constraint_identifier_collection(child, "table")
-                elif key in {"columns", "column_names", "referenced_columns", "referenced_column_names"}:
+                elif key in self._CONSTRAINT_COLUMN_COLLECTION_KEYS:
                     anonymized[key] = self._anonymize_constraint_identifier_collection(child, "column")
                 else:
                     if isinstance(child, (dict, list, tuple)):
@@ -455,33 +488,51 @@ class AnonymizationManager:
             return [self._anonymize_tuning_constraints(item) for item in value]
         return value
 
+    def _anonymize_constraint_identifier_value(self, value: Any, prefix: str) -> Any:
+        """Hash one identifier scalar, or walk a nested collection under a scalar key."""
+        if isinstance(value, (dict, list, tuple)):
+            return self._anonymize_constraint_identifier_collection(value, prefix)
+        if value in (None, ""):
+            return value
+        return self._hash_public_identifier(str(value), prefix)
+
     def _anonymize_constraint_identifier_collection(self, value: Any, prefix: str) -> Any:
-        """Hash identifier collections while preserving their container shape."""
+        """Hash identifier collections while preserving their container shape.
+
+        Dict keys are table/column identifiers. List/tuple string items are
+        hashed; nested dicts/lists recurse so list-of-dicts FK companions
+        (``tables: [{table, columns, referenced_table}, ...]``) do not pass
+        through unhashed.
+        """
         if isinstance(value, dict):
             return {
                 self._hash_public_identifier(str(key), prefix): self._anonymize_constraint_columns(child)
                 for key, child in value.items()
             }
-        if isinstance(value, list):
-            return [
-                self._hash_public_identifier(str(item), prefix) if isinstance(item, str) else item for item in value
-            ]
-        if isinstance(value, tuple):
-            return [
-                self._hash_public_identifier(str(item), prefix) if isinstance(item, str) else item for item in value
-            ]
+        if isinstance(value, (list, tuple)):
+            return [self._anonymize_constraint_identifier_item(item, prefix) for item in value]
         if isinstance(value, str):
             return self._hash_public_identifier(value, prefix)
         return value
 
+    def _anonymize_constraint_identifier_item(self, item: Any, prefix: str) -> Any:
+        """Hash one collection member, or recurse into nested companion structure."""
+        if isinstance(item, str):
+            return self._hash_public_identifier(item, prefix)
+        if isinstance(item, dict):
+            return self._anonymize_tuning_constraints(item)
+        if isinstance(item, (list, tuple)):
+            return [self._anonymize_constraint_identifier_item(child, prefix) for child in item]
+        return item
+
     def _anonymize_constraint_columns(self, value: Any) -> Any:
         """Hash column lists stored as values under a table identifier."""
         if isinstance(value, (list, tuple)):
-            return [
-                self._hash_public_identifier(str(item), "column") if isinstance(item, str) else item for item in value
-            ]
+            return [self._anonymize_constraint_identifier_item(item, "column") for item in value]
         if isinstance(value, dict):
             return self._anonymize_tuning_constraints(value)
+        if isinstance(value, str):
+            return self._hash_public_identifier(value, "column")
         return value
 
     def _anonymize_tuning_table_tunings(self, value: Any) -> Any:

--- a/tests/unit/core/results/test_anonymization.py
+++ b/tests/unit/core/results/test_anonymization.py
@@ -751,6 +751,83 @@ class TestTuningPayloadAnonymization:
             "column_"
         )
 
+    def test_nested_companion_constraint_shapes_are_pseudonymized(self):
+        """List-of-dicts FK tables, slash-delimited local_table, and TPC-DI-style
+        references_table/references_column must not leak identifiers. The simple
+        mapping shape was already covered; these companion shapes were the
+        residual leak after #1479.
+        """
+        out = AnonymizationManager().anonymize_tuning_payload(
+            {
+                "requested": {
+                    "constraints": {
+                        "foreign_keys": {
+                            "enabled": True,
+                            "on_delete_action": "CASCADE",
+                            "tables": [
+                                {
+                                    "table": "orders",
+                                    "columns": ["o_orderkey"],
+                                    "referenced_table": "customers",
+                                    "referenced_columns": ["c_custkey"],
+                                }
+                            ],
+                        },
+                        "local_table": "orders/o_orderkey",
+                        "references_table": "customers",
+                        "references_column": "c_custkey",
+                    }
+                }
+            }
+        )
+
+        serialized = json.dumps(out)
+        assert all(identifier not in serialized for identifier in ("orders", "o_orderkey", "customers", "c_custkey"))
+        constraints = out["requested"]["constraints"]
+        fk = constraints["foreign_keys"]
+        assert fk["enabled"] is True
+        assert fk["on_delete_action"] == "CASCADE"
+        assert isinstance(fk["tables"], list) and len(fk["tables"]) == 1
+        entry = fk["tables"][0]
+        assert entry["table"].startswith("table_")
+        assert entry["referenced_table"].startswith("table_")
+        assert entry["columns"][0].startswith("column_")
+        assert entry["referenced_columns"][0].startswith("column_")
+        assert constraints["local_table"].startswith("table_")
+        assert constraints["references_table"].startswith("table_")
+        assert constraints["references_column"].startswith("column_")
+
+    def test_mixed_and_list_constraint_companion_shapes(self):
+        """Mixed scalar/dict collections and top-level list constraints."""
+        out = AnonymizationManager().anonymize_tuning_payload(
+            {
+                "requested": {
+                    "constraints": {
+                        "foreign_keys": {
+                            "tables": [
+                                "orders",
+                                {"table": "customers", "columns": [{"name": "c_custkey"}, "c_nationkey"]},
+                            ]
+                        },
+                    }
+                }
+            }
+        )
+        serialized = json.dumps(out)
+        assert all(identifier not in serialized for identifier in ("orders", "customers", "c_custkey", "c_nationkey"))
+        tables = out["requested"]["constraints"]["foreign_keys"]["tables"]
+        assert tables[0].startswith("table_")
+        assert tables[1]["table"].startswith("table_")
+        assert tables[1]["columns"][0]["name"].startswith("column_")
+        assert tables[1]["columns"][1].startswith("column_")
+
+        list_constraints = AnonymizationManager().anonymize_tuning_payload(
+            {"requested": {"constraints": [{"table": "orders", "columns": ["o_orderkey"]}]}}
+        )
+        serialized_list = json.dumps(list_constraints)
+        assert "orders" not in serialized_list and "o_orderkey" not in serialized_list
+        assert list_constraints["requested"]["constraints"][0]["table"].startswith("table_")
+
     def test_table_and_column_identifiers_are_pseudonymized_but_source_is_preserved(self):
         manager = AnonymizationManager()
         out = manager.anonymize_tuning_payload(

--- a/tests/unit/test_results_exporter.py
+++ b/tests/unit/test_results_exporter.py
@@ -252,6 +252,62 @@ def test_canonical_bundle_export_serializes_primary_and_companions(monkeypatch, 
     _assert_canonical_json_file(tmp_path / f"{primary_path.stem}.tuning.json")
 
 
+def test_canonical_bundle_export_anonymizes_nested_tuning_constraint_shapes(monkeypatch, tmp_path):
+    """Anonymized .tuning.json must pseudonymize list-of-dicts FK companions and
+    slash-delimited local_table scalars while preserving enabled/action flags.
+    """
+    nested_constraints = {
+        "version": "2.1",
+        "run_id": "cost-duckdb",
+        "requested": {
+            "constraints": {
+                "foreign_keys": {
+                    "enabled": True,
+                    "on_delete_action": "CASCADE",
+                    "tables": [
+                        {
+                            "table": "orders",
+                            "columns": ["o_orderkey"],
+                            "referenced_table": "customers",
+                        }
+                    ],
+                },
+                "local_table": "orders/o_orderkey",
+                "references_table": "customers",
+                "primary_keys": {
+                    "enabled": True,
+                    "tables": {"orders": ["o_orderkey"]},
+                },
+            }
+        },
+    }
+    monkeypatch.setattr(exporter_module, "build_tuning_payload", lambda _result: nested_constraints)
+
+    exported = ResultExporter(output_dir=tmp_path, anonymize=True).export_result(
+        _minimal_result("duckdb"),
+        formats=["json"],
+    )
+    tuning_path = tmp_path / f"{exported['json'].stem}.tuning.json"
+    raw = tuning_path.read_text(encoding="utf-8")
+    assert all(identifier not in raw for identifier in ("orders", "o_orderkey", "customers"))
+
+    payload = json.loads(raw)
+    constraints = payload["requested"]["constraints"]
+    fk = constraints["foreign_keys"]
+    assert fk["enabled"] is True
+    assert fk["on_delete_action"] == "CASCADE"
+    assert fk["tables"][0]["table"].startswith("table_")
+    assert fk["tables"][0]["columns"][0].startswith("column_")
+    assert constraints["local_table"].startswith("table_")
+    assert constraints["references_table"].startswith("table_")
+    pk_tables = constraints["primary_keys"]["tables"]
+    table_key = next(iter(pk_tables))
+    assert table_key.startswith("table_")
+    assert pk_tables[table_key][0].startswith("column_")
+    assert constraints["primary_keys"]["enabled"] is True
+    _assert_canonical_json_file(tuning_path)
+
+
 def test_canonical_bundle_export_anonymizes_plans_raw_explain_output(monkeypatch, tmp_path):
     """qpc-07 w3: the plans companion bypassed anonymization entirely, so
     raw_explain_output (opaque per-platform EXPLAIN text that can embed


### PR DESCRIPTION
List-of-dicts FK tables, slash-delimited local_table values, and
TPC-DI-style references_table/references_column companions leaked raw
identifiers after the simple mapping fix. Recurse into nested dict/list
items under identifier collections and hash additional companion scalar
keys while preserving enabled/action semantics and non-identifier values.
