### PR TITLE
fix/staging manifest certifies stale data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Stale transactional staging data is now rebuilt, not certified** - The
+  staging provenance manifest that gates `is_setup()` for Transaction
+  Primitives and Write Primitives was written unconditionally at the end of
+  `setup()`, including on the path where `setup(force=False)` skipped
+  repopulation because the staging tables were already non-empty. A staging set
+  left over from a smaller scale factor was therefore detected as stale exactly
+  once, never rebuilt, and then stamped with a manifest asserting it belonged
+  to the new run — so the benchmark still reported timings for the wrong data
+  volume as a PASS. A manifest mismatch now triggers the same rebuild that
+  `force=True` does, and the manifest is written over data that was actually
+  repopulated. Databases that already carry a manifest written by the previous
+  behaviour pay one real staging rebuild on next use.
 - **Unrunnable precompiled TPC binaries now fall back to source compilation** -
   Binary selection probes that a bundled `dbgen`/`qgen`/`dsdgen`/`dsqgen`
   actually executes on the host before choosing it over compiling from source.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,8 +60,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   to the new run — so the benchmark still reported timings for the wrong data
   volume as a PASS. A manifest mismatch now triggers the same rebuild that
   `force=True` does, and the manifest is written over data that was actually
-  repopulated. Databases that already carry a manifest written by the previous
-  behaviour pay one real staging rebuild on next use.
+  repopulated. Manifest rows written by the previous behaviour cannot be
+  trusted — they are internally consistent (right scale, right spec version,
+  digest of the live source tables) while the staging data they describe is
+  stale — so the manifest moves to a new table generation that those rows
+  cannot satisfy. Any database the previous behaviour already mis-certified
+  therefore takes the missing-manifest path and pays one real staging rebuild
+  on next use; no operator action is required, and the superseded table is
+  dropped during that rebuild.
 - **Unrunnable precompiled TPC binaries now fall back to source compilation** -
   Binary selection probes that a bundled `dbgen`/`qgen`/`dsdgen`/`dsqgen`
   actually executes on the host before choosing it over compiling from source.

--- a/benchbox/core/transaction_primitives/benchmark.py
+++ b/benchbox/core/transaction_primitives/benchmark.py
@@ -376,12 +376,23 @@ class TransactionPrimitivesBenchmark(TransactionalBenchmarkBase["OperationResult
             )
 
         try:
-            # Drop existing staging tables if force=True (done once before loop)
-            if force:
+            # A staging set whose manifest does not match this run is stale, not
+            # reusable. Without this the population loop below takes its "already
+            # populated" branch on the leftover rows, nothing is rebuilt, and the
+            # unconditional _write_staging_manifest() at the end then certifies
+            # the stale data as this run's -- the exact silent wrong-results bug
+            # the manifest exists to close. Reuse the force drop path rather than
+            # adding a second one; a dropped table re-enters the loop empty and
+            # repopulates through the already-audited branch.
+            rebuild = force or not self._staging_manifest_matches(connection, required_tables)
+
+            # Drop existing staging tables when rebuilding (done once before loop)
+            if rebuild:
+                reason = "force mode" if force else "stale/absent staging manifest"
                 for table_name in STAGING_TABLES:
                     try:
                         connection.execute(f"DROP TABLE IF EXISTS {table_name}")
-                        self.log_verbose(f"Dropped existing {table_name} (force mode)")
+                        self.log_verbose(f"Dropped existing {table_name} ({reason})")
                     except Exception as e:
                         self.log_verbose(f"Warning: Could not drop {table_name}: {e}")
 

--- a/benchbox/core/transaction_primitives/benchmark.py
+++ b/benchbox/core/transaction_primitives/benchmark.py
@@ -389,6 +389,7 @@ class TransactionPrimitivesBenchmark(TransactionalBenchmarkBase["OperationResult
             # Drop existing staging tables when rebuilding (done once before loop)
             if rebuild:
                 reason = "force mode" if force else "stale/absent staging manifest"
+                self._drop_legacy_staging_manifests(connection)
                 for table_name in STAGING_TABLES:
                     try:
                         connection.execute(f"DROP TABLE IF EXISTS {table_name}")

--- a/benchbox/core/transactional/benchmark_base.py
+++ b/benchbox/core/transactional/benchmark_base.py
@@ -327,19 +327,66 @@ class TransactionalBenchmarkBase(GeneratorOutputDirMixin, BaseBenchmark, Operati
     #: produced. Keyed by ``benchmark`` so transaction_primitives and
     #: write_primitives sharing one physical database do not clobber each
     #: other's row.
-    _STAGING_MANIFEST_TABLE = "benchbox_staging_manifest"
+    #:
+    #: The ``_v2`` generation is load-bearing, not cosmetic. The first release
+    #: of this manifest wrote a row unconditionally at the end of ``setup()``,
+    #: including on the path that skipped repopulation because the staging
+    #: tables were already non-empty. Those rows are *internally consistent* --
+    #: correct scale, correct spec version, and a digest of the live source
+    #: tables -- while the staging data they describe is stale. Reusing the
+    #: original table name would therefore match them, ``is_setup()`` would
+    #: short-circuit, and every database that generation already mis-certified
+    #: would stay silently wrong forever. A new name makes them unmatchable, so
+    #: those databases take the missing-manifest path and rebuild once.
+    _STAGING_MANIFEST_TABLE = "benchbox_staging_manifest_v2"
+
+    #: Superseded manifest table, dropped on rebuild so a database does not
+    #: carry a stale generation's rows around indefinitely. Never read.
+    _LEGACY_STAGING_MANIFEST_TABLES: tuple[str, ...] = ("benchbox_staging_manifest",)
 
     def _quote_identifier(self, identifier: str) -> str:
         """Quote a SQL identifier. Subclasses override for dialect-specific quoting."""
         return quote_identifier(identifier)
 
+    def _drop_legacy_staging_manifests(self, connection: DatabaseConnection) -> None:
+        """Remove superseded manifest generations during a rebuild.
+
+        Best-effort: a failure here leaves harmless cruft, never an incorrect
+        reuse decision, because the superseded names are never read.
+        """
+        for legacy in self._LEGACY_STAGING_MANIFEST_TABLES:
+            try:
+                connection.execute(f"DROP TABLE IF EXISTS {self._quote_identifier(legacy)}")
+            except Exception:  # noqa: BLE001 - cleanup only; never fail setup over cruft
+                pass
+
     def _staging_provenance_key(self) -> tuple[str, str, str]:
-        """Return ``(benchmark_id, scale, spec_version)`` identifying this run's staging provenance."""
+        """Return ``(benchmark_id, scale, spec_version)`` identifying this run's staging provenance.
+
+        ``scale`` is normalised through ``float`` so a benchmark constructed
+        with ``scale_factor=1`` and one constructed with ``scale_factor=1.0``
+        agree. Without it the two stringify differently ("1" vs "1.0"), never
+        match each other's manifest, and each pays a full staging rebuild.
+        """
         benchmark_id = getattr(self, "_benchmark_label", self.__class__.__name__)
-        return str(benchmark_id), str(self.scale_factor), str(getattr(self, "_version", "unknown"))
+        try:
+            scale = str(float(self.scale_factor))
+        except (TypeError, ValueError):
+            scale = str(self.scale_factor)
+        return str(benchmark_id), scale, str(getattr(self, "_version", "unknown"))
 
     def _staging_source_digest(self, connection: DatabaseConnection, source_tables: list[str]) -> str:
         """Fingerprint the live TPC-H source tables backing this benchmark's staging data.
+
+        INVARIANT: no benchmark operation may mutate ``source_tables``. Both
+        operation catalogues read orders/lineitem/customer and write only to
+        their own staging tables, which is what keeps the digest stable for the
+        duration of a run. ``is_setup()`` legitimately goes False mid-run when
+        an operation empties a staging table it gates on; the manifest still
+        matching at that moment is what limits the response to repopulating
+        that one table. Add an operation that writes to a source table and
+        every subsequent operation instead pays a full drop-and-repopulate of
+        the whole staging set.
 
         Hashes ordered ``table:row_count`` pairs so a manifest written against
         one data volume cannot match a differently-provisioned database even

--- a/benchbox/core/write_primitives/benchmark.py
+++ b/benchbox/core/write_primitives/benchmark.py
@@ -798,13 +798,24 @@ class WritePrimitivesBenchmark(TransactionalBenchmarkBase["OperationResult"]):
             )
 
         try:
-            # Drop existing staging tables if force=True (done once before loop)
-            if force:
+            # A staging set whose manifest does not match this run is stale, not
+            # reusable. Without this the population loop below takes its "already
+            # populated" branch on the leftover rows, nothing is rebuilt, and the
+            # unconditional _write_staging_manifest() at the end then certifies
+            # the stale data as this run's -- the exact silent wrong-results bug
+            # the manifest exists to close. Kept identical to the
+            # transaction_primitives gate; these two setup() paths drifting is how
+            # the original bug survived review.
+            rebuild = force or not self._staging_manifest_matches(connection, required_tables)
+
+            # Drop existing staging tables when rebuilding (done once before loop)
+            if rebuild:
+                reason = "force mode" if force else "stale/absent staging manifest"
                 for table_name in STAGING_TABLES:
                     try:
                         quoted = self._quote_identifier(table_name)
                         connection.execute(f"DROP TABLE IF EXISTS {quoted}")
-                        self.log_verbose(f"Dropped existing {table_name} (force mode)")
+                        self.log_verbose(f"Dropped existing {table_name} ({reason})")
                     except Exception as e:
                         self.log_verbose(f"Warning: Could not drop {table_name}: {e}")
 

--- a/benchbox/core/write_primitives/benchmark.py
+++ b/benchbox/core/write_primitives/benchmark.py
@@ -811,6 +811,7 @@ class WritePrimitivesBenchmark(TransactionalBenchmarkBase["OperationResult"]):
             # Drop existing staging tables when rebuilding (done once before loop)
             if rebuild:
                 reason = "force mode" if force else "stale/absent staging manifest"
+                self._drop_legacy_staging_manifests(connection)
                 for table_name in STAGING_TABLES:
                     try:
                         quoted = self._quote_identifier(table_name)

--- a/tests/unit/core/transactional/test_staging_provenance.py
+++ b/tests/unit/core/transactional/test_staging_provenance.py
@@ -100,6 +100,34 @@ def _rows(conn: duckdb.DuckDBPyConnection, table: str) -> int:
     return conn.execute(f"SELECT COUNT(*) FROM {table}").fetchone()[0]
 
 
+#: Every staging table the corresponding ``is_setup()`` gates on. Assertions
+#: must cover ALL of them: a rebuild that refreshes only the one or two tables
+#: a test happens to name leaves the rest stale AND certified, and the suite
+#: stays green -- the same "healed and untouched are indistinguishable" hole
+#: that let the first version of this fix ship with its headline bug intact.
+_TXN_GATED_TABLES = ("txn_orders", "txn_lineitem", "txn_customer")
+_WRITE_GATED_TABLES = (
+    "update_ops_orders",
+    "delete_ops_orders",
+    "delete_ops_lineitem",
+    "merge_ops_target",
+    "merge_ops_source",
+    "merge_ops_lineitem_target",
+    "ddl_truncate_target",
+)
+
+
+def _snapshot(conn: duckdb.DuckDBPyConnection, tables: tuple[str, ...]) -> dict[str, int]:
+    return {t: _rows(conn, t) for t in tables}
+
+
+def _assert_all_rebuilt(conn: duckdb.DuckDBPyConnection, before: dict[str, int], tables: tuple[str, ...]) -> None:
+    """Every gated table must reflect the grown source, not just the asserted ones."""
+    after = _snapshot(conn, tables)
+    stale = {t: (before[t], after[t]) for t in tables if after[t] <= before[t]}
+    assert not stale, f"staging tables left stale after rebuild (before, after): {stale}"
+
+
 @pytest.fixture
 def loaded_tpch_conn():
     conn = _minimal_tpch_conn()
@@ -170,7 +198,7 @@ class TestTransactionPrimitivesStagingProvenance:
         """
         small = TransactionPrimitivesBenchmark(scale_factor=0.01, output_dir=tmp_path)
         small.setup(loaded_tpch_conn, force=False)
-        stale_rows = _rows(loaded_tpch_conn, "txn_orders")
+        before = _snapshot(loaded_tpch_conn, _TXN_GATED_TABLES)
 
         _grow_tpch_source(loaded_tpch_conn)
         large = TransactionPrimitivesBenchmark(scale_factor=1.0, output_dir=tmp_path)
@@ -178,9 +206,45 @@ class TestTransactionPrimitivesStagingProvenance:
 
         large.setup(loaded_tpch_conn, force=False)
 
+        _assert_all_rebuilt(loaded_tpch_conn, before, _TXN_GATED_TABLES)
         assert _rows(loaded_tpch_conn, "txn_orders") == _rows(loaded_tpch_conn, "orders")
-        assert _rows(loaded_tpch_conn, "txn_orders") != stale_rows
         assert large.is_setup(loaded_tpch_conn) is True
+
+    def test_manifest_from_the_pre_rebuild_generation_is_not_reused(self, tmp_path: Path, loaded_tpch_conn):
+        """A manifest written by the generation that certified without rebuilding must not match.
+
+        That generation wrote its row unconditionally at the end of setup(),
+        including on the path that skipped repopulation. Those rows are
+        internally consistent -- right scale, right spec, digest of the live
+        source -- while the staging data they describe is stale. If the current
+        code read them, every database that generation mis-certified would stay
+        silently wrong forever instead of rebuilding once.
+        """
+        bench = TransactionPrimitivesBenchmark(scale_factor=0.01, output_dir=tmp_path)
+        benchmark_id, scale, spec_version = bench._staging_provenance_key()
+        digest = bench._staging_source_digest(loaded_tpch_conn, ["orders", "lineitem", "customer"])
+
+        for legacy in bench._LEGACY_STAGING_MANIFEST_TABLES:
+            loaded_tpch_conn.execute(
+                f"CREATE TABLE {legacy} (benchmark VARCHAR, scale VARCHAR, spec_version VARCHAR, "
+                "source_digest VARCHAR, created_at VARCHAR)"
+            )
+            loaded_tpch_conn.execute(
+                f"INSERT INTO {legacy} VALUES "
+                f"('{benchmark_id}', '{scale}', '{spec_version}', '{digest}', '2026-08-05T00:00:00Z')"
+            )
+        loaded_tpch_conn.execute("CREATE TABLE txn_orders AS SELECT * FROM orders LIMIT 1")
+        loaded_tpch_conn.execute("CREATE TABLE txn_lineitem AS SELECT * FROM lineitem LIMIT 1")
+        loaded_tpch_conn.execute("CREATE TABLE txn_customer AS SELECT * FROM customer LIMIT 1")
+
+        assert bench.is_setup(loaded_tpch_conn) is False
+
+        bench.setup(loaded_tpch_conn, force=False)
+        assert _rows(loaded_tpch_conn, "txn_orders") == _rows(loaded_tpch_conn, "orders")
+        # The superseded generation's table is cleaned up, not left as cruft.
+        for legacy in bench._LEGACY_STAGING_MANIFEST_TABLES:
+            with pytest.raises(duckdb.CatalogException):
+                loaded_tpch_conn.execute(f"SELECT 1 FROM {legacy}")
 
 
 class TestWritePrimitivesStagingProvenance:
@@ -231,7 +295,7 @@ class TestWritePrimitivesStagingProvenance:
         """write_primitives has the identical setup() short-circuit; pin it too."""
         small = WritePrimitivesBenchmark(scale_factor=0.01, output_dir=tmp_path)
         small.setup(loaded_tpch_conn, force=False)
-        stale_rows = _rows(loaded_tpch_conn, "delete_ops_lineitem")
+        before = _snapshot(loaded_tpch_conn, _WRITE_GATED_TABLES)
 
         _grow_tpch_source(loaded_tpch_conn)
         large = WritePrimitivesBenchmark(scale_factor=1.0, output_dir=tmp_path)
@@ -239,8 +303,8 @@ class TestWritePrimitivesStagingProvenance:
 
         large.setup(loaded_tpch_conn, force=False)
 
+        _assert_all_rebuilt(loaded_tpch_conn, before, _WRITE_GATED_TABLES)
         assert _rows(loaded_tpch_conn, "delete_ops_lineitem") == _rows(loaded_tpch_conn, "lineitem")
-        assert _rows(loaded_tpch_conn, "delete_ops_lineitem") != stale_rows
         assert large.is_setup(loaded_tpch_conn) is True
 
 

--- a/tests/unit/core/transactional/test_staging_provenance.py
+++ b/tests/unit/core/transactional/test_staging_provenance.py
@@ -84,6 +84,22 @@ def _minimal_tpch_conn() -> duckdb.DuckDBPyConnection:
     return conn
 
 
+def _grow_tpch_source(conn: duckdb.DuckDBPyConnection) -> None:
+    """Double the source tables with fresh keys, as reloading at a larger scale does.
+
+    Key-shifted rather than a plain re-insert so the staging tables' primary
+    keys still hold after a rebuild -- a duplicate-key failure would mask the
+    behavior under test.
+    """
+    conn.execute("INSERT INTO orders SELECT * REPLACE (o_orderkey + 1000 AS o_orderkey) FROM orders")
+    conn.execute("INSERT INTO lineitem SELECT * REPLACE (l_orderkey + 1000 AS l_orderkey) FROM lineitem")
+    conn.execute("INSERT INTO customer SELECT * REPLACE (c_custkey + 1000 AS c_custkey) FROM customer")
+
+
+def _rows(conn: duckdb.DuckDBPyConnection, table: str) -> int:
+    return conn.execute(f"SELECT COUNT(*) FROM {table}").fetchone()[0]
+
+
 @pytest.fixture
 def loaded_tpch_conn():
     conn = _minimal_tpch_conn()
@@ -126,16 +142,45 @@ class TestTransactionPrimitivesStagingProvenance:
         fine" would just reinstate the bug this manifest exists to close."""
         bench = TransactionPrimitivesBenchmark(scale_factor=0.01, output_dir=tmp_path)
 
-        loaded_tpch_conn.execute("CREATE TABLE txn_orders AS SELECT * FROM orders")
-        loaded_tpch_conn.execute("CREATE TABLE txn_lineitem AS SELECT * FROM lineitem")
-        loaded_tpch_conn.execute("CREATE TABLE txn_customer AS SELECT * FROM customer")
+        # Seeded SHORT on purpose. Seeding the full source would make a healed
+        # database and an untouched one byte-identical, so the assertion below
+        # could not tell a real rebuild from a bare manifest write -- which is
+        # how the first version of this fix shipped with its headline bug
+        # intact and this test still green.
+        loaded_tpch_conn.execute("CREATE TABLE txn_orders AS SELECT * FROM orders LIMIT 1")
+        loaded_tpch_conn.execute("CREATE TABLE txn_lineitem AS SELECT * FROM lineitem LIMIT 1")
+        loaded_tpch_conn.execute("CREATE TABLE txn_customer AS SELECT * FROM customer LIMIT 1")
 
         assert bench.is_setup(loaded_tpch_conn) is False
 
-        # And it self-heals: running setup() writes the manifest, after which
-        # is_setup() reports True for this same benchmark/scale.
+        # Self-heal means the staging data is actually rebuilt from source, not
+        # merely stamped with a manifest.
         bench.setup(loaded_tpch_conn, force=False)
+        assert _rows(loaded_tpch_conn, "txn_orders") == _rows(loaded_tpch_conn, "orders")
+        assert _rows(loaded_tpch_conn, "txn_lineitem") == _rows(loaded_tpch_conn, "lineitem")
         assert bench.is_setup(loaded_tpch_conn) is True
+
+    def test_stale_scale_rebuild_repopulates_staging(self, tmp_path: Path, loaded_tpch_conn):
+        """Staging left over from a smaller scale is rebuilt, not certified.
+
+        `_prepare_operation` reacts to a False `is_setup()` by calling
+        `setup(force=False)`. If that call short-circuits on the non-empty
+        stale tables while still writing the manifest, the run benchmarks the
+        wrong data volume and the database is left asserting it did not.
+        """
+        small = TransactionPrimitivesBenchmark(scale_factor=0.01, output_dir=tmp_path)
+        small.setup(loaded_tpch_conn, force=False)
+        stale_rows = _rows(loaded_tpch_conn, "txn_orders")
+
+        _grow_tpch_source(loaded_tpch_conn)
+        large = TransactionPrimitivesBenchmark(scale_factor=1.0, output_dir=tmp_path)
+        assert large.is_setup(loaded_tpch_conn) is False
+
+        large.setup(loaded_tpch_conn, force=False)
+
+        assert _rows(loaded_tpch_conn, "txn_orders") == _rows(loaded_tpch_conn, "orders")
+        assert _rows(loaded_tpch_conn, "txn_orders") != stale_rows
+        assert large.is_setup(loaded_tpch_conn) is True
 
 
 class TestWritePrimitivesStagingProvenance:
@@ -164,20 +209,39 @@ class TestWritePrimitivesStagingProvenance:
     def test_legacy_populated_unmanifested_database_forces_rebuild(self, tmp_path: Path, loaded_tpch_conn):
         bench = WritePrimitivesBenchmark(scale_factor=0.01, output_dir=tmp_path)
 
-        loaded_tpch_conn.execute("CREATE TABLE update_ops_orders AS SELECT * FROM orders")
-        loaded_tpch_conn.execute("CREATE TABLE delete_ops_orders AS SELECT * FROM orders")
-        loaded_tpch_conn.execute("CREATE TABLE delete_ops_lineitem AS SELECT * FROM lineitem")
-        loaded_tpch_conn.execute("CREATE TABLE merge_ops_target AS SELECT * FROM orders")
-        loaded_tpch_conn.execute("CREATE TABLE merge_ops_source AS SELECT * FROM orders")
-        loaded_tpch_conn.execute("CREATE TABLE merge_ops_lineitem_target AS SELECT * FROM lineitem")
+        # Seeded SHORT for the same reason as the transaction_primitives case:
+        # a full-source seed cannot distinguish a rebuild from a manifest write.
+        loaded_tpch_conn.execute("CREATE TABLE update_ops_orders AS SELECT * FROM orders LIMIT 1")
+        loaded_tpch_conn.execute("CREATE TABLE delete_ops_orders AS SELECT * FROM orders LIMIT 1")
+        loaded_tpch_conn.execute("CREATE TABLE delete_ops_lineitem AS SELECT * FROM lineitem LIMIT 1")
+        loaded_tpch_conn.execute("CREATE TABLE merge_ops_target AS SELECT * FROM orders LIMIT 1")
+        loaded_tpch_conn.execute("CREATE TABLE merge_ops_source AS SELECT * FROM orders LIMIT 1")
+        loaded_tpch_conn.execute("CREATE TABLE merge_ops_lineitem_target AS SELECT * FROM lineitem LIMIT 1")
         loaded_tpch_conn.execute(
-            "CREATE TABLE ddl_truncate_target AS SELECT o_orderkey, o_custkey, o_orderdate FROM orders"
+            "CREATE TABLE ddl_truncate_target AS SELECT o_orderkey, o_custkey, o_orderdate FROM orders LIMIT 1"
         )
 
         assert bench.is_setup(loaded_tpch_conn) is False
 
         bench.setup(loaded_tpch_conn, force=False)
+        assert _rows(loaded_tpch_conn, "delete_ops_lineitem") == _rows(loaded_tpch_conn, "lineitem")
         assert bench.is_setup(loaded_tpch_conn) is True
+
+    def test_stale_scale_rebuild_repopulates_staging(self, tmp_path: Path, loaded_tpch_conn):
+        """write_primitives has the identical setup() short-circuit; pin it too."""
+        small = WritePrimitivesBenchmark(scale_factor=0.01, output_dir=tmp_path)
+        small.setup(loaded_tpch_conn, force=False)
+        stale_rows = _rows(loaded_tpch_conn, "delete_ops_lineitem")
+
+        _grow_tpch_source(loaded_tpch_conn)
+        large = WritePrimitivesBenchmark(scale_factor=1.0, output_dir=tmp_path)
+        assert large.is_setup(loaded_tpch_conn) is False
+
+        large.setup(loaded_tpch_conn, force=False)
+
+        assert _rows(loaded_tpch_conn, "delete_ops_lineitem") == _rows(loaded_tpch_conn, "lineitem")
+        assert _rows(loaded_tpch_conn, "delete_ops_lineitem") != stale_rows
+        assert large.is_setup(loaded_tpch_conn) is True
 
 
 class TestStagingManifestHelpers:


### PR DESCRIPTION
- **fix(core): rebuild stale staging data instead of certifying it**
- **fix(core): invalidate manifests from the certify-without-rebuild generation**
