### PR TITLE
fix(ci): require every develop-ruleset context in green-unmerged sweep

### DIFF
--- a/_project/scripts/fixtures/green_unmerged_fixture.json
+++ b/_project/scripts/fixtures/green_unmerged_fixture.json
@@ -12,9 +12,22 @@
       "head_pushed_at": "2026-07-23T08:00:00Z",
       "auto_merge": null,
       "timeline_events": [],
-      "changed_files": ["benchbox/platforms/duckdb/adapter.py"],
+      "changed_files": [
+        "benchbox/platforms/duckdb/adapter.py"
+      ],
       "check_runs": [
-        {"name": "ci-required-result", "status": "completed", "conclusion": "success", "started_at": "2026-07-23T08:10:00Z"}
+        {
+          "name": "ci-required-result",
+          "status": "completed",
+          "conclusion": "success",
+          "started_at": "2026-07-23T08:10:00Z"
+        },
+        {
+          "name": "Results Explorer browser gate",
+          "status": "completed",
+          "conclusion": "success",
+          "started_at": "2026-07-23T08:12:00Z"
+        }
       ]
     },
     {
@@ -25,10 +38,27 @@
       "updated_at": "2026-07-23T08:00:00Z",
       "head_pushed_at": "2026-07-23T08:00:00Z",
       "auto_merge": null,
-      "timeline_events": [{"event": "ready_for_review"}],
-      "changed_files": ["benchbox/core/equivalence/compare.py"],
+      "timeline_events": [
+        {
+          "event": "ready_for_review"
+        }
+      ],
+      "changed_files": [
+        "benchbox/core/equivalence/compare.py"
+      ],
       "check_runs": [
-        {"name": "ci-required-result", "status": "completed", "conclusion": "success", "started_at": "2026-07-23T08:10:00Z"}
+        {
+          "name": "ci-required-result",
+          "status": "completed",
+          "conclusion": "success",
+          "started_at": "2026-07-23T08:10:00Z"
+        },
+        {
+          "name": "Results Explorer browser gate",
+          "status": "completed",
+          "conclusion": "success",
+          "started_at": "2026-07-23T08:12:00Z"
+        }
       ]
     },
     {
@@ -38,11 +68,33 @@
       "draft": false,
       "updated_at": "2026-07-23T08:00:00Z",
       "head_pushed_at": "2026-07-23T08:00:00Z",
-      "auto_merge": {"enabled_by": {"login": "joeharris76"}, "merge_method": "squash"},
-      "timeline_events": [{"event": "auto_squash_enabled"}],
-      "changed_files": ["benchbox/platforms/snowflake/adapter.py"],
+      "auto_merge": {
+        "enabled_by": {
+          "login": "joeharris76"
+        },
+        "merge_method": "squash"
+      },
+      "timeline_events": [
+        {
+          "event": "auto_squash_enabled"
+        }
+      ],
+      "changed_files": [
+        "benchbox/platforms/snowflake/adapter.py"
+      ],
       "check_runs": [
-        {"name": "ci-required-result", "status": "completed", "conclusion": "success", "started_at": "2026-07-23T08:10:00Z"}
+        {
+          "name": "ci-required-result",
+          "status": "completed",
+          "conclusion": "success",
+          "started_at": "2026-07-23T08:10:00Z"
+        },
+        {
+          "name": "Results Explorer browser gate",
+          "status": "completed",
+          "conclusion": "success",
+          "started_at": "2026-07-23T08:12:00Z"
+        }
       ]
     },
     {
@@ -54,9 +106,22 @@
       "head_pushed_at": "2026-07-23T08:00:00Z",
       "auto_merge": null,
       "timeline_events": [],
-      "changed_files": ["README.md"],
+      "changed_files": [
+        "README.md"
+      ],
       "check_runs": [
-        {"name": "ci-required-result", "status": "completed", "conclusion": "success", "started_at": "2026-07-23T08:10:00Z"}
+        {
+          "name": "ci-required-result",
+          "status": "completed",
+          "conclusion": "success",
+          "started_at": "2026-07-23T08:10:00Z"
+        },
+        {
+          "name": "Results Explorer browser gate",
+          "status": "completed",
+          "conclusion": "success",
+          "started_at": "2026-07-23T08:12:00Z"
+        }
       ]
     },
     {
@@ -67,10 +132,27 @@
       "updated_at": "2026-07-23T08:00:00Z",
       "head_pushed_at": "2026-07-23T08:00:00Z",
       "auto_merge": null,
-      "timeline_events": [{"event": "auto_squash_enabled"}],
-      "changed_files": ["docs/development/adding-new-platforms.md"],
+      "timeline_events": [
+        {
+          "event": "auto_squash_enabled"
+        }
+      ],
+      "changed_files": [
+        "docs/development/adding-new-platforms.md"
+      ],
       "check_runs": [
-        {"name": "ci-required-result", "status": "completed", "conclusion": "failure", "started_at": "2026-07-23T08:10:00Z"}
+        {
+          "name": "ci-required-result",
+          "status": "completed",
+          "conclusion": "failure",
+          "started_at": "2026-07-23T08:10:00Z"
+        },
+        {
+          "name": "Results Explorer browser gate",
+          "status": "completed",
+          "conclusion": "success",
+          "started_at": "2026-07-23T08:12:00Z"
+        }
       ]
     },
     {
@@ -81,10 +163,27 @@
       "updated_at": "2026-07-23T11:30:00Z",
       "head_pushed_at": "2026-07-23T11:30:00Z",
       "auto_merge": null,
-      "timeline_events": [{"event": "ready_for_review"}],
-      "changed_files": ["docs/development/adding-new-platforms.md"],
+      "timeline_events": [
+        {
+          "event": "ready_for_review"
+        }
+      ],
+      "changed_files": [
+        "docs/development/adding-new-platforms.md"
+      ],
       "check_runs": [
-        {"name": "ci-required-result", "status": "completed", "conclusion": "success", "started_at": "2026-07-23T11:35:00Z"}
+        {
+          "name": "ci-required-result",
+          "status": "completed",
+          "conclusion": "success",
+          "started_at": "2026-07-23T11:35:00Z"
+        },
+        {
+          "name": "Results Explorer browser gate",
+          "status": "completed",
+          "conclusion": "success",
+          "started_at": "2026-07-23T08:12:00Z"
+        }
       ]
     },
     {
@@ -95,11 +194,36 @@
       "updated_at": "2026-07-23T08:00:00Z",
       "head_pushed_at": "2026-07-23T08:00:00Z",
       "auto_merge": null,
-      "timeline_events": [{"event": "committed"}, {"event": "reviewed"}],
-      "changed_files": ["benchbox/platforms/bigquery/adapter.py"],
+      "timeline_events": [
+        {
+          "event": "committed"
+        },
+        {
+          "event": "reviewed"
+        }
+      ],
+      "changed_files": [
+        "benchbox/platforms/bigquery/adapter.py"
+      ],
       "check_runs": [
-        {"name": "ci-required-result", "status": "completed", "conclusion": "failure", "started_at": "2026-07-23T07:00:00Z"},
-        {"name": "ci-required-result", "status": "completed", "conclusion": "success", "started_at": "2026-07-23T08:10:00Z"}
+        {
+          "name": "ci-required-result",
+          "status": "completed",
+          "conclusion": "failure",
+          "started_at": "2026-07-23T07:00:00Z"
+        },
+        {
+          "name": "ci-required-result",
+          "status": "completed",
+          "conclusion": "success",
+          "started_at": "2026-07-23T08:10:00Z"
+        },
+        {
+          "name": "Results Explorer browser gate",
+          "status": "completed",
+          "conclusion": "success",
+          "started_at": "2026-07-23T08:12:00Z"
+        }
       ]
     },
     {
@@ -110,10 +234,27 @@
       "updated_at": "2026-07-23T08:00:00Z",
       "head_pushed_at": "2026-07-23T08:00:00Z",
       "auto_merge": null,
-      "timeline_events": [{"event": "ready_for_review"}],
-      "changed_files": ["benchbox/platforms/duckdb/adapter.py"],
+      "timeline_events": [
+        {
+          "event": "ready_for_review"
+        }
+      ],
+      "changed_files": [
+        "benchbox/platforms/duckdb/adapter.py"
+      ],
       "check_runs": [
-        {"name": "ci-required-result", "status": "completed", "conclusion": "success", "started_at": "2026-07-23T08:10:00Z"}
+        {
+          "name": "ci-required-result",
+          "status": "completed",
+          "conclusion": "success",
+          "started_at": "2026-07-23T08:10:00Z"
+        },
+        {
+          "name": "Results Explorer browser gate",
+          "status": "completed",
+          "conclusion": "success",
+          "started_at": "2026-07-23T08:12:00Z"
+        }
       ]
     },
     {
@@ -125,12 +266,29 @@
       "head_pushed_at": "2026-07-23T08:00:00Z",
       "auto_merge": null,
       "timeline_events": [
-        {"event": "auto_squash_enabled"},
-        {"event": "auto_merge_disabled"}
+        {
+          "event": "auto_squash_enabled"
+        },
+        {
+          "event": "auto_merge_disabled"
+        }
       ],
-      "changed_files": ["benchbox/platforms/snowflake/adapter.py"],
+      "changed_files": [
+        "benchbox/platforms/snowflake/adapter.py"
+      ],
       "check_runs": [
-        {"name": "ci-required-result", "status": "completed", "conclusion": "success", "started_at": "2026-07-23T08:10:00Z"}
+        {
+          "name": "ci-required-result",
+          "status": "completed",
+          "conclusion": "success",
+          "started_at": "2026-07-23T08:10:00Z"
+        },
+        {
+          "name": "Results Explorer browser gate",
+          "status": "completed",
+          "conclusion": "success",
+          "started_at": "2026-07-23T08:12:00Z"
+        }
       ]
     },
     {
@@ -142,14 +300,92 @@
       "head_pushed_at": "2026-07-23T08:00:00Z",
       "auto_merge": null,
       "had_arm_intent": true,
-      "changed_files": ["benchbox/platforms/bigquery/adapter.py"],
+      "changed_files": [
+        "benchbox/platforms/bigquery/adapter.py"
+      ],
       "check_runs": [
-        {"name": "ci-required-result", "status": "completed", "conclusion": "failure", "started_at": "2026-07-23T07:00:00Z"},
-        {"name": "ci-required-result", "status": "completed", "conclusion": "success", "started_at": "2026-07-23T08:10:00Z"}
+        {
+          "name": "ci-required-result",
+          "status": "completed",
+          "conclusion": "failure",
+          "started_at": "2026-07-23T07:00:00Z"
+        },
+        {
+          "name": "ci-required-result",
+          "status": "completed",
+          "conclusion": "success",
+          "started_at": "2026-07-23T08:10:00Z"
+        },
+        {
+          "name": "Results Explorer browser gate",
+          "status": "completed",
+          "conclusion": "success",
+          "started_at": "2026-07-23T08:12:00Z"
+        }
+      ]
+    },
+    {
+      "number": 2011,
+      "title": "partial-green exclusion: umbrella green, browser gate never reported",
+      "html_url": "https://github.com/joeharris76/BenchBox/pull/2011",
+      "draft": false,
+      "updated_at": "2026-07-23T08:00:00Z",
+      "head_pushed_at": "2026-07-23T08:00:00Z",
+      "auto_merge": null,
+      "timeline_events": [
+        {
+          "event": "ready_for_review"
+        }
+      ],
+      "changed_files": [
+        "benchbox/platforms/duckdb/adapter.py"
+      ],
+      "check_runs": [
+        {
+          "name": "ci-required-result",
+          "status": "completed",
+          "conclusion": "success",
+          "started_at": "2026-07-23T08:10:00Z"
+        }
+      ]
+    },
+    {
+      "number": 2012,
+      "title": "partial-green exclusion: umbrella green, browser gate red",
+      "html_url": "https://github.com/joeharris76/BenchBox/pull/2012",
+      "draft": false,
+      "updated_at": "2026-07-23T08:00:00Z",
+      "head_pushed_at": "2026-07-23T08:00:00Z",
+      "auto_merge": null,
+      "timeline_events": [
+        {
+          "event": "ready_for_review"
+        }
+      ],
+      "changed_files": [
+        "benchbox/platforms/duckdb/adapter.py"
+      ],
+      "check_runs": [
+        {
+          "name": "ci-required-result",
+          "status": "completed",
+          "conclusion": "success",
+          "started_at": "2026-07-23T08:10:00Z"
+        },
+        {
+          "name": "Results Explorer browser gate",
+          "status": "completed",
+          "conclusion": "failure",
+          "started_at": "2026-07-23T08:12:00Z"
+        }
       ]
     }
   ],
-  "expected_stranded": [2008, 2009, 2010],
+  "expected_stranded": [
+    2008,
+    2009,
+    2010
+  ],
   "expected_excluded_reasons": {
     "2001": "intentional_hold",
     "2002": "soundness_gated",
@@ -157,7 +393,9 @@
     "2004": "draft",
     "2005": "not_green",
     "2006": "within_grace",
-    "2007": "no_arm_intent"
+    "2007": "no_arm_intent",
+    "2011": "not_green",
+    "2012": "not_green"
   },
   "post_merge_run": {
     "status": "completed",

--- a/_project/scripts/green_unmerged_sweep.py
+++ b/_project/scripts/green_unmerged_sweep.py
@@ -12,8 +12,15 @@ off" alone as stranded.
 It is a read-only external observer that classifies every OPEN develop PR
 and alerts only when all of the following hold:
 
-    (a) required-lane green -- the LATEST `ci-required-result` check run
-        on the PR's head SHA completed with conclusion `success`.
+    (a) required-lane green -- EVERY develop-ruleset required status
+        context in `REQUIRED_CHECK_NAMES` has its LATEST check run on the
+        PR's head SHA completed with conclusion `success`. Today that is
+        both `ci-required-result` and `Results Explorer browser gate`
+        (docs/operations/repo-admin-settings.md; live ruleset
+        develop-squash-only). Partial green (one context success, another
+        missing or red) is NOT required-green. The browser gate always
+        reports (path-aware skip still concludes success); a missing run
+        is fail-closed not-green.
     (b) auto-merge is OFF    -- the PR's own `auto_merge` field is falsy
         (null or an explicit off), re-read from REST (never inferred from
         a workflow run's conclusion; see "Known timing behavior" below).
@@ -111,7 +118,15 @@ from auto_merge_soundness_paths import any_soundness_path  # noqa: E402
 FIXTURE_PATH = SCRIPT_DIR / "fixtures" / "green_unmerged_fixture.json"
 
 DEFAULT_REPO = "joeharris76/BenchBox"
-REQUIRED_CHECK_NAME = "ci-required-result"
+# Develop ruleset `develop-squash-only` required status contexts.
+# Pin must match docs/operations/repo-admin-settings.md and the live
+# ruleset (id 15611785). Partial membership is incomplete green.
+# Prefer this constant over re-deriving from path-filters or workflow
+# names: ruleset contexts are the merge gate, not subordinate jobs.
+REQUIRED_CHECK_NAMES: tuple[str, ...] = (
+    "ci-required-result",
+    "Results Explorer browser gate",
+)
 GRACE_PERIOD_HOURS = 2.0
 API_ROOT = "https://api.github.com"
 DEVELOP_POST_MERGE_WORKFLOW = "develop-post-merge.yml"
@@ -173,23 +188,39 @@ def _parse_iso(value: str) -> dt.datetime:
     return dt.datetime.fromisoformat(value.replace("Z", "+00:00"))
 
 
-def required_lane_check_run(check_runs: list[dict[str, Any]]) -> dict[str, Any] | None:
-    """Return the latest ``ci-required-result`` check run, if present.
+def latest_check_run(check_runs: list[dict[str, Any]], name: str) -> dict[str, Any] | None:
+    """Return the latest check run for *name*, if present.
 
     A re-run can leave multiple same-named runs on one SHA; pick the most
     recently started so a stale conclusion never wins.
     """
-    matches = [run for run in check_runs if run.get("name") == REQUIRED_CHECK_NAME]
+    matches = [run for run in check_runs if run.get("name") == name]
     if not matches:
         return None
     return max(matches, key=lambda run: run.get("started_at") or "")
 
 
-def is_required_lane_green(check_runs: list[dict[str, Any]]) -> bool:
-    run = required_lane_check_run(check_runs)
+def is_check_run_success(run: dict[str, Any] | None) -> bool:
+    """True when *run* completed with conclusion ``success`` (not skipped/neutral)."""
     if run is None:
         return False
     return run.get("status") == "completed" and run.get("conclusion") == "success"
+
+
+def is_required_lane_green(check_runs: list[dict[str, Any]]) -> bool:
+    """True when every develop-ruleset required context is latest-success.
+
+    Partial green (e.g. ``ci-required-result`` success but browser gate
+    missing or red) returns False. Missing runs are fail-closed not-green;
+    the browser gate always reports on develop PRs (success when the
+    explorer suite is not needed).
+    """
+    if not REQUIRED_CHECK_NAMES:
+        return False
+    for name in REQUIRED_CHECK_NAMES:
+        if not is_check_run_success(latest_check_run(check_runs, name)):
+            return False
+    return True
 
 
 def is_soundness_gated(changed_files: list[str]) -> bool:

--- a/docs/operations/pr-triage.md
+++ b/docs/operations/pr-triage.md
@@ -91,7 +91,11 @@ a PR's mergeability — both only alert.
   `.github/workflows/nightly.yml`) — alerts only on **true stranding**:
   non-draft, non-soundness, non-hold-label PRs whose required lane is green,
   auto-merge is still off more than 2 hours after the head commit, **and**
-  the PR timeline shows prior arm intent that was lost. `--apply` only
+  the PR timeline shows prior arm intent that was lost. "Required lane
+  green" means **every** `develop-squash-only` required context is
+  latest-success — today both `ci-required-result` and `Results Explorer
+  browser gate` — so a PR that is green on one and red or silent on the
+  other is not green and is not alerted. `--apply` only
   upserts the digest issue; it **never** enables auto-merge and must not
   re-arm a hold it did not set.
 

--- a/tests/unit/scripts/test_green_unmerged_sweep.py
+++ b/tests/unit/scripts/test_green_unmerged_sweep.py
@@ -25,15 +25,19 @@ _SCRIPT = _ROOT / "_project" / "scripts" / "green_unmerged_sweep.py"
 _FIXTURE = _ROOT / "_project" / "scripts" / "fixtures" / "green_unmerged_fixture.json"
 
 
-def _load():
-    spec = importlib.util.spec_from_file_location("_green_unmerged_sweep", _SCRIPT)
+def _load_module(name: str, path: Path):
+    spec = importlib.util.spec_from_file_location(name, path)
     assert spec is not None and spec.loader is not None
-    mod = importlib.util.module_from_spec(spec)
+    module = importlib.util.module_from_spec(spec)
     # Register in sys.modules before exec: the module uses @dataclass, whose
     # field-type resolution looks the module up by name in sys.modules.
-    sys.modules[spec.name] = mod
-    spec.loader.exec_module(mod)
-    return mod
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def _load():
+    return _load_module("_green_unmerged_sweep", _SCRIPT)
 
 
 mod = _load()
@@ -44,24 +48,57 @@ def _now() -> dt.datetime:
 
 
 # ------------------------------------------------------------------ #
-# required_lane_check_run / is_required_lane_green                    #
+# latest_check_run / is_required_lane_green                           #
 # ------------------------------------------------------------------ #
+def _run(name: str, conclusion: str, started_at: str = "2026-07-23T08:00:00Z") -> dict[str, str]:
+    return {
+        "name": name,
+        "status": "completed",
+        "conclusion": conclusion,
+        "started_at": started_at,
+    }
+
+
+def _all_required_green() -> list[dict[str, str]]:
+    """One passing run per develop-ruleset required context."""
+    return [_run(name, "success") for name in mod.REQUIRED_CHECK_NAMES]
+
+
+def test_required_check_names_match_the_documented_ruleset() -> None:
+    # The pin that makes this module's green/not-green verdict trustworthy:
+    # it must track the `develop-squash-only` required contexts. Parse them
+    # from the same runbook block ruleset_drift_check.py reads, rather than
+    # restating the names here -- a second hardcoded copy would drift
+    # silently and reintroduce the false-green gap this classifier exists to
+    # close. Order is not asserted: every context is required, so the tuple
+    # order carries no meaning.
+    drift = _load_module("_ruleset_drift_check", _ROOT / "scripts" / "ruleset_drift_check.py")
+    runbook = (_ROOT / "docs" / "operations" / "repo-admin-settings.md").read_text(encoding="utf-8")
+    expected = drift.parse_expected_rulesets(runbook)["develop-squash-only"]
+    assert set(mod.REQUIRED_CHECK_NAMES) == set(expected.required_checks)
+    assert len(mod.REQUIRED_CHECK_NAMES) == len(set(mod.REQUIRED_CHECK_NAMES)), "duplicate context"
+
+
+def test_required_lane_green_when_every_context_succeeds() -> None:
+    assert mod.is_required_lane_green(_all_required_green()) is True
+
+
 def test_required_lane_picks_latest_started_run() -> None:
     runs = [
-        {
-            "name": "ci-required-result",
-            "status": "completed",
-            "conclusion": "failure",
-            "started_at": "2026-07-23T07:00:00Z",
-        },
-        {
-            "name": "ci-required-result",
-            "status": "completed",
-            "conclusion": "success",
-            "started_at": "2026-07-23T08:00:00Z",
-        },
+        _run("ci-required-result", "failure", "2026-07-23T07:00:00Z"),
+        _run("ci-required-result", "success", "2026-07-23T08:00:00Z"),
+        _run("Results Explorer browser gate", "success"),
     ]
     assert mod.is_required_lane_green(runs) is True
+
+
+def test_required_lane_stale_success_does_not_beat_latest_failure() -> None:
+    runs = [
+        _run("ci-required-result", "success", "2026-07-23T07:00:00Z"),
+        _run("ci-required-result", "failure", "2026-07-23T08:00:00Z"),
+        _run("Results Explorer browser gate", "success"),
+    ]
+    assert mod.is_required_lane_green(runs) is False
 
 
 def test_required_lane_missing_run_is_not_green() -> None:
@@ -69,15 +106,41 @@ def test_required_lane_missing_run_is_not_green() -> None:
 
 
 def test_required_lane_ignores_unrelated_check_names() -> None:
-    runs = [
+    assert mod.is_required_lane_green([_run("some-other-check", "success")]) is False
+
+
+@pytest.mark.parametrize("missing", list(mod.REQUIRED_CHECK_NAMES))
+def test_required_lane_not_green_when_any_context_never_reported(missing: str) -> None:
+    # Fail closed: a required context with no run at all is not green, no
+    # matter how many sibling contexts passed.
+    runs = [run for run in _all_required_green() if run["name"] != missing]
+    assert mod.is_required_lane_green(runs) is False
+
+
+@pytest.mark.parametrize("failing", list(mod.REQUIRED_CHECK_NAMES))
+@pytest.mark.parametrize("conclusion", ["failure", "cancelled", "timed_out", "skipped", "neutral"])
+def test_required_lane_not_green_when_any_context_is_not_success(failing: str, conclusion: str) -> None:
+    # Partial green is the exact false-green gap: `ci-required-result` alone
+    # passing must not classify the PR as required-lane green.
+    runs = [_run(name, conclusion if name == failing else "success") for name in mod.REQUIRED_CHECK_NAMES]
+    assert mod.is_required_lane_green(runs) is False
+
+
+def test_required_lane_not_green_while_a_context_is_still_running() -> None:
+    runs = [_run(name, "success") for name in mod.REQUIRED_CHECK_NAMES[1:]]
+    runs.append(
         {
-            "name": "some-other-check",
-            "status": "completed",
-            "conclusion": "success",
+            "name": mod.REQUIRED_CHECK_NAMES[0],
+            "status": "in_progress",
+            "conclusion": None,
             "started_at": "2026-07-23T08:00:00Z",
         }
-    ]
+    )
     assert mod.is_required_lane_green(runs) is False
+
+
+def test_latest_check_run_returns_none_for_unknown_name() -> None:
+    assert mod.latest_check_run(_all_required_green(), "no-such-check") is None
 
 
 # ------------------------------------------------------------------ #
@@ -203,14 +266,7 @@ def test_classify_pr_intentional_hold_not_stranded() -> None:
         "timeline_events": [],
         "changed_files": ["docs/readme.md"],
         "head_pushed_at": "2026-07-23T08:00:00Z",
-        "check_runs": [
-            {
-                "name": "ci-required-result",
-                "status": "completed",
-                "conclusion": "success",
-                "started_at": "2026-07-23T08:10:00Z",
-            }
-        ],
+        "check_runs": _all_required_green(),
     }
     c = mod.classify_pr(pr, _now(), grace_hours=2.0)
     assert c.required_green is True
@@ -232,14 +288,7 @@ def test_classify_pr_explicit_hold_label_not_stranded() -> None:
         "timeline_events": [{"event": "ready_for_review"}, {"event": "auto_squash_enabled"}],
         "changed_files": ["docs/readme.md"],
         "head_pushed_at": "2026-07-23T08:00:00Z",
-        "check_runs": [
-            {
-                "name": "ci-required-result",
-                "status": "completed",
-                "conclusion": "success",
-                "started_at": "2026-07-23T08:10:00Z",
-            }
-        ],
+        "check_runs": _all_required_green(),
     }
     c = mod.classify_pr(pr, _now(), grace_hours=2.0)
     assert c.had_arm_intent is True
@@ -257,14 +306,7 @@ def test_classify_pr_true_strand_ready_for_review() -> None:
         "timeline_events": [{"event": "ready_for_review"}],
         "changed_files": ["docs/readme.md"],
         "head_pushed_at": "2026-07-23T08:00:00Z",
-        "check_runs": [
-            {
-                "name": "ci-required-result",
-                "status": "completed",
-                "conclusion": "success",
-                "started_at": "2026-07-23T08:10:00Z",
-            }
-        ],
+        "check_runs": _all_required_green(),
     }
     c = mod.classify_pr(pr, _now(), grace_hours=2.0)
     assert c.had_arm_intent is True
@@ -285,18 +327,40 @@ def test_classify_pr_true_strand_auto_merge_dropped() -> None:
         ],
         "changed_files": ["docs/readme.md"],
         "head_pushed_at": "2026-07-23T08:00:00Z",
-        "check_runs": [
-            {
-                "name": "ci-required-result",
-                "status": "completed",
-                "conclusion": "success",
-                "started_at": "2026-07-23T08:10:00Z",
-            }
-        ],
+        "check_runs": _all_required_green(),
     }
     c = mod.classify_pr(pr, _now(), grace_hours=2.0)
     assert c.had_arm_intent is True
     assert c.stranded is True
+
+
+@pytest.mark.parametrize(
+    ("case", "gate_runs"),
+    [
+        ("never_reported", []),
+        ("red", [_run("Results Explorer browser gate", "failure")]),
+    ],
+)
+def test_classify_pr_partial_green_is_not_stranded(case: str, gate_runs: list[dict[str, str]]) -> None:
+    # End-to-end guard on the false-green gap: a PR that would otherwise be a
+    # textbook strand (arm intent, auto-merge off, aged, not soundness-gated)
+    # must NOT be alerted while a second required context is red or absent --
+    # it is genuinely not mergeable yet, so there is nothing stranded about it.
+    pr = {
+        "number": 4,
+        "title": f"partial green: {case}",
+        "html_url": "https://example.invalid/4",
+        "draft": False,
+        "auto_merge": None,
+        "timeline_events": [{"event": "ready_for_review"}],
+        "changed_files": ["docs/readme.md"],
+        "head_pushed_at": "2026-07-23T08:00:00Z",
+        "check_runs": [_run("ci-required-result", "success"), *gate_runs],
+    }
+    c = mod.classify_pr(pr, _now(), grace_hours=2.0)
+    assert c.had_arm_intent is True
+    assert c.required_green is False
+    assert c.stranded is False
 
 
 # ------------------------------------------------------------------ #


### PR DESCRIPTION
## Problem

The nightly green-unmerged sweep decided "required lane green" from the latest `ci-required-result` check run alone. Since 2026-08-03 the `develop-squash-only` ruleset has **two** required status contexts ([`docs/operations/repo-admin-settings.md`](docs/operations/repo-admin-settings.md)):

```text
- ci-required-result
- Results Explorer browser gate
```

So a PR green on the umbrella while `Results Explorer browser gate` was red — or had never reported — was classified green. Combined with the other strand predicates it could be alerted as stranded when it was in fact correctly unmergeable. Fetching is unfiltered (`commits/{sha}/check-runs`), so the gate's run was always present in the data; only the classifier ignored it.

## Change

- `latest_check_run(runs, name)` generalizes the old single-name lookup, keeping the newest-`started_at` wins rule that stops a stale re-run conclusion from winning.
- `is_required_lane_green` now requires **every** context in the new `REQUIRED_CHECK_NAMES` tuple to be latest-success. Missing runs stay fail-closed not-green — the browser gate always reports on develop PRs (its path-aware skip still concludes `success`), so a silent context is a real signal rather than an expected absence.
- `required_lane_check_run()` is **dropped**, not kept as a compat shim: nothing called it once `is_required_lane_green` stopped doing so, and its `REQUIRED_CHECK_NAMES[0]` indexing made tuple order load-bearing when the order carries no meaning.
- [`docs/operations/pr-triage.md`](docs/operations/pr-triage.md) now states what "required lane green" means, which was ambiguous next to `soundness-drain.md`'s single-context wording.

## Verification

```bash
uv run -- python _project/scripts/green_unmerged_sweep.py --self-test
uv run -- python -m pytest tests/unit/scripts/test_green_unmerged_sweep.py -q -n 0
```

- Self-test: 12 fixture PRs, 3 stranded (`2008/2009/2010` — unchanged from before).
- Unit tests: 61 passed. Full `tests/unit/scripts/` 1615 passed; `test_ruleset_drift_review_coverage.py` 26 passed.
- The ruleset pin parses the required contexts from the same runbook block [`scripts/ruleset_drift_check.py`](scripts/ruleset_drift_check.py) reads, rather than restating them as a second hardcoded copy that could drift silently.
- New fixture PRs `2011`/`2012` cover partial green (gate absent, gate red) as end-to-end `not_green` exclusions. Existing fixture PRs each gained a passing gate run so the case each was written to pin stays the only variable — verified additive-only against the previous fixture.
- Negative-tested: reverting the constant to a single context fails the drift pin, both partial-green regressions, and the self-test.

## Scope / guardrails

Follows the scope rules of the (already-complete) tracker item `auto-merge-verify-and-triage-runbook-2` that introduced this sweep in #1288 — all touched paths fall under its `only_modify` globs (`_project/scripts/**`, `tests/unit/scripts/**`, `docs/operations/**`); no `do_not_modify` path touched. Its preserved invariants hold: soundness-gated PRs are still excluded, `auto-merge-on-open.yml` is untouched, and the sweep remains alert-only — it still never enables auto-merge.