### PR TITLE
fix(uat): deduplicate benchbox/cli/tuning.py in surface allowlist

### DIFF
--- a/tests/uat/test_no_cli_surface_drift.py
+++ b/tests/uat/test_no_cli_surface_drift.py
@@ -118,10 +118,6 @@ ALLOWED_INTERNAL_CLI_FILES = {
     # fix-datafusion-df-mode-erasure: comment-only clarification of
     # PLATFORM_ALIASES' -df entries; no click surface in this module.
     "benchbox/cli/platform.py",
-    # cli-tuning-presort-hint: the interactive wizard body now derives its
-    # sorting hint/default from the core presort registry. This module has no
-    # Click decorators, so the change cannot alter the public CLI surface.
-    "benchbox/cli/tuning.py",
 }
 ALLOWED_HIDDEN_COMPAT_CLI_FILES = {
     # pr-review-followup-1394: SingleStore credential setup is intentionally


### PR DESCRIPTION
Fixes develop lint failure after #1648 merge (run 31326346337).\n\nBoth #1647's one-engine-batch (`a13b618fbf`) and #1648's presort-hint (`82ab2f3f5d`) added the same `"benchbox/cli/tuning.py"` entry — the set now violates ruff B033 (duplicate). Keep the first entry (lines 86-89) with its divergence justification; the second entry at EOF (cli-tuning-presort-hint) is redundant — the file has no Click decorators, so a single allowlist entry suffices. Verified: `uv run -- ruff check` now passes, `pytest tests/uat/test_no_cli_surface_drift.py` 7 passed.\n\nAuto-revert #1661 can be closed once this lands — the underlying lint is fixed, no revert of #1648's functional change is needed.