### PR TITLE
claude/benchbox auto merge eval 424d56

### DIFF
--- a/.github/workflows/auto-merge-on-open.yml
+++ b/.github/workflows/auto-merge-on-open.yml
@@ -1,71 +1,67 @@
-name: Auto-enable auto-merge
+name: Auto-merge revocation
 
-# Auto-merge arming policy (cross-layer with the Makefile):
+# Auto-merge policy (cross-layer with the Makefile):
 #
-# Local path:
-#   - `make pr-open` withholds auto-merge by default.
-#   - `make pr-ready` / `pr-arm-auto-merge` (or `make pr-open READY=1`) is the
-#     intentional arming path for a finished branch.
+# Arming is exclusively local. `make pr-open` withholds auto-merge; the only
+# arm paths are `make pr-ready` / `make pr-arm-auto-merge` (or
+# `make pr-open READY=1`) on a finished branch. This workflow NEVER arms.
 #
-# Workflow path (this file):
-#   - Do NOT arm on `opened` or `reopened`. Opening a non-draft PR (including
-#     bare `gh pr create`) is not the final signal — that is what defeated the
-#     Makefile hold after #1567 (live proof: #1568/#1569 merged hands-free).
-#   - DO arm on `ready_for_review` (draft → ready is the UI equivalent of
-#     `make pr-ready`), unless the PR carries the durable hold label
-#     `no-auto-merge` (see below).
-#   - On `synchronize` / `labeled` (and other events): only re-evaluate
-#     revocation — disable auto-merge if soundness paths are touched or the
-#     durable hold label is present. Never re-enable on synchronize; that
-#     would re-open the race on the first push after open.
+# History: this file used to arm on `opened` (defeating the #1567 Makefile
+# hold — live proof: #1568/#1569 merged hands-free seconds after creation),
+# then after #1592 armed only on `ready_for_review`. That arm path never
+# fired once: drafts are not used in this repo, so no `ready_for_review`
+# event ever occurred (0 events across PRs #1459–#1630). The dead arm step
+# was removed per _project/decisions/auto-merge-policy-consolidation-2026-08-06.md
+# (D2); a dead enabling path in the gate machinery is pure comprehension
+# cost. If the draft workflow is ever adopted, arm via `make pr-ready`, not
+# by resurrecting an arm step here.
 #
-# Durable holds (both re-arming paths honour these):
-#   1. Draft status — job-level skip. Opening a draft is "not yet ready".
-#   2. Label `no-auto-merge` — holds a non-draft PR without converting it to
-#      draft. Applying the label revokes any enabled auto-merge; ready_for_review
-#      will not re-arm while the label remains. The nightly green-unmerged
-#      sweep also treats this label as intentional (not stranded) and never
-#      enables auto-merge itself. See docs/operations/pr-triage.md.
-#
-# Intentional gap: a non-draft PR opened without `make pr-ready`, `READY=1`,
-# or marking a draft ready will not get auto-merge from this workflow. Use
-# one of those paths when the branch is final (and remove `no-auto-merge`
-# first if it was applied).
-#
-# `synchronize` re-evaluates on every push so a later commit that newly
-# touches a soundness-critical path can flip auto-merge back OFF. GitHub
-# only auto-disables auto-merge on push when the pusher lacks write access,
-# so in the normal same-repo/write-author flow a stale enabled auto-merge
-# would otherwise survive and merge after checks without review.
+# What this workflow does — revocation only, re-evaluated on every trigger:
+#   1. Soundness paths touched (union of base-ref and PR-copy predicate,
+#      fail-closed): disable auto-merge. A push that newly touches a
+#      soundness-critical path must not ride an auto-merge armed by an
+#      earlier (non-soundness) state. GitHub only auto-disables auto-merge
+#      on push when the pusher lacks write access, so in the normal
+#      same-repo/write-author flow a stale enabled auto-merge would
+#      otherwise survive and merge after checks without review.
+#   2. Durable hold label `no-auto-merge` present: disable auto-merge.
+#      `labeled` is in the trigger list so applying the label revokes
+#      without needing a push. The label also blocks the local arm path
+#      (`make pr-arm-auto-merge` refuses it) and the nightly green-unmerged
+#      sweep treats it as intentional (not stranded). Remove the label
+#      before arming. See docs/operations/pr-triage.md.
+#   3. Draft status — job-level skip: a draft cannot carry auto-merge, so
+#      there is nothing to revoke.
 #
 # Soundness predicate evaluation (disable path):
 #   Union of (a) the base-ref copy and (b) the PR checkout copy. Base-ref
 #   alone stops a PR from judging its own diff by a narrowed rule set.
 #   Evaluating the PR copy alongside it means a gate *widened* mid-flight
 #   in the same PR still revokes auto-merge for paths only the new gate
-#   covers. Enable still requires soundness_path != true (both false), so
-#   a PR cannot weaken its own gate. Self-touch of the predicate or this
-#   workflow forces soundness_path=true regardless.
+#   covers. Self-touch of the predicate or this workflow forces
+#   soundness_path=true regardless.
 #
 # HONESTY NOTE on the self-protection checks below (base-ref predicate
 # execution + self-touch override): they are BEST-EFFORT for same-repo PRs.
 # GitHub executes the PR's OWN copy of a pull_request-triggered workflow
 # file, so a PR that edits this workflow can delete these checks in the
-# same commit that would have triggered them. There is deliberately NO
-# repo-layer rule backing this up: the develop ruleset's
-# require_code_owner_review target was RETIRED 2026-07-18 (the sole code
-# owner authors every PR and GitHub forbids self-approval, so the rule
-# would deadlock soundness PRs, not gate them — see
+# same commit that would have triggered them. The repo-layer backstop is
+# the develop ruleset's require_code_owner_review rule, re-enabled
+# 2026-07-21 with required approvals 0 (retired 2026-07-18 over a
+# self-approval deadlock, then restored — see
 # docs/operations/repo-admin-settings.md, "Soundness-path review
-# enforcement (RETIRED 2026-07-18)"). The operative control is what this
-# workflow does: soundness PRs never merge hands-free; the owner reviews
-# the diff and merges manually. The residual workflow-tamper risk is
-# recorded and accepted in that runbook section.
+# enforcement"). CODEOWNERS mirrors the soundness prefixes 1:1. GitHub
+# forbids self-approval, so soundness PRs never merge hands-free: the owner
+# reviews the diff and merges manually. The residual workflow-tamper risk
+# is recorded and accepted in that runbook section.
 
 on:
   pull_request:
     # `labeled` so applying `no-auto-merge` revokes auto-merge without a push.
-    types: [opened, reopened, ready_for_review, synchronize, labeled]
+    # No `ready_for_review`: nothing armable exists on a draft, so the
+    # draft→ready transition has nothing to revoke (and never arms — see
+    # header).
+    types: [opened, reopened, synchronize, labeled]
     branches: [develop]
 
 permissions:
@@ -73,7 +69,7 @@ permissions:
   contents: write
 
 jobs:
-  enable:
+  revoke:
     if: github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     steps:
@@ -91,7 +87,8 @@ jobs:
           PR_LABELS: ${{ join(github.event.pull_request.labels.*.name, '\n') }}
         run: |
           set -euo pipefail
-          # Durable hold label shared with green_unmerged_sweep.AUTO_MERGE_HOLD_LABEL.
+          # Durable hold label shared with green_unmerged_sweep.AUTO_MERGE_HOLD_LABEL
+          # and the `make pr-arm-auto-merge` refusal.
           # Exact match only — substring false positives (e.g. no-auto-merge-except) rejected.
           held=false
           if printf '%s\n' "$PR_LABELS" | grep -qxF 'no-auto-merge'; then
@@ -99,7 +96,7 @@ jobs:
           fi
           echo "held=$held" >> "$GITHUB_OUTPUT"
           if [ "$held" = "true" ]; then
-            echo "Explicit hold label no-auto-merge present; will not arm auto-merge."
+            echo "Explicit hold label no-auto-merge present; will revoke any enabled auto-merge."
           fi
 
       - name: Check soundness-critical paths
@@ -129,8 +126,8 @@ jobs:
             fi
           fi
 
-          # Union: soundness if either copy says so. Enable requires both false,
-          # so a PR cannot weaken its own gate by narrowing the PR-side rules.
+          # Union: soundness if either copy says so, so a PR cannot weaken its
+          # own gate by narrowing the PR-side rules.
           if [ "$base_result" = "soundness_path=true" ] || [ "$pr_result" = "soundness_path=true" ]; then
             result="soundness_path=true"
           else
@@ -149,24 +146,6 @@ jobs:
           fi
 
           echo "$result" >> "$GITHUB_OUTPUT"
-
-      - name: Enable squash auto-merge
-        # Arm only on draft→ready, and only when neither soundness nor the
-        # durable hold label blocks. Never on opened/reopened/synchronize —
-        # those are not "branch is final" signals (see header policy).
-        if: >-
-          steps.soundness.outputs.soundness_path != 'true'
-          && steps.hold.outputs.held != 'true'
-          && github.event.action == 'ready_for_review'
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
-          REPO: ${{ github.repository }}
-        run: |
-          set -euo pipefail
-          # Idempotent: gh pr merge --auto is a no-op if auto-merge is already on
-          # for the same method. We keep the call simple and rely on that.
-          gh pr merge --auto --squash --repo "$REPO" "$PR_NUMBER"
 
       - name: Disable auto-merge for soundness PR
         if: steps.soundness.outputs.soundness_path == 'true'

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -98,7 +98,7 @@ The canonical loop is **branch → edit → preflight → `make pr-open` → (wh
    # make pr-open READY=1
    ```
 
-   Equivalent UI path: open as draft, then mark ready for review (`ready_for_review`); the workflow arms only on that event, not on bare `opened` / `reopened` / `synchronize`. Once armed, the PR squash-merges when required checks turn green — don't poll. Soundness-critical paths stay withheld pending review (see `docs/operations/repo-admin-settings.md`).
+   `make pr-ready` (or `READY=1`) is the only arm path: `auto-merge-on-open.yml` is revoke-only and never arms — not on `opened` / `reopened` / `synchronize`, and not on draft → ready (`ready_for_review` is not even a trigger; the historical workflow arm point never fired once and was deleted). Once armed, the PR squash-merges when required checks turn green — don't poll. Soundness-critical paths and the `no-auto-merge` hold label stay withheld pending review (see `docs/operations/repo-admin-settings.md`).
 
 6. **After merge**, the remote branch auto-deletes (repo setting `delete_branch_on_merge`). Sweep any stale local branches and worktrees with:
 

--- a/Makefile
+++ b/Makefile
@@ -1665,7 +1665,8 @@ pr-arm-auto-merge:
 		URL=$$(gh pr list --base develop --head "$$CURRENT" --state open --json url --jq '.[0].url' 2>/dev/null); \
 	fi; \
 	if [ -z "$$URL" ]; then echo "No open PR found for this branch." >&2; exit 1; fi; \
-	if gh pr view "$$URL" --json labels --jq '.labels[].name' | grep -qxF 'no-auto-merge'; then \
+	LABELS=$$(gh pr view "$$URL" --json labels --jq '.labels[].name') || { echo "Cannot read PR labels — refusing to arm (fail closed)." >&2; exit 1; }; \
+	if printf '%s\n' "$$LABELS" | grep -qxF 'no-auto-merge'; then \
 		echo "PR carries the durable no-auto-merge hold label; leaving auto-merge disabled. Remove the label first if arming is intended."; \
 		exit 0; \
 	fi; \

--- a/Makefile
+++ b/Makefile
@@ -1654,6 +1654,10 @@ pr-open:
 
 # Arms squash auto-merge for an already-open PR. Split out of pr-open so the
 # soundness check has exactly one implementation and both entry points get it.
+# Honours the durable `no-auto-merge` hold label: before this check, the label
+# was only durable against paths that never arm (workflow + sweep) while the
+# one live arm path ignored it — #1626 was armed 52s after being labeled. See
+# _project/decisions/auto-merge-policy-consolidation-2026-08-06.md (D3).
 pr-arm-auto-merge:
 	@URL="$(URL)"; \
 	if [ -z "$$URL" ]; then \
@@ -1661,6 +1665,10 @@ pr-arm-auto-merge:
 		URL=$$(gh pr list --base develop --head "$$CURRENT" --state open --json url --jq '.[0].url' 2>/dev/null); \
 	fi; \
 	if [ -z "$$URL" ]; then echo "No open PR found for this branch." >&2; exit 1; fi; \
+	if gh pr view "$$URL" --json labels --jq '.labels[].name' | grep -qxF 'no-auto-merge'; then \
+		echo "PR carries the durable no-auto-merge hold label; leaving auto-merge disabled. Remove the label first if arming is intended."; \
+		exit 0; \
+	fi; \
 	git fetch origin develop --quiet; \
 	SOUNDNESS_PATH=$$(git diff --name-only --no-renames origin/develop...HEAD | uv run --project _project/scripts -- python _project/scripts/auto_merge_soundness_paths.py --stdin); \
 	if [ "$$SOUNDNESS_PATH" = "true" ]; then \

--- a/_project/decisions/auto-merge-policy-consolidation-2026-08-06.md
+++ b/_project/decisions/auto-merge-policy-consolidation-2026-08-06.md
@@ -1,0 +1,280 @@
+# Auto-merge policy: adversarial evaluation and consolidation
+
+**Date**: 2026-08-06
+**Status**: evaluation recorded; decisions D1–D7 proposed, **not yet authorized**
+(read-only investigation; no mechanism was modified).
+**Related**: PRs #1567, #1592, #1622, #1623, #1624 (policy lineage);
+#1568/#1569 (live arm-on-open failure); #1503/#1521/#1531 (stranded review
+fixes); #1512 (anonymization auto-merge escape); #1543 (red-develop revert);
+UAT batch #1616–#1631. Evidence window: 150 merged PRs (#1459–#1630,
+2026-08-02 → 2026-08-06).
+
+## Executive summary
+
+The objective optimized here is **merged, correct work per unit of human and
+agent attention**. Against that objective the current policy is *roughly
+right and cheap* — post-#1592 the per-PR ceremony is one `make pr-ready` when
+final — but it carries four pieces of scar tissue: (1) the workflow's arm
+step is dead code (zero `ready_for_review` events in 150 PRs; drafts are
+never used); (2) the "durable" `no-auto-merge` hold is not durable against
+the only live arm path (`make pr-arm-auto-merge` never checks it — proven on
+#1626, armed 52 s after being labeled); (3) two files still document the
+code-owner rule as RETIRED when it is live again; (4) the hook-regenerated
+LOC block in `_project/specs/uat-framework.md` makes any two LOC-changing UAT
+PRs conflict by construction, which is what actually serializes concurrent
+agent batches. Recommendation: keep arm-when-final and the tiered soundness
+lane unchanged; fix (2) and (4); delete (1); correct (3). Do **not** add
+review gates.
+
+## The objective, named and defended
+
+Merge latency alone is the wrong target: median ready→merge is already 27
+minutes and nothing human-visible waits on it. Defect count alone is the
+wrong target: the measured escape rate is ~2% with same-day fix-forward SLA
+and post-merge auto-revert, so marginal defect suppression is cheap to buy
+back after the fact. The scarce resource in a solo-maintainer,
+33-merges/day, agent-fleet workflow is **attention**: every per-PR ceremony
+minute multiplies by ~33/day forever, while every escaped defect costs a
+bounded, observed ~minutes-to-2h once. Hence: merged correct work per unit
+attention, with a tier exception where blast radius makes a defect *not*
+cheaply reversible (published results, release path — see D5).
+
+## Reframe verdict — is auto-merge policy the constraint?
+
+**Partially. Two distinct problems have been conflated; only one of them is
+merge policy.**
+
+1. **The arm-when-final policy is not scar tissue.** Its originating failure
+   (auto-merge firing before the author's own review fixes landed —
+   #1503/#1521/#1531, and escape commit `16a5a1432e` "re-land review fixes
+   stranded by auto-merge on #1521 and #1531") is a real, observed defect
+   class, and the fix costs one command per PR. It stays.
+2. **The concurrent-batch serialization is not caused by merge policy at
+   all.** It is caused by `_project/scripts/uat_loc_table.py` +
+   `.pre-commit-config.yaml:32-38`, which force every net-LOC-changing UAT
+   change to rewrite a shared generated block in
+   `_project/specs/uat-framework.md:127-154` (module table) and `:174-190`
+   (bucket summary). The summary block ends in a single grand-total line
+   (`**Total: 11,043 production LOC across 26 modules.**`), so **any two
+   LOC-changing UAT PRs textually conflict regardless of which modules they
+   touch**. Measured: since 2026-07-15, 14 of 39 commits touching
+   `tests/uat/*.py` also rewrote the spec — including all four substantive
+   PRs of the 08-06 remediation batch. The 08-06 batch (#1618 armed at 00:28,
+   still open and unmerged 13+ hours later while #1616/#1628/#1630 landed
+   through the same file) is the arming-is-inert case: for *concurrent* UAT
+   PRs, arming state is theatre because `mergeable_state: dirty` gates the
+   merge, not the arm.
+
+   Caveat the other way: in the 150-PR window at large, this did not bind —
+   the 5 spec-touching merged PRs had **zero overlapping open windows**
+   (sub-hour PR lifetimes serialize naturally), and 141/150 PRs merged while
+   armed. The generated file is the binding constraint **only when multiple
+   UAT sessions run concurrently — which is precisely the workflow the repo
+   is moving toward.** Fix the file (D6); do not redesign merge policy
+   around it.
+
+Note: GitHub's server-side merge does not run custom merge drivers, so a
+`.gitattributes` driver cannot fix mergeability on github.com; `merge=union`
+(the `fast_lane_ceiling_log.md` precedent) would merge cleanly but produce
+wrong totals that `--check` then flags on develop. The only real fixes are
+derive-at-read-time (stop committing the volatile numbers) or coarsening the
+committed numbers so most PRs don't move them.
+
+## Prior art — every mechanism, with verdicts
+
+| # | Mechanism | Where | Originating incident | What it prevents | Failure mode still reachable? | Verdict |
+|---|---|---|---|---|---|---|
+| 1 | Workflow arm on `ready_for_review` | `.github/workflows/auto-merge-on-open.yml:153-169` | #1567/#1592 (was: arm on `opened`) | n/a (it is an *enabling* path) | Dead in practice: 0 `ready_for_review` events in 150 PRs; drafts unused; 0 bot arms since #1592 (last: 85 s before its merge) | **supersede** — delete the arm step; workflow becomes revoke-only (D2) |
+| 2 | Workflow soundness revocation | `auto-merge-on-open.yml:105-151,171-183`; `_project/scripts/auto_merge_soundness_paths.py` | #1512 (anonymization change auto-merged into every published byte) | Hands-free merge of correctness-/privacy-defining paths | Yes — reachable and firing: disable step executed in 20/100 recent runs (upper bound; `\|\| true` masks no-ops) | **extend** — keep; it is the tier boundary (D5) |
+| 3 | Makefile withhold/arm (`pr-open` withholds, `pr-ready`/`READY=1` arms) | `Makefile:1582-1643` | #1503/#1521/#1531 (stranded review fixes) | Merge before the author is finished | The defect class recurs whenever arming precedes finality; observed escapes `16a5a1432e`, #1543 | **keep unchanged** (D1) |
+| 4 | `no-auto-merge` durable hold label | `auto-merge-on-open.yml:87-103,185-194`; sweep `green_unmerged_sweep.py:119-123`; #1622 | Two sessions fighting over gating; no hold for a non-draft PR | Re-arming of an intentionally held PR | **Hold is bypassable today**: `pr-arm-auto-merge` (Makefile:1617-1630) never checks the label — #1626 was armed 2026-08-06T13:48:46Z *while labeled* (labeled 13:47:54, unlabeled 13:48:54, all actor `joeharris76`). Workflow disable-for-hold path: 0 executions in last 100 runs | **extend** — close the Makefile gap (D3); it is the only cross-session coordination primitive and costs one label check |
+| 5 | Nightly green-unmerged sweep | `_project/scripts/green_unmerged_sweep.py`; `nightly.yml:736-775`; #1624 | Post-#1592, green+unarmed is normal; sweep falsely flagged intentional holds | Silently stranded finished work | Report-only (one tracking issue; never arms/merges/labels) — cannot cause a bad merge | **keep** — correct shape for a backstop: alerting, not acting |
+| 6 | `pr-conflict-scan` (`git merge-tree --write-tree`) | `Makefile:1696-1709`, warn-only inside `pr-open` | concurrent-PR sessions | Surprise `dirty` states | n/a (advisory) | **keep** — cheap, right altitude |
+| 7 | `pr-base-guard` + zero-CI-for-stacked-PRs | `.github/workflows/pr-base-guard.yml`; `docs/development/pr-base-branch-policy.md` | stacked PRs silently get zero CI | Unvalidated content landing via parent squash | Yes, guard is load-bearing | **keep** — out of scope here but interacts: it is why "wait for the parent PR" is not a coordination option |
+| 8 | Ruleset: required CI only (`ci-required-result` + browser gate), no reviews, + code-owner rule on CODEOWNERS(=soundness) paths | `docs/operations/repo-admin-settings.md:47-91,117-186` | — | The actual merge gate | Live. **Doc contradiction**: `auto-merge-on-open.yml:50-63` and `auto_merge_soundness_paths.py:53-69` still say the code-owner rule was RETIRED 2026-07-18; `repo-admin-settings.md:119-124` records it re-enabled (verified 2026-07-21) | **extend** — fix the stale comments (D4) |
+
+## Quantified findings
+
+Window: full population of 150 merged PRs to `develop`, #1459–#1630,
+2026-08-02T01:09Z → 2026-08-06T13:45Z (~4.5 days, ~33 merges/day; every day
+exceeded 5 merges, peak 61). Classification: a PR is "auto-merged" if an
+`auto_squash_enabled` event was in force at merge time (`mergedBy` is the
+*enabler* identity under native auto-merge — `app/github-actions` means the
+pre-#1592 workflow token armed it, not that any workflow merged it).
+
+**Ready → merged latency** (no drafts exist, so created ≈ ready):
+
+| Class | n | p50 | p90 | mean | max |
+|---|---|---|---|---|---|
+| Auto-merged (armed at merge) | 141 (94%) | 0.45 h | 3.5 h | 2.85 h | 37.7 h |
+| — bot-armed (pre-#1592 arm-on-open) | 66 | 0.49 h | 3.0 h | 2.59 h | 37.7 h |
+| Manual (never armed) | 9 (6%) | 0.61 h | 12.1 h | 3.03 h | 12.1 h |
+
+Latency is statistically indistinguishable at the median. **The gate is not
+buying latency and manual merging is not costing much latency — at this
+scale the arming question is not a throughput question.**
+
+**Escaped defects** (the central number):
+
+| Signal | Auto (n=141) | Manual (n=9) |
+|---|---|---|
+| Direct `#N`-referencing fix commit ≤7 d | 2 (1.4%) | 0 |
+| Red-develop revert (#1543) | 1 | 0 |
+| File-overlap ≥75% follow-up "fix" PR ≤7 d | 33 (23.4%) | 2 (22.2%) |
+
+The overlap proxy is dominated by *planned* iterative hardening series
+(~half of all PRs in the window are themselves `fix(...)`) and is
+right-censored (mean observation 2.1 d of 7); read the honest escape rate as
+**~2% (3/150), and note both direct-reference escapes are the
+stranded-review-fix class that #1567/#1592 has since closed**. Manual n=9 is
+too small to support any auto-vs-manual defectiveness claim. **There is no
+evidence auto-merge causes defects; the one incident class it caused
+(premature merge of unfinished work) was an *arming-time* bug, fixed by
+arm-when-final, not by gating merges.**
+
+**Arming mechanics:**
+
+- 153 arm events: 84 by `joeharris76`, 69 by `github-actions[bot]`, 0 other.
+  Bot arms stop at exactly #1592's merge (last: 2026-08-06T00:39:43Z, 85 s
+  prior). Zero since → **the workflow arm step has never fired via
+  `ready_for_review`; `make pr-ready` is the only live arm path.**
+- Armed-but-never-fired: 0 among merged PRs (7 PRs saw 12 disable events,
+  every one re-armed and merged armed); 4 among the 6 closed-unmerged PRs
+  (closed/superseded, not conflict-wedged).
+- Soundness revocation: 20/100 recent workflow runs executed the disable
+  step (upper bound — the `\|\| true` makes already-off indistinguishable).
+  Explicit-hold disable step: **0/100 executions ever**.
+- `no-auto-merge` label lifetime usage: exactly 2 PRs (#1626: on for 60 s;
+  #1631: still held). It has not yet prevented any merge — #1626's arm was
+  stopped 9 minutes later by a session disarming it, not by the label.
+- Hands-free rate: 13/150 (9%) merged with zero activity of any kind;
+  105/150 (70%) with zero *human* review or comment. During the 08-06 UAT
+  batch, every Codex review attempt failed on usage limits — the entire
+  batch had zero completed external reviews, and develop did not break.
+
+**UAT batch claims from the session, verified:** #1568/#1569 hands-free
+merges 18 s/32 s after opening — confirmed. #1630 merged manually 36 min
+after open with zero completed reviews; cost ≈ 0 — confirmed (its follow-up,
+#1631, is open and held, so "landed later" is not yet true). The 60-second
+label fight — confirmed to the second on #1626, all four events actor
+`joeharris76`, no attribution possible. The #1626 trap/cleanup regression and
+the mutation-survival findings are session-reported and **not independently
+verified here**; note #1626 is unmerged, so nothing about it is "shipped".
+
+**Unanswerable from available data:** historical `mergeable_state` (GitHub
+doesn't retain it) — armed-but-dirty inertness is established structurally,
+not measured; CI-minutes burned on conflict-driven re-runs (not extracted);
+defects *prevented* by withholding (counterfactual; one candidate save: the
+review of unmerged #1626 while it sat unarmed).
+
+## Decision matrix
+
+Scored 1 (bad) – 5 (good) against: **A** attention cost/PR, **L** merge
+latency, **C** defect containment (weighted by tier blast radius), **M**
+multi-agent safety (indistinguishable actors), **S** comprehension cost of
+the mechanism set.
+
+| Policy | A | L | C | M | S | Total | Notes |
+|---|---|---|---|---|---|---|---|
+| (a) No gating: arm on `opened`, merge when green | 5 | 5 | 1 | 1 | 5 | 17 | The pre-#1567 world. Reproduces the only observed incident class (3 stranded-fix incidents in one session; #1512 privacy escape reached published bytes). Fails exactly where reverts are not cheap. |
+| (b) Full manual: no auto-merge anywhere | 2 | 3 | 3 | 2 | 4 | 14 | 141 armed merges become 141 human polls (~33/day). Manual cohort shows no measurable correctness gain (n=9, same defect proxy). Buys nothing the data can see; costs the scarce resource. |
+| (c) Status quo, untouched | 4 | 4 | 4 | 2 | 2 | 16 | Works, but: dead arm path, hold label bypassable by the live arm path, contradictory docs, conflict-by-construction spec file. M=2 because the one coordination primitive doesn't bind. |
+| (d) **Recommended**: status quo − dead code + label made real + generated-file fix; tiers unchanged | 4 | 4 | 4 | 4 | 4 | 20 | Same ceremony as (c); removes the multi-agent failure modes actually observed. |
+| (e) Tighten: require completed bot review before arm | 2 | 2 | 4 | 3 | 3 | 14 | The 08-06 batch shows this deadlocks on third-party outages (every Codex review failed on limits); couples merge availability to an external quota. |
+
+## Recommendation (D1–D7)
+
+| ID | Decision | Choice |
+|---|---|---|
+| D1 | Arm-when-final | **Keep unchanged.** `make pr-open` withholds; `make pr-ready` / `READY=1` arms. Its incident class is real and its cost is one command. |
+| D2 | Workflow arm step | **Delete** (`auto-merge-on-open.yml:153-169` and the `hold`-gated enable condition). The workflow becomes revoke-only: soundness revocation + label revocation. Update the header policy comment; keep `ready_for_review` in the trigger list only if the draft path is ever adopted — otherwise drop it. Rationale: 0 firings ever; every line of a dead enabling path is comprehension cost on a security-relevant file. |
+| D3 | Make the durable hold durable | **Extend** `pr-arm-auto-merge` (Makefile:1617-1630) to refuse when the PR carries `no-auto-merge` (one `gh pr view --json labels` check, exact match, same semantics as the workflow's `grep -qxF`). Add a pinning test beside `tests/unit/test_auto_merge_hold_is_durable.py`. This is the multi-agent coordination primitive: with indistinguishable actors, the label is the only cross-session signal; today the only live arm path ignores it (#1626, armed while labeled). |
+| D4 | Doc truth | **Correct** the stale "RETIRED 2026-07-18 / no repo-layer backstop" text in `auto-merge-on-open.yml:50-63` and `auto_merge_soundness_paths.py:53-69` to match `repo-admin-settings.md:117-186` (code-owner rule live again, verified 2026-07-21). A safety comment that understates the actual protection invites wrong risk decisions in both directions. |
+| D5 | Tiering | **Keep the tiered policy; do not unify.** UAT/test infrastructure: fix-forward tier (auto-merge on green; escapes cost ~2h bounded). Soundness paths (equivalence oracles, anonymization, result capture, resolver core) + release path: manual-merge tier (workflow revocation + CODEOWNERS + owner merge) — #1512 is the proof that this tier's escapes are *not* cheaply reversible (published bytes). A single uniform policy across these tiers is the error, in either direction. |
+| D6 | The reframe fix | **Stop committing the volatile LOC numbers.** Preferred: `uat_loc_table.py` keeps the module/bucket *definitions* in the spec but moves the generated numbers out of Git (emit to an untracked artifact, or demote the pre-commit `--check` to a scheduled/nightly drift report). Fallback if inline numbers must stay: round to coarse bands (nearest 250) so typical PRs don't move them, and drop the single grand-total line — it alone makes all pairs conflict. This, not merge policy, is what serializes concurrent UAT batches. |
+| D7 | Review gates | **Do not add any.** 70% of merges had zero human review activity and the escape rate is ~2% with same-day fix-forward + auto-revert backstops. Reviews are valuable (the #1626 catch) — fund them by keeping PRs unarmed until reviewed *when the author chooses*, not by a merge-blocking gate that deadlocks on reviewer outages. |
+
+**Migration path** (each independently landable, smallest first): D4 (comment
+edits + no behavior change) → D3 (Makefile guard + test) → D2 (workflow
+deletion + update `test_auto_merge_enablement_point.py`) → D6 (script + spec
++ `.pre-commit-config.yaml`; verify `guards-fix` and CI drift check follow).
+Leave alone: sweep, soundness predicate/CODEOWNERS lockstep, pr-base-guard,
+conflict-scan, ruleset.
+
+## What safety is given up — explicitly
+
+- **D2** gives up the draft→ready UI arming affordance. Accepted: it has
+  never been used (0 events / 150 PRs), and `make pr-ready` or the merge-box
+  button covers the need.
+- **D6** gives up always-current LOC numbers inside the committed spec.
+  Accepted: the numbers are decorative for correctness; drift becomes a
+  nightly report instead of a per-commit invariant. The failure mode "spec
+  quotes stale totals for up to a day" is affordable; the failure mode it
+  buys off — concurrent agent batches serially conflicting on a generated
+  total line — is the observed one.
+- **D7 (standing)** accepts that ~2% of merges will need a same-day fix or
+  revert, and that a defective UAT-tier change can sit on develop for up to
+  ~2 h before fix-forward. Accepted *for that tier only* because: squash
+  merges make reverts one commit; `develop-post-merge` auto-revert and the
+  same-day SLA exist; and #1630's premature merge measurably cost ≈ 0. Not
+  accepted for soundness/release tiers (D5 keeps them manual).
+- **Residual, unchanged**: a PR editing `auto-merge-on-open.yml` runs its own
+  workflow copy and can delete the self-protection in the same commit
+  (documented in the header). The live code-owner rule narrows this; the
+  residue is recorded in `repo-admin-settings.md` and accepted. D2 shrinks
+  the file but does not change this class.
+- **Actor attribution remains impossible.** Everything acts as
+  `joeharris76`; the 60-second label fight cannot be attributed. D3 makes
+  the label binding but cannot make it *auditable*. Any future policy that
+  needs "who did this" requires a session-identity convention (e.g., a
+  session tag in the label-event-adjacent PR comment) — costed at one
+  comment per hold; not required for D1–D7 and deliberately not proposed.
+
+## The case against this recommendation
+
+The strongest honest argument: **this window cannot show the counterfactual,
+and it was an anomalous window.** 4.5 days of burst remediation (61 merges
+on Aug 4) with the policy already in flux mid-window; every "the gate buys
+nothing" number is measured *under the gate*. The 2% escape rate is an
+escape rate *of gated merges* — under policy (a) the #1512 class recurs, and
+we know that because it did. If the fleet scales to N concurrent sessions,
+the serialized sub-hour lifetimes that made arming look clean disappear, and
+this ADR's own data (the stuck #1618) shows what that looks like. D6 removes
+the *textual* conflicts but not the *semantic* ones: two UAT PRs editing the
+same module still conflict, and with mutation-weak test suites
+(session-reported: weak mutants survived fully green suites) green CI is a
+softer oracle than this ADR's fix-forward economics assume. If the mutation
+finding generalizes, the correct response is not "merge faster" but
+"strengthen the oracle" — and until that is measured, deleting *any*
+friction is a bet that CI green means what we act like it means.
+Counter-position accepted as the reason D5 keeps the soundness tier manual
+and D7 funds reviews rather than abolishing them; it does not, however,
+justify per-PR ceremony on the fix-forward tier, where the observed cost of
+being wrong stayed under the cost of one day of polling.
+
+## Blind-spot audit (L2, per review-protocol §3/§4)
+
+What class of issue does this evaluation's framework miss?
+
+1. **Counterfactual blindness**: every measurement conditions on the policy
+   that was active; prevented incidents are invisible. The framework treats
+   absence of evidence (manual cohort n=9) as weak evidence of absence.
+2. **Oracle strength is assumed, not audited**: the whole fix-forward
+   economics rests on "green CI ≈ correct". The mutation-survival report is
+   exactly the kind of signal this framework has no lane for — it evaluated
+   merge *gating* while the load-bearing assumption is test *strength*. A
+   dedicated mutation-score baseline for `tests/uat/` would convert this
+   from anecdote to gate-able number.
+3. **Single-window sampling**: 4.5 days, mid-incident, policy changing
+   within the window (three regimes: arm-on-open → #1592 → #1622). Rates
+   were not stratified by regime except for arming actors; latency and
+   escape numbers mix regimes.
+4. **Attention was never directly measured**: the objective is per-unit
+   attention, but attention is proxied (ceremony steps, polling) rather than
+   measured (no session-time accounting exists). The recommendation would
+   survive a 2× error in the proxy, but the framework couldn't detect one.
+5. **Third-party dependency risk entered sideways**: the Codex usage-limit
+   outage materially changed the batch's review coverage and was discovered
+   incidentally. No mechanism inventories external dependencies of the merge
+   path (review bots, GitHub auto-merge semantics such as `mergedBy` =
+   enabler) or alerts when one degrades.

--- a/_project/scripts/auto_merge_soundness_paths.py
+++ b/_project/scripts/auto_merge_soundness_paths.py
@@ -54,13 +54,17 @@ SOUNDNESS_PREFIXES = (
     # base-ref execution + self-touch override in auto-merge-on-open.yml is
     # best-effort only for same-repo PRs (GitHub runs the PR's OWN copy of a
     # pull_request-triggered workflow file, so a PR editing that workflow can
-    # delete those checks in the same commit). There is no repo-layer
-    # backstop: the develop ruleset's require_code_owner_review target was
-    # retired 2026-07-18 (self-approval deadlock -- the sole code owner
-    # authors every PR; see docs/operations/repo-admin-settings.md,
-    # "Soundness-path review enforcement (RETIRED 2026-07-18)"). Listing
-    # these files here still matters: it stops auto-merge so the owner
-    # personally reviews and merges any change to the gate machinery.
+    # delete those checks in the same commit). The repo-layer backstop is the
+    # develop ruleset's require_code_owner_review rule, re-enabled 2026-07-21
+    # with required approvals 0 (it was retired 2026-07-18 over a
+    # self-approval deadlock, then restored -- see
+    # docs/operations/repo-admin-settings.md, "Soundness-path review
+    # enforcement"). CODEOWNERS mirrors SOUNDNESS_PREFIXES 1:1, lockstep-
+    # pinned by tests/unit/test_auto_merge_soundness_paths.py. GitHub forbids
+    # self-approval, so the operative effect is that soundness PRs never
+    # merge hands-free: the owner reviews the diff and merges manually.
+    # Listing these files here still matters: it revokes/withholds auto-merge
+    # so that manual step is reached at all.
     # release.yml is included
     # because it publishes to PyPI. .github/workflows/pr.yml is deliberately
     # NOT included: it is high-churn (routine CI-lane edits), and the

--- a/_project/scripts/green_unmerged_sweep.py
+++ b/_project/scripts/green_unmerged_sweep.py
@@ -42,7 +42,9 @@ and alerts only when all of the following hold:
     (f) prior arm intent     -- the issue/PR timeline shows evidence that
         auto-merge was requested or previously enabled, then lost. Signals
         (any one is enough):
-          * `ready_for_review` (draft → ready; workflow arm path)
+          * `ready_for_review` (draft → ready; historical workflow arm path,
+            deleted 2026-08-06 — still valid as arm-intent evidence in old
+            timelines)
           * `auto_squash_enabled` / `auto_merge_enabled` (arm succeeded once)
           * `auto_merge_disabled` (implies a prior enable that was dropped)
         Never-armed intentional holds have none of these events and are

--- a/docs/operations/pr-triage.md
+++ b/docs/operations/pr-triage.md
@@ -106,8 +106,12 @@ a PR's mergeability — both only alert.
 
   - `make pr-ready` (or `make pr-arm-auto-merge`) on a finished branch
   - `make pr-open READY=1` to open and arm in one step
-  - draft → ready (`ready_for_review` in `auto-merge-on-open.yml`), and only
-    when the PR does **not** carry the `no-auto-merge` label
+
+  Those are the **only** arm paths: `auto-merge-on-open.yml` is revoke-only
+  and never arms (its draft→ready arm point never fired once and was deleted
+  — see `_project/decisions/auto-merge-policy-consolidation-2026-08-06.md`,
+  D2). Both Makefile paths refuse while the PR carries the `no-auto-merge`
+  label or touches soundness paths.
 
   **Classifier (arm intent):** a PR is stranded only when auto-merge is off
   *and* the issue/PR timeline includes at least one of
@@ -122,12 +126,12 @@ a PR's mergeability — both only alert.
 
   Do **not** remediate a green-unmerged alert by re-pushing "to re-trigger
   synchronize." That path no longer enables auto-merge. When the branch is
-  final, arm via `make pr-ready` / `READY=1` / draft → ready; if work
-  continues, leave auto-merge off (or apply a durable hold — see below).
+  final, arm via `make pr-ready` / `READY=1`; if work continues, leave
+  auto-merge off (or apply a durable hold — see below).
 
-  A green `enable`-job run is also not proof the PR's `auto_merge` field is
-  set — the sweep re-reads the PR field (and the timeline) rather than
-  trusting the workflow conclusion.
+  A green revocation-workflow run is also not proof of the PR's `auto_merge`
+  field either way — the sweep re-reads the PR field (and the timeline)
+  rather than trusting the workflow conclusion.
 
 ## Durable auto-merge holds
 
@@ -138,14 +142,14 @@ honour these durable holds (and neither re-arms on push or nightly `--apply`):
 | Hold | Who honours it | Effect |
 | --- | --- | --- |
 | **Draft** | `auto-merge-on-open.yml` (job skip), green-unmerged sweep | Not ready; no arm, not stranded |
-| **Label `no-auto-merge`** | `auto-merge-on-open.yml` (enable blocked + disable on apply/`labeled`), green-unmerged sweep | Non-draft intentional hold; revoke any enabled auto-merge; not stranded |
+| **Label `no-auto-merge`** | `make pr-arm-auto-merge` / `pr-ready` (refuse to arm), `auto-merge-on-open.yml` (disable on apply/`labeled`), green-unmerged sweep | Non-draft intentional hold; revoke any enabled auto-merge; not stranded |
 | **Never armed** | green-unmerged sweep (timeline arm-intent classifier) | Green + auto-merge OFF with no prior arm events is normal after the post-#1592 policy; not stranded |
 
 Use draft while the branch is incomplete. Use `no-auto-merge` when the PR
 should stay non-draft (CI/review as ready) but must not auto-merge — for
 example waiting on another PR, or after an explicit disable that must survive
-a later `ready_for_review` / re-arm attempt. Remove the label before arming
-with `make pr-ready` or draft → ready.
+a later re-arm attempt. Remove the label before arming with `make pr-ready`
+(which refuses to arm while the label is present).
 
 Both sweeps upsert a single marker-tagged tracking issue while their
 respective queue is non-empty, and patch it to the empty state exactly

--- a/docs/operations/pr-triage.md
+++ b/docs/operations/pr-triage.md
@@ -149,7 +149,10 @@ Use draft while the branch is incomplete. Use `no-auto-merge` when the PR
 should stay non-draft (CI/review as ready) but must not auto-merge — for
 example waiting on another PR, or after an explicit disable that must survive
 a later re-arm attempt. Remove the label before arming with `make pr-ready`
-(which refuses to arm while the label is present).
+(which refuses to arm while the label is present, and fails closed when the
+label list cannot be read). The hold guarantee is **eventual, not atomic**: a
+label applied after the arm path's check but before the arm lands is caught
+by the workflow's `labeled`-trigger revoke within one run, not instantly.
 
 Both sweeps upsert a single marker-tagged tracking issue while their
 respective queue is non-empty, and patch it to the empty state exactly

--- a/docs/operations/repo-admin-settings.md
+++ b/docs/operations/repo-admin-settings.md
@@ -139,24 +139,24 @@ The soundness gate, as operated:
   `make pr-open READY=1`) does, so a PR cannot merge while a follow-up commit
   is still being written. Arming at creation stranded three commits in one
   session, two of them the fixes for their own review findings.
-- `.github/workflows/auto-merge-on-open.yml` matches that hold: it does **not**
-  arm on `opened` / `reopened` / `synchronize` (bare `gh pr create` no longer
-  auto-arms). It arms only on `ready_for_review` (draft → ready), which is the
-  UI equivalent of `make pr-ready`, and only when the PR does not carry the
-  durable hold label `no-auto-merge`. `synchronize` / `labeled` re-evaluate
-  revocation only (soundness paths or the hold label) — they never re-enable
-  auto-merge. The soundness check unions the base-ref predicate with the PR
-  checkout copy so a gate widened mid-flight still revokes; enable still
-  requires both false so a PR cannot weaken its own gate.
-- Durable holds both re-arm paths honour: **draft** (job/sweep skip) and
-  label **`no-auto-merge`** (workflow blocks enable + disables; nightly
-  green-unmerged sweep never enables auto-merge and does not classify the
-  label as stranded). See `docs/operations/pr-triage.md` "Durable auto-merge
-  holds".
-- The arming path and `auto-merge-on-open.yml` WITHHOLD squash auto-merge for
-  PRs touching those paths (and revoke it on a later push that newly touches
-  them). CI cannot catch a change that redefines the oracle it validates
-  against, so these PRs must not merge hands-free.
+- `.github/workflows/auto-merge-on-open.yml` is **revoke-only**: it never
+  arms on any event (bare `gh pr create` does not auto-arm, and the
+  historical `ready_for_review` arm point — which never fired once, drafts
+  being unused — was deleted per
+  `_project/decisions/auto-merge-policy-consolidation-2026-08-06.md`, D2).
+  `opened` / `reopened` / `synchronize` / `labeled` re-evaluate revocation
+  only (soundness paths or the hold label). The soundness check unions the
+  base-ref predicate with the PR checkout copy so a gate widened mid-flight
+  still revokes and a PR cannot weaken its own gate.
+- Durable holds every layer honours: **draft** (job/sweep skip) and label
+  **`no-auto-merge`** (`make pr-arm-auto-merge` / `pr-ready` refuse to arm;
+  workflow disables; nightly green-unmerged sweep never enables auto-merge
+  and does not classify the label as stranded). See
+  `docs/operations/pr-triage.md` "Durable auto-merge holds".
+- The Makefile arming path WITHHOLDS squash auto-merge for PRs touching those
+  paths, and `auto-merge-on-open.yml` revokes it on a later push that newly
+  touches them. CI cannot catch a change that redefines the oracle it
+  validates against, so these PRs must not merge hands-free.
 - The active ruleset now supplies the repo-layer control; the owner must still
   review and merge manually because the current single-owner account cannot
   approve its own PR. Adding a second code-owner or changing the PR identity

--- a/tests/unit/test_auto_merge_hold_is_durable.py
+++ b/tests/unit/test_auto_merge_hold_is_durable.py
@@ -191,6 +191,11 @@ def test_makefile_arm_path_refuses_hold_label() -> None:
     assert label_index < arm_index, "label check runs after arming, so it cannot withhold"
     # Exact-match semantics stay lockstep with the workflow's grep -qxF.
     assert "--json labels" in body
+    # Fail closed: an unreadable label list (gh auth/rate-limit failure) must
+    # abort the arm, not fall through as "no label". Without this, a transient
+    # gh error piped into grep reads as label-absent and arms through the hold.
+    assert "refusing to arm (fail closed)" in body, "label read no longer fails closed"
+    assert body.index("refusing to arm (fail closed)") < arm_index
 
 
 def test_soundness_unions_base_ref_and_pr_copy_predicates() -> None:

--- a/tests/unit/test_auto_merge_hold_is_durable.py
+++ b/tests/unit/test_auto_merge_hold_is_durable.py
@@ -6,13 +6,18 @@ auto-merge (historically: synchronize re-enable; nightly --apply if it ever
 armed). Draft was the only durable hold. This suite pins the durable-hold
 contract across workflow + sweep layers:
 
-1. Synchronize never re-enables auto-merge (only revokes).
-2. Label ``no-auto-merge`` blocks enable and triggers disable.
+1. The workflow never arms at all (revoke-only since
+   auto-merge-policy-consolidation-2026-08-06, D2); in particular no event —
+   synchronize included — can re-enable auto-merge.
+2. Label ``no-auto-merge`` triggers workflow disable AND blocks the one live
+   arm path, ``make pr-arm-auto-merge`` (D3 — before that check, #1626 was
+   armed 52s after being labeled because only never-arming layers honoured
+   the label).
 3. Draft remains a job-level hold.
 4. Nightly green-unmerged ``--apply`` never enables auto-merge and does not
    classify an explicit hold as stranded.
-5. Soundness disable unions base-ref + PR-copy predicates (enable still needs
-   both false so a PR cannot weaken its own gate).
+5. Soundness disable unions base-ref + PR-copy predicates so a PR cannot
+   weaken its own gate.
 """
 
 from __future__ import annotations
@@ -38,15 +43,12 @@ HOLD_LABEL = "no-auto-merge"
 ARM_COMMAND = "gh pr merge --auto --squash"
 DISABLE_COMMAND = "gh pr merge --disable-auto"
 
-# Exact enable/disable `if:` pins (collapsed form). Keep lockstep with
+# Exact disable `if:` pins (collapsed form). Keep lockstep with
 # tests/unit/workflows/test_auto_merge_enablement_point.py.
-ENABLE_IF = (
-    "steps.soundness.outputs.soundness_path != 'true' "
-    "&& steps.hold.outputs.held != 'true' "
-    "&& github.event.action == 'ready_for_review'"
-)
 SOUNDNESS_DISABLE_IF = "steps.soundness.outputs.soundness_path == 'true'"
 HOLD_DISABLE_IF = "steps.hold.outputs.held == 'true'"
+
+MAKEFILE = REPO_ROOT / "Makefile"
 
 
 def _load_yaml(path: Path) -> dict[str, Any]:
@@ -73,11 +75,19 @@ def _collapsed_if(step: dict[str, Any]) -> str:
     return re.sub(r"\s+", " ", raw)
 
 
-def _enable_job() -> dict[str, Any]:
+def _revoke_job() -> dict[str, Any]:
     workflow = _load_yaml(AUTO_MERGE_WORKFLOW)
     jobs = workflow.get("jobs") or {}
-    assert "enable" in jobs
-    return jobs["enable"]
+    assert "revoke" in jobs
+    return jobs["revoke"]
+
+
+def _makefile_target_body(name: str) -> str:
+    """Return the recipe lines of a Makefile target."""
+    text = MAKEFILE.read_text(encoding="utf-8")
+    match = re.search(rf"^{re.escape(name)}:.*?\n((?:\t.*\n|\n)*)", text, re.MULTILINE)
+    assert match, f"Makefile has no target {name!r}"
+    return match.group(1)
 
 
 def _load_sweep():
@@ -90,32 +100,31 @@ def _load_sweep():
 
 
 # ---------------------------------------------------------------------------
-# Workflow: never re-arm on synchronize; hold label + draft are durable
+# Workflow: revoke-only (never arms); hold label + draft are durable
 # ---------------------------------------------------------------------------
 
 
-def test_workflow_never_enables_on_synchronize() -> None:
-    """Push must not re-arm auto-merge (historical defect class)."""
-    steps = _steps_by_name(_enable_job())
-    enable = steps["Enable squash auto-merge"]
-    condition = _collapsed_if(enable)
-    assert condition == ENABLE_IF
-    assert "synchronize" not in condition
-    assert ARM_COMMAND in str(enable.get("run") or "")
+def test_workflow_never_arms_auto_merge_at_all() -> None:
+    """The workflow is revoke-only: no step may arm auto-merge on any event.
 
-
-def test_workflow_enable_requires_absence_of_hold_label() -> None:
-    """ready_for_review must not arm while no-auto-merge is present."""
-    steps = _steps_by_name(_enable_job())
-    enable = steps["Enable squash auto-merge"]
-    assert _collapsed_if(enable) == ENABLE_IF
-    assert "steps.hold.outputs.held != 'true'" in _collapsed_if(enable)
+    This subsumes the historical synchronize/opened re-arm defect class: with
+    no arm command in the file, no event can re-enable auto-merge. Arming is
+    exclusively `make pr-ready` / `pr-arm-auto-merge` (D2).
+    """
+    text = AUTO_MERGE_WORKFLOW.read_text(encoding="utf-8")
+    for step in _revoke_job().get("steps") or []:
+        run = str(step.get("run") or "")
+        assert ARM_COMMAND not in run, f"workflow step {step.get('name')!r} arms auto-merge"
+        assert "--auto" not in run.replace("--disable-auto", ""), (
+            f"workflow step {step.get('name')!r} contains an arming flag"
+        )
+    assert "Enable squash auto-merge" not in text, "the dead arm step is back"
 
 
 def test_workflow_hold_step_matches_exact_label() -> None:
     """Hold detection must be exact-name (grep -qxF), shared constant name."""
     text = AUTO_MERGE_WORKFLOW.read_text(encoding="utf-8")
-    steps = _steps_by_name(_enable_job())
+    steps = _steps_by_name(_revoke_job())
     hold = steps.get("Check explicit hold label")
     assert hold is not None, "hold check step missing"
     assert hold.get("id") == "hold"
@@ -128,7 +137,7 @@ def test_workflow_hold_step_matches_exact_label() -> None:
 
 def test_workflow_disables_on_explicit_hold() -> None:
     """Applying the hold label must revoke any enabled auto-merge."""
-    steps = _steps_by_name(_enable_job())
+    steps = _steps_by_name(_revoke_job())
     disable = steps.get("Disable auto-merge for explicit hold")
     assert disable is not None, "explicit-hold disable step missing"
     assert _collapsed_if(disable) == HOLD_DISABLE_IF
@@ -137,7 +146,7 @@ def test_workflow_disables_on_explicit_hold() -> None:
 
 def test_workflow_disables_on_soundness() -> None:
     """Soundness revocation must remain independent of the hold path."""
-    steps = _steps_by_name(_enable_job())
+    steps = _steps_by_name(_revoke_job())
     disable = steps.get("Disable auto-merge for soundness PR")
     assert disable is not None
     assert _collapsed_if(disable) == SOUNDNESS_DISABLE_IF
@@ -148,14 +157,40 @@ def test_workflow_listens_for_labeled_to_make_hold_durable() -> None:
     """Without `labeled`, applying no-auto-merge would not revoke until a push."""
     types = _triggers(_load_yaml(AUTO_MERGE_WORKFLOW))["pull_request"]["types"]
     assert "labeled" in types
-    for required in ("opened", "reopened", "ready_for_review", "synchronize"):
+    for required in ("opened", "reopened", "synchronize"):
         assert required in types
+    # Revoke-only workflow: draft→ready has nothing to revoke and must not
+    # become an arm point again (D2).
+    assert "ready_for_review" not in types
 
 
 def test_workflow_skips_drafts_at_job_level() -> None:
-    job = _enable_job()
+    job = _revoke_job()
     assert "draft" in str(job.get("if") or "")
     assert "false" in str(job.get("if") or "")
+
+
+# ---------------------------------------------------------------------------
+# Makefile: the one live arm path honours the hold label (D3)
+# ---------------------------------------------------------------------------
+
+
+def test_makefile_arm_path_refuses_hold_label() -> None:
+    """`make pr-arm-auto-merge` must check the label before arming.
+
+    Before this guard the label was only honoured by layers that never arm
+    (workflow revocation + report-only sweep), while the one live arm path
+    ignored it: #1626 was armed at 2026-08-06T13:48:46Z, 52s after the label
+    was applied. A durable hold the arm path ignores is not a hold.
+    """
+    body = _makefile_target_body("pr-arm-auto-merge")
+    assert f"grep -qxF '{HOLD_LABEL}'" in body, "arm path no longer checks the hold label"
+    assert ARM_COMMAND in body
+    label_index = body.index(f"grep -qxF '{HOLD_LABEL}'")
+    arm_index = body.index(ARM_COMMAND)
+    assert label_index < arm_index, "label check runs after arming, so it cannot withhold"
+    # Exact-match semantics stay lockstep with the workflow's grep -qxF.
+    assert "--json labels" in body
 
 
 def test_soundness_unions_base_ref_and_pr_copy_predicates() -> None:

--- a/tests/unit/test_auto_merge_soundness_paths.py
+++ b/tests/unit/test_auto_merge_soundness_paths.py
@@ -104,10 +104,10 @@ def test_backstop_workflow_uses_shared_predicate_and_skips_auto_merge() -> None:
 
     # Diff via git with --no-renames (gh pr diff --name-only drops rename sources).
     assert "git diff --name-only --no-renames" in workflow
-    # Enable is multi-line (`if: >-`); pin the soundness gate fragment rather than
-    # a single-line `if:` that no longer exists after the hold-label conjunction.
-    assert "steps.soundness.outputs.soundness_path != 'true'" in workflow
+    # Revoke-only workflow (D2): the disable step is the only consumer of the
+    # predicate output; no enable step exists to pin.
     assert "if: steps.soundness.outputs.soundness_path == 'true'" in workflow
+    assert "gh pr merge --auto" not in workflow.replace("gh pr merge --disable-auto", "")
     # A soundness-touching push must re-evaluate and clear any stale auto-merge.
     assert "synchronize" in workflow
     assert "gh pr merge --disable-auto" in workflow
@@ -120,8 +120,8 @@ def test_backstop_workflow_uses_shared_predicate_and_skips_auto_merge() -> None:
     )
     assert "python3 /tmp/predicate_base.py --stdin --format github-output" in workflow
     # PR checkout copy is evaluated alongside base-ref (union/OR) so a gate
-    # *widened* mid-flight still revokes. Enable requires soundness_path != true
-    # (both false), so the PR copy cannot weaken the gate by narrowing rules.
+    # *widened* mid-flight still revokes, and the PR copy cannot weaken the
+    # gate by narrowing rules (union means either copy saying true wins).
     assert "python3 _project/scripts/auto_merge_soundness_paths.py --stdin --format github-output" in workflow
     assert '[ "$base_result" = "soundness_path=true" ] || [ "$pr_result" = "soundness_path=true" ]' in workflow
 

--- a/tests/unit/test_contributing_pr_open_auto_merge_docs.py
+++ b/tests/unit/test_contributing_pr_open_auto_merge_docs.py
@@ -1,7 +1,8 @@
 """Pin CONTRIBUTING.md to the post-#1567/#1592 auto-merge enablement policy.
 
-``make pr-open`` withholds auto-merge; arming is explicit via ``make pr-ready``,
-``make pr-open READY=1``, or draft → ready_for_review. CONTRIBUTING used to
+``make pr-open`` withholds auto-merge; arming is explicit via ``make pr-ready``
+or ``make pr-open READY=1`` (the only arm paths — the workflow is revoke-only
+since auto-merge-policy-consolidation-2026-08-06, D2). CONTRIBUTING used to
 teach the opposite (``gh pr merge --auto --squash`` as part of pr-open). This
 module is a cheap docs contract so that drift fails in the fast unit lane.
 """
@@ -40,5 +41,5 @@ def test_contributing_documents_withhold_and_hands_free_arm_path(contributing_te
     """Finished-branch path must stay documented: pr-ready / READY=1 / withhold."""
     for required in ("withhold", "pr-ready", "READY=1"):
         assert required in contributing_text, f"CONTRIBUTING missing hands-free arm cue {required!r}"
-    # Draft → ready is the UI equivalent of pr-ready.
-    assert "ready_for_review" in contributing_text
+    # The workflow must be documented as revoke-only: no draft→ready arm path.
+    assert "revoke-only" in contributing_text

--- a/tests/unit/workflows/test_auto_merge_enablement_point.py
+++ b/tests/unit/workflows/test_auto_merge_enablement_point.py
@@ -13,12 +13,15 @@ three the working tree was clean when the PR was opened.
 
 #1567 moved the Makefile hold (`pr-open` withholds; `pr-ready` arms). The
 workflow `auto-merge-on-open.yml` still armed on `opened` for any non-draft
-PR, so bare `gh pr create` defeated the hold (#1568/#1569). The cross-layer
-policy is therefore:
+PR, so bare `gh pr create` defeated the hold (#1568/#1569). #1592 narrowed
+the workflow arm to `ready_for_review` — which then never fired once (drafts
+are unused; 0 events across 150 PRs), so the arm step was deleted outright
+(auto-merge-policy-consolidation-2026-08-06, D2). The cross-layer policy is
+therefore:
 
-- Local: `pr-open` withholds; `pr-ready` / `READY=1` arms.
-- Workflow: arm only on `ready_for_review`; never enable on
-  opened/reopened/synchronize. Soundness disable still runs on those events.
+- Local: `pr-open` withholds; `pr-ready` / `READY=1` is the ONLY arm path.
+- Workflow: revoke-only (soundness paths + `no-auto-merge` label); it never
+  arms on any event. Soundness disable runs on opened/reopened/synchronize.
 """
 
 from __future__ import annotations
@@ -38,13 +41,7 @@ AUTO_MERGE_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "auto-merge-on-open.
 
 ARM_COMMAND = "gh pr merge --auto --squash"
 
-# Exact enable/disable `if:` pins for auto-merge-on-open.yml (collapsed form).
-# Enable also requires the durable hold label absent (steps.hold).
-ENABLE_IF = (
-    "steps.soundness.outputs.soundness_path != 'true' "
-    "&& steps.hold.outputs.held != 'true' "
-    "&& github.event.action == 'ready_for_review'"
-)
+# Exact disable `if:` pins for auto-merge-on-open.yml (collapsed form).
 DISABLE_IF = "steps.soundness.outputs.soundness_path == 'true'"
 HOLD_DISABLE_IF = "steps.hold.outputs.held == 'true'"
 
@@ -68,10 +65,10 @@ def _triggers(workflow: dict[str, Any]) -> dict[str, Any]:
     return triggers
 
 
-def _enable_job(workflow: dict[str, Any]) -> dict[str, Any]:
+def _revoke_job(workflow: dict[str, Any]) -> dict[str, Any]:
     jobs = workflow.get("jobs") or {}
-    assert "enable" in jobs, "auto-merge workflow has no enable job"
-    return jobs["enable"]
+    assert "revoke" in jobs, "auto-merge workflow has no revoke job"
+    return jobs["revoke"]
 
 
 def _steps_by_name(job: dict[str, Any]) -> dict[str, dict[str, Any]]:
@@ -148,73 +145,47 @@ def test_auto_merge_enablement_point_preserves_soundness_withholding() -> None:
 
 
 # ---------------------------------------------------------------------------
-# Workflow layer (do not arm on opened; arm only on ready_for_review)
+# Workflow layer (revoke-only: never arms on any event)
 # ---------------------------------------------------------------------------
 
 
-def test_auto_merge_workflow_enable_if_is_exact_policy() -> None:
-    """Enable step must arm only for non-soundness ready_for_review.
+def test_auto_merge_workflow_never_arms() -> None:
+    """The workflow must contain no arm path at all.
 
-    Exact pin: opened/reopened/synchronize cannot arm even if someone later
-    rewrites the condition into a looser OR of event actions.
+    The historical defect was arming on `opened` (defeating the Makefile
+    hold — #1568/#1569); the #1592 fix narrowed arming to `ready_for_review`,
+    which never fired once (drafts unused). The step was deleted (D2): with
+    no arm command in the file, no event — opened, reopened, synchronize, or
+    a future looser condition — can arm.
     """
     workflow = _load_workflow()
-    steps = _steps_by_name(_enable_job(workflow))
-    enable = steps.get("Enable squash auto-merge")
-    assert enable is not None, "enable step missing from auto-merge-on-open.yml"
-    assert _collapsed_if(enable) == ENABLE_IF, (
-        f"enable step if: drifted from policy pin\n  got:  {_collapsed_if(enable)!r}\n  want: {ENABLE_IF!r}"
-    )
-    assert ARM_COMMAND in str(enable.get("run") or ""), "enable step no longer arms squash auto-merge"
+    text = AUTO_MERGE_WORKFLOW.read_text(encoding="utf-8")
+    assert "Enable squash auto-merge" not in text, "the dead arm step is back"
+    for step in _revoke_job(workflow).get("steps") or []:
+        run = str(step.get("run") or "")
+        assert ARM_COMMAND not in run, f"workflow step {step.get('name')!r} arms auto-merge"
 
 
-def test_auto_merge_workflow_does_not_enable_merely_because_pr_was_opened() -> None:
-    """No layer may arm auto-merge solely because a non-draft PR was opened.
-
-    After #1567 the Makefile held at pr-open, but this workflow still ran
-    `gh pr merge --auto --squash` on the `opened` event for any non-draft
-    develop PR. That is the defect under test.
-    """
-    workflow = _load_workflow()
-    steps = _steps_by_name(_enable_job(workflow))
-    condition = _collapsed_if(steps["Enable squash auto-merge"])
-    # Exact policy already asserted above; restate exclusions for the defect.
-    assert condition == ENABLE_IF
-    for forbidden in ("opened", "reopened", "synchronize"):
-        assert f"== '{forbidden}'" not in condition and f'== "{forbidden}"' not in condition, (
-            f"enable step still matches event action {forbidden!r}: {condition!r}"
-        )
-
-
-def test_auto_merge_workflow_keeps_opened_trigger_for_soundness_re_eval() -> None:
+def test_auto_merge_workflow_keeps_revocation_triggers() -> None:
     """opened/reopened/synchronize must still run for soundness disable.
 
-    Dropping those triggers would leave a soundness PR that was opened with
-    auto-merge already on (or that later gains a soundness commit) without a
-    revocation path from this workflow. `labeled` is also required so the
-    durable hold label revokes without needing a push.
+    Dropping those triggers would leave a soundness PR that later gains a
+    soundness commit without a revocation path from this workflow. `labeled`
+    is also required so the durable hold label revokes without needing a
+    push. `ready_for_review` must stay absent: a draft cannot carry
+    auto-merge (nothing to revoke), and its only historical use was the dead
+    arm point.
     """
     types = _triggers(_load_workflow())["pull_request"]["types"]
-    for required in ("opened", "reopened", "ready_for_review", "synchronize", "labeled"):
+    for required in ("opened", "reopened", "synchronize", "labeled"):
         assert required in types, f"pull_request types missing {required!r}: {types}"
-
-
-def test_auto_merge_workflow_does_not_re_enable_on_synchronize() -> None:
-    """synchronize must not re-arm auto-merge.
-
-    Re-enabling on every push would defeat the open-time hold as soon as the
-    first post-open push lands, restoring the partial-stack race.
-    """
-    workflow = _load_workflow()
-    condition = _collapsed_if(_steps_by_name(_enable_job(workflow))["Enable squash auto-merge"])
-    assert condition == ENABLE_IF
-    assert "synchronize" not in condition
+    assert "ready_for_review" not in types, "ready_for_review is back; the arm point must not return"
 
 
 def test_auto_merge_workflow_preserves_soundness_disable() -> None:
     """Must-preserve: soundness paths still revoke auto-merge."""
     workflow = _load_workflow()
-    steps = _steps_by_name(_enable_job(workflow))
+    steps = _steps_by_name(_revoke_job(workflow))
     disable = steps.get("Disable auto-merge for soundness PR")
     assert disable is not None, "soundness disable step is gone"
     assert "--disable-auto" in str(disable.get("run") or ""), "soundness disable no longer calls --disable-auto"
@@ -226,7 +197,7 @@ def test_auto_merge_workflow_preserves_soundness_disable() -> None:
 def test_auto_merge_workflow_preserves_explicit_hold_disable() -> None:
     """Must-preserve: no-auto-merge label revokes auto-merge independently."""
     workflow = _load_workflow()
-    steps = _steps_by_name(_enable_job(workflow))
+    steps = _steps_by_name(_revoke_job(workflow))
     disable = steps.get("Disable auto-merge for explicit hold")
     assert disable is not None, "explicit-hold disable step is gone"
     assert "--disable-auto" in str(disable.get("run") or "")

--- a/tests/unit/workflows/test_auto_merge_partial_stack_race.py
+++ b/tests/unit/workflows/test_auto_merge_partial_stack_race.py
@@ -1,11 +1,11 @@
 """Guards against auto-merge landing a PR before its later commits are pushed.
 
 Auto-merge is no longer armed at bare PR creation (`make pr-open` withholds;
-`auto-merge-on-open.yml` arms only on `ready_for_review`). The partial-stack
+`auto-merge-on-open.yml` is revoke-only and never arms). The partial-stack
 race remains when a branch is marked final too early (`make pr-ready` /
-`READY=1` / draft→ready) and more commits follow: the PR can satisfy its
-checks and merge while a later commit is still being written, so develop
-receives a partial change and the remainder is orphaned on a closed branch.
+`READY=1`) and more commits follow: the PR can satisfy its checks and merge
+while a later commit is still being written, so develop receives a partial
+change and the remainder is orphaned on a closed branch.
 
 This is not hypothetical. PR #1503 merged carrying only its first commit; the
 `Results Explorer browser gate` job that its own PR body described never landed,
@@ -114,7 +114,10 @@ def test_auto_merge_partial_stack_soundness_revocation_is_unchanged() -> None:
     steps = [step for job in workflow["jobs"].values() for step in job.get("steps", [])]
     commands = [step.get("run", "") for step in steps]
     assert any("--disable-auto" in command for command in commands), "soundness revocation step is gone"
-    assert any("--auto --squash" in command for command in commands), (
+    # Hands-free auto-merge for ordinary PRs lives in the Makefile arm path
+    # (`make pr-ready`), not in this revoke-only workflow.
+    makefile = (REPO_ROOT / "Makefile").read_text(encoding="utf-8")
+    assert "gh pr merge --auto --squash" in makefile, (
         "hands-free auto-merge for ordinary PRs is gone - the common case must stay hands-free"
     )
 


### PR DESCRIPTION
## Summary

Implements the ADR `_project/decisions/auto-merge-policy-consolidation-2026-08-06.md` (included in this PR), which adversarially evaluated the five auto-merge mechanisms over the last 150 merged PRs (#1459–#1630).

- **ADR** — full evaluation: quantified findings (94% of merges fired while armed; median ready→merge 27 min; honest escape rate ~2%; the workflow arm step never fired once), decision matrix including the no-gating and full-manual extremes, and the counter-argument section.
- **D2 — revoke-only workflow.** The `ready_for_review` arm step in `auto-merge-on-open.yml` was dead code: drafts are never used, zero `ready_for_review` events exist across 150 PRs, and the last workflow arm was 85 s before #1592 merged. Step deleted, job renamed `enable`→`revoke`, trigger dropped. Arming is exclusively `make pr-ready` / `pr-arm-auto-merge` / `READY=1`.
- **D3 — durable hold made durable.** `make pr-arm-auto-merge` now refuses while the PR carries `no-auto-merge` (exact match). Before this, the one live arm path ignored the label: #1626 was armed at 13:48:46Z on 2026-08-06, 52 s after being labeled.
- **D4 — doc truth.** The "RETIRED 2026-07-18 / no repo-layer backstop" comments in the workflow and the soundness predicate contradicted `repo-admin-settings.md`, which records the `require_code_owner_review` rule re-enabled 2026-07-21. Comments corrected.
- **D6 — no committed volatile LOC numbers.** The generated Actual column + summary block in `_project/specs/uat-framework.md` (single grand-total line) made any two net-LOC-changing UAT PRs conflict by construction, serializing concurrent UAT batches. `uat_loc_table.py` now guards the module set and keeps a static pointer; live numbers via `--report`. Hook/CI wiring unchanged.

Kept unchanged per the ADR (D1/D5/D7): arm-when-final, the tiered soundness lane, the report-only sweeps, and no new review gates.

## Review notes

This PR touches `.github/workflows/auto-merge-on-open.yml` and `_project/scripts/auto_merge_soundness_paths.py` — both on the soundness list — so it correctly self-classifies as soundness: auto-merge stays withheld and the owner merges manually after review.

## Verification

- `make pr-preflight`: green (27,408 passed, 19 skipped).
- All pinning suites updated and passing: `test_auto_merge_hold_is_durable.py`, `test_auto_merge_enablement_point.py`, `test_auto_merge_partial_stack_race.py`, `test_auto_merge_soundness_paths.py`, `test_contributing_pr_open_auto_merge_docs.py`, `test_guard_messages.py`, `test_green_unmerged_sweep.py` (115 passed).
- `uat_loc_table.py --check` green on the rewritten spec; `--report` prints live per-bucket numbers matching the previously committed totals.
