### PR TITLE
test(uat): classify compose ps as its own verb in the durability docker fake

### DIFF
--- a/tests/uat/test_sweep_durability.py
+++ b/tests/uat/test_sweep_durability.py
@@ -292,7 +292,11 @@ def test_interrupt_mid_cell_still_tears_down_docker_stack(tmp_path: Path):
     sequence: list[str] = []
 
     def fake_docker(argv, **_kwargs):
-        action = "up" if "up" in argv else "down"
+        # Classify up/ps/down, not just up/down: the post-start readiness
+        # `compose ps` re-check must not be recorded as a teardown, or the
+        # ordering assertion below matches that instead of the real `down`
+        # (same three-way classify as test_phases.py's `_docker_verb`).
+        action = "up" if "up" in argv else ("ps" if "ps" in argv else "down")
         sequence.append(action)
         return docker_assets.DockerCommandResult(tuple(argv), 0, "", "")
 


### PR DESCRIPTION
test_interrupt_mid_cell_still_tears_down_docker_stack's fake docker_runner
classified every argv as up-or-down, so any compose verb that is not `up`
was recorded as a teardown. The post-start readiness re-check planned in
uat-container-readiness-and-memory-headroom-gate-20260805 w0 issues a
`compose ps` through the same injected runner before any cell runs, which
that fake would record as a spurious `down` ahead of the `cell` entry and
break `sequence.index("down") > sequence.index("cell")` -- the assertion
would match the readiness probe instead of the real teardown.

Classify up/ps/down, matching the `_docker_verb` helper the same work adds
to tests/uat/test_phases.py. No-op against the current tree (no `ps` is
issued today) and no production code changes; the two ordering assertions
are unchanged because ['up','ps','cell','down'] still satisfies them.
