### PR TITLE
fix(explorer): pin read-model compatibility policy

### DIFF
--- a/_project/scripts/explorer_pipeline/contract.py
+++ b/_project/scripts/explorer_pipeline/contract.py
@@ -29,10 +29,15 @@ EXPLORER_BUILD_CONTRACT_VERSION = "6"
 #     missing test_type as `power`. Existing snapshots must be rebuilt so their
 #     ranking and cohort tables cannot be queried under the new semantics.
 EXPLORER_READ_MODEL_VERSION = 7
+EXPLORER_READ_MODEL_COMPATIBILITY = {
+    "minimum_supported": EXPLORER_READ_MODEL_VERSION,
+    "newer_policy": "warn-and-continue",
+}
 
 EXPLORER_BUILD_CONTRACT = {
     "version": EXPLORER_BUILD_CONTRACT_VERSION,
     "read_model_version": EXPLORER_READ_MODEL_VERSION,
+    "read_model_compatibility": EXPLORER_READ_MODEL_COMPATIBILITY,
     "command": "uv run -- python _project/scripts/explorer_publish.py build",
     "flags": [
         "--data-dir",
@@ -60,5 +65,6 @@ EXPLORER_BUILD_CONTRACT = {
 __all__ = [
     "EXPLORER_BUILD_CONTRACT",
     "EXPLORER_BUILD_CONTRACT_VERSION",
+    "EXPLORER_READ_MODEL_COMPATIBILITY",
     "EXPLORER_READ_MODEL_VERSION",
 ]

--- a/results-explorer/scripts/explorer-build-contract.mjs
+++ b/results-explorer/scripts/explorer-build-contract.mjs
@@ -4,6 +4,7 @@ import { fileURLToPath } from "node:url";
 
 const EXPECTED_CONTRACT_VERSION = "6";
 export const EXPECTED_READ_MODEL_VERSION = 7;
+const EXPECTED_NEWER_READ_MODEL_POLICY = "warn-and-continue";
 const REQUIRED_FLAGS = ["--data-dir", "--output", "--trust-label", "--visibility"];
 const REQUIRED_OUTPUTS = ["results.duckdb", "bundles/{result_id}.json"];
 const REMOVED_LEGACY_OUTPUTS = [
@@ -72,6 +73,20 @@ export function readExplorerBuildContract() {
     throw new Error(
       `Explorer read-model version ${EXPECTED_READ_MODEL_VERSION} expected, got ${contract.read_model_version}. ` +
         ALIGNMENT_HINT,
+    );
+  }
+
+  const compatibility = contract.read_model_compatibility ?? {};
+  if (compatibility.minimum_supported !== EXPECTED_READ_MODEL_VERSION) {
+    throw new Error(
+      `Explorer minimum supported read-model version ${EXPECTED_READ_MODEL_VERSION} expected, got ` +
+        `${compatibility.minimum_supported}. ${ALIGNMENT_HINT}`,
+    );
+  }
+  if (compatibility.newer_policy !== EXPECTED_NEWER_READ_MODEL_POLICY) {
+    throw new Error(
+      `Explorer newer read-model policy ${EXPECTED_NEWER_READ_MODEL_POLICY} expected, got ` +
+        `${compatibility.newer_policy}. ${ALIGNMENT_HINT}`,
     );
   }
 

--- a/results-explorer/src/db.ts
+++ b/results-explorer/src/db.ts
@@ -59,7 +59,8 @@ type DuckDBConnection = Awaited<ReturnType<duckdb.AsyncDuckDB["connect"]>>;
 // Keep this value aligned with
 // `_project/scripts/explorer_pipeline/contract.py::EXPLORER_READ_MODEL_VERSION`.
 // `results-explorer/src/lib/__tests__/db-remediation-pin.test.ts` pins the
-// browser constant against the live Python contract.
+// browser constant against an independently reviewed contract value and
+// exercises the older/equal/newer compatibility policy below.
 const EXPECTED_READ_MODEL_VERSION = 7;
 
 // Required scans must be queryable AND non-empty for the snapshot to be

--- a/results-explorer/src/lib/__tests__/db-remediation-pin.test.ts
+++ b/results-explorer/src/lib/__tests__/db-remediation-pin.test.ts
@@ -1,11 +1,25 @@
 import { spawnSync } from "node:child_process";
 import { resolve } from "node:path";
-import { describe, expect, it } from "vitest";
-import { _EXPECTED_READ_MODEL_VERSION_FOR_TEST } from "@/db";
+import { describe, expect, it, vi } from "vitest";
+import { _EXPECTED_READ_MODEL_VERSION_FOR_TEST, _verifyReadModelVersionForTest } from "@/db";
 
 const EXPECTED_EXPLORER_BUILD_COMMAND =
   "uv run -- python _project/scripts/explorer_publish.py build";
+// Independent migration pin: update this reviewed value when the snapshot
+// schema changes; do not derive it from db.ts or the Python contract.
+const CURRENT_READ_MODEL_VERSION = 7;
+const NEWER_READ_MODEL_POLICY = "warn-and-continue";
 const repoRoot = resolve(process.cwd(), "..");
+
+type SnapshotConnection = Parameters<typeof _verifyReadModelVersionForTest>[0];
+
+function connectionWithReadModelVersion(version: number): SnapshotConnection {
+  return {
+    query: async () => ({
+      toArray: () => [{ toJSON: () => ({ read_model_version: version }) }],
+    }),
+  } as unknown as SnapshotConnection;
+}
 
 describe("db remediation command pin", () => {
   it("matches the live explorer build contract", () => {
@@ -23,8 +37,46 @@ describe("db remediation command pin", () => {
     const contract = JSON.parse(result.stdout) as {
       command?: string;
       read_model_version?: number;
+      read_model_compatibility?: {
+        minimum_supported?: number;
+        newer_policy?: string;
+      };
     };
     expect(contract.command).toBe(EXPECTED_EXPLORER_BUILD_COMMAND);
-    expect(contract.read_model_version).toBe(_EXPECTED_READ_MODEL_VERSION_FOR_TEST);
+    expect(contract.read_model_version).toBe(CURRENT_READ_MODEL_VERSION);
+    expect(contract.read_model_compatibility).toEqual({
+      minimum_supported: CURRENT_READ_MODEL_VERSION,
+      newer_policy: NEWER_READ_MODEL_POLICY,
+    });
+    expect(_EXPECTED_READ_MODEL_VERSION_FOR_TEST).toBe(CURRENT_READ_MODEL_VERSION);
+  });
+
+  it.each([
+    { label: "older", version: CURRENT_READ_MODEL_VERSION - 1 },
+    { label: "missing", version: 0 },
+  ])("rejects $label incompatible snapshots clearly", async ({ version }) => {
+    await expect(_verifyReadModelVersionForTest(connectionWithReadModelVersion(version))).rejects.toThrow(
+      `DuckDB snapshot read-model v${version}; UI requires v${CURRENT_READ_MODEL_VERSION}.`,
+    );
+  });
+
+  it("accepts the current read-model version", async () => {
+    await expect(
+      _verifyReadModelVersionForTest(connectionWithReadModelVersion(CURRENT_READ_MODEL_VERSION)),
+    ).resolves.toBeUndefined();
+  });
+
+  it("warns and continues for a newer forward-compatible snapshot", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+
+    await expect(
+      _verifyReadModelVersionForTest(connectionWithReadModelVersion(CURRENT_READ_MODEL_VERSION + 1)),
+    ).resolves.toBeUndefined();
+    expect(warn).toHaveBeenCalledWith(
+      `DuckDB snapshot read-model v${CURRENT_READ_MODEL_VERSION + 1}; ` +
+        `UI expects v${CURRENT_READ_MODEL_VERSION}. Proceeding with forward-compatible reads.`,
+    );
+
+    warn.mockRestore();
   });
 });

--- a/tests/unit/scripts/test_explorer_build_contract.py
+++ b/tests/unit/scripts/test_explorer_build_contract.py
@@ -30,9 +30,18 @@ def test_explorer_build_contract_command_emits_expected_json() -> None:
 
 def test_explorer_build_contract_matches_duckdb_only_output_contract() -> None:
     outputs = EXPLORER_BUILD_CONTRACT["outputs"]
+    # Independent migration pin: a version bump must update this reviewed
+    # expectation and the compatibility matrix deliberately, not just copy a
+    # changed production constant into another consumer.
+    current_read_model_version = 7
 
     assert EXPLORER_BUILD_CONTRACT["version"] == "6"
-    assert EXPLORER_BUILD_CONTRACT["read_model_version"] == EXPLORER_READ_MODEL_VERSION
+    assert EXPLORER_BUILD_CONTRACT["read_model_version"] == current_read_model_version
+    assert current_read_model_version == EXPLORER_READ_MODEL_VERSION
+    assert EXPLORER_BUILD_CONTRACT["read_model_compatibility"] == {
+        "minimum_supported": current_read_model_version,
+        "newer_policy": "warn-and-continue",
+    }
     assert isinstance(EXPLORER_BUILD_CONTRACT["read_model_version"], int)
     assert EXPLORER_BUILD_CONTRACT["read_model_version"] >= 1
     assert "results_schema.json" not in outputs["required"]


### PR DESCRIPTION
## Summary
- Add a machine-readable read-model compatibility policy to the Explorer build contract.
- Validate the policy in the Node build-contract checker.
- Make the version pin non-tautological with independently reviewed expectations.
- Test older/missing snapshots fail clearly, current snapshots pass, and newer snapshots warn-and-continue.

## Verification
- `make pr-preflight` — 27,733 passed, 19 skipped.
- `npm run typecheck`
- `npm test -- --run` — 866 tests passed.
- Focused Python/Vitest contract tests and Ruff checks passed.
- Tracker verification rungs 1–2 passed for `results-explorer-read-model-version-literal-pin-20260802`.

TODO: `results-explorer-read-model-version-literal-pin-20260802`