### PR TITLE
fix(ci): durable auto-merge hold via no-auto-merge label

### DIFF
--- a/.github/workflows/auto-merge-on-open.yml
+++ b/.github/workflows/auto-merge-on-open.yml
@@ -12,25 +12,40 @@ name: Auto-enable auto-merge
 #     bare `gh pr create`) is not the final signal — that is what defeated the
 #     Makefile hold after #1567 (live proof: #1568/#1569 merged hands-free).
 #   - DO arm on `ready_for_review` (draft → ready is the UI equivalent of
-#     `make pr-ready`).
-#   - On `synchronize` (and other events): only re-evaluate soundness
-#     revocation — disable auto-merge if soundness paths are touched. Never
-#     re-enable on synchronize; that would re-open the race on the first push
-#     after open.
+#     `make pr-ready`), unless the PR carries the durable hold label
+#     `no-auto-merge` (see below).
+#   - On `synchronize` / `labeled` (and other events): only re-evaluate
+#     revocation — disable auto-merge if soundness paths are touched or the
+#     durable hold label is present. Never re-enable on synchronize; that
+#     would re-open the race on the first push after open.
+#
+# Durable holds (both re-arming paths honour these):
+#   1. Draft status — job-level skip. Opening a draft is "not yet ready".
+#   2. Label `no-auto-merge` — holds a non-draft PR without converting it to
+#      draft. Applying the label revokes any enabled auto-merge; ready_for_review
+#      will not re-arm while the label remains. The nightly green-unmerged
+#      sweep also treats this label as intentional (not stranded) and never
+#      enables auto-merge itself. See docs/operations/pr-triage.md.
 #
 # Intentional gap: a non-draft PR opened without `make pr-ready`, `READY=1`,
 # or marking a draft ready will not get auto-merge from this workflow. Use
-# one of those paths when the branch is final.
-#
-# Drafts remain skipped at the job level — opening a draft is the user's
-# signal that the PR is not yet ready. Auto-merge is enabled when the draft
-# is marked ready (`ready_for_review`).
+# one of those paths when the branch is final (and remove `no-auto-merge`
+# first if it was applied).
 #
 # `synchronize` re-evaluates on every push so a later commit that newly
 # touches a soundness-critical path can flip auto-merge back OFF. GitHub
 # only auto-disables auto-merge on push when the pusher lacks write access,
 # so in the normal same-repo/write-author flow a stale enabled auto-merge
 # would otherwise survive and merge after checks without review.
+#
+# Soundness predicate evaluation (disable path):
+#   Union of (a) the base-ref copy and (b) the PR checkout copy. Base-ref
+#   alone stops a PR from judging its own diff by a narrowed rule set.
+#   Evaluating the PR copy alongside it means a gate *widened* mid-flight
+#   in the same PR still revokes auto-merge for paths only the new gate
+#   covers. Enable still requires soundness_path != true (both false), so
+#   a PR cannot weaken its own gate. Self-touch of the predicate or this
+#   workflow forces soundness_path=true regardless.
 #
 # HONESTY NOTE on the self-protection checks below (base-ref predicate
 # execution + self-touch override): they are BEST-EFFORT for same-repo PRs.
@@ -49,7 +64,8 @@ name: Auto-enable auto-merge
 
 on:
   pull_request:
-    types: [opened, reopened, ready_for_review, synchronize]
+    # `labeled` so applying `no-auto-merge` revokes auto-merge without a push.
+    types: [opened, reopened, ready_for_review, synchronize, labeled]
     branches: [develop]
 
 permissions:
@@ -68,6 +84,24 @@ jobs:
       - name: Fetch base branch
         run: git fetch --no-tags origin "${{ github.base_ref }}:refs/remotes/origin/${{ github.base_ref }}"
 
+      - name: Check explicit hold label
+        id: hold
+        env:
+          # Newline-joined so grep -xF matches whole label names only.
+          PR_LABELS: ${{ join(github.event.pull_request.labels.*.name, '\n') }}
+        run: |
+          set -euo pipefail
+          # Durable hold label shared with green_unmerged_sweep.AUTO_MERGE_HOLD_LABEL.
+          # Exact match only — substring false positives (e.g. no-auto-merge-except) rejected.
+          held=false
+          if printf '%s\n' "$PR_LABELS" | grep -qxF 'no-auto-merge'; then
+            held=true
+          fi
+          echo "held=$held" >> "$GITHUB_OUTPUT"
+          if [ "$held" = "true" ]; then
+            echo "Explicit hold label no-auto-merge present; will not arm auto-merge."
+          fi
+
       - name: Check soundness-critical paths
         id: soundness
         run: |
@@ -78,25 +112,37 @@ jobs:
           # file via rename would slip past the gate.
           diff_paths="$(git diff --name-only --no-renames "origin/${{ github.base_ref }}...HEAD")"
 
-          # Run the BASE-REF copy of the predicate, not the PR's own checkout
-          # copy. For a same-repo (non-fork) PR - the normal case here - the
-          # checked-out copy IS whatever the PR itself introduces, so a PR
-          # that edits auto_merge_soundness_paths.py (e.g. narrows
-          # SOUNDNESS_PREFIXES) would otherwise evaluate its own diff against
-          # its own modified rules, neutralizing its review gate in the same
-          # commit that would otherwise have triggered it. The base branch is
-          # already fetched by the preceding "Fetch base branch" step.
-          git show "origin/${{ github.base_ref }}:_project/scripts/auto_merge_soundness_paths.py" > /tmp/predicate.py
+          # (a) BASE-REF copy: a PR that narrows SOUNDNESS_PREFIXES must still be
+          # judged by develop's rules, not its own. The base branch is already
+          # fetched by the preceding "Fetch base branch" step.
+          git show "origin/${{ github.base_ref }}:_project/scripts/auto_merge_soundness_paths.py" > /tmp/predicate_base.py
+          base_result="$(printf '%s\n' "$diff_paths" | python3 /tmp/predicate_base.py --stdin --format github-output)"
 
-          result="$(printf '%s\n' "$diff_paths" | python3 /tmp/predicate.py --stdin --format github-output)"
+          # (b) PR checkout copy: a gate *widened* in this PR still revokes
+          # auto-merge for paths only the new gate covers. Fail closed (treat as
+          # soundness) if the PR copy is missing or errors — never let a broken
+          # PR-side predicate silence revocation.
+          pr_result="soundness_path=false"
+          if [ -f "_project/scripts/auto_merge_soundness_paths.py" ]; then
+            if ! pr_result="$(printf '%s\n' "$diff_paths" | python3 _project/scripts/auto_merge_soundness_paths.py --stdin --format github-output)"; then
+              pr_result="soundness_path=true"
+            fi
+          fi
 
-          # Base-ref execution alone stops the predicate from judging its own
-          # diff leniently, but doesn't by itself flag "this diff touches the
+          # Union: soundness if either copy says so. Enable requires both false,
+          # so a PR cannot weaken its own gate by narrowing the PR-side rules.
+          if [ "$base_result" = "soundness_path=true" ] || [ "$pr_result" = "soundness_path=true" ]; then
+            result="soundness_path=true"
+          else
+            result="soundness_path=false"
+          fi
+
+          # Base-ref + PR-copy union alone does not flag "this diff touches the
           # predicate (or the workflow that runs it)" as review-worthy - a PR
           # could still edit the predicate to make FUTURE PRs unsafe without
           # itself needing owner review. Force soundness_path=true whenever
-          # the diff touches either file, regardless of what the (correctly
-          # base-ref-evaluated) predicate says about the rest of the diff.
+          # the diff touches either file, regardless of what either predicate
+          # says about the rest of the diff.
           if printf '%s\n' "$diff_paths" | grep -qxF "_project/scripts/auto_merge_soundness_paths.py" \
              || printf '%s\n' "$diff_paths" | grep -qxF ".github/workflows/auto-merge-on-open.yml"; then
             result="soundness_path=true"
@@ -105,11 +151,13 @@ jobs:
           echo "$result" >> "$GITHUB_OUTPUT"
 
       - name: Enable squash auto-merge
-        # Arm only on draft→ready. Never on opened/reopened/synchronize — those
-        # are not "branch is final" signals (see header policy). Soundness
-        # predicate first so the existing substring pin in
-        # test_auto_merge_soundness_paths still matches.
-        if: steps.soundness.outputs.soundness_path != 'true' && github.event.action == 'ready_for_review'
+        # Arm only on draft→ready, and only when neither soundness nor the
+        # durable hold label blocks. Never on opened/reopened/synchronize —
+        # those are not "branch is final" signals (see header policy).
+        if: >-
+          steps.soundness.outputs.soundness_path != 'true'
+          && steps.hold.outputs.held != 'true'
+          && github.event.action == 'ready_for_review'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
@@ -132,4 +180,15 @@ jobs:
           # A push that newly touches a soundness path must not ride an auto-merge
           # enabled by an earlier (non-soundness) push. --disable-auto exits
           # non-zero when auto-merge is already off, so tolerate that.
+          gh pr merge --disable-auto --repo "$REPO" "$PR_NUMBER" || true
+
+      - name: Disable auto-merge for explicit hold
+        if: steps.hold.outputs.held == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          echo "Explicit hold label no-auto-merge present; clearing any auto-merge."
           gh pr merge --disable-auto --repo "$REPO" "$PR_NUMBER" || true

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -739,7 +739,9 @@ jobs:
     # `conclusion: success` while the PR's own `auto_merge` field never ends
     # up populated (see the script's "Known timing behavior" note). This job
     # does NOT modify auto-merge-on-open.yml and does NOT enable auto-merge
-    # itself -- it only alerts via one marker-tagged tracking issue. See
+    # itself -- `--apply` only upserts one marker-tagged tracking issue. It
+    # must never re-arm a hold it did not set (draft or `no-auto-merge`
+    # label); the sweep classifies those as intentional, not stranded. See
     # docs/operations/pr-triage.md.
     runs-on: ubuntu-latest
     timeout-minutes: 10

--- a/_project/scripts/green_unmerged_sweep.py
+++ b/_project/scripts/green_unmerged_sweep.py
@@ -23,8 +23,14 @@ every OPEN, non-draft develop PR and alerts when one looks stranded:
         soundness-drain digest, not this sweep.
     (d) past the grace period -- more than `GRACE_PERIOD_HOURS` (default
         2h) since the head commit was pushed, so the enable workflow's
-        `synchronize`-triggered re-run has had every chance to fire
-        before this sweep calls a PR stranded.
+        soundness re-eval has had every chance to fire before this sweep
+        calls a PR stranded.
+    (e) not explicitly held -- the PR does not carry the durable hold
+        label ``no-auto-merge`` (``AUTO_MERGE_HOLD_LABEL``). That label is
+        the same durable hold ``auto-merge-on-open.yml`` honours: drafts
+        are already excluded by (job skip / draft check); the label holds
+        a non-draft without converting it to draft. An explicit hold is
+        intentional, not stranded — this sweep must never re-arm it.
 
 The only mutation this script ever performs (and only under `--apply`) is
 creating/updating ONE marker-tagged tracking issue (title "Green-but-unmerged
@@ -33,7 +39,8 @@ set is non-empty (or develop post-merge is red, see `--check-post-merge`
 below), and patched to the empty state exactly once when it drains, then
 left alone. It never enables auto-merge, never merges, never labels, and
 never comments on a PR -- enabling auto-merge outside the sanctioned
-predicate path in `auto-merge-on-open.yml` would bypass the soundness gate.
+predicate path in `auto-merge-on-open.yml` would bypass the soundness gate
+and would re-arm a hold this sweep did not set.
 
 `--check-post-merge` additionally checks the most recent "Develop post-merge"
 workflow run; if its conclusion is `failure`, a prominent section is added to
@@ -95,6 +102,12 @@ GRACE_PERIOD_HOURS = 2.0
 API_ROOT = "https://api.github.com"
 DEVELOP_POST_MERGE_WORKFLOW = "develop-post-merge.yml"
 
+# Durable explicit hold shared with `.github/workflows/auto-merge-on-open.yml`
+# (exact label name; keep both layers in lockstep — pinned by
+# tests/unit/test_auto_merge_hold_is_durable.py). Applying this label is the
+# non-draft durable hold; drafts remain a separate, job-level hold.
+AUTO_MERGE_HOLD_LABEL = "no-auto-merge"
+
 PINNED_ISSUE_TITLE = "Green-but-unmerged PR sweep"
 # Body marker: proves the digest issue was written by this script, so
 # find_pinned_issue never adopts (and later clobbers) a human issue that
@@ -117,6 +130,9 @@ class ClassifiedPR:
     auto_merge_enabled: bool
     head_age_hours: float
     stranded: bool
+    # True when the PR carries AUTO_MERGE_HOLD_LABEL. Composable with other
+    # intentional-hold classifiers (draft is tracked separately via `draft`).
+    explicit_hold: bool = False
 
     def to_dict(self) -> dict[str, Any]:
         return asdict(self)
@@ -150,6 +166,18 @@ def is_soundness_gated(changed_files: list[str]) -> bool:
     return any_soundness_path(changed_files)
 
 
+def has_auto_merge_hold_label(labels: list[str] | tuple[str, ...] | None) -> bool:
+    """True when *labels* includes the durable ``no-auto-merge`` hold label.
+
+    Exact name match only (case-sensitive, same as the workflow's
+    ``grep -qxF``). Composable: intentional-hold classifiers can OR this
+    with draft / other signals without forking the label constant.
+    """
+    if not labels:
+        return False
+    return AUTO_MERGE_HOLD_LABEL in {str(label).strip() for label in labels if label is not None}
+
+
 def head_age_hours(pr: dict[str, Any], now: dt.datetime) -> float:
     """Hours since the PR's head commit was pushed.
 
@@ -178,13 +206,20 @@ def is_stranded(
     soundness_gated: bool,
     age_hours: float,
     grace_hours: float,
+    explicit_hold: bool = False,
 ) -> bool:
-    """True when a PR looks like a stranded (never-enabled-or-dropped) auto-merge."""
+    """True when a PR looks like a stranded (never-enabled-or-dropped) auto-merge.
+
+    An explicit hold (``no-auto-merge`` label) is intentional, not stranded:
+    both this sweep and ``auto-merge-on-open.yml`` honour it, and ``--apply``
+    must never re-arm a hold it did not set.
+    """
     return (
         (not draft)
         and required_green
         and (not auto_merge_enabled)
         and (not soundness_gated)
+        and (not explicit_hold)
         and age_hours > grace_hours
     )
 
@@ -198,11 +233,13 @@ def classify_pr(
     """Classify one normalized PR record. Pure -- no I/O."""
     check_runs = pr.get("check_runs") or []
     changed_files = pr.get("changed_files") or []
+    labels = pr.get("labels") or []
 
     required_green = is_required_lane_green(check_runs)
     soundness_gated = is_soundness_gated(changed_files)
     auto_merge_enabled = bool(pr.get("auto_merge"))
     draft = bool(pr.get("draft"))
+    explicit_hold = has_auto_merge_hold_label(labels)
     age_h = head_age_hours(pr, now)
     stranded = is_stranded(
         draft=draft,
@@ -211,6 +248,7 @@ def classify_pr(
         soundness_gated=soundness_gated,
         age_hours=age_h,
         grace_hours=grace_hours,
+        explicit_hold=explicit_hold,
     )
 
     return ClassifiedPR(
@@ -223,6 +261,7 @@ def classify_pr(
         auto_merge_enabled=auto_merge_enabled,
         head_age_hours=age_h,
         stranded=stranded,
+        explicit_hold=explicit_hold,
     )
 
 
@@ -307,9 +346,10 @@ def build_digest(
         lines.append(f"- #{c.number} {c.title} -- head pushed {_fmt_hours(c.head_age_hours)} ago -- {c.html_url}")
     lines.append("")
     lines.append(
-        "This sweep never enables auto-merge itself -- re-run `gh pr merge --auto --squash` "
-        "by hand (or re-push to retrigger auto-merge-on-open.yml's `synchronize` path) after "
-        "confirming the PR is genuinely ready. See docs/operations/pr-triage.md."
+        "This sweep never enables auto-merge itself (and must not re-arm a hold it did not set). "
+        "When the branch is final, arm via `make pr-ready` / `make pr-arm-auto-merge` (or draft → "
+        "ready). A re-push will NOT re-arm auto-merge. To hold a non-draft intentionally, apply "
+        f"the `{AUTO_MERGE_HOLD_LABEL}` label (or convert to draft). See docs/operations/pr-triage.md."
     )
     lines.append(f"(repo: {repo})")
     return "\n".join(lines)
@@ -438,6 +478,10 @@ def fetch_open_prs(client: GitHubClient, owner: str, repo: str) -> list[dict[str
         head_pushed_at = (commit_info.get("committer") or {}).get("date") or (commit_info.get("author") or {}).get(
             "date"
         )
+        raw_labels = raw.get("labels") or []
+        label_names = [
+            (item.get("name") if isinstance(item, dict) else str(item)) for item in raw_labels if item is not None
+        ]
         normalized.append(
             {
                 "number": number,
@@ -450,6 +494,8 @@ def fetch_open_prs(client: GitHubClient, owner: str, repo: str) -> list[dict[str
                 # never inferred from a workflow run's conclusion. See "Known
                 # timing behavior" in the module docstring.
                 "auto_merge": raw.get("auto_merge"),
+                # Durable hold signal shared with auto-merge-on-open.yml.
+                "labels": [name for name in label_names if name],
                 "changed_files": [f.get("filename", "") for f in files],
                 "check_runs": [
                     {
@@ -550,6 +596,8 @@ def run_self_test() -> int:
             expect(c.soundness_gated, f"PR #{number} expected soundness_gated=True")
         elif reason == "within_grace":
             expect(c.head_age_hours <= grace_hours, f"PR #{number} expected head_age_hours <= {grace_hours}")
+        elif reason == "explicit_hold":
+            expect(c.explicit_hold, f"PR #{number} expected explicit_hold=True")
 
     # build_digest must always carry the marker, whatever the queue state.
     expect(

--- a/docs/operations/pr-triage.md
+++ b/docs/operations/pr-triage.md
@@ -88,9 +88,11 @@ a PR's mergeability — both only alert.
   waiting on the owner's manual review and merge.
 - **Green-unmerged nightly sweep**
   (`_project/scripts/green_unmerged_sweep.py`,
-  `.github/workflows/nightly.yml`) — alerts on non-draft, non-soundness
-  PRs whose required lane is green but auto-merge is still off for more
-  than 2 hours after the head commit.
+  `.github/workflows/nightly.yml`) — alerts on non-draft, non-soundness,
+  non-hold-label PRs whose required lane is green but auto-merge is still
+  off for more than 2 hours after the head commit. `--apply` only upserts
+  the digest issue; it **never** enables auto-merge and must not re-arm a
+  hold it did not set.
 
   After the auto-merge hold, **an intentional non-armed green PR is normal**,
   not a stuck state. Auto-merge is **not** armed by `opened`, `reopened`, or
@@ -99,18 +101,36 @@ a PR's mergeability — both only alert.
 
   - `make pr-ready` (or `make pr-arm-auto-merge`) on a finished branch
   - `make pr-open READY=1` to open and arm in one step
-  - draft → ready (`ready_for_review` in `auto-merge-on-open.yml`)
+  - draft → ready (`ready_for_review` in `auto-merge-on-open.yml`), and only
+    when the PR does **not** carry the `no-auto-merge` label
 
   Do **not** remediate a green-unmerged alert by re-pushing "to re-trigger
   synchronize." That path no longer enables auto-merge. If the branch is
-  final, arm it; if work continues, leave auto-merge off.
+  final, arm it; if work continues, leave auto-merge off (or apply a durable
+  hold — see below).
 
-  Known follow-up: `green_unmerged_sweep.py` still classifies many of these
-  intentional holds as stranded (false positives). Fixing the classifier is
-  out of the enablement-hold change set (`_project/scripts/`); until then,
-  treat sweep hits as triage signals, not proof of a broken arm path. A green
-  `enable`-job run is also not proof the PR's `auto_merge` field is set —
-  the sweep re-reads the PR field rather than trusting the workflow conclusion.
+  A green `enable`-job run is also not proof the PR's `auto_merge` field is
+  set — the sweep re-reads the PR field rather than trusting the workflow
+  conclusion. Default non-armed greens that were never intended to arm can
+  still appear as sweep hits until a broader intentional-hold classifier
+  lands; treat those as triage signals, not proof of a broken arm path.
+
+## Durable auto-merge holds
+
+`gh pr merge --disable-auto` alone is **not** a durable product signal: a later
+intentional arm path could still enable auto-merge. Both re-arming layers
+honour these durable holds (and neither re-arms on push or nightly `--apply`):
+
+| Hold | Who honours it | Effect |
+| --- | --- | --- |
+| **Draft** | `auto-merge-on-open.yml` (job skip), green-unmerged sweep | Not ready; no arm, not stranded |
+| **Label `no-auto-merge`** | `auto-merge-on-open.yml` (enable blocked + disable on apply/`labeled`), green-unmerged sweep | Non-draft intentional hold; revoke any enabled auto-merge; not stranded |
+
+Use draft while the branch is incomplete. Use `no-auto-merge` when the PR
+should stay non-draft (CI/review as ready) but must not auto-merge — for
+example waiting on another PR, or after an explicit disable that must survive
+a later `ready_for_review` / re-arm attempt. Remove the label before arming
+with `make pr-ready` or draft → ready.
 
 Both sweeps upsert a single marker-tagged tracking issue while their
 respective queue is non-empty, and patch it to the empty state exactly

--- a/docs/operations/repo-admin-settings.md
+++ b/docs/operations/repo-admin-settings.md
@@ -142,8 +142,17 @@ The soundness gate, as operated:
 - `.github/workflows/auto-merge-on-open.yml` matches that hold: it does **not**
   arm on `opened` / `reopened` / `synchronize` (bare `gh pr create` no longer
   auto-arms). It arms only on `ready_for_review` (draft → ready), which is the
-  UI equivalent of `make pr-ready`. `synchronize` still re-evaluates soundness
-  revocation only — it never re-enables auto-merge.
+  UI equivalent of `make pr-ready`, and only when the PR does not carry the
+  durable hold label `no-auto-merge`. `synchronize` / `labeled` re-evaluate
+  revocation only (soundness paths or the hold label) — they never re-enable
+  auto-merge. The soundness check unions the base-ref predicate with the PR
+  checkout copy so a gate widened mid-flight still revokes; enable still
+  requires both false so a PR cannot weaken its own gate.
+- Durable holds both re-arm paths honour: **draft** (job/sweep skip) and
+  label **`no-auto-merge`** (workflow blocks enable + disables; nightly
+  green-unmerged sweep never enables auto-merge and does not classify the
+  label as stranded). See `docs/operations/pr-triage.md` "Durable auto-merge
+  holds".
 - The arming path and `auto-merge-on-open.yml` WITHHOLD squash auto-merge for
   PRs touching those paths (and revoke it on a later push that newly touches
   them). CI cannot catch a change that redefines the oracle it validates

--- a/tests/unit/scripts/test_green_unmerged_sweep.py
+++ b/tests/unit/scripts/test_green_unmerged_sweep.py
@@ -109,17 +109,20 @@ def test_head_age_hours_unknown_anchor_is_zero() -> None:
 
 
 @pytest.mark.parametrize(
-    ("draft", "required_green", "auto_merge_enabled", "soundness_gated", "age_hours", "expected"),
+    ("draft", "required_green", "auto_merge_enabled", "soundness_gated", "age_hours", "explicit_hold", "expected"),
     [
-        (False, True, False, False, 3.0, True),  # stranded
-        (True, True, False, False, 3.0, False),  # draft excluded
-        (False, False, False, False, 3.0, False),  # red lane excluded
-        (False, True, True, False, 3.0, False),  # auto-merge already on
-        (False, True, False, True, 3.0, False),  # soundness-gated excluded
-        (False, True, False, False, 1.0, False),  # within grace period
+        (False, True, False, False, 3.0, False, True),  # stranded
+        (True, True, False, False, 3.0, False, False),  # draft excluded
+        (False, False, False, False, 3.0, False, False),  # red lane excluded
+        (False, True, True, False, 3.0, False, False),  # auto-merge already on
+        (False, True, False, True, 3.0, False, False),  # soundness-gated excluded
+        (False, True, False, False, 1.0, False, False),  # within grace period
+        (False, True, False, False, 3.0, True, False),  # explicit hold label excluded
     ],
 )
-def test_is_stranded_matrix(draft, required_green, auto_merge_enabled, soundness_gated, age_hours, expected) -> None:
+def test_is_stranded_matrix(
+    draft, required_green, auto_merge_enabled, soundness_gated, age_hours, explicit_hold, expected
+) -> None:
     assert (
         mod.is_stranded(
             draft=draft,
@@ -128,9 +131,16 @@ def test_is_stranded_matrix(draft, required_green, auto_merge_enabled, soundness
             soundness_gated=soundness_gated,
             age_hours=age_hours,
             grace_hours=2.0,
+            explicit_hold=explicit_hold,
         )
         is expected
     )
+
+
+def test_has_auto_merge_hold_label() -> None:
+    assert mod.has_auto_merge_hold_label([mod.AUTO_MERGE_HOLD_LABEL]) is True
+    assert mod.has_auto_merge_hold_label(["enhancement"]) is False
+    assert mod.has_auto_merge_hold_label(None) is False
 
 
 # ------------------------------------------------------------------ #

--- a/tests/unit/test_auto_merge_hold_is_durable.py
+++ b/tests/unit/test_auto_merge_hold_is_durable.py
@@ -1,0 +1,318 @@
+"""Explicit auto-merge holds must survive push and nightly re-arm paths.
+
+Defect (auto-merge-explicit-hold-is-not-durable): ``gh pr merge --disable-auto``
+was not a durable product signal while re-arm paths could silently re-enable
+auto-merge (historically: synchronize re-enable; nightly --apply if it ever
+armed). Draft was the only durable hold. This suite pins the durable-hold
+contract across workflow + sweep layers:
+
+1. Synchronize never re-enables auto-merge (only revokes).
+2. Label ``no-auto-merge`` blocks enable and triggers disable.
+3. Draft remains a job-level hold.
+4. Nightly green-unmerged ``--apply`` never enables auto-merge and does not
+   classify an explicit hold as stranded.
+5. Soundness disable unions base-ref + PR-copy predicates (enable still needs
+   both false so a PR cannot weaken its own gate).
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import re
+import sys
+from pathlib import Path
+from typing import Any
+
+import pytest
+import yaml
+
+pytestmark = [pytest.mark.unit, pytest.mark.fast]
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+AUTO_MERGE_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "auto-merge-on-open.yml"
+NIGHTLY_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "nightly.yml"
+SWEEP_SCRIPT = REPO_ROOT / "_project" / "scripts" / "green_unmerged_sweep.py"
+PR_TRIAGE_DOC = REPO_ROOT / "docs" / "operations" / "pr-triage.md"
+
+HOLD_LABEL = "no-auto-merge"
+ARM_COMMAND = "gh pr merge --auto --squash"
+DISABLE_COMMAND = "gh pr merge --disable-auto"
+
+# Exact enable/disable `if:` pins (collapsed form). Keep lockstep with
+# tests/unit/workflows/test_auto_merge_enablement_point.py.
+ENABLE_IF = (
+    "steps.soundness.outputs.soundness_path != 'true' "
+    "&& steps.hold.outputs.held != 'true' "
+    "&& github.event.action == 'ready_for_review'"
+)
+SOUNDNESS_DISABLE_IF = "steps.soundness.outputs.soundness_path == 'true'"
+HOLD_DISABLE_IF = "steps.hold.outputs.held == 'true'"
+
+
+def _load_yaml(path: Path) -> dict[str, Any]:
+    return yaml.safe_load(path.read_text(encoding="utf-8"))
+
+
+def _triggers(workflow: dict[str, Any]) -> dict[str, Any]:
+    triggers = workflow.get("on", workflow.get(True))
+    assert triggers is not None, "workflow has no `on:` block"
+    return triggers
+
+
+def _steps_by_name(job: dict[str, Any]) -> dict[str, dict[str, Any]]:
+    named: dict[str, dict[str, Any]] = {}
+    for step in job.get("steps") or []:
+        name = step.get("name")
+        if name:
+            named[str(name)] = step
+    return named
+
+
+def _collapsed_if(step: dict[str, Any]) -> str:
+    raw = str(step.get("if") or "").strip()
+    return re.sub(r"\s+", " ", raw)
+
+
+def _enable_job() -> dict[str, Any]:
+    workflow = _load_yaml(AUTO_MERGE_WORKFLOW)
+    jobs = workflow.get("jobs") or {}
+    assert "enable" in jobs
+    return jobs["enable"]
+
+
+def _load_sweep():
+    spec = importlib.util.spec_from_file_location("_green_unmerged_sweep_hold", SWEEP_SCRIPT)
+    assert spec is not None and spec.loader is not None
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+# ---------------------------------------------------------------------------
+# Workflow: never re-arm on synchronize; hold label + draft are durable
+# ---------------------------------------------------------------------------
+
+
+def test_workflow_never_enables_on_synchronize() -> None:
+    """Push must not re-arm auto-merge (historical defect class)."""
+    steps = _steps_by_name(_enable_job())
+    enable = steps["Enable squash auto-merge"]
+    condition = _collapsed_if(enable)
+    assert condition == ENABLE_IF
+    assert "synchronize" not in condition
+    assert ARM_COMMAND in str(enable.get("run") or "")
+
+
+def test_workflow_enable_requires_absence_of_hold_label() -> None:
+    """ready_for_review must not arm while no-auto-merge is present."""
+    steps = _steps_by_name(_enable_job())
+    enable = steps["Enable squash auto-merge"]
+    assert _collapsed_if(enable) == ENABLE_IF
+    assert "steps.hold.outputs.held != 'true'" in _collapsed_if(enable)
+
+
+def test_workflow_hold_step_matches_exact_label() -> None:
+    """Hold detection must be exact-name (grep -qxF), shared constant name."""
+    text = AUTO_MERGE_WORKFLOW.read_text(encoding="utf-8")
+    steps = _steps_by_name(_enable_job())
+    hold = steps.get("Check explicit hold label")
+    assert hold is not None, "hold check step missing"
+    assert hold.get("id") == "hold"
+    run = str(hold.get("run") or "")
+    assert f"grep -qxF '{HOLD_LABEL}'" in run or f'grep -qxF "{HOLD_LABEL}"' in run
+    assert "held=$held" in run or "held=" in run
+    # Label constant appears in both layers for lockstep.
+    assert HOLD_LABEL in text
+
+
+def test_workflow_disables_on_explicit_hold() -> None:
+    """Applying the hold label must revoke any enabled auto-merge."""
+    steps = _steps_by_name(_enable_job())
+    disable = steps.get("Disable auto-merge for explicit hold")
+    assert disable is not None, "explicit-hold disable step missing"
+    assert _collapsed_if(disable) == HOLD_DISABLE_IF
+    assert DISABLE_COMMAND in str(disable.get("run") or "")
+
+
+def test_workflow_disables_on_soundness() -> None:
+    """Soundness revocation must remain independent of the hold path."""
+    steps = _steps_by_name(_enable_job())
+    disable = steps.get("Disable auto-merge for soundness PR")
+    assert disable is not None
+    assert _collapsed_if(disable) == SOUNDNESS_DISABLE_IF
+    assert DISABLE_COMMAND in str(disable.get("run") or "")
+
+
+def test_workflow_listens_for_labeled_to_make_hold_durable() -> None:
+    """Without `labeled`, applying no-auto-merge would not revoke until a push."""
+    types = _triggers(_load_yaml(AUTO_MERGE_WORKFLOW))["pull_request"]["types"]
+    assert "labeled" in types
+    for required in ("opened", "reopened", "ready_for_review", "synchronize"):
+        assert required in types
+
+
+def test_workflow_skips_drafts_at_job_level() -> None:
+    job = _enable_job()
+    assert "draft" in str(job.get("if") or "")
+    assert "false" in str(job.get("if") or "")
+
+
+def test_soundness_unions_base_ref_and_pr_copy_predicates() -> None:
+    """Disable uses base OR PR-copy; enable still requires soundness_path != true.
+
+    Base-ref alone cannot see a gate widened in the same PR. PR-copy alone
+    would let a PR narrow the surface. Union + enable-on-not-true preserves
+    both properties.
+    """
+    text = AUTO_MERGE_WORKFLOW.read_text(encoding="utf-8")
+    assert "predicate_base.py" in text
+    assert 'git show "origin/${{ github.base_ref }}:_project/scripts/auto_merge_soundness_paths.py"' in text
+    # PR checkout copy is evaluated for the union (widening).
+    assert "python3 _project/scripts/auto_merge_soundness_paths.py --stdin --format github-output" in text
+    # Union is OR of both results.
+    assert '[ "$base_result" = "soundness_path=true" ] || [ "$pr_result" = "soundness_path=true" ]' in text
+    # Self-touch override remains.
+    assert 'grep -qxF "_project/scripts/auto_merge_soundness_paths.py"' in text
+    assert 'grep -qxF ".github/workflows/auto-merge-on-open.yml"' in text
+
+
+# ---------------------------------------------------------------------------
+# Sweep: never re-arm; honour the same hold label
+# ---------------------------------------------------------------------------
+
+
+def test_sweep_hold_label_constant_matches_workflow() -> None:
+    sweep = _load_sweep()
+    assert sweep.AUTO_MERGE_HOLD_LABEL == HOLD_LABEL
+    assert HOLD_LABEL in AUTO_MERGE_WORKFLOW.read_text(encoding="utf-8")
+
+
+def test_sweep_has_auto_merge_hold_label_is_exact() -> None:
+    sweep = _load_sweep()
+    assert sweep.has_auto_merge_hold_label([HOLD_LABEL]) is True
+    assert sweep.has_auto_merge_hold_label(["no-auto-merge-except"]) is False
+    assert sweep.has_auto_merge_hold_label(["enhancement", HOLD_LABEL]) is True
+    assert sweep.has_auto_merge_hold_label([]) is False
+    assert sweep.has_auto_merge_hold_label(None) is False
+
+
+def test_sweep_explicit_hold_is_not_stranded() -> None:
+    sweep = _load_sweep()
+    assert (
+        sweep.is_stranded(
+            draft=False,
+            required_green=True,
+            auto_merge_enabled=False,
+            soundness_gated=False,
+            age_hours=10.0,
+            grace_hours=2.0,
+            explicit_hold=True,
+        )
+        is False
+    )
+    # Control: same row without hold is stranded.
+    assert (
+        sweep.is_stranded(
+            draft=False,
+            required_green=True,
+            auto_merge_enabled=False,
+            soundness_gated=False,
+            age_hours=10.0,
+            grace_hours=2.0,
+            explicit_hold=False,
+        )
+        is True
+    )
+
+
+def test_sweep_classify_pr_reads_hold_label() -> None:
+    import datetime as dt
+
+    sweep = _load_sweep()
+    now = dt.datetime(2026, 7, 23, 12, 0, tzinfo=dt.timezone.utc)
+    pr = {
+        "number": 99,
+        "title": "held",
+        "html_url": "https://example.invalid/99",
+        "draft": False,
+        "updated_at": "2026-07-23T08:00:00Z",
+        "head_pushed_at": "2026-07-23T08:00:00Z",
+        "auto_merge": None,
+        "labels": [HOLD_LABEL],
+        "changed_files": ["benchbox/platforms/duckdb/adapter.py"],
+        "check_runs": [
+            {
+                "name": "ci-required-result",
+                "status": "completed",
+                "conclusion": "success",
+                "started_at": "2026-07-23T08:10:00Z",
+            }
+        ],
+    }
+    classified = sweep.classify_pr(pr, now)
+    assert classified.explicit_hold is True
+    assert classified.stranded is False
+
+
+def test_sweep_apply_never_enables_auto_merge() -> None:
+    """`--apply` must not call gh pr merge --auto / REST merge enablement.
+
+    This is the nightly re-arm pin: the job runs with --apply, so any arming
+    call in the script would re-arm holds the sweep did not set.
+    """
+    import ast
+
+    text = SWEEP_SCRIPT.read_text(encoding="utf-8")
+    tree = ast.parse(text)
+    # Walk Call nodes: no gh pr merge / merge-enable REST helpers.
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        # subprocess.run([...]) or similar list/tuple first arg with "gh" "pr" "merge"
+        if not node.args:
+            continue
+        first = node.args[0]
+        elts: list[ast.AST] = []
+        if isinstance(first, (ast.List, ast.Tuple)):
+            elts = list(first.elts)
+        words: list[str] = []
+        for elt in elts:
+            if isinstance(elt, ast.Constant) and isinstance(elt.value, str):
+                words.append(elt.value)
+        if len(words) >= 3 and words[0] == "gh" and words[1] == "pr" and words[2] == "merge":
+            raise AssertionError(f"sweep must not invoke gh pr merge (found {words!r})")
+        # Direct string call forms
+    assert "never enables auto-merge" in text
+    assert "/merges" not in text
+    assert "put_auto_merge" not in text
+    assert "enable_auto_merge" not in text
+    # Apply path only mutates the digest issue, never a PR merge endpoint.
+    apply_src = ast.get_source_segment(
+        text, next(n for n in tree.body if isinstance(n, ast.FunctionDef) and n.name == "main")
+    )
+    assert apply_src is not None
+    assert "upsert_pinned_issue" in apply_src
+    assert "gh pr merge" not in apply_src
+    assert "auto_merge" in text  # still reads the field for classification
+
+
+def test_nightly_invokes_sweep_apply_without_arming_flags() -> None:
+    text = NIGHTLY_WORKFLOW.read_text(encoding="utf-8")
+    assert "green_unmerged_sweep.py --apply" in text
+    # Nightly must not pass any arm/enable flag if one is ever added.
+    apply_lines = [
+        line for line in text.splitlines() if "green_unmerged_sweep.py" in line and not line.lstrip().startswith("#")
+    ]
+    assert apply_lines, "nightly has no executable green_unmerged_sweep.py invocation"
+    for apply_line in apply_lines:
+        assert "--apply" in apply_line
+        assert "--enable" not in apply_line
+        assert "--arm" not in apply_line
+
+
+def test_ops_docs_document_durable_hold() -> None:
+    doc = PR_TRIAGE_DOC.read_text(encoding="utf-8")
+    assert "Durable auto-merge holds" in doc
+    assert HOLD_LABEL in doc
+    assert "never" in doc.lower() and "enables auto-merge" in doc.lower()

--- a/tests/unit/test_auto_merge_soundness_paths.py
+++ b/tests/unit/test_auto_merge_soundness_paths.py
@@ -104,29 +104,31 @@ def test_backstop_workflow_uses_shared_predicate_and_skips_auto_merge() -> None:
 
     # Diff via git with --no-renames (gh pr diff --name-only drops rename sources).
     assert "git diff --name-only --no-renames" in workflow
-    assert "if: steps.soundness.outputs.soundness_path != 'true'" in workflow
+    # Enable is multi-line (`if: >-`); pin the soundness gate fragment rather than
+    # a single-line `if:` that no longer exists after the hold-label conjunction.
+    assert "steps.soundness.outputs.soundness_path != 'true'" in workflow
     assert "if: steps.soundness.outputs.soundness_path == 'true'" in workflow
     # A soundness-touching push must re-evaluate and clear any stale auto-merge.
     assert "synchronize" in workflow
     assert "gh pr merge --disable-auto" in workflow
 
-    # auto-merge-predicate-base-ref-execution: the predicate must be executed
-    # from the base ref's copy of the file, not the PR's own checkout copy,
-    # so a PR that edits the predicate can't judge its own diff by its own
-    # modified rules.
+    # auto-merge-predicate-base-ref-execution: base-ref copy must still run so
+    # a PR that narrows the predicate can't judge its own diff by its own rules.
     assert (
-        'git show "origin/${{ github.base_ref }}:_project/scripts/auto_merge_soundness_paths.py" > /tmp/predicate.py'
+        'git show "origin/${{ github.base_ref }}:_project/scripts/auto_merge_soundness_paths.py" > /tmp/predicate_base.py'
         in workflow
     )
-    assert "python3 /tmp/predicate.py --stdin --format github-output" in workflow
-    # The predicate script itself is executed from the checked-out repo
-    # nowhere in this workflow (only the base-ref materialized copy).
-    assert "_project/scripts/auto_merge_soundness_paths.py --stdin --format github-output" not in workflow
+    assert "python3 /tmp/predicate_base.py --stdin --format github-output" in workflow
+    # PR checkout copy is evaluated alongside base-ref (union/OR) so a gate
+    # *widened* mid-flight still revokes. Enable requires soundness_path != true
+    # (both false), so the PR copy cannot weaken the gate by narrowing rules.
+    assert "python3 _project/scripts/auto_merge_soundness_paths.py --stdin --format github-output" in workflow
+    assert '[ "$base_result" = "soundness_path=true" ] || [ "$pr_result" = "soundness_path=true" ]' in workflow
 
     # A PR touching the predicate or this workflow itself must be forced to
-    # soundness_path=true, regardless of what the base-ref predicate says
-    # about the rest of the diff (closes the "edit the predicate to make
-    # future PRs unsafe" gap that base-ref execution alone doesn't cover).
+    # soundness_path=true, regardless of what either predicate says about the
+    # rest of the diff (closes the "edit the predicate to make future PRs
+    # unsafe" gap that predicate evaluation alone doesn't cover).
     assert 'grep -qxF "_project/scripts/auto_merge_soundness_paths.py"' in workflow
     assert 'grep -qxF ".github/workflows/auto-merge-on-open.yml"' in workflow
     assert 'result="soundness_path=true"' in workflow

--- a/tests/unit/workflows/test_auto_merge_enablement_point.py
+++ b/tests/unit/workflows/test_auto_merge_enablement_point.py
@@ -39,8 +39,14 @@ AUTO_MERGE_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "auto-merge-on-open.
 ARM_COMMAND = "gh pr merge --auto --squash"
 
 # Exact enable/disable `if:` pins for auto-merge-on-open.yml (collapsed form).
-ENABLE_IF = "steps.soundness.outputs.soundness_path != 'true' && github.event.action == 'ready_for_review'"
+# Enable also requires the durable hold label absent (steps.hold).
+ENABLE_IF = (
+    "steps.soundness.outputs.soundness_path != 'true' "
+    "&& steps.hold.outputs.held != 'true' "
+    "&& github.event.action == 'ready_for_review'"
+)
 DISABLE_IF = "steps.soundness.outputs.soundness_path == 'true'"
+HOLD_DISABLE_IF = "steps.hold.outputs.held == 'true'"
 
 
 def _target_body(name: str) -> str:
@@ -185,10 +191,11 @@ def test_auto_merge_workflow_keeps_opened_trigger_for_soundness_re_eval() -> Non
 
     Dropping those triggers would leave a soundness PR that was opened with
     auto-merge already on (or that later gains a soundness commit) without a
-    revocation path from this workflow.
+    revocation path from this workflow. `labeled` is also required so the
+    durable hold label revokes without needing a push.
     """
     types = _triggers(_load_workflow())["pull_request"]["types"]
-    for required in ("opened", "reopened", "ready_for_review", "synchronize"):
+    for required in ("opened", "reopened", "ready_for_review", "synchronize", "labeled"):
         assert required in types, f"pull_request types missing {required!r}: {types}"
 
 
@@ -213,4 +220,16 @@ def test_auto_merge_workflow_preserves_soundness_disable() -> None:
     assert "--disable-auto" in str(disable.get("run") or ""), "soundness disable no longer calls --disable-auto"
     assert _collapsed_if(disable) == DISABLE_IF, (
         f"disable step if: drifted from policy pin\n  got:  {_collapsed_if(disable)!r}\n  want: {DISABLE_IF!r}"
+    )
+
+
+def test_auto_merge_workflow_preserves_explicit_hold_disable() -> None:
+    """Must-preserve: no-auto-merge label revokes auto-merge independently."""
+    workflow = _load_workflow()
+    steps = _steps_by_name(_enable_job(workflow))
+    disable = steps.get("Disable auto-merge for explicit hold")
+    assert disable is not None, "explicit-hold disable step is gone"
+    assert "--disable-auto" in str(disable.get("run") or "")
+    assert _collapsed_if(disable) == HOLD_DISABLE_IF, (
+        f"hold disable if: drifted from policy pin\n  got:  {_collapsed_if(disable)!r}\n  want: {HOLD_DISABLE_IF!r}"
     )


### PR DESCRIPTION
## Summary

Implements `auto-merge-explicit-hold-is-not-durable`.

After #1592, synchronize no longer re-enables auto-merge. Remaining durable-hold gaps:
nightly was never arming (issue-only), but there was still no first-class durable hold
signal for a non-draft PR, and synchronize only evaluated the base-ref soundness predicate.

### Changes

1. **Durable hold label `no-auto-merge`** (plus existing draft hold)
   - `auto-merge-on-open.yml`: check label; block enable on `ready_for_review`; disable when held; listen for `labeled` so applying the label revokes without a push
   - `green_unmerged_sweep.py`: composable `has_auto_merge_hold_label` / `AUTO_MERGE_HOLD_LABEL`; exclude from stranded; `--apply` remains issue-only and never re-arms a hold it did not set

2. **Soundness predicate union on re-eval**
   - Base-ref copy (cannot weaken) OR PR checkout copy (gate widened mid-flight still revokes)
   - Enable still requires `soundness_path != true` (both false)
   - Self-touch override retained

3. **Docs**: `docs/operations/pr-triage.md` + `repo-admin-settings.md`

4. **Guard**: `tests/unit/test_auto_merge_hold_is_durable.py`

### Must preserve

- Ordinary arming still available via `make pr-ready` / draft→ready (without the hold label)
- Drafts still skipped
- Soundness withholding intact; PR cannot weaken its own gate

### Verify

```bash
uv run -- python -m pytest tests/unit/test_auto_merge_hold_is_durable.py -q
uv run -- python -m pytest tests/unit/test_auto_merge_soundness_paths.py -q
```

Repo label `no-auto-merge` created for use on held PRs.
