### PR TITLE
fix(uat): surface unvalidated cells in every machine-readable roll-up

### DIFF
--- a/_project/specs/uat-framework.md
+++ b/_project/specs/uat-framework.md
@@ -130,7 +130,7 @@ tests/uat/
 | `matrix.py` | Registry-driven benchmark enumeration, platform grouping, compose-derived TCP reachability probe (connection facts now owned by `docker_assets`) | 250 | 515 |
 | `runner.py` | Build `benchbox run` argv per cell; capture stdout+stderr to per-run log; extract result-JSON path; submit classification via shared `benchbox.core.results.submit_classification` | 120 | 354 |
 | `config.py` | Load YAML, validate against schema (Section 3), expose typed dataclass access | 180 | 751 |
-| `_cli.py` | UAT CLI entrypoint: argument parsing, sweep/execute/validate/report/package subcommands, output wiring | — | 806 |
+| `_cli.py` | UAT CLI entrypoint: argument parsing, sweep/execute/validate/report/package subcommands, output wiring | — | 816 |
 | `timeouts.py` | Signal-based timeout (POSIX process-group kill ladder) | 80 | 123 |
 | `cleanup.py` | Track cell completions; prune `databases/` at safe reuse boundaries; preserve `datagen/` | 150 | 121 |
 | `compatibility.py` | Platform/benchmark compatibility rules; record compatibility-pruned cells with rule metadata | — | 198 |
@@ -139,7 +139,7 @@ tests/uat/
 | `container_cleanup.py` | Apple `container`-engine sibling of `docker_cleanup.py`; backs `make uat-docker-cleanup ENGINE=container` | — | 557 |
 | `artifact_hygiene.py` | Local-artifact hygiene guard: flags worktree-local `benchmark_runs/` growth whenever the resolved output root is outside the worktree — including the default `../benchmark_runs`, not only a configured one; report-only (`make uat-artifact-hygiene`) | — | 315 |
 | `cells_io.py` | `cells.jsonl` + accounting-sidecar read/write codec; single schema shared by `orchestrator.py` and `_cli.py` | — | 464 |
-| `gate_summary.py` | Writes/reads the versioned `uat_gate_summary.json` per-sweep evidence artifact; powers `make uat-gate-check` cross-stage aggregation | — | 274 |
+| `gate_summary.py` | Writes/reads the versioned `uat_gate_summary.json` per-sweep evidence artifact; powers `make uat-gate-check` cross-stage aggregation | — | 284 |
 | `throughput.py` | Multi-stream throughput/concurrent cell support via `benchbox run-official --streams`; TPC-compliant scale-factor gate | — | 316 |
 | `ladder.py` | Per-(platform, benchmark) rung order; wall-clock and exit-code early-stop; pruning bookkeeping | 100 | 83 |
 | `preflight_budget.py` | Disk free-space floor budgeting and cell-key accounting | — | 236 |
@@ -150,8 +150,8 @@ tests/uat/
 | `phases/validate.py` | Call `benchbox.validation.bundle` in-process; write validator TSV; compute clean-rate floor | 100 | 304 |
 | `phases/package.py` | Read `submit_terminal_state`; invoke `benchbox submit --output` or `--service`; `draft-pr`/`merged-to-published-results` are **stubs** (dispatcher only, per `PR_STUB_TERMINAL_STATES`) that emit the same argv as `local-stage` plus an operator warning -- PR-opening to `published-results` is not implemented | 130 | 180 |
 | `phases/explorer_smoke.py` | Branch-presence-guarded explorer smoke: always-on corpus contract, delegates build+Playwright to the Results Explorer | 60 | 387 |
-| `phases/report.py` | Read each phase's outputs; emit `matrix_summary.tsv`; cross-scale coverage check | 130 | 462 |
-| `orchestrator.py` | Walk YAML `phases:` list in order; surface phase failures; respect `dry_run:` toggle | 100 | 906 |
+| `phases/report.py` | Read each phase's outputs; emit `matrix_summary.tsv`; cross-scale coverage check | 130 | 490 |
+| `orchestrator.py` | Walk YAML `phases:` list in order; surface phase failures; respect `dry_run:` toggle | 100 | 924 |
 
 **Budget reconciliation (revised 2026-06-01, `uat-loc-budget-reconciliation`; re-measured
 2026-07-19, `uat-config-schema-spec-realignment`).**
@@ -175,17 +175,17 @@ remain hand-tracked.
 
 **Per-bucket production LOC** (auto-generated -- run the script to refresh):
 
-- plumbing (orchestrator/config/`_cli`): 2,463
+- plumbing (orchestrator/config/`_cli`): 2,491
 - core exercise (execute/matrix/runner/enumerate/cleanup/ladder): 2,366
 - preflight/compat/timeouts: 1,008
 - Docker lifecycle (default-OFF, incl. `container_cleanup.py`): 1,743
-- chartered evidence artifacts (validate/report/package/cells_io/gate_summary): 1,684
+- chartered evidence artifacts (validate/report/package/cells_io/gate_summary): 1,722
 - explorer-prep: 387
 - throughput: 316
 - artifact hygiene: 315
 - package init markers: 23
 
-**Total: 10,305 production LOC across 26 modules.**
+**Total: 10,371 production LOC across 26 modules.**
 
 <!-- UAT-LOC-SUMMARY:END -->
 

--- a/tests/uat/_cli.py
+++ b/tests/uat/_cli.py
@@ -241,6 +241,16 @@ def _handle_report(args: argparse.Namespace) -> int:
                 "passed": summary.pass_count,
                 "failed": summary.fail_count,
                 "timed_out": summary.timeout_count,
+                # Cross-cutting, already included in "passed"/"attempted" above --
+                # not a disjoint bucket. Named to match ReportSummary.unvalidated_count
+                # and PhaseAccounting.unvalidated (unvalidated-results-misclassified-
+                # as-schema-violations): this JSON is the third machine-readable
+                # surface built from the same ReportSummary (matrix_summary.tsv's
+                # `# UNVALIDATED_CELLS=` footer and uat_gate_summary.json's
+                # accounting.unvalidated are the other two), and must not be the one
+                # that silently omits it while "passed" quietly includes never-
+                # validated cells with no adjacent disclosure.
+                "unvalidated": summary.unvalidated_count,
                 "finalized": finalized,
                 "cross_scale_clean_pairs": summary.cross_scale_clean_pairs,
                 "cross_scale_floor": summary.cross_scale_floor,

--- a/tests/uat/gate_summary.py
+++ b/tests/uat/gate_summary.py
@@ -73,7 +73,16 @@ def gate_summary_path(log_dir: Path) -> Path:
 
 @dataclass(frozen=True)
 class PhaseAccounting:
-    """Per-sweep cell counts, disjoint components mirroring the report-phase footer."""
+    """Per-sweep cell counts, disjoint components mirroring the report-phase footer.
+
+    ``unvalidated`` is the one exception to "disjoint components": it mirrors
+    ``ReportSummary.unvalidated_count`` (see `tests/uat/phases/report.py`), a
+    cross-cutting visibility count of ``passed`` cells whose
+    ``submit_terminal_state`` is ``unvalidated`` -- already included in
+    ``passed``/``attempted``, not a fifth bucket alongside them, and must
+    never make a stage's verdict red on its own
+    (unvalidated-results-misclassified-as-schema-violations).
+    """
 
     attempted: int = 0
     passed: int = 0
@@ -86,6 +95,7 @@ class PhaseAccounting:
     early_stop_pruned: int = 0
     registry_pruned: int = 0
     total_defined: int = 0
+    unvalidated: int = 0
 
 
 @dataclass(frozen=True)

--- a/tests/uat/orchestrator.py
+++ b/tests/uat/orchestrator.py
@@ -29,7 +29,7 @@ from tests.uat.phases import (
     preflight as preflight_phase,
     report as report_phase,
 )
-from tests.uat.runner import CellResult
+from tests.uat.runner import CellResult, SubmitTerminalState
 
 
 @dataclass(frozen=True)
@@ -753,6 +753,15 @@ def _accounting_for_gate_summary(report_summary: Any, execute_outcome: Any) -> g
     `make uat-execute`'s scoped `[preflight, execute]` loop) mirrors
     write_report's counting on the outcome directly rather than writing a
     throwaway TSV.
+
+    `unvalidated` is threaded through in both branches so `uat_gate_summary.json`
+    -- the machine-readable artifact a release gate reads -- cannot silently
+    disagree with the human-readable `matrix_summary.tsv` footer's
+    `# UNVALIDATED_CELLS=N` line. Leaving it at the `PhaseAccounting` default
+    of 0 here would have been worse than the original bug: the TSV would
+    honestly show N unvalidated DataFrame cells while the one artifact
+    automation actually consumes asserted zero
+    (unvalidated-results-misclassified-as-schema-violations).
     """
     if report_summary is not None:
         return gate_summary.PhaseAccounting(
@@ -767,6 +776,7 @@ def _accounting_for_gate_summary(report_summary: Any, execute_outcome: Any) -> g
             early_stop_pruned=report_summary.early_stop_pruned_count,
             registry_pruned=report_summary.registry_pruned_count,
             total_defined=report_summary.total_defined_count,
+            unvalidated=report_summary.unvalidated_count,
         )
     if execute_outcome is None:
         return gate_summary.PhaseAccounting()
@@ -776,6 +786,13 @@ def _accounting_for_gate_summary(report_summary: Any, execute_outcome: Any) -> g
     timed_out = sum(1 for r in results if r.status == "timed-out")
     row_skipped = sum(1 for r in results if report_phase.is_skipped_status(r.status))
     row_unreachable = sum(1 for r in results if report_phase.is_unreachable_status(r.status))
+    # Mirror the report phase's unvalidated_count math exactly (see
+    # tests.uat.phases.report.write_report): a passed cell whose classifier
+    # verdict is `unvalidated`, cross-cutting and already included in
+    # `passed`/`attempted` above, not a disjoint bucket.
+    unvalidated = sum(
+        1 for r in results if r.status == "passed" and r.submit_terminal_state == SubmitTerminalState.unvalidated.value
+    )
     # Mirror the sidecar accounting written by the streaming path above:
     # execute_outcome.compatibility_pruned is a MIXED stream of compatibility-
     # rule drops and registry/ladder drops, so split it by kind rather than
@@ -804,6 +821,7 @@ def _accounting_for_gate_summary(report_summary: Any, execute_outcome: Any) -> g
         early_stop_pruned=early_stop_pruned,
         registry_pruned=registry_pruned,
         total_defined=attempted + skipped + unreachable + startup_failed,
+        unvalidated=unvalidated,
     )
 
 

--- a/tests/uat/phases/report.py
+++ b/tests/uat/phases/report.py
@@ -49,7 +49,7 @@ from pathlib import Path
 from typing import Iterable, Protocol
 
 from tests.uat.phases import PhaseResult
-from tests.uat.runner import CellResult
+from tests.uat.runner import CellResult, SubmitTerminalState
 
 REPORT_HEADER = (
     "platform\tbenchmark\tscale\tstatus\tterminal_state\telapsed_s\tlog_path\tresult_path\t"
@@ -122,6 +122,17 @@ class ReportSummary(PhaseResult):
     # partial cells.jsonl must never read as a clean sweep, so this forces a
     # nonzero exit regardless of what the rows-so-far happen to say.
     unfinalized: bool = False
+    # Cells classified `unvalidated` (a completed run whose validation never
+    # executed -- DataFrame mode, --validation disabled): these are `passed`
+    # cells, already counted in `pass_count`/`attempted_count` above, NOT an
+    # additional disjoint bucket. This is a cross-cutting visibility counter
+    # only -- unlike unreachable_count/startup_failed_count it must never
+    # feed exit_code() below, since UAT must not treat unvalidated as a cell
+    # failure (unvalidated-results-misclassified-as-schema-violations). Its
+    # purpose is the opposite of hiding: keep a majority-unvalidated sweep
+    # (e.g. a DataFrame release-gate stage) visible in the roll-up rather
+    # than reading as an ordinary clean pass.
+    unvalidated_count: int = 0
 
     def exit_code(self) -> int:
         if self.aborted or self.unfinalized:
@@ -278,6 +289,13 @@ def write_report(
     unreachable_count = row_unreachable_count + skipped_unreachable_count
     total_defined_count = attempted_count + skipped_count + unreachable_count + startup_failed_count
     candidate_count = total_defined_count
+    # Cross-cutting, NOT one of the disjoint total_defined_count components
+    # above (an unvalidated cell is already `passed`, already counted in
+    # attempted_count/pass_count) -- see the ReportSummary.unvalidated_count
+    # field docstring for why this must stay out of exit_code().
+    unvalidated_count = sum(
+        1 for r in rows if r.status == "passed" and r.submit_terminal_state == SubmitTerminalState.unvalidated.value
+    )
 
     lines: list[str] = [REPORT_HEADER + "\n"]
     for cell in rows:
@@ -319,6 +337,15 @@ def write_report(
         )
     if startup_failed_count:
         lines.append(f"# STARTUP_FAILED_CELLS={startup_failed_count} release_gate_attention=required\n")
+    if unvalidated_count:
+        # Visible-by-construction: a reader scanning per-row
+        # submit_terminal_state values across 200 rows is not a safeguard,
+        # so a majority-unvalidated sweep (e.g. a DataFrame release-gate
+        # stage) still gets its own aggregate line, same as
+        # UNREACHABLE_CELLS/STARTUP_FAILED_CELLS -- even though, unlike
+        # those two, this does NOT affect exit_code() (see
+        # ReportSummary.unvalidated_count).
+        lines.append(f"# UNVALIDATED_CELLS={unvalidated_count} release_gate_attention=required\n")
     footer = f"# run_status={run_status}"
     if source_info is not None:
         footer += f" source_commit_sha={source_info.commit_sha} source_dirty={str(source_info.dirty).lower()}"
@@ -361,6 +388,7 @@ def write_report(
         aborted=run_status in {"ABORTED", "BLOCKED"},
         abort_reason=abort_reason,
         unfinalized=not finalized,
+        unvalidated_count=unvalidated_count,
     )
 
 

--- a/tests/uat/test_cli_dispatch.py
+++ b/tests/uat/test_cli_dispatch.py
@@ -481,6 +481,60 @@ def test_execute_main_reports_success_for_dry_run_config(tmp_path, monkeypatch, 
 
 
 # ---------------------------------------------------------------------------
+# unvalidated-results-misclassified-as-schema-violations: `report`'s JSON
+# stdout is a third machine-readable surface built from the same
+# ReportSummary as matrix_summary.tsv's `# UNVALIDATED_CELLS=` footer and
+# uat_gate_summary.json's accounting.unvalidated (see tests/uat/phases/report.py
+# and tests/uat/orchestrator.py::_accounting_for_gate_summary). It must not be
+# the one surface that silently omits the count while "passed" quietly
+# includes never-validated cells with no adjacent disclosure.
+# ---------------------------------------------------------------------------
+
+
+def test_report_json_includes_unvalidated_count(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    from tests.uat import cells_io, orchestrator
+    from tests.uat.runner import CellResult
+
+    source_info = orchestrator.RunSourceInfo(commit_sha="deadbeef", commit_short_sha="deadbee", dirty=False)
+    clean_cell = CellResult(
+        platform="duckdb",
+        benchmark="tpch",
+        scale=0.01,
+        status="passed",
+        exit_code=0,
+        elapsed_s=1.0,
+        log_path=tmp_path / "duckdb.log",
+        result_path=tmp_path / "duckdb_result.json",
+        submit_terminal_state="submittable",
+    )
+    unvalidated_cell = CellResult(
+        platform="polars-df",
+        benchmark="tpch",
+        scale=0.01,
+        status="passed",
+        exit_code=0,
+        elapsed_s=1.0,
+        log_path=tmp_path / "polars_df.log",
+        result_path=tmp_path / "polars_df_result.json",
+        submit_terminal_state="unvalidated",
+    )
+    cells_jsonl = tmp_path / "cells.jsonl"
+    cells_io.write_cells_jsonl(cells_jsonl, [clean_cell, unvalidated_cell], source_info=source_info)
+
+    exit_code = _cli.main(
+        ["report", "--cells-jsonl", str(cells_jsonl), "--output-tsv", str(tmp_path / "matrix_summary.tsv")]
+    )
+
+    assert exit_code == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["passed"] == 2
+    # Already counted in "passed"/"attempted" above -- not a disjoint bucket.
+    assert payload["attempted"] == 2
+    # The one assertion this test exists for: present, and not 0.
+    assert payload["unvalidated"] == 1
+
+
+# ---------------------------------------------------------------------------
 # uat-release-gate-enforcement w3: gate-check subcommand.
 # ---------------------------------------------------------------------------
 

--- a/tests/uat/test_orchestrator.py
+++ b/tests/uat/test_orchestrator.py
@@ -1303,6 +1303,79 @@ def test_green_sweep_writes_green_gate_summary_with_accounting(tmp_path: Path):
     assert payload["explorer_smoke_status"] == "not_run"
 
 
+def test_green_sweep_with_unvalidated_cells_reports_unvalidated_count_not_zero(tmp_path: Path):
+    """Regression: uat_gate_summary.json must not silently disagree with matrix_summary.tsv.
+
+    tests.uat.phases.report.write_report already rolls an unvalidated DataFrame
+    cell into ReportSummary.unvalidated_count and the TSV's
+    `# UNVALIDATED_CELLS=N` footer; this pins that
+    orchestrator._accounting_for_gate_summary actually copies that count into
+    PhaseAccounting.unvalidated rather than leaving the gate summary --
+    the one artifact a release gate reads by machine, not by a human scanning
+    rows -- silently asserting 0. The verdict must still be green: unvalidated
+    is not a UAT cell failure.
+    """
+    cfg = validate_config(
+        {
+            "name": "gate-green-unvalidated",
+            "phases": ["execute", "report"],
+            "platforms": {"include": ["duckdb", "polars-df"]},
+            "benchmarks": {"include": ["tpch"]},
+            "scales": {"rungs": [0.01]},
+            "report": {"cross_scale_coverage_min_pairs": 1},
+        }
+    )
+    clean_cell = CellResult(
+        platform="duckdb",
+        benchmark="tpch",
+        scale=0.01,
+        status="passed",
+        exit_code=0,
+        elapsed_s=1.0,
+        log_path=tmp_path / "duckdb.log",
+        result_path=tmp_path / "duckdb_result.json",
+        submit_terminal_state="submittable",
+    )
+    unvalidated_cell = CellResult(
+        platform="polars-df",
+        benchmark="tpch",
+        scale=0.01,
+        status="passed",
+        exit_code=0,
+        elapsed_s=1.0,
+        log_path=tmp_path / "polars_df.log",
+        result_path=tmp_path / "polars_df_result.json",
+        submit_terminal_state="unvalidated",
+    )
+    fake_execute = type(
+        "ExecuteOutcome",
+        (),
+        {
+            "results": (clean_cell, unvalidated_cell),
+            "pruned": (),
+            "skipped_unreachable": (),
+            "startup_failed": (),
+            "compatibility_pruned": (),
+            "aborted": False,
+            "abort_reason": None,
+            "exit_code": lambda self: 0,
+        },
+    )()
+    with patch.object(orchestrator.exec_phase, "run_execute", return_value=fake_execute):
+        result = orchestrator.run_sweep(cfg, log_dir_override=tmp_path)
+
+    assert result.exit_code() == 0
+    payload = _read_gate_summary(tmp_path)
+    assert payload["verdict"] == "green"
+    assert payload["accounting"]["passed"] == 2
+    assert payload["accounting"]["attempted"] == 2
+    # The one assertion this test exists for: not 0.
+    assert payload["accounting"]["unvalidated"] == 1
+
+    tsv_text = (tmp_path / "matrix_summary.tsv").read_text(encoding="utf-8")
+    assert "# UNVALIDATED_CELLS=1 release_gate_attention=required" in tsv_text
+
+
 def test_failed_cell_sweep_writes_red_gate_summary(tmp_path: Path):
     cfg = validate_config(
         {

--- a/tests/uat/test_report_accounting.py
+++ b/tests/uat/test_report_accounting.py
@@ -8,15 +8,22 @@ from pathlib import Path
 import pytest
 
 from tests.uat import _cli as uat_cli
+from tests.uat.gate_summary import PhaseAccounting
 from tests.uat.phases import report
-from tests.uat.runner import CellResult
+from tests.uat.runner import CellResult, SubmitTerminalState
 
 pytestmark = pytest.mark.fast
 
 FIXTURE = Path(__file__).resolve().parent / "fixtures" / "report-accounting-skipped-unreachable-cells.jsonl"
 
 
-def _cell(platform: str, benchmark: str, scale: float, status: str = "passed") -> CellResult:
+def _cell(
+    platform: str,
+    benchmark: str,
+    scale: float,
+    status: str = "passed",
+    submit_terminal_state: str = SubmitTerminalState.submittable.value,
+) -> CellResult:
     return CellResult(
         platform=platform,
         benchmark=benchmark,
@@ -26,6 +33,7 @@ def _cell(platform: str, benchmark: str, scale: float, status: str = "passed") -
         elapsed_s=1.0 if status in {"passed", "failed", "timed-out"} else 0.0,
         log_path=Path(f"/tmp/{platform}_{benchmark}_{scale}.log"),
         result_path=Path(f"/tmp/{platform}_{benchmark}_{scale}.json") if status == "passed" else None,
+        submit_terminal_state=submit_terminal_state,
     )
 
 
@@ -391,6 +399,84 @@ def test_write_report_threads_registry_pruned_count_into_total_defined(tmp_path:
 
     text = (tmp_path / "matrix_summary.tsv").read_text(encoding="utf-8")
     assert "registry_pruned=3" in text
+
+
+# ---------------------------------------------------------------------------
+# unvalidated-results-misclassified-as-schema-violations: an aggregate
+# unvalidated=N counter, visible in the matrix_summary.tsv footer and on
+# ReportSummary/PhaseAccounting, so a majority-unvalidated sweep (e.g. every
+# DataFrame platform in a release-gate stage) cannot pass as an ordinary
+# clean run purely because the per-row submit_terminal_state column went
+# unread. Per the parent fix's contract, this counter must NEVER affect
+# exit_code() -- unvalidated is still not a UAT cell failure.
+# ---------------------------------------------------------------------------
+
+
+def test_write_report_counts_unvalidated_cells_without_affecting_exit_code(tmp_path: Path):
+    summary = report.write_report(
+        [
+            _cell("polars-df", "tpch", 0.01, status="passed", submit_terminal_state="unvalidated"),
+            _cell("datafusion-df", "tpch", 0.01, status="passed", submit_terminal_state="unvalidated"),
+            _cell("duckdb", "tpch", 0.01, status="passed"),
+        ],
+        output_path=tmp_path / "matrix_summary.tsv",
+    )
+
+    assert summary.unvalidated_count == 2
+    # Already counted in pass_count/attempted_count -- not a fifth disjoint
+    # total_defined_count bucket alongside skipped/unreachable/startup_failed.
+    assert summary.pass_count == 3
+    assert summary.attempted_count == 3
+    assert summary.total_defined_count == 3
+    # The whole point of this fix: unvalidated must not turn a clean sweep red.
+    assert summary.exit_code() == 0
+
+    text = (tmp_path / "matrix_summary.tsv").read_text(encoding="utf-8")
+    assert "# UNVALIDATED_CELLS=2 release_gate_attention=required" in text
+
+
+def test_write_report_omits_unvalidated_footer_line_when_zero(tmp_path: Path):
+    summary = report.write_report(
+        [_cell("duckdb", "tpch", 0.01, status="passed")],
+        output_path=tmp_path / "matrix_summary.tsv",
+    )
+    assert summary.unvalidated_count == 0
+    text = (tmp_path / "matrix_summary.tsv").read_text(encoding="utf-8")
+    assert "UNVALIDATED_CELLS" not in text
+
+
+def test_write_report_unvalidated_count_ignores_non_passed_cells(tmp_path: Path):
+    """Defensive: a `failed` cell must never count toward unvalidated_count.
+
+    `run_cell` sets `submit_terminal_state` from the classifier regardless of
+    the cell's final status (e.g. a `query_failure` cell is still `failed`
+    with that state recorded), and `submit_state_is_cell_failure` guarantees
+    `unvalidated` never itself turns a cell `failed`. But this counter
+    shouldn't trust that invariant blindly -- a cell that is `failed` for an
+    unrelated reason (a real subprocess crash) while its stale/partial
+    exported result also happens to read as `unvalidated` must not be folded
+    into a "these are just fine, only unvalidated" count.
+    """
+    summary = report.write_report(
+        [_cell("duckdb", "tpch", 0.01, status="failed", submit_terminal_state="unvalidated")],
+        output_path=tmp_path / "matrix_summary.tsv",
+    )
+    assert summary.unvalidated_count == 0
+    assert summary.fail_count == 1
+
+
+def test_phase_accounting_carries_unvalidated_and_defaults_to_zero():
+    """PhaseAccounting gained an `unvalidated` field alongside unreachable/startup_failed/registry_pruned."""
+    default = PhaseAccounting()
+    assert default.unvalidated == 0
+
+    accounting = PhaseAccounting(attempted=5, passed=5, total_defined=5, unvalidated=2)
+    assert accounting.unvalidated == 2
+    # asdict()-based JSON round trip (gate_summary.write_gate_summary /
+    # read_gate_summary's _dataclass_from_payload) must carry the field.
+    from dataclasses import asdict
+
+    assert asdict(accounting)["unvalidated"] == 2
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
PR #1577 added SubmitTerminalState.unvalidated and stopped the package
phase treating a never-validated cell as a failure, which was the
headline bug: a full DataFrame sweep read as 0% pass. It stopped at the
classifier and the package phase.

Three roll-up surfaces are built from the same ReportSummary and none of
them knew the state existed, so an unvalidated cell was folded silently
into `passed` with no adjacent disclosure:

  - matrix_summary.tsv's footer (human-readable)
  - uat_gate_summary.json's accounting block (what a release gate reads)
  - `uat report --json`'s summary object (what tooling reads)

A DataFrame release-gate stage could therefore be majority-unvalidated
and every artifact would report an ordinary clean pass. That is a worse
failure than the one #1577 fixed: the first was loud and wrong, this one
is quiet and wrong.

ReportSummary gains unvalidated_count and PhaseAccounting gains
unvalidated, both threaded through orchestrator._accounting_for_gate_summary
in both its branches. The count is cross-cutting, NOT a disjoint bucket:
an unvalidated cell is already counted in passed/attempted, and the count
deliberately does not feed exit_code() -- UAT must not treat unvalidated
as a cell failure.

Mutation-checked: with the four source files reverted, six of the added
tests fail.

TODO: unvalidated-results-misclassified-as-schema-violations-20260805
