### PR TITLE
fix/agents md mocker databend caveat

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -146,14 +146,10 @@ claimable items).
 - CLI dry runs must propagate explicit phases; deterministic runs use a seed.
 - Green focused/fast tests are not UAT or production certification.
 
-Apple/macOS notes: `make test-correctness-gate` uses Linux-generated digests;
-use `make ci-linux` for parity. Mocker is local-only, never CI. Multi-service
-stacks are NOT validated under mocker: databend stays healthy on docker but its
-`minio` service exits under mocker, so use docker for databend; doris and
-starrocks are all-in-one single containers and are fine either way. See
-`docs/operations/uat-framework.md` ("Mocker validation status") for the full
-caveats, container lifecycle, and cleanup. Never globally prune without
-approval.
+Apple/macOS notes: `make test-correctness-gate` uses Linux-generated digests; use `make ci-linux` for parity.
+Mocker is local-only, never CI: databend needs docker (its `minio` service exits under mocker),
+doris/starrocks are single-container. See `docs/operations/uat-framework.md` ("Mocker validation status") for
+lifecycle, cleanup, and caveats. Never globally prune without approval.
 
 ## Skills and generated mirrors
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -146,10 +146,14 @@ claimable items).
 - CLI dry runs must propagate explicit phases; deterministic runs use a seed.
 - Green focused/fast tests are not UAT or production certification.
 
-Apple/macOS notes: `make test-correctness-gate` uses Linux-generated digests; use
-`make ci-linux` for parity. Mocker is local-only and unsuitable for the known multi-service
-stacks; follow `docs/operations/uat-framework.md` for container lifecycle and cleanup. Never
-globally prune without approval.
+Apple/macOS notes: `make test-correctness-gate` uses Linux-generated digests;
+use `make ci-linux` for parity. Mocker is local-only, never CI. Multi-service
+stacks are NOT validated under mocker: databend stays healthy on docker but its
+`minio` service exits under mocker, so use docker for databend; doris and
+starrocks are all-in-one single containers and are fine either way. See
+`docs/operations/uat-framework.md` ("Mocker validation status") for the full
+caveats, container lifecycle, and cleanup. Never globally prune without
+approval.
 
 ## Skills and generated mirrors
 

--- a/docs/operations/uat-framework.md
+++ b/docs/operations/uat-framework.md
@@ -245,19 +245,33 @@ lifecycle parity and end-to-end `test-docker-questdb` (load + query).
 
 NOT validated: multi-service stacks. `docker/databend/docker-compose.yml`
 declares three services (`minio`, `minio-setup`, `databend`); databend stays
-healthy on docker, but its `minio` service exits under mocker, so use
-`CONTAINER_ENGINE=docker` for databend. This is specific to databend's
-dependency on a separate MinIO container for S3-compatible storage -- it is
-not evidence that mocker cannot run multi-service compose stacks in general.
-`docker/doris/docker-compose.yml` and `docker/starrocks/docker-compose.yml`
-each declare exactly one service (the official all-in-one FE+BE image), so
-both are unaffected and fine under mocker.
+healthy on docker, but its `minio` service exits under mocker. This was last
+observed 2026-07-03 against a 4-service databend and 3-service doris/
+starrocks (TODO `migrate-test-docker-stacks-to-mocker`, w2); all three
+compose files have since been rewritten, and current service counts are
+pinned by the test below, but the failure has not been re-measured against
+today's compose files. Set the resolver override
+`BENCHBOX_CONTAINER_CLI=docker` for UAT's own compose lifecycle
+(`resolve_container_cli()`, above -- this is the path a macOS operator
+actually takes; on macOS it otherwise resolves to mocker when present).
+`CONTAINER_ENGINE=docker` is a different knob: it only feeds
+`make test-docker-*`'s `$(COMPOSE)` (`Makefile:462`) and is already the
+default there, so setting it is a no-op for that path. This databend/minio
+failure is specific to its dependency on a separate MinIO container for
+S3-compatible storage -- it is not evidence that mocker cannot run
+multi-service compose stacks in general. `docker/doris/docker-compose.yml`
+and `docker/starrocks/docker-compose.yml` each declare exactly one service
+(the official all-in-one FE+BE image); databend's separate-MinIO failure
+mode does not apply to them structurally, but they are not separately
+validated under mocker.
 
-`tests/uat/test_docker_assets.py` pins these three service counts against the
-compose files so this guidance cannot silently drift out of sync again (it
-drifted once, in commit `fd29aa77c0`, when a canonicalization pass compressed
-this section into a vague "unsuitable for certain multi-service stacks"
-claim with no named platform).
+`tests/uat/test_docker_assets.py` pins these compose files' service *names*
+(not just counts) so this guidance cannot silently drift out of sync again.
+It drifted once already: commit `fd29aa77c0` compressed AGENTS.md's former
+"Mocker as a local test-docker engine" section -- which is where this
+databend/minio caveat originally lived, not this file -- down to a vague
+"Mocker is local-only and unsuitable for the known multi-service stacks"
+line with no named platform.
 
 ## Explorer smoke (browser)
 

--- a/docs/operations/uat-framework.md
+++ b/docs/operations/uat-framework.md
@@ -237,6 +237,28 @@ is empty for them; mocker tracks its own compose-created volumes separately.
 Use `ENGINE=docker` (the default) for volume cleanup and `ENGINE=container`
 for everything else.
 
+### Mocker validation status
+
+Apple silicon + macOS 26, LOCAL DEV ONLY -- never CI (CI runs `test-docker-*`
+on ubuntu with real docker). Validated on mocker: `questdb` + `postgresql`
+lifecycle parity and end-to-end `test-docker-questdb` (load + query).
+
+NOT validated: multi-service stacks. `docker/databend/docker-compose.yml`
+declares three services (`minio`, `minio-setup`, `databend`); databend stays
+healthy on docker, but its `minio` service exits under mocker, so use
+`CONTAINER_ENGINE=docker` for databend. This is specific to databend's
+dependency on a separate MinIO container for S3-compatible storage -- it is
+not evidence that mocker cannot run multi-service compose stacks in general.
+`docker/doris/docker-compose.yml` and `docker/starrocks/docker-compose.yml`
+each declare exactly one service (the official all-in-one FE+BE image), so
+both are unaffected and fine under mocker.
+
+`tests/uat/test_docker_assets.py` pins these three service counts against the
+compose files so this guidance cannot silently drift out of sync again (it
+drifted once, in commit `fd29aa77c0`, when a canonicalization pass compressed
+this section into a vague "unsuitable for certain multi-service stacks"
+claim with no named platform).
+
 ## Explorer smoke (browser)
 
 `make uat-explorer-smoke` invokes Playwright directly against a freshly

--- a/tests/uat/test_docker_assets.py
+++ b/tests/uat/test_docker_assets.py
@@ -6,6 +6,7 @@ import re
 from pathlib import Path
 
 import pytest
+import yaml
 
 from tests.uat import docker_assets, matrix
 from tests.uat.docker_path_helpers import compose_path_ends_with
@@ -451,3 +452,31 @@ def test_sweep_leaked_mocker_volumes_swallows_individual_removal_failure(tmp_pat
 
     # One volume's rm failure does not abort the rest of the sweep.
     assert removed == ("benchbox-uat-demo-cache",)
+
+
+@pytest.mark.parametrize(
+    ("platform", "expected_service_count"),
+    [
+        # minio, minio-setup, databend -- the validated mocker failure is
+        # databend's minio service exiting under mocker (AGENTS.md).
+        ("databend", 3),
+        # all-in-one FE+BE image -- single container, unaffected by mocker.
+        ("doris", 1),
+        # all-in-one image -- single container, unaffected by mocker.
+        ("starrocks", 1),
+    ],
+)
+def test_multi_service_platform_service_counts_match_documented_guidance(platform, expected_service_count):
+    """Pin the compose service counts AGENTS.md and uat-framework.md cite.
+
+    Guards against the mocker multi-service guidance drifting out of sync
+    with the compose files it describes, the way it silently did once before
+    (commit fd29aa77c0 compressed the specific databend/minio caveat into a
+    vague, unverifiable claim).
+    """
+    spec = docker_assets.docker_platform_spec(platform)
+    total_services = 0
+    for compose_file in spec.compose_files:
+        data = yaml.safe_load(compose_file.read_text(encoding="utf-8"))
+        total_services += len(data.get("services", {}))
+    assert total_services == expected_service_count

--- a/tests/uat/test_docker_assets.py
+++ b/tests/uat/test_docker_assets.py
@@ -455,28 +455,31 @@ def test_sweep_leaked_mocker_volumes_swallows_individual_removal_failure(tmp_pat
 
 
 @pytest.mark.parametrize(
-    ("platform", "expected_service_count"),
+    ("platform", "expected_service_names"),
     [
-        # minio, minio-setup, databend -- the validated mocker failure is
-        # databend's minio service exiting under mocker (AGENTS.md).
-        ("databend", 3),
+        # The validated mocker failure is specifically databend's `minio`
+        # service exiting under mocker (AGENTS.md) -- `minio` is the
+        # load-bearing token in that guidance, not just "three services".
+        ("databend", frozenset({"minio", "minio-setup", "databend"})),
         # all-in-one FE+BE image -- single container, unaffected by mocker.
-        ("doris", 1),
+        ("doris", frozenset({"doris"})),
         # all-in-one image -- single container, unaffected by mocker.
-        ("starrocks", 1),
+        ("starrocks", frozenset({"starrocks"})),
     ],
 )
-def test_multi_service_platform_service_counts_match_documented_guidance(platform, expected_service_count):
-    """Pin the compose service counts AGENTS.md and uat-framework.md cite.
+def test_multi_service_platform_service_names_match_documented_guidance(platform, expected_service_names):
+    """Pin the compose service *identities* AGENTS.md and uat-framework.md cite.
 
     Guards against the mocker multi-service guidance drifting out of sync
     with the compose files it describes, the way it silently did once before
     (commit fd29aa77c0 compressed the specific databend/minio caveat into a
-    vague, unverifiable claim).
+    vague, unverifiable claim). A count-only assertion would stay green even
+    if databend's `minio` service were renamed to something else, so this
+    pins the actual service names, not just how many there are.
     """
     spec = docker_assets.docker_platform_spec(platform)
-    total_services = 0
+    service_names: set[str] = set()
     for compose_file in spec.compose_files:
         data = yaml.safe_load(compose_file.read_text(encoding="utf-8"))
-        total_services += len(data.get("services", {}))
-    assert total_services == expected_service_count
+        service_names.update(data.get("services", {}).keys())
+    assert service_names == expected_service_names


### PR DESCRIPTION
- **fix(docs): restore the specific mocker/databend multi-service caveat in AGENTS.md**
- **fix(docs): close review findings on mocker/databend caveat restoration**
