### PR TITLE
fix(ci): stop the submission gate failing open on a failing validator

### DIFF
--- a/.github/workflows/validate-submission.yml
+++ b/.github/workflows/validate-submission.yml
@@ -250,6 +250,18 @@ jobs:
           IS_FORK: ${{ github.event.pull_request.head.repo.fork }}
           HEAD_REF: ${{ github.head_ref }}
         run: |
+          # `pipefail` is load-bearing, not hygiene. The validator's exit code is
+          # this gate: it is piped into `tee` below, and a bash pipeline returns
+          # the status of its LAST command. GitHub's default shell is
+          # `bash -e {0}` -- `-e` but NOT `-o pipefail` -- so without this line
+          # `tee`'s zero masked a failing validator entirely. Observed on PR
+          # #1629: the validator reported "Submission Validation: FAILED" with
+          # 105/105 bundles failing, this step still exited 0, and the required
+          # check went green. It also silently disarmed the corpus-inventory step
+          # below, which is gated on `steps.validate.outcome == 'success'`.
+          # Do not remove `| tee` without keeping the exit code, and do not
+          # remove this line while the pipe exists.
+          set -euo pipefail
           REQUIRE_MANIFEST="--require-manifest"
           if [ "$IS_FORK" = "false" ]; then
             case "$HEAD_REF" in
@@ -257,7 +269,9 @@ jobs:
             esac
           fi
           # Validate and generate PR comment in a single invocation.
-          # --pr-comment writes the Markdown file; exit code reflects validation result.
+          # --pr-comment writes the Markdown file; exit code reflects validation
+          # result -- which reaches this step's outcome only because of the
+          # `set -o pipefail` above.
           xargs -d '\n' uv run -- python scripts/validate_submission.py $REQUIRE_MANIFEST --pr-comment /tmp/pr_comment.md < /tmp/changed_bundles.txt \
             | tee /tmp/validation_output.txt
 

--- a/tests/unit/workflows/test_validate_submission_fail_open.py
+++ b/tests/unit/workflows/test_validate_submission_fail_open.py
@@ -1,0 +1,123 @@
+"""The submission gate must FAIL when the validator fails.
+
+Observed on PR #1629 (a maintainer corpus mirror into `published-results`):
+`scripts/validate_submission.py` posted "Submission Validation: FAILED" with
+**105 of 105 bundles failing**, yet the `Validate bundles` step exited 0 and the
+required check went green.
+
+Cause: the validator's stdout is piped into `tee`, and a bash pipeline returns
+the status of its LAST command. GitHub Actions' default shell for `run:` is
+`bash -e {0}` -- `-e` but NOT `-o pipefail` -- and this workflow declared no
+`defaults.run.shell`, so `tee`'s zero exit masked the validator's non-zero one
+completely.
+
+It also silently disarmed the next step: `Check corpus inventory` is gated on
+`steps.validate.outcome == 'success'`, which had become permanently true.
+
+The rung below runs the REAL `run:` block out of the workflow under a real
+shell, substituting only the validator invocation, and asserts the exit status.
+Asserting that the string "pipefail" appears in the YAML would be the weaker
+test: it pins the current spelling of the fix rather than the behaviour, and
+would keep passing if someone later restructured the step into a pipeline that
+loses the status a different way.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+from tests.utilities.posix_shell import run_posix_shell, skip_without_posix_shell
+
+pytestmark = [pytest.mark.unit, pytest.mark.fast]
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+WORKFLOW_PATH = REPO_ROOT / ".github" / "workflows" / "validate-submission.yml"
+
+# The real validator invocation inside the step, replaced with a stub whose exit
+# status we control. Everything else about the block -- the shell options, the
+# `| tee` pipe, the manifest-waiver branch -- is executed verbatim.
+_VALIDATOR_CALL = (
+    "xargs -d '\\n' uv run -- python scripts/validate_submission.py "
+    "$REQUIRE_MANIFEST --pr-comment /tmp/pr_comment.md < /tmp/changed_bundles.txt"
+)
+
+
+def _validate_step() -> dict:
+    workflow = yaml.safe_load(WORKFLOW_PATH.read_text(encoding="utf-8"))
+    return next(step for step in workflow["jobs"]["validate"]["steps"] if step.get("id") == "validate")
+
+
+def _run_step_with_validator_exiting(status: int, tmp_path: Path):
+    """Execute the real `Validate bundles` run block with a stubbed validator.
+
+    The stub stands in for the validator only. `xargs -d` is GNU-only and the
+    real call would die on BSD xargs for a reason unrelated to this gate, so
+    substituting it keeps the rung from going red incidentally on macOS -- the
+    exact "red for the wrong reason" trap this suite is meant to avoid.
+    """
+    script = _validate_step()["run"]
+    assert _VALIDATOR_CALL in script, (
+        "the validator invocation in validate-submission.yml no longer matches what this test "
+        "substitutes; update _VALIDATOR_CALL so the rung keeps exercising the real block"
+    )
+    # `exit N | tee` preserves the pipeline shape the bug lived in.
+    script = script.replace(_VALIDATOR_CALL, f"(exit {status})")
+    # Mirror GitHub's default `run:` interpreter: bash with -e and no pipefail.
+    return run_posix_shell(
+        f"set -e\n{script}",
+        capture_output=True,
+        text=True,
+        cwd=tmp_path,
+        env={"IS_FORK": "false", "HEAD_REF": "auto/results-mirror-deadbeef", "PATH": "/usr/bin:/bin:/usr/local/bin"},
+    )
+
+
+def test_failing_validator_fails_the_step(tmp_path: Path) -> None:
+    """must_preserve: a non-zero validator must make the gate non-zero.
+
+    This is the PR #1629 regression. Without `set -o pipefail` in the block,
+    `tee` returns 0 and this assertion is what catches it.
+    """
+    skip_without_posix_shell()
+
+    result = _run_step_with_validator_exiting(1, tmp_path)
+
+    assert result.returncode != 0, (
+        "the Validate bundles step exited 0 with a FAILING validator -- the submission gate is "
+        "fail-open. The validator's status is being swallowed by the `| tee` pipeline (GitHub's "
+        "default shell is `bash -e`, without `-o pipefail`), so bad bundles reach "
+        "published-results with a green check. See PR #1629."
+    )
+
+
+def test_passing_validator_still_passes_the_step(tmp_path: Path) -> None:
+    """The fix must not make the gate unconditionally red.
+
+    Without this, `test_failing_validator_fails_the_step` would still pass if
+    the step were broken into always failing -- a green-to-red overcorrection
+    that blocks every legitimate submission.
+    """
+    skip_without_posix_shell()
+
+    result = _run_step_with_validator_exiting(0, tmp_path)
+
+    assert result.returncode == 0, (
+        f"the Validate bundles step exited {result.returncode} with a PASSING validator; stderr:\n{result.stderr}"
+    )
+
+
+def test_corpus_inventory_step_is_gated_on_the_validate_outcome() -> None:
+    """The downstream gate depends on the fix above actually working.
+
+    `Check corpus inventory` runs only `if steps.validate.outcome == 'success'`.
+    While the step above was fail-open that condition was permanently true, so
+    the inventory check silently lost its skip-on-failure behaviour too. Pinned
+    here so the coupling is visible to whoever edits either step.
+    """
+    workflow = yaml.safe_load(WORKFLOW_PATH.read_text(encoding="utf-8"))
+    step = next(s for s in workflow["jobs"]["validate"]["steps"] if s.get("name") == "Check corpus inventory")
+
+    assert step["if"] == "steps.validate.outcome == 'success'"


### PR DESCRIPTION
## The bug

`Validate bundles` pipes `scripts/validate_submission.py`'s stdout into `tee`. A bash pipeline returns the status of its **last** command, and GitHub Actions' default shell for `run:` is `bash -e {0}` — `-e` but **not** `-o pipefail`. This workflow declares no `defaults.run.shell`, so `tee`'s zero exit masked the validator's non-zero one completely.

Found on [#1629](https://github.com/joeharris76/BenchBox/pull/1629), a maintainer corpus mirror into `published-results`. The validator posted:

> ## Submission Validation: FAILED
> Validated **105** bundle(s).

**105 of 105 bundles failing** — every one reporting both `summary.validation must be 'passed' for public submissions, got 'partial'` and a bundle hash mismatch. The required check went green anyway and the PR reported `MERGEABLE / CLEAN`.

## Why this is worth its own PR

The blast radius is not one PR. This is the gate on **every** submission, community ones included, and it has been reporting green regardless of the validator's verdict.

It also silently disarmed the step after it — `Check corpus inventory` runs `if steps.validate.outcome == 'success'`, a condition that had become permanently true.

## The fix

`set -euo pipefail` in the step.

I swept every workflow for a `| tee` inside a `run:` block without pipefail. The only other two sites are in `release-canary.yml`, and both already handle it correctly with `|| rc=${PIPESTATUS[0]}`. This was the sole defective site — and the repo already had a house idiom for it.

The comment above the invocation claimed *"exit code reflects validation result"*, which was false. Corrected, and the reason the pipefail line is load-bearing now sits where someone might otherwise delete it as hygiene.

## Regression rung

`tests/unit/workflows/test_validate_submission_fail_open.py` executes the **real** `run:` block lifted from the workflow under a real shell, substituting only the validator invocation with a stub of known exit status.

Asserting that `"pipefail"` appears in the YAML would have been the weaker test: it pins the current *spelling* of the fix rather than the behaviour, and would survive a later restructuring that loses the status some other way.

The validator call is stubbed rather than executed because `xargs -d` is GNU-only and would make the rung red on macOS for a reason unrelated to this gate — the "red for the wrong reason" trap.

## Verification

| Mutation | Result |
|---|---|
| `set -euo pipefail` removed (reverts to the #1629 state) | **KILLED** — step exits 0 with a failing validator, rung fails with that exact diagnostic |
| Paired passing-validator rung | stays **green** — the fix is not a green-to-red overcorrection that would block every legitimate submission |

`tests/unit/workflows` + `tests/unit/scripts`: **1,834 passed**. YAML validates. Full pre-commit suite passed on commit.

## Out of scope

This does **not** address *why* #1629's 105 bundles fail. The `partial` validation status and the universal manifest hash mismatch are a separate question deserving their own change — plausibly two separate ones. This PR only ensures such a failure is visible instead of green.