### PR TITLE
fix(submit): require BENCHBOX_MACHINE_ID_SALT for community publish

### DIFF
--- a/benchbox/cli/commands/submit.py
+++ b/benchbox/cli/commands/submit.py
@@ -24,6 +24,10 @@ from benchbox.cli.submit_service import (
     HostedSubmitUnauthorized,
     submit_hosted_bundle,
 )
+from benchbox.core.results.anonymization import (
+    MissingPublicPseudonymSaltError,
+    require_public_pseudonym_salt,
+)
 from benchbox.core.results.canonical_json import canonical_json_file_bytes, canonical_json_text
 from benchbox.core.results.loader import (
     ResultLoadError,
@@ -185,6 +189,15 @@ def _build_submission_manifest(
     if submission_notes:
         manifest["submission_notes"] = submission_notes
     return manifest
+
+
+def _refuse_missing_public_pseudonym_salt(ctx: click.Context) -> None:
+    """Hard-refuse community submit when the deployment salt is unset."""
+    try:
+        require_public_pseudonym_salt()
+    except MissingPublicPseudonymSaltError as exc:
+        console.print(f"\n[red]❌ Submission refused: {exc}[/red]")
+        ctx.exit(1)
 
 
 def _refuse_non_submittable_result(ctx: click.Context, result: object, submit_state: SubmitTerminalState) -> None:
@@ -670,6 +683,11 @@ def submit(
         console.print(f"[red]Unexpected error: {e}[/red]")
         ctx.exit(1)
         return
+
+    # Community publish requires a deployment-private public pseudonym salt.
+    # Empty OSS default remains for private/local export; submit is the
+    # community-facing gate (retained-field salt decision 2026-08-05).
+    _refuse_missing_public_pseudonym_salt(ctx)
 
     # Submit-classification policy is shared with UAT via
     # benchbox.core.results.submit_classification so the two surfaces cannot

--- a/benchbox/core/results/anonymization.py
+++ b/benchbox/core/results/anonymization.py
@@ -112,6 +112,59 @@ def _is_public_pseudonym(value: str, prefix: str) -> bool:
     return len(digest) == _PUBLIC_HASH_WIDTH and all(char in _PUBLIC_HASH_DIGITS for char in digest)
 
 
+# Community-facing publish paths (``benchbox submit``) require a non-empty salt
+# from this env var. The value must not be baked into the repository.
+PUBLIC_PSEUDONYM_SALT_ENV = "BENCHBOX_MACHINE_ID_SALT"
+
+
+class MissingPublicPseudonymSaltError(ValueError):
+    """Raised when a community-facing path is used without a deployment salt."""
+
+
+def resolve_public_pseudonym_salt(
+    *,
+    explicit: Optional[str] = None,
+    environ: Optional[dict[str, str]] = None,
+) -> Optional[str]:
+    """Return a non-empty public pseudonym salt, or ``None`` if unset.
+
+    Precedence: *explicit* argument, then :data:`PUBLIC_PSEUDONYM_SALT_ENV`.
+    Empty strings are treated as unset. The OSS default remains empty so a
+    repository-baked constant cannot pretend to be a secret.
+    """
+    if explicit is not None:
+        stripped = str(explicit).strip()
+        return stripped or None
+    env = environ if environ is not None else os.environ
+    raw = env.get(PUBLIC_PSEUDONYM_SALT_ENV)
+    if raw is None:
+        return None
+    stripped = str(raw).strip()
+    return stripped or None
+
+
+def require_public_pseudonym_salt(
+    *,
+    explicit: Optional[str] = None,
+    environ: Optional[dict[str, str]] = None,
+) -> str:
+    """Return a non-empty salt or raise :class:`MissingPublicPseudonymSaltError`.
+
+    Use on community-facing publish paths only. Private/local export may still
+    use an empty default salt.
+    """
+    salt = resolve_public_pseudonym_salt(explicit=explicit, environ=environ)
+    if salt is None:
+        raise MissingPublicPseudonymSaltError(
+            "Community publish requires a non-empty public pseudonym salt. "
+            f"Set the {PUBLIC_PSEUDONYM_SALT_ENV} environment variable to a "
+            "deployment-private value before the first public export/submit. "
+            "See docs/development/adr/adr-published-identifier-field-set.md "
+            "(retained-field salt decision)."
+        )
+    return salt
+
+
 @dataclass
 class AnonymizationConfig:
     """Configuration for result anonymization.
@@ -122,8 +175,9 @@ class AnonymizationConfig:
     salt decision). Open-source BenchBox keeps the empty default so a
     repository-baked salt cannot pretend to be a secret. Operators who publish
     community-facing results must set a non-empty salt known only to the
-    deployment before the first public export. Already-public-shaped tokens
-    still pass through unchanged (publication fixed point).
+    deployment before the first public export (via ``machine_id_salt`` or
+    :data:`PUBLIC_PSEUDONYM_SALT_ENV`). Already-public-shaped tokens still pass
+    through unchanged (publication fixed point).
     """
 
     # Machine identification. The salt feeds both get_anonymous_machine_id and
@@ -142,6 +196,25 @@ class AnonymizationConfig:
 
     # Custom sanitizers
     custom_sanitizers: dict[str, str] = field(default_factory=dict)
+
+    @classmethod
+    def from_public_environ(
+        cls,
+        *,
+        environ: Optional[dict[str, str]] = None,
+        require_salt: bool = False,
+    ) -> "AnonymizationConfig":
+        """Build config from the public-salt environment variable.
+
+        When *require_salt* is true, raises :class:`MissingPublicPseudonymSaltError`
+        if the salt is unset (community publish). When false, empty salt is allowed
+        for private/local use.
+        """
+        if require_salt:
+            salt: Optional[str] = require_public_pseudonym_salt(environ=environ)
+        else:
+            salt = resolve_public_pseudonym_salt(environ=environ)
+        return cls(machine_id_salt=salt)
 
 
 class AnonymizationManager:
@@ -746,8 +819,12 @@ def find_public_path_leaks(value: Any, key_path: tuple[str, ...] = ()) -> list[s
 
 
 __all__ = [
+    "PUBLIC_PSEUDONYM_SALT_ENV",
     "PUBLIC_REDACTED_VALUE",
     "AnonymizationConfig",
     "AnonymizationManager",
+    "MissingPublicPseudonymSaltError",
     "find_public_path_leaks",
+    "require_public_pseudonym_salt",
+    "resolve_public_pseudonym_salt",
 ]

--- a/benchbox/core/results/exporter.py
+++ b/benchbox/core/results/exporter.py
@@ -96,7 +96,9 @@ class ResultExporter:
         Args:
             output_dir: Output directory for results. Defaults to benchmark_runs/results.
             anonymize: Whether to anonymize system information. Defaults to True.
-            anonymization_config: Configuration for anonymization.
+            anonymization_config: Configuration for anonymization. When omitted and
+                ``anonymize`` is true, soft-reads ``BENCHBOX_MACHINE_ID_SALT`` via
+                :meth:`AnonymizationConfig.from_public_environ` (empty salt if unset).
             console: Rich console for output. Creates new one if not provided.
             plan_history_dir: Opt-in directory to record this run's plan
                 fingerprints into via ``PlanHistory.add_run`` (see
@@ -122,9 +124,15 @@ class ResultExporter:
 
         self.console = console or Console()
         self.anonymize = anonymize
-        self.anonymization_manager = (
-            AnonymizationManager(anonymization_config or AnonymizationConfig()) if anonymize else None
-        )
+        # Soft-read BENCHBOX_MACHINE_ID_SALT when present so public-shaped
+        # exports mint salted tokens at export time. Empty/unset remains the
+        # OSS default (private/local export still works). Community submit is
+        # the hard-require gate; this path must not refuse without salt.
+        if anonymize:
+            default_config = anonymization_config or AnonymizationConfig.from_public_environ()
+            self.anonymization_manager = AnonymizationManager(default_config)
+        else:
+            self.anonymization_manager = None
         self._validator = SchemaV2Validator()
 
         resolved_plan_history_dir = plan_history_dir or os.environ.get("BENCHBOX_PLAN_HISTORY_DIR")

--- a/benchbox/platforms/base/result_capture.py
+++ b/benchbox/platforms/base/result_capture.py
@@ -1869,7 +1869,9 @@ class ResultCaptureMixin:
             )
             from benchbox.utils.system_info import get_system_info
 
-            anonymization_manager = AnonymizationManager(AnonymizationConfig())
+            # Soft-read env salt when present so capture-side machine ids match
+            # salted public export. Unset salt keeps the empty OSS default.
+            anonymization_manager = AnonymizationManager(AnonymizationConfig.from_public_environ())
             system_info = get_system_info()
             system_profile = system_info.to_dict()
             anonymous_machine_id = anonymization_manager.get_anonymous_machine_id()

--- a/docs/development/adr/adr-published-identifier-field-set.md
+++ b/docs/development/adr/adr-published-identifier-field-set.md
@@ -119,9 +119,12 @@ Rationale:
    plus whatever community submitters put in retained keys — the latter is why
    operators must set a real salt before accepting third-party submissions.
 4. **Operators close the residual.** Set `AnonymizationConfig.machine_id_salt`
-   (or the equivalent export config) to a non-empty value known only to the
-   deployment *before* the first public publish. New raw values then hash under
-   that salt; already-published tokens still pass through by design.
+   or the `BENCHBOX_MACHINE_ID_SALT` environment variable to a non-empty value
+   known only to the deployment *before* the first public publish. New raw
+   values then hash under that salt; already-published tokens still pass
+   through by design. **`benchbox submit` hard-refuses** when the salt is
+   unset/empty (community-facing gate); private/local export without salt
+   remains allowed.
 
 ## Alternatives considered (field-set)
 

--- a/docs/development/adr/adr-published-identifier-field-set.md
+++ b/docs/development/adr/adr-published-identifier-field-set.md
@@ -120,11 +120,14 @@ Rationale:
    operators must set a real salt before accepting third-party submissions.
 4. **Operators close the residual.** Set `AnonymizationConfig.machine_id_salt`
    or the `BENCHBOX_MACHINE_ID_SALT` environment variable to a non-empty value
-   known only to the deployment *before* the first public publish. New raw
-   values then hash under that salt; already-published tokens still pass
-   through by design. **`benchbox submit` hard-refuses** when the salt is
-   unset/empty (community-facing gate); private/local export without salt
-   remains allowed.
+   known only to the deployment *before* the first public export, so raw
+   retained-field values hash under that salt at mint time. Public export
+   soft-reads the env salt when present; unset salt still allows local/private
+   export with the empty default. **`benchbox submit` hard-refuses** when the
+   salt is unset/empty (community-facing gate only). Setting salt only at
+   submit does not re-hash already-exported files — already-public-shaped
+   tokens pass through by fixed-point design — so the submit gate alone does
+   not close the empty-salt confirmation oracle for previously minted bundles.
 
 ## Alternatives considered (field-set)
 

--- a/docs/reference/result-formats.md
+++ b/docs/reference/result-formats.md
@@ -490,10 +490,18 @@ documented rather than denied.
 A non-empty salt closes the oracle only if it is **not** shipped in the public
 tree. Operators who will publish community submissions must set
 `machine_id_salt` or the `BENCHBOX_MACHINE_ID_SALT` environment variable to a
-deployment-private value before the first public export. `benchbox submit`
-refuses when that salt is missing. A repository-baked "default salt" would
-still be public and is rejected. Private/local export without salt remains
-allowed.
+deployment-private value **before the first public export**, so retained-field
+tokens are salted when they are minted. `ResultExporter(anonymize=True)`
+soft-reads `BENCHBOX_MACHINE_ID_SALT` when present; without it, public-shaped
+export still succeeds with the empty default (local/private use).
+
+`benchbox submit` hard-refuses when that salt env is unset/empty — a
+community-path gate so operators cannot forget to configure salt on the
+submission machine. That gate does **not** re-hash already-exported files:
+already-public-shaped tokens pass through under the publication fixed point,
+so setting salt only at submit time does not close the empty-salt oracle for
+bundles that were minted earlier without salt. A repository-baked "default
+salt" would still be public and is rejected.
 
 #### Salt rotation
 

--- a/docs/reference/result-formats.md
+++ b/docs/reference/result-formats.md
@@ -489,8 +489,11 @@ documented rather than denied.
 
 A non-empty salt closes the oracle only if it is **not** shipped in the public
 tree. Operators who will publish community submissions must set
-`machine_id_salt` to a deployment-private value before the first public export.
-A repository-baked "default salt" would still be public and is rejected.
+`machine_id_salt` or the `BENCHBOX_MACHINE_ID_SALT` environment variable to a
+deployment-private value before the first public export. `benchbox submit`
+refuses when that salt is missing. A repository-baked "default salt" would
+still be public and is rejected. Private/local export without salt remains
+allowed.
 
 #### Salt rotation
 

--- a/tests/integration/test_cross_branch_validator_contract.py
+++ b/tests/integration/test_cross_branch_validator_contract.py
@@ -85,6 +85,10 @@ def test_writer_emits_hash_format_validator_accepts(monkeypatch: pytest.MonkeyPa
     that the shared published-results validator accepts."""
     sub = importlib.import_module("benchbox.cli.commands.submit")
 
+    # `benchbox submit` is community-facing end-to-end (both --output and
+    # --service modes) and hard-refuses without a deployment salt.
+    monkeypatch.setenv("BENCHBOX_MACHINE_ID_SALT", "integration-test-community-publish-salt")
+
     src = tmp_path / "tpch_duckdb.json"
     src.write_text(json.dumps(_minimal_schema_v2_bundle()), encoding="utf-8")
 
@@ -111,6 +115,10 @@ def test_writer_companion_hashes_validator_accepts(monkeypatch: pytest.MonkeyPat
     """Companion files (.plans.json / .tuning.json) — the per-file hash
     contract covers them too via manifest.companion_hashes."""
     sub = importlib.import_module("benchbox.cli.commands.submit")
+
+    # `benchbox submit` is community-facing end-to-end and hard-refuses
+    # without a deployment salt.
+    monkeypatch.setenv("BENCHBOX_MACHINE_ID_SALT", "integration-test-community-publish-salt")
 
     src = tmp_path / "tpch_duckdb.json"
     src.write_text(json.dumps(_minimal_schema_v2_bundle()), encoding="utf-8")

--- a/tests/integration/test_hosted_submission.py
+++ b/tests/integration/test_hosted_submission.py
@@ -23,6 +23,14 @@ pytestmark = [
 ]
 
 
+@pytest.fixture(autouse=True)
+def _community_publish_salt(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Every test here exercises `--service` (hosted/community submit), which
+    now hard-refuses without a deployment salt. Mirrors the autouse fixture in
+    tests/unit/cli/commands/test_submit.py."""
+    monkeypatch.setenv("BENCHBOX_MACHINE_ID_SALT", "integration-test-community-publish-salt")
+
+
 class FakeKeyring:
     def __init__(self) -> None:
         self.passwords: dict[tuple[str, str], str] = {}

--- a/tests/integration/test_hosted_submit_validator_contract.py
+++ b/tests/integration/test_hosted_submit_validator_contract.py
@@ -234,6 +234,10 @@ def test_hosted_and_pr_manifest_built_via_dispatch_call_sites(tmp_path: Path, mo
 
     sub = importlib.import_module("benchbox.cli.commands.submit")
 
+    # `benchbox submit` is community-facing end-to-end (both dispatch call
+    # sites exercised below) and hard-refuses without a deployment salt.
+    monkeypatch.setenv("BENCHBOX_MACHINE_ID_SALT", "integration-test-community-publish-salt")
+
     src = tmp_path / "tpch_duckdb.json"
     src.write_text(json.dumps(_minimal_schema_v2_bundle()), encoding="utf-8")
 

--- a/tests/integration/test_submission_validation.py
+++ b/tests/integration/test_submission_validation.py
@@ -83,7 +83,7 @@ def populated_corpus(tmp_path: Path) -> Path:
     return bundles_dir
 
 
-def _package_via_submit(bundle_path: Path, output_dir: Path) -> Path:
+def _package_via_submit(bundle_path: Path, output_dir: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
     """Run `benchbox submit` to produce a manifest. Returns the manifest path."""
     repo_root = Path(__file__).resolve().parents[2]
     # Invoke via the click command directly (not the console script) so the
@@ -91,6 +91,10 @@ def _package_via_submit(bundle_path: Path, output_dir: Path) -> Path:
     from click.testing import CliRunner
 
     from benchbox.cli.commands.submit import submit
+
+    # `benchbox submit` is community-facing end-to-end and hard-refuses
+    # without a deployment salt.
+    monkeypatch.setenv("BENCHBOX_MACHINE_ID_SALT", "integration-test-community-publish-salt")
 
     runner = CliRunner()
     result = runner.invoke(
@@ -106,7 +110,9 @@ def _package_via_submit(bundle_path: Path, output_dir: Path) -> Path:
     return manifest
 
 
-def test_round_trip_validates_clean_submission(tmp_path: Path, populated_corpus: Path) -> None:
+def test_round_trip_validates_clean_submission(
+    tmp_path: Path, populated_corpus: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
     """Package a bundle, drop it next to existing bundles, validate: must pass."""
     # 1. Generate a fresh bundle outside the corpus.
     source_dir = tmp_path / "fresh"
@@ -115,7 +121,7 @@ def test_round_trip_validates_clean_submission(tmp_path: Path, populated_corpus:
 
     # 2. Package via `benchbox submit`.
     out_dir = tmp_path / "submission"
-    manifest_src = _package_via_submit(bundle, out_dir)
+    manifest_src = _package_via_submit(bundle, out_dir, monkeypatch)
 
     # 3. Copy bundle + manifest into the populated corpus.
     submitted_bundle = out_dir / "bundle" / bundle.name
@@ -133,14 +139,16 @@ def test_round_trip_validates_clean_submission(tmp_path: Path, populated_corpus:
     assert "FAIL" not in proc.stdout, proc.stdout
 
 
-def test_round_trip_rejects_tampered_bundle(tmp_path: Path, populated_corpus: Path) -> None:
+def test_round_trip_rejects_tampered_bundle(
+    tmp_path: Path, populated_corpus: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
     """Bundle mutated after the manifest hash is computed must be rejected."""
     source_dir = tmp_path / "fresh"
     source_dir.mkdir()
     bundle = _write_bundle(source_dir, "tpch_sf001_duckdb_tamper", "tamper")
 
     out_dir = tmp_path / "submission"
-    manifest_src = _package_via_submit(bundle, out_dir)
+    manifest_src = _package_via_submit(bundle, out_dir, monkeypatch)
 
     submitted_bundle = out_dir / "bundle" / bundle.name
     target_bundle = populated_corpus / bundle.name

--- a/tests/unit/cli/commands/test_submit.py
+++ b/tests/unit/cli/commands/test_submit.py
@@ -21,6 +21,12 @@ pytestmark = [
 ]
 
 
+@pytest.fixture(autouse=True)
+def _community_publish_salt(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Community submit requires a deployment salt; tests use a private test value."""
+    monkeypatch.setenv("BENCHBOX_MACHINE_ID_SALT", "unit-test-community-publish-salt")
+
+
 def _fake_result() -> SimpleNamespace:
     return SimpleNamespace(
         benchmark_name="tpch",
@@ -86,6 +92,18 @@ def _canonical_file_bytes(path: Path) -> bytes:
 # ---------------------------------------------------------------------------
 # 1. No args - explains usage, exit 1
 # ---------------------------------------------------------------------------
+
+
+def test_submit_refuses_without_public_pseudonym_salt(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """Community submit hard-refuses when BENCHBOX_MACHINE_ID_SALT is unset."""
+    monkeypatch.delenv("BENCHBOX_MACHINE_ID_SALT", raising=False)
+    src = tmp_path / "ok.json"
+    _write_valid_submission_bundle(src)
+    monkeypatch.setattr(sub, "load_result_file", lambda *_a, **_k: (_fake_result(), {}))
+    result = CliRunner().invoke(sub.submit, [str(src), "--dry-run", "--output", str(tmp_path / "out")])
+    assert result.exit_code == 1
+    assert "Submission refused" in result.output
+    assert "BENCHBOX_MACHINE_ID_SALT" in result.output
 
 
 def test_submit_requires_file_or_last(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/unit/core/results/test_public_pseudonym_salt.py
+++ b/tests/unit/core/results/test_public_pseudonym_salt.py
@@ -1,16 +1,22 @@
-"""Public pseudonym salt resolution for community publish."""
+"""Public pseudonym salt resolution for community publish and export soft-read."""
 
 from __future__ import annotations
+
+import json
+from datetime import datetime
 
 import pytest
 
 from benchbox.core.results.anonymization import (
     PUBLIC_PSEUDONYM_SALT_ENV,
     AnonymizationConfig,
+    AnonymizationManager,
     MissingPublicPseudonymSaltError,
     require_public_pseudonym_salt,
     resolve_public_pseudonym_salt,
 )
+from benchbox.core.results.exporter import ResultExporter
+from benchbox.core.results.models import BenchmarkResults
 
 pytestmark = [pytest.mark.unit, pytest.mark.fast]
 
@@ -41,3 +47,109 @@ def test_from_public_environ_require_salt() -> None:
     assert cfg.machine_id_salt == "secret"
     with pytest.raises(MissingPublicPseudonymSaltError):
         AnonymizationConfig.from_public_environ(environ={}, require_salt=True)
+
+
+def test_from_public_environ_soft_read_allows_empty() -> None:
+    cfg = AnonymizationConfig.from_public_environ(environ={})
+    assert cfg.machine_id_salt is None
+
+
+_RAW_ENDPOINT = "https://warehouse.example.invalid/query"
+_RAW_DATABASE = "analytics_db"
+
+
+def _minimal_result_with_endpoint() -> BenchmarkResults:
+    """Result carrying a retained identifier that is hashed (not dropped)."""
+    return BenchmarkResults(
+        benchmark_name="TPC-H",
+        platform="duckdb",
+        scale_factor=0.01,
+        execution_id="salt-export-test",
+        timestamp=datetime(2026, 1, 1, 12, 0, 0),
+        duration_seconds=1.0,
+        total_queries=1,
+        successful_queries=1,
+        failed_queries=0,
+        query_results=[
+            {
+                "query_id": "Q1",
+                "execution_time_seconds": 0.1,
+                "rows_returned": 1,
+                "status": "SUCCESS",
+                "run_type": "measurement",
+            }
+        ],
+        platform_info={
+            "name": "duckdb",
+            "version": "1.0",
+            "endpoint": _RAW_ENDPOINT,
+            "database_name": _RAW_DATABASE,
+        },
+    )
+
+
+def test_exporter_soft_reads_env_salt_for_public_hash(
+    tmp_path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """With BENCHBOX_MACHINE_ID_SALT set, default anonymized export uses it."""
+    salt = "deployment-private-export-salt"
+    monkeypatch.setenv(PUBLIC_PSEUDONYM_SALT_ENV, salt)
+
+    expected = AnonymizationManager(AnonymizationConfig(machine_id_salt=salt))._hash_public_identifier(
+        _RAW_ENDPOINT,
+        "endpoint",
+    )
+    empty_expected = AnonymizationManager(AnonymizationConfig())._hash_public_identifier(
+        _RAW_ENDPOINT,
+        "endpoint",
+    )
+    assert expected != empty_expected, "salt must change retained-field digest"
+
+    exporter = ResultExporter(output_dir=tmp_path, anonymize=True)
+    assert exporter.anonymization_manager is not None
+    assert exporter.anonymization_manager.config.machine_id_salt == salt
+
+    exported = exporter.export_result(_minimal_result_with_endpoint(), formats=["json"])
+    with open(exported["json"], encoding="utf-8") as handle:
+        payload = json.load(handle)
+
+    # platform.config.endpoint is a retained hashed identifier in public export.
+    endpoint = payload["platform"]["config"]["endpoint"]
+    assert endpoint == expected
+    assert endpoint != empty_expected
+
+
+def test_exporter_without_env_salt_still_exports_empty_default(
+    tmp_path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Unset salt must not block local/private anonymized export."""
+    monkeypatch.delenv(PUBLIC_PSEUDONYM_SALT_ENV, raising=False)
+
+    empty_expected = AnonymizationManager(AnonymizationConfig())._hash_public_identifier(
+        _RAW_ENDPOINT,
+        "endpoint",
+    )
+
+    exporter = ResultExporter(output_dir=tmp_path, anonymize=True)
+    assert exporter.anonymization_manager is not None
+    assert exporter.anonymization_manager.config.machine_id_salt is None
+
+    exported = exporter.export_result(_minimal_result_with_endpoint(), formats=["json"])
+    with open(exported["json"], encoding="utf-8") as handle:
+        payload = json.load(handle)
+
+    assert payload["platform"]["config"]["endpoint"] == empty_expected
+    assert payload["export"]["anonymized"] is True
+
+
+def test_exporter_explicit_config_overrides_env(
+    tmp_path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv(PUBLIC_PSEUDONYM_SALT_ENV, "from-env")
+    explicit = AnonymizationConfig(machine_id_salt="from-arg")
+    exporter = ResultExporter(output_dir=tmp_path, anonymize=True, anonymization_config=explicit)
+    assert exporter.anonymization_manager is not None
+    assert exporter.anonymization_manager.config.machine_id_salt == "from-arg"

--- a/tests/unit/core/results/test_public_pseudonym_salt.py
+++ b/tests/unit/core/results/test_public_pseudonym_salt.py
@@ -1,0 +1,43 @@
+"""Public pseudonym salt resolution for community publish."""
+
+from __future__ import annotations
+
+import pytest
+
+from benchbox.core.results.anonymization import (
+    PUBLIC_PSEUDONYM_SALT_ENV,
+    AnonymizationConfig,
+    MissingPublicPseudonymSaltError,
+    require_public_pseudonym_salt,
+    resolve_public_pseudonym_salt,
+)
+
+pytestmark = [pytest.mark.unit, pytest.mark.fast]
+
+
+def test_resolve_prefers_explicit_over_env() -> None:
+    assert resolve_public_pseudonym_salt(explicit="  a  ", environ={PUBLIC_PSEUDONYM_SALT_ENV: "b"}) == "a"
+
+
+def test_resolve_reads_env() -> None:
+    assert resolve_public_pseudonym_salt(environ={PUBLIC_PSEUDONYM_SALT_ENV: "deploy-secret"}) == "deploy-secret"
+
+
+def test_resolve_empty_is_unset() -> None:
+    assert resolve_public_pseudonym_salt(explicit="  ") is None
+    assert resolve_public_pseudonym_salt(environ={PUBLIC_PSEUDONYM_SALT_ENV: ""}) is None
+
+
+def test_require_raises_when_missing() -> None:
+    with pytest.raises(MissingPublicPseudonymSaltError, match=PUBLIC_PSEUDONYM_SALT_ENV):
+        require_public_pseudonym_salt(environ={})
+
+
+def test_from_public_environ_require_salt() -> None:
+    cfg = AnonymizationConfig.from_public_environ(
+        environ={PUBLIC_PSEUDONYM_SALT_ENV: "secret"},
+        require_salt=True,
+    )
+    assert cfg.machine_id_salt == "secret"
+    with pytest.raises(MissingPublicPseudonymSaltError):
+        AnonymizationConfig.from_public_environ(environ={}, require_salt=True)

--- a/tests/unit/core/results/test_submit_classifier_contract.py
+++ b/tests/unit/core/results/test_submit_classifier_contract.py
@@ -167,6 +167,11 @@ def test_submit_classifier_contract_load_error_distinct_from_integrity(tmp_path:
 
 def test_submit_classifier_contract_cli_refusal_tracks_state(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
     """The CLI's externally observable refuse/accept verdict equals the shared state."""
+    # This test drives `sub.submit` end-to-end, which is community-facing and
+    # hard-refuses without a deployment salt. That precondition is orthogonal
+    # to the classification-refusal contract under test here, so satisfy it
+    # once up front (mirrors tests/unit/cli/commands/test_submit.py).
+    monkeypatch.setenv("BENCHBOX_MACHINE_ID_SALT", "unit-test-community-publish-salt")
     out_dir = tmp_path / "out"
     for label, path, expected in _loadable_cases(tmp_path):
         loaded, _raw = load_result_file(path)


### PR DESCRIPTION
Hard-refuse benchbox submit when the public pseudonym salt is unset so
operators cannot ship empty-salt confirmation-oracle community bundles.
Private/local export without salt remains allowed.
