### PR TITLE
fix/one engine unify stats

### DIFF
--- a/benchbox/core/vector_search/metrics.py
+++ b/benchbox/core/vector_search/metrics.py
@@ -13,6 +13,8 @@ from __future__ import annotations
 import statistics
 from typing import Sequence
 
+from benchbox.core.results.metrics import percentile_ms
+
 
 def recall_at_k(ground_truth: Sequence[int], approximate: Sequence[int], k: int) -> float:
     """Compute recall@k between an exact ground truth and an approximate result.
@@ -41,6 +43,11 @@ def latency_percentiles(
 ) -> dict[str, float]:
     """Compute p50, p95, and p99 latency percentiles.
 
+    Delegates to :func:`benchbox.core.results.metrics.percentile_ms` so
+    that vector-search surfaces and result bundles share one
+    nearest-rank definition. Values are in seconds; convert to
+    milliseconds for the canonical helper, then back to seconds.
+
     Args:
         latencies_seconds: List of per-query latency values in seconds.
 
@@ -50,21 +57,11 @@ def latency_percentiles(
     """
     if not latencies_seconds:
         return {"p50": 0.0, "p95": 0.0, "p99": 0.0}
-    sorted_lat = sorted(latencies_seconds)
-    n = len(sorted_lat)
-
-    def _percentile(p: float) -> float:
-        idx = (p / 100.0) * (n - 1)
-        low = int(idx)
-        frac = idx - low
-        if low + 1 < n:
-            return sorted_lat[low] + frac * (sorted_lat[low + 1] - sorted_lat[low])
-        return sorted_lat[low]
-
+    latencies_ms = [v * 1000.0 for v in latencies_seconds]
     return {
-        "p50": _percentile(50),
-        "p95": _percentile(95),
-        "p99": _percentile(99),
+        "p50": percentile_ms(latencies_ms, 0.50) / 1000.0,
+        "p95": percentile_ms(latencies_ms, 0.95) / 1000.0,
+        "p99": percentile_ms(latencies_ms, 0.99) / 1000.0,
     }
 
 

--- a/benchbox/experimental/load_testing/analyzer.py
+++ b/benchbox/experimental/load_testing/analyzer.py
@@ -12,6 +12,8 @@ import statistics
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING
 
+from benchbox.core.results.metrics import percentile_ms
+
 if TYPE_CHECKING:
     from benchbox.experimental.load_testing.executor import ConcurrentLoadResult
 
@@ -161,9 +163,9 @@ class LoadAnalyzer:
             max_wait_ms=max(wait_times_ms),
             avg_wait_ms=statistics.mean(wait_times_ms),
             median_wait_ms=statistics.median(wait_times_ms),
-            p90_wait_ms=self._percentile(wait_times_ms, 90),
-            p95_wait_ms=self._percentile(wait_times_ms, 95),
-            p99_wait_ms=self._percentile(wait_times_ms, 99),
+            p90_wait_ms=percentile_ms(wait_times_ms, 0.90),
+            p95_wait_ms=percentile_ms(wait_times_ms, 0.95),
+            p99_wait_ms=percentile_ms(wait_times_ms, 0.99),
             stdev_wait_ms=statistics.stdev(wait_times_ms) if len(wait_times_ms) > 1 else 0,
             max_queue_depth=self._result.max_concurrency_reached,
             avg_queue_depth=len(self._result.streams) / max(1, self._result.total_duration_seconds),
@@ -429,12 +431,3 @@ class LoadAnalyzer:
                 "optimal_concurrency": scaling_analysis.optimal_concurrency,
             },
         }
-
-    @staticmethod
-    def _percentile(sorted_data: list[float], p: float) -> float:
-        """Calculate percentile from sorted data."""
-        if not sorted_data:
-            return 0.0
-        index = int((p / 100) * len(sorted_data))
-        index = min(index, len(sorted_data) - 1)
-        return sorted_data[index]

--- a/benchbox/platforms/base/result_capture.py
+++ b/benchbox/platforms/base/result_capture.py
@@ -30,7 +30,6 @@ from __future__ import annotations
 
 import hashlib
 import logging
-import math
 import os
 import platform
 import re
@@ -47,6 +46,7 @@ from benchbox.core.results.builder import (
     _BENCHMARK_FAMILY,
     normalize_benchmark_id,
 )
+from benchbox.core.results.metrics import percentile_ms, sample_stdev_ms
 from benchbox.core.results.models import QUERY_RUN_TYPE_MEASUREMENT
 from benchbox.core.results.query_plan_models import (
     DEFAULT_PLAN_MAX_DEPTH,
@@ -287,41 +287,29 @@ def _coerce_time_seconds(result: Any) -> float | None:
     return seconds
 
 
-def _percentile(values: list[float], percentile: float) -> float:
-    """Linear-interpolation percentile on a sorted list."""
-    if not values:
-        return 0.0
-    if len(values) == 1:
-        return values[0]
-
-    rank = (percentile / 100) * (len(values) - 1)
-    lower_idx = math.floor(rank)
-    upper_idx = math.ceil(rank)
-
-    if lower_idx == upper_idx:
-        return values[int(rank)]
-
-    weight = rank - lower_idx
-    return values[lower_idx] + weight * (values[upper_idx] - values[lower_idx])
-
-
 def _build_latency_stats(values: list[float]) -> dict[str, Any] | None:
     """Compute latency stats (min/max/mean/median/p90/p95/p99/stdev) in both units."""
+
     if not values:
         return None
 
     sorted_values = sorted(values)
     count = len(sorted_values)
+    # Percentiles and stdev delegate to the canonical core helpers so that
+    # result bundles and CLI/MCP surfaces report the same numbers.  Values
+    # are in seconds; convert to milliseconds for percentile_ms /
+    # sample_stdev_ms, then back to seconds for the seconds block.
+    values_ms = [v * 1000.0 for v in sorted_values]
     stats_seconds = {
         "count": count,
         "min": sorted_values[0],
         "max": sorted_values[-1],
         "mean": statistics.fmean(sorted_values),
         "median": statistics.median(sorted_values),
-        "p90": _percentile(sorted_values, 90),
-        "p95": _percentile(sorted_values, 95),
-        "p99": _percentile(sorted_values, 99),
-        "stdev": statistics.pstdev(sorted_values) if count > 1 else 0.0,
+        "p90": percentile_ms(values_ms, 0.90) / 1000.0,
+        "p95": percentile_ms(values_ms, 0.95) / 1000.0,
+        "p99": percentile_ms(values_ms, 0.99) / 1000.0,
+        "stdev": sample_stdev_ms(values_ms) / 1000.0,
     }
 
     stats_milliseconds = {key: (value * 1000.0 if key != "count" else value) for key, value in stats_seconds.items()}
@@ -336,15 +324,20 @@ def _build_numeric_stats(values: list[float]) -> dict[str, Any] | None:
 
     sorted_values = sorted(values)
     count = len(sorted_values)
+    # Row-count percentiles use the same nearest-rank definition as timing
+    # percentiles; percentile_ms is reused for its rank math (unit is
+    # irrelevant to the percentile) and sample_stdev_ms for stdev so that
+    # every surface shares one stdev definition (sample, not population).
+    values_float = [float(v) for v in sorted_values]
     return {
         "count": count,
         "min": sorted_values[0],
         "max": sorted_values[-1],
         "mean": statistics.fmean(sorted_values),
         "median": statistics.median(sorted_values),
-        "p90": _percentile(sorted_values, 90),
-        "p95": _percentile(sorted_values, 95),
-        "stdev": statistics.pstdev(sorted_values) if count > 1 else 0.0,
+        "p90": percentile_ms(values_float, 0.90),
+        "p95": percentile_ms(values_float, 0.95),
+        "stdev": sample_stdev_ms(values_float),
     }
 
 


### PR DESCRIPTION
- **docs: ADR freeze supersedes claim-check for 0.3 cutover**
- **fix(todo-db): shim w2/w3 — RO/RW token + drafts dir, refuse fork DB, add 0.3.0 verb coverage**
- **refactor(results): unify remaining percentile/stdev onto core metrics (#1551 follow-up)**
