### PR TITLE
fix(ci): require every develop-ruleset context in soundness drain report

### DIFF
--- a/_project/scripts/fixtures/soundness_drain_fixture.json
+++ b/_project/scripts/fixtures/soundness_drain_fixture.json
@@ -10,7 +10,10 @@
     "9102": "auto_merge_on",
     "9103": "too_young",
     "9104": "not_green",
-    "9106": "draft"
+    "9106": "draft",
+    "9108": "not_green",
+    "9109": "not_green",
+    "9110": "too_young"
   },
   "prs": [
     {
@@ -33,6 +36,12 @@
           "status": "completed",
           "conclusion": "success",
           "completed_at": "2026-07-16T08:00:00Z"
+        },
+        {
+          "name": "Results Explorer browser gate",
+          "status": "completed",
+          "conclusion": "success",
+          "completed_at": "2026-07-16T07:55:00Z"
         }
       ]
     },
@@ -59,6 +68,12 @@
           "status": "completed",
           "conclusion": "success",
           "completed_at": "2026-07-15T08:30:00Z"
+        },
+        {
+          "name": "Results Explorer browser gate",
+          "status": "completed",
+          "conclusion": "success",
+          "completed_at": "2026-07-15T08:25:00Z"
         }
       ]
     },
@@ -82,6 +97,12 @@
           "status": "completed",
           "conclusion": "success",
           "completed_at": "2026-07-23T09:45:00Z"
+        },
+        {
+          "name": "Results Explorer browser gate",
+          "status": "completed",
+          "conclusion": "success",
+          "completed_at": "2026-07-23T09:40:00Z"
         }
       ]
     },
@@ -105,6 +126,12 @@
           "status": "completed",
           "conclusion": "failure",
           "completed_at": "2026-07-18T08:30:00Z"
+        },
+        {
+          "name": "Results Explorer browser gate",
+          "status": "completed",
+          "conclusion": "success",
+          "completed_at": "2026-07-18T08:25:00Z"
         }
       ]
     },
@@ -128,6 +155,12 @@
           "status": "completed",
           "conclusion": "success",
           "completed_at": "2026-07-17T08:15:00Z"
+        },
+        {
+          "name": "Results Explorer browser gate",
+          "status": "completed",
+          "conclusion": "success",
+          "completed_at": "2026-07-17T08:10:00Z"
         }
       ]
     },
@@ -151,6 +184,12 @@
           "status": "completed",
           "conclusion": "success",
           "completed_at": "2026-07-13T08:30:00Z"
+        },
+        {
+          "name": "Results Explorer browser gate",
+          "status": "completed",
+          "conclusion": "success",
+          "completed_at": "2026-07-13T08:25:00Z"
         }
       ]
     },
@@ -175,6 +214,93 @@
           "conclusion": "success",
           "started_at": "2026-07-18T08:00:00Z",
           "completed_at": "2026-07-18T08:10:00Z"
+        },
+        {
+          "name": "Results Explorer browser gate",
+          "status": "completed",
+          "conclusion": "success",
+          "completed_at": "2026-07-18T08:05:00Z"
+        }
+      ]
+    },
+    {
+      "number": 9108,
+      "title": "partial green: umbrella green, browser gate never reported",
+      "html_url": "https://github.com/joeharris76/BenchBox/pull/9108",
+      "draft": false,
+      "created_at": "2026-07-15T09:00:00Z",
+      "updated_at": "2026-07-16T09:00:00Z",
+      "auto_merge": null,
+      "requested_reviewers": [
+        "joeharris76"
+      ],
+      "changed_files": [
+        "benchbox/core/equivalence/comparator.py"
+      ],
+      "check_runs": [
+        {
+          "name": "ci-required-result",
+          "status": "completed",
+          "conclusion": "success",
+          "completed_at": "2026-07-16T08:00:00Z"
+        }
+      ]
+    },
+    {
+      "number": 9109,
+      "title": "partial green: umbrella green, browser gate red",
+      "html_url": "https://github.com/joeharris76/BenchBox/pull/9109",
+      "draft": false,
+      "created_at": "2026-07-15T09:00:00Z",
+      "updated_at": "2026-07-16T09:00:00Z",
+      "auto_merge": null,
+      "requested_reviewers": [
+        "joeharris76"
+      ],
+      "changed_files": [
+        "benchbox/core/equivalence/comparator.py"
+      ],
+      "check_runs": [
+        {
+          "name": "ci-required-result",
+          "status": "completed",
+          "conclusion": "success",
+          "completed_at": "2026-07-16T08:00:00Z"
+        },
+        {
+          "name": "Results Explorer browser gate",
+          "status": "completed",
+          "conclusion": "failure",
+          "completed_at": "2026-07-16T08:05:00Z"
+        }
+      ]
+    },
+    {
+      "number": 9110,
+      "title": "park time anchors on the last required context to finish",
+      "html_url": "https://github.com/joeharris76/BenchBox/pull/9110",
+      "draft": false,
+      "created_at": "2026-07-15T09:00:00Z",
+      "updated_at": "2026-07-23T02:30:00Z",
+      "auto_merge": null,
+      "requested_reviewers": [
+        "joeharris76"
+      ],
+      "changed_files": [
+        "benchbox/core/equivalence/comparator.py"
+      ],
+      "check_runs": [
+        {
+          "name": "ci-required-result",
+          "status": "completed",
+          "conclusion": "success",
+          "completed_at": "2026-07-21T08:00:00Z"
+        },
+        {
+          "name": "Results Explorer browser gate",
+          "status": "completed",
+          "conclusion": "success",
+          "completed_at": "2026-07-23T02:00:00Z"
         }
       ]
     }

--- a/_project/scripts/soundness_drain_report.py
+++ b/_project/scripts/soundness_drain_report.py
@@ -13,13 +13,19 @@ the missing "someone should look at this" signal:
 
 - It classifies every OPEN PR targeting ``develop`` as qualifying for the
   drain queue when ALL of the following hold:
-    (a) required-lane green  -- the ``ci-required-result`` check run on the
-        PR's head SHA completed with conclusion ``success``.
+    (a) required-lane green  -- EVERY develop-ruleset required status
+        context in ``REQUIRED_CHECK_NAMES`` has its LATEST check run on the
+        PR's head SHA completed with conclusion ``success``. Today that is
+        both ``ci-required-result`` and ``Results Explorer browser gate``
+        (docs/operations/repo-admin-settings.md; live ruleset
+        develop-squash-only). Partial green -- one context success, another
+        red or never reported -- is NOT required-green; a missing run is
+        fail-closed not-green.
     (b) awaiting the owner   -- auto-merge is OFF *and* (the PR touches a
         soundness-critical path per ``SOUNDNESS_PREFIXES``, OR the owner is
         a requested reviewer).
     (c) parked > 24h          -- more than 24 hours of park time (anchored
-        on the required lane going green, NOT ``updated_at``: the label
+        on the LAST required context to finish, NOT ``updated_at``: the label
         writes below and ordinary human comments bump ``updated_at``, and a
         gate based on it would flap a genuinely parked PR out of the queue).
 - The only mutations it ever performs (and only under ``--apply``) are:
@@ -73,7 +79,20 @@ FIXTURE_PATH = SCRIPT_DIR / "fixtures" / "soundness_drain_fixture.json"
 OWNER_LOGIN = "joeharris76"
 
 DEFAULT_REPO = "joeharris76/BenchBox"
-REQUIRED_CHECK_NAME = "ci-required-result"
+# Develop ruleset `develop-squash-only` required status contexts. Pin must
+# match docs/operations/repo-admin-settings.md and the live ruleset
+# (id 15611785). Partial membership is incomplete green. Prefer this constant
+# over re-deriving from path-filters or workflow names: ruleset contexts are
+# the merge gate, not subordinate jobs.
+#
+# Kept deliberately identical to green_unmerged_sweep.py's copy: both scripts
+# classify the same lane, and the two implementations converge into one shared
+# helper once PR #1633 lands (tracked separately). Changing one without the
+# other reintroduces the split this comment exists to prevent.
+REQUIRED_CHECK_NAMES: tuple[str, ...] = (
+    "ci-required-result",
+    "Results Explorer browser gate",
+)
 DRAIN_LABEL = "awaiting-owner"
 DRAIN_LABEL_COLOR = "b60205"
 DRAIN_LABEL_DESCRIPTION = "Green, gated on owner review, parked >24h (see docs/operations/soundness-drain.md)"
@@ -113,23 +132,56 @@ def _parse_iso(value: str) -> dt.datetime:
     return dt.datetime.fromisoformat(value.replace("Z", "+00:00"))
 
 
-def required_lane_check_run(check_runs: list[dict[str, Any]]) -> dict[str, Any] | None:
-    """Return the latest ``ci-required-result`` check run, if present.
+def latest_check_run(check_runs: list[dict[str, Any]], name: str) -> dict[str, Any] | None:
+    """Return the latest check run for *name*, if present.
 
     A re-run can leave multiple same-named runs on one SHA; pick the most
     recently started so a stale conclusion never wins.
     """
-    matches = [run for run in check_runs if run.get("name") == REQUIRED_CHECK_NAME]
+    matches = [run for run in check_runs if run.get("name") == name]
     if not matches:
         return None
     return max(matches, key=lambda run: run.get("started_at") or "")
 
 
-def is_required_lane_green(check_runs: list[dict[str, Any]]) -> bool:
-    run = required_lane_check_run(check_runs)
+def is_check_run_success(run: dict[str, Any] | None) -> bool:
+    """True when *run* completed with conclusion ``success`` (not skipped/neutral)."""
     if run is None:
         return False
     return run.get("status") == "completed" and run.get("conclusion") == "success"
+
+
+def is_required_lane_green(check_runs: list[dict[str, Any]]) -> bool:
+    """True when every develop-ruleset required context is latest-success.
+
+    Partial green (e.g. ``ci-required-result`` success but browser gate red
+    or never reported) returns False. Missing runs are fail-closed not-green;
+    the browser gate always reports on develop PRs (success when the explorer
+    suite is not needed), so silence is a real signal, not an expected gap.
+    """
+    if not REQUIRED_CHECK_NAMES:
+        return False
+    return all(is_check_run_success(latest_check_run(check_runs, name)) for name in REQUIRED_CHECK_NAMES)
+
+
+def required_lane_green_at(check_runs: list[dict[str, Any]]) -> str | None:
+    """Timestamp at which the required lane went green: the LAST context to finish.
+
+    A PR is only green once *every* required context has completed, so the
+    park-time anchor is the maximum ``completed_at`` across them -- not
+    ``ci-required-result``'s alone, which would overstate park time whenever
+    the browser gate finishes later and trip the >24h gate early. Returns
+    None when any required context lacks a completion timestamp, leaving the
+    caller to fall back rather than anchor on a half-finished lane.
+    """
+    stamps: list[str] = []
+    for name in REQUIRED_CHECK_NAMES:
+        stamp = (latest_check_run(check_runs, name) or {}).get("completed_at")
+        if not stamp:
+            return None
+        stamps.append(stamp)
+    # RFC3339 UTC ("...Z") sorts lexicographically in chronological order.
+    return max(stamps) if stamps else None
 
 
 def is_soundness_gated(changed_files: list[str]) -> bool:
@@ -153,18 +205,17 @@ def idle_hours(updated_at: str, now: dt.datetime) -> float:
 def park_time_hours(pr: dict[str, Any], now: dt.datetime, *, required_green: bool) -> float | None:
     """Hours since the PR became ready-and-green.
 
-    Anchored on the ``ci-required-result`` check run's ``completed_at`` --
-    the point the PR became green (the soundness-path/auto-merge-off state
+    Anchored on the ``completed_at`` of the LAST required context to finish
+    -- the point the PR became green (the soundness-path/auto-merge-off state
     is static from the diff and typically already true by then, so "went
     green" is the later, load-bearing event in practice). Falls back to
-    ``updated_at`` if the check run lacks a completion timestamp. Returns
-    None when the required lane is not green (park time is undefined until
-    it is).
+    ``updated_at`` if any required context lacks a completion timestamp.
+    Returns None when the required lane is not green (park time is undefined
+    until it is).
     """
     if not required_green:
         return None
-    run = required_lane_check_run(pr.get("check_runs") or [])
-    anchor = (run or {}).get("completed_at") or pr.get("updated_at")
+    anchor = required_lane_green_at(pr.get("check_runs") or []) or pr.get("updated_at")
     if not anchor:
         return None
     return (now - _parse_iso(anchor)).total_seconds() / 3600.0

--- a/docs/operations/soundness-drain.md
+++ b/docs/operations/soundness-drain.md
@@ -33,9 +33,14 @@ mutations it performs are:
 `develop` and includes a PR in the digest when **all** of the following
 hold:
 
-- **(a) required-lane green** — the `ci-required-result` check run (the
-  aggregate required-check job defined in `.github/workflows/pr.yml`) on the
-  PR's head SHA completed with `conclusion: success`.
+- **(a) required-lane green** — **every** required status context of the
+  `develop-squash-only` ruleset has its latest check run on the PR's head
+  SHA completed with `conclusion: success`. Today that is both
+  `ci-required-result` (the aggregate required-check job defined in
+  `.github/workflows/pr.yml`) and `Results Explorer browser gate` (see
+  [`repo-admin-settings.md`](repo-admin-settings.md)). Partial green — one
+  context green while another is red or has never reported — is not green;
+  a missing run is fail-closed, not an absent requirement.
 - **(b) awaiting the owner** — auto-merge is currently OFF, **and** either
   the diff touches a soundness-critical path (reused via
   `any_soundness_path` imported from `auto_merge_soundness_paths.py` —
@@ -52,11 +57,14 @@ Draft PRs are always excluded regardless of the above.
 ### Park time
 
 Each qualifying PR also reports **park time**: hours since the PR became
-ready-and-green, anchored on the `ci-required-result` check run's
-`completed_at` (falling back to `updated_at` if that timestamp is
-unavailable). This is emitted per PR in both the text digest and `--json`
-output, and is the intended input for park-time re-measurement work (the
-WS9 re-measure references this field rather than recomputing it).
+ready-and-green, anchored on the `completed_at` of the **last** required
+context to finish (falling back to `updated_at` if any required context
+lacks that timestamp). The lane is only green once every context has
+finished, so anchoring on `ci-required-result` alone would overstate park
+time whenever the browser gate completes later — and trip the 24h gate
+early. This is emitted per PR in both the text digest and `--json` output,
+and is the intended input for park-time re-measurement work (the WS9
+re-measure references this field rather than recomputing it).
 
 ## Running locally
 

--- a/tests/unit/scripts/test_soundness_drain_report.py
+++ b/tests/unit/scripts/test_soundness_drain_report.py
@@ -1,0 +1,264 @@
+"""Unit tests for _project/scripts/soundness_drain_report.py's pure classification logic.
+
+The GitHub-API I/O is exercised by the scheduled workflow itself and by the
+script's own `--self-test` (fixture-driven, offline); here we pin the
+individual classification predicates with no network.
+
+Companion to tests/unit/scripts/test_green_unmerged_sweep.py: both scripts
+classify the same develop required lane. Rather than asserting the two
+constants equal each other -- which would couple this file to the sibling's
+merge order -- each side pins itself to the required-context block in
+docs/operations/repo-admin-settings.md, so they agree transitively.
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+# medium, not fast: mirrors the sibling sweep tests -- the drain report gets
+# pre-merge CI coverage via the medium-test job without contending on the
+# shared fast-lane budget (see fast_test_lane_policy.json).
+pytestmark = [pytest.mark.unit, pytest.mark.medium]
+
+_ROOT = Path(__file__).resolve().parents[3]
+_SCRIPT = _ROOT / "_project" / "scripts" / "soundness_drain_report.py"
+
+
+def _load_module(name: str, path: Path):
+    spec = importlib.util.spec_from_file_location(name, path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    # Register in sys.modules before exec: the module uses @dataclass, whose
+    # field-type resolution looks the module up by name in sys.modules.
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+mod = _load_module("_soundness_drain_report", _SCRIPT)
+
+
+def _now() -> dt.datetime:
+    return dt.datetime(2026, 7, 23, 12, 0, tzinfo=dt.timezone.utc)
+
+
+def _run(
+    name: str,
+    conclusion: str,
+    *,
+    started_at: str = "2026-07-23T08:00:00Z",
+    completed_at: str | None = "2026-07-23T08:30:00Z",
+) -> dict[str, str | None]:
+    run: dict[str, str | None] = {
+        "name": name,
+        "status": "completed",
+        "conclusion": conclusion,
+        "started_at": started_at,
+    }
+    if completed_at is not None:
+        run["completed_at"] = completed_at
+    return run
+
+
+def _all_required_green(completed_at: str = "2026-07-23T08:30:00Z") -> list[dict[str, str | None]]:
+    """One passing run per develop-ruleset required context."""
+    return [_run(name, "success", completed_at=completed_at) for name in mod.REQUIRED_CHECK_NAMES]
+
+
+# ------------------------------------------------------------------ #
+# REQUIRED_CHECK_NAMES pin                                            #
+# ------------------------------------------------------------------ #
+def test_required_check_names_match_the_documented_ruleset() -> None:
+    # Parse the contexts from the same runbook block ruleset_drift_check.py
+    # reads rather than restating them here: a second hardcoded copy drifts
+    # silently and reintroduces the false-green gap this classifier closes.
+    drift = _load_module("_ruleset_drift_check_sd", _ROOT / "scripts" / "ruleset_drift_check.py")
+    runbook = (_ROOT / "docs" / "operations" / "repo-admin-settings.md").read_text(encoding="utf-8")
+    expected = drift.parse_expected_rulesets(runbook)["develop-squash-only"]
+    assert set(mod.REQUIRED_CHECK_NAMES) == set(expected.required_checks)
+    assert len(mod.REQUIRED_CHECK_NAMES) == len(set(mod.REQUIRED_CHECK_NAMES)), "duplicate context"
+
+
+# ------------------------------------------------------------------ #
+# latest_check_run / is_required_lane_green                           #
+# ------------------------------------------------------------------ #
+def test_required_lane_green_when_every_context_succeeds() -> None:
+    assert mod.is_required_lane_green(_all_required_green()) is True
+
+
+def test_required_lane_picks_latest_started_run() -> None:
+    runs = [
+        _run("ci-required-result", "failure", started_at="2026-07-23T07:00:00Z"),
+        _run("ci-required-result", "success", started_at="2026-07-23T08:00:00Z"),
+        _run("Results Explorer browser gate", "success"),
+    ]
+    assert mod.is_required_lane_green(runs) is True
+
+
+def test_required_lane_stale_success_does_not_beat_latest_failure() -> None:
+    runs = [
+        _run("ci-required-result", "success", started_at="2026-07-23T07:00:00Z"),
+        _run("ci-required-result", "failure", started_at="2026-07-23T08:00:00Z"),
+        _run("Results Explorer browser gate", "success"),
+    ]
+    assert mod.is_required_lane_green(runs) is False
+
+
+def test_required_lane_missing_run_is_not_green() -> None:
+    assert mod.is_required_lane_green([]) is False
+
+
+def test_required_lane_ignores_unrelated_check_names() -> None:
+    assert mod.is_required_lane_green([_run("some-other-check", "success")]) is False
+
+
+@pytest.mark.parametrize("missing", list(mod.REQUIRED_CHECK_NAMES))
+def test_required_lane_not_green_when_any_context_never_reported(missing: str) -> None:
+    # Fail closed: a required context with no run at all is not green, no
+    # matter how many sibling contexts passed.
+    runs = [run for run in _all_required_green() if run["name"] != missing]
+    assert mod.is_required_lane_green(runs) is False
+
+
+@pytest.mark.parametrize("failing", list(mod.REQUIRED_CHECK_NAMES))
+@pytest.mark.parametrize("conclusion", ["failure", "cancelled", "timed_out", "skipped", "neutral"])
+def test_required_lane_not_green_when_any_context_is_not_success(failing: str, conclusion: str) -> None:
+    runs = [_run(name, conclusion if name == failing else "success") for name in mod.REQUIRED_CHECK_NAMES]
+    assert mod.is_required_lane_green(runs) is False
+
+
+def test_required_lane_not_green_while_a_context_is_still_running() -> None:
+    runs = [_run(name, "success") for name in mod.REQUIRED_CHECK_NAMES[1:]]
+    runs.append(
+        {
+            "name": mod.REQUIRED_CHECK_NAMES[0],
+            "status": "in_progress",
+            "conclusion": None,
+            "started_at": "2026-07-23T08:00:00Z",
+        }
+    )
+    assert mod.is_required_lane_green(runs) is False
+
+
+def test_latest_check_run_returns_none_for_unknown_name() -> None:
+    assert mod.latest_check_run(_all_required_green(), "no-such-check") is None
+
+
+# ------------------------------------------------------------------ #
+# required_lane_green_at (park-time anchor)                           #
+# ------------------------------------------------------------------ #
+def test_green_at_is_the_last_required_context_to_finish() -> None:
+    # The lane is green only once every context has finished, so the anchor
+    # is the maximum completed_at -- not the first context's.
+    runs = [
+        _run("ci-required-result", "success", completed_at="2026-07-21T08:00:00Z"),
+        _run("Results Explorer browser gate", "success", completed_at="2026-07-23T02:00:00Z"),
+    ]
+    assert mod.required_lane_green_at(runs) == "2026-07-23T02:00:00Z"
+
+
+def test_green_at_is_order_independent() -> None:
+    runs = [
+        _run("Results Explorer browser gate", "success", completed_at="2026-07-23T02:00:00Z"),
+        _run("ci-required-result", "success", completed_at="2026-07-21T08:00:00Z"),
+    ]
+    assert mod.required_lane_green_at(runs) == "2026-07-23T02:00:00Z"
+
+
+@pytest.mark.parametrize("missing", list(mod.REQUIRED_CHECK_NAMES))
+def test_green_at_is_none_when_a_context_has_no_completion_stamp(missing: str) -> None:
+    runs = [
+        _run(name, "success", completed_at=None if name == missing else "2026-07-23T08:30:00Z")
+        for name in mod.REQUIRED_CHECK_NAMES
+    ]
+    assert mod.required_lane_green_at(runs) is None
+
+
+def test_green_at_is_none_when_a_context_is_absent() -> None:
+    assert mod.required_lane_green_at([_run("ci-required-result", "success")]) is None
+
+
+# ------------------------------------------------------------------ #
+# park_time_hours                                                      #
+# ------------------------------------------------------------------ #
+def test_park_time_anchors_on_the_last_required_context() -> None:
+    # Regression for the anchor bug: umbrella finished 52h before now, the
+    # gate only 10h before. Park time is 10h -- anchoring on the umbrella
+    # alone would report 52h and trip the >24h drain gate early.
+    pr = {
+        "updated_at": "2026-07-23T02:30:00Z",
+        "check_runs": [
+            _run("ci-required-result", "success", completed_at="2026-07-21T08:00:00Z"),
+            _run("Results Explorer browser gate", "success", completed_at="2026-07-23T02:00:00Z"),
+        ],
+    }
+    assert mod.park_time_hours(pr, _now(), required_green=True) == pytest.approx(10.0)
+
+
+def test_park_time_falls_back_to_updated_at_without_completion_stamps() -> None:
+    pr = {
+        "updated_at": "2026-07-23T09:00:00Z",
+        "check_runs": [_run(name, "success", completed_at=None) for name in mod.REQUIRED_CHECK_NAMES],
+    }
+    assert mod.park_time_hours(pr, _now(), required_green=True) == pytest.approx(3.0)
+
+
+def test_park_time_is_none_when_lane_is_not_green() -> None:
+    pr = {"updated_at": "2026-07-23T09:00:00Z", "check_runs": _all_required_green()}
+    assert mod.park_time_hours(pr, _now(), required_green=False) is None
+
+
+# ------------------------------------------------------------------ #
+# classify_pr                                                          #
+# ------------------------------------------------------------------ #
+def _soundness_pr(**over) -> dict:
+    pr = {
+        "number": 1,
+        "title": "parked soundness PR",
+        "html_url": "https://example.invalid/1",
+        "draft": False,
+        "created_at": "2026-07-15T09:00:00Z",
+        "updated_at": "2026-07-16T09:00:00Z",
+        "auto_merge": None,
+        "requested_reviewers": ["joeharris76"],
+        "changed_files": ["benchbox/core/equivalence/comparator.py"],
+        "check_runs": _all_required_green(completed_at="2026-07-16T08:00:00Z"),
+    }
+    pr.update(over)
+    return pr
+
+
+def test_classify_pr_fully_green_soundness_pr_qualifies() -> None:
+    c = mod.classify_pr(_soundness_pr(), _now())
+    assert c.required_green is True
+    assert c.awaiting_owner is True
+    assert c.qualifies is True
+
+
+@pytest.mark.parametrize(
+    ("case", "gate_runs"),
+    [
+        ("never_reported", []),
+        ("red", [_run("Results Explorer browser gate", "failure", completed_at="2026-07-16T08:00:00Z")]),
+    ],
+)
+def test_classify_pr_partial_green_does_not_qualify(case: str, gate_runs: list) -> None:
+    # A PR that would otherwise be a textbook drain-queue entry must not be
+    # labelled while a second required context is red or absent: it is
+    # genuinely not mergeable yet, so it is not parked on the owner.
+    pr = _soundness_pr(
+        check_runs=[_run("ci-required-result", "success", completed_at="2026-07-16T08:00:00Z"), *gate_runs]
+    )
+    c = mod.classify_pr(pr, _now())
+    assert c.required_green is False
+    assert c.park_time_hours is None
+    assert c.qualifies is False
+
+
+def test_self_test_passes() -> None:
+    assert mod.run_self_test() == 0


### PR DESCRIPTION
Sibling of #1633, same class of defect in the other script that classifies the develop required lane.

## Problem

`_project/scripts/soundness_drain_report.py` carried its own copy of the single-context logic: `REQUIRED_CHECK_NAME = "ci-required-result"`, matched by `required_lane_check_run()`, with `is_required_lane_green()` returning True from that one run. The `develop-squash-only` ruleset has had **two** required status contexts since 2026-08-03 ([`repo-admin-settings.md`](docs/operations/repo-admin-settings.md)):

```text
- ci-required-result
- Results Explorer browser gate
```

So a PR green on the umbrella with the browser gate red — or never reported — was classified required-lane green, and the report could label it `awaiting-owner` and file it in the drain digest as "parked on the owner" when it was in fact correctly unmergeable.

## The second bug, not in the original report

`park_time_hours()` anchored *"when did this PR go green"* on the umbrella's `completed_at`. The lane is only green once **every** required context has finished, so anchoring on the earlier one overstates park time whenever the browser gate completes later — tripping the >24h drain gate early and generating a false "parked 2 days" alert.

Fixture PR `9110` pins exactly this: umbrella finished 52h before `as_of`, gate 10h before.

| anchor | park time | verdict |
|---|---|---|
| umbrella only (old) | 52.0h | qualifies — **false alert** |
| last context (new) | 10.0h | too young — correct |

Fixing the classifier without the anchor would have left this live.

## Change

- `latest_check_run(runs, name)` + `is_check_run_success()` replace the single-name lookup; `is_required_lane_green()` requires **every** context in the new `REQUIRED_CHECK_NAMES` tuple to be latest-success, missing runs fail closed.
- `required_lane_green_at()` returns the `completed_at` of the last required context to finish, falling back to `updated_at` only when a context lacks a stamp.
- [`docs/operations/soundness-drain.md`](docs/operations/soundness-drain.md) updated for both the green definition and the park-time anchor.

## Tests

This script had **no unit test file** — only the fixture-driven `--self-test`. Adds `tests/unit/scripts/test_soundness_drain_report.py` (32 tests): required-context predicates, park-time anchoring, partial-green classification. The ruleset pin parses the contexts from the same runbook block [`scripts/ruleset_drift_check.py`](scripts/ruleset_drift_check.py) reads rather than restating them.

```bash
uv run -- python _project/scripts/soundness_drain_report.py --self-test
uv run -- python -m pytest tests/unit/scripts/ -q -n 0
```

- Self-test: 10 fixture PRs, 3 qualifying — `9101/9105/9107`, unchanged.
- `tests/unit/scripts/`: 1628 passed.
- New fixture PRs `9108`/`9109` (gate absent, gate red) as `not_green`; `9110` for the anchor.
- Existing fixture PRs each gained a gate run completing *before* their umbrella, so the park anchor and every prior expectation are untouched — verified additive-only against the previous fixture.
- Negative-tested: reverting only the anchor makes `9110` wrongly qualify, caught by both the self-test and the unit test.

## Why no shared helper yet

The obvious dedup — one helper module for both scripts, alongside the existing `auto_merge_soundness_paths.py` precedent — is deliberately **not** in this PR. `green_unmerged_sweep.py` is in flight in unmerged #1633, so editing it here would either conflict on merge or require a stacked PR, which gets zero CI in this repo. Filed as a follow-up to do once #1633 lands. Until then both sides independently pin to the runbook, so they agree transitively rather than through a merge-order coupling.

Tracker: `soundness-drain-all-ruleset-required-checks-20260806`.