### PR TITLE
fix(uat): preserve failed result bundle paths

### DIFF
--- a/tests/uat/runner.py
+++ b/tests/uat/runner.py
@@ -252,8 +252,13 @@ def run_cell(
             scale=scale,
         )
     else:
-        result_path_str = last_nonempty_output_line(stdout_text) if timeout_result.exit_code == 0 else None
+        # A failed query can still export a result bundle before the CLI exits
+        # nonzero. Preserve that path so reporting/classification can explain
+        # the query failure instead of misclassifying it as missing JSON.
+        result_path_str = last_nonempty_output_line(stdout_text)
         result_path = _resolve_result_path(result_path_str, runs_dir) if result_path_str else None
+        if result_path is not None and (result_path.suffix.lower() != ".json" or not result_path.exists()):
+            result_path = None
     status = _classify(timeout_result)
     submit_state = classify_for_submit(result_path) if result_path is not None else SubmitTerminalState.missing_manifest
     exit_code = timeout_result.exit_code

--- a/tests/uat/test_runner.py
+++ b/tests/uat/test_runner.py
@@ -233,6 +233,21 @@ def test_run_cell_marks_failure(tmp_path: Path):
     assert result.result_path is None
 
 
+def test_run_cell_preserves_result_path_when_failed_child_exports_json(tmp_path: Path):
+    """A nonzero query run with a result bundle remains classifiable as a query failure."""
+    result_path = tmp_path / "benchmark_runs" / "results" / "failed-query.json"
+    _write_result_json(result_path, failed=1)
+    fake_argv = [sys.executable, "-c", f"print({str(result_path)!r}); raise SystemExit(2)"]
+
+    with patch.object(runner, "benchbox_run_argv", return_value=fake_argv):
+        result = runner.run_cell("clickhouse-server", "read_primitives", 0.01, timeout_s=10, log_dir=tmp_path)
+
+    assert result.status == "failed"
+    assert result.exit_code == 2
+    assert result.result_path == result_path
+    assert result.submit_terminal_state == "query_failure"
+
+
 def test_run_cell_diagnostic_rerun_fires_for_empty_stdout_failure(tmp_path: Path):
     captured_quiet = []
 


### PR DESCRIPTION
## Summary
- preserve a result JSON path printed by a non-official UAT child even when it exits nonzero
- require the candidate path to be an existing JSON file before classifying it
- add regression coverage proving a failed ClickHouse-server cell is recorded as a query failure with its result path

## Verification
- `uv run -- python -m pytest -p no:cacheprovider -n 0 tests/uat/test_runner.py -q` (34 passed)
- Ruff check/format passed
- commit hooks passed

## Scope note
This implements the result-path/diagnostic routing work unit. ClickHouse query-rewrite and metadata compatibility work units still require live ClickHouse-server UAT evidence and remain open.

## Tracker
The hosted TODO write path currently fails with `SQLite error: table events has no column named item_id`; tracker claim/work-unit completion remains blocked pending approved hosted schema reconciliation.