### PR TITLE
fix: address recent merged-PR review follow-ups

### DIFF
--- a/_project/scripts/todo_db_standalone_compat.py
+++ b/_project/scripts/todo_db_standalone_compat.py
@@ -62,6 +62,7 @@ COMMANDS = frozenset(
 )
 
 GLOBAL_VALUE_OPTIONS = frozenset({"--actor", "--db", "--project-id", "--repository"})
+OFFLINE_FINDING_SUBCOMMANDS = frozenset({"create", "candidates"})
 
 
 def _repo_root() -> Path:
@@ -100,6 +101,12 @@ def _has_database_environment() -> bool:
 
 def _has_config_json(root: Path) -> bool:
     return (root / ".todo-db" / "config.json").is_file()
+
+
+def _is_offline_finding_command(args: list[str], command_index: int, command: str) -> bool:
+    """Return whether a finding command only reads or writes local drafts."""
+    subcommand = args[command_index + 1] if command_index + 1 < len(args) else None
+    return command == "finding" and subcommand in OFFLINE_FINDING_SUBCOMMANDS
 
 
 def _with_identity(argv: list[str], command_index: int) -> list[str]:
@@ -339,7 +346,7 @@ def _main(argv: list[str] | None = None) -> int:
         # Refuse loudly if no DB is configured via env, --db, or config.json; honor config.json as configured.
         # w5: doctor without DB must diagnose no-backend-configured, not refuse exit-2.
         has_db = _has_database_environment() or _has_option(args, "--db") or _has_config_json(root)
-        if not has_db and command != "doctor":
+        if not has_db and command != "doctor" and not _is_offline_finding_command(args, command_index, command):
             print(
                 f"error: standalone shim cannot route '{command}' without explicit --db, TODO_DB_PATH/URL, or .todo-db/config.json; refusing to create fork DB at {root / '.todo-db' / 'todo.sqlite'}",
                 file=sys.stderr,

--- a/benchbox/platforms/duckdb.py
+++ b/benchbox/platforms/duckdb.py
@@ -36,12 +36,20 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 # Adapter-level memory-size validation: broader than the MCP request contract
-# (which is intentionally narrow for remote admisson) but still bounded and
-# injection-safe. Accepts DuckDB's documented sizes such as "4GB", "2GiB",
-# "100 MB", "1.5e9", etc., with optional spaces and binary units, while
-# rejecting SQL metacharacters. See duckdb-set-statement-value-hardening.
+# (which is intentionally narrow for remote admission) but still bounded and
+# injection-safe. Accepts DuckDB's supported decimal and binary spellings,
+# including long-form decimal units, optional spaces, and scientific notation,
+# while rejecting SQL metacharacters. See duckdb-set-statement-value-hardening.
+_DUCKDB_MEMORY_SIZE_PATTERN = (
+    r"\s*[0-9]+(?:\.[0-9]+)?(?:[eE][+-]?[0-9]+)?\s*"
+    r"(?:B|bytes?|K|KB|kilobytes?|M|MB|megabytes?|G|GB|gigabytes?|T|TB|terabytes?|KiB|MiB|GiB|TiB)\s*"
+)
 _MEMORY_LIMIT_PATTERN = re.compile(
-    r"^\s*[0-9]+(?:\.[0-9]+)?(?:[eE][+-]?[0-9]+)?\s*(?:B|KB|MB|GB|TB|KiB|MiB|GiB|TiB)?\s*$",
+    rf"^{_DUCKDB_MEMORY_SIZE_PATTERN}$",
+    re.IGNORECASE,
+)
+_MAX_TEMP_DIRECTORY_SIZE_PATTERN = re.compile(
+    rf"^(?:{_DUCKDB_MEMORY_SIZE_PATTERN}|90%\s+of\s+available\s+disk\s+space)$",
     re.IGNORECASE,
 )
 
@@ -680,8 +688,10 @@ class DuckDBAdapter(PlatformAdapter):
         self.memory_limit = raw_memory
         raw_temp = config.get("max_temp_directory_size")
         if raw_temp is not None:
-            if not isinstance(raw_temp, str) or not _MEMORY_LIMIT_PATTERN.fullmatch(raw_temp):
-                raise ValueError("max_temp_directory_size must use a bounded memory size (e.g., '4GB')")
+            if not isinstance(raw_temp, str) or not _MAX_TEMP_DIRECTORY_SIZE_PATTERN.fullmatch(raw_temp):
+                raise ValueError(
+                    "max_temp_directory_size must use a DuckDB size (e.g., '4GB' or '90% of available disk space')"
+                )
         self.max_temp_directory_size = raw_temp
         raw_threads = config.get("thread_limit")
         if raw_threads is not None:
@@ -810,14 +820,21 @@ class DuckDBAdapter(PlatformAdapter):
             )
 
         # Apply DuckDB settings
+        from benchbox.platforms.base.data_loading import escape_sql_string_literal
+
         config_applied = []
         if self.memory_limit:
-            conn.execute(f"SET memory_limit = '{self.memory_limit}'")
+            # DuckDB does not support parameters in SET statements. Keep the
+            # value a string literal, with the adapter-level whitelist above
+            # providing the validation boundary and escaping as defense in depth.
+            memory_limit = escape_sql_string_literal(str(self.memory_limit))
+            conn.execute(f"SET memory_limit = '{memory_limit}'")
             config_applied.append(f"memory_limit={self.memory_limit}")
             self.log_very_verbose(f"DuckDB memory limit set to: {self.memory_limit}")
 
         if self.max_temp_directory_size:
-            conn.execute(f"SET max_temp_directory_size = '{self.max_temp_directory_size}'")
+            max_temp_directory_size = escape_sql_string_literal(str(self.max_temp_directory_size))
+            conn.execute(f"SET max_temp_directory_size = '{max_temp_directory_size}'")
             config_applied.append(f"max_temp_directory_size={self.max_temp_directory_size}")
             self.log_very_verbose(f"DuckDB max temp directory size set to: {self.max_temp_directory_size}")
 

--- a/tests/unit/platforms/test_duckdb_adapter.py
+++ b/tests/unit/platforms/test_duckdb_adapter.py
@@ -48,6 +48,28 @@ class TestDuckDBAdapter:
             assert adapter.thread_limit is None
             assert adapter.enable_progress_bar is False
 
+    @pytest.mark.parametrize("value", ["2GiB", "2 GB", "2 gigabytes", "2e3 MB", "976.5 KiB"])
+    def test_initialization_accepts_duckdb_memory_size_syntax(self, value):
+        """Direct adapter configuration must preserve DuckDB's supported spellings."""
+        with patch("benchbox.platforms.duckdb.duckdb"):
+            adapter = DuckDBAdapter(memory_limit=value, max_temp_directory_size=value)
+
+        assert adapter.memory_limit == value
+        assert adapter.max_temp_directory_size == value
+
+    def test_initialization_accepts_duckdb_default_temp_size_expression(self):
+        with patch("benchbox.platforms.duckdb.duckdb"):
+            adapter = DuckDBAdapter(max_temp_directory_size="90% of available disk space")
+
+        assert adapter.max_temp_directory_size == "90% of available disk space"
+
+    @pytest.mark.parametrize("value", ["2", "2 tebibytes", "2GB'; DROP TABLE results; --", "/tmp/secret"])
+    def test_initialization_rejects_invalid_or_unsafe_memory_size(self, value):
+        """Invalid SET values must fail before they can reach SQL construction."""
+        with patch("benchbox.platforms.duckdb.duckdb"):
+            with pytest.raises(ValueError, match="memory_limit"):
+                DuckDBAdapter(memory_limit=value)
+
     def test_create_external_tables_uses_read_parquet_views(self, tmp_path):
         """External mode should create views over read_parquet() sources."""
         with patch("benchbox.platforms.duckdb.duckdb"):

--- a/tests/unit/scripts/test_todo_db_standalone_compat.py
+++ b/tests/unit/scripts/test_todo_db_standalone_compat.py
@@ -442,8 +442,31 @@ def test_standalone_030_verbs_are_routable_through_shim(
         assert calls == [""]
 
 
-def test_standalone_refuses_unroutable_finding_without_db(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
-    """w2/w3: finding without DB refuses loudly and does not create fork DB."""
+@pytest.mark.parametrize("subcommand", ["create", "candidates"])
+def test_standalone_offline_finding_commands_do_not_require_db(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, subcommand: str
+) -> None:
+    """Offline finding capture/listing must delegate without inventing a DB."""
+    calls: list[tuple[list[str], str]] = []
+
+    def fake_delegate(argv: list[str], *, command: str, cwd: Path, capture: bool = True) -> CompletedProcess[str]:
+        calls.append((argv, command))
+        return CompletedProcess(argv, 0, stdout="", stderr="")
+
+    monkeypatch.setattr(compat, "_delegate", fake_delegate)
+    monkeypatch.setenv("BENCHBOX_REPO_ROOT", str(tmp_path))
+    monkeypatch.setenv("BENCHBOX_TODO_DB_STANDALONE", "1")
+    monkeypatch.delenv("TODO_DB_PATH", raising=False)
+    monkeypatch.delenv("TODO_DB_URL", raising=False)
+
+    assert compat.main(["finding", subcommand]) == 0
+    assert calls[0][1] == "finding"
+    assert "--db" not in calls[0][0]
+    assert not (tmp_path / ".todo-db" / "todo.sqlite").exists()
+
+
+def test_standalone_finding_sync_still_requires_db(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """Database-backed finding sync must remain fail-closed without a backend."""
     monkeypatch.setenv("BENCHBOX_REPO_ROOT", str(tmp_path))
     monkeypatch.setenv("BENCHBOX_TODO_DB_STANDALONE", "1")
     monkeypatch.delenv("TODO_DB_PATH", raising=False)


### PR DESCRIPTION
## Summary

Addresses all three unresolved actionable review threads found across the 29 recently merged PRs scanned by `make pr-review-followups-list`:

- DuckDB `SET` values remain safely formatted literals, with broader adapter validation for documented decimal/binary size spellings, long-form units, spaces, and scientific notation.
- Standalone todo-db permits credential-free `finding create` and `finding candidates` without a database, while keeping `finding sync` fail-closed.
- Adds regression coverage for both fixes.

Source review threads: #1642 (2), #1641 (1).

## Validation

- `uv run -- python -m pytest tests/unit/ -x -q` — 27373 passed, 24 skipped
- `make pr-preflight` — passed (27555 passed, 19 skipped in fast lane)
- Targeted DuckDB/todo-db tests — 129 passed
- `uv run -- ruff check ...` and `uv run -- ruff format --check ...` — passed