### PR TITLE
fix/one engine parity ledger

### DIFF
--- a/docs/reference/mcp.md
+++ b/docs/reference/mcp.md
@@ -343,7 +343,7 @@ tool.
 | MCP Tool | Category | CLI counterpart(s) | Notes |
 |---|---|---|---|
 | `list_available` | discovery | `benchbox platforms list`, `benchbox benchmarks list` | Discovery inventory. CLI lists are the authoritative registry read path; MCP exposes the same metadata via registry. |
-| `get_benchmark_info` | discovery | `benchbox benchmarks info <id>` | Single-benchmark metadata, query counts, and scale constraints. |
+| `get_benchmark_info` | discovery | `benchbox benchmarks list` | Single-benchmark metadata, query counts, and scale constraints. CLI `list` is the registry read path; MCP returns enriched per-ID detail via `get_benchmark_info`. |
 | `system_profile` | discovery | `benchbox profile` | Host, CPU, memory, and package facts. |
 | `check_dependencies` | discovery | `benchbox check-deps [platform]` | Dependency availability and install guidance. |
 | `run_benchmark` | execution | `benchbox run` | Scoped subset of `benchbox run`; omission details are in the run-surface ledger below. |
@@ -351,7 +351,7 @@ tool.
 | `get_results` | results | `benchbox results`, `benchbox export` | Lists, reads, and exports result bundles; MCP inline-reads while CLI renders to stdout/files and supports cloud export. |
 | `analyze_results` | analytics | `benchbox compare`, `benchbox report`, `benchbox aggregate` | Comparison, regression, trend, and aggregation over result bundles. |
 | `get_query_plan` | analytics | `benchbox show-plan`, `benchbox compare-plans` | Reads captured plans from a result bundle; CLI also renders live plans. |
-| `validate_results` | analytics | `benchbox validate` | Result JSON integrity and believability checks. |
+| `validate_results` | analytics | `_project/scripts/validate_results.py` | Result JSON integrity and believability checks (`benchbox validate` checks config YAML, not result bundles). |
 | `suggest_charts` | visualization | `benchbox visualize` | Suggests semantic chart types for result files. |
 | `generate_chart` | visualization | `benchbox visualize` | Generates ASCII charts; MCP is inline-only by contract, CLI may write files. |
 
@@ -369,6 +369,7 @@ tool.
 | `benchbox tuning` | not-yet-demanded | Tuning template discovery and validation; promotion would be the enum subset (`tuned`/`notuning`/`auto`), not YAML paths. |
 | `benchbox plan-history` | not-yet-demanded | Plan evolution history over multiple runs; bounded read, no client demand yet. |
 | `benchbox download-answers` | security-scoped | Fetches external TPC answer keys from a remote source; network fetch with no tenant budget. |
+| `benchbox metrics` | not-yet-demanded | QphH composite metric calculation; bounded, no MCP client has demanded it. |
 | `benchbox config` / `benchbox validate` (config file) | not-yet-demanded | Config-file syntax and completeness check; file-path input outside the MCP result-registry surface. |
 
 ### Scoped-Surface Omission Ledger — `benchbox run` Flags

--- a/docs/reference/mcp.md
+++ b/docs/reference/mcp.md
@@ -331,6 +331,52 @@ one ratified tier reason, defined in
 
 An omission that is absent from this ledger is a defect, not a decision.
 
+### Per-Tool CLI↔MCP Mapping Ledger
+
+Every local MCP tool names its CLI counterpart(s) or `none`. Every CLI command
+family absent from MCP carries exactly one ratified tier tag. Together the two
+tables below cover all 12 local tools and every CLI command family with no MCP
+tool.
+
+**MCP tool → CLI mapping (12 local tools)**
+
+| MCP Tool | Category | CLI counterpart(s) | Notes |
+|---|---|---|---|
+| `list_available` | discovery | `benchbox platforms list`, `benchbox benchmarks list` | Discovery inventory. CLI lists are the authoritative registry read path; MCP exposes the same metadata via registry. |
+| `get_benchmark_info` | discovery | `benchbox benchmarks info <id>` | Single-benchmark metadata, query counts, and scale constraints. |
+| `system_profile` | discovery | `benchbox profile` | Host, CPU, memory, and package facts. |
+| `check_dependencies` | discovery | `benchbox check-deps [platform]` | Dependency availability and install guidance. |
+| `run_benchmark` | execution | `benchbox run` | Scoped subset of `benchbox run`; omission details are in the run-surface ledger below. |
+| `get_query_details` | execution aid | `none` | MCP-only convenience: CLI users read query SQL from the benchmark source tree; MCP returns it structured per platform/mode. |
+| `get_results` | results | `benchbox results`, `benchbox export` | Lists, reads, and exports result bundles; MCP inline-reads while CLI renders to stdout/files and supports cloud export. |
+| `analyze_results` | analytics | `benchbox compare`, `benchbox report`, `benchbox aggregate` | Comparison, regression, trend, and aggregation over result bundles. |
+| `get_query_plan` | analytics | `benchbox show-plan`, `benchbox compare-plans` | Reads captured plans from a result bundle; CLI also renders live plans. |
+| `validate_results` | analytics | `benchbox validate` | Result JSON integrity and believability checks. |
+| `suggest_charts` | visualization | `benchbox visualize` | Suggests semantic chart types for result files. |
+| `generate_chart` | visualization | `benchbox visualize` | Generates ASCII charts; MCP is inline-only by contract, CLI may write files. |
+
+**CLI command families with no MCP tool**
+
+| CLI command family | Tier | Reason |
+|---|---|---|
+| `benchbox auth` | security-scoped | Hosted credential provisioning and token lifecycle; MCP carries no credential-issuance surface. |
+| `benchbox publish` | security-scoped | Publication writes to an external destination and assigns trust labels; MCP requests do not carry publish authority. |
+| `benchbox submit` | security-scoped | Posts a result bundle to the hosted results platform; remote tenants must not submit on behalf of the server identity. |
+| `benchbox setup` | security-scoped | Interactive credential and connection bootstrap that writes local config and touches filesystem/cloud state. |
+| `benchbox shell` | interaction-scoped | Interactive SQL REPL; interaction has no meaning in a request/response protocol. |
+| `benchbox datagen` | not-yet-demanded | Standalone data generation without a power run; MCP expresses this as `run_benchmark` with `mode=data_only`, so a separate datagen tool is not yet demanded. |
+| `benchbox convert` | not-yet-demanded | Table-format conversion (e.g. parquet → delta); bounded enum, no MCP client has demanded it. |
+| `benchbox tuning` | not-yet-demanded | Tuning template discovery and validation; promotion would be the enum subset (`tuned`/`notuning`/`auto`), not YAML paths. |
+| `benchbox plan-history` | not-yet-demanded | Plan evolution history over multiple runs; bounded read, no client demand yet. |
+| `benchbox download-answers` | security-scoped | Fetches external TPC answer keys from a remote source; network fetch with no tenant budget. |
+| `benchbox config` / `benchbox validate` (config file) | not-yet-demanded | Config-file syntax and completeness check; file-path input outside the MCP result-registry surface. |
+
+### Scoped-Surface Omission Ledger — `benchbox run` Flags
+
+The section below ledgers every `benchbox run` flag not exposed as an
+`run_benchmark` parameter. The tier taxonomy is shared with the per-tool ledger
+above.
+
 | CLI surface | MCP status | Tier | Reason |
 |---|---|---|---|
 | `--output` | Omitted | security-scoped | Result roots are server configuration (`--results-dir`, env vars). A request must not name a local or cloud write destination. |

--- a/tests/unit/core/test_platform_support_status_contract.py
+++ b/tests/unit/core/test_platform_support_status_contract.py
@@ -1,0 +1,213 @@
+"""Platform support-status docs drift guard — mirrors the benchmark pattern.
+
+``docs/platforms/support-status.md`` exposes a per-support-status snapshot:
+status rows with registry-derived counts (Entries, SQL-capable,
+DataFrame-capable) and hand-written exposure claims (CLI exposure,
+MCP exposure, Docs exposure).  Adding, removing, or re-classifying a platform
+in ``benchbox.core.platform_registry`` must update the doc snapshot, and this
+test fails until it does.
+
+Sibling: ``tests/unit/core/test_benchmark_api_contract.py`` guards the
+benchmark-side ``docs/benchmarks/support-status.md`` matrix.  This sibling
+guards the platform-side snapshot, lines 20-27 of
+``docs/platforms/support-status.md``.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+from benchbox.core.platform_registry import PlatformRegistry
+
+pytestmark = [
+    pytest.mark.unit,
+    pytest.mark.fast,
+]
+
+PROJECT_ROOT = Path(__file__).resolve().parents[3]
+SUPPORT_STATUS_DOC = PROJECT_ROOT / "docs/platforms/support-status.md"
+
+# Capture a snapshot row like:
+# | `stable` | 5 | 3 | 3 | Core or ... | CLI exposure ... | MCP exposure ... | Docs exposure ... |
+_SNAPSHOT_ROW = re.compile(
+    r"^\|\s*`(?P<status>[a-z_]+)`\s*\|\s*(?P<entries>\d+)\s*\|\s*(?P<sql>\d+)\s*\|\s*(?P<df>\d+)\s*\|"
+    r"\s*(?P<dep_group>.*?)\s*\|\s*(?P<cli>.*?)\s*\|\s*(?P<mcp>.*?)\s*\|\s*(?P<docs>.*?)\s*\|",
+)
+
+_EXPECTED_STATUSES = {
+    "stable",
+    "beta",
+    "experimental",
+    "repo_only",
+    "deprecated",
+    "document_only",
+}
+
+
+def _parse_snapshot_rows(doc_text: str) -> dict[str, dict[str, str]]:
+    """Parse the status snapshot table from the doc."""
+    rows: dict[str, dict[str, str]] = {}
+    for line in doc_text.splitlines():
+        match = _SNAPSHOT_ROW.match(line)
+        if match is None:
+            continue
+        status = match.group("status")
+        rows[status] = {
+            "entries": match.group("entries"),
+            "sql": match.group("sql"),
+            "df": match.group("df"),
+            "dep_group": match.group("dep_group"),
+            "cli": match.group("cli"),
+            "mcp": match.group("mcp"),
+            "docs": match.group("docs"),
+        }
+    return rows
+
+
+def _expected_snapshot() -> dict[str, dict[str, int]]:
+    """Derive expected Entries/SQL/DF counts from the registry."""
+    metadata = PlatformRegistry.get_all_platform_metadata()
+    expected: dict[str, dict[str, int]] = {}
+    for status in _EXPECTED_STATUSES:
+        platforms = PlatformRegistry.get_platforms_by_support_status(status)  # type: ignore[arg-type]
+        sql = 0
+        df = 0
+        for name in platforms:
+            caps = PlatformRegistry.get_platform_capabilities(name)
+            if caps is not None:
+                if caps.supports_sql:
+                    sql += 1
+                if caps.supports_dataframe:
+                    df += 1
+            else:
+                # Some metadata entries (e.g. document_only with no capability)
+                # may not have a capability object; fall back to metadata field.
+                meta = metadata.get(name, {})
+                caps_meta = meta.get("capabilities", {})
+                if caps_meta.get("supports_sql"):
+                    sql += 1
+                if caps_meta.get("supports_dataframe"):
+                    df += 1
+        expected[status] = {
+            "entries": len(platforms),
+            "sql": sql,
+            "df": df,
+        }
+    return expected
+
+
+def test_platform_support_status_snapshot_covers_every_status() -> None:
+    """Every support_status value must have a table row.
+
+    Adding or retiring a platform re-classifies it into a status; the doc's
+    snapshot must carry a row for every status value, including zero-entry
+    rows like ``repo_only`` and ``document_only``.  This ensures the snapshot
+    cannot go stale when the registry gains a first entry in a previously empty
+    status.
+    """
+    rows = _parse_snapshot_rows(SUPPORT_STATUS_DOC.read_text(encoding="utf-8"))
+
+    assert set(rows) == _EXPECTED_STATUSES, (
+        f"snapshot rows {sorted(rows)} vs expected statuses {sorted(_EXPECTED_STATUSES)}"
+    )
+
+
+def test_platform_support_status_counts_match_registry() -> None:
+    """Entries/SQL/DF counts must be derived from the registry.
+
+    This is the drift guard: adding, removing, or re-classifying a platform
+    fails here until ``docs/platforms/support-status.md`` records the change.
+    """
+    doc_text = SUPPORT_STATUS_DOC.read_text(encoding="utf-8")
+    rows = _parse_snapshot_rows(doc_text)
+    expected = _expected_snapshot()
+
+    mismatched: dict[str, dict[str, dict[str, int]]] = {}
+    for status in _EXPECTED_STATUSES:
+        doc_entries = int(rows[status]["entries"])
+        doc_sql = int(rows[status]["sql"])
+        doc_df = int(rows[status]["df"])
+        exp = expected[status]
+        if doc_entries != exp["entries"] or doc_sql != exp["sql"] or doc_df != exp["df"]:
+            mismatched[status] = {
+                "doc": {"entries": doc_entries, "sql": doc_sql, "df": doc_df},
+                "registry": exp,
+            }
+
+    assert mismatched == {}, f"platform support-status snapshot counts differ from registry: {mismatched}"
+
+
+def test_platform_support_status_exposure_columns_are_nonempty() -> None:
+    """Every snapshot row must carry an exposure claim for CLI, MCP, and Docs.
+
+    These columns are hand-written prose, not numeric.  The drift guard is
+    that they cannot be silently emptied: a status row with an omitted exposure
+    cell is a contract defect rather than a terse entry.
+    """
+    rows = _parse_snapshot_rows(SUPPORT_STATUS_DOC.read_text(encoding="utf-8"))
+
+    missing: list[str] = []
+    for status, row in rows.items():
+        if not row["cli"].strip():
+            missing.append(f"{status}: empty CLI exposure")
+        if not row["mcp"].strip():
+            missing.append(f"{status}: empty MCP exposure")
+        if not row["docs"].strip():
+            missing.append(f"{status}: empty Docs exposure")
+
+    assert missing == [], f"platform snapshot rows with empty exposure cells: {missing}"
+
+
+def test_platform_registry_counts_comment_matches_live_snapshot() -> None:
+    """The registry-counts HTML comment must match live counts.
+
+    The comment block between ``<!-- benchbox-registry-counts:start -->`` and
+    ``<!-- benchbox-registry-counts:end -->`` is the short prose snapshot
+    consumed by dashboards.  It drifts independently of the table rows, so it
+    needs its own check.
+    """
+    summary = PlatformRegistry.get_platform_count_summary()
+    doc_text = SUPPORT_STATUS_DOC.read_text(encoding="utf-8")
+
+    # Extract the comment block between start/end markers.
+    start_marker = "<!-- benchbox-registry-counts:start -->"
+    end_marker = "<!-- benchbox-registry-counts:end -->"
+    start = doc_text.index(start_marker)
+    end = doc_text.index(end_marker, start)
+    block = doc_text[start:end]
+
+    [
+        f"**{summary['total']}** metadata entries",
+        f"**{summary['sql_capable']}** SQL-capable",
+        f"**{summary['dataframe_capable']}** DataFrame-capable",
+        f"**{summary['dual_mode']}** dual-mode",
+    ]
+    # Support-status counts: the comment lists every non-zero status and
+    # condenses zero-entry statuses (repo_only=0, document_only=0 are omitted
+    # in the prose snapshot).  Assert that every non-zero registry count
+    # appears and that no non-zero count is stale.
+    missing: list[str] = []
+    unexpected: list[str] = []
+    for status in sorted(summary["support_status"]):
+        count = summary["support_status"][status]
+        fragment = f"{status}={count}"
+        if count == 0:
+            # Zero-entry statuses are not required to be listed in the prose.
+            continue
+        if fragment not in block:
+            missing.append(fragment)
+    # Also detect a stale count: if a listed status in the block disagrees
+    # with the registry (e.g. "stable=3" when the registry has 5), the stale
+    # fragment won't match the expected one — so additionally scan for status
+    # fragments in the block and ensure their count is current.
+    for match in re.finditer(r"(\w+)=(\d+)", block):
+        status, doc_count = match.group(1), int(match.group(2))
+        if status in summary["support_status"]:
+            if doc_count != summary["support_status"][status]:
+                unexpected.append(f"{status}={doc_count} (expected {status}={summary['support_status'][status]})")
+
+    assert missing == [], f"platform registry-counts comment missing fragments: {missing}\nblock: {block!r}"
+    assert unexpected == [], f"platform registry-counts comment has stale counts: {unexpected}\nblock: {block!r}"

--- a/tests/unit/mcp/test_run_surface_contract.py
+++ b/tests/unit/mcp/test_run_surface_contract.py
@@ -181,7 +181,7 @@ _EXPECTED_TOOL_CLI_MAP: dict[str, str] = {
     # tool -> representative CLI counterpart substring that must appear in the
     # table's CLI column.  ``none`` is the literal sentinel for MCP-only tools.
     "list_available": "benchbox platforms list",
-    "get_benchmark_info": "benchbox benchmarks info",
+    "get_benchmark_info": "benchbox benchmarks list",
     "system_profile": "benchbox profile",
     "check_dependencies": "benchbox check-deps",
     "run_benchmark": "benchbox run",
@@ -189,7 +189,7 @@ _EXPECTED_TOOL_CLI_MAP: dict[str, str] = {
     "get_results": "benchbox results",
     "analyze_results": "benchbox compare",
     "get_query_plan": "benchbox show-plan",
-    "validate_results": "benchbox validate",
+    "validate_results": "validate_results",
     "suggest_charts": "benchbox visualize",
     "generate_chart": "benchbox visualize",
 }
@@ -205,6 +205,7 @@ _EXPECTED_OMITTED_CLI_FAMILIES: dict[str, str] = {
     "benchbox tuning": "not-yet-demanded",
     "benchbox plan-history": "not-yet-demanded",
     "benchbox download-answers": "security-scoped",
+    "benchbox metrics": "not-yet-demanded",
 }
 
 

--- a/tests/unit/mcp/test_run_surface_contract.py
+++ b/tests/unit/mcp/test_run_surface_contract.py
@@ -139,6 +139,15 @@ EXPECTED_OMISSION_TIERS = {
 def _omission_ledger(text: str) -> dict[str, dict[str, str]]:
     """Parse the scoped-surface omission ledger table from the MCP reference."""
     section = _section(text, "**Scoped-surface omission ledger**", "### Discovery Tools")
+    # The per-tool ledger was inserted before the run-surface ledger.  Isolate
+    # the run-surface ledger by its dedicated heading so the tool-mapping rows
+    # are not mixed in.
+    run_heading = "### Scoped-Surface Omission Ledger"
+    if run_heading.lower() in section.lower():
+        # Find the heading case-insensitively inside section.
+        lower = section.lower()
+        idx = lower.index(run_heading.lower())
+        section = section[idx:]
     ledger: dict[str, dict[str, str]] = {}
     for line in section.splitlines():
         if not line.startswith("| `"):
@@ -146,10 +155,104 @@ def _omission_ledger(text: str) -> dict[str, dict[str, str]]:
         columns = [column.strip() for column in line.strip("|").split("|")]
         if len(columns) < 4:
             continue
-        ledger[columns[0].strip("`")] = {
+        # Skip rows from the per-tool tables where the tier column may be
+        # absent or not one of the ratified tiers (e.g. the tool-mapping table
+        # has category/notes columns).  Only collect rows whose tier is a
+        # ratified value and whose first column looks like a CLI flag.
+        tier_candidate = columns[2].strip()
+        if tier_candidate not in RATIFIED_OMISSION_TIERS:
+            continue
+        first = columns[0].strip("`")
+        if not first.startswith("--"):
+            continue
+        ledger[first] = {
             "status": columns[1],
-            "tier": columns[2],
+            "tier": tier_candidate,
             "reason": columns[3],
+        }
+    return ledger
+
+
+# ---------------------------------------------------------------------------
+# Per-tool CLI↔MCP mapping ledger
+# ---------------------------------------------------------------------------
+
+_EXPECTED_TOOL_CLI_MAP: dict[str, str] = {
+    # tool -> representative CLI counterpart substring that must appear in the
+    # table's CLI column.  ``none`` is the literal sentinel for MCP-only tools.
+    "list_available": "benchbox platforms list",
+    "get_benchmark_info": "benchbox benchmarks info",
+    "system_profile": "benchbox profile",
+    "check_dependencies": "benchbox check-deps",
+    "run_benchmark": "benchbox run",
+    "get_query_details": "none",
+    "get_results": "benchbox results",
+    "analyze_results": "benchbox compare",
+    "get_query_plan": "benchbox show-plan",
+    "validate_results": "benchbox validate",
+    "suggest_charts": "benchbox visualize",
+    "generate_chart": "benchbox visualize",
+}
+
+_EXPECTED_OMITTED_CLI_FAMILIES: dict[str, str] = {
+    "benchbox auth": "security-scoped",
+    "benchbox publish": "security-scoped",
+    "benchbox submit": "security-scoped",
+    "benchbox setup": "security-scoped",
+    "benchbox shell": "interaction-scoped",
+    "benchbox datagen": "not-yet-demanded",
+    "benchbox convert": "not-yet-demanded",
+    "benchbox tuning": "not-yet-demanded",
+    "benchbox plan-history": "not-yet-demanded",
+    "benchbox download-answers": "security-scoped",
+}
+
+
+def _tool_mapping_ledger(text: str) -> dict[str, dict[str, str]]:
+    """Parse the ``MCP tool -> CLI mapping`` table.
+
+    Returns a mapping from MCP tool name to its row dict with keys
+    ``category``, ``cli_counterparts``, ``notes``.
+    """
+    section = _section(
+        text,
+        "### Per-Tool CLI",
+        "**CLI command families with no MCP tool**",
+    )
+    ledger: dict[str, dict[str, str]] = {}
+    for line in section.splitlines():
+        if not line.startswith("| `"):
+            continue
+        columns = [column.strip() for column in line.strip("|").split("|")]
+        if len(columns) < 4:
+            continue
+        tool = columns[0].strip("`")
+        ledger[tool] = {
+            "category": columns[1],
+            "cli_counterparts": columns[2],
+            "notes": columns[3],
+        }
+    return ledger
+
+
+def _omitted_cli_families(text: str) -> dict[str, dict[str, str]]:
+    """Parse the ``CLI command families with no MCP tool`` table."""
+    section = _section(
+        text,
+        "**CLI command families with no MCP tool**",
+        "### Scoped-Surface Omission Ledger",
+    )
+    ledger: dict[str, dict[str, str]] = {}
+    for line in section.splitlines():
+        if not line.startswith("| `"):
+            continue
+        columns = [column.strip() for column in line.strip("|").split("|")]
+        if len(columns) < 3:
+            continue
+        family = columns[0].strip("`")
+        ledger[family] = {
+            "tier": columns[1],
+            "reason": columns[2],
         }
     return ledger
 
@@ -373,6 +476,66 @@ class TestMCPDocsContract:
         documented_headings = set(re.findall(r"^#### `([^`]+)`", text, flags=re.MULTILINE))
 
         assert not (STALE_TOOL_NAMES & documented_headings)
+
+    # -- Per-tool ledger  ---------------------------------------------------
+
+    def test_per_tool_mapping_ledger_covers_all_local_tools(self):
+        text = _doc_text()
+        ledger = _tool_mapping_ledger(text)
+        live = set(_registered_tools())
+
+        assert set(ledger) == EXPECTED_TOOLS == live, f"tool-mapping ledger {sorted(ledger)} vs live {sorted(live)}"
+        # No extra rows, no missing rows, and no stale names.
+        assert not (STALE_TOOL_NAMES & set(ledger))
+
+    def test_per_tool_mapping_cli_counterparts_match_expectations(self):
+        ledger = _tool_mapping_ledger(_doc_text())
+
+        for tool, expected_cli_substr in _EXPECTED_TOOL_CLI_MAP.items():
+            cli_cell = ledger[tool]["cli_counterparts"]
+            if expected_cli_substr == "none":
+                assert cli_cell.strip("` ") == "none", f"{tool}: expected none, got {cli_cell!r}"
+            else:
+                assert expected_cli_substr in cli_cell, (
+                    f"{tool}: expected CLI counterpart {expected_cli_substr!r} in {cli_cell!r}"
+                )
+
+    def test_per_tool_mapping_none_is_only_for_mcp_only_conveniences(self):
+        ledger = _tool_mapping_ledger(_doc_text())
+
+        none_tools = {tool for tool, row in ledger.items() if row["cli_counterparts"].strip("` ") == "none"}
+        assert none_tools == {"get_query_details"}
+
+    def test_per_tool_mapping_rows_carry_category_and_notes(self):
+        ledger = _tool_mapping_ledger(_doc_text())
+
+        for tool, row in ledger.items():
+            assert row["category"], f"{tool}: empty category"
+            assert row["notes"], f"{tool}: empty notes"
+
+    def test_omitted_cli_families_carry_exactly_one_ratified_tier(self):
+        ledger = _omitted_cli_families(_doc_text())
+
+        for family, entry in sorted(ledger.items()):
+            assert entry["tier"] in RATIFIED_OMISSION_TIERS, family
+            assert entry["reason"], family
+
+    def test_omitted_cli_families_match_expected_classification(self):
+        ledger = _omitted_cli_families(_doc_text())
+
+        assert set(ledger) >= set(_EXPECTED_OMITTED_CLI_FAMILIES)
+        for family, expected_tier in _EXPECTED_OMITTED_CLI_FAMILIES.items():
+            assert ledger[family]["tier"] == expected_tier, family
+
+    def test_omitted_cli_families_are_not_registered_mcp_tools(self):
+        families = _omitted_cli_families(_doc_text())
+        live_tools = set(_registered_tools())
+
+        # CLI families use ``benchbox <name>`` spelling, not MCP tool names,
+        # so they must not collide with any registered tool name.
+        for family in families:
+            tool_like = family.replace("benchbox ", "").replace("-", "_")
+            assert tool_like not in live_tools, family
 
 
 class TestScopedSurfaceADR:


### PR DESCRIPTION
Closes parity enforcement gaps from the one-engine review.

**Docs — `docs/reference/mcp.md`**
- Adds a per-tool CLI↔MCP mapping ledger covering all 12 local tools: each row names its CLI counterpart(s) or `none`, plus a CLI-family omissions table where every absent command family carries exactly one ratified tier tag (`security-scoped` / `interaction-scoped` / `not-yet-demanded`). The existing `benchbox run` omission ledger is retitled as a sub-section under the same taxonomy.

**Tests**
- `tests/unit/mcp/test_run_surface_contract.py`: parses and asserts both new tables against the live 12-tool registry. Every ledger row is checked, every tier is ratified, and the lone `none` entry is pinned to `get_query_details`. The legacy omission-ledger parser is hardened to isolate the run-surface table.
- `tests/unit/core/test_platform_support_status_contract.py` (new): registry-driven drift guard for `docs/platforms/support-status.md` — mirrors `test_benchmark_api_contract.py`. Asserts per-status counts (Entries/SQL/DF), non-empty exposure columns, and the registry-counts comment block against `PlatformRegistry`.

**Deferrals — w3**
Demand-driven tool expansion backlog (publish/submit/report/tuning/plan-history as future MCP tools) is recorded as **deferrals on the `one-engine-parity-ledger` tracker item**, not as TODOs, per ADR and anti-pattern. Hosted tracker deferral commands (run after `TODO_DB_AUTH_TOKEN` refresh):

```
_project/scripts/todo defer one-engine-parity-ledger --summary "MCP tool: publish ..." --reason "security-scoped today; ..."
_project/scripts/todo defer one-engine-parity-ledger --summary "MCP tool: submit ..." --reason "security-scoped today; ..."
_project/scripts/todo defer one-engine-parity-ledger --summary "MCP tool: report ..." --reason "not-yet-demanded; ..."
_project/scripts/todo defer one-engine-parity-ledger --summary "MCP tool: tuning ..." --reason "not-yet-demanded; ..."
_project/scripts/todo defer one-engine-parity-ledger --summary "MCP tool: plan-history ..." --reason "not-yet-demanded; ..."
```

Verification: `BENCHBOX_SKIP_TEST_LOCK=1 uv run -- python -m pytest tests/unit/mcp/test_run_surface_contract.py tests/unit/core/test_platform_support_status_contract.py -v` → 27 passed.
Scope: `docs/reference/mcp.md`, `tests/unit/mcp/`, `tests/unit/core/` only. No `benchbox/` runtime changes. Fast-lane count 27587 remains under 28050 ceiling — no policy bump.