### PR TITLE
fix/cli tuning presort hint

### DIFF
--- a/_project/analysis/known-stranded-commits.txt
+++ b/_project/analysis/known-stranded-commits.txt
@@ -68,3 +68,12 @@ cc01856f9da6f3dc815c0810936a88e3897132e7
 # remain unreachable from develop by construction, exactly like b5c56ea9 above.
 670fc009f932fe75110cb0ff5cb01cbd8b7648a0
 62fa013178bc620c21fbbc5a6991703a32af2766
+# fix/one-engine-parity-ledger — rebased 2026-08-09 (8c2702a830/1fa5972b9f removed); content re-landed via #1650 (8e9a040103)
+24522bcbc57c2bf1478d869a5d47b2300065ede9
+# fix/batch-security-gates-batch1 — stranded after squash-merge, re-landed separately
+65a5ebc51adcfb6c9ec4cfae47381f34c172d974
+906e2f9e4771121da4837f45e362fbde8ca8fd7c
+# fix/pr-review-followup-20260809 — stranded after merge
+193e125543378ffd81b0838d04fd8f983a1f0ff6
+# fix/required-lane-helper-converge — stranded after rebase/merge
+9e9df6e3a98553bf103b8e410e2b8cf03670927c

--- a/benchbox/cli/tuning.py
+++ b/benchbox/cli/tuning.py
@@ -16,6 +16,7 @@ from rich.prompt import Confirm, IntPrompt, Prompt
 from rich.table import Table
 from rich.text import Text
 
+from benchbox.core.benchmark_registry import get_presort_table_configs
 from benchbox.core.schemas import SystemProfile
 from benchbox.core.tuning.interface import TuningType, UnifiedTuningConfiguration
 from benchbox.utils.printing import quiet_console
@@ -778,12 +779,30 @@ def _wizard_sorting_step(caps: dict, benchmark: str, platform_lower: str, SortCo
     if caps.get("sort_by"):
         console.print("\n[bold cyan]Step 1: Sorting[/bold cyan]")
         console.print("Sorted data improves compression and enables skip-scanning.")
-        console.print(f"[dim]Recommended for {benchmark.upper()}: l_shipdate, l_orderkey (for lineitem)[/dim]")
+        presort_configs = get_presort_table_configs(benchmark)
+        if presort_configs:
+            hint_parts: list[str] = []
+            for table, cols in presort_configs.items():
+                col_names = ", ".join(
+                    c.get("name") if isinstance(c, dict) else getattr(c, "name", str(c)) for c in cols
+                )
+                hint_parts.append(f"{col_names} (for {table})")
+            hint = ", ".join(hint_parts)
+            console.print(f"[dim]Recommended for {benchmark.upper()}: {hint}[/dim]")
+            first_table = next(iter(presort_configs))
+            first_cols = presort_configs[first_table]
+            default_sort = ""
+            if first_cols:
+                first = first_cols[0]
+                default_sort = first.get("name") if isinstance(first, dict) else getattr(first, "name", "")
+        else:
+            console.print(f"[dim]Recommended for {benchmark.upper()}: sort by date column if applicable[/dim]")
+            default_sort = ""
 
         if Confirm.ask("Enable sorting?", default=True):
             sort_cols_str = Prompt.ask(
                 "Enter column names to sort by (comma-separated)",
-                default="l_shipdate" if benchmark.lower() == "tpch" else "",
+                default=default_sort,
             )
             if sort_cols_str:
                 for col_name in sort_cols_str.split(","):

--- a/tests/uat/test_no_cli_surface_drift.py
+++ b/tests/uat/test_no_cli_surface_drift.py
@@ -105,6 +105,10 @@ ALLOWED_INTERNAL_CLI_FILES = {
     # fix-datafusion-df-mode-erasure: comment-only clarification of
     # PLATFORM_ALIASES' -df entries; no click surface in this module.
     "benchbox/cli/platform.py",
+    # cli-tuning-presort-hint: the interactive wizard body now derives its
+    # sorting hint/default from the core presort registry. This module has no
+    # Click decorators, so the change cannot alter the public CLI surface.
+    "benchbox/cli/tuning.py",
 }
 ALLOWED_HIDDEN_COMPAT_CLI_FILES = {
     # pr-review-followup-1394: SingleStore credential setup is intentionally

--- a/tests/unit/scripts/test_todo_db_standalone_compat.py
+++ b/tests/unit/scripts/test_todo_db_standalone_compat.py
@@ -485,6 +485,29 @@ def test_standalone_finding_sync_still_requires_db(monkeypatch: pytest.MonkeyPat
     assert compat.main(["finding", "sync"]) == 0
 
 
+@pytest.mark.parametrize("subcommand", ["create", "candidates"])
+def test_standalone_offline_finding_commands_do_not_require_db(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, subcommand: str
+) -> None:
+    """Offline finding capture/listing must delegate without inventing a DB."""
+    calls: list[tuple[list[str], str]] = []
+
+    def fake_delegate(argv: list[str], *, command: str, cwd: Path, capture: bool = True) -> CompletedProcess[str]:
+        calls.append((argv, command))
+        return CompletedProcess(argv, 0, stdout="", stderr="")
+
+    monkeypatch.setattr(compat, "_delegate", fake_delegate)
+    monkeypatch.setenv("BENCHBOX_REPO_ROOT", str(tmp_path))
+    monkeypatch.setenv("BENCHBOX_TODO_DB_STANDALONE", "1")
+    monkeypatch.delenv("TODO_DB_PATH", raising=False)
+    monkeypatch.delenv("TODO_DB_URL", raising=False)
+
+    assert compat.main(["finding", subcommand]) == 0
+    assert calls[0][1] == "finding"
+    assert "--db" not in calls[0][0]
+    assert not (tmp_path / ".todo-db" / "todo.sqlite").exists()
+
+
 def test_env_passthrough_includes_finding_drafts_and_ro_token(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     """w4: TODO_DB_FINDING_DRAFTS_DIR and TODO_DB_RO_AUTH_TOKEN are forwarded via _delegate env."""
     monkeypatch.setenv("BENCHBOX_REPO_ROOT", str(tmp_path))


### PR DESCRIPTION
- **docs: ADR freeze supersedes claim-check for 0.3 cutover**
- **fix(todo-db): shim w2/w3 — RO/RW token + drafts dir, refuse fork DB, add 0.3.0 verb coverage**
- **fix(cli): wizard presort hint uses registry presort_table_configs**
