### PR TITLE
fix(explorer): reject empty browser snapshots

### DIFF
--- a/_project/scripts/results_explorer_snapshot_invariants.py
+++ b/_project/scripts/results_explorer_snapshot_invariants.py
@@ -55,6 +55,17 @@ REQUIRED_COLUMNS: dict[str, set[str]] = {
     },
 }
 
+# These are the same required non-empty scans used by the browser during
+# snapshot initialisation. Keeping the list here makes an empty or partially
+# populated candidate fail before it can replace the last known-good output.
+REQUIRED_NONEMPTY_SCANS: tuple[tuple[str, str], ...] = (
+    ("results", "SELECT COUNT(*) FROM results"),
+    ("platform_index_rows", "SELECT COUNT(*) FROM platform_index_rows"),
+    ("benchmark_rankings", "SELECT COUNT(*) FROM benchmark_rankings"),
+    ("benchmark_matrix_cells", "SELECT COUNT(*) FROM benchmark_matrix_cells"),
+    ("result_detail_metrics", "SELECT COUNT(*) FROM result_detail_metrics"),
+)
+
 
 def _count(con: Any, sql: str) -> int:
     row = con.execute(sql).fetchone()
@@ -68,6 +79,15 @@ def _required_column_errors(con: Any) -> list[str]:
         missing = sorted(required - actual)
         if missing:
             errors.append(f"{table} missing required eligibility columns: {', '.join(missing)}")
+    return errors
+
+
+def _required_nonempty_scan_errors(con: Any) -> list[str]:
+    errors: list[str] = []
+    for label, sql in REQUIRED_NONEMPTY_SCANS:
+        count = _count(con, sql)
+        if count < 1:
+            errors.append(f"required browser scan {label} must be non-empty: {count} row(s)")
     return errors
 
 
@@ -86,6 +106,7 @@ def check_snapshot(db_path: Path) -> list[str]:
         errors.extend(_required_column_errors(con))
         if errors:
             return errors
+        errors.extend(_required_nonempty_scan_errors(con))
 
         checks = [
             (
@@ -105,13 +126,13 @@ def check_snapshot(db_path: Path) -> list[str]:
                 "public snapshot must expose at least one compare-eligible display row",
                 """
                 SELECT CASE
-                    WHEN COUNT(*) > 0
-                     AND SUM(CASE WHEN comparison_exclusion_reason IS NULL THEN 1 ELSE 0 END) = 0
+                    WHEN COUNT(*) = 0
                     THEN 1
                     ELSE 0
                 END
                 FROM results
                 WHERE has_display_timing = TRUE
+                  AND comparison_exclusion_reason IS NULL
                 """,
             ),
             (

--- a/tests/unit/scripts/explorer_pipeline/test_pipeline.py
+++ b/tests/unit/scripts/explorer_pipeline/test_pipeline.py
@@ -122,6 +122,22 @@ class TestExplorerPipelineRun:
         results = _duckdb_results(output)
         assert len(results) == 1
 
+    def test_one_usable_row_populates_every_required_browser_scan(self, data_dir: Path, tmp_path: Path) -> None:
+        output = tmp_path / "out"
+        ExplorerPipeline().run(data_dir, output)
+
+        required_scans = (
+            "results",
+            "platform_index_rows",
+            "benchmark_rankings",
+            "benchmark_matrix_cells",
+            "result_detail_metrics",
+        )
+        with duckdb.connect(str(output / "results.duckdb"), read_only=True) as con:
+            counts = {table: con.execute(f"SELECT COUNT(*) FROM {table}").fetchone()[0] for table in required_scans}
+
+        assert all(count >= 1 for count in counts.values()), counts
+
     def test_result_row_fields_from_bundle(self, data_dir: Path, tmp_path: Path) -> None:
         output = tmp_path / "out"
         ExplorerPipeline().run(data_dir, output)
@@ -321,22 +337,52 @@ class TestExplorerPipelineRun:
 
         assert len(_duckdb_results(output)) == 1
 
-    def test_empty_data_dir_produces_empty_duckdb(self, tmp_path: Path) -> None:
+    def test_empty_data_dir_is_rejected_before_promotion(self, tmp_path: Path) -> None:
         data_dir = tmp_path / "empty_data"
         data_dir.mkdir()
         # No bundles/ sub-directory at all
         output = tmp_path / "out"
-        ExplorerPipeline().run(data_dir, output)
+        with pytest.raises(ValueError, match="required browser scan"):
+            ExplorerPipeline().run(data_dir, output)
 
-        assert _duckdb_results(output) == []
+        assert not output.exists()
 
-    def test_empty_bundles_dir_produces_empty_duckdb(self, tmp_path: Path) -> None:
+    def test_empty_bundles_dir_is_rejected_before_promotion(self, tmp_path: Path) -> None:
         data_dir = tmp_path / "data"
         (data_dir / "bundles").mkdir(parents=True)
         output = tmp_path / "out"
-        ExplorerPipeline().run(data_dir, output)
+        with pytest.raises(ValueError, match="required browser scan"):
+            ExplorerPipeline().run(data_dir, output)
 
-        assert _duckdb_results(output) == []
+        assert not output.exists()
+
+    def test_all_skipped_corpus_fails_before_promotion(self, tmp_path: Path) -> None:
+        data_dir = tmp_path / "data"
+        bundles_dir = data_dir / "bundles"
+        bundles_dir.mkdir(parents=True)
+        (bundles_dir / "invalid.json").write_text("{not valid json", encoding="utf-8")
+        output = tmp_path / "out"
+
+        with pytest.raises(ValueError, match="required browser scan"):
+            ExplorerPipeline().run(data_dir, output)
+
+        assert not output.exists()
+
+    def test_unpublishable_rebuild_preserves_last_known_good_output(self, data_dir: Path, tmp_path: Path) -> None:
+        output = tmp_path / "out"
+        ExplorerPipeline().run(data_dir, output)
+        before_db = (output / "results.duckdb").read_bytes()
+        before_bundles = sorted(path.name for path in (output / "bundles").iterdir())
+
+        invalid_data_dir = tmp_path / "invalid_data"
+        (invalid_data_dir / "bundles").mkdir(parents=True)
+        (invalid_data_dir / "bundles" / "invalid.json").write_text("{not valid json", encoding="utf-8")
+
+        with pytest.raises(ValueError, match="required browser scan"):
+            ExplorerPipeline().run(invalid_data_dir, output)
+
+        assert (output / "results.duckdb").read_bytes() == before_db
+        assert sorted(path.name for path in (output / "bundles").iterdir()) == before_bundles
 
     def test_submission_manifest_sidecar_overrides_trust_label(self, tmp_path: Path) -> None:
         """A bundle with a submission-manifest.json sidecar gets community-submission trust."""


### PR DESCRIPTION
## What changed

- require the five browser readiness scans to contain at least one row before a snapshot is publishable
- require at least one display row with no comparison exclusion
- add regressions for empty/all-skipped corpora, one-row previews, and last-known-good preservation

## Why

The pipeline previously accepted a valid-but-empty DuckDB because the compare-eligibility check only rejected an all-invalid nonempty `results` table. The browser requires nonempty results, platform, ranking, matrix, and detail scans, so an all-private or all-invalid corpus could replace the published snapshot and leave the Explorer unable to initialize.

## Validation

- `uv run -- python -m pytest tests/unit/scripts/explorer_pipeline tests/unit/scripts/test_results_explorer_snapshot_invariants.py -q` — 336 passed
- `uv run ruff check .` — passed
- `uv run ty check <changed files>` — passed
- `uv run -- python -m pytest -m fast -q` — 27,727 passed, 19 skipped
- configured repository-wide `ty check` remains baseline-red with 646 diagnostics outside this slice