### PR TITLE
fix(flightdata,clickhouse): sync DataFrame default window + orphaned clickhouse config

### DIFF
--- a/benchbox/core/flightdata/dataframe_queries.py
+++ b/benchbox/core/flightdata/dataframe_queries.py
@@ -28,9 +28,21 @@ from benchbox.core.dataframe.query import DataFrameQuery, QueryCategory, QueryRe
 # Default parameters
 # ---------------------------------------------------------------------------
 
+# Single source of truth: the generated data covers up to LAST_AVAILABLE_YEAR
+# (benchbox/core/flightdata/downloader_specs.yaml).  The SQL catalog derives
+# its date literals from the same constant via FlightDataBenchmark's
+# query window, so the DataFrame default must match it -- otherwise the
+# window matches zero rows (2024 data vs 2018 window).  Import lazily to
+# avoid a hard cycle; fall back to the known default if the spec is
+# unavailable in a partial install.
+try:
+    from benchbox.core.flightdata.downloader import LAST_AVAILABLE_YEAR as _LAST_YEAR
+except Exception:  # pragma: no cover - import guard
+    _LAST_YEAR = 2024
+
 FLIGHTDATA_DEFAULT_PARAMS: dict[str, Any] = {
-    "start_date": date(2018, 1, 1),
-    "end_date": date(2019, 1, 1),
+    "start_date": date(_LAST_YEAR, 12, 1),
+    "end_date": date(_LAST_YEAR + 1, 1, 1),
 }
 
 _parameter_overrides: dict[str, Any] | None = None

--- a/benchbox/core/flightdata/dataframe_queries.py
+++ b/benchbox/core/flightdata/dataframe_queries.py
@@ -32,12 +32,13 @@ from benchbox.core.dataframe.query import DataFrameQuery, QueryCategory, QueryRe
 # (benchbox/core/flightdata/downloader_specs.yaml).  The SQL catalog derives
 # its date literals from the same constant via FlightDataBenchmark's
 # query window, so the DataFrame default must match it -- otherwise the
-# window matches zero rows (2024 data vs 2018 window).  Import lazily to
-# avoid a hard cycle; fall back to the known default if the spec is
-# unavailable in a partial install.
+# window matches zero rows (2024 data vs 2018 window).  Imported at module
+# load; fallback is the last known value from the spec and is covered by
+# the verification that asserts the default year is in the SQL window, so
+# a spec bump without a code bump fails fast.
 try:
     from benchbox.core.flightdata.downloader import LAST_AVAILABLE_YEAR as _LAST_YEAR
-except Exception:  # pragma: no cover - import guard
+except (ImportError, FileNotFoundError, KeyError, ValueError):  # pragma: no cover - import guard for partial installs
     _LAST_YEAR = 2024
 
 FLIGHTDATA_DEFAULT_PARAMS: dict[str, Any] = {

--- a/benchbox/platforms/clickhouse/setup.py
+++ b/benchbox/platforms/clickhouse/setup.py
@@ -34,6 +34,11 @@ class ClickHouseSetupMixin:
         self.max_execution_time = config.get("max_execution_time", 300)
         self.max_threads = config.get("max_threads", 8)
 
+        # Orphaned: max_server_memory_usage_ratio has no live ClickHouse consumer
+        # since the session-setting cleanup. Keep as None for backwards compat;
+        # do not reintroduce the removed session setting to consume it.
+        self.max_server_memory_usage_ratio = None
+
         # Result cache control - disable by default for accurate benchmarking
         self.disable_result_cache = config.get("disable_result_cache", True)
 
@@ -51,9 +56,10 @@ class ClickHouseSetupMixin:
         self.max_execution_time = config.get("max_execution_time", 300)
         self.max_threads = config.get("max_threads", 4)  # Lower default for local
 
-        # NOTE: max_server_memory_usage_ratio removed (was orphaned after
-        # session-setting cleanup - no live ClickHouse setting consumed it).
-        # Kept documented here to avoid reintroducing removed settings.
+        # Orphaned: max_server_memory_usage_ratio has no live ClickHouse consumer
+        # since the session-setting cleanup. Keep as None for backwards compat;
+        # do not reintroduce the removed session setting to consume it.
+        self.max_server_memory_usage_ratio = None
 
         # Result cache control - disable by default for accurate benchmarking
         self.disable_result_cache = config.get("disable_result_cache", True)
@@ -121,6 +127,8 @@ class ClickHouseSetupMixin:
         self.strict_validation = config.get("strict_validation", True)
 
         # Cloud-specific settings
+        # Orphaned: max_server_memory_usage_ratio has no live ClickHouse consumer
+        # in any mode. Kept as None for backwards compat in all three modes.
         self.max_server_memory_usage_ratio = None  # Not applicable for cloud
 
         # Cloud storage staging configuration for data loading

--- a/benchbox/platforms/clickhouse/setup.py
+++ b/benchbox/platforms/clickhouse/setup.py
@@ -34,10 +34,6 @@ class ClickHouseSetupMixin:
         self.max_execution_time = config.get("max_execution_time", 300)
         self.max_threads = config.get("max_threads", 8)
 
-        # Server-wide memory limit (overrides ClickHouse default 0.9 ratio)
-        # Set conservatively to 0.8 (80%) to leave headroom for OS and prevent OOM killer on macOS
-        self.max_server_memory_usage_ratio = config.get("max_server_memory_usage_ratio", 0.8)
-
         # Result cache control - disable by default for accurate benchmarking
         self.disable_result_cache = config.get("disable_result_cache", True)
 
@@ -55,9 +51,9 @@ class ClickHouseSetupMixin:
         self.max_execution_time = config.get("max_execution_time", 300)
         self.max_threads = config.get("max_threads", 4)  # Lower default for local
 
-        # Server-wide memory limit (overrides ClickHouse default 0.9 ratio)
-        # Set conservatively to 0.8 (80%) to leave headroom for OS and prevent OOM killer on macOS
-        self.max_server_memory_usage_ratio = config.get("max_server_memory_usage_ratio", 0.8)
+        # NOTE: max_server_memory_usage_ratio removed (was orphaned after
+        # session-setting cleanup - no live ClickHouse setting consumed it).
+        # Kept documented here to avoid reintroducing removed settings.
 
         # Result cache control - disable by default for accurate benchmarking
         self.disable_result_cache = config.get("disable_result_cache", True)

--- a/tests/unit/core/flightdata/test_dataframe_queries.py
+++ b/tests/unit/core/flightdata/test_dataframe_queries.py
@@ -121,6 +121,7 @@ class TestParameterOverrides:
 
     def test_parameter_override(self):
         from benchbox.core.flightdata.dataframe_queries import (
+            FLIGHTDATA_DEFAULT_PARAMS,
             get_flightdata_parameters,
             set_parameter_overrides,
         )
@@ -136,7 +137,7 @@ class TestParameterOverrides:
         # Restore defaults
         set_parameter_overrides(None)
         params = get_flightdata_parameters()
-        assert params["start_date"] == date(2018, 1, 1)
+        assert params["start_date"] == FLIGHTDATA_DEFAULT_PARAMS["start_date"]
 
     def test_clear_overrides(self):
         from benchbox.core.flightdata.dataframe_queries import (

--- a/tests/unit/core/flightdata/test_dataframe_queries.py
+++ b/tests/unit/core/flightdata/test_dataframe_queries.py
@@ -161,12 +161,15 @@ def pandas_ctx():
     pytest.importorskip("pandas")
     import pandas as pd
 
+    # Align synthetic dates with FLIGHTDATA_DEFAULT_PARAMS (2024-12-01/2025-01-01)
+    # so DataFrame queries with default window return rows. Previously 2018
+    # matched the old hardcoded default and now would be filtered out.
     flights = pd.DataFrame(
         {
             "flight_id": range(1, 11),
-            "flight_date": [date(2018, 1, i) for i in range(1, 11)],
-            "year": [2018] * 10,
-            "month": [1] * 10,
+            "flight_date": [date(2024, 12, i) for i in range(1, 11)],
+            "year": [2024] * 10,
+            "month": [12] * 10,
             "day_of_month": list(range(1, 11)),
             "day_of_week": [1, 2, 3, 4, 5, 6, 7, 1, 2, 3],
             "reporting_airline": ["AA", "AA", "DL", "DL", "UA", "UA", "WN", "WN", "B6", "B6"],
@@ -257,7 +260,7 @@ def polars_ctx():
         pl.DataFrame(
             {
                 "flight_id": range(1, 11),
-                "flight_date": [date(2018, 1, i) for i in range(1, 11)],
+                "flight_date": [date(2024, 12, i) for i in range(1, 11)],
                 "month": [1, 2, 3, 4, 5, 6, 7, 11, 12, 12],
                 "day_of_month": [1, 2, 3, 4, 26, 6, 4, 24, 24, 31],
                 "day_of_week": [1, 2, 3, 4, 1, 6, 7, 4, 1, 2],


### PR DESCRIPTION
Batch UAT & Platform Hardening — 2 of 7 landed (adversarial-reviewed).

**Scope**
- `benchbox/core/flightdata/dataframe_queries.py` — `flightdata-dataframe-date-params-miss-the-generated-data` w1/w2
- `benchbox/platforms/clickhouse/setup.py` — `uat-clickhouse-server-ddl-compatibility` w5 (w0)

**Changes**
- FlightData: `FLIGHTDATA_DEFAULT_PARAMS` now derives from `downloader.LAST_AVAILABLE_YEAR` (2024-12-01/2025-01-01) matching SQL catalog at SF=0.01. Was hardcoded 2018/2019 → Variant:0 empty. Runner already syncs via `set_parameter_overrides`; this fixes fallback verification (`P['start_date'].year in SQL years`). Import narrowed to `ImportError/FileNotFoundError/KeyError/ValueError`, comment clarifies module-load vs 'lazily', fallback is last-known spec value covered by verification.
- ClickHouse: `max_server_memory_usage_ratio` had no live consumer after session-setting cleanup (orphaned). Now kept as `None` in all three modes (`server/local/cloud`) for backwards-compat attribute presence, with orphan comment 'do not reintroduce removed session setting' per preserves. Previously server/local set 0.8, cloud None → inconsistent AttributeError flagged in adversarial review.

**Adversarial review findings addressed**
- Critical: ClickHouse inconsistent attribute presence (server/local missing vs cloud None) → unified to `None` in all modes.
- Required: FlightData broad `except Exception` + stale comment + hardcoded fallback drift → narrowed, clarified, documented fail-fast on spec bump.
- Bundling note: flightdata (correctness) + clickhouse w5 (orphaned config) are independent but small hardening items; bundled in batch per `batch.md` single-authorization. Remaining w1-w4 (MergeTree/TIME DDL) and TPCH binary rebuilds tracked separately.

**Verification**
- `uv run ruff check/format` + `ty check` pass
- `uv run python -c FLIGHTDATA_DEFAULT_PARAMS` → `2024-12-01` in SQL `['2024','2025']`
- `pytest tests/unit/platforms/test_clickhouse_adapter.py -q` → 80 passed
- `pytest tests/uat/test_timeouts.py` / `test_sweep_durability -k orphan` still 16/1 passed (no change to timeout logic)
- `pr-preflight` pass

**TODOs**
- Closes `flightdata-dataframe-date-params-miss-the-generated-data` w1/w2 (verify `uv run python -c "...P['start_date'].year in ys..."`)
- Partial `uat-clickhouse-server-ddl-compatibility` w0+w5 (w1-w4 pending MergeTree/TIME)

**Remaining batch (not in this PR)**
- `tpch-darwin-arm64-deployment-target-rebuild` (minos 26.0), `resync-tpch-darwin-x86-64-binaries` (BSD checksums + -DEOL_HANDLING), `uat-clickhouse-server-ddl-compatibility` w1-w4, `uat-release-gate-first-evidence-bootstrap` (operator sweep)
