### PR TITLE
fix(results): strip residual empty client_host from the public corpus

### DIFF
--- a/benchbox/core/results/anonymization.py
+++ b/benchbox/core/results/anonymization.py
@@ -526,15 +526,14 @@ class AnonymizationManager:
                 else:
                     child_value = self._anonymize_public_value(child, child_path)
                 # After dropping identifier-only content (e.g. client_host with
-                # only machine_id), omit the empty optional block rather than
+                # only machine_id), omit empty optional blocks rather than
                 # publishing a hollow object. Non-empty profiles keep.
-                # Already-empty `{}` maps in stored corpus pass through so the
-                # publication fixed point is not broken without a re-derive.
+                # One-time corpus re-derive (rederive-prune-empty-client-host)
+                # also strips already-empty `{}` residuals so stored bytes match
+                # the fresh public shape.
                 if (
                     isinstance(child_value, dict)
                     and not child_value
-                    and isinstance(child, dict)
-                    and child
                     and _compact_key(str(key)) in _PUBLIC_EMPTY_OPTIONAL_MAP_KEYS
                 ):
                     continue

--- a/results-data/CORPUS_NOTES.md
+++ b/results-data/CORPUS_NOTES.md
@@ -39,3 +39,49 @@ Both cohorts meet the >=3-platform depth criterion required for the Compare view
 ## Public-path single-pass status (2026-08-05)
 
 Verified with `results_explorer_corpus_migrate.py` dry-run: 0/207 bundles changed under the current public anonymization pass. The `test_rederiv_fresh_public_pass_equals_curated_for_all_fields` gate pins the fixed point.
+
+---
+
+# Regeneration - strip residual empty `client_host` (2026-08-05 / 2026-08-06)
+
+**Related PR:** #1614 (`fix/strip-empty-client-host-corpus`)
+**Date:** 2026-08-05 (local) / 2026-08-06 (UTC commit)
+
+## Reason
+
+After `machine_id` was dropped from public environment maps, some already
+public-shaped primary bundles retained residual empty `client_host: {}`
+objects. Those hollow maps were identifier-only leftovers, not real host
+profiles. Anonymization policy now **always omits empty optional environment
+maps** (including already-empty `{}` residuals) so the public shape has no
+hollow blocks.
+
+## What landed together
+
+Code change and corpus re-derive shipped in one fixed-point commit so stored
+bytes match the fresh public shape:
+
+1. **Policy** (`benchbox/core/results/anonymization.py`): omit empty optional
+   maps under `_PUBLIC_EMPTY_OPTIONAL_MAP_KEYS` even when the stored input was
+   already `{}` (not only when non-empty content was stripped to empty).
+2. **Corpus**: re-derived **105** primary bundles under
+   `results-data/bundles/` (plus inventory refresh) so checked-in bytes match
+   re-anonymization output. Count verified as the primary-bundle delta vs
+   `origin/develop` on this branch (105 `results-data/bundles/*.json` primaries;
+   not plans/tuning/manifest sidecars).
+
+No full corpus rewrite beyond those residual hollow maps; non-empty
+`client_host` profiles and unrelated fields were left alone. Anonymization
+policy was not expanded beyond empty optional map omission.
+
+## How to verify
+
+- Unit: `tests/unit/core/results/test_anonymization.py` —
+  `test_already_empty_client_host_is_omitted` (and related public-unread
+  identifier drop cases).
+- Corpus fixed point: re-anonymize primary bundles and assert byte-identical
+  publication (existing re-derived / fixed-point corpus gates; no empty
+  `client_host` objects remain in primary bundles).
+- Spot check: `rg -n '"client_host": \{\}' results-data/bundles` should not
+  match residual hollow maps in primary result JSON.
+

--- a/results-data/bundles/amplab_sf001_datafusion_df_20260502_223331_f228f907.json
+++ b/results-data/bundles/amplab_sf001_datafusion_df_20260502_223331_f228f907.json
@@ -21,7 +21,6 @@
     "total_usd": 0
   },
   "environment": {
-    "client_host": {},
     "platform_runtime": {
       "collection_status": "partial",
       "runtime_type": "dataframe_process",

--- a/results-data/bundles/amplab_sf001_polars_df_20260502_211246_1df590de.json
+++ b/results-data/bundles/amplab_sf001_polars_df_20260502_211246_1df590de.json
@@ -21,7 +21,6 @@
     "total_usd": 0
   },
   "environment": {
-    "client_host": {},
     "platform_runtime": {
       "collection_status": "partial",
       "runtime_type": "dataframe_process",

--- a/results-data/bundles/amplab_sf001_pyspark_df_20260502_214643_2bcec2f4.json
+++ b/results-data/bundles/amplab_sf001_pyspark_df_20260502_214643_2bcec2f4.json
@@ -21,7 +21,6 @@
     "total_usd": 0
   },
   "environment": {
-    "client_host": {},
     "platform_runtime": {
       "collection_status": "partial",
       "runtime_type": "dataframe_process",

--- a/results-data/bundles/amplab_sf01_datafusion_df_20260502_223335_8ed41c67.json
+++ b/results-data/bundles/amplab_sf01_datafusion_df_20260502_223335_8ed41c67.json
@@ -21,7 +21,6 @@
     "total_usd": 0
   },
   "environment": {
-    "client_host": {},
     "platform_runtime": {
       "collection_status": "partial",
       "runtime_type": "dataframe_process",

--- a/results-data/bundles/amplab_sf01_polars_df_20260502_211250_6407c9a7.json
+++ b/results-data/bundles/amplab_sf01_polars_df_20260502_211250_6407c9a7.json
@@ -21,7 +21,6 @@
     "total_usd": 0
   },
   "environment": {
-    "client_host": {},
     "platform_runtime": {
       "collection_status": "partial",
       "runtime_type": "dataframe_process",

--- a/results-data/bundles/amplab_sf01_pyspark_df_20260502_214650_c2b86db0.json
+++ b/results-data/bundles/amplab_sf01_pyspark_df_20260502_214650_c2b86db0.json
@@ -21,7 +21,6 @@
     "total_usd": 0
   },
   "environment": {
-    "client_host": {},
     "platform_runtime": {
       "collection_status": "partial",
       "runtime_type": "dataframe_process",

--- a/results-data/bundles/amplab_sf1_datafusion_df_20260502_223336_92b1324f.json
+++ b/results-data/bundles/amplab_sf1_datafusion_df_20260502_223336_92b1324f.json
@@ -21,7 +21,6 @@
     "total_usd": 0
   },
   "environment": {
-    "client_host": {},
     "platform_runtime": {
       "collection_status": "partial",
       "runtime_type": "dataframe_process",

--- a/results-data/bundles/amplab_sf1_polars_df_20260502_211251_ca2adb92.json
+++ b/results-data/bundles/amplab_sf1_polars_df_20260502_211251_ca2adb92.json
@@ -21,7 +21,6 @@
     "total_usd": 0
   },
   "environment": {
-    "client_host": {},
     "platform_runtime": {
       "collection_status": "partial",
       "runtime_type": "dataframe_process",

--- a/results-data/bundles/amplab_sf1_pyspark_df_20260502_214655_0cfbd748.json
+++ b/results-data/bundles/amplab_sf1_pyspark_df_20260502_214655_0cfbd748.json
@@ -21,7 +21,6 @@
     "total_usd": 0
   },
   "environment": {
-    "client_host": {},
     "platform_runtime": {
       "collection_status": "partial",
       "runtime_type": "dataframe_process",

--- a/results-data/bundles/clickbench_sf1_datafusion_df_20260502_223259_c911f151.json
+++ b/results-data/bundles/clickbench_sf1_datafusion_df_20260502_223259_c911f151.json
@@ -21,7 +21,6 @@
     "total_usd": 0
   },
   "environment": {
-    "client_host": {},
     "platform_runtime": {
       "collection_status": "partial",
       "runtime_type": "dataframe_process",

--- a/results-data/bundles/clickbench_sf1_polars_df_20260502_211211_9f5a3ffd.json
+++ b/results-data/bundles/clickbench_sf1_polars_df_20260502_211211_9f5a3ffd.json
@@ -21,7 +21,6 @@
     "total_usd": 0
   },
   "environment": {
-    "client_host": {},
     "platform_runtime": {
       "collection_status": "partial",
       "runtime_type": "dataframe_process",

--- a/results-data/bundles/clickbench_sf1_pyspark_df_20260502_214548_16a1516b.json
+++ b/results-data/bundles/clickbench_sf1_pyspark_df_20260502_214548_16a1516b.json
@@ -21,7 +21,6 @@
     "total_usd": 0
   },
   "environment": {
-    "client_host": {},
     "platform_runtime": {
       "collection_status": "partial",
       "runtime_type": "dataframe_process",

--- a/results-data/bundles/coffeeshop_sf001_datafusion_df_20260502_223317_dda954ed.json
+++ b/results-data/bundles/coffeeshop_sf001_datafusion_df_20260502_223317_dda954ed.json
@@ -21,7 +21,6 @@
     "total_usd": 0
   },
   "environment": {
-    "client_host": {},
     "platform_runtime": {
       "collection_status": "partial",
       "runtime_type": "dataframe_process",

--- a/results-data/bundles/coffeeshop_sf001_polars_df_20260502_211230_fe693d45.json
+++ b/results-data/bundles/coffeeshop_sf001_polars_df_20260502_211230_fe693d45.json
@@ -21,7 +21,6 @@
     "total_usd": 0
   },
   "environment": {
-    "client_host": {},
     "platform_runtime": {
       "collection_status": "partial",
       "runtime_type": "dataframe_process",

--- a/results-data/bundles/coffeeshop_sf01_datafusion_df_20260502_223321_08fec735.json
+++ b/results-data/bundles/coffeeshop_sf01_datafusion_df_20260502_223321_08fec735.json
@@ -21,7 +21,6 @@
     "total_usd": 0
   },
   "environment": {
-    "client_host": {},
     "platform_runtime": {
       "collection_status": "partial",
       "runtime_type": "dataframe_process",

--- a/results-data/bundles/coffeeshop_sf01_polars_df_20260502_211235_07bd0fff.json
+++ b/results-data/bundles/coffeeshop_sf01_polars_df_20260502_211235_07bd0fff.json
@@ -21,7 +21,6 @@
     "total_usd": 0
   },
   "environment": {
-    "client_host": {},
     "platform_runtime": {
       "collection_status": "partial",
       "runtime_type": "dataframe_process",

--- a/results-data/bundles/coffeeshop_sf1_datafusion_df_20260502_223323_0eb2e311.json
+++ b/results-data/bundles/coffeeshop_sf1_datafusion_df_20260502_223323_0eb2e311.json
@@ -21,7 +21,6 @@
     "total_usd": 0
   },
   "environment": {
-    "client_host": {},
     "platform_runtime": {
       "collection_status": "partial",
       "runtime_type": "dataframe_process",

--- a/results-data/bundles/coffeeshop_sf1_polars_df_20260502_211238_ec90759f.json
+++ b/results-data/bundles/coffeeshop_sf1_polars_df_20260502_211238_ec90759f.json
@@ -21,7 +21,6 @@
     "total_usd": 0
   },
   "environment": {
-    "client_host": {},
     "platform_runtime": {
       "collection_status": "partial",
       "runtime_type": "dataframe_process",

--- a/results-data/bundles/datavault_sf001_pyspark_df_20260502_215849_95a24d45.json
+++ b/results-data/bundles/datavault_sf001_pyspark_df_20260502_215849_95a24d45.json
@@ -21,7 +21,6 @@
     "total_usd": 0
   },
   "environment": {
-    "client_host": {},
     "platform_runtime": {
       "collection_status": "partial",
       "runtime_type": "dataframe_process",

--- a/results-data/bundles/datavault_sf01_pyspark_df_20260502_215856_7a32012a.json
+++ b/results-data/bundles/datavault_sf01_pyspark_df_20260502_215856_7a32012a.json
@@ -21,7 +21,6 @@
     "total_usd": 0
   },
   "environment": {
-    "client_host": {},
     "platform_runtime": {
       "collection_status": "partial",
       "runtime_type": "dataframe_process",

--- a/results-data/bundles/datavault_sf1_pyspark_df_20260502_215903_105a29f7.json
+++ b/results-data/bundles/datavault_sf1_pyspark_df_20260502_215903_105a29f7.json
@@ -21,7 +21,6 @@
     "total_usd": 0
   },
   "environment": {
-    "client_host": {},
     "platform_runtime": {
       "collection_status": "partial",
       "runtime_type": "dataframe_process",

--- a/results-data/bundles/flightdata_sf001_datafusion_df_20260502_223348_d9e8bf20.json
+++ b/results-data/bundles/flightdata_sf001_datafusion_df_20260502_223348_d9e8bf20.json
@@ -21,7 +21,6 @@
     "total_usd": 0
   },
   "environment": {
-    "client_host": {},
     "platform_runtime": {
       "collection_status": "partial",
       "runtime_type": "dataframe_process",

--- a/results-data/bundles/flightdata_sf001_polars_df_20260502_211311_d255f81b.json
+++ b/results-data/bundles/flightdata_sf001_polars_df_20260502_211311_d255f81b.json
@@ -21,7 +21,6 @@
     "total_usd": 0
   },
   "environment": {
-    "client_host": {},
     "platform_runtime": {
       "collection_status": "partial",
       "runtime_type": "dataframe_process",

--- a/results-data/bundles/flightdata_sf001_pyspark_df_20260502_214742_a9d32e46.json
+++ b/results-data/bundles/flightdata_sf001_pyspark_df_20260502_214742_a9d32e46.json
@@ -21,7 +21,6 @@
     "total_usd": 0
   },
   "environment": {
-    "client_host": {},
     "platform_runtime": {
       "collection_status": "partial",
       "runtime_type": "dataframe_process",

--- a/results-data/bundles/flightdata_sf01_datafusion_df_20260502_223350_9310d61f.json
+++ b/results-data/bundles/flightdata_sf01_datafusion_df_20260502_223350_9310d61f.json
@@ -21,7 +21,6 @@
     "total_usd": 0
   },
   "environment": {
-    "client_host": {},
     "platform_runtime": {
       "collection_status": "partial",
       "runtime_type": "dataframe_process",

--- a/results-data/bundles/flightdata_sf01_polars_df_20260502_211318_602c45de.json
+++ b/results-data/bundles/flightdata_sf01_polars_df_20260502_211318_602c45de.json
@@ -21,7 +21,6 @@
     "total_usd": 0
   },
   "environment": {
-    "client_host": {},
     "platform_runtime": {
       "collection_status": "partial",
       "runtime_type": "dataframe_process",

--- a/results-data/bundles/flightdata_sf01_pyspark_df_20260502_214754_8699bacb.json
+++ b/results-data/bundles/flightdata_sf01_pyspark_df_20260502_214754_8699bacb.json
@@ -21,7 +21,6 @@
     "total_usd": 0
   },
   "environment": {
-    "client_host": {},
     "platform_runtime": {
       "collection_status": "partial",
       "runtime_type": "dataframe_process",

--- a/results-data/bundles/h2odb_sf001_datafusion_df_20260502_223300_05b6d4eb.json
+++ b/results-data/bundles/h2odb_sf001_datafusion_df_20260502_223300_05b6d4eb.json
@@ -21,7 +21,6 @@
     "total_usd": 0
   },
   "environment": {
-    "client_host": {},
     "platform_runtime": {
       "collection_status": "partial",
       "runtime_type": "dataframe_process",

--- a/results-data/bundles/h2odb_sf001_polars_df_20260502_211213_b684dd1e.json
+++ b/results-data/bundles/h2odb_sf001_polars_df_20260502_211213_b684dd1e.json
@@ -21,7 +21,6 @@
     "total_usd": 0
   },
   "environment": {
-    "client_host": {},
     "platform_runtime": {
       "collection_status": "partial",
       "runtime_type": "dataframe_process",

--- a/results-data/bundles/h2odb_sf001_pyspark_df_20260502_214553_9a5c5350.json
+++ b/results-data/bundles/h2odb_sf001_pyspark_df_20260502_214553_9a5c5350.json
@@ -21,7 +21,6 @@
     "total_usd": 0
   },
   "environment": {
-    "client_host": {},
     "platform_runtime": {
       "collection_status": "partial",
       "runtime_type": "dataframe_process",

--- a/results-data/bundles/h2odb_sf01_datafusion_df_20260502_223314_b024941c.json
+++ b/results-data/bundles/h2odb_sf01_datafusion_df_20260502_223314_b024941c.json
@@ -21,7 +21,6 @@
     "total_usd": 0
   },
   "environment": {
-    "client_host": {},
     "platform_runtime": {
       "collection_status": "partial",
       "runtime_type": "dataframe_process",

--- a/results-data/bundles/h2odb_sf01_polars_df_20260502_211227_562cdd64.json
+++ b/results-data/bundles/h2odb_sf01_polars_df_20260502_211227_562cdd64.json
@@ -21,7 +21,6 @@
     "total_usd": 0
   },
   "environment": {
-    "client_host": {},
     "platform_runtime": {
       "collection_status": "partial",
       "runtime_type": "dataframe_process",

--- a/results-data/bundles/h2odb_sf01_pyspark_df_20260502_214610_81e6974f.json
+++ b/results-data/bundles/h2odb_sf01_pyspark_df_20260502_214610_81e6974f.json
@@ -21,7 +21,6 @@
     "total_usd": 0
   },
   "environment": {
-    "client_host": {},
     "platform_runtime": {
       "collection_status": "partial",
       "runtime_type": "dataframe_process",

--- a/results-data/bundles/h2odb_sf1_datafusion_df_20260502_223315_db3ffa2a.json
+++ b/results-data/bundles/h2odb_sf1_datafusion_df_20260502_223315_db3ffa2a.json
@@ -21,7 +21,6 @@
     "total_usd": 0
   },
   "environment": {
-    "client_host": {},
     "platform_runtime": {
       "collection_status": "partial",
       "runtime_type": "dataframe_process",

--- a/results-data/bundles/h2odb_sf1_polars_df_20260502_211228_368e2b57.json
+++ b/results-data/bundles/h2odb_sf1_polars_df_20260502_211228_368e2b57.json
@@ -21,7 +21,6 @@
     "total_usd": 0
   },
   "environment": {
-    "client_host": {},
     "platform_runtime": {
       "collection_status": "partial",
       "runtime_type": "dataframe_process",

--- a/results-data/bundles/h2odb_sf1_pyspark_df_20260502_214614_33209063.json
+++ b/results-data/bundles/h2odb_sf1_pyspark_df_20260502_214614_33209063.json
@@ -21,7 +21,6 @@
     "total_usd": 0
   },
   "environment": {
-    "client_host": {},
     "platform_runtime": {
       "collection_status": "partial",
       "runtime_type": "dataframe_process",

--- a/results-data/bundles/metadata_primitives_sf1_polars_df_20260502_211203_5a803e74.json
+++ b/results-data/bundles/metadata_primitives_sf1_polars_df_20260502_211203_5a803e74.json
@@ -21,7 +21,6 @@
     "total_usd": 0
   },
   "environment": {
-    "client_host": {},
     "platform_runtime": {
       "collection_status": "partial",
       "runtime_type": "dataframe_process",

--- a/results-data/bundles/metadata_primitives_sf1_pyspark_df_20260502_214436_50a3043f.json
+++ b/results-data/bundles/metadata_primitives_sf1_pyspark_df_20260502_214436_50a3043f.json
@@ -21,7 +21,6 @@
     "total_usd": 0
   },
   "environment": {
-    "client_host": {},
     "platform_runtime": {
       "collection_status": "partial",
       "runtime_type": "dataframe_process",

--- a/results-data/bundles/nyctaxi_sf001_datafusion_df_20260502_223343_11bf3d15.json
+++ b/results-data/bundles/nyctaxi_sf001_datafusion_df_20260502_223343_11bf3d15.json
@@ -21,7 +21,6 @@
     "total_usd": 0
   },
   "environment": {
-    "client_host": {},
     "platform_runtime": {
       "collection_status": "partial",
       "runtime_type": "dataframe_process",

--- a/results-data/bundles/nyctaxi_sf001_polars_df_20260502_211302_0e34be37.json
+++ b/results-data/bundles/nyctaxi_sf001_polars_df_20260502_211302_0e34be37.json
@@ -21,7 +21,6 @@
     "total_usd": 0
   },
   "environment": {
-    "client_host": {},
     "platform_runtime": {
       "collection_status": "partial",
       "runtime_type": "dataframe_process",

--- a/results-data/bundles/nyctaxi_sf001_pyspark_df_20260502_214722_7f225978.json
+++ b/results-data/bundles/nyctaxi_sf001_pyspark_df_20260502_214722_7f225978.json
@@ -21,7 +21,6 @@
     "total_usd": 0
   },
   "environment": {
-    "client_host": {},
     "platform_runtime": {
       "collection_status": "partial",
       "runtime_type": "dataframe_process",

--- a/results-data/bundles/nyctaxi_sf01_datafusion_df_20260502_223345_6b902570.json
+++ b/results-data/bundles/nyctaxi_sf01_datafusion_df_20260502_223345_6b902570.json
@@ -21,7 +21,6 @@
     "total_usd": 0
   },
   "environment": {
-    "client_host": {},
     "platform_runtime": {
       "collection_status": "partial",
       "runtime_type": "dataframe_process",

--- a/results-data/bundles/nyctaxi_sf01_polars_df_20260502_211304_2459ce33.json
+++ b/results-data/bundles/nyctaxi_sf01_polars_df_20260502_211304_2459ce33.json
@@ -21,7 +21,6 @@
     "total_usd": 0
   },
   "environment": {
-    "client_host": {},
     "platform_runtime": {
       "collection_status": "partial",
       "runtime_type": "dataframe_process",

--- a/results-data/bundles/nyctaxi_sf01_pyspark_df_20260502_214726_f8c1d2c5.json
+++ b/results-data/bundles/nyctaxi_sf01_pyspark_df_20260502_214726_f8c1d2c5.json
@@ -21,7 +21,6 @@
     "total_usd": 0
   },
   "environment": {
-    "client_host": {},
     "platform_runtime": {
       "collection_status": "partial",
       "runtime_type": "dataframe_process",

--- a/results-data/bundles/nyctaxi_sf1_datafusion_df_20260502_223346_08ffc8ba.json
+++ b/results-data/bundles/nyctaxi_sf1_datafusion_df_20260502_223346_08ffc8ba.json
@@ -21,7 +21,6 @@
     "total_usd": 0
   },
   "environment": {
-    "client_host": {},
     "platform_runtime": {
       "collection_status": "partial",
       "runtime_type": "dataframe_process",

--- a/results-data/bundles/nyctaxi_sf1_polars_df_20260502_211308_a0a21b10.json
+++ b/results-data/bundles/nyctaxi_sf1_polars_df_20260502_211308_a0a21b10.json
@@ -21,7 +21,6 @@
     "total_usd": 0
   },
   "environment": {
-    "client_host": {},
     "platform_runtime": {
       "collection_status": "partial",
       "runtime_type": "dataframe_process",

--- a/results-data/bundles/nyctaxi_sf1_pyspark_df_20260502_214732_33f405ff.json
+++ b/results-data/bundles/nyctaxi_sf1_pyspark_df_20260502_214732_33f405ff.json
@@ -21,7 +21,6 @@
     "total_usd": 0
   },
   "environment": {
-    "client_host": {},
     "platform_runtime": {
       "collection_status": "partial",
       "runtime_type": "dataframe_process",

--- a/results-data/bundles/read_primitives_sf001_datafusion_df_20260502_222935_faede093.json
+++ b/results-data/bundles/read_primitives_sf001_datafusion_df_20260502_222935_faede093.json
@@ -21,7 +21,6 @@
     "total_usd": 0
   },
   "environment": {
-    "client_host": {},
     "platform_runtime": {
       "collection_status": "partial",
       "runtime_type": "dataframe_process",

--- a/results-data/bundles/read_primitives_sf001_polars_df_20260502_210839_881199ef.json
+++ b/results-data/bundles/read_primitives_sf001_polars_df_20260502_210839_881199ef.json
@@ -21,7 +21,6 @@
     "total_usd": 0
   },
   "environment": {
-    "client_host": {},
     "platform_runtime": {
       "collection_status": "partial",
       "runtime_type": "dataframe_process",

--- a/results-data/bundles/read_primitives_sf001_pyspark_df_20260502_213754_a17d36be.json
+++ b/results-data/bundles/read_primitives_sf001_pyspark_df_20260502_213754_a17d36be.json
@@ -21,7 +21,6 @@
     "total_usd": 0
   },
   "environment": {
-    "client_host": {},
     "platform_runtime": {
       "collection_status": "partial",
       "runtime_type": "dataframe_process",

--- a/results-data/bundles/read_primitives_sf01_datafusion_df_20260502_222939_c6938183.json
+++ b/results-data/bundles/read_primitives_sf01_datafusion_df_20260502_222939_c6938183.json
@@ -21,7 +21,6 @@
     "total_usd": 0
   },
   "environment": {
-    "client_host": {},
     "platform_runtime": {
       "collection_status": "partial",
       "runtime_type": "dataframe_process",

--- a/results-data/bundles/read_primitives_sf01_polars_df_20260502_210844_1cb50efa.json
+++ b/results-data/bundles/read_primitives_sf01_polars_df_20260502_210844_1cb50efa.json
@@ -21,7 +21,6 @@
     "total_usd": 0
   },
   "environment": {
-    "client_host": {},
     "platform_runtime": {
       "collection_status": "partial",
       "runtime_type": "dataframe_process",

--- a/results-data/bundles/read_primitives_sf01_pyspark_df_20260502_214131_e2b3c755.json
+++ b/results-data/bundles/read_primitives_sf01_pyspark_df_20260502_214131_e2b3c755.json
@@ -21,7 +21,6 @@
     "total_usd": 0
   },
   "environment": {
-    "client_host": {},
     "platform_runtime": {
       "collection_status": "partial",
       "runtime_type": "dataframe_process",

--- a/results-data/bundles/ssb_sf001_datafusion_df_20260502_223324_971d48d2.json
+++ b/results-data/bundles/ssb_sf001_datafusion_df_20260502_223324_971d48d2.json
@@ -21,7 +21,6 @@
     "total_usd": 0
   },
   "environment": {
-    "client_host": {},
     "platform_runtime": {
       "collection_status": "partial",
       "runtime_type": "dataframe_process",

--- a/results-data/bundles/ssb_sf001_polars_df_20260502_211239_4e92eecf.json
+++ b/results-data/bundles/ssb_sf001_polars_df_20260502_211239_4e92eecf.json
@@ -21,7 +21,6 @@
     "total_usd": 0
   },
   "environment": {
-    "client_host": {},
     "platform_runtime": {
       "collection_status": "partial",
       "runtime_type": "dataframe_process",

--- a/results-data/bundles/ssb_sf001_pyspark_df_20260502_214625_deed8b90.json
+++ b/results-data/bundles/ssb_sf001_pyspark_df_20260502_214625_deed8b90.json
@@ -21,7 +21,6 @@
     "total_usd": 0
   },
   "environment": {
-    "client_host": {},
     "platform_runtime": {
       "collection_status": "partial",
       "runtime_type": "dataframe_process",

--- a/results-data/bundles/ssb_sf01_datafusion_df_20260502_223328_8c02d649.json
+++ b/results-data/bundles/ssb_sf01_datafusion_df_20260502_223328_8c02d649.json
@@ -21,7 +21,6 @@
     "total_usd": 0
   },
   "environment": {
-    "client_host": {},
     "platform_runtime": {
       "collection_status": "partial",
       "runtime_type": "dataframe_process",

--- a/results-data/bundles/ssb_sf01_polars_df_20260502_211243_69643606.json
+++ b/results-data/bundles/ssb_sf01_polars_df_20260502_211243_69643606.json
@@ -21,7 +21,6 @@
     "total_usd": 0
   },
   "environment": {
-    "client_host": {},
     "platform_runtime": {
       "collection_status": "partial",
       "runtime_type": "dataframe_process",

--- a/results-data/bundles/ssb_sf01_pyspark_df_20260502_214632_a3ddcc95.json
+++ b/results-data/bundles/ssb_sf01_pyspark_df_20260502_214632_a3ddcc95.json
@@ -21,7 +21,6 @@
     "total_usd": 0
   },
   "environment": {
-    "client_host": {},
     "platform_runtime": {
       "collection_status": "partial",
       "runtime_type": "dataframe_process",

--- a/results-data/bundles/ssb_sf1_datafusion_df_20260502_223330_2b2f5243.json
+++ b/results-data/bundles/ssb_sf1_datafusion_df_20260502_223330_2b2f5243.json
@@ -21,7 +21,6 @@
     "total_usd": 0
   },
   "environment": {
-    "client_host": {},
     "platform_runtime": {
       "collection_status": "partial",
       "runtime_type": "dataframe_process",

--- a/results-data/bundles/ssb_sf1_polars_df_20260502_211245_7e3e0e7c.json
+++ b/results-data/bundles/ssb_sf1_polars_df_20260502_211245_7e3e0e7c.json
@@ -21,7 +21,6 @@
     "total_usd": 0
   },
   "environment": {
-    "client_host": {},
     "platform_runtime": {
       "collection_status": "partial",
       "runtime_type": "dataframe_process",

--- a/results-data/bundles/ssb_sf1_pyspark_df_20260502_214638_4d83c4c3.json
+++ b/results-data/bundles/ssb_sf1_pyspark_df_20260502_214638_4d83c4c3.json
@@ -21,7 +21,6 @@
     "total_usd": 0
   },
   "environment": {
-    "client_host": {},
     "platform_runtime": {
       "collection_status": "partial",
       "runtime_type": "dataframe_process",

--- a/results-data/bundles/tpcds_obt_sf1_datafusion_df_20260502_223354_54c58248.json
+++ b/results-data/bundles/tpcds_obt_sf1_datafusion_df_20260502_223354_54c58248.json
@@ -21,7 +21,6 @@
     "total_usd": 0
   },
   "environment": {
-    "client_host": {},
     "platform_runtime": {
       "collection_status": "partial",
       "runtime_type": "dataframe_process",

--- a/results-data/bundles/tpcds_obt_sf1_polars_df_20260502_211324_60c565bf.json
+++ b/results-data/bundles/tpcds_obt_sf1_polars_df_20260502_211324_60c565bf.json
@@ -21,7 +21,6 @@
     "total_usd": 0
   },
   "environment": {
-    "client_host": {},
     "platform_runtime": {
       "collection_status": "partial",
       "runtime_type": "dataframe_process",

--- a/results-data/bundles/tpcds_obt_sf1_pyspark_df_20260502_214826_df0f9d07.json
+++ b/results-data/bundles/tpcds_obt_sf1_pyspark_df_20260502_214826_df0f9d07.json
@@ -21,7 +21,6 @@
     "total_usd": 0
   },
   "environment": {
-    "client_host": {},
     "platform_runtime": {
       "collection_status": "partial",
       "runtime_type": "dataframe_process",

--- a/results-data/bundles/tpch_sf001_datafusion_df_20260502_222800_536a69c2.json
+++ b/results-data/bundles/tpch_sf001_datafusion_df_20260502_222800_536a69c2.json
@@ -21,7 +21,6 @@
     "total_usd": 0
   },
   "environment": {
-    "client_host": {},
     "platform_runtime": {
       "collection_status": "partial",
       "runtime_type": "dataframe_process",

--- a/results-data/bundles/tpch_sf001_polars_df_20260502_210713_8408d471.json
+++ b/results-data/bundles/tpch_sf001_polars_df_20260502_210713_8408d471.json
@@ -21,7 +21,6 @@
     "total_usd": 0
   },
   "environment": {
-    "client_host": {},
     "platform_runtime": {
       "collection_status": "partial",
       "runtime_type": "dataframe_process",

--- a/results-data/bundles/tpch_sf001_pyspark_df_20260502_212950_2dbda97e.json
+++ b/results-data/bundles/tpch_sf001_pyspark_df_20260502_212950_2dbda97e.json
@@ -21,7 +21,6 @@
     "total_usd": 0
   },
   "environment": {
-    "client_host": {},
     "platform_runtime": {
       "collection_status": "partial",
       "runtime_type": "dataframe_process",

--- a/results-data/bundles/tpch_sf01_datafusion_df_20260502_222802_da96c80b.json
+++ b/results-data/bundles/tpch_sf01_datafusion_df_20260502_222802_da96c80b.json
@@ -21,7 +21,6 @@
     "total_usd": 0
   },
   "environment": {
-    "client_host": {},
     "platform_runtime": {
       "collection_status": "partial",
       "runtime_type": "dataframe_process",

--- a/results-data/bundles/tpch_sf01_polars_df_20260502_210715_372f12c6.json
+++ b/results-data/bundles/tpch_sf01_polars_df_20260502_210715_372f12c6.json
@@ -21,7 +21,6 @@
     "total_usd": 0
   },
   "environment": {
-    "client_host": {},
     "platform_runtime": {
       "collection_status": "partial",
       "runtime_type": "dataframe_process",

--- a/results-data/bundles/tpch_sf01_pyspark_df_20260502_213125_f90c8f1d.json
+++ b/results-data/bundles/tpch_sf01_pyspark_df_20260502_213125_f90c8f1d.json
@@ -21,7 +21,6 @@
     "total_usd": 0
   },
   "environment": {
-    "client_host": {},
     "platform_runtime": {
       "collection_status": "partial",
       "runtime_type": "dataframe_process",

--- a/results-data/bundles/tpch_sf1_datafusion_df_20260502_222808_0c34d662.json
+++ b/results-data/bundles/tpch_sf1_datafusion_df_20260502_222808_0c34d662.json
@@ -21,7 +21,6 @@
     "total_usd": 0
   },
   "environment": {
-    "client_host": {},
     "platform_runtime": {
       "collection_status": "partial",
       "runtime_type": "dataframe_process",

--- a/results-data/bundles/tpch_sf1_polars_df_20260502_210721_02521fdb.json
+++ b/results-data/bundles/tpch_sf1_polars_df_20260502_210721_02521fdb.json
@@ -21,7 +21,6 @@
     "total_usd": 0
   },
   "environment": {
-    "client_host": {},
     "platform_runtime": {
       "collection_status": "partial",
       "runtime_type": "dataframe_process",

--- a/results-data/bundles/tpch_sf1_pyspark_df_20260502_213448_a88d204d.json
+++ b/results-data/bundles/tpch_sf1_pyspark_df_20260502_213448_a88d204d.json
@@ -21,7 +21,6 @@
     "total_usd": 0
   },
   "environment": {
-    "client_host": {},
     "platform_runtime": {
       "collection_status": "partial",
       "runtime_type": "dataframe_process",

--- a/results-data/bundles/tpch_skew_sf001_datafusion_df_20260502_223501_3f2a7e6a.json
+++ b/results-data/bundles/tpch_skew_sf001_datafusion_df_20260502_223501_3f2a7e6a.json
@@ -21,7 +21,6 @@
     "total_usd": 0
   },
   "environment": {
-    "client_host": {},
     "platform_runtime": {
       "collection_status": "partial",
       "runtime_type": "dataframe_process",

--- a/results-data/bundles/tpch_skew_sf001_polars_df_20260502_211424_e25cb06f.json
+++ b/results-data/bundles/tpch_skew_sf001_polars_df_20260502_211424_e25cb06f.json
@@ -21,7 +21,6 @@
     "total_usd": 0
   },
   "environment": {
-    "client_host": {},
     "platform_runtime": {
       "collection_status": "partial",
       "runtime_type": "dataframe_process",

--- a/results-data/bundles/tpch_skew_sf001_pyspark_df_20260502_215832_e75f78eb.json
+++ b/results-data/bundles/tpch_skew_sf001_pyspark_df_20260502_215832_e75f78eb.json
@@ -21,7 +21,6 @@
     "total_usd": 0
   },
   "environment": {
-    "client_host": {},
     "platform_runtime": {
       "collection_status": "partial",
       "runtime_type": "dataframe_process",

--- a/results-data/bundles/tpch_skew_sf01_datafusion_df_20260502_223502_4943b03a.json
+++ b/results-data/bundles/tpch_skew_sf01_datafusion_df_20260502_223502_4943b03a.json
@@ -21,7 +21,6 @@
     "total_usd": 0
   },
   "environment": {
-    "client_host": {},
     "platform_runtime": {
       "collection_status": "partial",
       "runtime_type": "dataframe_process",

--- a/results-data/bundles/tpch_skew_sf01_polars_df_20260502_211426_50cb1511.json
+++ b/results-data/bundles/tpch_skew_sf01_polars_df_20260502_211426_50cb1511.json
@@ -21,7 +21,6 @@
     "total_usd": 0
   },
   "environment": {
-    "client_host": {},
     "platform_runtime": {
       "collection_status": "partial",
       "runtime_type": "dataframe_process",

--- a/results-data/bundles/tpch_skew_sf01_pyspark_df_20260502_215837_80510f48.json
+++ b/results-data/bundles/tpch_skew_sf01_pyspark_df_20260502_215837_80510f48.json
@@ -21,7 +21,6 @@
     "total_usd": 0
   },
   "environment": {
-    "client_host": {},
     "platform_runtime": {
       "collection_status": "partial",
       "runtime_type": "dataframe_process",

--- a/results-data/bundles/tpch_skew_sf1_datafusion_df_20260502_223504_37626a17.json
+++ b/results-data/bundles/tpch_skew_sf1_datafusion_df_20260502_223504_37626a17.json
@@ -21,7 +21,6 @@
     "total_usd": 0
   },
   "environment": {
-    "client_host": {},
     "platform_runtime": {
       "collection_status": "partial",
       "runtime_type": "dataframe_process",

--- a/results-data/bundles/tpch_skew_sf1_polars_df_20260502_211431_81b53055.json
+++ b/results-data/bundles/tpch_skew_sf1_polars_df_20260502_211431_81b53055.json
@@ -21,7 +21,6 @@
     "total_usd": 0
   },
   "environment": {
-    "client_host": {},
     "platform_runtime": {
       "collection_status": "partial",
       "runtime_type": "dataframe_process",

--- a/results-data/bundles/tpch_skew_sf1_pyspark_df_20260502_215843_cabb8984.json
+++ b/results-data/bundles/tpch_skew_sf1_pyspark_df_20260502_215843_cabb8984.json
@@ -21,7 +21,6 @@
     "total_usd": 0
   },
   "environment": {
-    "client_host": {},
     "platform_runtime": {
       "collection_status": "partial",
       "runtime_type": "dataframe_process",

--- a/results-data/bundles/tpchavoc_sf001_datafusion_df_20260502_223402_ce19d6b3.json
+++ b/results-data/bundles/tpchavoc_sf001_datafusion_df_20260502_223402_ce19d6b3.json
@@ -21,7 +21,6 @@
     "total_usd": 0
   },
   "environment": {
-    "client_host": {},
     "platform_runtime": {
       "collection_status": "partial",
       "runtime_type": "dataframe_process",

--- a/results-data/bundles/tpchavoc_sf001_polars_df_20260502_211328_5ac5485d.json
+++ b/results-data/bundles/tpchavoc_sf001_polars_df_20260502_211328_5ac5485d.json
@@ -21,7 +21,6 @@
     "total_usd": 0
   },
   "environment": {
-    "client_host": {},
     "platform_runtime": {
       "collection_status": "partial",
       "runtime_type": "dataframe_process",

--- a/results-data/bundles/tpchavoc_sf01_datafusion_df_20260502_223414_b035e313.json
+++ b/results-data/bundles/tpchavoc_sf01_datafusion_df_20260502_223414_b035e313.json
@@ -21,7 +21,6 @@
     "total_usd": 0
   },
   "environment": {
-    "client_host": {},
     "platform_runtime": {
       "collection_status": "partial",
       "runtime_type": "dataframe_process",

--- a/results-data/bundles/tpchavoc_sf01_polars_df_20260502_211336_7281b720.json
+++ b/results-data/bundles/tpchavoc_sf01_polars_df_20260502_211336_7281b720.json
@@ -21,7 +21,6 @@
     "total_usd": 0
   },
   "environment": {
-    "client_host": {},
     "platform_runtime": {
       "collection_status": "partial",
       "runtime_type": "dataframe_process",

--- a/results-data/bundles/tsbs_devops_sf001_datafusion_df_20260502_223339_f536ebb4.json
+++ b/results-data/bundles/tsbs_devops_sf001_datafusion_df_20260502_223339_f536ebb4.json
@@ -21,7 +21,6 @@
     "total_usd": 0
   },
   "environment": {
-    "client_host": {},
     "platform_runtime": {
       "collection_status": "partial",
       "runtime_type": "dataframe_process",

--- a/results-data/bundles/tsbs_devops_sf001_polars_df_20260502_211255_aaef4b29.json
+++ b/results-data/bundles/tsbs_devops_sf001_polars_df_20260502_211255_aaef4b29.json
@@ -21,7 +21,6 @@
     "total_usd": 0
   },
   "environment": {
-    "client_host": {},
     "platform_runtime": {
       "collection_status": "partial",
       "runtime_type": "dataframe_process",

--- a/results-data/bundles/tsbs_devops_sf001_pyspark_df_20260502_214706_2b64f5a8.json
+++ b/results-data/bundles/tsbs_devops_sf001_pyspark_df_20260502_214706_2b64f5a8.json
@@ -21,7 +21,6 @@
     "total_usd": 0
   },
   "environment": {
-    "client_host": {},
     "platform_runtime": {
       "collection_status": "partial",
       "runtime_type": "dataframe_process",

--- a/results-data/bundles/tsbs_devops_sf01_datafusion_df_20260502_223340_24b27f9e.json
+++ b/results-data/bundles/tsbs_devops_sf01_datafusion_df_20260502_223340_24b27f9e.json
@@ -21,7 +21,6 @@
     "total_usd": 0
   },
   "environment": {
-    "client_host": {},
     "platform_runtime": {
       "collection_status": "partial",
       "runtime_type": "dataframe_process",

--- a/results-data/bundles/tsbs_devops_sf01_polars_df_20260502_211256_08ff769e.json
+++ b/results-data/bundles/tsbs_devops_sf01_polars_df_20260502_211256_08ff769e.json
@@ -21,7 +21,6 @@
     "total_usd": 0
   },
   "environment": {
-    "client_host": {},
     "platform_runtime": {
       "collection_status": "partial",
       "runtime_type": "dataframe_process",

--- a/results-data/bundles/tsbs_devops_sf01_pyspark_df_20260502_214711_86d7cc38.json
+++ b/results-data/bundles/tsbs_devops_sf01_pyspark_df_20260502_214711_86d7cc38.json
@@ -21,7 +21,6 @@
     "total_usd": 0
   },
   "environment": {
-    "client_host": {},
     "platform_runtime": {
       "collection_status": "partial",
       "runtime_type": "dataframe_process",

--- a/results-data/bundles/tsbs_devops_sf1_datafusion_df_20260502_223342_cba14069.json
+++ b/results-data/bundles/tsbs_devops_sf1_datafusion_df_20260502_223342_cba14069.json
@@ -21,7 +21,6 @@
     "total_usd": 0
   },
   "environment": {
-    "client_host": {},
     "platform_runtime": {
       "collection_status": "partial",
       "runtime_type": "dataframe_process",

--- a/results-data/bundles/tsbs_devops_sf1_polars_df_20260502_211300_8dc54836.json
+++ b/results-data/bundles/tsbs_devops_sf1_polars_df_20260502_211300_8dc54836.json
@@ -21,7 +21,6 @@
     "total_usd": 0
   },
   "environment": {
-    "client_host": {},
     "platform_runtime": {
       "collection_status": "partial",
       "runtime_type": "dataframe_process",

--- a/results-data/bundles/tsbs_devops_sf1_pyspark_df_20260502_214717_7465048e.json
+++ b/results-data/bundles/tsbs_devops_sf1_pyspark_df_20260502_214717_7465048e.json
@@ -21,7 +21,6 @@
     "total_usd": 0
   },
   "environment": {
-    "client_host": {},
     "platform_runtime": {
       "collection_status": "partial",
       "runtime_type": "dataframe_process",

--- a/results-data/bundles/write_primitives_sf001_datafusion_df_20260502_223008_c5299ef7.json
+++ b/results-data/bundles/write_primitives_sf001_datafusion_df_20260502_223008_c5299ef7.json
@@ -21,7 +21,6 @@
     "total_usd": 0
   },
   "environment": {
-    "client_host": {},
     "platform_runtime": {
       "collection_status": "partial",
       "runtime_type": "dataframe_process",

--- a/results-data/bundles/write_primitives_sf001_polars_df_20260502_210917_f2787858.json
+++ b/results-data/bundles/write_primitives_sf001_polars_df_20260502_210917_f2787858.json
@@ -21,7 +21,6 @@
     "total_usd": 0
   },
   "environment": {
-    "client_host": {},
     "platform_runtime": {
       "collection_status": "partial",
       "runtime_type": "dataframe_process",

--- a/results-data/bundles/write_primitives_sf001_pyspark_df_20260502_214140_804d82c4.json
+++ b/results-data/bundles/write_primitives_sf001_pyspark_df_20260502_214140_804d82c4.json
@@ -21,7 +21,6 @@
     "total_usd": 0
   },
   "environment": {
-    "client_host": {},
     "platform_runtime": {
       "collection_status": "partial",
       "runtime_type": "dataframe_process",

--- a/results-data/bundles/write_primitives_sf01_datafusion_df_20260502_223035_e908538a.json
+++ b/results-data/bundles/write_primitives_sf01_datafusion_df_20260502_223035_e908538a.json
@@ -21,7 +21,6 @@
     "total_usd": 0
   },
   "environment": {
-    "client_host": {},
     "platform_runtime": {
       "collection_status": "partial",
       "runtime_type": "dataframe_process",

--- a/results-data/bundles/write_primitives_sf01_polars_df_20260502_210944_e79b8a43.json
+++ b/results-data/bundles/write_primitives_sf01_polars_df_20260502_210944_e79b8a43.json
@@ -21,7 +21,6 @@
     "total_usd": 0
   },
   "environment": {
-    "client_host": {},
     "platform_runtime": {
       "collection_status": "partial",
       "runtime_type": "dataframe_process",

--- a/results-data/bundles/write_primitives_sf01_pyspark_df_20260502_214207_429683c1.json
+++ b/results-data/bundles/write_primitives_sf01_pyspark_df_20260502_214207_429683c1.json
@@ -21,7 +21,6 @@
     "total_usd": 0
   },
   "environment": {
-    "client_host": {},
     "platform_runtime": {
       "collection_status": "partial",
       "runtime_type": "dataframe_process",

--- a/results-data/bundles/write_primitives_sf1_datafusion_df_20260502_223254_30f1d742.json
+++ b/results-data/bundles/write_primitives_sf1_datafusion_df_20260502_223254_30f1d742.json
@@ -21,7 +21,6 @@
     "total_usd": 0
   },
   "environment": {
-    "client_host": {},
     "platform_runtime": {
       "collection_status": "partial",
       "runtime_type": "dataframe_process",

--- a/results-data/bundles/write_primitives_sf1_polars_df_20260502_211202_4af2f436.json
+++ b/results-data/bundles/write_primitives_sf1_polars_df_20260502_211202_4af2f436.json
@@ -21,7 +21,6 @@
     "total_usd": 0
   },
   "environment": {
-    "client_host": {},
     "platform_runtime": {
       "collection_status": "partial",
       "runtime_type": "dataframe_process",

--- a/results-data/bundles/write_primitives_sf1_pyspark_df_20260502_214426_38430ee4.json
+++ b/results-data/bundles/write_primitives_sf1_pyspark_df_20260502_214426_38430ee4.json
@@ -21,7 +21,6 @@
     "total_usd": 0
   },
   "environment": {
-    "client_host": {},
     "platform_runtime": {
       "collection_status": "partial",
       "runtime_type": "dataframe_process",

--- a/results-data/corpus-inventory.json
+++ b/results-data/corpus-inventory.json
@@ -1,6 +1,6 @@
 {
   "schema_version": "2.3",
-  "generated_at": "2026-08-05T20:06:22.664928+00:00",
+  "generated_at": "2026-08-06T00:09:03.714568+00:00",
   "bundles": [
     {
       "file": "amplab_sf001_datafusion_sql_20260502_182815_88aab2ac.json",
@@ -26,7 +26,7 @@
       "query_count": 0,
       "trust_label": "community-submission",
       "funding": "unspecified",
-      "bundle_sha256": "7004544d13fadef37a058776a1176fb6355db0f25180ada415e83942dca30fa8"
+      "bundle_sha256": "1f0a7c306bb99fbd2466123a447666e0c96e3502d4a1a6edd36e8bebb2211d42"
     },
     {
       "file": "amplab_sf01_datafusion_df_20260502_223335_8ed41c67.json",
@@ -39,7 +39,7 @@
       "query_count": 0,
       "trust_label": "community-submission",
       "funding": "unspecified",
-      "bundle_sha256": "1ddc173ee4eb490a55e3fddd4b0d73b2981f9fc501a84302433d5390b472a276"
+      "bundle_sha256": "2ee55f42402cf3850536e17f7512799cc52a62b853c11cd4f3253095b4df8081"
     },
     {
       "file": "amplab_sf1_datafusion_df_20260502_223336_92b1324f.json",
@@ -52,7 +52,7 @@
       "query_count": 0,
       "trust_label": "community-submission",
       "funding": "unspecified",
-      "bundle_sha256": "61aec83d9a40a8cc2e858186dca68fea5aec7ddf6c61afd0be77124cc4407828"
+      "bundle_sha256": "7eed18f3c1917f5c18d95f2891c8ddd74a727afc630714312aae49ea5fad6061"
     },
     {
       "file": "amplab_sf001_polars_df_20260502_211246_1df590de.json",
@@ -65,7 +65,7 @@
       "query_count": 0,
       "trust_label": "community-submission",
       "funding": "unspecified",
-      "bundle_sha256": "6f52ba304cba2c0770ebcc5fe836973910e1d7823ff1ef2776f6be95a98c5696"
+      "bundle_sha256": "1419967e382b681ff84d7d8c2e86be1584259fd64b0dfd5645a19a5935d40841"
     },
     {
       "file": "amplab_sf01_polars_df_20260502_211250_6407c9a7.json",
@@ -78,7 +78,7 @@
       "query_count": 0,
       "trust_label": "community-submission",
       "funding": "unspecified",
-      "bundle_sha256": "7cc0663f28ae75c94db74a0d5c7e0aa393b841abcee5f621976c3b0049e94c0c"
+      "bundle_sha256": "afba8548c384118c3882f66e6c30b5c1c9c7bfed1115fdd811a55e7c044bd8a0"
     },
     {
       "file": "amplab_sf1_polars_df_20260502_211251_ca2adb92.json",
@@ -91,7 +91,7 @@
       "query_count": 0,
       "trust_label": "community-submission",
       "funding": "unspecified",
-      "bundle_sha256": "cf8765cd5ab87077d0cc4d3514f1efcffe8e636aa3e6e88616e7dc4bb114ec37"
+      "bundle_sha256": "fcad57b5969070436f1cc4c2fd38cd129a14bc58538714e8f7044174b062f041"
     },
     {
       "file": "amplab_sf001_pyspark_df_20260502_214643_2bcec2f4.json",
@@ -104,7 +104,7 @@
       "query_count": 0,
       "trust_label": "community-submission",
       "funding": "unspecified",
-      "bundle_sha256": "59566ed897122feed2b1b276d64eddda2a8dac8d34c332d886af31de06837a8b"
+      "bundle_sha256": "000cf42333c68ff1febc06b51962fa27a4f37c909b6f0af1dc2af3f75a100d9f"
     },
     {
       "file": "amplab_sf01_pyspark_df_20260502_214650_c2b86db0.json",
@@ -117,7 +117,7 @@
       "query_count": 0,
       "trust_label": "community-submission",
       "funding": "unspecified",
-      "bundle_sha256": "0a357b75c15b770ddc0e76c6fea2302ba28999b49ef595896ffe1a58cd3df407"
+      "bundle_sha256": "91979f890aa3e799ff8f02b797f5e6437747aaf65918ab37b5a3952c1cf0726f"
     },
     {
       "file": "amplab_sf1_pyspark_df_20260502_214655_0cfbd748.json",
@@ -130,7 +130,7 @@
       "query_count": 0,
       "trust_label": "community-submission",
       "funding": "unspecified",
-      "bundle_sha256": "c58c8dd13cfff5dd7328e2955e2f6da6afd3837b3a40624b80d70fb954bf547d"
+      "bundle_sha256": "3e612fb2fb56a1cdaaf84be7e9f049b021c981699038d7f3339619d297505144"
     },
     {
       "file": "amplab_sf001_sqlite_sql_20260502_195711_0e182993.json",
@@ -234,7 +234,7 @@
       "query_count": 129,
       "trust_label": "community-submission",
       "funding": "unspecified",
-      "bundle_sha256": "06450c5df32bcd7d48941d8cfa81c4e38143c55ab6c2813dff99b85d57b78f06"
+      "bundle_sha256": "8feffcac7aaa50f27ef3869bafe0003587951da05ce27dfe60fd5720b1402cb8"
     },
     {
       "file": "clickbench_sf1_polars_df_20260502_211211_9f5a3ffd.json",
@@ -247,7 +247,7 @@
       "query_count": 129,
       "trust_label": "community-submission",
       "funding": "unspecified",
-      "bundle_sha256": "e02efcd560aec93d2f9d9ec4c3d62237dbc03d0fb7df60fb487626262ced9652"
+      "bundle_sha256": "3dc1e25825b6553dee9c48d154ea4552003a6e22ca511ba455897b7262f6bc4b"
     },
     {
       "file": "clickbench_sf1_pyspark_df_20260502_214548_16a1516b.json",
@@ -260,7 +260,7 @@
       "query_count": 129,
       "trust_label": "community-submission",
       "funding": "unspecified",
-      "bundle_sha256": "c379e5aa665d49df2855e4a5053b7caeec727a7c48ca00e4836dd0baaeb9fd59"
+      "bundle_sha256": "86c72387874eb6e5425f24f906cb8f85e666d201ce647936e351e7fb5be737f3"
     },
     {
       "file": "clickbench_sf1_sqlite_sql_20260502_193842_c618230d.json",
@@ -312,7 +312,7 @@
       "query_count": 0,
       "trust_label": "community-submission",
       "funding": "unspecified",
-      "bundle_sha256": "c6d481d967f258c4d6a392199d0cf0e4958ea021d7b560ac44c1099f5274aa1f"
+      "bundle_sha256": "e47369198dd247f8d740d6479e43ca63d640fe3490820fa2b02df1305f973acb"
     },
     {
       "file": "coffeeshop_sf01_datafusion_df_20260502_223321_08fec735.json",
@@ -325,7 +325,7 @@
       "query_count": 0,
       "trust_label": "community-submission",
       "funding": "unspecified",
-      "bundle_sha256": "26685e37e4993d50784448e53af55164181947e1a0eda684abd1b8557c94e1ed"
+      "bundle_sha256": "391bdda0b79aa0b77f7f5f1e98b77976fffb4db13fb004de0de4d5ab61d84d9c"
     },
     {
       "file": "coffeeshop_sf1_datafusion_df_20260502_223323_0eb2e311.json",
@@ -338,7 +338,7 @@
       "query_count": 0,
       "trust_label": "community-submission",
       "funding": "unspecified",
-      "bundle_sha256": "31702138bd580db6936cb36fa0e82452901d3f512c66c3d38450f61417e9c179"
+      "bundle_sha256": "347bb8bcf925d55215aff69f713530dcc77b9b88f2491a02d2201cfbd5912c61"
     },
     {
       "file": "coffeeshop_sf001_polars_df_20260502_211230_fe693d45.json",
@@ -351,7 +351,7 @@
       "query_count": 0,
       "trust_label": "community-submission",
       "funding": "unspecified",
-      "bundle_sha256": "b9ce57a939ea6f0451c49487589a52a6747120bf6614b0c497809d48f36d960b"
+      "bundle_sha256": "db27c345a8bb281c0e9f019d6a18fdefc3d9caee12b774f2b5b6206250ab2f3d"
     },
     {
       "file": "coffeeshop_sf01_polars_df_20260502_211235_07bd0fff.json",
@@ -364,7 +364,7 @@
       "query_count": 0,
       "trust_label": "community-submission",
       "funding": "unspecified",
-      "bundle_sha256": "6b10683760508c60ba0766153f1fb74ff6b28a82dda1aa81b04d64555d675f1d"
+      "bundle_sha256": "1b9e2d9a3b50d2d2a86fb09a65871be0fcea737bc453b39d242169083756afa9"
     },
     {
       "file": "coffeeshop_sf1_polars_df_20260502_211238_ec90759f.json",
@@ -377,7 +377,7 @@
       "query_count": 0,
       "trust_label": "community-submission",
       "funding": "unspecified",
-      "bundle_sha256": "9301978aeae0865c7928b097ef538e7dd6f0b6182c4e85d7d7da5dadb7973a7b"
+      "bundle_sha256": "85ace8efc689badfb667eab2edc2d28c3e4c3cdf9ed9b2c5864b37ca9c35c7ca"
     },
     {
       "file": "coffeeshop_sf001_sqlite_sql_20260502_194231_d0a49f29.json",
@@ -546,7 +546,7 @@
       "query_count": 66,
       "trust_label": "community-submission",
       "funding": "unspecified",
-      "bundle_sha256": "4e04083ede1c34b68d4ec8c6b80de00398505968df5a52f84c36ba8b65f07851"
+      "bundle_sha256": "115b485bb5e0da966658a4a0daf4621f374efdc39fa9212b018e81c549fc40e9"
     },
     {
       "file": "datavault_sf01_pyspark_df_20260502_215856_7a32012a.json",
@@ -559,7 +559,7 @@
       "query_count": 66,
       "trust_label": "community-submission",
       "funding": "unspecified",
-      "bundle_sha256": "9cda52905d33c29754a5d4498979925faec8c473649549240f6a79b8c597aba5"
+      "bundle_sha256": "7f210e5e9febacab68a4a8a328afc4b7b091c41dda3a876d12f69da5b37d1b90"
     },
     {
       "file": "datavault_sf1_pyspark_df_20260502_215903_105a29f7.json",
@@ -572,7 +572,7 @@
       "query_count": 66,
       "trust_label": "community-submission",
       "funding": "unspecified",
-      "bundle_sha256": "83bf6008362c6b2435d03024f050f88a9248a8e194aeb27c76171e212f283a6b"
+      "bundle_sha256": "6d763f6d38a4f829dd3e867dc2e9596e393bd5b486ed4d529669d1564a4cec2d"
     },
     {
       "file": "flightdata_sf001_datafusion_df_20260502_223348_d9e8bf20.json",
@@ -585,7 +585,7 @@
       "query_count": 60,
       "trust_label": "community-submission",
       "funding": "unspecified",
-      "bundle_sha256": "f594fa0f036747f222f76f2af82e617cac280d2f825f32fcaa0105b9d9446a20"
+      "bundle_sha256": "e63f6052e5ad7133ed95699ecdbba030cbbc719fe5995d5651d8cef8dad1d9a1"
     },
     {
       "file": "flightdata_sf01_datafusion_df_20260502_223350_9310d61f.json",
@@ -598,7 +598,7 @@
       "query_count": 60,
       "trust_label": "community-submission",
       "funding": "unspecified",
-      "bundle_sha256": "d08298f94c3bf5b59e271d2a70174fca2ef000de2b1d0caa8218f684a5817d9e"
+      "bundle_sha256": "4187f1a18516414bf08df16fa7b53a2e27813470ea2c910ec932c1625b1b2836"
     },
     {
       "file": "flightdata_sf001_polars_df_20260502_211311_d255f81b.json",
@@ -611,7 +611,7 @@
       "query_count": 60,
       "trust_label": "community-submission",
       "funding": "unspecified",
-      "bundle_sha256": "a5356e214abf83b96c970aa6e157b9af6b5a325fc0d51e0597c59dbd4dc633d0"
+      "bundle_sha256": "f0533da507e4cf278842b5af6a50c39de40e0cd2fac54a97aae922a3cacbcb01"
     },
     {
       "file": "flightdata_sf01_polars_df_20260502_211318_602c45de.json",
@@ -624,7 +624,7 @@
       "query_count": 60,
       "trust_label": "community-submission",
       "funding": "unspecified",
-      "bundle_sha256": "7970bed73f4b353424f0e9234915f1bff102405a25fa69870430e5a4cad10967"
+      "bundle_sha256": "6dd5ca200473822781f54f2aee84671a8cbfbf68d92f4311ba0b0d286648f15c"
     },
     {
       "file": "flightdata_sf001_pyspark_df_20260502_214742_a9d32e46.json",
@@ -637,7 +637,7 @@
       "query_count": 60,
       "trust_label": "community-submission",
       "funding": "unspecified",
-      "bundle_sha256": "312a6f14b6fd07b92f44eb1bed59f0b6a4556b4cb36191f06d8a6c2a317ba93a"
+      "bundle_sha256": "13ac8c5ce7b4bbecb57d989109813bd64768229ec5a255fa15f3b63842fe8c96"
     },
     {
       "file": "flightdata_sf01_pyspark_df_20260502_214754_8699bacb.json",
@@ -650,7 +650,7 @@
       "query_count": 60,
       "trust_label": "community-submission",
       "funding": "unspecified",
-      "bundle_sha256": "9a998724901a596578781b9e0fe21ccc5be94e8a8adb16675562d6f9305db97b"
+      "bundle_sha256": "981877ab3092642772d0278f51e0cf95c81d419bf3dd063a330fab48af848d18"
     },
     {
       "file": "h2odb_sf001_datafusion_sql_20260502_182748_cd8a576b.json",
@@ -676,7 +676,7 @@
       "query_count": 0,
       "trust_label": "community-submission",
       "funding": "unspecified",
-      "bundle_sha256": "adf88e45f731cc5932c3a57650a4c110a0bacc834f419acd70b4ee676f2de72e"
+      "bundle_sha256": "cea4aaffd5a29345e165cda2f8129688a7569ea3b0a2dabbd8c5d90c16957e0b"
     },
     {
       "file": "h2odb_sf01_datafusion_df_20260502_223314_b024941c.json",
@@ -689,7 +689,7 @@
       "query_count": 0,
       "trust_label": "community-submission",
       "funding": "unspecified",
-      "bundle_sha256": "78b7d5f80b3cb5f83932bfdbd67d3c28e6904812282d1f93d125dde8a43a445a"
+      "bundle_sha256": "4035b70b574dc1b743e735c02fa6ccca96096edf47266cc710488d6cae67510c"
     },
     {
       "file": "h2odb_sf1_datafusion_df_20260502_223315_db3ffa2a.json",
@@ -702,7 +702,7 @@
       "query_count": 0,
       "trust_label": "community-submission",
       "funding": "unspecified",
-      "bundle_sha256": "5c893fb4615e4321ecdc5b7c386ef626d401fa5b1f62e8e6626a8431b77a5335"
+      "bundle_sha256": "b52e374c5acd9a6a2909685edff8026681fd0c769f18a1d1334acc833ffe0798"
     },
     {
       "file": "h2odb_sf001_polars_df_20260502_211213_b684dd1e.json",
@@ -715,7 +715,7 @@
       "query_count": 0,
       "trust_label": "community-submission",
       "funding": "unspecified",
-      "bundle_sha256": "dbb03bee9d7d1b17bd923d4bb058e739cad50f3051600c396837c818f6517082"
+      "bundle_sha256": "d4894259f8365b379780d75c399b4942f078a64fa3452a2bab779847f229f214"
     },
     {
       "file": "h2odb_sf01_polars_df_20260502_211227_562cdd64.json",
@@ -728,7 +728,7 @@
       "query_count": 0,
       "trust_label": "community-submission",
       "funding": "unspecified",
-      "bundle_sha256": "d9c18ddfc16c6da5b4529429907f715c9b61688ba6b534bee5b90427b28ad8d2"
+      "bundle_sha256": "5d646e226085db78e9649e9ba6f6c5c5691c96df3d81a30682bb9bc9fefb4597"
     },
     {
       "file": "h2odb_sf1_polars_df_20260502_211228_368e2b57.json",
@@ -741,7 +741,7 @@
       "query_count": 0,
       "trust_label": "community-submission",
       "funding": "unspecified",
-      "bundle_sha256": "74f23ef87d3ff44e3c767baef4087cad469f781c16dbd48c7d7cce8658f77d28"
+      "bundle_sha256": "55350bbf8a652bbcabb1c3dbb333e182cc88cf04fc78beba54f974d269da8685"
     },
     {
       "file": "h2odb_sf001_pyspark_df_20260502_214553_9a5c5350.json",
@@ -754,7 +754,7 @@
       "query_count": 0,
       "trust_label": "community-submission",
       "funding": "unspecified",
-      "bundle_sha256": "9b6a94b2a085da54627f0d5528a444eea1802ddfd3bff7bc3c5ca548eda148ba"
+      "bundle_sha256": "5971c6a85d8a89b94fb9ea142522416723ed8c52c3bb6c1bd2f0b4120fea567b"
     },
     {
       "file": "h2odb_sf01_pyspark_df_20260502_214610_81e6974f.json",
@@ -767,7 +767,7 @@
       "query_count": 0,
       "trust_label": "community-submission",
       "funding": "unspecified",
-      "bundle_sha256": "83561b7dfa66d8a44531d522124e085c06af8387094588219aa9608757fde330"
+      "bundle_sha256": "31cd2e90836afe51df1d1386a1f3bd4a6fa896d2f4d9b276744ff682bf348914"
     },
     {
       "file": "h2odb_sf1_pyspark_df_20260502_214614_33209063.json",
@@ -780,7 +780,7 @@
       "query_count": 0,
       "trust_label": "community-submission",
       "funding": "unspecified",
-      "bundle_sha256": "bf1a0c88f96885ddaa2f96ae56375aa602c25e349f68147cf56781e011c51de5"
+      "bundle_sha256": "b11be06c2ab550021ae8c8545da61aa12296eebe022c0856bf361a948c09c3cd"
     },
     {
       "file": "h2odb_sf001_sqlite_sql_20260502_193845_cf9a1f28.json",
@@ -923,7 +923,7 @@
       "query_count": 48,
       "trust_label": "community-submission",
       "funding": "unspecified",
-      "bundle_sha256": "c12517b04986ffc15955c2babe5c416354796e5465741ce36c3fa29d166e7134"
+      "bundle_sha256": "f9363b1d8029ba968a0f5cc6c1ac3b016b3944a90d14f428e0e5c1764e5ae411"
     },
     {
       "file": "metadata_primitives_sf1_pyspark_df_20260502_214436_50a3043f.json",
@@ -936,7 +936,7 @@
       "query_count": 50,
       "trust_label": "community-submission",
       "funding": "unspecified",
-      "bundle_sha256": "b88bcdcb70ba79df97f38a873344610c2174f5a8eb9c78e8a0373de0d006817d"
+      "bundle_sha256": "f035d5400c45b9ebb506a09a12d6e8bbc63e440d88774442b5b2bdfe6525df4e"
     },
     {
       "file": "nyctaxi_sf001_datafusion_df_20260502_223343_11bf3d15.json",
@@ -949,7 +949,7 @@
       "query_count": 0,
       "trust_label": "community-submission",
       "funding": "unspecified",
-      "bundle_sha256": "fea3f4709e656d3dc5cbf45da767bb9d4bb4c150472f6ef727fee0a1381f6d1d"
+      "bundle_sha256": "5455f713e2b0ac3f7016a188fcc06d223a2f43e8ac042a2966bb3a224d9a8917"
     },
     {
       "file": "nyctaxi_sf01_datafusion_df_20260502_223345_6b902570.json",
@@ -962,7 +962,7 @@
       "query_count": 0,
       "trust_label": "community-submission",
       "funding": "unspecified",
-      "bundle_sha256": "7362b293833bcc380af21bbe60972adc61ba5013ba2bb63d9d9be5d3cca8312a"
+      "bundle_sha256": "bfb56fe84534132d83cdb460783ba249c31348db2947000adae33d60d2ee1cfb"
     },
     {
       "file": "nyctaxi_sf1_datafusion_df_20260502_223346_08ffc8ba.json",
@@ -975,7 +975,7 @@
       "query_count": 0,
       "trust_label": "community-submission",
       "funding": "unspecified",
-      "bundle_sha256": "bfe768eab79c911246686c7098548b0baa295720ef7a97fd0c1acba70a49776d"
+      "bundle_sha256": "9c8371da7e1a43c817755bd084f9ac1caf2ddeeaac4b78f2a7075b981378915d"
     },
     {
       "file": "nyctaxi_sf001_polars_df_20260502_211302_0e34be37.json",
@@ -988,7 +988,7 @@
       "query_count": 0,
       "trust_label": "community-submission",
       "funding": "unspecified",
-      "bundle_sha256": "cad6b99aa29145b99bc621ee62f939907139ca024471847bd4ca8cfab4d55c6d"
+      "bundle_sha256": "03bab1d2322f81ffc580db1c5c0bd8341bb5712098d0c3bd78c7fd7a70a84635"
     },
     {
       "file": "nyctaxi_sf01_polars_df_20260502_211304_2459ce33.json",
@@ -1001,7 +1001,7 @@
       "query_count": 0,
       "trust_label": "community-submission",
       "funding": "unspecified",
-      "bundle_sha256": "74ff9b705ccc9a10356b834af442dfd4576cc20db091bab2789e32f7c858842c"
+      "bundle_sha256": "7d349fb67dc99f2a45347b812e062a21472d6d3e3aefe5680f0fb17c878e733c"
     },
     {
       "file": "nyctaxi_sf1_polars_df_20260502_211308_a0a21b10.json",
@@ -1014,7 +1014,7 @@
       "query_count": 0,
       "trust_label": "community-submission",
       "funding": "unspecified",
-      "bundle_sha256": "a2043c301955df4c0c7388a2398cae7aac3a3648e46895fb756fef4efdd33bd0"
+      "bundle_sha256": "99f1f59b748e5a96630f1d768ff1a59ccbf87e048f367bee3b2b3ebd0ca620d9"
     },
     {
       "file": "nyctaxi_sf001_pyspark_df_20260502_214722_7f225978.json",
@@ -1027,7 +1027,7 @@
       "query_count": 0,
       "trust_label": "community-submission",
       "funding": "unspecified",
-      "bundle_sha256": "361a35941b755e862dbb7016011a455ccbe4545b3ef1dd7ed7eb3a1adf800953"
+      "bundle_sha256": "fd326a49341ac6ed44ba9a32d015a4093015a44aba0cb8c9914c618c29df2800"
     },
     {
       "file": "nyctaxi_sf01_pyspark_df_20260502_214726_f8c1d2c5.json",
@@ -1040,7 +1040,7 @@
       "query_count": 0,
       "trust_label": "community-submission",
       "funding": "unspecified",
-      "bundle_sha256": "56559e67cd34476f2256fa0ad654ad0a2b3dc1971748ec078112326d151065ce"
+      "bundle_sha256": "1d70708f1461b7ea2ab9a523bb3e0d2aafa241a5c45d240a4bf119bc62483ff4"
     },
     {
       "file": "nyctaxi_sf1_pyspark_df_20260502_214732_33f405ff.json",
@@ -1053,7 +1053,7 @@
       "query_count": 0,
       "trust_label": "community-submission",
       "funding": "unspecified",
-      "bundle_sha256": "08d578965bbd9e3cab3829722c54b5cd69828cc25e0a1b211262cd42f590a1a7"
+      "bundle_sha256": "e8f46e70a1ae72b2a53af079fd55edee9adf6242fac1531dc31e2fda325d3f45"
     },
     {
       "file": "read_primitives_sf001_datafusion_sql_20260502_182650_763aa432.json",
@@ -1079,7 +1079,7 @@
       "query_count": 438,
       "trust_label": "community-submission",
       "funding": "unspecified",
-      "bundle_sha256": "c2e737a2cbc3526da72016416cc1046b35fdcf3d7aac8dbc8f8b883b09f12f3f"
+      "bundle_sha256": "6257ceb9554202512640131df42618e67749c6abfc8f99ce19668c0ec2e09e9e"
     },
     {
       "file": "read_primitives_sf01_datafusion_sql_20260502_182654_e6da3ba3.json",
@@ -1105,7 +1105,7 @@
       "query_count": 438,
       "trust_label": "community-submission",
       "funding": "unspecified",
-      "bundle_sha256": "0274d5f2b2775585b6fada5cb7b64ac04825cc411f57d7c039573210cdb916b0"
+      "bundle_sha256": "370f298630819ebec8682bccfb22109b2fb43f346d8ffa76c1542ed5f783b989"
     },
     {
       "file": "read_primitives_sf001_polars_df_20260502_210839_881199ef.json",
@@ -1118,7 +1118,7 @@
       "query_count": 441,
       "trust_label": "community-submission",
       "funding": "unspecified",
-      "bundle_sha256": "54e8a24e47bc4f594735859449e4b25caaaf37c284049a6ed54710f171829e4d"
+      "bundle_sha256": "cfe005d3c6de88665a6725135fc9c06c9cb530cbdec8c3e6a402d49ddb73d6cc"
     },
     {
       "file": "read_primitives_sf01_polars_df_20260502_210844_1cb50efa.json",
@@ -1131,7 +1131,7 @@
       "query_count": 441,
       "trust_label": "community-submission",
       "funding": "unspecified",
-      "bundle_sha256": "f8c42cce0278699086b8ee11fcc555c12361e9763950a942d6b8411c84987a32"
+      "bundle_sha256": "7b5a64c8dc66073da261dec0ae73ae77e6fec27efdc542b2a00f3a1f8649f046"
     },
     {
       "file": "read_primitives_sf001_pyspark_df_20260502_213754_a17d36be.json",
@@ -1144,7 +1144,7 @@
       "query_count": 444,
       "trust_label": "community-submission",
       "funding": "unspecified",
-      "bundle_sha256": "125acce29b5ef20fd9438f35ef85fdcf25e64f1ce5ca9766f7e54296dbffe7db"
+      "bundle_sha256": "30062bb08ea2e3195667f6430c812e88d7b06f106971d42eb8abf79367316389"
     },
     {
       "file": "read_primitives_sf01_pyspark_df_20260502_214131_e2b3c755.json",
@@ -1157,7 +1157,7 @@
       "query_count": 444,
       "trust_label": "community-submission",
       "funding": "unspecified",
-      "bundle_sha256": "a6007b419fd05aa97b7cc13d0dda6240b487b3bf2c80f15f2b37cf79863af825"
+      "bundle_sha256": "00d508a76792689aee1290757ba9763be91c191446186b68c2292d379a69f58e"
     },
     {
       "file": "read_primitives_sf001_sqlite_sql_20260502_191534_54aa6b45.json",
@@ -1196,7 +1196,7 @@
       "query_count": 0,
       "trust_label": "community-submission",
       "funding": "unspecified",
-      "bundle_sha256": "e388516c7c4a6055c1fe4cb919ceb17b95f5d7d9a124105cbde5612a13475490"
+      "bundle_sha256": "60d938ce0f564598247085ec5a6b2beb81c0d50445633caf3748f9848f05c2c0"
     },
     {
       "file": "ssb/datafusion/sf0.01/ssb_sf001_datafusion_sql_20260730_192204_090d9fc0.json",
@@ -1222,7 +1222,7 @@
       "query_count": 0,
       "trust_label": "community-submission",
       "funding": "unspecified",
-      "bundle_sha256": "097c1163c8fee679fabfc0ff5d8550e46c55a4aea54acf7e450e6ecca666dc7d"
+      "bundle_sha256": "c325d3dd37bc554caffa74aa88da6f4d7e44f3ce6451e988fd3af849c484af1d"
     },
     {
       "file": "ssb/datafusion/sf0.1/ssb_sf01_datafusion_sql_20260730_192207_30516ed8.json",
@@ -1248,7 +1248,7 @@
       "query_count": 0,
       "trust_label": "community-submission",
       "funding": "unspecified",
-      "bundle_sha256": "7454411b021dd2441f80ef3bf570be5119f11b475db594a5af11c078e1ebcc14"
+      "bundle_sha256": "962911ae77e0c64dd712d07c59ee8b412a3a92524f5f0211240e8f3ba8d075d7"
     },
     {
       "file": "ssb/duckdb/sf0.01/ssb_sf001_duckdb_sql_20260730_192156_cfc95eee.json",
@@ -1287,7 +1287,7 @@
       "query_count": 0,
       "trust_label": "community-submission",
       "funding": "unspecified",
-      "bundle_sha256": "8bad9eb71f668b496a2bfb41f1b80a8adf0a41d3feeeb5cea12d3314349b7e2a"
+      "bundle_sha256": "6ed0b1c01cc19c0ec1eb7c481cc753448341c43a3ee52a0129988d30b4792033"
     },
     {
       "file": "ssb_sf01_polars_df_20260502_211243_69643606.json",
@@ -1300,7 +1300,7 @@
       "query_count": 0,
       "trust_label": "community-submission",
       "funding": "unspecified",
-      "bundle_sha256": "6124ac2442a17d7104bc43af1ee6d86ab3ce0b18014b2639f327aa8b70bff37a"
+      "bundle_sha256": "4e90141068d66a0154e3d28fdc81715f5057f08c370a286bcf80d528b4b8ec11"
     },
     {
       "file": "ssb_sf1_polars_df_20260502_211245_7e3e0e7c.json",
@@ -1313,7 +1313,7 @@
       "query_count": 0,
       "trust_label": "community-submission",
       "funding": "unspecified",
-      "bundle_sha256": "9bf40356e1c40f44af85be94bf699724be4d022d1e4b558395ca6909b14c33f2"
+      "bundle_sha256": "c4ddbf6bfca5ba3aa8b420138baad506fd540dabe9ef050587ed0d2b315f0a4c"
     },
     {
       "file": "ssb_sf001_pyspark_df_20260502_214625_deed8b90.json",
@@ -1326,7 +1326,7 @@
       "query_count": 0,
       "trust_label": "community-submission",
       "funding": "unspecified",
-      "bundle_sha256": "78fb729a2a0b391c8da04537547940ac6bce093b7b25d4c16360904908496262"
+      "bundle_sha256": "8a1a1dc3612248e41d748bb92ef3717ea8d65610fa5cd3ca611209a0f69f94c3"
     },
     {
       "file": "ssb_sf01_pyspark_df_20260502_214632_a3ddcc95.json",
@@ -1339,7 +1339,7 @@
       "query_count": 0,
       "trust_label": "community-submission",
       "funding": "unspecified",
-      "bundle_sha256": "4f62952ee1e400320222c435fb8e4a9b0741ef3521ca010cfce845da2f7fd36d"
+      "bundle_sha256": "d9ba1ea6b7bfb3b0e672d6d50f190c7d49923ec40cc7df5aca8bccda2e8bd546"
     },
     {
       "file": "ssb_sf1_pyspark_df_20260502_214638_4d83c4c3.json",
@@ -1352,7 +1352,7 @@
       "query_count": 0,
       "trust_label": "community-submission",
       "funding": "unspecified",
-      "bundle_sha256": "375ccaac10a8601232abb09784b2f8530727b14ecdd5fbef3a0931215da4ae41"
+      "bundle_sha256": "69b50224b93afd60fe1ae7a59e9a5a7ba3f5310353140dc2d6fbf57e80097100"
     },
     {
       "file": "ssb_sf001_sqlite_sql_20260502_195149_f66686e5.json",
@@ -1651,7 +1651,7 @@
       "query_count": 9,
       "trust_label": "community-submission",
       "funding": "unspecified",
-      "bundle_sha256": "08da69c95cfc040c759bc55d6360ceb665db9dd27a2deaa7fcd230b135a548da"
+      "bundle_sha256": "9dad602ebc94d8f45957c119133e152260828141dbab244a650190d12831aa1d"
     },
     {
       "file": "tpcds_obt_sf1_duckdb_sql_20260502_181039_062dfcbc.json",
@@ -1677,7 +1677,7 @@
       "query_count": 9,
       "trust_label": "community-submission",
       "funding": "unspecified",
-      "bundle_sha256": "b8aea7569b84abc416f2cfd06b876af4dc9daa97956a7d078340b11f80c2f1e0"
+      "bundle_sha256": "11aec8778b86663c324c827b5e2a40f9283cdfb7b0c358ff7cf5fa66eeb4a86f"
     },
     {
       "file": "tpcds_obt_sf1_pyspark_df_20260502_214826_df0f9d07.json",
@@ -1690,7 +1690,7 @@
       "query_count": 9,
       "trust_label": "community-submission",
       "funding": "unspecified",
-      "bundle_sha256": "a59693b5d50817a8007c95392f18194de16ad7e04ee1a6b3e9837dc6c7875ff3"
+      "bundle_sha256": "de36021e0a5f0d7c6c734b4814c60ac7f17719de4017e97a1390160126c0b2bd"
     },
     {
       "file": "tpch_sf001_datafusion_20260403_093731_c235e698.json",
@@ -1729,7 +1729,7 @@
       "query_count": 66,
       "trust_label": "community-submission",
       "funding": "unspecified",
-      "bundle_sha256": "1d377900bff96f27b4f485da6a56cdb3dc248711c4d4d6cd6335ef14301854c9"
+      "bundle_sha256": "1bd0cb28d50f65858d9b70dd56ad92fe1d174b16f84242bb77e38b4de45ea921"
     },
     {
       "file": "tpch_sf01_datafusion_sql_20260404_191814_890f931e.json",
@@ -1768,7 +1768,7 @@
       "query_count": 66,
       "trust_label": "community-submission",
       "funding": "unspecified",
-      "bundle_sha256": "941c00c6295b67a49c4c442c827e4a297918a296f21e74fdd2d67d6f64830492"
+      "bundle_sha256": "ba63d75a2eb2a4df83bdbc4a47dcf85e931547d4f4b798f8a5d7bbdee70ba3bc"
     },
     {
       "file": "tpch_sf1_datafusion_sql_20260502_182446_cec107c3.json",
@@ -1794,7 +1794,7 @@
       "query_count": 66,
       "trust_label": "community-submission",
       "funding": "unspecified",
-      "bundle_sha256": "e594a23a8118902ea8864dbc81a6cfb9de5700510c07247c61826f07c59125e3"
+      "bundle_sha256": "a78c59f1a3c7a7d0121d06f746a2578df2e0296115c8219717c77c601df7a45d"
     },
     {
       "file": "tpch_sf001_duckdb_20260403_093653_9c0925d1.json",
@@ -1846,7 +1846,7 @@
       "query_count": 66,
       "trust_label": "community-submission",
       "funding": "unspecified",
-      "bundle_sha256": "5b176a0542e75369baa1852ef08414aedeb8771c96fac768de9f7623c3a9e94e"
+      "bundle_sha256": "09ea8e65a2caf3ad4db1c5d8f2c56a329732f3374612e8cfee5e83956f8025b0"
     },
     {
       "file": "tpch_sf01_polars_df_20260404_191727_mcp_b897c572.json",
@@ -1872,7 +1872,7 @@
       "query_count": 66,
       "trust_label": "community-submission",
       "funding": "unspecified",
-      "bundle_sha256": "ca3d779b115dca3b03df41fa1534d6bcac3e6045230fb04be251187ab0708adc"
+      "bundle_sha256": "106127504c2e1483302ed83c6f62743bb02d9c68e323fd96986b24278b9f881d"
     },
     {
       "file": "tpch_sf1_polars_df_20260502_210721_02521fdb.json",
@@ -1885,7 +1885,7 @@
       "query_count": 66,
       "trust_label": "community-submission",
       "funding": "unspecified",
-      "bundle_sha256": "b802d949b3bc334bbc5a73d0d050972a0c72c9e98a074b00b207a91cf4f5ebb8"
+      "bundle_sha256": "8abe3e490d7159a83a88e4a83b773ad4bf3580180964e266510a0e6c67cd44ef"
     },
     {
       "file": "tpch_sf001_pyspark_df_20260502_212950_2dbda97e.json",
@@ -1898,7 +1898,7 @@
       "query_count": 66,
       "trust_label": "community-submission",
       "funding": "unspecified",
-      "bundle_sha256": "e4b5c120fadd1b69c63529d57c39af740c32237b129c14b755eb560d260a0113"
+      "bundle_sha256": "0adf3a7678633d8021cb5a7b4472070e5570fef2108cc3b3ceabad437b66cc2a"
     },
     {
       "file": "tpch_sf01_pyspark_df_20260502_213125_f90c8f1d.json",
@@ -1911,7 +1911,7 @@
       "query_count": 66,
       "trust_label": "community-submission",
       "funding": "unspecified",
-      "bundle_sha256": "5ac1073cf697f23d65d8e3c5bb1cf36502688b82b2e984c281b195121200ef20"
+      "bundle_sha256": "d32f6e636d7593a8e5e3903892f56eb4ac4d49f6719f417f50d2777f1c61ea2e"
     },
     {
       "file": "tpch_sf1_pyspark_df_20260502_213448_a88d204d.json",
@@ -1924,7 +1924,7 @@
       "query_count": 66,
       "trust_label": "community-submission",
       "funding": "unspecified",
-      "bundle_sha256": "9d125b6abc47d86fe79c82b83f9e42a356491a5e293b20136f22f55c338267f1"
+      "bundle_sha256": "315986c5e92a7fce50a18b174f426ae4fa65ede887d4e3626f68460ecfe648d3"
     },
     {
       "file": "tpch_sf001_sqlite_sql_20260502_191208_1df8890c.json",
@@ -2002,7 +2002,7 @@
       "query_count": 0,
       "trust_label": "community-submission",
       "funding": "unspecified",
-      "bundle_sha256": "6ef73c0954528239e2da11887ee3ad70ced20e4350f80e793c191b135a46826c"
+      "bundle_sha256": "b3f6893dd0f94d79de51ec8f8a2102a54a893660437319f9b181896ee0fa9309"
     },
     {
       "file": "tpch_skew_sf01_datafusion_sql_20260502_183802_eb69285f.json",
@@ -2028,7 +2028,7 @@
       "query_count": 0,
       "trust_label": "community-submission",
       "funding": "unspecified",
-      "bundle_sha256": "487e7288fbab48855b43e4c9ffe3910f7e010f3e2641a17890ce9ce375fcc5a9"
+      "bundle_sha256": "4b122e5b5a6accb6c6e2e32288f0706cc7e355e4d0c49e69e79ff3300e75e5b7"
     },
     {
       "file": "tpch_skew_sf1_datafusion_sql_20260502_183813_4aab199c.json",
@@ -2054,7 +2054,7 @@
       "query_count": 0,
       "trust_label": "community-submission",
       "funding": "unspecified",
-      "bundle_sha256": "cf4350bd844bed68f5efa181b140bc304b785286f494f9cbbae29b43ed207cfa"
+      "bundle_sha256": "137c3172759a20efb6b8342245301a724f170d544d498c9b32684e8a94ce330e"
     },
     {
       "file": "tpch_skew_sf001_duckdb_sql_20260502_182132_91fbee24.json",
@@ -2106,7 +2106,7 @@
       "query_count": 0,
       "trust_label": "community-submission",
       "funding": "unspecified",
-      "bundle_sha256": "9adcd647568f68bbc088b2b50c838cc069df398330ec4ba64ad7abb71d3c2651"
+      "bundle_sha256": "fa904aaf0d1e83308cddd69e59cccfca962d36959a1ab866cb8bea26c18e74d2"
     },
     {
       "file": "tpch_skew_sf01_polars_df_20260502_211426_50cb1511.json",
@@ -2119,7 +2119,7 @@
       "query_count": 0,
       "trust_label": "community-submission",
       "funding": "unspecified",
-      "bundle_sha256": "c604dfdd9d884daadf71e5f985d2d50eb1c8e30b8e4718c0e040b25230394f4a"
+      "bundle_sha256": "d082aeb4cc95c467f1685053fa7815b03d699a5e5d45e082d1f517e92320a88b"
     },
     {
       "file": "tpch_skew_sf1_polars_df_20260502_211431_81b53055.json",
@@ -2132,7 +2132,7 @@
       "query_count": 0,
       "trust_label": "community-submission",
       "funding": "unspecified",
-      "bundle_sha256": "2872b350a503ed0082888ead143549d7639fbe6ca4f7211c92526ec517bd45f3"
+      "bundle_sha256": "21d529061054517981abb1532a5d6b5a7eb04dd99ff774a76f94e538b9c7661e"
     },
     {
       "file": "tpch_skew_sf001_pyspark_df_20260502_215832_e75f78eb.json",
@@ -2145,7 +2145,7 @@
       "query_count": 0,
       "trust_label": "community-submission",
       "funding": "unspecified",
-      "bundle_sha256": "46ace31548ff5e4d33e269b83e9bf860bd79ea890a1e5c8ee8b8e92d71aeba57"
+      "bundle_sha256": "4d08186b1e50024087c4d363042b075060e690040486ee7e75997eb2d9b8c9ad"
     },
     {
       "file": "tpch_skew_sf01_pyspark_df_20260502_215837_80510f48.json",
@@ -2158,7 +2158,7 @@
       "query_count": 0,
       "trust_label": "community-submission",
       "funding": "unspecified",
-      "bundle_sha256": "309755cd197e02e1c6ba1f6c3ef02ecc227dfb2890ce23f6574f3fd34e173d3a"
+      "bundle_sha256": "329c8d3258f8bc8873993cee8c5f5d5ff073ded8523d3d748d0d7508f8c4eab9"
     },
     {
       "file": "tpch_skew_sf1_pyspark_df_20260502_215843_cabb8984.json",
@@ -2171,7 +2171,7 @@
       "query_count": 0,
       "trust_label": "community-submission",
       "funding": "unspecified",
-      "bundle_sha256": "b589541d6272c21f1960cc8e1b0795572d07ae7d79d882912b25294022839a94"
+      "bundle_sha256": "00ac2e463609680a0550a94c86e31fca45c09f388c96155b880ea4930eb35eb7"
     },
     {
       "file": "tpch_skew_sf001_sqlite_sql_20260502_202559_fda6d32a.json",
@@ -2249,7 +2249,7 @@
       "query_count": 660,
       "trust_label": "community-submission",
       "funding": "unspecified",
-      "bundle_sha256": "3d4c11513a472b6270aa57e8f020e7109794b53da0c1ef0045fe79449826f7cd"
+      "bundle_sha256": "b5005f31519f1545dc1109a0d88d79c9ba92b08be7184579149a10cbfd255328"
     },
     {
       "file": "tpchavoc_sf01_datafusion_sql_20260502_182935_7f00b0db.json",
@@ -2275,7 +2275,7 @@
       "query_count": 660,
       "trust_label": "community-submission",
       "funding": "unspecified",
-      "bundle_sha256": "c2c9fe249c5bbaf072b6287eace88c582ae97841558524f1435193514684ec0c"
+      "bundle_sha256": "0e0a6375e283584c7687e81a8e0e4e07aec5ca2f76bd22c984134a20295d94dd"
     },
     {
       "file": "tpchavoc_sf001_duckdb_sql_20260502_180425_a78e0c25.json",
@@ -2314,7 +2314,7 @@
       "query_count": 660,
       "trust_label": "community-submission",
       "funding": "unspecified",
-      "bundle_sha256": "697d1775456a0e0ff926ef86f915fa36f66b19dcc8153d4aab6edefe67664f3c"
+      "bundle_sha256": "afaad9eb2ed3c8f289cedd5463942b8441aa974ae90d44c80498ffd95896bbeb"
     },
     {
       "file": "tpchavoc_sf01_polars_df_20260502_211336_7281b720.json",
@@ -2327,7 +2327,7 @@
       "query_count": 660,
       "trust_label": "community-submission",
       "funding": "unspecified",
-      "bundle_sha256": "6c3eac0bc0aaeb0964634c76b6fcbcf1c4505af8f2a735f011e18da6a6c43d93"
+      "bundle_sha256": "690ec27db320d8c0a05421c7caf47acaddb6b261773fe4d05f3af042b0dec34b"
     },
     {
       "file": "tpchavoc_sf001_spark_sql_20260502_205516_33819f47.json",
@@ -2366,7 +2366,7 @@
       "query_count": 0,
       "trust_label": "community-submission",
       "funding": "unspecified",
-      "bundle_sha256": "ac4efcee86ce618d0828c384fe7bce82b7b674f482d06d46b423af2f1e87e2e0"
+      "bundle_sha256": "0e9d5e5dcedb30fc3b2a04314f8a64bc928c0013ccc748d4549cb5bb868f5252"
     },
     {
       "file": "tsbs_devops_sf01_datafusion_df_20260502_223340_24b27f9e.json",
@@ -2379,7 +2379,7 @@
       "query_count": 0,
       "trust_label": "community-submission",
       "funding": "unspecified",
-      "bundle_sha256": "1fa69d4032b164f289d86120098153339a5ef7ccee6aa87f85a25c293f985f97"
+      "bundle_sha256": "89174c382c1fcfd058b5aa3215100aa4f75a1381613b2d5ac2adbb68702dec1b"
     },
     {
       "file": "tsbs_devops_sf1_datafusion_df_20260502_223342_cba14069.json",
@@ -2392,7 +2392,7 @@
       "query_count": 0,
       "trust_label": "community-submission",
       "funding": "unspecified",
-      "bundle_sha256": "763851b7ac63c4593a52beb547ebe9d1b59c73b50eb98cbf2108a5e7d98e90f0"
+      "bundle_sha256": "0d17e451323dda3607e509c207b44d67ada2c0f704ab08cbb03ff8ff338e3198"
     },
     {
       "file": "tsbs_devops_sf001_polars_df_20260502_211255_aaef4b29.json",
@@ -2405,7 +2405,7 @@
       "query_count": 0,
       "trust_label": "community-submission",
       "funding": "unspecified",
-      "bundle_sha256": "91493e1262f9f55dfbdc1ef01e8afecf800a108f8675cd6cd53ebed14b12c35a"
+      "bundle_sha256": "496963fa348e41f24866ce0c1f3523f5c7c1cfcad6c62227b690d9a130d8184c"
     },
     {
       "file": "tsbs_devops_sf01_polars_df_20260502_211256_08ff769e.json",
@@ -2418,7 +2418,7 @@
       "query_count": 0,
       "trust_label": "community-submission",
       "funding": "unspecified",
-      "bundle_sha256": "8bc2c112d2abaf9cfba1452913e4839fede07991043d8e1d64a4313148f9a1f6"
+      "bundle_sha256": "9e5ec698dd9a389c279b1dcb06f25d76ce601990d8b39a77aa9a60f65bdfd84c"
     },
     {
       "file": "tsbs_devops_sf1_polars_df_20260502_211300_8dc54836.json",
@@ -2431,7 +2431,7 @@
       "query_count": 0,
       "trust_label": "community-submission",
       "funding": "unspecified",
-      "bundle_sha256": "1feed8b36457078b98fdb82b9433ac571939c006cf797f3154b9782ac741a4e6"
+      "bundle_sha256": "a506949dca9bfbf79305804a17b7a173fdf89cf1cc669ab92fc02974f857dc6a"
     },
     {
       "file": "tsbs_devops_sf001_pyspark_df_20260502_214706_2b64f5a8.json",
@@ -2444,7 +2444,7 @@
       "query_count": 0,
       "trust_label": "community-submission",
       "funding": "unspecified",
-      "bundle_sha256": "911e478289867c034ed6faa13091933ce60b7cb41807a5992a51782d015c5309"
+      "bundle_sha256": "bf703412da7b8018e9f2fd564e47c85a7e112dea4242ace2f5a4a0c9d22a8ed5"
     },
     {
       "file": "tsbs_devops_sf01_pyspark_df_20260502_214711_86d7cc38.json",
@@ -2457,7 +2457,7 @@
       "query_count": 0,
       "trust_label": "community-submission",
       "funding": "unspecified",
-      "bundle_sha256": "7496fdf5f2c7cc8d15b07b39c4461f368ede876601b875723fe8b2a3161af04f"
+      "bundle_sha256": "4bba9319877b95378f74d2d910505e2d05212802ea8d7d4ed081347e4d08e2c9"
     },
     {
       "file": "tsbs_devops_sf1_pyspark_df_20260502_214717_7465048e.json",
@@ -2470,7 +2470,7 @@
       "query_count": 0,
       "trust_label": "community-submission",
       "funding": "unspecified",
-      "bundle_sha256": "99a725abf151bb3f3e5a6038c403c735c0dbaa8a9dbc33f75bbffc5cd0f72587"
+      "bundle_sha256": "707b03fc7f3e1fa3c1cdc11a39367e3749d33966434784bd3c7aeee738378280"
     },
     {
       "file": "tsbs_devops_sf001_sqlite_sql_20260502_195923_2b0073d0.json",
@@ -2535,7 +2535,7 @@
       "query_count": 351,
       "trust_label": "community-submission",
       "funding": "unspecified",
-      "bundle_sha256": "c59012a1a89ba12e2a2cfd9a3d4e6d0cae9e1a3de2477b13199c7b33ecb4bf42"
+      "bundle_sha256": "9d58ad0ec6001fee6a997e7cdfebd4c03e6e807a73bf24e526ab6dd5a120f3bd"
     },
     {
       "file": "write_primitives_sf01_datafusion_sql_20260502_182723_36dce482.json",
@@ -2561,7 +2561,7 @@
       "query_count": 351,
       "trust_label": "community-submission",
       "funding": "unspecified",
-      "bundle_sha256": "0fbdcb8f24390432412f56750e213fb0b62178bb73d22218f0ac814f5886958f"
+      "bundle_sha256": "65cea8c33a069cffd9ac3fabc295801dfbf741f4fd8b902561a440aa3d2aa342"
     },
     {
       "file": "write_primitives_sf1_datafusion_sql_20260502_182728_b4c8a69b.json",
@@ -2587,7 +2587,7 @@
       "query_count": 351,
       "trust_label": "community-submission",
       "funding": "unspecified",
-      "bundle_sha256": "027964061b325dddd2c25ea66d03572d226b76140b935471102f868f250a073f"
+      "bundle_sha256": "866f2ca11f0a5174e06af788ed3c1b74dfa1ceac79d68a11715e2d2e09230e2a"
     },
     {
       "file": "write_primitives_sf001_polars_df_20260502_210917_f2787858.json",
@@ -2600,7 +2600,7 @@
       "query_count": 351,
       "trust_label": "community-submission",
       "funding": "unspecified",
-      "bundle_sha256": "0917836cd17c95b4ddc1cdff4df0e2e429c902e2db59832f51b93da197560737"
+      "bundle_sha256": "3f25ebe1e6aea55fb937791f02a7b43f2ae859be1c42b03fda19e8eb94434d45"
     },
     {
       "file": "write_primitives_sf01_polars_df_20260502_210944_e79b8a43.json",
@@ -2613,7 +2613,7 @@
       "query_count": 351,
       "trust_label": "community-submission",
       "funding": "unspecified",
-      "bundle_sha256": "392c75dbde3a932d7f6b0d4f5155f6281f517a07e9bbd386f0f4053eaaacc437"
+      "bundle_sha256": "74859d81a82d65bd1091caccc9ddca85f620169c67098ca8d7ecdff6627e607c"
     },
     {
       "file": "write_primitives_sf1_polars_df_20260502_211202_4af2f436.json",
@@ -2626,7 +2626,7 @@
       "query_count": 351,
       "trust_label": "community-submission",
       "funding": "unspecified",
-      "bundle_sha256": "898537513fe7d906e66d3cc38a8ae1b7238fba86ac86573d0d62153f812d6ee9"
+      "bundle_sha256": "3ee69ec6dea9c7fdd60fb3ce0c3e64fbf2ac1cec33cdcdcf7cb25693a20890a9"
     },
     {
       "file": "write_primitives_sf001_pyspark_df_20260502_214140_804d82c4.json",
@@ -2639,7 +2639,7 @@
       "query_count": 351,
       "trust_label": "community-submission",
       "funding": "unspecified",
-      "bundle_sha256": "fec45f44695cbf50115a93b413f432b8f0345505f429fb7fce5c9aa1f1573008"
+      "bundle_sha256": "b42f0c0f4f7990936d95c9569151caa6cedf0a4ba9f39406eb30d1ca956abc66"
     },
     {
       "file": "write_primitives_sf01_pyspark_df_20260502_214207_429683c1.json",
@@ -2652,7 +2652,7 @@
       "query_count": 351,
       "trust_label": "community-submission",
       "funding": "unspecified",
-      "bundle_sha256": "800ea99a63823b6a657aab24b5f19f1b58946e8ca3e9439514a8c1f0798d3bbe"
+      "bundle_sha256": "e8fcc38d6cf97a28ae627e3bacc6107e00cb70440beb07740aa67016051f434c"
     },
     {
       "file": "write_primitives_sf1_pyspark_df_20260502_214426_38430ee4.json",
@@ -2665,7 +2665,7 @@
       "query_count": 351,
       "trust_label": "community-submission",
       "funding": "unspecified",
-      "bundle_sha256": "08125b25328e9afccd6910f0f741e73de0a8583fd03dbf2b9f2cfc3168198e48"
+      "bundle_sha256": "836c57f7b6d68ca54329c68a93f544c1138ffb0f4a762c24f0551ccdc9dd180d"
     },
     {
       "file": "write_primitives_sf001_sqlite_sql_20260502_192540_036c84f7.json",

--- a/tests/unit/core/results/test_anonymization.py
+++ b/tests/unit/core/results/test_anonymization.py
@@ -1114,11 +1114,12 @@ class TestPublicUnreadIdentifierDrop:
         assert "client_host" not in out.get("environment", {})
         assert out["environment"]["other"] == 1
 
-    def test_already_empty_client_host_passes_through_for_fixed_point(self):
-        """Stored `client_host: {}` is left alone until an explicit re-derive."""
-        payload = {"environment": {"client_host": {}}}
+    def test_already_empty_client_host_is_omitted(self):
+        """Empty client_host maps are omitted so stored residuals can be re-derived away."""
+        payload = {"environment": {"client_host": {}, "other": 1}}
         out = AnonymizationManager().anonymize_result_payload(payload)
-        assert out["environment"]["client_host"] == {}
+        assert "client_host" not in out.get("environment", {})
+        assert out["environment"]["other"] == 1
 
     def test_nonempty_client_host_profile_still_exports(self):
         out = AnonymizationManager().anonymize_result_payload(


### PR DESCRIPTION
Omit hollow client_host maps at the public boundary and re-derive 105
primary bundles so stored bytes match the fresh public shape.
