### PR TITLE
fix: close merged-PR review follow-ups across pipeline, tracker, and docs

### DIFF
--- a/.claude/skills/skill-sync.config.yaml
+++ b/.claude/skills/skill-sync.config.yaml
@@ -6,6 +6,11 @@ code:
   line_length: 120
   lint: uv run ruff check .
   lint_fix: uv run ruff check --fix .
+  review_checklist:
+    - For TODOs claiming to retire a SQL-translation post-fixup from a harness
+      PASS, grep the helper call site and confirm the harness probe matches the
+      wrapper's `read=` argument. A single-dialect PASS cannot retire a helper
+      invoked with SQLGlot cross-dialect translation.
   typecheck: uv run ty check
   verify: uv run ruff check . && uv run ty check && uv run -- python -m pytest -m
     fast -q

--- a/_project/scripts/explorer_pipeline/pipeline.py
+++ b/_project/scripts/explorer_pipeline/pipeline.py
@@ -42,6 +42,7 @@ from _project.scripts.explorer_pipeline.transformer import (
     _applied_receipt,
     _platform_percentile_stats,
     _public_companion_bytes,
+    _sanitize_applied_receipt,
 )
 from _project.scripts.results_explorer_snapshot_invariants import check_snapshot
 from benchbox.core.results.anonymization import AnonymizationManager, find_public_path_leaks
@@ -229,13 +230,13 @@ def _public_applied_receipt(bundle_path: Path, anonymizer: AnonymizationManager)
     if receipt_json is None:
         return None
     try:
-        public_receipt = anonymizer.anonymize_result_payload(json.loads(receipt_json))
+        public_receipt = _sanitize_applied_receipt(anonymizer.anonymize_result_payload(json.loads(receipt_json)))
     except (TypeError, ValueError, json.JSONDecodeError) as exc:
         raise ValueError(f"could not sanitize applied receipt {bundle_path.name}: {exc}") from exc
     leaks = find_public_path_leaks(public_receipt)
     if leaks:
         raise PrivacyRejectionError(
-            "public applied receipt privacy check failed for fields: " + ", ".join(sorted(set(leaks)))
+            f"{bundle_path}: public applied receipt privacy check failed for fields: " + ", ".join(sorted(set(leaks)))
         )
     return canonical_json_bytes(public_receipt).decode("utf-8")
 
@@ -249,8 +250,12 @@ def _public_bundle_data(
     public_bundle = anonymizer.anonymize_result_payload(bundle_data)
     public_leaks = find_public_path_leaks(public_bundle)
     if public_leaks:
+        # The path is part of the message, not just the log line: this exception
+        # aborts the whole build, and `explorer_publish.py` prints only
+        # `str(exc)`. Without it a multi-bundle corpus reports which *fields*
+        # leaked but not which file to fix, forcing a binary search of the corpus.
         raise PrivacyRejectionError(
-            "public bundle privacy check failed for fields: " + ", ".join(sorted(set(public_leaks)))
+            f"{bundle_path}: public bundle privacy check failed for fields: " + ", ".join(sorted(set(public_leaks)))
         )
     return public_bundle, _public_applied_receipt(bundle_path, anonymizer)
 
@@ -753,7 +758,7 @@ class ExplorerPipeline:
                         try:
                             public_companion = _public_companion_bytes(bundle_path, suffix, public_anonymizer)
                         except CompanionPrivacyError as exc:
-                            raise PrivacyRejectionError(str(exc)) from exc
+                            raise PrivacyRejectionError(f"{bundle_path} ({suffix} companion): {exc}") from exc
                         if public_companion is None:
                             continue
 

--- a/_project/scripts/explorer_pipeline/transformer.py
+++ b/_project/scripts/explorer_pipeline/transformer.py
@@ -65,27 +65,70 @@ def _sanitize_applied_drift_check(drift_check: Any) -> None:
         drift_check["drift_redacted"] = True
 
 
-def _sanitize_applied_receipt(receipt: Any) -> None:
+# Stand-in for a receipt container whose shape none of the redaction rules
+# below can reach. Publishing such a value verbatim is the failure this marker
+# exists to prevent, so it carries no payload from the source document.
+_REDACTED_APPLIED_SHAPE: dict[str, Any] = {"redacted": True, "reason": "unexpected_shape"}
+
+
+def _sanitize_applied_entry(entry: dict[str, Any]) -> None:
+    for key in ("statement", "diff", "detail", "evidence", "table", "name", "expected_columns", "observed_columns"):
+        entry.pop(key, None)
+    if "reason" in entry:
+        entry.pop("reason", None)
+        entry["reason_redacted"] = True
+    entry["statement_redacted"] = True
+
+
+def _sanitize_applied_observed(observed: dict[str, Any]) -> None:
+    for key in ("table", "name", "columns", "evidence"):
+        observed.pop(key, None)
+    observed["redacted"] = True
+
+
+def _sanitized_applied_container(value: Any, sanitize_item: Any) -> Any:
+    """Sanitize a receipt sub-list, failing closed on an unexpected shape.
+
+    A non-list here (or a non-object inside it) is free text no redaction rule
+    matches. Iterating it would silently pass the original through - a string
+    yields characters, none of which are dicts - so replace it with a marker.
+    """
+    if value is None:
+        return None
+    if not isinstance(value, list):
+        return dict(_REDACTED_APPLIED_SHAPE)
+    sanitized: list[Any] = []
+    for item in value:
+        if not isinstance(item, dict):
+            sanitized.append(dict(_REDACTED_APPLIED_SHAPE))
+            continue
+        sanitize_item(item)
+        sanitized.append(item)
+    return sanitized
+
+
+def _sanitize_applied_receipt(receipt: Any) -> Any:
+    """Sanitize the introspection receipt, redacting shapes it cannot inspect.
+
+    Returning an unexpected shape untouched published it verbatim: a companion
+    such as ``{"receipt": "private_customer_catalog"}`` parses, survives the
+    generic anonymizer, and carries no absolute path for the leak detector to
+    catch, so the free text reached the public sidecar intact.
+    """
+    if receipt is None:
+        return None
     if not isinstance(receipt, dict):
-        return
+        return dict(_REDACTED_APPLIED_SHAPE)
     if "error" in receipt:
         receipt.pop("error", None)
         receipt["error_redacted"] = True
-    for entry in receipt.get("entries") or []:
-        if not isinstance(entry, dict):
-            continue
-        for key in ("statement", "diff", "detail", "evidence", "table", "name", "expected_columns", "observed_columns"):
-            entry.pop(key, None)
-        if "reason" in entry:
-            entry.pop("reason", None)
-            entry["reason_redacted"] = True
-        entry["statement_redacted"] = True
-    for observed in receipt.get("observed") or []:
-        if isinstance(observed, dict):
-            for key in ("table", "name", "columns", "evidence"):
-                observed.pop(key, None)
-            observed["redacted"] = True
+    # Keyed on presence, not truthiness, so an absent key is never introduced.
+    if "entries" in receipt:
+        receipt["entries"] = _sanitized_applied_container(receipt["entries"], _sanitize_applied_entry)
+    if "observed" in receipt:
+        receipt["observed"] = _sanitized_applied_container(receipt["observed"], _sanitize_applied_observed)
     _redact_applied_dropped(receipt)
+    return receipt
 
 
 def _sanitize_applied_companion(payload: dict[str, Any]) -> dict[str, Any]:
@@ -108,7 +151,8 @@ def _sanitize_applied_companion(payload: dict[str, Any]) -> dict[str, Any]:
             entry["statement_redacted"] = True
     _redact_applied_dropped(sanitized)
     _sanitize_applied_drift_check(sanitized.get("drift_check"))
-    _sanitize_applied_receipt(sanitized.get("receipt"))
+    if "receipt" in sanitized:
+        sanitized["receipt"] = _sanitize_applied_receipt(sanitized["receipt"])
     return sanitized
 
 

--- a/_project/scripts/todo_db.py
+++ b/_project/scripts/todo_db.py
@@ -2530,13 +2530,28 @@ def claim_item(
     return order
 
 
-def release_item(conn: sqlite3.Connection, actor: str, item_id: str) -> None:
+def release_item(
+    conn: sqlite3.Connection,
+    actor: str,
+    item_id: str,
+    ttl_hours: float = DEFAULT_LEASE_TTL_HOURS,
+) -> None:
     with _write_txn(conn):
         item = _require_item(conn, item_id)
-        if item["claimed_by"] is None:
+        holder = item["claimed_by"]
+        if holder is None:
             return
+        # Mirror `claim_item`'s takeover rule: the holder may always release,
+        # and a third party only once the lease has expired. Without this the
+        # command cleared any live claim and returned success, handing another
+        # worker's in-flight item back to the ready queue.
+        if holder != actor and not _lease_expired(item["claimed_at"], ttl_hours):
+            raise TodoError(
+                f"{item_id!r} is claimed by {holder!r} since {item['claimed_at']};"
+                f" only {holder!r} can release it, or wait for the lease to expire"
+            )
         conn.execute("UPDATE items SET claimed_by = NULL, claimed_at = NULL WHERE id = ?", (item_id,))
-        log_event(conn, actor, item_id, "release", {"holder": item["claimed_by"]})
+        log_event(conn, actor, item_id, "release", {"holder": holder})
 
 
 def _touch_lease(
@@ -4867,8 +4882,21 @@ def _parse_verify_flag(specs: list[str]) -> list[dict[str, str]]:
         # Keep the legacy two/three-field form byte-for-byte compatible. The
         # explicit alternate form is unambiguous for commands such as
         # ``pytest path.py::TestClass::test_case``.
-        if len(_split_unquoted(spec, VERIFY_SPEC_SEPARATOR, 1)) > 1:
-            fields = _split_unquoted(spec, VERIFY_SPEC_SEPARATOR)
+        # Pick the form by whichever delimiter appears FIRST, positionally and
+        # without any quote state. Whatever precedes that first delimiter is the
+        # description, so a delimiter cannot hide inside it and prose needs no
+        # escaping. Quote-aware scanning from position 0 used to decide this,
+        # which let an ordinary apostrophe ("don't regress") open a shell quote
+        # that swallowed every following `|||`; the spec then silently fell back
+        # to `::` and stored fragments of a pytest node id as the command.
+        # Shell quoting is already resolved by argv before it reaches here.
+        alternate_at = spec.find(VERIFY_SPEC_SEPARATOR)
+        legacy_at = spec.find("::")
+        if alternate_at != -1 and (legacy_at == -1 or alternate_at < legacy_at):
+            description, _, remainder = spec.partition(VERIFY_SPEC_SEPARATOR)
+            # Past the description the text is a shell command, where a *quoted*
+            # `|||` is literal payload rather than a field separator.
+            fields = [description, *_split_unquoted(remainder, VERIFY_SPEC_SEPARATOR, 1)]
         else:
             fields = spec.split("::", 2)
         entry = {"description": fields[0]}

--- a/_project/scripts/todo_schema_migration_check.py
+++ b/_project/scripts/todo_schema_migration_check.py
@@ -183,7 +183,12 @@ def validate_contract(*, tracker: Path, wrapper: Path, inventory: Path) -> None:
             entry,
             revision=revision,
             expected_count=expected_count,
-            is_empty=revision in empty_revisions or expected_count == 0,
+            # Emptiness comes solely from the parsed MIGRATIONS literal. Falling
+            # back to `expected_count == 0` let a fence whose entry gained a DDL
+            # statement still report empty while its count stayed 0, so the drift
+            # guard accepted the inconsistency that `_check_fence_declaration`
+            # exists to reject.
+            is_empty=revision in empty_revisions,
             inventory=inventory,
         )
     current = entries[-1]

--- a/docs/operations/browser-ci.md
+++ b/docs/operations/browser-ci.md
@@ -243,7 +243,11 @@ the host first — fixture generation shells out to `uv`/Python, which the
 Playwright image does not carry:
 
 ```bash
-cd results-explorer && npm run test:e2e:fixtures && npm run build
+# Build in a subshell so the rsync source below still resolves from the
+# repository root, and create the mount point first - rsync will not create
+# multiple missing destination components on a machine with no leftover state.
+(cd results-explorer && npm run test:e2e:fixtures && npm run build)
+mkdir -p /tmp/linux-wk
 rsync -a --exclude node_modules --exclude playwright-report \
   --exclude test-results results-explorer/ /tmp/linux-wk/results-explorer/
 mocker run -d -m 8g --cpus 4 -v /tmp/linux-wk:/work \

--- a/docs/operations/results-explorer-qa.md
+++ b/docs/operations/results-explorer-qa.md
@@ -39,8 +39,13 @@ against `vite dev` or the Explorer-only test server:
 ```bash
 cd results-explorer
 E2E_SITE_DIR=/absolute/path/to/site \\
-E2E_PAGES_SHAPED=1 npx playwright test --project=chromium --workers=1 e2e/routes/direct-route.spec.ts
+E2E_PAGES_SHAPED=1 npx playwright test --project=chromium --workers=1 e2e/routes/pages-artifact.spec.ts
 ```
+
+This spec is deliberately fixture-free, so it needs no `npm run test:e2e:fixtures`
+first and asserts nothing about corpus row counts. Do not point this command at
+`direct-route.spec.ts`: that file pins generated fixture ids and exact row
+counts, which fail against a production artifact.
 
 The server returns the assembled root `404.html` with HTTP 404 for missing
 Pages routes, so the test proves the browser redirect/route restoration and a

--- a/docs/reference/python-api/result-analysis.rst
+++ b/docs/reference/python-api/result-analysis.rst
@@ -491,43 +491,39 @@ Manage anonymization of benchmark results for privacy-preserving sharing.
        print(f"Anonymous ID: {machine_id}")
        # Output: machine_a1b2c3d4e5f6g7h8
 
-.. method:: anonymize_system_profile() -> dict[str, Any]
+.. method:: anonymize_result_payload(payload) -> dict[str, Any]
 
-   Generate anonymized system profile information.
-
-   **Returns**: dict - Anonymized system information (OS, architecture, CPU, memory)
-
-   **Example**:
-
-   .. code-block:: python
-
-       profile = manager.anonymize_system_profile()
-       print(f"OS: {profile['os_type']} {profile['os_release']}")
-       print(f"Architecture: {profile['architecture']}")
-       print(f"CPU count: {profile['cpu_count']}")
-       print(f"Memory: {profile['memory_gb']} GB")
-       print(f"Hostname: {profile['hostname']}")  # Anonymized: host_abc123de
-       print(f"Username: {profile['username']}")  # Anonymized: user_def456gh
-
-.. method:: sanitize_path(path) -> str
-
-   Sanitize file paths by removing or anonymizing sensitive components.
+   Anonymize a whole result bundle payload. This is the entry point that
+   replaced the former per-field helpers: path sanitizing, system-profile
+   scrubbing, and query-metadata anonymization now happen inside this single
+   pass rather than through separate public methods.
 
    **Parameters**:
 
-   - **path** (str): File path to sanitize
+   - **payload** (dict): Result bundle payload to anonymize
 
-   **Returns**: str - Sanitized path
+   **Returns**: dict - Anonymized payload, safe for publication
 
    **Example**:
 
    .. code-block:: python
 
-       # Sensitive path
-       original = "/home/john.doe/projects/benchbox/data/customer_data.csv"
-       sanitized = manager.sanitize_path(original)
-       print(sanitized)
-       # Output: /home/dir_a1b2c3d4/projects/benchbox/data/dir_e5f6g7h8.csv
+       from benchbox.core.results.anonymization import AnonymizationManager
+
+       manager = AnonymizationManager()
+       public_payload = manager.anonymize_result_payload(raw_payload)
+
+.. method:: anonymize_tuning_payload(payload) -> dict[str, Any]
+
+   Anonymize a tuning companion payload using the same pseudonym domain as
+   :meth:`anonymize_result_payload`, so a bundle and its sidecars stay
+   mutually consistent.
+
+   **Parameters**:
+
+   - **payload** (dict): Tuning companion payload
+
+   **Returns**: dict - Anonymized payload
 
 .. method:: remove_pii(text) -> str
 
@@ -548,38 +544,16 @@ Manage anonymization of benchmark results for privacy-preserving sharing.
        print(cleaned)
        # Output: "Contact [REDACTED] or call [REDACTED]"
 
-.. method:: anonymize_query_metadata(query_metadata) -> dict[str, Any]
+.. note::
 
-   Anonymize query execution metadata.
-
-   **Parameters**:
-
-   - **query_metadata** (dict): Original query metadata
-
-   **Returns**: dict - Anonymized metadata
-
-.. method:: validate_anonymization(original_data, anonymized_data) -> dict[str, Any]
-
-   Validate that anonymization was successful.
-
-   **Parameters**:
-
-   - **original_data** (dict): Original data before anonymization
-   - **anonymized_data** (dict): Data after anonymization
-
-   **Returns**: dict - Validation results with warnings and errors
-
-   **Example**:
-
-   .. code-block:: python
-
-       validation = manager.validate_anonymization(original, anonymized)
-       if validation['is_valid']:
-           print("✅ Anonymization successful")
-       else:
-           print("❌ Anonymization issues:")
-           for error in validation['errors']:
-               print(f"  - {error}")
+   **Migrating from the pre-consolidation API.** ``anonymize_system_profile()``,
+   ``sanitize_path()``, ``anonymize_query_metadata()``, and
+   ``validate_anonymization()`` were removed. Call
+   :meth:`anonymize_result_payload` on the whole payload instead - it applies
+   all of those transforms in one pass. To confirm a payload is publishable,
+   use :func:`benchbox.core.results.anonymization.find_public_path_leaks`,
+   which returns the offending field paths and replaces the old
+   ``validate_anonymization`` check.
 
 Anonymization Config
 ~~~~~~~~~~~~~~~~~~~~
@@ -591,15 +565,20 @@ Configuration for result anonymization.
 
 **Attributes**:
 
-- **include_machine_id** (bool): Include anonymous machine identifier (default: True)
-- **machine_id_salt** (str | None): Custom salt for machine ID generation
-- **anonymize_paths** (bool): Sanitize file paths (default: True)
-- **allowed_path_prefixes** (list[str]): Paths to keep unchanged (default: ["/tmp", "/var/tmp"])
-- **include_system_profile** (bool): Include system information (default: True)
-- **anonymize_hostnames** (bool): Anonymize machine hostnames (default: True)
-- **anonymize_usernames** (bool): Anonymize usernames (default: True)
-- **pii_patterns** (list[str]): Regex patterns for PII detection
-- **custom_sanitizers** (dict[str, str]): Custom regex replacements
+- **machine_id_salt** (str | None): Salt for machine-ID pseudonyms (default: ``None``).
+  With the default, pseudonyms are deterministic across installations - set a
+  salt when you need cross-installation correlation resistance.
+- **pii_patterns** (list[str]): Regex patterns for PII detection (defaults cover
+  IPv4 addresses, email addresses, and US SSN-shaped strings)
+- **custom_sanitizers** (dict[str, str]): Custom regex replacements (default: ``{}``)
+
+.. note::
+
+   ``include_machine_id``, ``anonymize_paths``, ``allowed_path_prefixes``,
+   ``include_system_profile``, ``anonymize_hostnames``, and
+   ``anonymize_usernames`` were removed. Path, hostname, and username handling
+   is no longer optional - it always applies - so passing any of these now
+   raises ``TypeError``. Drop them from existing configs.
 
 **Example**:
 
@@ -612,10 +591,7 @@ Configuration for result anonymization.
 
     # Custom configuration
     config = AnonymizationConfig(
-        anonymize_hostnames=True,
-        anonymize_usernames=True,
-        anonymize_paths=True,
-        allowed_path_prefixes=["/tmp", "/var/tmp", "/opt/benchbox"],
+        machine_id_salt="your-org-salt",
         custom_sanitizers={
             r"customer_\d+": "customer_[REDACTED]",
             r"project_[a-z]+": "project_[REDACTED]"

--- a/results-explorer/e2e/routes/direct-route.spec.ts
+++ b/results-explorer/e2e/routes/direct-route.spec.ts
@@ -102,38 +102,3 @@ test.describe("direct route parity", () => {
     await expect(guardrails).not.toContainText(/coverage\.\./i);
   });
 });
-
-test.describe("assembled GitHub Pages artifact", () => {
-  test.skip(
-    !process.env.E2E_SITE_DIR,
-    "Set E2E_SITE_DIR to the workflow-produced site directory for Pages-shaped acceptance.",
-  );
-
-  test("preserves direct routes through root 404 fallback and native docs links", async ({ page }) => {
-    const directRouteStatuses: number[] = [];
-    const docsStatuses: number[] = [];
-    page.on("response", (response) => {
-      const pathname = new URL(response.url()).pathname;
-      if (pathname === "/results/p/polars/") directRouteStatuses.push(response.status());
-      if (pathname === "/docs/usage/installation.html") docsStatuses.push(response.status());
-    });
-
-    const fallback = await page.request.get("/404.html");
-    expect(fallback.status()).toBe(200);
-    expect(await fallback.text()).toContain("benchbox.results.redirect");
-
-    await page.goto("/results/p/polars/");
-    await waitForShell(page);
-    await waitForDataElement(page, page.getByRole("heading", { name: /^Polars Results$/ }));
-    await expect(page).toHaveURL(/\/results\/p\/polars\/$/);
-    expect(directRouteStatuses).toContain(404);
-    await expect(page.locator("main table tbody tr[data-testid]")).toHaveCount(1);
-    await expectNoFalsePlatformEmpty(page);
-
-    await page.goto("/results/");
-    await waitForDataLoaded(page, /Recent Results/i);
-    await page.getByRole("link", { name: "Run a benchmark" }).click();
-    await expect(page).toHaveURL(/\/docs\/usage\/installation\.html$/);
-    expect(docsStatuses).toContain(200);
-  });
-});

--- a/results-explorer/e2e/routes/pages-artifact.spec.ts
+++ b/results-explorer/e2e/routes/pages-artifact.spec.ts
@@ -1,0 +1,54 @@
+import { expect, test } from "@playwright/test";
+import { waitForDataElement, waitForDataLoaded, waitForShell } from "../support/fixtures";
+
+/**
+ * Acceptance for the assembled GitHub Pages artifact.
+ *
+ * Deliberately fixture-free. This runs against the exact `site/` directory the
+ * protected docs workflow produced, which is built from the production corpus
+ * and has no relationship to the generated browser fixtures. Living in
+ * `direct-route.spec.ts` meant it could not even be *discovered* without
+ * `test-fixtures/.generated/data/fixture-ids.json`, and once discovered it
+ * dragged five fixture-pinned tests - fixed short ids, exact row counts -
+ * against a production artifact, so ordinary corpus changes failed a check that
+ * only exists to prove route restoration.
+ *
+ * Keep assertions here structural: routes resolve, the 404 fallback restores
+ * them, and docs links navigate natively. Nothing that counts corpus rows.
+ */
+test.describe("assembled GitHub Pages artifact", () => {
+  test.skip(
+    !process.env.E2E_SITE_DIR,
+    "Set E2E_SITE_DIR to the workflow-produced site directory for Pages-shaped acceptance.",
+  );
+
+  test("preserves direct routes through root 404 fallback and native docs links", async ({ page }) => {
+    const directRouteStatuses: number[] = [];
+    const docsStatuses: number[] = [];
+    page.on("response", (response) => {
+      const pathname = new URL(response.url()).pathname;
+      if (pathname === "/results/p/polars/") directRouteStatuses.push(response.status());
+      if (pathname === "/docs/usage/installation.html") docsStatuses.push(response.status());
+    });
+
+    const fallback = await page.request.get("/404.html");
+    expect(fallback.status()).toBe(200);
+    expect(await fallback.text()).toContain("benchbox.results.redirect");
+
+    await page.goto("/results/p/polars/");
+    await waitForShell(page);
+    await waitForDataElement(page, page.getByRole("heading", { name: /^Polars Results$/ }));
+    await expect(page).toHaveURL(/\/results\/p\/polars\/$/);
+    expect(directRouteStatuses).toContain(404);
+    // At least one row, not an exact count: the production corpus decides how
+    // many Polars results exist, and that is not what this check is proving.
+    await expect(page.locator("main table tbody tr[data-testid]").first()).toBeVisible();
+    await expect(page.getByText(/No results found for platform/i)).not.toBeVisible();
+
+    await page.goto("/results/");
+    await waitForDataLoaded(page, /Recent Results/i);
+    await page.getByRole("link", { name: "Run a benchmark" }).click();
+    await expect(page).toHaveURL(/\/docs\/usage\/installation\.html$/);
+    expect(docsStatuses).toContain(200);
+  });
+});

--- a/results-explorer/e2e/support/fixtures.ts
+++ b/results-explorer/e2e/support/fixtures.ts
@@ -59,17 +59,39 @@ const FIXTURE_IDS_PATH = join(
   "fixture-ids.json",
 );
 
-export const fixtureIds: FixtureIds = (() => {
-  try {
-    return JSON.parse(readFileSync(FIXTURE_IDS_PATH, "utf8")) as FixtureIds;
-  } catch (cause) {
-    throw new Error(
-      `Could not read ${FIXTURE_IDS_PATH}. Run \`npm run test:e2e:fixtures\` first - ` +
-        "the browser suite needs the generated fixture corpus.",
-      { cause },
-    );
+let loadedFixtureIds: FixtureIds | null = null;
+
+function loadFixtureIds(): FixtureIds {
+  if (loadedFixtureIds === null) {
+    try {
+      loadedFixtureIds = JSON.parse(readFileSync(FIXTURE_IDS_PATH, "utf8")) as FixtureIds;
+    } catch (cause) {
+      throw new Error(
+        `Could not read ${FIXTURE_IDS_PATH}. Run \`npm run test:e2e:fixtures\` first - ` +
+          "the browser suite needs the generated fixture corpus.",
+        { cause },
+      );
+    }
   }
-})();
+  return loadedFixtureIds;
+}
+
+/**
+ * Generated fixture identifiers, resolved on first property access.
+ *
+ * Deliberately lazy: this module also exports the `waitFor*` helpers, and an
+ * eager read made *importing* it fail whenever the generated corpus was absent.
+ * That broke Playwright discovery - not just execution - for fixture-free specs
+ * such as the assembled-artifact acceptance, which runs against a downloaded
+ * `site/` directory and never needs a fixture id.
+ */
+export const fixtureIds: FixtureIds = new Proxy({} as FixtureIds, {
+  get: (_target, property) => Reflect.get(loadFixtureIds(), property),
+  has: (_target, property) => Reflect.has(loadFixtureIds(), property),
+  ownKeys: () => Reflect.ownKeys(loadFixtureIds()),
+  getOwnPropertyDescriptor: (_target, property) =>
+    Reflect.getOwnPropertyDescriptor(loadFixtureIds(), property),
+});
 
 /**
  * Wait until the explorer's initial Preact bundle has mounted. We pick

--- a/skill-sync.yaml
+++ b/skill-sync.yaml
@@ -35,6 +35,15 @@ config:
     fast_test: "uv run -- python -m pytest -m fast -q"
     verify: "uv run ruff check . && uv run ty check && uv run -- python -m pytest -m fast -q"
     line_length: 120
+    # Project-specific review checks. The shared five-axis rubric deliberately
+    # carries no BenchBox-specific items and only applies these when this key is
+    # set, so a check dropped from the rubric without landing here is simply lost.
+    review_checklist:
+      - >-
+        For TODOs claiming to retire a SQL-translation post-fixup from a harness
+        PASS, grep the helper call site and confirm the harness probe matches the
+        wrapper's `read=` argument. A single-dialect PASS cannot retire a helper
+        invoked with SQLGlot cross-dialect translation.
   test:
     runner: pytest
     coverage: "uv run -- python -m pytest --cov=benchbox --cov-report=term-missing"

--- a/tests/unit/scripts/explorer_pipeline/test_pipeline.py
+++ b/tests/unit/scripts/explorer_pipeline/test_pipeline.py
@@ -246,6 +246,27 @@ class TestExplorerPipelineRun:
         assert row["applied_receipt"] is not None
         assert "/Users/alice" not in row["applied_receipt"]
 
+    def test_unexpected_applied_receipt_shape_is_redacted_from_read_model(self, tmp_path: Path) -> None:
+        bundles_dir = tmp_path / "data" / "bundles"
+        bundles_dir.mkdir(parents=True)
+        source = bundles_dir / "with_unexpected_receipt.json"
+        source.write_text(json.dumps(MINIMAL_BUNDLE), encoding="utf-8")
+        source.with_name("with_unexpected_receipt.applied.json").write_text(
+            json.dumps({"receipt": "private_customer_catalog"}),
+            encoding="utf-8",
+        )
+
+        output = tmp_path / "out"
+        ExplorerPipeline().run(tmp_path / "data", output)
+
+        expected = {"reason": "unexpected_shape", "redacted": True}
+        row = _duckdb_results(output)[0]
+        assert json.loads(row["applied_receipt"]) == expected
+        with duckdb.connect(str(output / "results.duckdb"), read_only=True) as con:
+            projected = con.execute("SELECT applied_receipt FROM result_detail_metrics").fetchone()
+        assert projected is not None
+        assert json.loads(projected[0]) == expected
+
     def test_publishes_plans_sidecar_when_present(self, tmp_path: Path) -> None:
         """w1 wire-up: when a ``*.plans.json`` sidecar exists alongside a
         bundle, the pipeline must copy it to ``out/bundles/<result_id>.plans.json``
@@ -619,7 +640,7 @@ class TestExplorerPipelineRun:
         assert len(_duckdb_results(output)) == 1
 
     def test_applied_receipt_reaches_results_table_and_detail_view(self, tmp_path: Path) -> None:
-        """End-to-end: the companion's receipt lands in DuckDB verbatim.
+        """End-to-end: the companion's sanitized receipt lands in DuckDB.
 
         Pins the DDL / positional-INSERT / ``result_detail_metrics`` projection
         alignment for the ``applied_receipt`` column -- a mismatch there would
@@ -643,11 +664,16 @@ class TestExplorerPipelineRun:
 
         rows = _duckdb_results(output)
         assert len(rows) == 1
-        assert json.loads(rows[0]["applied_receipt"]) == receipt
+        expected = {
+            "platform": "duckdb",
+            "corroborated": True,
+            "entries": [{"statement_redacted": True, "verdict": "corroborated"}],
+        }
+        assert json.loads(rows[0]["applied_receipt"]) == expected
 
         with duckdb.connect(str(output / "results.duckdb"), read_only=True) as con:
             projected = con.execute("SELECT applied_receipt FROM result_detail_metrics").fetchall()
-        assert json.loads(projected[0][0]) == receipt
+        assert json.loads(projected[0][0]) == expected
 
     def test_applied_receipt_null_when_no_companion(self, tmp_path: Path) -> None:
         """A run with no receipt stores SQL NULL, not an empty string."""

--- a/tests/unit/scripts/explorer_pipeline/test_result_id_contract.py
+++ b/tests/unit/scripts/explorer_pipeline/test_result_id_contract.py
@@ -17,6 +17,7 @@ from pathlib import Path
 
 import pytest
 
+from _project.scripts.explorer_pipeline.pipeline import ExplorerPipeline
 from _project.scripts.explorer_pipeline.transformer import BundleTransformer
 from benchbox.core.results.anonymization import AnonymizationManager
 from benchbox.core.results.canonical_json import canonical_json_bytes
@@ -74,3 +75,28 @@ def test_pipeline_derives_the_id_after_anonymizing() -> None:
     derivation = source[id_assign : id_assign + 220]
     assert "raw=public_raw" in derivation, "result_id is no longer derived from the published bytes"
     assert "raw=bundle_raw" not in derivation, "result_id reverted to hashing raw source bytes"
+
+
+def test_published_artifact_bytes_recompute_the_result_id(data_dir: Path, tmp_path: Path) -> None:
+    """Recompute the ID from the emitted artifact, not from in-memory bytes.
+
+    The two tests above pass even if the publisher stops writing the bytes it
+    hashed - one feeds the same `public_bytes` to the transformer twice, the
+    other only inspects the derivation call. The advertised contract is that
+    anyone holding `bundles/{result_id}.json` can recompute its name, so run
+    the pipeline and check the artifact it actually wrote.
+    """
+    output = tmp_path / "out"
+    ExplorerPipeline().run(data_dir, output)
+
+    published = sorted((output / "bundles").glob("*.json"))
+    assert published, "pipeline published no bundle"
+
+    transformer = BundleTransformer()
+    for artifact in published:
+        emitted = artifact.read_bytes()
+        recomputed = transformer.result_id_from_bundle(artifact, data=json.loads(emitted), raw=emitted)
+        assert recomputed == artifact.stem, (
+            f"{artifact.name}: filename does not match the ID recomputed from its own bytes; "
+            "the publisher is writing bytes other than the ones it hashed"
+        )

--- a/tests/unit/scripts/test_todo_db.py
+++ b/tests/unit/scripts/test_todo_db.py
@@ -440,6 +440,20 @@ class TestVerifyFlagParsing:
             "expected": "exit 0",
         }
 
+    def test_verify_flag_alternate_separator_survives_apostrophe_in_description(self):
+        """A prose contraction must not be read as an opening shell quote.
+
+        Quote-aware scanning from position 0 let the apostrophe in "don't" open
+        a quote that swallowed both `|||`, silently demoting the spec to the
+        `::` form and storing pieces of the pytest node id as command/expected.
+        """
+        spec = "don't regress|||pytest tests/x.py::T::test_x|||exit 0"
+        assert todo_db._parse_verify_flag([spec])[0] == {
+            "description": "don't regress",
+            "command": "pytest tests/x.py::T::test_x",
+            "expected": "exit 0",
+        }
+
     @pytest.mark.parametrize("command", ["create", "update", "promote"])
     def test_verify_help_documents_alternate_separator(self, command, capsys):
         with pytest.raises(SystemExit) as exc_info:

--- a/tests/unit/scripts/test_todo_db_hardening.py
+++ b/tests/unit/scripts/test_todo_db_hardening.py
@@ -285,6 +285,13 @@ class TestClaimRenewal:
             work=[{"id": "w1", "summary": "a unit of work"}],
         )
         todo_db.claim_item(conn, "agent-a", "long-work")
+
+        # A third party cannot release a live claim: doing so handed another
+        # worker's in-flight item back to the ready queue and reported success.
+        with pytest.raises(todo_db.TodoError, match="only 'agent-a' can release it"):
+            todo_db.release_item(conn, "agent-b", "long-work")
+        assert conn.execute("SELECT claimed_by FROM items WHERE id = 'long-work'").fetchone()[0] == "agent-a"
+
         todo_db.release_item(conn, "agent-a", "long-work")
 
         with pytest.raises(todo_db.TodoError, match="lease"):

--- a/tests/unit/workflows/test_auto_merge_partial_stack_race.py
+++ b/tests/unit/workflows/test_auto_merge_partial_stack_race.py
@@ -153,8 +153,11 @@ def test_auto_merge_partial_stack_backstop_runs_at_least_daily() -> None:
     crons = [entry["cron"] for entry in schedule]
     assert crons, "detector has no scheduled backstop"
     for cron in crons:
-        day_of_week = cron.split()[4]
-        day_of_month = cron.split()[2]
-        assert day_of_week == "*" and day_of_month == "*", (
-            f"backstop cron {cron!r} runs less often than daily; a stale-branch orphan stays invisible until it fires"
+        day_of_month, month, day_of_week = (cron.split()[2], cron.split()[3], cron.split()[4])
+        # The month field counts too: `0 7 * 1 *` is daily *within January* and
+        # silent for the other eleven months, which day-of-month and day-of-week
+        # checks alone accept as an at-least-daily backstop.
+        assert day_of_week == "*" and day_of_month == "*" and month == "*", (
+            f"backstop cron {cron!r} runs less often than daily year-round; "
+            "a stale-branch orphan stays invisible until it fires"
         )


### PR DESCRIPTION
Second sweep of unresolved `chatgpt-codex-connector` threads on merged PRs. Scanned the 70 most recently updated merged PRs (#1425-#1683) and found 35 unresolved threads. This PR actions the 12 that need a code change; 8 were already fixed on `develop` and 15 are the non-actionable identity finding (see below).

## Explorer pipeline

- **P1 #1670 — redact applied-receipt shapes the sanitizer cannot inspect.** `_sanitize_applied_receipt` returned early on a non-object `receipt`, leaving the value intact. A companion such as `{"receipt": "private_customer_catalog"}` then passed the generic anonymizer and the absolute-path leak detector — it carries no path — and was published verbatim in the public sidecar. Non-object receipts and non-list `entries`/`observed` now become redaction markers, and non-object items inside those lists are redacted rather than skipped.
- **P2 #1569 — name the rejected bundle in privacy failures.** `PrivacyRejectionError` aborts the whole build and `explorer_publish.py` prints only `str(exc)`, so a multi-bundle corpus reported which *fields* leaked but not which file to fix.

## Tracker

- **P2 #1682 — enforce release ownership.** `release_item` never compared `actor` with `claimed_by`, so any actor could clear a live claim and return success, handing another worker's in-flight item back to the ready queue. Now mirrors `claim_item`'s takeover rule: the holder may always release, a third party only once the lease has expired.
- **P2 #1671 — decide the verification-spec form positionally.** Quote-aware scanning from position 0 let an apostrophe in prose (`don't regress`) open a shell quote that swallowed every following `|||`, silently demoting the spec to the `::` fallback and storing fragments of a pytest node id as command and expected. The earlier delimiter now wins, decided with no quote state; quote-awareness is retained *past* the description so a quoted `|||` inside a command stays literal (that case is pinned by an existing test).
- **P2 #1533 — derive fence emptiness from the parsed migration literal.** The `or expected_count == 0` fallback let a fence whose entry gained a DDL statement still report empty while its count stayed 0, so the drift guard accepted exactly the inconsistency it exists to reject.

## CI guards and tests

- **P2 #1547 — validate the month field in the daily-cadence guard.** `0 7 * 1 *` runs daily only during January; checking day-of-month and day-of-week alone accepted it as a year-round backstop.
- **P2 #1505 — recompute the result_id from the emitted artifact.** Both existing tests passed even if the publisher stopped writing the bytes it hashed — one fed the same in-memory bytes to the transformer twice, the other grepped the derivation call. The new test runs the pipeline and recomputes from `bundles/{result_id}.json`; confirmed to fail under the exact `write_bytes(bundle_raw)` mutation the review named.

## Docs and QA

- **P2 #1672 — restore the displaced SQLGlot review check** under `config.code.review_checklist` and regenerate the tracked mirror. The shared five-axis rubric only applies project-specific checks when that key is set, so the check the same sync removed was silently lost. It was added after a single-dialect PASS caused an incorrect retirement conclusion.
- **P2 #1680 — isolate Pages-artifact acceptance from the fixture suite.** The documented command could not even be *discovered* without `fixture-ids.json`, and once discovered it ran five fixture-pinned tests (fixed short ids, exact row counts) against an independently built production artifact. Extracted into a fixture-free `e2e/routes/pages-artifact.spec.ts`, made `fixtureIds` lazily resolved so importing the wait helpers no longer requires generated fixtures, and dropped the exact-row-count assertion.
- **P2 #1502 — fix the Linux WebKit reproduction.** `cd results-explorer` left the shell inside that directory so the rsync source resolved to `results-explorer/results-explorer/`; `/tmp/linux-wk` was never created. Now a subshell plus `mkdir -p`.
- **P2 #1528 — correct the Python API reference.** It still documented `anonymize_system_profile`, `sanitize_path`, `anonymize_query_metadata`, and `validate_anonymization` (all removed, now `AttributeError`) and six deleted `AnonymizationConfig` fields whose example raises `TypeError`. Replaced with the surviving payload methods plus migration notes.

## Already fixed on develop — resolved, no change

#1516 and #1532 (companion-aware duplicate digest, incremental hashing) by #1532; #1536 (UTC rule epoch); #1525 (slowdown-ratio claims withdrawn); #1675 (table-separator detection); #1528's salt qualification; #1540 (`deferrals.id` deliberately excluded from `_REASSIGNABLE_PK` with a tracked follow-up); #1534's stale-branch limitation (documented in the workflow trigger block).

## Not actionable

15 threads ask to re-author merged commits recorded as `Codex <codex@openai.com>` (#1516, #1517, #1518, #1532, #1534, #1544, #1547, #1665, #1666, #1669, #1671, #1672, #1674, #1678, #1681). Those commits are merged, so re-authoring means rewriting published history on `develop` — a maintainer call, not a sweep's. Worth flagging that this is now 15 in one window, up from one last sweep: something upstream is routinely committing as Codex.

## Verification

- `uv run -- python -m pytest tests/unit/ -x -q` — 27672 passed, 24 skipped
- `npm test -- --run` (results-explorer) — 866 passed across 70 files
- `npm run typecheck` and `tsc -p tsconfig.e2e.json` — clean
- `ruff check` / `ruff format --check` — clean
- `make skill-sync-check` — no new failures