### PR TITLE
fix(todo-db): preserve activity fingerprint

### DIFF
--- a/_project/scripts/todo_db_standalone_compat.py
+++ b/_project/scripts/todo_db_standalone_compat.py
@@ -385,7 +385,11 @@ def _delegate_compat_command(argv: list[str], *, command: str, cwd: Path) -> sub
         if guard.returncode:
             return guard
     result = _delegate_extension(argv, cwd=cwd) if command == "renew" else _delegate(argv, command=command, cwd=cwd)
-    if command == "stats" and os.environ.get("BENCHBOX_TODO_DB_STANDALONE") == "1":
+    if (
+        command == "stats"
+        and os.environ.get("BENCHBOX_TODO_DB_STANDALONE") == "1"
+        and not any(value in {"-h", "--help", "--version"} for value in argv)
+    ):
         result = _preserve_stats_activity(result, argv, cwd=cwd)
     if command == "claim" and result.returncode == 0:
         _append_claim_context(result, argv, cwd=cwd)

--- a/_project/scripts/todo_db_standalone_compat.py
+++ b/_project/scripts/todo_db_standalone_compat.py
@@ -278,6 +278,31 @@ def _normalize_findings_banner(result: subprocess.CompletedProcess[str], *, comm
         result.stderr = result.stderr.rstrip("\n") + ("\n" if result.stderr else "") + banner + "\n"
 
 
+def _preserve_stats_activity(
+    result: subprocess.CompletedProcess[str], argv: list[str], *, cwd: Path
+) -> subprocess.CompletedProcess[str]:
+    """Restore BenchBox's activity fingerprint on standalone stats output."""
+    if result.returncode:
+        return result
+    located = _command_index(argv)
+    assert located is not None
+    activity = _delegate_extension(argv[: located[0]] + ["activity"], cwd=cwd)
+    if activity.returncode:
+        return activity
+    try:
+        stats = json.loads(result.stdout)
+        stats.update(json.loads(activity.stdout))
+    except (AttributeError, TypeError, ValueError, json.JSONDecodeError) as exc:
+        return subprocess.CompletedProcess(
+            argv,
+            2,
+            stdout="",
+            stderr=f"error: standalone stats activity payload is invalid: {exc}\n",
+        )
+    result.stdout = _canonical_json(stats)
+    return result
+
+
 def _command_mutates_tracker(argv: list[str], command: str) -> bool:
     if any(value in {"-h", "--help", "--version"} for value in argv):
         return False
@@ -360,6 +385,8 @@ def _delegate_compat_command(argv: list[str], *, command: str, cwd: Path) -> sub
         if guard.returncode:
             return guard
     result = _delegate_extension(argv, cwd=cwd) if command == "renew" else _delegate(argv, command=command, cwd=cwd)
+    if command == "stats" and os.environ.get("BENCHBOX_TODO_DB_STANDALONE") == "1":
+        result = _preserve_stats_activity(result, argv, cwd=cwd)
     if command == "claim" and result.returncode == 0:
         _append_claim_context(result, argv, cwd=cwd)
     if command == "defer" and result.returncode == 2 and " is terminal;" in result.stderr:

--- a/_project/scripts/todo_db_standalone_extensions.py
+++ b/_project/scripts/todo_db_standalone_extensions.py
@@ -51,6 +51,7 @@ def _parser() -> argparse.ArgumentParser:
     freeze.add_argument("--ttl", type=float, default=legacy.DEFAULT_FREEZE_TTL_HOURS)
     freeze.add_argument("--force", action="store_true")
     sub.add_parser("freeze-guard")
+    sub.add_parser("activity")
     return parser
 
 
@@ -142,9 +143,20 @@ def _clear_freeze(tracker: TodoTracker, *, force: bool) -> bool:
 
 def _run(args: argparse.Namespace) -> int:
     actor = args.actor or legacy.default_actor()
-    mode = CredentialMode.READ_ONLY if args.command == "freeze-guard" else CredentialMode.READ_WRITE
+    mode = CredentialMode.READ_ONLY if args.command in {"freeze-guard", "activity"} else CredentialMode.READ_WRITE
     with _open_database(args, mode) as database:
         tracker = TodoTracker(database, actor=actor)
+        if args.command == "activity":
+            print(
+                legacy.json.dumps(
+                    {
+                        "events": legacy.write_activity(tracker.connection),
+                        "stale": bool(getattr(tracker.connection, "stale", False)),
+                    },
+                    sort_keys=True,
+                )
+            )
+            return 0
         if args.command == "freeze-guard":
             live = legacy.get_freeze(tracker.connection)
             if live and live["holder"] != tracker.actor:

--- a/tests/unit/scripts/test_todo_db_standalone_compat.py
+++ b/tests/unit/scripts/test_todo_db_standalone_compat.py
@@ -493,6 +493,11 @@ def test_explicit_missing_local_read_target_is_initialized(monkeypatch: pytest.M
         return CompletedProcess(argv, 0, stdout="{}\n" if command == "stats" else "", stderr="")
 
     monkeypatch.setattr(compat, "_delegate", fake_delegate)
+    monkeypatch.setattr(
+        compat,
+        "_delegate_extension",
+        lambda argv, *, cwd: CompletedProcess(argv, 0, stdout='{"events": {}, "stale": false}\n', stderr=""),
+    )
     monkeypatch.setenv("BENCHBOX_REPO_ROOT", str(tmp_path))
     monkeypatch.setenv("BENCHBOX_TODO_DB_STANDALONE", "1")
     target = tmp_path / "missing.sqlite"
@@ -581,10 +586,34 @@ def test_ready_and_stats_findings_banners_are_stderr_only(
         "_delegate",
         lambda argv, *, command, cwd, capture=True: CompletedProcess(argv, 0, stdout=stdout, stderr=""),
     )
+    monkeypatch.setattr(
+        compat,
+        "_delegate_extension",
+        lambda argv, *, cwd: CompletedProcess(
+            argv,
+            0,
+            stdout=(
+                '{"events": {"count": 1, "last_seq": 1, "latest": "2026-08-11T00:00:00Z", '
+                '"findings": {"count": 2, "last_seq": 2, "latest": "2026-08-11T00:00:01Z"}}, '
+                '"stale": false}\n'
+            ),
+            stderr="",
+        ),
+    )
 
     assert compat.main(["--db", str(tmp_path / "todo.sqlite"), command]) == 0
     captured = capsys.readouterr()
-    assert captured.out == expected_stdout
+    if command == "stats":
+        stats = json.loads(captured.out)
+        assert stats["events"] == {
+            "count": 1,
+            "last_seq": 1,
+            "latest": "2026-08-11T00:00:00Z",
+            "findings": {"count": 2, "last_seq": 2, "latest": "2026-08-11T00:00:01Z"},
+        }
+        assert stats["stale"] is False
+    else:
+        assert captured.out == expected_stdout
     assert captured.err == expected_banner
 
 

--- a/tests/unit/scripts/test_todo_db_standalone_compat.py
+++ b/tests/unit/scripts/test_todo_db_standalone_compat.py
@@ -506,6 +506,33 @@ def test_explicit_missing_local_read_target_is_initialized(monkeypatch: pytest.M
     assert calls == ["init", "stats"]
 
 
+@pytest.mark.parametrize(
+    ("argv", "stdout"), [(["stats", "--help"], "stats help\n"), (["--version", "stats"], "todo-db 0.3.1\n")]
+)
+def test_stats_metadata_skips_activity_lookup(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+    argv: list[str],
+    stdout: str,
+) -> None:
+    monkeypatch.setattr(
+        compat,
+        "_delegate",
+        lambda argv, *, command, cwd, capture=True: CompletedProcess(argv, 0, stdout=stdout, stderr=""),
+    )
+    monkeypatch.setattr(
+        compat,
+        "_delegate_extension",
+        lambda *args, **kwargs: pytest.fail("metadata-only stats must not open the database"),
+    )
+    monkeypatch.setenv("BENCHBOX_REPO_ROOT", str(tmp_path))
+    monkeypatch.setenv("BENCHBOX_TODO_DB_STANDALONE", "1")
+
+    assert compat.main(argv) == 0
+    assert capsys.readouterr().out == stdout
+
+
 def test_existing_local_init_checks_freeze_before_package_command(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:


### PR DESCRIPTION
## Summary
- restore BenchBox `events` and `stale` fields on standalone `todo stats`
- reuse the existing read-only compatibility connection and `write_activity()` helper
- fail closed when the activity payload cannot be read

## Validation
- live hosted `todo stats` returned `stale=false`, item events 8340, findings events 354
- 156 focused wrapper/freeze tests passed
- `make pr-preflight`: 27,762 passed, 19 skipped

This is the prerequisite exposed by the hosted cutover quiescence gate; no restore was attempted.