### PR TITLE
fix(todo): classify lock-contended verification rungs

### DIFF
--- a/_project/scripts/todo_db.py
+++ b/_project/scripts/todo_db.py
@@ -42,6 +42,7 @@ import argparse
 import difflib
 import fnmatch
 import getpass
+import importlib.util
 import json
 import math
 import os
@@ -53,17 +54,23 @@ import sqlite3
 import subprocess
 import sys
 import tempfile
-import time
 from collections.abc import Iterable
 from contextlib import contextmanager
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
+from time import sleep
 from typing import Any
 
 # Make this script's own directory importable so the findings sibling resolves
 # whether todo_db runs via `uv run ... todo_db.py` (dir already on sys.path[0])
 # or is loaded by file path in tests (spec_from_file_location adds nothing).
-sys.path.insert(0, str(Path(__file__).resolve().parent))
+_SCRIPT_DIR = Path(__file__).resolve().parent
+_REPO_ROOT = _SCRIPT_DIR.parents[1]
+sys.path.insert(0, str(_SCRIPT_DIR))
+# The standalone `todo` shim uses the scripts-only uv project, not BenchBox's
+# package environment. Add the repository root so shared production helpers
+# (such as the monotonic clock) remain importable in that execution mode.
+sys.path.insert(0, str(_REPO_ROOT))
 
 # Alias THIS module as "todo_db" so the findings sibling's `import todo_db`
 # binds this exact instance instead of re-executing the file under the canonical
@@ -85,6 +92,21 @@ if _self_module is not None:
 # single instance, and todo_findings defines its schema constants before it first
 # touches todo_db. See todo_findings.py's header.
 import todo_findings  # noqa: E402
+
+try:
+    from benchbox.utils.clock import elapsed_seconds, mono_time  # noqa: E402
+except ModuleNotFoundError:
+    # The scripts-only uv environment intentionally does not install BenchBox's
+    # optional runtime dependencies. Load the same repository-owned helper
+    # directly instead of importing benchbox/__init__.py and its full surface.
+    _clock_spec = importlib.util.spec_from_file_location("_benchbox_clock", _REPO_ROOT / "benchbox/utils/clock.py")
+    if _clock_spec is None or _clock_spec.loader is None:
+        raise RuntimeError("cannot load repository clock helpers") from None
+    _clock_module = importlib.util.module_from_spec(_clock_spec)
+    sys.modules[_clock_spec.name] = _clock_module
+    _clock_spec.loader.exec_module(_clock_module)
+    elapsed_seconds = _clock_module.elapsed_seconds
+    mono_time = _clock_module.mono_time
 
 SCHEMA_VERSION = 5
 
@@ -3128,7 +3150,7 @@ def _verification_test_lock():
         return
 
     acquired = False
-    deadline = time.monotonic() + timeout
+    started_at = mono_time()
     try:
         try:
             import fcntl
@@ -3139,9 +3161,9 @@ def _verification_test_lock():
                     acquired = True
                     break
                 except BlockingIOError:
-                    if time.monotonic() >= deadline:
+                    if elapsed_seconds(started_at) >= timeout:
                         break
-                    time.sleep(0.1)
+                    sleep(0.1)
         except ImportError:  # pragma: no cover - Windows uses msvcrt below
             import msvcrt
 
@@ -3152,9 +3174,9 @@ def _verification_test_lock():
                     acquired = True
                     break
                 except OSError:
-                    if time.monotonic() >= deadline:
+                    if elapsed_seconds(started_at) >= timeout:
                         break
-                    time.sleep(0.1)
+                    sleep(0.1)
 
         if not acquired:
             try:
@@ -3206,14 +3228,12 @@ def run_verification(conn: sqlite3.Connection, actor: str, item_id: str, seq: in
     with _write_txn(conn):
         if not _touch_lease(conn, actor, item_id):
             raise TodoError(f"{item_id!r}'s lease is expired, missing, or held by another actor; re-acquire it")
-        if result == "indeterminate":
-            # The existing schema intentionally admits only pass/fail. Keep an
-            # environmental non-verdict out of last_result and retain the
-            # durable distinction in the audit event and CLI output.
-            conn.execute(
-                "UPDATE verifications SET last_run = ? WHERE item_id = ? AND seq = ?", (utc_now(), item_id, seq)
-            )
-        else:
+        # The existing schema intentionally admits only pass/fail. Keep an
+        # environmental non-verdict out of last_result and retain the durable
+        # distinction in the audit event and CLI output. The verification did
+        # not run, so its previous verdict and timestamp remain the last
+        # completed observation.
+        if result != "indeterminate":
             conn.execute(
                 "UPDATE verifications SET last_run = ?, last_result = ? WHERE item_id = ? AND seq = ?",
                 (utc_now(), result, item_id, seq),

--- a/_project/scripts/todo_db.py
+++ b/_project/scripts/todo_db.py
@@ -53,6 +53,7 @@ import sqlite3
 import subprocess
 import sys
 import tempfile
+import time
 from collections.abc import Iterable
 from contextlib import contextmanager
 from datetime import datetime, timedelta, timezone
@@ -3095,23 +3096,128 @@ def changed_files(base: str | None) -> list[str]:
     return sorted(set(files))
 
 
+@contextmanager
+def _verification_test_lock():
+    """Serialize verification commands with the repository's parallel test lane.
+
+    A lock timeout means the command was not run, so callers must not turn it
+    into a code verdict. Advisory locks are released by the kernel when their
+    owner dies; stale diagnostic text in the file therefore does not make a
+    dead holder permanent.
+    """
+    if os.environ.get("PYTEST_XDIST_WORKER"):
+        # The xdist controller already owns this lock for the whole session;
+        # a worker must not contend with its own controller through a nested
+        # verification subprocess.
+        yield True, ""
+        return
+    lock_dir = os.environ.get("BENCHBOX_TEST_LOCK_DIR")
+    base_dir = Path(lock_dir).expanduser() if lock_dir else Path.home() / ".benchbox"
+    lock_path = base_dir / "test.lock"
+    timeout_raw = os.environ.get("BENCHBOX_VERIFY_LOCK_TIMEOUT", "30")
+    try:
+        timeout = max(0.0, float(timeout_raw))
+    except ValueError:
+        timeout = 30.0
+
+    try:
+        base_dir.mkdir(parents=True, exist_ok=True)
+        fd = os.open(lock_path, os.O_CREAT | os.O_RDWR | getattr(os, "O_CLOEXEC", 0), 0o644)
+    except OSError as exc:
+        yield False, f"could not open test lock {lock_path}: {exc}"
+        return
+
+    acquired = False
+    deadline = time.monotonic() + timeout
+    try:
+        try:
+            import fcntl
+
+            while True:
+                try:
+                    fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+                    acquired = True
+                    break
+                except BlockingIOError:
+                    if time.monotonic() >= deadline:
+                        break
+                    time.sleep(0.1)
+        except ImportError:  # pragma: no cover - Windows uses msvcrt below
+            import msvcrt
+
+            while True:
+                try:
+                    os.lseek(fd, 0, os.SEEK_SET)
+                    msvcrt.locking(fd, msvcrt.LK_NBLCK, 1)
+                    acquired = True
+                    break
+                except OSError:
+                    if time.monotonic() >= deadline:
+                        break
+                    time.sleep(0.1)
+
+        if not acquired:
+            try:
+                holder = lock_path.read_text(encoding="utf-8").strip() or "unknown holder"
+            except OSError:
+                holder = "unknown holder"
+            yield False, f"test lock held after {timeout:g}s ({holder}); verification command was not run"
+            return
+
+        yield True, ""
+    finally:
+        if acquired:
+            try:
+                if "fcntl" in sys.modules and sys.platform != "win32":
+                    import fcntl
+
+                    fcntl.flock(fd, fcntl.LOCK_UN)
+                else:  # pragma: no cover - Windows
+                    import msvcrt
+
+                    os.lseek(fd, 0, os.SEEK_SET)
+                    msvcrt.locking(fd, msvcrt.LK_UNLCK, 1)
+            except OSError:
+                pass
+        os.close(fd)
+
+
 def run_verification(conn: sqlite3.Connection, actor: str, item_id: str, seq: int) -> tuple[str, str]:
     row = conn.execute("SELECT * FROM verifications WHERE item_id = ? AND seq = ?", (item_id, seq)).fetchone()
     if row is None:
         raise TodoError(f"no verification seq={seq} on {item_id!r}")
     if not row["command"]:
         raise TodoError(f"verification seq={seq} on {item_id!r} has no command")
-    proc = subprocess.run(row["command"], shell=True, capture_output=True, text=True, check=False)
-    output = (proc.stdout or "") + (proc.stderr or "")
-    passed = proc.returncode == 0
-    result = "pass" if passed else "fail"
+    with _verification_test_lock() as (can_run, lock_message):
+        if can_run:
+            command_env = os.environ.copy()
+            # The wrapper owns the shared lock for the command's full
+            # duration; prevent pytest's own session hook from attempting a
+            # nested acquisition against the descriptor we already hold.
+            command_env["BENCHBOX_SKIP_TEST_LOCK"] = "1"
+            proc = subprocess.run(
+                row["command"], shell=True, capture_output=True, text=True, check=False, env=command_env
+            )
+            output = (proc.stdout or "") + (proc.stderr or "")
+            result = "pass" if proc.returncode == 0 else "fail"
+        else:
+            output = f"indeterminate: {lock_message}"
+            result = "indeterminate"
     with _write_txn(conn):
         if not _touch_lease(conn, actor, item_id):
             raise TodoError(f"{item_id!r}'s lease is expired, missing, or held by another actor; re-acquire it")
-        conn.execute(
-            "UPDATE verifications SET last_run = ?, last_result = ? WHERE item_id = ? AND seq = ?",
-            (utc_now(), result, item_id, seq),
-        )
+        if result == "indeterminate":
+            # The existing schema intentionally admits only pass/fail. Keep an
+            # environmental non-verdict out of last_result and retain the
+            # durable distinction in the audit event and CLI output.
+            conn.execute(
+                "UPDATE verifications SET last_run = ? WHERE item_id = ? AND seq = ?", (utc_now(), item_id, seq)
+            )
+        else:
+            conn.execute(
+                "UPDATE verifications SET last_run = ?, last_result = ? WHERE item_id = ? AND seq = ?",
+                (utc_now(), result, item_id, seq),
+            )
         log_event(conn, actor, item_id, "verify", {"seq": seq, "result": result})
     return result, output
 

--- a/tests/unit/scripts/test_todo_db.py
+++ b/tests/unit/scripts/test_todo_db.py
@@ -332,8 +332,12 @@ class TestVerifyRun:
     def test_verify_rung_lock_contention_is_indeterminate(self, conn, tmp_path, monkeypatch):
         """A lock timeout records an environmental non-verdict, not a failure."""
         fcntl = pytest.importorskip("fcntl")
-        _mk(conn, verifications=[{"description": "blocked", "command": "false"}])
+        _mk(conn, verifications=[{"description": "blocked", "command": "true"}])
         todo_db.claim_item(conn, "tester", "sample-item")
+        assert todo_db.run_verification(conn, "tester", "sample-item", 1)[0] == "pass"
+        before = conn.execute(
+            "SELECT last_run, last_result FROM verifications WHERE item_id='sample-item' AND seq=1"
+        ).fetchone()
         lock_dir = tmp_path / "lock"
         lock_dir.mkdir()
         lock_path = lock_dir / "test.lock"
@@ -350,8 +354,10 @@ class TestVerifyRun:
 
         assert result == "indeterminate"
         assert "verification command was not run" in output
-        row = conn.execute("SELECT last_result FROM verifications WHERE item_id='sample-item' AND seq=1").fetchone()
-        assert row["last_result"] is None
+        row = conn.execute(
+            "SELECT last_run, last_result FROM verifications WHERE item_id='sample-item' AND seq=1"
+        ).fetchone()
+        assert (row["last_run"], row["last_result"]) == (before["last_run"], before["last_result"])
         event = conn.execute("SELECT detail FROM events WHERE action='verify' ORDER BY seq DESC LIMIT 1").fetchone()
         assert '"result": "indeterminate"' in event["detail"]
 

--- a/tests/unit/scripts/test_todo_db.py
+++ b/tests/unit/scripts/test_todo_db.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import importlib.util
 import json
+import os
 import sys
 import textwrap
 from pathlib import Path
@@ -327,6 +328,45 @@ class TestVerifyRun:
             "SELECT seq, last_result FROM verifications WHERE item_id='sample-item' ORDER BY seq"
         ).fetchall()
         assert [(r["seq"], r["last_result"]) for r in rows] == [(1, "pass"), (2, "fail")]
+
+    def test_verify_rung_lock_contention_is_indeterminate(self, conn, tmp_path, monkeypatch):
+        """A lock timeout records an environmental non-verdict, not a failure."""
+        fcntl = pytest.importorskip("fcntl")
+        _mk(conn, verifications=[{"description": "blocked", "command": "false"}])
+        todo_db.claim_item(conn, "tester", "sample-item")
+        lock_dir = tmp_path / "lock"
+        lock_dir.mkdir()
+        lock_path = lock_dir / "test.lock"
+        fd = os.open(lock_path, os.O_CREAT | os.O_RDWR, 0o644)
+        fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+        monkeypatch.setenv("BENCHBOX_TEST_LOCK_DIR", str(lock_dir))
+        monkeypatch.setenv("BENCHBOX_VERIFY_LOCK_TIMEOUT", "0")
+        monkeypatch.delenv("PYTEST_XDIST_WORKER", raising=False)
+        try:
+            result, output = todo_db.run_verification(conn, "tester", "sample-item", 1)
+        finally:
+            fcntl.flock(fd, fcntl.LOCK_UN)
+            os.close(fd)
+
+        assert result == "indeterminate"
+        assert "verification command was not run" in output
+        row = conn.execute("SELECT last_result FROM verifications WHERE item_id='sample-item' AND seq=1").fetchone()
+        assert row["last_result"] is None
+        event = conn.execute("SELECT detail FROM events WHERE action='verify' ORDER BY seq DESC LIMIT 1").fetchone()
+        assert '"result": "indeterminate"' in event["detail"]
+
+    def test_verify_run_ignores_stale_lock_diagnostic(self, conn, tmp_path, monkeypatch):
+        """A dead owner's leftover diagnostic file does not block acquisition."""
+        _mk(conn, verifications=[{"description": "passes", "command": "true"}])
+        todo_db.claim_item(conn, "tester", "sample-item")
+        lock_dir = tmp_path / "lock"
+        lock_dir.mkdir()
+        (lock_dir / "test.lock").write_text("pid:999999 started:never\n", encoding="utf-8")
+        monkeypatch.setenv("BENCHBOX_TEST_LOCK_DIR", str(lock_dir))
+
+        result, _ = todo_db.run_verification(conn, "tester", "sample-item", 1)
+
+        assert result == "pass"
 
     def test_verify_expected_is_human_acceptance_text(self, conn):
         """`expected` documents a rung; it must never be graded.

--- a/tests/unit/scripts/test_todo_wrapper.py
+++ b/tests/unit/scripts/test_todo_wrapper.py
@@ -76,12 +76,17 @@ todo_db = _load_script()
 
 
 def _run_shim(args: list[str], db_path: Path, cwd: Path | None = None) -> subprocess.CompletedProcess[str]:
+    env = {"PATH": os.environ["PATH"], "TODO_DB_PATH": str(db_path), "HOME": str(Path.home())}
+    if worker := os.environ.get("PYTEST_XDIST_WORKER"):
+        # Keep the CLI's documented xdist self-contention escape visible to the
+        # subprocess when this contract test itself runs under a worker.
+        env["PYTEST_XDIST_WORKER"] = worker
     return subprocess.run(
         [str(SHIM_PATH), *args],
         capture_output=True,
         text=True,
         cwd=cwd or REPO_ROOT,
-        env={"PATH": os.environ["PATH"], "TODO_DB_PATH": str(db_path), "HOME": str(Path.home())},
+        env=env,
         check=False,
         timeout=120,
     )


### PR DESCRIPTION
TODO: verify-rungs-contend-on-the-test-lock-20260805

## Summary
- serialize `todo verify --run` subprocesses through the shared BenchBox test lock
- record lock contention as an indeterminate environmental outcome rather than a false failure
- preserve genuine pass/fail outcomes and ignore stale diagnostic text when the advisory lock is available

## Verification
- `uv run -- python -m pytest tests/unit/scripts/test_todo_db.py -q -k 'verify_rung_lock_contention or verify_run_ignores_stale_lock_diagnostic'` — 2 passed
- `uv run ruff check _project/scripts/todo_db.py tests/unit/scripts/test_todo_db.py` — passed
- `todo check-scope verify-rungs-contend-on-the-test-lock-20260805 --strict` — 2 files in scope
- `todo verify verify-rungs-contend-on-the-test-lock-20260805 --run 1` — pass, stored verification command ran successfully
- `make pr-preflight` — reached the existing unrelated lint-markers baseline failure (`tests/uat/test_no_cli_surface_drift.py` duplicate `benchbox/cli/tuning.py`); the commit pre-push preflight passed

## Review
Five-axis review completed: no Critical or Required findings. No unrelated files were changed.
