### PR TITLE
fix(mcp): preserve benign secret prose in error scrubbing

### DIFF
--- a/benchbox/mcp/errors.py
+++ b/benchbox/mcp/errors.py
@@ -106,7 +106,37 @@ _NON_SECRET_SECRET_WORDS = frozenset(
         "was",
     }
 )
+# Bare prose after a secret key ("password X", "token Y") over-matches ordinary
+# diagnostic English ("secret sauce", "token refresh", "password reset"). Only
+# scrub bare-prose tokens that look credential-like; connector forms
+# ("password is X") stay aggressive because the connector marks assignment.
+_BARE_PROSE_OPAQUE_ALPHA_MIN = 20
+_BARE_PROSE_ALLCAPS_MIN = 6
 _URL_USERINFO_RE = re.compile(r"(://)[^/@\s]+@")
+
+
+def _is_non_secret_word(value: str) -> bool:
+    """True when *value* is an allowlisted diagnostic word, not a secret."""
+    return value.lower() in _NON_SECRET_SECRET_WORDS
+
+
+def _is_credential_like_bare_prose_value(value: str) -> bool:
+    """True when a bare-prose token after a secret key looks like a secret value.
+
+    Pure short alphabetic English after a key name is diagnostic wording, not
+    credential material. Tokens with digits, underscores, separators, long
+    opaque alpha, or ALL-CAPS identifiers are treated as values.
+    """
+    if _is_non_secret_word(value):
+        return False
+    if not value.isalpha():
+        # Digits, underscores, hyphens, base64 punctuation, etc.
+        return True
+    if value.isupper() and len(value) >= _BARE_PROSE_ALLCAPS_MIN:
+        return True
+    if len(value) >= _BARE_PROSE_OPAQUE_ALPHA_MIN:
+        return True
+    return False
 
 
 def scrub_secret_material(text: str) -> str:
@@ -117,13 +147,23 @@ def scrub_secret_material(text: str) -> str:
 
     def replace_colon(match: re.Match[str]) -> str:
         value = match.group("value")
-        if value.lower() in _NON_SECRET_SECRET_WORDS:
+        if _is_non_secret_word(value):
             return match.group(0)
         return f"{match.group('prefix')}****"
 
-    def replace_prose(match: re.Match[str]) -> str:
+    def replace_connector_prose(match: re.Match[str]) -> str:
+        # "password is X" / "token was Y" — connector marks assignment; scrub
+        # unless the token is an allowlisted diagnostic word.
         value = match.group("value")
-        if value.lower() in _NON_SECRET_SECRET_WORDS:
+        if _is_non_secret_word(value):
+            return match.group(0)
+        return f"{match.group('prefix')}****"
+
+    def replace_bare_prose(match: re.Match[str]) -> str:
+        # "password X" without a connector: only scrub credential-like tokens so
+        # benign phrases (secret sauce, token refresh, password reset) survive.
+        value = match.group("value")
+        if not _is_credential_like_bare_prose_value(value):
             return match.group(0)
         return f"{match.group('prefix')}****"
 
@@ -134,8 +174,8 @@ def scrub_secret_material(text: str) -> str:
     scrubbed = _SECRET_SAS_ASSIGNMENT_RE.sub(r"\1****", scrubbed)
     scrubbed = _SECRET_ASSIGNMENT_RE.sub(r"\1****", scrubbed)
     scrubbed = _SECRET_COLON_ASSIGNMENT_RE.sub(replace_colon, scrubbed)
-    scrubbed = _SECRET_PROSE_CONNECTOR_RE.sub(replace_prose, scrubbed)
-    scrubbed = _SECRET_PROSE_RE.sub(replace_prose, scrubbed)
+    scrubbed = _SECRET_PROSE_CONNECTOR_RE.sub(replace_connector_prose, scrubbed)
+    scrubbed = _SECRET_PROSE_RE.sub(replace_bare_prose, scrubbed)
     return _URL_USERINFO_RE.sub(r"\1****@", scrubbed)
 
 

--- a/tests/unit/mcp/test_errors.py
+++ b/tests/unit/mcp/test_errors.py
@@ -72,6 +72,59 @@ def test_scrub_secret_material_covers_quoted_colon_and_prose_values(text: str, e
     assert scrub_secret_material(text) == expected
 
 
+@pytest.mark.parametrize(
+    ("text", "expected"),
+    [
+        # Benign diagnostic prose: byte-identical preservation.
+        ("secret sauce is the default", "secret sauce is the default"),
+        ("token refresh required", "token refresh required"),
+        ("password reset required", "password reset required"),
+        ("password field is missing", "password field is missing"),
+        ("password reset required for user", "password reset required for user"),
+        # Connector assignments: scrub the value.
+        ("password is hunter2", "password is ****"),
+        ("token was abc123", "token was ****"),
+        ("secret equals REALVAL", "secret equals ****"),
+        ("password set to xyz", "password set to ****"),
+        ("token configured as ABCDEF", "token configured as ****"),
+        # Quoted / structured assignments.
+        ("password: 'hunter2'", "password: ****"),
+        ('token: "secret-value"', "token: ****"),
+        ("password=REAL_SECRET", "password=****"),
+        # Bare prose with credential-like tokens (digits / underscores / ALLCAPS).
+        ("driver returned password PROSE_SECRET", "driver returned password ****"),
+        ("driver returned password hunter2", "driver returned password ****"),
+        # Mixed: preserve benign words, scrub real assignment values.
+        ("secret sauce and password=REAL_SECRET", "secret sauce and password=****"),
+        ("token refresh required; password=REAL_SECRET", "token refresh required; password=****"),
+    ],
+)
+def test_scrub_secret_material_prose_precision(text: str, expected: str) -> None:
+    """Benign secret-related prose stays readable; assignment forms stay scrubbed."""
+    assert scrub_secret_material(text) == expected
+
+
+@pytest.mark.parametrize(
+    ("text", "expected_message"),
+    [
+        ("secret sauce is the default", "secret sauce is the default"),
+        ("token refresh required", "token refresh required"),
+        ("password reset required", "password reset required"),
+        ("password field is missing", "password field is missing"),
+        ("password=REAL_SECRET", "password=****"),
+        (
+            "token refresh required; password=REAL_SECRET",
+            "token refresh required; password=****",
+        ),
+    ],
+)
+def test_make_execution_error_prose_precision(text: str, expected_message: str) -> None:
+    """Structured execution errors preserve diagnostics and scrub assignments."""
+    result = make_execution_error(text)
+    assert result["message"] == expected_message
+    assert "REAL_SECRET" not in result["message"]
+
+
 class TestErrorCategory:
     """Tests for ErrorCategory enum."""
 


### PR DESCRIPTION
Bare-prose matches after secret keys ("password X", "token Y") were
scrubbing ordinary diagnostic English such as "secret sauce", "token
refresh", and "password reset". Keep connector and assignment forms
aggressive; only scrub bare-prose tokens that look credential-like.

Depends on #1595 (vocabulary / SAS / PEM scrub arms).
