### PR TITLE
fix: converge required-lane helper and address 4 follow-ups

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2071,7 +2071,7 @@ worktree-release-locked:
 	fi; \
 	git checkout --detach origin/develop; \
 	git reset --hard origin/develop; \
-	if [ "$(FORCE)" = "1" ] && [ -n "$$branch" ]; then \
+	if [ -n "$$branch" ]; then \
 		case "$$branch" in develop|main|release) ;; *) git branch -D "$$branch" >/dev/null 2>&1 || true ;; esac; \
 	fi; \
 	git remote prune origin; \

--- a/Makefile
+++ b/Makefile
@@ -2064,10 +2064,16 @@ worktree-release-locked:
 		state=$$(gh pr view "$$branch" --json state --jq .state 2>/dev/null || true); \
 		[ "$$state" = "MERGED" ] || { echo "Refusing: PR for $$branch is not MERGED; open or close PR first, or rerun with FORCE=1."; exit 1; }; \
 	fi; \
-	git checkout --detach origin/develop; \
 	git fetch origin develop --quiet; \
+	if [ "$(FORCE)" = "1" ]; then \
+		git reset --hard HEAD; \
+		git clean -fdx -e .benchbox >/dev/null; \
+	fi; \
+	git checkout --detach origin/develop; \
 	git reset --hard origin/develop; \
-	git branch -D "$$branch"; \
+	if [ "$(FORCE)" = "1" ] && [ -n "$$branch" ]; then \
+		case "$$branch" in develop|main|release) ;; *) git branch -D "$$branch" >/dev/null 2>&1 || true ;; esac; \
+	fi; \
 	git remote prune origin; \
 	rm -rf "$$top/.venv"; \
 	echo "Released $$branch; worktree is detached at origin/develop (.venv cleared; next claim will re-sync)."
@@ -2265,9 +2271,12 @@ worktree-pool-reset-locked:
 		[ "$$answer" = "RESET" ] || { echo "Aborted."; exit 1; }; \
 	fi; \
 	git -C "$$wt" fetch origin develop --quiet; \
+	if [ "$(FORCE)" = "1" ]; then \
+		git -C "$$wt" reset --hard HEAD; \
+		git -C "$$wt" clean -fdx -e .benchbox >/dev/null; \
+	fi; \
 	git -C "$$wt" checkout --detach origin/develop; \
 	git -C "$$wt" reset --hard origin/develop; \
-	if [ "$(FORCE)" = "1" ]; then git -C "$$wt" clean -fdx -e .benchbox >/dev/null; fi; \
 	if [ "$(FORCE)" = "1" ] && [ -n "$$branch" ]; then \
 		case "$$branch" in develop|main|release) ;; *) git branch -D "$$branch" >/dev/null 2>&1 || true ;; esac; \
 	fi; \

--- a/_project/scripts/green_unmerged_sweep.py
+++ b/_project/scripts/green_unmerged_sweep.py
@@ -115,10 +115,10 @@ sys.path.insert(0, str(SCRIPT_DIR))
 
 from auto_merge_soundness_paths import any_soundness_path  # noqa: E402
 from required_lane import (  # noqa: E402
-    REQUIRED_CHECK_NAMES,
-    is_check_run_success,
+    REQUIRED_CHECK_NAMES,  # noqa: F401 - re-exported for tests
+    is_check_run_success,  # noqa: F401 - re-exported for compat
     is_required_lane_green,
-    latest_check_run,
+    latest_check_run,  # noqa: F401 - re-exported for tests
 )
 
 FIXTURE_PATH = SCRIPT_DIR / "fixtures" / "green_unmerged_fixture.json"
@@ -183,7 +183,7 @@ class ClassifiedPR:
 def _parse_iso(value: str) -> dt.datetime:
     # Re-export for fixture/tests that import via the sweep module. Real logic
     # lives in required_lane to keep timestamp handling consistent.
-    from required_lane import _parse_iso as _rl_parse_iso
+    from required_lane import _parse_iso as _rl_parse_iso  # noqa: E402
 
     return _rl_parse_iso(value)
 

--- a/_project/scripts/green_unmerged_sweep.py
+++ b/_project/scripts/green_unmerged_sweep.py
@@ -114,19 +114,16 @@ SCRIPT_DIR = Path(__file__).resolve().parent
 sys.path.insert(0, str(SCRIPT_DIR))
 
 from auto_merge_soundness_paths import any_soundness_path  # noqa: E402
+from required_lane import (  # noqa: E402
+    REQUIRED_CHECK_NAMES,
+    is_check_run_success,
+    is_required_lane_green,
+    latest_check_run,
+)
 
 FIXTURE_PATH = SCRIPT_DIR / "fixtures" / "green_unmerged_fixture.json"
 
 DEFAULT_REPO = "joeharris76/BenchBox"
-# Develop ruleset `develop-squash-only` required status contexts.
-# Pin must match docs/operations/repo-admin-settings.md and the live
-# ruleset (id 15611785). Partial membership is incomplete green.
-# Prefer this constant over re-deriving from path-filters or workflow
-# names: ruleset contexts are the merge gate, not subordinate jobs.
-REQUIRED_CHECK_NAMES: tuple[str, ...] = (
-    "ci-required-result",
-    "Results Explorer browser gate",
-)
 GRACE_PERIOD_HOURS = 2.0
 API_ROOT = "https://api.github.com"
 DEVELOP_POST_MERGE_WORKFLOW = "develop-post-merge.yml"
@@ -184,43 +181,11 @@ class ClassifiedPR:
 
 
 def _parse_iso(value: str) -> dt.datetime:
-    # GitHub timestamps are RFC3339 with a trailing "Z".
-    return dt.datetime.fromisoformat(value.replace("Z", "+00:00"))
+    # Re-export for fixture/tests that import via the sweep module. Real logic
+    # lives in required_lane to keep timestamp handling consistent.
+    from required_lane import _parse_iso as _rl_parse_iso
 
-
-def latest_check_run(check_runs: list[dict[str, Any]], name: str) -> dict[str, Any] | None:
-    """Return the latest check run for *name*, if present.
-
-    A re-run can leave multiple same-named runs on one SHA; pick the most
-    recently started so a stale conclusion never wins.
-    """
-    matches = [run for run in check_runs if run.get("name") == name]
-    if not matches:
-        return None
-    return max(matches, key=lambda run: run.get("started_at") or "")
-
-
-def is_check_run_success(run: dict[str, Any] | None) -> bool:
-    """True when *run* completed with conclusion ``success`` (not skipped/neutral)."""
-    if run is None:
-        return False
-    return run.get("status") == "completed" and run.get("conclusion") == "success"
-
-
-def is_required_lane_green(check_runs: list[dict[str, Any]]) -> bool:
-    """True when every develop-ruleset required context is latest-success.
-
-    Partial green (e.g. ``ci-required-result`` success but browser gate
-    missing or red) returns False. Missing runs are fail-closed not-green;
-    the browser gate always reports on develop PRs (success when the
-    explorer suite is not needed).
-    """
-    if not REQUIRED_CHECK_NAMES:
-        return False
-    for name in REQUIRED_CHECK_NAMES:
-        if not is_check_run_success(latest_check_run(check_runs, name)):
-            return False
-    return True
+    return _rl_parse_iso(value)
 
 
 def is_soundness_gated(changed_files: list[str]) -> bool:

--- a/_project/scripts/required_lane.py
+++ b/_project/scripts/required_lane.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python3
+"""Shared required-lane classifier for develop PR observers.
+
+Both ``green_unmerged_sweep.py`` and ``soundness_drain_report.py`` classify
+the same lane — every required status context in the ``develop-squash-only``
+ruleset (``docs/operations/repo-admin-settings.md``, live id ``15611785``).
+This module is the single source of truth for that set and its predicates so
+the two observers cannot drift.
+
+Prior art: ``auto_merge_soundness_paths.py`` already provides a precedent for
+``sys.path.insert(SCRIPT_DIR)`` + ``from <helper> import …`` consumption.
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+from typing import Any
+
+# Develop ruleset `develop-squash-only` required status contexts.
+# Pin must match docs/operations/repo-admin-settings.md and the live
+# ruleset (id 15611785). Partial membership is incomplete green.
+REQUIRED_CHECK_NAMES: tuple[str, ...] = (
+    "ci-required-result",
+    "Results Explorer browser gate",
+)
+
+
+def _parse_iso(value: str) -> dt.datetime:
+    # GitHub timestamps are RFC3339 with a trailing "Z". Fractions and offsets
+    # are accepted via the replace so fractional seconds compare correctly.
+    return dt.datetime.fromisoformat(value.replace("Z", "+00:00"))
+
+
+def _started_at_key(run: dict[str, Any]) -> dt.datetime | None:
+    raw = run.get("started_at")
+    if not raw:
+        return None
+    try:
+        return _parse_iso(str(raw))
+    except (ValueError, TypeError):
+        return None
+
+
+def latest_check_run(check_runs: list[dict[str, Any]], name: str) -> dict[str, Any] | None:
+    """Return the latest check run for *name*, if present.
+
+    A re-run can leave multiple same-named runs on one SHA; pick the most
+    recently started so a stale conclusion never wins. Comparison is by
+    parsed datetime so fractional seconds and offset forms are ordered
+    correctly; unparsable or missing stamps sort as oldest.
+    """
+    matches = [run for run in check_runs if run.get("name") == name]
+    if not matches:
+        return None
+
+    def _key(run: dict[str, Any]) -> tuple[int, dt.datetime]:
+        parsed = _started_at_key(run)
+        if parsed is None:
+            # Missing/unparsable stamp is oldest. Use min datetime.
+            return (0, dt.datetime.min.replace(tzinfo=dt.timezone.utc))
+        return (1, parsed)
+
+    return max(matches, key=_key)
+
+
+def is_check_run_success(run: dict[str, Any] | None) -> bool:
+    """True when *run* completed with conclusion ``success`` (not skipped/neutral)."""
+    if run is None:
+        return False
+    return run.get("status") == "completed" and run.get("conclusion") == "success"
+
+
+def is_required_lane_green(check_runs: list[dict[str, Any]]) -> bool:
+    """True when every develop-ruleset required context is latest-success.
+
+    Partial green (e.g. ``ci-required-result`` success but browser gate
+    missing or red) returns False. Missing runs are fail-closed not-green;
+    the browser gate always reports on develop PRs (success when the explorer
+    suite is not needed).
+    """
+    if not REQUIRED_CHECK_NAMES:
+        return False
+    for name in REQUIRED_CHECK_NAMES:
+        if not is_check_run_success(latest_check_run(check_runs, name)):
+            return False
+    return True

--- a/_project/scripts/soundness_drain_report.py
+++ b/_project/scripts/soundness_drain_report.py
@@ -70,6 +70,13 @@ SCRIPT_DIR = Path(__file__).resolve().parent
 sys.path.insert(0, str(SCRIPT_DIR))
 
 from auto_merge_soundness_paths import any_soundness_path  # noqa: E402
+from required_lane import (  # noqa: E402
+    REQUIRED_CHECK_NAMES,
+    _parse_iso,
+    is_check_run_success,
+    is_required_lane_green,
+    latest_check_run,
+)
 
 FIXTURE_PATH = SCRIPT_DIR / "fixtures" / "soundness_drain_fixture.json"
 
@@ -79,20 +86,6 @@ FIXTURE_PATH = SCRIPT_DIR / "fixtures" / "soundness_drain_fixture.json"
 OWNER_LOGIN = "joeharris76"
 
 DEFAULT_REPO = "joeharris76/BenchBox"
-# Develop ruleset `develop-squash-only` required status contexts. Pin must
-# match docs/operations/repo-admin-settings.md and the live ruleset
-# (id 15611785). Partial membership is incomplete green. Prefer this constant
-# over re-deriving from path-filters or workflow names: ruleset contexts are
-# the merge gate, not subordinate jobs.
-#
-# Kept deliberately identical to green_unmerged_sweep.py's copy: both scripts
-# classify the same lane, and the two implementations converge into one shared
-# helper once PR #1633 lands (tracked separately). Changing one without the
-# other reintroduces the split this comment exists to prevent.
-REQUIRED_CHECK_NAMES: tuple[str, ...] = (
-    "ci-required-result",
-    "Results Explorer browser gate",
-)
 DRAIN_LABEL = "awaiting-owner"
 DRAIN_LABEL_COLOR = "b60205"
 DRAIN_LABEL_DESCRIPTION = "Green, gated on owner review, parked >24h (see docs/operations/soundness-drain.md)"
@@ -127,43 +120,6 @@ class ClassifiedPR:
         return asdict(self)
 
 
-def _parse_iso(value: str) -> dt.datetime:
-    # GitHub timestamps are RFC3339 with a trailing "Z".
-    return dt.datetime.fromisoformat(value.replace("Z", "+00:00"))
-
-
-def latest_check_run(check_runs: list[dict[str, Any]], name: str) -> dict[str, Any] | None:
-    """Return the latest check run for *name*, if present.
-
-    A re-run can leave multiple same-named runs on one SHA; pick the most
-    recently started so a stale conclusion never wins.
-    """
-    matches = [run for run in check_runs if run.get("name") == name]
-    if not matches:
-        return None
-    return max(matches, key=lambda run: run.get("started_at") or "")
-
-
-def is_check_run_success(run: dict[str, Any] | None) -> bool:
-    """True when *run* completed with conclusion ``success`` (not skipped/neutral)."""
-    if run is None:
-        return False
-    return run.get("status") == "completed" and run.get("conclusion") == "success"
-
-
-def is_required_lane_green(check_runs: list[dict[str, Any]]) -> bool:
-    """True when every develop-ruleset required context is latest-success.
-
-    Partial green (e.g. ``ci-required-result`` success but browser gate red
-    or never reported) returns False. Missing runs are fail-closed not-green;
-    the browser gate always reports on develop PRs (success when the explorer
-    suite is not needed), so silence is a real signal, not an expected gap.
-    """
-    if not REQUIRED_CHECK_NAMES:
-        return False
-    return all(is_check_run_success(latest_check_run(check_runs, name)) for name in REQUIRED_CHECK_NAMES)
-
-
 def required_lane_green_at(check_runs: list[dict[str, Any]]) -> str | None:
     """Timestamp at which the required lane went green: the LAST context to finish.
 
@@ -173,15 +129,22 @@ def required_lane_green_at(check_runs: list[dict[str, Any]]) -> str | None:
     the browser gate finishes later and trip the >24h gate early. Returns
     None when any required context lacks a completion timestamp, leaving the
     caller to fall back rather than anchor on a half-finished lane.
+    Uses datetime parsing so fractional seconds and offsets sort correctly.
     """
-    stamps: list[str] = []
+    stamps: list[dt.datetime] = []
+    raw: list[str] = []
     for name in REQUIRED_CHECK_NAMES:
         stamp = (latest_check_run(check_runs, name) or {}).get("completed_at")
         if not stamp:
             return None
-        stamps.append(stamp)
-    # RFC3339 UTC ("...Z") sorts lexicographically in chronological order.
-    return max(stamps) if stamps else None
+        raw.append(str(stamp))
+        try:
+            stamps.append(_parse_iso(str(stamp)))
+        except (ValueError, TypeError):
+            return None
+    # Return the raw string of the latest timestamp (caller parses it).
+    latest = max(zip(stamps, raw), key=lambda x: x[0])[1]
+    return latest
 
 
 def is_soundness_gated(changed_files: list[str]) -> bool:

--- a/_project/scripts/soundness_drain_report.py
+++ b/_project/scripts/soundness_drain_report.py
@@ -73,7 +73,7 @@ from auto_merge_soundness_paths import any_soundness_path  # noqa: E402
 from required_lane import (  # noqa: E402
     REQUIRED_CHECK_NAMES,
     _parse_iso,
-    is_check_run_success,
+    is_check_run_success,  # noqa: F401 - re-exported for compat
     is_required_lane_green,
     latest_check_run,
 )

--- a/_project/scripts/todo_db.py
+++ b/_project/scripts/todo_db.py
@@ -580,10 +580,35 @@ def _load_config_url() -> str | None:
         raise TodoError(f"todo backend config {path}: 'url' must be a non-empty string")
     url = _normalize_url(raw)
     if not _is_hosted_url(url):
-        raise TodoError(
-            f"todo backend config {path}: 'url' must be a libsql:// or https:// hosted URL, got {url!r}"
-        )
+        raise TodoError(f"todo backend config {path}: 'url' must be a libsql:// or https:// hosted URL, got {url!r}")
     return _require_secure_url(url)
+
+
+def _try_turso_token_auto_mint() -> tuple[str | None, str | None]:
+    """Mint only a token for the already-known hosted backend via turso CLI.
+
+    Used when ``.todo-db/config.json`` supplies a URL but no token is present.
+    Mirrors the error-class contract of ``_try_turso_auto_provision``.
+    """
+    if not shutil.which("turso"):
+        return None, None
+    name = _turso_db_name()
+    try:
+        tokens = subprocess.run(
+            ["turso", "db", "tokens", "create", name, "--expiration", "1d"],
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=15,
+        )
+        if tokens.returncode != 0:
+            return None, "token-create-failed"
+        token = tokens.stdout.strip()
+        if not token:
+            return None, "token-empty"
+        return token, None
+    except (OSError, subprocess.SubprocessError):
+        return None, "turso-error"
 
 
 def _try_turso_auto_provision() -> tuple[tuple[str, str] | None, str | None]:
@@ -676,10 +701,26 @@ def _resolve_backend(explicit: str | None) -> tuple[Path | str, bool, bool, str 
         return _normalize_url(env_url), False, False, None
     config_url = _load_config_url()
     if config_url:
-        # Selected hosted backend (same class as TODO_DB_URL). Token still
-        # comes from TODO_DB_AUTH_TOKEN; missing token surfaces through the
-        # existing connect/auth failure paths. Do not auto-mint here --
-        # full auto-provision (URL+token) only runs when no URL is known.
+        # Selected hosted backend (same class as TODO_DB_URL). If a token is
+        # already present we return immediately. If not but the maintainer's
+        # turso CLI is logged in, auto-mint a short-lived token for this
+        # config URL (env-only, never written to disk) so a configured-hosted
+        # checkout does not require a manual `turso db tokens create` every
+        # shell. This extends the sanctioned local provisioning to the
+        # "config URL but no token" case without changing the plaintext-URL
+        # refusal or the env-only token posture.
+        if _auth_token():
+            return config_url, False, False, None
+        token_only, token_failure = _try_turso_token_auto_mint()
+        if token_only:
+            os.environ["TODO_DB_AUTH_TOKEN"] = token_only
+            return config_url, False, True, None
+        # Token mint failed — fall through to the existing auth-failure path
+        # but preserve the mint failure reason so the caller can surface a
+        # sharper diagnostic if desired. Returning the config URL (not local
+        # fallback) ensures the missing-token error remains the primary signal.
+        if token_failure:
+            return config_url, False, False, token_failure
         return config_url, False, False, None
     provisioned, provision_failure = _try_turso_auto_provision()
     if provisioned:
@@ -1601,9 +1642,7 @@ def run_doctor(
     # a batch run that silently used it would write real work to a throwaway DB.
     if hosted:
         backend_detail = (
-            "hosted (auto-provisioned via turso CLI, URL withheld)"
-            if auto_provisioned
-            else "hosted (URL withheld)"
+            "hosted (auto-provisioned via turso CLI, URL withheld)" if auto_provisioned else "hosted (URL withheld)"
         )
         identity_status, identity_detail = (
             ("OK", "hosted backend auto-provisioned via turso CLI")
@@ -1742,9 +1781,7 @@ def _preconnect_command(
 
     if implicit_default_local and _command_mutates_tracker(args):
         provision_note = (
-            f" (turso auto-provision was attempted but failed: {provision_failure})"
-            if provision_failure
-            else ""
+            f" (turso auto-provision was attempted but failed: {provision_failure})" if provision_failure else ""
         )
         print(
             "error: refusing to write through the implicit local fallback"
@@ -2245,9 +2282,7 @@ def _update_metadata_fields(
     return changes
 
 
-def _update_edit_work(
-    conn: sqlite3.Connection, item_id: str, edits: dict[str, str]
-) -> dict[str, dict[str, str]]:
+def _update_edit_work(conn: sqlite3.Connection, item_id: str, edits: dict[str, str]) -> dict[str, dict[str, str]]:
     work_edited: dict[str, dict[str, str]] = {}
     for wid, summary in edits.items():
         unit = _require_unit(conn, item_id, wid)
@@ -2268,9 +2303,7 @@ def _update_edit_work(
     return work_edited
 
 
-def _update_add_work(
-    conn: sqlite3.Connection, item_id: str, adds: list[dict[str, Any]]
-) -> list[dict[str, Any]]:
+def _update_add_work(conn: sqlite3.Connection, item_id: str, adds: list[dict[str, Any]]) -> list[dict[str, Any]]:
     wid_rows = conn.execute("SELECT wid FROM work_units WHERE item_id = ?", (item_id,))
     wids = {row["wid"] for row in wid_rows}
     work_added: list[dict[str, Any]] = []
@@ -3604,6 +3637,7 @@ def lint_item(conn: sqlite3.Connection, item_id: str, *, item: dict[str, Any] | 
         findings.extend(_missing_scope_test_files(item))
     return findings
 
+
 # ---------------------------------------------------------------------------
 # Export
 
@@ -4607,13 +4641,32 @@ def _cmd_import_yaml(conn, actor, args):
 def _parse_work_flag(specs: list[str]) -> list[dict[str, Any]]:
     work = []
     for spec in specs:
-        parts = spec.split(":", 2)
-        if len(parts) < 2:
+        # Split WID from the rest on the first colon; summary may contain colons.
+        if ":" not in spec:
             raise TodoError(f"--work expects WID:SUMMARY[:needs=...], got {spec!r}")
-        needs = []
-        if len(parts) == 3 and parts[2].startswith("needs="):
-            needs = [n for n in parts[2][len("needs=") :].split(",") if n]
-        work.append({"id": parts[0], "summary": parts[1], "needs": needs})
+        wid, rest = spec.split(":", 1)
+        if not WID_RE.match(wid):
+            raise TodoError(f"invalid work-unit id {wid!r} (expect w0..w999)")
+        if not rest:
+            raise TodoError(f"--work expects WID:SUMMARY[:needs=...], got {spec!r} (empty summary)")
+        # Needs clause is a trailing ":needs=..." — split on the LAST occurrence
+        # so colons inside the summary survive (e.g. "w0:Fix foo: bar:needs=w1").
+        if ":needs=" in rest:
+            head, tail = rest.rsplit(":needs=", 1)
+            # rsplit always reconstructs, no need to re-validate.
+            summary = head
+            needs = [n for n in tail.split(",") if n]
+            if not summary:
+                raise TodoError(f"--work expects WID:SUMMARY[:needs=...], got {spec!r} (empty summary)")
+        else:
+            summary = rest
+            needs = []
+            # Old code silently truncated at the second colon and dropped the tail
+            # unless it was "needs=". That was silent data loss. Now the whole
+            # tail is preserved as summary, so "w0:a:b:c" is summary "a:b:c" — no
+            # error needed. Only an explicit ambiguous ":needs=" fragment without
+            # the colon prefix is impossible here because we already handled it.
+        work.append({"id": wid, "summary": summary, "needs": needs})
     return work
 
 
@@ -4925,6 +4978,17 @@ def _cmd_check_scope(conn, actor, args):
     # had never looked at. Say what actually happened instead.
     if not item["scope"]:
         print(f"SCOPE_UNCHECKED: no scope rules on {args.id!r}; {len(files)} changed file(s) were not checked")
+        return 1 if getattr(args, "strict", False) else 0
+
+    # Zero-file diff is not "scope OK" — it means nothing was compared. This
+    # happens when check-scope is run before committing, or when the shim
+    # resolves the wrong tree/branch (main clone vs worktree), or when --base
+    # points at the wrong ref. Report what was compared and fail under --strict.
+    if not files:
+        base_desc = args.base if args.base else "HEAD"
+        print(
+            f"SCOPE_UNCHECKED: no changed files vs {base_desc!r} ({len(files)} file(s)); diff was empty or targeted the wrong branch"
+        )
         return 1 if getattr(args, "strict", False) else 0
 
     violations = check_paths(files, item["scope"])


### PR DESCRIPTION
Converges the duplicated required-lane classifier and fixes the four remaining planning items from the handoff.

**1. converge-required-lane-classifier-helper-20260806 (medium)**
- Extract `_project/scripts/required_lane.py` (`REQUIRED_CHECK_NAMES`, `_parse_iso`, `latest_check_run`, `is_check_run_success`, `is_required_lane_green`) and repoint both observers via `sys.path` import (precedent: `auto_merge_soundness_paths`).
- Fixes lexicographic timestamp ordering → parsed datetime (fractional/offset safe); `required_lane_green_at` now datetime-aware and stays in `soundness_drain_report.py`.
- Verification: `! rg -q '^REQUIRED_CHECK_NAMES' _project/scripts/{green_unmerged_sweep,soundness_drain_report}.py`, both `--self-test`, `pytest tests/unit/scripts/test_{green_unmerged_sweep,soundness_drain_report}.py` (93 tests) pass. Adversarial review found no live defect — this is the hardening follow-up.

**2. worktree-release-force-does-not-force-past-dirty-tree-20260806 (medium)**
- Reorder both FORCE paths to `fetch` → `reset --hard`/`clean -fdx -e .benchbox` → `checkout --detach` → `reset --hard origin/develop` → `branch -D`; give `worktree-release` the missing `clean` that `pool-reset` already had.

**3. check-scope-reports-ok-when-nothing-was-diffed-20260806 (medium)**
- Fail closed on zero-file diff under `--strict` with `SCOPE_UNCHECKED: no changed files vs <base>`.

**4. todo-work-flag-silently-truncates-summaries-at-colons-20260806 (medium)**
- `split(":",1)` + `rsplit(":needs=",1)` so colons in summaries survive; needs clause parsed off the end.

**5. todo-auto-remint-when-config-url-but-no-token-20260806 (low)**
- When `.todo-db/config.json` supplies a URL but no token, auto-mint via `turso db tokens create` into `TODO_DB_AUTH_TOKEN` (env-only, never persisted); preserves plaintext-URL refusal and all other precedence.

Adversarial review summary (live verified): both PRs #1633/#1635 correctly require both contexts, always-report gate is sound, ruleset drift canary covers doc-vs-live, lexicographic and fallback nits were fail-safe — no live false-negative.

Closes the five planning items above (manual `todo done` after merge).

### Verification
- `uv run -- python _project/scripts/green_unmerged_sweep.py --self-test` — PASSED (12 PRs, 3 stranded)
- `uv run -- python _project/scripts/soundness_drain_report.py --self-test` — PASSED (10 PRs, 3 qualifying)
- `uv run -- python -m pytest tests/unit/scripts/test_green_unmerged_sweep.py tests/unit/scripts/test_soundness_drain_report.py -q -n 0` — 93 passed
- `uv run -- python -m pytest tests/unit/scripts -k todo -q -n 0` — 614 passed
- `ruff check` / `ruff format --check` — pass