### PR TITLE
test(explorer): verify assembled Pages routes

### DIFF
--- a/docs/operations/results-explorer-qa.md
+++ b/docs/operations/results-explorer-qa.md
@@ -30,6 +30,24 @@ cd results-explorer
 npm run test:e2e:fixtures
 ```
 
+### Pages-shaped assembled-artifact acceptance
+
+After downloading the exact `site/` directory produced by the protected docs
+workflow, run the direct-route acceptance against that artifact rather than
+against `vite dev` or the Explorer-only test server:
+
+```bash
+cd results-explorer
+E2E_SITE_DIR=/absolute/path/to/site \\
+E2E_PAGES_SHAPED=1 npx playwright test --project=chromium --workers=1 e2e/routes/direct-route.spec.ts
+```
+
+The server returns the assembled root `404.html` with HTTP 404 for missing
+Pages routes, so the test proves the browser redirect/route restoration and a
+native `/docs/` navigation. The test also checks that the snapshot is served
+from the artifact itself. This command is an acceptance check only; it does
+not upload or deploy the artifact.
+
 ## Audit develop SHA contract
 
 Every Markdown report under `_project/audits/*.md` must begin with YAML

--- a/results-explorer/e2e/routes/direct-route.spec.ts
+++ b/results-explorer/e2e/routes/direct-route.spec.ts
@@ -102,3 +102,38 @@ test.describe("direct route parity", () => {
     await expect(guardrails).not.toContainText(/coverage\.\./i);
   });
 });
+
+test.describe("assembled GitHub Pages artifact", () => {
+  test.skip(
+    !process.env.E2E_SITE_DIR,
+    "Set E2E_SITE_DIR to the workflow-produced site directory for Pages-shaped acceptance.",
+  );
+
+  test("preserves direct routes through root 404 fallback and native docs links", async ({ page }) => {
+    const directRouteStatuses: number[] = [];
+    const docsStatuses: number[] = [];
+    page.on("response", (response) => {
+      const pathname = new URL(response.url()).pathname;
+      if (pathname === "/results/p/polars/") directRouteStatuses.push(response.status());
+      if (pathname === "/docs/usage/installation.html") docsStatuses.push(response.status());
+    });
+
+    const fallback = await page.request.get("/404.html");
+    expect(fallback.status()).toBe(200);
+    expect(await fallback.text()).toContain("benchbox.results.redirect");
+
+    await page.goto("/results/p/polars/");
+    await waitForShell(page);
+    await waitForDataElement(page, page.getByRole("heading", { name: /^Polars Results$/ }));
+    await expect(page).toHaveURL(/\/results\/p\/polars\/$/);
+    expect(directRouteStatuses).toContain(404);
+    await expect(page.locator("main table tbody tr[data-testid]")).toHaveCount(1);
+    await expectNoFalsePlatformEmpty(page);
+
+    await page.goto("/results/");
+    await waitForDataLoaded(page, /Recent Results/i);
+    await page.getByRole("link", { name: "Run a benchmark" }).click();
+    await expect(page).toHaveURL(/\/docs\/usage\/installation\.html$/);
+    expect(docsStatuses).toContain(200);
+  });
+});

--- a/results-explorer/scripts/serve-browser-tests.mjs
+++ b/results-explorer/scripts/serve-browser-tests.mjs
@@ -26,6 +26,8 @@ const { values } = parseArgs({
     host: { type: "string", default: process.env.E2E_HOST ?? "127.0.0.1" },
     "dist-dir": { type: "string" },
     "fixture-dir": { type: "string" },
+    "site-dir": { type: "string", default: process.env.E2E_SITE_DIR },
+    "pages-shaped": { type: "boolean", default: Boolean(process.env.E2E_PAGES_SHAPED) },
   },
 });
 
@@ -37,15 +39,21 @@ const fixtureDir = resolve(
     process.env.E2E_FIXTURE_DIR ??
     join(projectRoot, "test-fixtures", ".generated", "data"),
 );
+const siteDir = values["site-dir"] ? resolve(values["site-dir"]) : null;
+const pagesShaped = values["pages-shaped"];
 
-if (!existsSync(distDir)) {
+if (pagesShaped && !siteDir) {
+  console.error("[serve-browser-tests] --pages-shaped requires --site-dir or E2E_SITE_DIR.");
+  process.exit(2);
+}
+if (!pagesShaped && !existsSync(distDir)) {
   console.error(
     `[serve-browser-tests] dist dir not found: ${distDir}\n` +
       `Run \`npm run build\` inside results-explorer/ before starting the e2e server.`,
   );
   process.exit(2);
 }
-if (!existsSync(fixtureDir)) {
+if (!pagesShaped && !existsSync(fixtureDir)) {
   console.error(
     `[serve-browser-tests] fixture dir not found: ${fixtureDir}\n` +
       `Run \`npm run test:e2e:fixtures\` inside results-explorer/ to generate the corpus.`,
@@ -81,7 +89,7 @@ const writeNotFound = (res, reason) => {
   res.end(`not found: ${reason}\n`);
 };
 
-const sendFile = (req, res, absPath, logPath) => {
+const sendFile = (req, res, absPath, logPath, statusCode = 200) => {
   let stat;
   try {
     stat = statSync(absPath);
@@ -91,7 +99,7 @@ const sendFile = (req, res, absPath, logPath) => {
   }
   if (stat.isDirectory()) {
     const indexPath = join(absPath, "index.html");
-    if (existsSync(indexPath)) return sendFile(req, res, indexPath, logPath);
+    if (existsSync(indexPath)) return sendFile(req, res, indexPath, logPath, statusCode);
     writeNotFound(res, absPath);
     return;
   }
@@ -145,7 +153,7 @@ const sendFile = (req, res, absPath, logPath) => {
     }
   }
 
-  res.writeHead(200, { ...headers, "Content-Length": String(stat.size) });
+  res.writeHead(statusCode, { ...headers, "Content-Length": String(stat.size) });
   if (logPath) {
     transferLog.push({
       path: logPath,
@@ -160,6 +168,16 @@ const sendFile = (req, res, absPath, logPath) => {
   } else {
     createReadStream(absPath).pipe(res);
   }
+};
+
+const servePagesArtifact = (req, res, pathname) => {
+  const rel = pathname.replace(/^\/+/, "") || "index.html";
+  const abs = safeJoin(siteDir, rel);
+  if (abs && existsSync(abs)) return sendFile(req, res, abs);
+
+  const fallback = safeJoin(siteDir, "404.html");
+  if (fallback && existsSync(fallback)) return sendFile(req, res, fallback, undefined, 404);
+  return writeNotFound(res, pathname);
 };
 
 // Any path whose extension *isn't* a known static asset is treated as an
@@ -178,6 +196,8 @@ const handler = (req, res) => {
   // Strip query string but keep the pathname for routing.
   const url = new URL(req.url ?? "/", `http://${req.headers.host ?? "localhost"}`);
   const pathname = decodeURIComponent(url.pathname);
+
+  if (pagesShaped) return servePagesArtifact(req, res, pathname);
 
   // Test-only transfer-log endpoints. Not exposed in production builds -
   // this server is only used by the e2e harness.


### PR DESCRIPTION
## Summary
- Add an explicit Pages-shaped mode to the browser test server for a downloaded workflow `site/` artifact.
- Validate root `404.html` redirect recovery for direct Explorer routes and native `/docs/` navigation.
- Document the exact acceptance command and keep it non-deploying.

## Verification
- Pages-shaped assembled artifact: 6 Chromium tests passed.
- Default Explorer server: 5 passed, 1 Pages acceptance test skipped without `E2E_SITE_DIR`.
- `npm run typecheck:e2e`
- `tests/unit/workflows`: 191 passed.
- `git diff --check`

TODO: `results-explorer-pages-environment-and-curated-preview-launch` (local w0/w1 only; Pages policy/deployment remain gated externally)