### PR TITLE
test(explorer): typecheck playwright harness

### DIFF
--- a/.github/workflows/results-explorer-browser.yml
+++ b/.github/workflows/results-explorer-browser.yml
@@ -108,6 +108,10 @@ jobs:
         run: npm ci
         working-directory: results-explorer
 
+      - name: Typecheck explorer e2e harness
+        run: npm run typecheck:e2e
+        working-directory: results-explorer
+
       - name: Audit frontend dependencies
         run: npm run audit:high
         working-directory: results-explorer

--- a/results-explorer/package.json
+++ b/results-explorer/package.json
@@ -9,6 +9,7 @@
     "dev": "vite",
     "build": "vite build",
     "typecheck": "tsc --noEmit",
+    "typecheck:e2e": "tsc --project tsconfig.e2e.json --noEmit",
     "preview": "vite preview",
     "test": "vitest run",
     "test:watch": "vitest",

--- a/results-explorer/tsconfig.e2e.json
+++ b/results-explorer/tsconfig.e2e.json
@@ -1,0 +1,11 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "target": "ES2022",
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "types": ["node"]
+  },
+  "include": ["e2e/**/*.ts", "playwright.config.ts"],
+  "exclude": ["node_modules", "dist", "test-results", "playwright-report"]
+}

--- a/tests/unit/workflows/test_results_explorer_browser_gate.py
+++ b/tests/unit/workflows/test_results_explorer_browser_gate.py
@@ -16,6 +16,7 @@ documented agreement here and confirm the ruleset with `gh api` when triaging.
 
 from __future__ import annotations
 
+import json
 from pathlib import Path
 from typing import Any
 
@@ -198,3 +199,16 @@ def test_chromium_runs_the_full_suite_entrypoint(workflow: dict[str, Any]) -> No
     assert any("test:e2e:chromium" in command for command in run_commands), (
         "Chromium job no longer runs the npm test:e2e:chromium entrypoint"
     )
+
+
+def test_chromium_typechecks_e2e_harness_before_playwright(workflow: dict[str, Any]) -> None:
+    """The blocking browser lane must compile the Playwright harness first."""
+    package = json.loads((REPO_ROOT / "results-explorer/package.json").read_text(encoding="utf-8"))
+    assert package["scripts"]["typecheck:e2e"] == "tsc --project tsconfig.e2e.json --noEmit"
+    assert (REPO_ROOT / "results-explorer/tsconfig.e2e.json").is_file()
+
+    steps = workflow["jobs"][CHROMIUM_JOB]["steps"]
+    typecheck_index = next(index for index, step in enumerate(steps) if step.get("run") == "npm run typecheck:e2e")
+    playwright_index = next(index for index, step in enumerate(steps) if "playwright install" in step.get("run", ""))
+    assert typecheck_index < playwright_index
+    assert steps[typecheck_index]["working-directory"] == "results-explorer"


### PR DESCRIPTION
## What changed

- add an isolated `results-explorer/tsconfig.e2e.json` for Playwright specs, support fixtures, and `playwright.config.ts`
- add `npm run typecheck:e2e` without widening the existing app `npm run typecheck`
- run the e2e typecheck in the blocking Chromium workflow before Playwright installation
- add a workflow contract test for the script and ordering

## Why

The app TypeScript config includes only `src` and `vite.config.ts`, so the blocking browser harness compiled only when Playwright ran. A dedicated compile gate catches harness errors before the expensive browser job and preserves the app check's current scope.

## Validation

- deliberate `fixtures.ts` type-error negative control failed with TS2322/TS6133, then was removed
- `npm run typecheck:e2e` — passed
- `npm run typecheck` — passed
- `npm test -- --run` — 70 files, 862 tests passed
- `uv run -- python -m pytest tests/unit/workflows/test_results_explorer_browser_gate.py -q` — 13 passed
- `uv run -- python -m pytest -m fast -q` — 27,726 passed, 18 skipped