### PR TITLE
fix(explorer): publish validated companion artifacts

### DIFF
--- a/_project/scripts/explorer_pipeline/pipeline.py
+++ b/_project/scripts/explorer_pipeline/pipeline.py
@@ -38,8 +38,10 @@ from _project.scripts.explorer_pipeline.models import (
 from _project.scripts.explorer_pipeline.ranking import RankedCohort, rank_platforms
 from _project.scripts.explorer_pipeline.transformer import (
     BundleTransformer,
+    CompanionPrivacyError,
     _applied_receipt,
     _platform_percentile_stats,
+    _public_companion_bytes,
 )
 from _project.scripts.results_explorer_snapshot_invariants import check_snapshot
 from benchbox.core.results.anonymization import AnonymizationManager, find_public_path_leaks
@@ -741,37 +743,30 @@ class ExplorerPipeline:
 
                     dest_bundle.write_bytes(public_raw)
 
-                    # Publish the plans sidecar alongside the bundle when present
-                    # and set ``plans_published`` on the detail so the explorer UI
-                    # only renders a download link for plans that actually exist
-                    # at the published URL. Without this wire-up, the consumer-side
-                    # gate (results-explorer/src/components/RunReceipt.tsx) sees
-                    # ``plans_published=undefined`` and never renders a link, so
-                    # the feature stays dark even when plans are available.
-                    plans_src = bundle_path.with_name(f"{bundle_path.stem}.plans.json")
-                    if plans_src.exists():
-                        plans_dest = (out_bundles_dir / f"{result_id}.plans.json").resolve()
-                        if plans_dest.is_relative_to(out_bundles_dir.resolve()):
-                            try:
-                                plans_payload = json.loads(plans_src.read_text(encoding="utf-8"))
-                                public_plans = public_anonymizer.anonymize_result_payload(plans_payload)
-                                plans_leaks = find_public_path_leaks(public_plans)
-                                if plans_leaks:
-                                    # Escapes both this block's handler and the
-                                    # per-bundle one. A leaking companion used to
-                                    # be the quietest case of all: the bundle
-                                    # still published, only `plans_published`
-                                    # stayed false, so the corpus looked complete.
-                                    raise PrivacyRejectionError(
-                                        "public plans privacy check failed for fields: "
-                                        + ", ".join(sorted(set(plans_leaks)))
-                                    )
-                                plans_dest.write_bytes(canonical_json_bytes(public_plans))
-                                detail.plans_published = True
-                            except (OSError, json.JSONDecodeError, TypeError, ValueError) as exc:
-                                logger.warning(
-                                    "Skipping plans companion %s - %s: %s", plans_src, type(exc).__name__, exc
-                                )
+                    # Publish only the validated, anonymized companions that
+                    # actually exist. Source-side ``has_tuning`` is not enough:
+                    # the browser derives the tuning URL from that flag, so it
+                    # must be set only after the public sidecar is committed.
+                    detail.has_tuning = False
+                    detail.plans_published = False
+                    for suffix in COMPANION_SUFFIXES:
+                        try:
+                            public_companion = _public_companion_bytes(bundle_path, suffix, public_anonymizer)
+                        except CompanionPrivacyError as exc:
+                            raise PrivacyRejectionError(str(exc)) from exc
+                        if public_companion is None:
+                            continue
+
+                        companion_dest = (out_bundles_dir / f"{result_id}{suffix}").resolve()
+                        if not companion_dest.is_relative_to(out_bundles_dir.resolve()):
+                            raise PrivacyRejectionError(
+                                f"published companion path escapes bundles directory: {companion_dest.name}"
+                            )
+                        companion_dest.write_bytes(public_companion)
+                        if suffix == ".plans.json":
+                            detail.plans_published = True
+                        elif suffix == ".tuning.json":
+                            detail.has_tuning = True
 
                     # Add the entry only after the public bundle has been copied
                     # successfully.  A privacy rejection must not leave a

--- a/_project/scripts/explorer_pipeline/transformer.py
+++ b/_project/scripts/explorer_pipeline/transformer.py
@@ -6,6 +6,7 @@ ManifestEntry and DetailResult shapes consumed by the explorer frontend.
 
 from __future__ import annotations
 
+import copy
 import hashlib
 import json
 import logging
@@ -26,12 +27,141 @@ from _project.scripts.explorer_pipeline.models import (
 )
 from benchbox.core.cost.models import CostScope, CostStatus, DeploymentMetadata, NormalizedCost
 from benchbox.core.cost.pricing import PRICING_VERSION
+from benchbox.core.results.anonymization import AnonymizationManager, find_public_path_leaks
+from benchbox.core.results.canonical_json import canonical_json_bytes
 from benchbox.core.results.schema_policy import EXPLORER_INPUT_SCHEMA_POLICY
 from benchbox.core.results.status import bundle_failed_query_count, bundle_non_clean_reason, normalize_validation_status
 from benchbox.core.tuning.modes import is_canonical_mode
-from benchbox.validation.bundle import APPLIED_COMPANION_MAX_BYTES, APPLIED_RECEIPT_MAX_ENTRIES
+from benchbox.validation.bundle import APPLIED_COMPANION_MAX_BYTES, APPLIED_RECEIPT_MAX_ENTRIES, COMPANION_SUFFIXES
 
 logger = logging.getLogger(__name__)
+
+
+class CompanionPrivacyError(Exception):
+    """A companion remained private after the public anonymization boundary."""
+
+
+def _companion_path(bundle_path: Path, suffix: str) -> Path:
+    """Return the exact same-stem companion path for a primary bundle."""
+    return bundle_path.with_name(f"{bundle_path.stem}{suffix}")
+
+
+def _redact_applied_dropped(payload: dict[str, Any], key: str = "dropped") -> None:
+    dropped = payload.get(key)
+    if dropped:
+        count = len(dropped) if isinstance(dropped, list) else 1
+        payload[key] = [{"redacted": True} for _ in range(count)]
+
+
+def _sanitize_applied_drift_check(drift_check: Any) -> None:
+    if not isinstance(drift_check, dict):
+        return
+    removed = False
+    for key in ("errors", "warnings", "configuration_mismatches", "missing_tables", "extra_tables"):
+        if key in drift_check:
+            drift_check.pop(key, None)
+            removed = True
+    if removed:
+        drift_check["drift_redacted"] = True
+
+
+def _sanitize_applied_receipt(receipt: Any) -> None:
+    if not isinstance(receipt, dict):
+        return
+    if "error" in receipt:
+        receipt.pop("error", None)
+        receipt["error_redacted"] = True
+    for entry in receipt.get("entries") or []:
+        if not isinstance(entry, dict):
+            continue
+        for key in ("statement", "diff", "detail", "evidence", "table", "name", "expected_columns", "observed_columns"):
+            entry.pop(key, None)
+        if "reason" in entry:
+            entry.pop("reason", None)
+            entry["reason_redacted"] = True
+        entry["statement_redacted"] = True
+    for observed in receipt.get("observed") or []:
+        if isinstance(observed, dict):
+            for key in ("table", "name", "columns", "evidence"):
+                observed.pop(key, None)
+            observed["redacted"] = True
+    _redact_applied_dropped(receipt)
+
+
+def _sanitize_applied_companion(payload: dict[str, Any]) -> dict[str, Any]:
+    """Remove free-text and user identifiers from an applied-ledger payload.
+
+    Applied statements, dropped-intent reasons, and introspection evidence are
+    execution-path text and may contain paths, DSNs, or user-chosen catalog
+    names. Preserve only the structural/status evidence needed by the public
+    companion; this mirrors the exporter boundary for already-exported inputs.
+    """
+    sanitized = copy.deepcopy(payload)
+    statements = sanitized.get("statements")
+    if isinstance(statements, list):
+        for entry in statements:
+            if not isinstance(entry, dict):
+                continue
+            entry.pop("statement", None)
+            entry.pop("error", None)
+            entry.pop("table", None)
+            entry["statement_redacted"] = True
+    _redact_applied_dropped(sanitized)
+    _sanitize_applied_drift_check(sanitized.get("drift_check"))
+    _sanitize_applied_receipt(sanitized.get("receipt"))
+    return sanitized
+
+
+def _public_companion_bytes(
+    bundle_path: Path,
+    suffix: str,
+    anonymizer: AnonymizationManager,
+) -> bytes | None:
+    """Load, validate, anonymize, and canonicalize one optional companion.
+
+    Missing, malformed, oversized, or non-regular companions are ignored so a
+    bad sidecar cannot be advertised or copied. A companion that still contains
+    a private path after anonymization is different: that is a publication
+    boundary violation and must fail the build rather than silently publish a
+    partial public artifact.
+    """
+    if suffix not in COMPANION_SUFFIXES:
+        raise ValueError(f"unsupported explorer companion suffix: {suffix}")
+
+    source = _companion_path(bundle_path, suffix)
+    if not source.exists():
+        return None
+    if source.is_symlink() or not source.is_file():
+        logger.warning("Skipping non-regular companion %s", source)
+        return None
+    try:
+        if suffix == ".applied.json" and source.stat().st_size > APPLIED_COMPANION_MAX_BYTES:
+            logger.warning("Skipping oversized applied companion %s", source)
+            return None
+        payload = json.loads(source.read_text(encoding="utf-8"))
+    except (OSError, UnicodeError, json.JSONDecodeError, TypeError, ValueError) as exc:
+        logger.warning("Skipping malformed companion %s - %s: %s", source, type(exc).__name__, exc)
+        return None
+
+    if not isinstance(payload, dict):
+        logger.warning("Skipping non-object companion %s", source)
+        return None
+
+    if suffix == ".tuning.json":
+        public_payload = anonymizer.anonymize_tuning_payload(payload)
+    elif suffix == ".applied.json":
+        public_payload = _sanitize_applied_companion(anonymizer.anonymize_result_payload(payload))
+    else:
+        public_payload = anonymizer.anonymize_result_payload(payload)
+
+    leaks = find_public_path_leaks(public_payload)
+    if leaks:
+        raise CompanionPrivacyError(
+            f"public {suffix.removesuffix('.json').lstrip('.')} privacy check failed for fields: "
+            + ", ".join(sorted(set(leaks)))
+        )
+    return canonical_json_bytes(public_payload)
+
 
 # Status values that are considered passing for the query timing status field.
 _PASS_STATUSES = {"SUCCESS", "PASS", "pass", "success"}

--- a/results-explorer/scripts/generate-browser-fixtures.mjs
+++ b/results-explorer/scripts/generate-browser-fixtures.mjs
@@ -564,7 +564,11 @@ const readShortIds = () => {
  */
 const writeFixtureIds = () => {
   const rows = readdirSync(join(genDataDir, "bundles"))
-    .filter((name) => name.endsWith(".json"))
+    // Companion tuning sidecars are deliberately published beside their
+    // primary result bundle, but they are not browser fixtures and have no
+    // `run.id`. Keep them available for detail-page sidecar requests while
+    // excluding them from role discovery.
+    .filter((name) => name.endsWith(".json") && !name.endsWith(".tuning.json"))
     .map((name) => name.slice(0, -".json".length));
   const runIdOf = (rid) => JSON.parse(readFileSync(join(genDataDir, "bundles", `${rid}.json`), "utf8"))?.run?.id;
   const shortIds = readShortIds();

--- a/tests/unit/scripts/explorer_pipeline/test_pipeline.py
+++ b/tests/unit/scripts/explorer_pipeline/test_pipeline.py
@@ -284,6 +284,78 @@ class TestExplorerPipelineRun:
         assert all(row["plans_published"] is False for row in rows)
         assert not list((output / "bundles").glob("*.plans.json"))
 
+    def test_publishes_tuning_sidecar_and_sets_has_tuning_after_copy(self, tmp_path: Path) -> None:
+        bundles_dir = tmp_path / "data" / "bundles"
+        bundles_dir.mkdir(parents=True)
+        bundle_path = bundles_dir / "with_tuning.json"
+        bundle_path.write_text(json.dumps(MINIMAL_BUNDLE), encoding="utf-8")
+        bundle_path.with_name("with_tuning.tuning.json").write_text(
+            json.dumps(
+                {
+                    "version": "2.1",
+                    "run_id": "test-exec-001",
+                    "source_file": "/Users/alice/private/tuning.yaml",
+                    "requested": {"table_tunings": {"lineitem": {"table_name": "lineitem"}}},
+                }
+            ),
+            encoding="utf-8",
+        )
+
+        output = tmp_path / "out"
+        ExplorerPipeline().run(tmp_path / "data", output)
+
+        row = _duckdb_results(output)[0]
+        result_id = row["result_id"]
+        tuning_path = output / "bundles" / f"{result_id}.tuning.json"
+        assert row["has_tuning"] is True
+        assert tuning_path.exists()
+        published = tuning_path.read_text(encoding="utf-8")
+        assert "/Users/alice" not in published
+        assert "lineitem" not in published
+
+    def test_publishes_sanitized_applied_companion(self, tmp_path: Path) -> None:
+        bundles_dir = tmp_path / "data" / "bundles"
+        bundles_dir.mkdir(parents=True)
+        bundle_path = bundles_dir / "with_applied.json"
+        bundle_path.write_text(json.dumps(MINIMAL_BUNDLE), encoding="utf-8")
+        bundle_path.with_name("with_applied.applied.json").write_text(
+            json.dumps(
+                {
+                    "status": "applied_unverified",
+                    "applied_ledger_hash": "a" * 64,
+                    "statements": [{"statement": "SET warehouse=/Users/alice/private", "status": "executed"}],
+                    "dropped": [{"reason": "private adapter detail"}],
+                    "receipt": {"entries": [{"statement": "CREATE INDEX private_table", "verdict": "unknown"}]},
+                }
+            ),
+            encoding="utf-8",
+        )
+
+        output = tmp_path / "out"
+        ExplorerPipeline().run(tmp_path / "data", output)
+
+        row = _duckdb_results(output)[0]
+        result_id = row["result_id"]
+        applied_path = output / "bundles" / f"{result_id}.applied.json"
+        assert applied_path.exists()
+        published = applied_path.read_text(encoding="utf-8")
+        assert "/Users/alice" not in published
+        assert '"statement"' not in published
+
+    @pytest.mark.parametrize("suffix", [".tuning.json", ".applied.json"])
+    def test_malformed_companion_is_not_published_or_advertised(
+        self, data_dir: Path, tmp_path: Path, suffix: str
+    ) -> None:
+        bundle = next(data_dir.joinpath("bundles").rglob("*.json"))
+        bundle.with_name(f"{bundle.stem}{suffix}").write_text("{not json", encoding="utf-8")
+
+        output = tmp_path / "out"
+        ExplorerPipeline().run(data_dir, output)
+
+        row = _duckdb_results(output)[0]
+        assert row["has_tuning"] is False
+        assert not list((output / "bundles").glob(f"*{suffix}"))
+
     def test_discovers_nested_bundle_layout(self, tmp_path: Path) -> None:
         nested_dir = tmp_path / "data" / "bundles" / "tpch" / "duckdb" / "sf0.1"
         nested_dir.mkdir(parents=True)


### PR DESCRIPTION
## Summary
- publish validated tuning and applied companion artifacts alongside result bundles
- derive publication flags only after successful companion writes
- sanitize and fail closed on malformed, oversized, private, or escaping companions

## Validation
- `uv run -- python -m pytest tests/unit/scripts/explorer_pipeline -q` — 339 passed
- `uv run -- python -m pytest tests/integration -q` — 951 passed, 12 skipped
- `make pr-preflight` — 27716 passed, 19 skipped