### PR TITLE
fix(worktree): container-vantage guards, lock-aware prune, worktree-lock-all

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -69,21 +69,21 @@ cd <WORKTREE_PATH>
 make agent-write-preflight
 ```
 
-`worktree-claim` pins your identity to the claimed worktree via
-`git config --worktree`; that outranks the shared config, so a later write
-there cannot reauthor it.
+`worktree-claim` pins your identity via `git config --worktree`, outranking
+the shared config so a later write there cannot reauthor it.
 
-Stop if `git rev-parse --show-toplevel` is the primary clone. Emergency writes
-there require explicit user authorization and
-`BENCHBOX_ALLOW_MAIN_CLONE_WRITE=1`. Preserve unrelated dirty work. Never use
-destructive Git/filesystem commands without explicit approval. Use `rg`, and
-stage only authorized paths; never `git add -A`.
+Stop if `git rev-parse --show-toplevel` is the primary clone; emergency writes
+there need explicit user authorization plus `BENCHBOX_ALLOW_MAIN_CLONE_WRITE=1`.
+Preserve unrelated dirty work; never use destructive Git/filesystem commands
+without approval. Use `rg`; stage only authorized paths; never `git add -A`.
 
-A disposable clone — a remote agent session, a CI runner — has no canonical
-clone to protect and no pool to claim from, so it declares
-`BENCHBOX_EPHEMERAL_CLONE=1` instead of the emergency override. That declaration
-is ignored wherever a pool exists, so it cannot weaken the guard on a machine
-that uses one.
+A disposable clone (remote agent session, CI runner) has no canonical clone or
+pool; it declares `BENCHBOX_EPHEMERAL_CLONE=1` instead of the emergency
+override — ignored wherever a pool exists, so it cannot weaken that guard.
+
+Never run `git worktree prune`/`gc`/`make worktree-prune` inside a container
+mounting `.git` — host registrations read prunable there and pruning destroys
+them. Worktrees stay locked; unlock only for safe removal; `make worktree-lock-all` re-locks.
 
 ## Tooling and implementation
 

--- a/Makefile
+++ b/Makefile
@@ -2378,7 +2378,7 @@ worktree-list:
 # only at the moment this target has decided, by the merged check, that
 # removal is safe.
 worktree-prune:
-	@case "$$(hostname)" in agentbox-*) \
+	@case "$$(hostname)" in agentbox-*|obento-*) \
 		echo "REFUSING: this looks like a sandbox container (hostname $$(hostname))." >&2; \
 		echo "Inside a container the shared .git records absolute host paths that are" >&2; \
 		echo "not mounted, so every host worktree reads as prunable and pruning would" >&2; \
@@ -2425,7 +2425,7 @@ worktree-lock-all:
 	git worktree list --porcelain | awk '/^worktree /{print substr($$0,10)}' | \
 		while IFS= read -r wt; do \
 			[ "$$wt" = "$$MAIN_CLONE" ] && continue; \
-			if git worktree lock --reason "agentbox mount guard: .git may be bind-mounted into a container where this entry reads prunable but is live. Never prune. Unlock: git worktree unlock" "$$wt" 2>/dev/null; then \
+			if git worktree lock --reason "obento mount guard (formerly agentbox): .git may be bind-mounted into a container where this entry reads prunable but is live. Never prune. Unlock: git worktree unlock" "$$wt" 2>/dev/null; then \
 				echo "locked: $$wt"; \
 			else \
 				echo "already locked (or missing): $$wt"; \

--- a/Makefile
+++ b/Makefile
@@ -2367,9 +2367,31 @@ worktree-list:
 	@git worktree list
 
 
-# Remove worktrees whose branches are gone on origin (already merged).
+# Remove worktrees whose branches are BOTH gone on origin AND merged into
+# origin/develop. The merged check matters: "gone on origin" alone also
+# matches never-pushed local branches, which are live work, not leftovers.
 # Legacy cleanup only. Pool worktrees are retained and released instead.
+# Guarded against running from a container vantage (see AGENTS.md
+# "Worktree safety"): inside a sandbox with this repo's .git bind-mounted,
+# every host worktree reads as prunable and pruning destroys real host
+# registrations. Locked worktrees ("agentbox mount guard") are unlocked
+# only at the moment this target has decided, by the merged check, that
+# removal is safe.
 worktree-prune:
+	@case "$$(hostname)" in agentbox-*) \
+		echo "REFUSING: this looks like a sandbox container (hostname $$(hostname))." >&2; \
+		echo "Inside a container the shared .git records absolute host paths that are" >&2; \
+		echo "not mounted, so every host worktree reads as prunable and pruning would" >&2; \
+		echo "destroy real host registrations. Run this target on the host only." >&2; \
+		exit 1 ;; esac
+	@PRUNABLE=$$(git worktree list --porcelain | grep -c '^prunable' || true); \
+	if [ "$${PRUNABLE:-0}" -gt 3 ]; then \
+		echo "REFUSING: $$PRUNABLE worktrees read as prunable. On a healthy host that" >&2; \
+		echo "number is ~0; a large count means this vantage cannot see the worktree" >&2; \
+		echo "paths (container, moved checkout) and pruning would destroy live" >&2; \
+		echo "registrations. Investigate before overriding." >&2; \
+		exit 1; \
+	fi
 	@git fetch --prune --quiet
 	@MAIN_CLONE=$$(dirname "$$(realpath "$$(git rev-parse --git-common-dir)")"); \
 	git worktree list --porcelain | awk 'function emit(){if (wt != "") print wt "|" br} /^worktree /{emit(); wt=$$2; br=""} /^branch /{br=$$2} END{emit()}' | \
@@ -2379,13 +2401,37 @@ worktree-prune:
 			case "$$base" in *.pool-[0-9][0-9]) pool=$${base##*.}; echo "Skipping pool worktree $$pool (retained)"; continue ;; esac; \
 			[ -n "$$br" ] || continue; \
 			short=$${br#refs/heads/}; \
-			if ! git ls-remote --exit-code --heads origin "$$short" >/dev/null 2>&1; then \
-				echo "Removing worktree (branch gone on origin): $$wt [$$short]"; \
-				git worktree remove "$$wt" 2>/dev/null || git worktree remove --force "$$wt"; \
-				git branch -D "$$short" 2>/dev/null || true; \
+			if git ls-remote --exit-code --heads origin "$$short" >/dev/null 2>&1; then continue; fi; \
+			if ! git merge-base --is-ancestor "$$short" origin/develop 2>/dev/null; then \
+				echo "Keeping $$wt [$$short]: gone on origin but NOT merged into origin/develop (likely never pushed)"; \
+				continue; \
 			fi; \
+			echo "Removing worktree (branch merged into origin/develop, gone on origin): $$wt [$$short]"; \
+			git worktree unlock "$$wt" 2>/dev/null || true; \
+			git worktree remove "$$wt" 2>/dev/null || git worktree remove --force "$$wt"; \
+			git branch -D "$$short" 2>/dev/null || true; \
 		done
 	@git worktree prune
+
+# Lock every linked worktree against `git worktree prune` / `git gc` run
+# from a vantage that cannot see the worktree paths (a sandbox container
+# with this repo's .git bind-mounted; see AGENTS.md "Worktree safety").
+# Locks do NOT affect claiming or normal work (status/checkout/commit all
+# work in a locked worktree); they only block worktree remove/move until
+# `git worktree unlock`, and make prune skip the entry. Re-run after
+# creating new worktrees; locking is idempotent (already-locked is OK).
+worktree-lock-all:
+	@MAIN_CLONE=$$(dirname "$$(realpath "$$(git rev-parse --git-common-dir)")"); \
+	git worktree list --porcelain | awk '/^worktree /{print substr($$0,10)}' | \
+		while IFS= read -r wt; do \
+			[ "$$wt" = "$$MAIN_CLONE" ] && continue; \
+			if git worktree lock --reason "agentbox mount guard: .git may be bind-mounted into a container where this entry reads prunable but is live. Never prune. Unlock: git worktree unlock" "$$wt" 2>/dev/null; then \
+				echo "locked: $$wt"; \
+			else \
+				echo "already locked (or missing): $$wt"; \
+			fi; \
+		done
+	@git worktree list | grep -c 'locked' | sed 's/^/locked total: /'
 
 # Blind-spot finding triage (file-first capture; see _project/blind-spots/README.md).
 blind-spots-list:


### PR DESCRIPTION
## Why

An agent inside a sandbox container that bind-mounts this repo's `.git` sees every host worktree as `prunable` (registrations hold absolute host paths that are not mounted), and `git worktree prune` from that vantage destroys real host registrations — all 35, including active session worktrees. Found via the agent-container project's worktree-mount-hazard investigation; all git mechanics re-verified on host git 2.50.1.

Containment already applied on the host: every linked worktree is locked (`git worktree lock`, reason "agentbox mount guard") and a registration snapshot exists under `.git/`. Locks were verified to allow all normal work (status/checkout/commit) and to make prune/gc skip the entry; they only block `worktree remove`/`move`.

## What

- **`make worktree-prune`** now refuses on an `agentbox-*` hostname or a mass-prunable count (>3) — both signals of a container/bad-mount vantage.
- **Removal criterion tightened**: branch must be *merged into origin/develop*, not merely gone on origin. The old test also matched never-pushed local branches and, via the `remove --force` fallback, could delete live work — and the lock-aware unlock added here would have re-exposed exactly that without the merged check.
- **Unlock only at the point removal is decided safe** (locks otherwise block the remove).
- **New `make worktree-lock-all`**: idempotent re-lock of every linked worktree, for restoring coverage after new worktrees are created.
- **AGENTS.md**: worktree-registration safety rules (never prune/gc inside a container; lock semantics; re-lock pointer); surrounding paragraphs condensed in place to hold the 170-line/16k-byte instruction budget.

## Testing

A/B on a scratch repo with a fake origin: merged-and-gone branch removed through its lock; never-pushed branch kept with an explanatory message; still-on-origin branch kept; a 4-prunable vantage refused before any mutation; hostname guard verified for both agentbox-* and normal hostnames; `worktree-lock-all` verified idempotent against 34 already-locked worktrees.