### PR TITLE
fix/uat cell teardown orphans

### DIFF
--- a/_project/specs/uat-framework.md
+++ b/_project/specs/uat-framework.md
@@ -131,7 +131,7 @@ tests/uat/
 | `runner.py` | Build `benchbox run` argv per cell; capture stdout+stderr to per-run log; extract result-JSON path; submit classification via shared `benchbox.core.results.submit_classification` | 120 | 354 |
 | `config.py` | Load YAML, validate against schema (Section 3), expose typed dataclass access | 180 | 807 |
 | `_cli.py` | UAT CLI entrypoint: argument parsing, sweep/execute/validate/report/package subcommands, output wiring | — | 816 |
-| `timeouts.py` | Signal-based timeout (POSIX process-group kill ladder) | 80 | 123 |
+| `timeouts.py` | Signal-based timeout (POSIX process-group kill ladder) | 80 | 199 |
 | `cleanup.py` | Track cell completions; prune `databases/` at safe reuse boundaries; preserve `datagen/` | 150 | 121 |
 | `compatibility.py` | Platform/benchmark compatibility rules; record compatibility-pruned cells with rule metadata | — | 198 |
 | `docker_assets.py` | Single connection registry: compose-file map, compose-derived host ports + platform options, safe project-scoped compose commands | 180 | 841 |
@@ -151,7 +151,7 @@ tests/uat/
 | `phases/package.py` | Read `submit_terminal_state`; invoke `benchbox submit --output` or `--service`; `draft-pr`/`merged-to-published-results` are **stubs** (dispatcher only, per `PR_STUB_TERMINAL_STATES`) that emit the same argv as `local-stage` plus an operator warning -- PR-opening to `published-results` is not implemented | 130 | 180 |
 | `phases/explorer_smoke.py` | Branch-presence-guarded explorer smoke: always-on corpus contract, delegates build+Playwright to the Results Explorer | 60 | 387 |
 | `phases/report.py` | Read each phase's outputs; emit `matrix_summary.tsv`; cross-scale coverage check | 130 | 490 |
-| `orchestrator.py` | Walk YAML `phases:` list in order; surface phase failures; respect `dry_run:` toggle | 100 | 924 |
+| `orchestrator.py` | Walk YAML `phases:` list in order; surface phase failures; respect `dry_run:` toggle | 100 | 934 |
 
 **Budget reconciliation (revised 2026-06-01, `uat-loc-budget-reconciliation`; re-measured
 2026-07-19, `uat-config-schema-spec-realignment`).**
@@ -175,9 +175,9 @@ remain hand-tracked.
 
 **Per-bucket production LOC** (auto-generated -- run the script to refresh):
 
-- plumbing (orchestrator/config/`_cli`): 2,547
+- plumbing (orchestrator/config/`_cli`): 2,557
 - core exercise (execute/matrix/runner/enumerate/cleanup/ladder): 2,642
-- preflight/compat/timeouts: 1,107
+- preflight/compat/timeouts: 1,183
 - Docker lifecycle (default-OFF, incl. `container_cleanup.py`): 1,824
 - chartered evidence artifacts (validate/report/package/cells_io/gate_summary): 1,722
 - explorer-prep: 387
@@ -185,7 +185,7 @@ remain hand-tracked.
 - artifact hygiene: 315
 - package init markers: 23
 
-**Total: 10,883 production LOC across 26 modules.**
+**Total: 10,969 production LOC across 26 modules.**
 
 <!-- UAT-LOC-SUMMARY:END -->
 

--- a/_project/specs/uat-framework.md
+++ b/_project/specs/uat-framework.md
@@ -131,7 +131,7 @@ tests/uat/
 | `runner.py` | Build `benchbox run` argv per cell; capture stdout+stderr to per-run log; extract result-JSON path; submit classification via shared `benchbox.core.results.submit_classification` | 120 | 354 |
 | `config.py` | Load YAML, validate against schema (Section 3), expose typed dataclass access | 180 | 807 |
 | `_cli.py` | UAT CLI entrypoint: argument parsing, sweep/execute/validate/report/package subcommands, output wiring | — | 816 |
-| `timeouts.py` | Signal-based timeout (POSIX process-group kill ladder) | 80 | 172 |
+| `timeouts.py` | Signal-based timeout (POSIX process-group kill ladder) | 80 | 279 |
 | `cleanup.py` | Track cell completions; prune `databases/` at safe reuse boundaries; preserve `datagen/` | 150 | 121 |
 | `compatibility.py` | Platform/benchmark compatibility rules; record compatibility-pruned cells with rule metadata | — | 198 |
 | `docker_assets.py` | Single connection registry: compose-file map, compose-derived host ports + platform options, safe project-scoped compose commands | 180 | 841 |
@@ -177,7 +177,7 @@ remain hand-tracked.
 
 - plumbing (orchestrator/config/`_cli`): 2,551
 - core exercise (execute/matrix/runner/enumerate/cleanup/ladder): 2,642
-- preflight/compat/timeouts: 1,156
+- preflight/compat/timeouts: 1,263
 - Docker lifecycle (default-OFF, incl. `container_cleanup.py`): 1,824
 - chartered evidence artifacts (validate/report/package/cells_io/gate_summary): 1,722
 - explorer-prep: 387
@@ -185,7 +185,7 @@ remain hand-tracked.
 - artifact hygiene: 315
 - package init markers: 23
 
-**Total: 10,936 production LOC across 26 modules.**
+**Total: 11,043 production LOC across 26 modules.**
 
 <!-- UAT-LOC-SUMMARY:END -->
 

--- a/_project/specs/uat-framework.md
+++ b/_project/specs/uat-framework.md
@@ -131,7 +131,7 @@ tests/uat/
 | `runner.py` | Build `benchbox run` argv per cell; capture stdout+stderr to per-run log; extract result-JSON path; submit classification via shared `benchbox.core.results.submit_classification` | 120 | 354 |
 | `config.py` | Load YAML, validate against schema (Section 3), expose typed dataclass access | 180 | 807 |
 | `_cli.py` | UAT CLI entrypoint: argument parsing, sweep/execute/validate/report/package subcommands, output wiring | — | 816 |
-| `timeouts.py` | Signal-based timeout (POSIX process-group kill ladder) | 80 | 199 |
+| `timeouts.py` | Signal-based timeout (POSIX process-group kill ladder) | 80 | 172 |
 | `cleanup.py` | Track cell completions; prune `databases/` at safe reuse boundaries; preserve `datagen/` | 150 | 121 |
 | `compatibility.py` | Platform/benchmark compatibility rules; record compatibility-pruned cells with rule metadata | — | 198 |
 | `docker_assets.py` | Single connection registry: compose-file map, compose-derived host ports + platform options, safe project-scoped compose commands | 180 | 841 |
@@ -151,7 +151,7 @@ tests/uat/
 | `phases/package.py` | Read `submit_terminal_state`; invoke `benchbox submit --output` or `--service`; `draft-pr`/`merged-to-published-results` are **stubs** (dispatcher only, per `PR_STUB_TERMINAL_STATES`) that emit the same argv as `local-stage` plus an operator warning -- PR-opening to `published-results` is not implemented | 130 | 180 |
 | `phases/explorer_smoke.py` | Branch-presence-guarded explorer smoke: always-on corpus contract, delegates build+Playwright to the Results Explorer | 60 | 387 |
 | `phases/report.py` | Read each phase's outputs; emit `matrix_summary.tsv`; cross-scale coverage check | 130 | 490 |
-| `orchestrator.py` | Walk YAML `phases:` list in order; surface phase failures; respect `dry_run:` toggle | 100 | 934 |
+| `orchestrator.py` | Walk YAML `phases:` list in order; surface phase failures; respect `dry_run:` toggle | 100 | 928 |
 
 **Budget reconciliation (revised 2026-06-01, `uat-loc-budget-reconciliation`; re-measured
 2026-07-19, `uat-config-schema-spec-realignment`).**
@@ -175,9 +175,9 @@ remain hand-tracked.
 
 **Per-bucket production LOC** (auto-generated -- run the script to refresh):
 
-- plumbing (orchestrator/config/`_cli`): 2,557
+- plumbing (orchestrator/config/`_cli`): 2,551
 - core exercise (execute/matrix/runner/enumerate/cleanup/ladder): 2,642
-- preflight/compat/timeouts: 1,183
+- preflight/compat/timeouts: 1,156
 - Docker lifecycle (default-OFF, incl. `container_cleanup.py`): 1,824
 - chartered evidence artifacts (validate/report/package/cells_io/gate_summary): 1,722
 - explorer-prep: 387
@@ -185,7 +185,7 @@ remain hand-tracked.
 - artifact hygiene: 315
 - package init markers: 23
 
-**Total: 10,969 production LOC across 26 modules.**
+**Total: 10,936 production LOC across 26 modules.**
 
 <!-- UAT-LOC-SUMMARY:END -->
 

--- a/tests/uat/orchestrator.py
+++ b/tests/uat/orchestrator.py
@@ -21,7 +21,7 @@ from dataclasses import dataclass, replace
 from pathlib import Path
 from typing import Any
 
-from tests.uat import cells_io, docker_assets, gate_summary, preflight_budget, timeouts
+from tests.uat import cells_io, docker_assets, gate_summary, preflight_budget
 from tests.uat.config import UATConfig, disk_gate_disabled_warning, load_config
 from tests.uat.phases import (
     enumerate as enumerate_phase,
@@ -100,18 +100,13 @@ def _install_sweep_sigterm_shim(log_dir: Path, phase_holder: list[str | None]) -
     thread -- `signal.signal` raises there). Installing in the sweep's own
     process does not touch cell subprocesses directly: `timeouts.py` owns
     their process-group kill semantics via `run_with_timeout`'s own
-    `except BaseException` guard, which fires as `SweepCancelled` unwinds
-    through a blocked `communicate()` call. Returning the sentinel (rather
-    than raising) keeps a sweep driven from a worker thread working with
-    default SIGTERM behavior; row durability does not depend on the shim,
-    only the orderly-teardown upgrade does.
-
-    Before raising, the handler also drains `timeouts._LIVE_PROCESS_GROUPS`
-    (`timeouts.drain_live_process_groups()`): the narrow window between a
-    cell's `Popen()` and `run_with_timeout` entering its own try/except has
-    no kill path armed yet, so a signal landing exactly there would
-    otherwise escape with the child still alive
-    (uat-cell-teardown-orphans-child-processes-20260805 w2).
+    `except BaseException` guard (with `Popen()` itself inside that guarded
+    `try`, see its docstring), which fires as `SweepCancelled` unwinds
+    through wherever `run_with_timeout` currently is -- including a blocked
+    `communicate()` call. Returning the sentinel (rather than raising) keeps
+    a sweep driven from a worker thread working with default SIGTERM
+    behavior; row durability does not depend on the shim, only the
+    orderly-teardown upgrade does.
 
     The handler records the cancellation (signal name, phase in flight,
     timestamp) to uat_lifecycle.log before raising (w3), so a killed sweep
@@ -121,7 +116,6 @@ def _install_sweep_sigterm_shim(log_dir: Path, phase_holder: list[str | None]) -
 
     def _raise_cancelled(signum: int, _frame: object) -> None:
         signal_name = signal.Signals(signum).name
-        timeouts.drain_live_process_groups()
         exec_phase.append_lifecycle_log(
             log_dir,
             f"[cancel] signal={signal_name} phase={phase_holder[0]} "

--- a/tests/uat/orchestrator.py
+++ b/tests/uat/orchestrator.py
@@ -21,7 +21,7 @@ from dataclasses import dataclass, replace
 from pathlib import Path
 from typing import Any
 
-from tests.uat import cells_io, docker_assets, gate_summary, preflight_budget
+from tests.uat import cells_io, docker_assets, gate_summary, preflight_budget, timeouts
 from tests.uat.config import UATConfig, disk_gate_disabled_warning, load_config
 from tests.uat.phases import (
     enumerate as enumerate_phase,
@@ -98,11 +98,20 @@ def _install_sweep_sigterm_shim(log_dir: Path, phase_holder: list[str | None]) -
     Returns the previous SIGTERM handler to restore, or the not-installed
     sentinel when the shim could not be installed (not running in the main
     thread -- `signal.signal` raises there). Installing in the sweep's own
-    process does not touch cell subprocesses: `timeouts.py` owns their
-    process-group kill semantics, and those subprocesses never import this
-    shim. Returning the sentinel (rather than raising) keeps a sweep driven
-    from a worker thread working with default SIGTERM behavior; row durability
-    does not depend on the shim, only the orderly-teardown upgrade does.
+    process does not touch cell subprocesses directly: `timeouts.py` owns
+    their process-group kill semantics via `run_with_timeout`'s own
+    `except BaseException` guard, which fires as `SweepCancelled` unwinds
+    through a blocked `communicate()` call. Returning the sentinel (rather
+    than raising) keeps a sweep driven from a worker thread working with
+    default SIGTERM behavior; row durability does not depend on the shim,
+    only the orderly-teardown upgrade does.
+
+    Before raising, the handler also drains `timeouts._LIVE_PROCESS_GROUPS`
+    (`timeouts.drain_live_process_groups()`): the narrow window between a
+    cell's `Popen()` and `run_with_timeout` entering its own try/except has
+    no kill path armed yet, so a signal landing exactly there would
+    otherwise escape with the child still alive
+    (uat-cell-teardown-orphans-child-processes-20260805 w2).
 
     The handler records the cancellation (signal name, phase in flight,
     timestamp) to uat_lifecycle.log before raising (w3), so a killed sweep
@@ -112,6 +121,7 @@ def _install_sweep_sigterm_shim(log_dir: Path, phase_holder: list[str | None]) -
 
     def _raise_cancelled(signum: int, _frame: object) -> None:
         signal_name = signal.Signals(signum).name
+        timeouts.drain_live_process_groups()
         exec_phase.append_lifecycle_log(
             log_dir,
             f"[cancel] signal={signal_name} phase={phase_holder[0]} "

--- a/tests/uat/test_sweep_durability.py
+++ b/tests/uat/test_sweep_durability.py
@@ -13,7 +13,10 @@ uat-sweep-durability-and-signal-teardown:
 from __future__ import annotations
 
 import json
+import os
 import signal
+import sys
+import time
 from collections.abc import Callable
 from pathlib import Path
 from types import FrameType
@@ -22,7 +25,7 @@ from unittest.mock import patch
 
 import pytest
 
-from tests.uat import _cli as uat_cli, cells_io, docker_assets, orchestrator
+from tests.uat import _cli as uat_cli, cells_io, docker_assets, orchestrator, timeouts
 from tests.uat.config import validate_config
 from tests.uat.phases import execute as exec_phase
 from tests.uat.runner import CellResult
@@ -318,3 +321,67 @@ def test_interrupt_mid_cell_still_tears_down_docker_stack(tmp_path: Path):
 
     assert "cell" in sequence and "down" in sequence
     assert sequence.index("down") > sequence.index("cell")
+
+
+# --------------------------------------------------------------------- w2/w4 (uat-cell-teardown-orphans-child-processes-20260805)
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="POSIX signal/process-group behavior")
+def test_sweep_cancel_reaps_orphaned_child_no_survivor(tmp_path: Path):
+    """A cancelled sweep leaves no surviving descendant process.
+
+    Uses the real sweep-process SIGTERM shim (`orchestrator._install_sweep_sigterm_shim`,
+    the exact handler `run_sweep` installs) and a real spawned child through
+    `timeouts.run_with_timeout` (the exact wrapper `exec_phase.run_cell` uses) --
+    not a mocked `communicate()`, which could look correct while a real
+    process kept running. Before the fix, `SweepCancelled` (a
+    `KeyboardInterrupt` subclass, not an `Exception`) escaped
+    `run_with_timeout`'s `except subprocess.TimeoutExpired` untouched and the
+    grandchild-capable child survived; this asserts it does not.
+    """
+    pid_file = tmp_path / "child.pid"
+    script = f"""
+import pathlib
+import os
+import time
+
+pathlib.Path({str(pid_file)!r}).write_text(str(os.getpid()), encoding="utf-8")
+time.sleep(30)
+"""
+    phase_holder: list[str | None] = ["execute"]
+    previous_sigterm = orchestrator._install_sweep_sigterm_shim(tmp_path, phase_holder)
+    sigterm_handler = signal.getsignal(signal.SIGTERM)
+
+    def _deliver_cancellation(signum: int, frame: FrameType | None) -> None:
+        # Fire the exact SIGTERM handler the orchestrator installed, from a
+        # SIGALRM tick landing while the main thread is blocked inside
+        # run_with_timeout's communicate() -- the same real scenario an
+        # operator `kill` on the sweep process produces.
+        typed_handler = cast(Callable[[int, FrameType | None], None], sigterm_handler)
+        typed_handler(signal.SIGTERM, frame)
+
+    previous_alarm = signal.signal(signal.SIGALRM, _deliver_cancellation)
+    signal.alarm(1)
+    try:
+        with pytest.raises(orchestrator.SweepCancelled):
+            timeouts.run_with_timeout([sys.executable, "-c", script], timeout_s=0)
+    finally:
+        signal.alarm(0)
+        signal.signal(signal.SIGALRM, previous_alarm)
+        orchestrator._restore_sweep_sigterm_shim(previous_sigterm)
+
+    child_pid = int(pid_file.read_text(encoding="utf-8"))
+    deadline = time.monotonic() + 2.0
+    while _pid_exists(child_pid) and time.monotonic() < deadline:
+        time.sleep(0.05)
+    assert not _pid_exists(child_pid)
+
+
+def _pid_exists(pid: int) -> bool:
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        return True
+    return True

--- a/tests/uat/test_sweep_durability.py
+++ b/tests/uat/test_sweep_durability.py
@@ -13,10 +13,8 @@ uat-sweep-durability-and-signal-teardown:
 from __future__ import annotations
 
 import json
-import os
 import signal
 import sys
-import time
 from collections.abc import Callable
 from pathlib import Path
 from types import FrameType
@@ -25,7 +23,18 @@ from unittest.mock import patch
 
 import pytest
 
-from tests.uat import _cli as uat_cli, cells_io, docker_assets, orchestrator, timeouts
+# `test_timeouts` is imported for its real-process probe script and
+# process-state predicates: they live with the module they exercise, and
+# sharing them keeps one implementation instead of the verbatim `_pid_exists`
+# copy this file used to carry.
+from tests.uat import (
+    _cli as uat_cli,
+    cells_io,
+    docker_assets,
+    orchestrator,
+    test_timeouts as timeouts_test,
+    timeouts,
+)
 from tests.uat.config import validate_config
 from tests.uat.phases import execute as exec_phase
 from tests.uat.runner import CellResult
@@ -330,58 +339,69 @@ def test_interrupt_mid_cell_still_tears_down_docker_stack(tmp_path: Path):
 def test_sweep_cancel_reaps_orphaned_child_no_survivor(tmp_path: Path):
     """A cancelled sweep leaves no surviving descendant process.
 
-    Uses the real sweep-process SIGTERM shim (`orchestrator._install_sweep_sigterm_shim`,
-    the exact handler `run_sweep` installs) and a real spawned child through
-    `timeouts.run_with_timeout` (the exact wrapper `exec_phase.run_cell` uses) --
-    not a mocked `communicate()`, which could look correct while a real
-    process kept running. Before the fix, `SweepCancelled` (a
-    `KeyboardInterrupt` subclass, not an `Exception`) escaped
-    `run_with_timeout`'s `except subprocess.TimeoutExpired` untouched and the
-    grandchild-capable child survived; this asserts it does not.
-    """
-    pid_file = tmp_path / "child.pid"
-    script = f"""
-import pathlib
-import os
-import time
+    The end-to-end wiring test: the real sweep-process SIGTERM shim
+    (`orchestrator._install_sweep_sigterm_shim`, the exact handler
+    `run_sweep` installs) raising the real `SweepCancelled` through the real
+    `timeouts.run_with_timeout` (the exact wrapper `exec_phase.run_cell`
+    uses), at the production timeout, around a real child that owns a real
+    grandchild and traps SIGTERM the way a cell's database server does.
 
-pathlib.Path({str(pid_file)!r}).write_text(str(os.getpid()), encoding="utf-8")
-time.sleep(30)
-"""
+    The unit-level equivalents in test_timeouts.py pin the same behavior
+    against a locally defined `KeyboardInterrupt` subclass; this one proves
+    the orchestrator's actual exception type reaches the guard, which is the
+    whole premise of the fix -- `SweepCancelled` is not an `Exception`, so
+    `except subprocess.TimeoutExpired` never saw it and the descendant tree
+    survived.
+    """
     phase_holder: list[str | None] = ["execute"]
     previous_sigterm = orchestrator._install_sweep_sigterm_shim(tmp_path, phase_holder)
     sigterm_handler = signal.getsignal(signal.SIGTERM)
+    ready_path = tmp_path / "child.ready"
+    child_pid_path = tmp_path / "child.pid"
+    grandchild_pid_path = tmp_path / "grandchild.pid"
+    argv = [
+        sys.executable,
+        "-c",
+        timeouts_test._CANCEL_PROBE_SRC,
+        str(child_pid_path),
+        str(grandchild_pid_path),
+        str(tmp_path / "child.sigterm"),
+        str(ready_path),
+        timeouts_test._GRANDCHILD_SRC,
+    ]
+    ticks = {"count": 0}
 
     def _deliver_cancellation(signum: int, frame: FrameType | None) -> None:
         # Fire the exact SIGTERM handler the orchestrator installed, from a
         # SIGALRM tick landing while the main thread is blocked inside
         # run_with_timeout's communicate() -- the same real scenario an
-        # operator `kill` on the sweep process produces.
+        # operator `kill` on the sweep process produces. No-op until the
+        # probe reports ready so the grandchild is guaranteed to exist by
+        # the time the cancellation lands, on a loaded machine too.
+        ticks["count"] += 1
+        if not ready_path.exists():
+            if ticks["count"] >= timeouts_test._PROBE_MAX_TICKS:
+                signal.setitimer(signal.ITIMER_REAL, 0)
+                raise AssertionError("probe never reported readiness")
+            return
+        signal.setitimer(signal.ITIMER_REAL, 0)
         typed_handler = cast(Callable[[int, FrameType | None], None], sigterm_handler)
         typed_handler(signal.SIGTERM, frame)
 
     previous_alarm = signal.signal(signal.SIGALRM, _deliver_cancellation)
-    signal.alarm(1)
+    signal.setitimer(signal.ITIMER_REAL, timeouts_test._PROBE_TICK_S, timeouts_test._PROBE_TICK_S)
     try:
-        with pytest.raises(orchestrator.SweepCancelled):
-            timeouts.run_with_timeout([sys.executable, "-c", script], timeout_s=0)
+        with pytest.raises(orchestrator.SweepCancelled) as cancelled:
+            timeouts.run_with_timeout(argv, timeout_s=timeouts_test._PRODUCTION_LIKE_TIMEOUT_S)
     finally:
-        signal.alarm(0)
+        signal.setitimer(signal.ITIMER_REAL, 0)
         signal.signal(signal.SIGALRM, previous_alarm)
         orchestrator._restore_sweep_sigterm_shim(previous_sigterm)
 
-    child_pid = int(pid_file.read_text(encoding="utf-8"))
-    deadline = time.monotonic() + 2.0
-    while _pid_exists(child_pid) and time.monotonic() < deadline:
-        time.sleep(0.05)
-    assert not _pid_exists(child_pid)
-
-
-def _pid_exists(pid: int) -> bool:
-    try:
-        os.kill(pid, 0)
-    except ProcessLookupError:
-        return False
-    except PermissionError:
-        return True
-    return True
+    child_pid = int(child_pid_path.read_text(encoding="utf-8"))
+    grandchild_pid = int(grandchild_pid_path.read_text(encoding="utf-8"))
+    assert timeouts_test._await_process_state(grandchild_pid, {timeouts_test._PROC_GONE}) == timeouts_test._PROC_GONE
+    assert timeouts_test._await_process_state(child_pid, {timeouts_test._PROC_GONE}) == timeouts_test._PROC_GONE
+    # Keeps run_with_timeout's `proc` local reachable through the traceback
+    # for the duration of the assertions above; see _run_cancelled_probe.
+    assert isinstance(cancelled.value, orchestrator.SweepCancelled)

--- a/tests/uat/test_timeouts.py
+++ b/tests/uat/test_timeouts.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import os
+import signal
 import subprocess
 import sys
 import time
@@ -141,6 +142,112 @@ def test_kill_process_group_uses_killpg_when_available(monkeypatch):
 
     assert calls == [(999, sigterm), (999, sigkill)]
     mock_proc.kill.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# uat-cell-teardown-orphans-child-processes-20260805 (w0/w1): a sweep
+# cancellation is `SweepCancelled`, a `KeyboardInterrupt` subclass -- NOT an
+# `Exception` -- so it used to propagate straight out of `communicate()`
+# with the child untouched. Both branches of `run_with_timeout` now guard
+# `communicate()` with `except BaseException: kill; raise`.
+# ---------------------------------------------------------------------------
+
+
+def test_run_with_timeout_kills_group_on_base_exception_before_reraising(monkeypatch):
+    """A BaseException (e.g. SweepCancelled) raised while blocked in
+    communicate() must trigger the group-kill ladder BEFORE it escapes
+    run_with_timeout -- not just subprocess.TimeoutExpired."""
+
+    class _Cancelled(KeyboardInterrupt):
+        pass
+
+    class FakeProc:
+        pid = 4242
+        returncode = None
+
+        def communicate(self, timeout=None):
+            raise _Cancelled("simulated sweep cancellation")
+
+        def kill(self):
+            pass
+
+    monkeypatch.setattr(timeouts.subprocess, "Popen", lambda *a, **k: FakeProc())
+    killpg_calls: list[tuple[int, object]] = []
+    monkeypatch.setattr(timeouts.os, "killpg", lambda pid, sig: killpg_calls.append((pid, sig)))
+
+    with pytest.raises(_Cancelled):
+        timeouts.run_with_timeout([sys.executable, "-c", "pass"], timeout_s=5)
+
+    # killpg fired (SIGTERM, then SIGKILL after the 200ms ladder sleep) before
+    # the cancellation escaped -- proving the kill happens, not just that the
+    # exception eventually propagates.
+    assert killpg_calls[0] == (4242, timeouts.signal.SIGTERM)
+    assert killpg_calls[-1] == (4242, timeouts.signal.SIGKILL)
+
+
+def test_run_with_timeout_zero_timeout_kills_group_on_base_exception(monkeypatch):
+    """The timeout_s == 0 branch must use the same guarded-kill Popen path as
+    the timed branch, not the old bare subprocess.run with no teardown."""
+
+    class _Cancelled(KeyboardInterrupt):
+        pass
+
+    class FakeProc:
+        pid = 4343
+        returncode = None
+
+        def communicate(self, timeout=None):
+            raise _Cancelled("simulated sweep cancellation")
+
+        def kill(self):
+            pass
+
+    monkeypatch.setattr(timeouts.subprocess, "Popen", lambda *a, **k: FakeProc())
+    killpg_calls: list[tuple[int, object]] = []
+    monkeypatch.setattr(timeouts.os, "killpg", lambda pid, sig: killpg_calls.append((pid, sig)))
+
+    with pytest.raises(_Cancelled):
+        timeouts.run_with_timeout([sys.executable, "-c", "pass"], timeout_s=0)
+
+    assert killpg_calls[0] == (4343, timeouts.signal.SIGTERM)
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="POSIX-only kill ladder / SIGALRM")
+def test_run_with_timeout_zero_timeout_kills_real_child_on_cancellation(tmp_path):
+    """Real-process proof for the timeout_s == 0 branch: a genuine spawned
+    grandchild-capable child must not survive a BaseException landing while
+    run_with_timeout blocks in communicate() -- a mocked communicate() could
+    look correct while a real process kept running."""
+    pid_file = tmp_path / "child.pid"
+    script = f"""
+import pathlib
+import os
+import time
+
+pathlib.Path({str(pid_file)!r}).write_text(str(os.getpid()), encoding="utf-8")
+time.sleep(30)
+"""
+
+    class _Cancelled(KeyboardInterrupt):
+        pass
+
+    def _raise_cancel(signum, frame):
+        raise _Cancelled("simulated sweep cancellation")
+
+    previous = signal.signal(signal.SIGALRM, _raise_cancel)
+    signal.alarm(1)
+    try:
+        with pytest.raises(_Cancelled):
+            timeouts.run_with_timeout([sys.executable, "-c", script], timeout_s=0)
+    finally:
+        signal.alarm(0)
+        signal.signal(signal.SIGALRM, previous)
+
+    child_pid = int(pid_file.read_text(encoding="utf-8"))
+    deadline = time.monotonic() + 2.0
+    while _pid_exists(child_pid) and time.monotonic() < deadline:
+        time.sleep(0.05)
+    assert not _pid_exists(child_pid)
 
 
 def _pid_exists(pid: int) -> bool:

--- a/tests/uat/test_timeouts.py
+++ b/tests/uat/test_timeouts.py
@@ -171,9 +171,18 @@ def test_run_with_timeout_kills_group_on_base_exception_before_reraising(monkeyp
         def kill(self):
             pass
 
-    monkeypatch.setattr(timeouts.subprocess, "Popen", lambda *a, **k: FakeProc())
+    sigterm = object()
+    sigkill = object()
     killpg_calls: list[tuple[int, object]] = []
-    monkeypatch.setattr(timeouts.os, "killpg", lambda pid, sig: killpg_calls.append((pid, sig)))
+
+    monkeypatch.setattr(timeouts.subprocess, "Popen", lambda *a, **k: FakeProc())
+    # raising=False so this also runs on win32, where os.killpg/SIGKILL do not
+    # exist: injecting them makes the hasattr guard take the POSIX branch,
+    # which is exactly the ladder under test -- same technique as
+    # test_kill_process_group_uses_killpg_when_available above.
+    monkeypatch.setattr(timeouts.os, "killpg", lambda pid, sig: killpg_calls.append((pid, sig)), raising=False)
+    monkeypatch.setattr(timeouts.signal, "SIGTERM", sigterm, raising=False)
+    monkeypatch.setattr(timeouts.signal, "SIGKILL", sigkill, raising=False)
 
     with pytest.raises(_Cancelled):
         timeouts.run_with_timeout([sys.executable, "-c", "pass"], timeout_s=5)
@@ -181,8 +190,8 @@ def test_run_with_timeout_kills_group_on_base_exception_before_reraising(monkeyp
     # killpg fired (SIGTERM, then SIGKILL after the 200ms ladder sleep) before
     # the cancellation escaped -- proving the kill happens, not just that the
     # exception eventually propagates.
-    assert killpg_calls[0] == (4242, timeouts.signal.SIGTERM)
-    assert killpg_calls[-1] == (4242, timeouts.signal.SIGKILL)
+    assert killpg_calls[0] == (4242, sigterm)
+    assert killpg_calls[-1] == (4242, sigkill)
 
 
 def test_run_with_timeout_zero_timeout_kills_group_on_base_exception(monkeypatch):
@@ -202,14 +211,20 @@ def test_run_with_timeout_zero_timeout_kills_group_on_base_exception(monkeypatch
         def kill(self):
             pass
 
-    monkeypatch.setattr(timeouts.subprocess, "Popen", lambda *a, **k: FakeProc())
+    sigterm = object()
+    sigkill = object()
     killpg_calls: list[tuple[int, object]] = []
-    monkeypatch.setattr(timeouts.os, "killpg", lambda pid, sig: killpg_calls.append((pid, sig)))
+
+    monkeypatch.setattr(timeouts.subprocess, "Popen", lambda *a, **k: FakeProc())
+    # raising=False -- see the sibling timed-branch test above for why.
+    monkeypatch.setattr(timeouts.os, "killpg", lambda pid, sig: killpg_calls.append((pid, sig)), raising=False)
+    monkeypatch.setattr(timeouts.signal, "SIGTERM", sigterm, raising=False)
+    monkeypatch.setattr(timeouts.signal, "SIGKILL", sigkill, raising=False)
 
     with pytest.raises(_Cancelled):
         timeouts.run_with_timeout([sys.executable, "-c", "pass"], timeout_s=0)
 
-    assert killpg_calls[0] == (4343, timeouts.signal.SIGTERM)
+    assert killpg_calls[0] == (4343, sigterm)
 
 
 @pytest.mark.skipif(sys.platform == "win32", reason="POSIX-only kill ladder / SIGALRM")

--- a/tests/uat/test_timeouts.py
+++ b/tests/uat/test_timeouts.py
@@ -7,6 +7,8 @@ import signal
 import subprocess
 import sys
 import time
+from dataclasses import dataclass
+from pathlib import Path
 from unittest.mock import Mock
 
 import pytest
@@ -67,11 +69,8 @@ time.sleep(30)
 
     assert result.timed_out is True
     assert result.exit_code == timeouts.EXIT_TIMEOUT
-    child_pid = int(pid_file.read_text(encoding="utf-8"))
-    deadline = time.monotonic() + 2.0
-    while _pid_exists(child_pid) and time.monotonic() < deadline:
-        time.sleep(0.05)
-    assert not _pid_exists(child_pid)
+    grandchild_pid = int(pid_file.read_text(encoding="utf-8"))
+    assert _await_process_state(grandchild_pid, {_PROC_GONE}) == _PROC_GONE
 
 
 @pytest.mark.skipif(sys.platform == "win32", reason="POSIX timeout semantics")
@@ -171,6 +170,9 @@ def test_run_with_timeout_kills_group_on_base_exception_before_reraising(monkeyp
         def kill(self):
             pass
 
+        def wait(self, timeout=None):
+            return 0
+
     sigterm = object()
     sigkill = object()
     killpg_calls: list[tuple[int, object]] = []
@@ -211,6 +213,9 @@ def test_run_with_timeout_zero_timeout_kills_group_on_base_exception(monkeypatch
         def kill(self):
             pass
 
+        def wait(self, timeout=None):
+            return 0
+
     sigterm = object()
     sigkill = object()
     killpg_calls: list[tuple[int, object]] = []
@@ -228,48 +233,292 @@ def test_run_with_timeout_zero_timeout_kills_group_on_base_exception(monkeypatch
 
 
 @pytest.mark.skipif(sys.platform == "win32", reason="POSIX-only kill ladder / SIGALRM")
-def test_run_with_timeout_zero_timeout_kills_real_child_on_cancellation(tmp_path):
-    """Real-process proof for the timeout_s == 0 branch: a genuine spawned
-    grandchild-capable child must not survive a BaseException landing while
-    run_with_timeout blocks in communicate() -- a mocked communicate() could
-    look correct while a real process kept running."""
-    pid_file = tmp_path / "child.pid"
-    script = f"""
-import pathlib
+def test_cancellation_kills_trapping_child_and_grandchild(tmp_path):
+    """Production-path real-process proof: cancel a cell on the *timed*
+    branch and neither the child nor its grandchild may survive.
+
+    This is the capability the branch exists for, so every axis is the
+    production one:
+
+    * a positive `timeout_s`, not 0 -- a sweep can never reach the
+      zero-timeout branch (`runner.run_cell` defaults `timeout_s=600`,
+      `phases/execute.py` passes `config.execute.per_cell_timeout_s`, and
+      `config.py` rejects `<= 0`), so a cancellation test pinned at 0 tests
+      code no operator can run;
+    * a real GRANDCHILD -- the direct child died on the pre-fix code too
+      (`subprocess.run` kills it, `Popen` + `TimeoutExpired` at least left a
+      handle); descendants are what leaked, so descendants are what the
+      assertion has to be about;
+    * a child that TRAPS SIGTERM, like the database servers a real cell
+      spawns, so the group survives the grace window and the SIGKILL rung is
+      actually exercised rather than skipped;
+    * a "gone" check that cannot be satisfied by a zombie or by CPython's
+      `Popen` finalizer -- see `_process_state`.
+    """
+    probe = _run_cancelled_probe(tmp_path, timeout_s=_PRODUCTION_LIKE_TIMEOUT_S)
+
+    assert probe.sigterm_path.exists(), "SIGTERM rung never reached the child"
+    assert _await_process_state(probe.grandchild_pid, {_PROC_GONE}) == _PROC_GONE
+    assert _await_process_state(probe.child_pid, {_PROC_GONE}) == _PROC_GONE
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="POSIX-only kill ladder / SIGALRM")
+def test_zero_timeout_cancellation_kills_trapping_child_and_grandchild(tmp_path):
+    """Same proof for `timeout_s == 0`.
+
+    Kept alongside the production-path test because it is the only thing
+    that can see the zero-timeout branch regress: reverting it to the
+    original bare `subprocess.run` leaves the direct child dead (that call
+    has its own `except BaseException: process.kill()` and a context manager
+    that `wait()`s) but never calls `setsid()` and never signals a group, so
+    the grandchild survives.
+    """
+    probe = _run_cancelled_probe(tmp_path, timeout_s=0)
+
+    assert probe.sigterm_path.exists(), "SIGTERM rung never reached the child"
+    assert _await_process_state(probe.grandchild_pid, {_PROC_GONE}) == _PROC_GONE
+    assert _await_process_state(probe.child_pid, {_PROC_GONE}) == _PROC_GONE
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="POSIX-only kill ladder / SIGALRM")
+def test_kill_ladder_completes_sigkill_when_interrupted_during_grace(tmp_path):
+    """A second signal inside the grace window must not drop the SIGKILL.
+
+    An exception raised inside one `except` clause is not caught by a
+    sibling `except` of the same `try`. So a cancellation landing in
+    `_kill_process_group`'s 200 ms sleep used to unwind straight out of
+    `run_with_timeout` with SIGTERM as the only signal ever delivered --
+    and against a SIGTERM-trapping child (a database server running its own
+    shutdown) that means nothing dies. Exactly the operator sequence that
+    produces it: `kill` the sweep, see nothing exit, `kill` it again.
+
+    The child is reaped here rather than polled for disappearance: this
+    path deliberately skips `_kill_and_reap_process_group`'s `wait()` (the
+    second signal unwinds through it), so the child is a zombie and
+    `waitpid` can report *how* it died. `WTERMSIG == SIGKILL` is the direct
+    assertion that the second rung ran.
+    """
+    probe = _run_cancelled_probe(tmp_path, timeout_s=_PRODUCTION_LIKE_TIMEOUT_S, deliveries=2)
+
+    assert _await_process_state(probe.grandchild_pid, {_PROC_GONE}) == _PROC_GONE
+    status = _reap(probe.child_pid)
+    assert status is not None, "child was never reaped -- it outlived the interrupted ladder"
+    assert os.WIFSIGNALED(status), f"child exited normally (status={status}) instead of being killed"
+    assert os.WTERMSIG(status) == signal.SIGKILL
+
+
+# ---------------------------------------------------------------------------
+# Real-process probe + process-state helpers.
+#
+# `os.kill(pid, 0)` is the wrong predicate for teardown assertions and was
+# duplicated verbatim in test_sweep_durability.py; both problems are fixed
+# here and that module imports these.
+# ---------------------------------------------------------------------------
+
+_PROC_GONE = "gone"
+_PROC_ZOMBIE = "zombie"
+_PROC_LIVE = "live"
+
+# Any positive value takes the same timed branch as the 600 s
+# `execute.per_cell_timeout_s` default; small enough that a wedged probe
+# fails the suite in seconds instead of stalling it for ten minutes.
+_PRODUCTION_LIKE_TIMEOUT_S = 30
+
+# Gate polling for the probe, bounded so nothing here can wait forever. The
+# tick has to be short relative to `timeouts._KILL_GRACE_S`, because one of the
+# gates is "the kill ladder has entered its grace window".
+_PROBE_TICK_S = 0.02
+_PROBE_MAX_TICKS = 500
+_STATE_TIMEOUT_S = 5.0
+
+# Ignores SIGTERM, so its disappearance can only be the group SIGKILL rung.
+_GRANDCHILD_SRC = "import signal, time; signal.signal(signal.SIGTERM, signal.SIG_IGN); time.sleep(600)"
+
+_CANCEL_PROBE_SRC = """
 import os
+import pathlib
+import signal
+import subprocess
+import sys
 import time
 
-pathlib.Path({str(pid_file)!r}).write_text(str(os.getpid()), encoding="utf-8")
-time.sleep(30)
+child_pid_path, grandchild_pid_path, sigterm_path, ready_path, grandchild_src = sys.argv[1:6]
+
+
+def _trap_sigterm(signum, frame):
+    # Acknowledge and survive, the way a database server runs its own
+    # shutdown: the ladder must escalate to SIGKILL to end this process.
+    pathlib.Path(sigterm_path).write_text("1", encoding="utf-8")
+
+
+signal.signal(signal.SIGTERM, _trap_sigterm)
+
+grandchild = subprocess.Popen([sys.executable, "-c", grandchild_src])
+pathlib.Path(grandchild_pid_path).write_text(str(grandchild.pid), encoding="utf-8")
+pathlib.Path(child_pid_path).write_text(str(os.getpid()), encoding="utf-8")
+pathlib.Path(ready_path).write_text("1", encoding="utf-8")
+
+while True:
+    time.sleep(0.05)
 """
 
-    class _Cancelled(KeyboardInterrupt):
-        pass
 
-    def _raise_cancel(signum, frame):
+class _Cancelled(KeyboardInterrupt):
+    """Stand-in for orchestrator.SweepCancelled: a BaseException, not an Exception."""
+
+
+@dataclass(frozen=True)
+class _ProbeOutcome:
+    child_pid: int
+    grandchild_pid: int
+    sigterm_path: Path
+    cancelled: pytest.ExceptionInfo[_Cancelled]
+
+
+def _run_cancelled_probe(tmp_path: Path, *, timeout_s: int, deliveries: int = 1) -> _ProbeOutcome:
+    """Cancel `run_with_timeout` around a real child that owns a grandchild.
+
+    Cancellations are driven by a repeating interval timer whose handler
+    no-ops until a *gate file* proves the target moment has arrived, rather
+    than by a fixed `alarm(1)` that has to guess. Both gates are causal, so
+    the test is not timing-tuned:
+
+    * gate 1, `child.ready` -- the probe has spawned its grandchild and
+      recorded both pids, so the cancellation is guaranteed to land while
+      `run_with_timeout` is blocked in `communicate()` with a full
+      descendant tree alive, on a loaded machine as well as an idle one;
+    * gate 2, `child.sigterm` -- the child's SIGTERM trap has fired, i.e.
+      the kill ladder has just entered its 200 ms grace window, which is
+      exactly where a follow-up signal has to land.
+
+    Gate 2 cannot be replaced by "N ms after gate 1": CPython's
+    `Popen.wait()`/`communicate()` deliberately swallow the first
+    `KeyboardInterrupt` and re-`_wait` for `_sigint_wait_secs` (0.25 s by
+    default) before re-raising it (bpo-25942), so the first cancellation
+    reaches `run_with_timeout`'s handler a quarter of a second late and a
+    fixed follow-up interval lands back inside `communicate()` instead of
+    inside the ladder.
+
+    `_PROBE_MAX_TICKS` bounds the whole thing, so a probe that never
+    reaches a gate fails the test instead of hanging it.
+    """
+    child_pid_path = tmp_path / "child.pid"
+    grandchild_pid_path = tmp_path / "grandchild.pid"
+    sigterm_path = tmp_path / "child.sigterm"
+    ready_path = tmp_path / "child.ready"
+    argv = [
+        sys.executable,
+        "-c",
+        _CANCEL_PROBE_SRC,
+        str(child_pid_path),
+        str(grandchild_pid_path),
+        str(sigterm_path),
+        str(ready_path),
+        _GRANDCHILD_SRC,
+    ]
+    gates = [ready_path, sigterm_path][:deliveries]
+    counters = {"ticks": 0, "delivered": 0}
+
+    def _on_alarm(signum: int, frame: object) -> None:
+        counters["ticks"] += 1
+        if counters["ticks"] >= _PROBE_MAX_TICKS:
+            signal.setitimer(signal.ITIMER_REAL, 0)
+            raise AssertionError(f"probe never reached gate {gates[counters['delivered']].name}")
+        if not gates[counters["delivered"]].exists():
+            return
+        counters["delivered"] += 1
+        if counters["delivered"] >= deliveries:
+            signal.setitimer(signal.ITIMER_REAL, 0)
         raise _Cancelled("simulated sweep cancellation")
 
-    previous = signal.signal(signal.SIGALRM, _raise_cancel)
-    signal.alarm(1)
+    assert len(gates) == deliveries, "no gate defined for that many deliveries"
+    previous = signal.signal(signal.SIGALRM, _on_alarm)
+    signal.setitimer(signal.ITIMER_REAL, _PROBE_TICK_S, _PROBE_TICK_S)
     try:
-        with pytest.raises(_Cancelled):
-            timeouts.run_with_timeout([sys.executable, "-c", script], timeout_s=0)
+        with pytest.raises(_Cancelled) as cancelled:
+            timeouts.run_with_timeout(argv, timeout_s=timeout_s)
     finally:
-        signal.alarm(0)
+        signal.setitimer(signal.ITIMER_REAL, 0)
         signal.signal(signal.SIGALRM, previous)
 
-    child_pid = int(pid_file.read_text(encoding="utf-8"))
-    deadline = time.monotonic() + 2.0
-    while _pid_exists(child_pid) and time.monotonic() < deadline:
-        time.sleep(0.05)
-    assert not _pid_exists(child_pid)
+    assert counters["delivered"] == deliveries
+    return _ProbeOutcome(
+        child_pid=int(child_pid_path.read_text(encoding="utf-8")),
+        grandchild_pid=int(grandchild_pid_path.read_text(encoding="utf-8")),
+        sigterm_path=sigterm_path,
+        # Held deliberately. `cancelled` keeps the traceback alive, and with
+        # it `run_with_timeout`'s `proc` local; drop it and CPython's
+        # `Popen.__del__` reaps the child, so "pid gone" would pass for a
+        # garbage-collection reason with nothing to do with the code under
+        # test.
+        cancelled=cancelled,
+    )
 
 
-def _pid_exists(pid: int) -> bool:
+def _process_state(pid: int) -> str:
+    """Classify `pid` as gone / zombie / live.
+
+    `os.kill(pid, 0)` on its own is not a teardown predicate: it succeeds
+    for a `<defunct>` zombie, so it measures *reaping* rather than killing,
+    and the reaper is often CPython's `Popen` finalizer rather than
+    `timeouts.py`. Reading the state makes "terminated" and "still
+    scheduled" distinguishable and makes a zombie an explicit third answer.
+    """
     try:
         os.kill(pid, 0)
     except ProcessLookupError:
-        return False
+        return _PROC_GONE
     except PermissionError:
-        return True
-    return True
+        return _PROC_LIVE
+    linux_stat = Path(f"/proc/{pid}/stat")
+    try:
+        raw = linux_stat.read_text(encoding="utf-8")
+    except FileNotFoundError:
+        return _bsd_process_state(pid)
+    except OSError:
+        return _PROC_LIVE
+    # Field 3 is the state code; comm (field 2) is parenthesised and may
+    # itself contain spaces, so split after the final ')'.
+    fields = raw.rpartition(")")[2].split()
+    return _PROC_ZOMBIE if fields and fields[0] == "Z" else _PROC_LIVE
+
+
+def _bsd_process_state(pid: int) -> str:
+    """macOS/BSD fallback: `ps` state code ('Z', 'Ss', 'S+', ...)."""
+    try:
+        completed = subprocess.run(
+            ["ps", "-o", "state=", "-p", str(pid)],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+    except OSError:
+        return _PROC_LIVE
+    state = completed.stdout.strip()
+    if not state:
+        return _PROC_GONE
+    return _PROC_ZOMBIE if state.startswith("Z") else _PROC_LIVE
+
+
+def _await_process_state(pid: int, accepted: set[str], *, timeout_s: float = _STATE_TIMEOUT_S) -> str:
+    """Poll until `pid` reaches one of `accepted`, or `timeout_s` elapses."""
+    deadline = time.monotonic() + timeout_s
+    state = _process_state(pid)
+    while state not in accepted and time.monotonic() < deadline:
+        time.sleep(0.02)
+        state = _process_state(pid)
+    return state
+
+
+def _reap(pid: int, *, timeout_s: float = _STATE_TIMEOUT_S) -> int | None:
+    """`waitpid(WNOHANG)` until `pid` is collected; None if it never is."""
+    deadline = time.monotonic() + timeout_s
+    while time.monotonic() < deadline:
+        try:
+            reaped, status = os.waitpid(pid, os.WNOHANG)
+        except ChildProcessError:
+            return None
+        if reaped == pid:
+            return status
+        time.sleep(0.02)
+    return None

--- a/tests/uat/timeouts.py
+++ b/tests/uat/timeouts.py
@@ -15,6 +15,15 @@ from typing import Any, Mapping
 
 EXIT_TIMEOUT = 124  # POSIX coreutils convention: SIGTERM after timeout.
 
+# Live child process groups spawned by `run_with_timeout`, keyed by pid
+# (== pgid under `setsid`). Registered right after `Popen()` and drained on
+# every exit path (including the finally below), so a sweep cancellation
+# landing in the narrow window between `Popen()` returning and this
+# function's own try/except being entered still has a kill path: the
+# orchestrator's SIGTERM shim calls `drain_live_process_groups()` before it
+# raises `SweepCancelled` (uat-cell-teardown-orphans-child-processes w2).
+_LIVE_PROCESS_GROUPS: dict[int, subprocess.Popen] = {}
+
 
 @dataclass(frozen=True)
 class TimeoutResult:
@@ -45,23 +54,50 @@ def run_with_timeout(
     `stdout` and `stderr` accept anything `subprocess.Popen` would. When
     callers pass `subprocess.PIPE`, this wrapper drains the pipes with
     `communicate()` so a noisy child cannot block timeout enforcement.
+
+    Both branches (`timeout_s == 0` and the timed branch) use `Popen` and
+    guard `communicate()` with `except BaseException: kill; raise`. This
+    matters because `SweepCancelled` (tests/uat/orchestrator.py) subclasses
+    `KeyboardInterrupt`, which is NOT an `Exception` -- an
+    `except subprocess.TimeoutExpired` (or `except Exception`) clause never
+    fires for it, so without a `BaseException` handler a sweep cancellation
+    propagates straight out of `communicate()` with the child untouched
+    (uat-cell-teardown-orphans-child-processes-20260805).
     """
     import time
 
     start = time.monotonic()
-    if timeout_s == 0:
-        proc = subprocess.run(argv, stdout=stdout, stderr=stderr, env=env, cwd=cwd, check=False)
-        return TimeoutResult(
-            exit_code=proc.returncode,
-            timed_out=False,
-            elapsed_s=time.monotonic() - start,
-            stdout=proc.stdout,
-            stderr=proc.stderr,
-        )
-
     # New session so we can kill the whole process group; matches the
-    # `setsid()` call in the perl wrapper.
+    # `setsid()` call in the perl wrapper. Applies to both branches below --
+    # the zero-timeout branch used to skip this entirely via a bare
+    # `subprocess.run`, which left it with no teardown path at all.
     preexec = os.setsid if sys.platform != "win32" else None
+
+    if timeout_s == 0:
+        proc = subprocess.Popen(
+            argv,
+            stdout=stdout,
+            stderr=stderr,
+            env=env,
+            cwd=cwd,
+            preexec_fn=preexec,
+        )
+        _register_live_group(proc)
+        try:
+            out, err = proc.communicate()
+            return TimeoutResult(
+                exit_code=proc.returncode,
+                timed_out=False,
+                elapsed_s=time.monotonic() - start,
+                stdout=out,
+                stderr=err,
+            )
+        except BaseException:
+            _kill_process_group(proc)
+            raise
+        finally:
+            _unregister_live_group(proc)
+
     proc = subprocess.Popen(
         argv,
         stdout=stdout,
@@ -70,30 +106,41 @@ def run_with_timeout(
         cwd=cwd,
         preexec_fn=preexec,
     )
+    _register_live_group(proc)
     try:
-        out, err = proc.communicate(timeout=timeout_s)
-        return TimeoutResult(
-            exit_code=proc.returncode,
-            timed_out=False,
-            elapsed_s=time.monotonic() - start,
-            stdout=out,
-            stderr=err,
-        )
-    except subprocess.TimeoutExpired:
-        _kill_process_group(proc)
         try:
-            out, err = proc.communicate(timeout=1.0)
+            out, err = proc.communicate(timeout=timeout_s)
+            return TimeoutResult(
+                exit_code=proc.returncode,
+                timed_out=False,
+                elapsed_s=time.monotonic() - start,
+                stdout=out,
+                stderr=err,
+            )
         except subprocess.TimeoutExpired:
-            # SIGKILL did not reap or output could not drain; keep timeout
-            # classification stable and return without blocking the caller.
-            out, err = None, None
-        return TimeoutResult(
-            exit_code=EXIT_TIMEOUT,
-            timed_out=True,
-            elapsed_s=time.monotonic() - start,
-            stdout=out,
-            stderr=err,
-        )
+            _kill_process_group(proc)
+            try:
+                out, err = proc.communicate(timeout=1.0)
+            except subprocess.TimeoutExpired:
+                # SIGKILL did not reap or output could not drain; keep timeout
+                # classification stable and return without blocking the caller.
+                out, err = None, None
+            return TimeoutResult(
+                exit_code=EXIT_TIMEOUT,
+                timed_out=True,
+                elapsed_s=time.monotonic() - start,
+                stdout=out,
+                stderr=err,
+            )
+        except BaseException:
+            # Any other unwind (SweepCancelled/KeyboardInterrupt included --
+            # see the docstring above) still reaps the group before
+            # propagating unchanged: the sweep must keep unwinding so the
+            # platform teardown and finalize markers run.
+            _kill_process_group(proc)
+            raise
+    finally:
+        _unregister_live_group(proc)
 
 
 def _kill_process_group(proc: subprocess.Popen) -> None:
@@ -121,3 +168,32 @@ def _kill_process_group(proc: subprocess.Popen) -> None:
         os.killpg(proc.pid, signal.SIGKILL)
     except (ProcessLookupError, PermissionError):
         return
+
+
+def _register_live_group(proc: subprocess.Popen) -> None:
+    """Track a just-`Popen`'d child so `drain_live_process_groups` can reap it.
+
+    Covers the window between `Popen()` returning and `run_with_timeout`
+    entering its own try/except: a cancellation landing there would
+    otherwise unwind past this function with no kill call armed yet.
+    """
+    _LIVE_PROCESS_GROUPS[proc.pid] = proc
+
+
+def _unregister_live_group(proc: subprocess.Popen) -> None:
+    _LIVE_PROCESS_GROUPS.pop(proc.pid, None)
+
+
+def drain_live_process_groups() -> None:
+    """Kill and clear every currently-registered live child process group.
+
+    Called by the sweep orchestrator's SIGTERM handler
+    (`orchestrator._install_sweep_sigterm_shim`) before it raises
+    `SweepCancelled`, so a signal landing in the narrow gap between a
+    child's `Popen()` and `run_with_timeout`'s own `except BaseException`
+    guard still gets reaped instead of orphaned
+    (uat-cell-teardown-orphans-child-processes-20260805 w2).
+    """
+    for proc in list(_LIVE_PROCESS_GROUPS.values()):
+        _kill_process_group(proc)
+    _LIVE_PROCESS_GROUPS.clear()

--- a/tests/uat/timeouts.py
+++ b/tests/uat/timeouts.py
@@ -15,15 +15,6 @@ from typing import Any, Mapping
 
 EXIT_TIMEOUT = 124  # POSIX coreutils convention: SIGTERM after timeout.
 
-# Live child process groups spawned by `run_with_timeout`, keyed by pid
-# (== pgid under `setsid`). Registered right after `Popen()` and drained on
-# every exit path (including the finally below), so a sweep cancellation
-# landing in the narrow window between `Popen()` returning and this
-# function's own try/except being entered still has a kill path: the
-# orchestrator's SIGTERM shim calls `drain_live_process_groups()` before it
-# raises `SweepCancelled` (uat-cell-teardown-orphans-child-processes w2).
-_LIVE_PROCESS_GROUPS: dict[int, subprocess.Popen] = {}
-
 
 @dataclass(frozen=True)
 class TimeoutResult:
@@ -63,6 +54,17 @@ def run_with_timeout(
     fires for it, so without a `BaseException` handler a sweep cancellation
     propagates straight out of `communicate()` with the child untouched
     (uat-cell-teardown-orphans-child-processes-20260805).
+
+    `Popen()` itself runs *inside* the guarded `try` (with `proc` seeded to
+    `None` beforehand) rather than being called and assigned before the
+    `try` starts. That closes the gap a cancellation landing between
+    `Popen()` returning and a subsequent statement would otherwise fall
+    into, without needing any registry of live children outside this
+    function: `except BaseException` only calls `_kill_process_group` when
+    `proc is not None`, i.e. once `Popen()` has actually returned a handle.
+    A signal arriving before that point has no process to kill yet; one
+    arriving after it is caught by this same guard regardless of exactly
+    which line was executing.
     """
     import time
 
@@ -74,16 +76,16 @@ def run_with_timeout(
     preexec = os.setsid if sys.platform != "win32" else None
 
     if timeout_s == 0:
-        proc = subprocess.Popen(
-            argv,
-            stdout=stdout,
-            stderr=stderr,
-            env=env,
-            cwd=cwd,
-            preexec_fn=preexec,
-        )
-        _register_live_group(proc)
+        proc: subprocess.Popen | None = None
         try:
+            proc = subprocess.Popen(
+                argv,
+                stdout=stdout,
+                stderr=stderr,
+                env=env,
+                cwd=cwd,
+                preexec_fn=preexec,
+            )
             out, err = proc.communicate()
             return TimeoutResult(
                 exit_code=proc.returncode,
@@ -93,54 +95,54 @@ def run_with_timeout(
                 stderr=err,
             )
         except BaseException:
-            _kill_process_group(proc)
+            if proc is not None:
+                _kill_process_group(proc)
             raise
-        finally:
-            _unregister_live_group(proc)
 
-    proc = subprocess.Popen(
-        argv,
-        stdout=stdout,
-        stderr=stderr,
-        env=env,
-        cwd=cwd,
-        preexec_fn=preexec,
-    )
-    _register_live_group(proc)
+    proc = None
     try:
+        proc = subprocess.Popen(
+            argv,
+            stdout=stdout,
+            stderr=stderr,
+            env=env,
+            cwd=cwd,
+            preexec_fn=preexec,
+        )
+        out, err = proc.communicate(timeout=timeout_s)
+        return TimeoutResult(
+            exit_code=proc.returncode,
+            timed_out=False,
+            elapsed_s=time.monotonic() - start,
+            stdout=out,
+            stderr=err,
+        )
+    except subprocess.TimeoutExpired:
+        # Only raised by the `proc.communicate(timeout=...)` call above, so
+        # `proc` is always assigned here.
+        assert proc is not None
+        _kill_process_group(proc)
         try:
-            out, err = proc.communicate(timeout=timeout_s)
-            return TimeoutResult(
-                exit_code=proc.returncode,
-                timed_out=False,
-                elapsed_s=time.monotonic() - start,
-                stdout=out,
-                stderr=err,
-            )
+            out, err = proc.communicate(timeout=1.0)
         except subprocess.TimeoutExpired:
+            # SIGKILL did not reap or output could not drain; keep timeout
+            # classification stable and return without blocking the caller.
+            out, err = None, None
+        return TimeoutResult(
+            exit_code=EXIT_TIMEOUT,
+            timed_out=True,
+            elapsed_s=time.monotonic() - start,
+            stdout=out,
+            stderr=err,
+        )
+    except BaseException:
+        # Any other unwind (SweepCancelled/KeyboardInterrupt included -- see
+        # the docstring above) still reaps the group, when one was actually
+        # spawned, before propagating unchanged: the sweep must keep
+        # unwinding so the platform teardown and finalize markers run.
+        if proc is not None:
             _kill_process_group(proc)
-            try:
-                out, err = proc.communicate(timeout=1.0)
-            except subprocess.TimeoutExpired:
-                # SIGKILL did not reap or output could not drain; keep timeout
-                # classification stable and return without blocking the caller.
-                out, err = None, None
-            return TimeoutResult(
-                exit_code=EXIT_TIMEOUT,
-                timed_out=True,
-                elapsed_s=time.monotonic() - start,
-                stdout=out,
-                stderr=err,
-            )
-        except BaseException:
-            # Any other unwind (SweepCancelled/KeyboardInterrupt included --
-            # see the docstring above) still reaps the group before
-            # propagating unchanged: the sweep must keep unwinding so the
-            # platform teardown and finalize markers run.
-            _kill_process_group(proc)
-            raise
-    finally:
-        _unregister_live_group(proc)
+        raise
 
 
 def _kill_process_group(proc: subprocess.Popen) -> None:
@@ -168,32 +170,3 @@ def _kill_process_group(proc: subprocess.Popen) -> None:
         os.killpg(proc.pid, signal.SIGKILL)
     except (ProcessLookupError, PermissionError):
         return
-
-
-def _register_live_group(proc: subprocess.Popen) -> None:
-    """Track a just-`Popen`'d child so `drain_live_process_groups` can reap it.
-
-    Covers the window between `Popen()` returning and `run_with_timeout`
-    entering its own try/except: a cancellation landing there would
-    otherwise unwind past this function with no kill call armed yet.
-    """
-    _LIVE_PROCESS_GROUPS[proc.pid] = proc
-
-
-def _unregister_live_group(proc: subprocess.Popen) -> None:
-    _LIVE_PROCESS_GROUPS.pop(proc.pid, None)
-
-
-def drain_live_process_groups() -> None:
-    """Kill and clear every currently-registered live child process group.
-
-    Called by the sweep orchestrator's SIGTERM handler
-    (`orchestrator._install_sweep_sigterm_shim`) before it raises
-    `SweepCancelled`, so a signal landing in the narrow gap between a
-    child's `Popen()` and `run_with_timeout`'s own `except BaseException`
-    guard still gets reaped instead of orphaned
-    (uat-cell-teardown-orphans-child-processes-20260805 w2).
-    """
-    for proc in list(_LIVE_PROCESS_GROUPS.values()):
-        _kill_process_group(proc)
-    _LIVE_PROCESS_GROUPS.clear()

--- a/tests/uat/timeouts.py
+++ b/tests/uat/timeouts.py
@@ -15,6 +15,11 @@ from typing import Any, Mapping
 
 EXIT_TIMEOUT = 124  # POSIX coreutils convention: SIGTERM after timeout.
 
+# SIGTERM -> SIGKILL grace, and the bounded `wait()` that follows the ladder so
+# a cancelled sweep does not leave `<defunct>` children behind.
+_KILL_GRACE_S = 0.2
+_REAP_TIMEOUT_S = 1.0
+
 
 @dataclass(frozen=True)
 class TimeoutResult:
@@ -46,25 +51,77 @@ def run_with_timeout(
     callers pass `subprocess.PIPE`, this wrapper drains the pipes with
     `communicate()` so a noisy child cannot block timeout enforcement.
 
+    Cancellation teardown
+    ---------------------
     Both branches (`timeout_s == 0` and the timed branch) use `Popen` and
-    guard `communicate()` with `except BaseException: kill; raise`. This
-    matters because `SweepCancelled` (tests/uat/orchestrator.py) subclasses
-    `KeyboardInterrupt`, which is NOT an `Exception` -- an
+    guard `communicate()` with `except BaseException: kill; reap; raise`.
+    This matters because `SweepCancelled` (tests/uat/orchestrator.py)
+    subclasses `KeyboardInterrupt`, which is NOT an `Exception` -- an
     `except subprocess.TimeoutExpired` (or `except Exception`) clause never
     fires for it, so without a `BaseException` handler a sweep cancellation
-    propagates straight out of `communicate()` with the child untouched
+    propagates straight out of `communicate()`
     (uat-cell-teardown-orphans-child-processes-20260805).
 
+    State the prior bug precisely, because the case for this change rests on
+    it: what leaked was *descendants*, not the direct child. The timed
+    branch already spawned into its own session but only handled
+    `TimeoutExpired`, so a cancellation left the entire cell process group
+    -- database server, datagen, benchbox itself -- running. The
+    zero-timeout branch used a bare `subprocess.run`, which has its own
+    `except BaseException: process.kill()` plus a context manager that
+    `wait()`s, so the direct child did die; but it never called `setsid()`
+    and never signalled a group, so every grandchild survived. Measured on
+    a child that spawns a grandchild:
+
+        pre-fix  (bare subprocess.run)   child=gone  grandchild=ALIVE
+        shipped  (Popen+setsid+killpg)   child=gone  grandchild=gone
+
+    Residual spawn-window exposure (measured, accepted)
+    ---------------------------------------------------
     `Popen()` itself runs *inside* the guarded `try` (with `proc` seeded to
     `None` beforehand) rather than being called and assigned before the
-    `try` starts. That closes the gap a cancellation landing between
-    `Popen()` returning and a subsequent statement would otherwise fall
-    into, without needing any registry of live children outside this
-    function: `except BaseException` only calls `_kill_process_group` when
-    `proc is not None`, i.e. once `Popen()` has actually returned a handle.
-    A signal arriving before that point has no process to kill yet; one
-    arriving after it is caught by this same guard regardless of exactly
-    which line was executing.
+    `try` starts. That catches any cancellation landing after `Popen()`
+    returns, without a registry of live children outside this function:
+    `except BaseException` only kills when `proc is not None`.
+
+    It does NOT close the window *inside* `Popen.__init__`. The child is
+    forked, `setsid()`-ed and exec'd while the parent is still blocked
+    reading the exec-status pipe, so a signal delivered in there finds
+    `proc is None`, the guard no-ops, and a live process in its own session
+    is orphaned (state `Ss`, not `Z`). Sweeping 150 SIGALRM deliveries
+    across that window produced 12 survivors.
+
+    Accepted rather than closed. `Popen()` returns in ~1 ms idle and ~3 ms
+    under 2x load, against an `execute.per_cell_timeout_s` that defaults to
+    600 s and is rejected at `<= 0` (tests/uat/config.py), so an operator
+    `kill` has to land inside roughly 3 ms out of every 600 s of cell, and
+    the result is one visible process rather than a silent leak.
+
+    What would close it, and why it is not done here: block SIGINT/SIGTERM
+    with `signal.pthread_sigmask` around the `Popen()` call and unblock
+    inside the guarded `try`, deferring delivery until `proc` is bound.
+    That is not free -- a child inherits the parent's blocked mask across
+    `fork` + `exec` (measured: a child spawned under a `{SIGINT, SIGTERM}`
+    block reports both blocked), so it also needs the mask cleared in
+    `preexec_fn`, and getting that wrong leaves every cell child deaf to
+    the SIGTERM rung of the ladder below -- a 100%-of-cells regression
+    traded against a ~0.0005% window. The other option, a module-level
+    registry of live process groups, was deliberately deleted on this
+    branch because 589 tests passed with it neutered; restoring it needs
+    tests that pin it first.
+
+    Tradeoff: both branches now detach into a new session
+    ----------------------------------------------------
+    `preexec_fn=os.setsid` now applies to the zero-timeout branch too, so
+    its child leaves the caller's foreground process group. Better under an
+    operator `kill` of the sweep: teardown reaches the whole descendant
+    tree instead of only the direct child. Worse under terminal-generated
+    signals: Ctrl-C (SIGINT) and Ctrl-\\ (SIGQUIT) are delivered to the
+    foreground process group, which the detached child has left, so it now
+    dies only via the ladder this wrapper runs -- and if the sweep process
+    is itself `kill -9`'d, nothing runs the ladder and the group is
+    orphaned. The timed branch already had that property; this extends it
+    to `timeout_s == 0`.
     """
     import time
 
@@ -72,7 +129,8 @@ def run_with_timeout(
     # New session so we can kill the whole process group; matches the
     # `setsid()` call in the perl wrapper. Applies to both branches below --
     # the zero-timeout branch used to skip this entirely via a bare
-    # `subprocess.run`, which left it with no teardown path at all.
+    # `subprocess.run`, so it reaped only the direct child and left every
+    # descendant running (see the docstring).
     preexec = os.setsid if sys.platform != "win32" else None
 
     if timeout_s == 0:
@@ -96,7 +154,7 @@ def run_with_timeout(
             )
         except BaseException:
             if proc is not None:
-                _kill_process_group(proc)
+                _kill_and_reap_process_group(proc)
             raise
 
     proc = None
@@ -118,9 +176,13 @@ def run_with_timeout(
             stderr=err,
         )
     except subprocess.TimeoutExpired:
-        # Only raised by the `proc.communicate(timeout=...)` call above, so
-        # `proc` is always assigned here.
-        assert proc is not None
+        if proc is None:  # pragma: no cover - unreachable
+            # Only `proc.communicate(timeout=...)` above can raise
+            # TimeoutExpired, so `proc` is always bound here. This is a real
+            # branch rather than an `assert` because `assert` is stripped
+            # under `python -O`: it would read as a runtime invariant while
+            # only ever narrowing the type for the checker.
+            raise
         _kill_process_group(proc)
         try:
             out, err = proc.communicate(timeout=1.0)
@@ -141,8 +203,35 @@ def run_with_timeout(
         # spawned, before propagating unchanged: the sweep must keep
         # unwinding so the platform teardown and finalize markers run.
         if proc is not None:
-            _kill_process_group(proc)
+            _kill_and_reap_process_group(proc)
         raise
+
+
+def _kill_and_reap_process_group(proc: subprocess.Popen) -> None:
+    """Run the kill ladder, then reap, so an unwinding caller leaves no zombie.
+
+    `_kill_process_group` only *signals*; nothing on the cancellation path
+    ever calls `wait()`, so without this the killed child lingers as
+    `<defunct>` until CPython's `Popen` finalizer happens to collect it.
+    Harmless in production (the sweep process is on its way out and the
+    zombie dies with it) but it makes "the pid disappeared" an untrustworthy
+    teardown assertion, because the disappearance is then attributable to
+    garbage collection rather than to this module.
+
+    Bounded and non-fatal: SIGKILL has already been delivered, so a child
+    still unreaped after `_REAP_TIMEOUT_S` is a kernel-level anomaly, not
+    something an unwinding sweep should block on.
+
+    Not reached when a *second* signal lands inside the ladder's grace
+    window -- that unwinds out of `_kill_process_group` after its `finally`
+    has delivered SIGKILL, skipping this reap. Accepted residue: the group
+    is dead either way, only the `<defunct>` entry survives.
+    """
+    _kill_process_group(proc)
+    try:
+        proc.wait(timeout=_REAP_TIMEOUT_S)
+    except subprocess.TimeoutExpired:
+        pass
 
 
 def _kill_process_group(proc: subprocess.Popen) -> None:
@@ -155,6 +244,18 @@ def _kill_process_group(proc: subprocess.Popen) -> None:
     on win32, `SIGKILL` on POSIX), so a per-cell timeout still reaps the
     child instead of crashing the whole execute phase with an uncaught
     AttributeError.
+
+    The SIGKILL rung lives in a `finally`, not on the straight line after
+    the sleep. An exception raised inside one `except` clause is not caught
+    by a sibling `except` of the same `try`, so a second signal arriving
+    during the 200 ms grace -- precisely what an operator does when the
+    first `kill` appears to do nothing to a SIGTERM-trapping database server
+    -- used to unwind out of the sleep and out of `run_with_timeout`'s
+    handler with only SIGTERM ever delivered, leaving the group orphaned
+    (observed: signals reaching the cell group `[15]`, child state `Ss`).
+    The `try` opens *before* the SIGTERM call so there is no unguarded gap
+    between the two rungs; the cost is one wasted `killpg` when the group
+    was already gone, which `_killpg` swallows.
     """
     import time
 
@@ -162,11 +263,17 @@ def _kill_process_group(proc: subprocess.Popen) -> None:
         proc.kill()
         return
     try:
-        os.killpg(proc.pid, signal.SIGTERM)
-    except (ProcessLookupError, PermissionError):
-        return
-    time.sleep(0.2)
+        if not _killpg(proc.pid, signal.SIGTERM):
+            return
+        time.sleep(_KILL_GRACE_S)
+    finally:
+        _killpg(proc.pid, signal.SIGKILL)
+
+
+def _killpg(pgid: int, sig: int) -> bool:
+    """`os.killpg`, reporting whether the signal reached a group."""
     try:
-        os.killpg(proc.pid, signal.SIGKILL)
+        os.killpg(pgid, sig)
     except (ProcessLookupError, PermissionError):
-        return
+        return False
+    return True


### PR DESCRIPTION
- **fix(uat): reap orphaned child process groups on sweep cancellation**
- **fix(uat): review follow-up on child-process-group teardown fix**
- **fix(uat): complete the kill ladder under a second signal; retarget its tests**
