### PR TITLE
fix(skills): separate TODO skill actions from CLI

### DIFF
--- a/.claude/skills/todo/SKILL.md
+++ b/.claude/skills/todo/SKILL.md
@@ -20,7 +20,7 @@ Use `_project/scripts/todo`. Check that the wrapper supports the command you nee
 * Run `_project/scripts/todo --help` and confirm the subcommand appears.
 * If the subcommand is missing, report the gap and stop.
 
-`prioritize` has no CLI command. It is a skill-only analysis. Follow `references/prioritize.md` and use only the inspect commands it lists.
+Skill-only actions: `prioritize`, `batch`, `handoff`, and `closeout`; follow their guides, not the CLI.
 
 If one request combines review or validation with close-out, perform the
 read-only review and stop at findings under `SHARED/review-protocol/SKILL.md`.
@@ -54,7 +54,7 @@ The `--help` output for the command you chose is the full contract.
 | `prioritize` — skill-only, no CLI command | You rank open items and group by topic | `references/prioritize.md` |
 | `lint` | You review an item | `references/review.md` |
 | `finding candidates`, `finding triage`, `finding import`, `finding sync`, `finding promote` | You triage findings | `references/implement.md` |
-| `batch` — a set of related TODOs | You implement several TODOs in order | `references/batch.md` |
+| `batch` — skill-only, no CLI command | You implement several TODOs in order | `references/batch.md` |
 | `handoff` — skill-only, no CLI command | You create a self-contained batch handoff | `references/handoff.md` |
 | `closeout` — skill-only, no CLI command | You remediate a separately reviewed batch and close its items | `references/closeout.md` |
 | `help` | You need the action list | This table |

--- a/.claude/skills/todo/references/handoff.md
+++ b/.claude/skills/todo/references/handoff.md
@@ -6,8 +6,8 @@ reviewed batch. Assume the next session knows only what the prompt states.
 Include these sections in order:
 
 1. **Objective and item set** — batch label, every TODO id, and whether the
-   next action is the standalone skill action `todo batch` or the standalone
-   skill action `todo closeout`; neither is a project-wrapper command.
+   next action is the Todo skill's `batch` action or `closeout` action; neither
+   is a CLI command.
 2. **Tracker preflight** — how to reach the tracker and confirm the intended
    backend before any write.
 3. **Current state** — live PR states, branch names, required checks, and the

--- a/.claude/skills/todo/skill.yaml
+++ b/.claude/skills/todo/skill.yaml
@@ -9,6 +9,4 @@ category: workflow
 targets:
   claude: true
   codex: true
-standalone_only_commands:
-  batch: 0.9.0
-  closeout: 0.9.0
+standalone_only_commands: {}

--- a/skill-sync.lock
+++ b/skill-sync.lock
@@ -1,16 +1,16 @@
 {
   "version": 1,
-  "lockedAt": "2026-08-12T12:08:21.099Z",
+  "lockedAt": "2026-08-12T16:12:31.186Z",
   "skills": {
     "blog": {
       "source": {
         "type": "git",
         "name": "canonical",
         "url": "https://github.com/joeharris76/skill-sync-skills.git",
-        "ref": "78a17e9ea0513aba51663226ef0292a815ac48e3",
+        "ref": "7b63719927992bd7f7fff6b90449bbba2bb94ba3",
         "subdir": "skills",
-        "revision": "78a17e9ea0513aba51663226ef0292a815ac48e3",
-        "fetchedAt": "2026-08-12T12:08:12.743Z"
+        "revision": "7b63719927992bd7f7fff6b90449bbba2bb94ba3",
+        "fetchedAt": "2026-08-12T16:12:21.558Z"
       },
       "installMode": "mirror",
       "files": {
@@ -61,10 +61,10 @@
         "type": "git",
         "name": "canonical",
         "url": "https://github.com/joeharris76/skill-sync-skills.git",
-        "ref": "78a17e9ea0513aba51663226ef0292a815ac48e3",
+        "ref": "7b63719927992bd7f7fff6b90449bbba2bb94ba3",
         "subdir": "skills",
-        "revision": "78a17e9ea0513aba51663226ef0292a815ac48e3",
-        "fetchedAt": "2026-08-12T12:08:13.586Z"
+        "revision": "7b63719927992bd7f7fff6b90449bbba2bb94ba3",
+        "fetchedAt": "2026-08-12T16:12:23.386Z"
       },
       "installMode": "mirror",
       "files": {
@@ -115,10 +115,10 @@
         "type": "git",
         "name": "canonical",
         "url": "https://github.com/joeharris76/skill-sync-skills.git",
-        "ref": "78a17e9ea0513aba51663226ef0292a815ac48e3",
+        "ref": "7b63719927992bd7f7fff6b90449bbba2bb94ba3",
         "subdir": "skills",
-        "revision": "78a17e9ea0513aba51663226ef0292a815ac48e3",
-        "fetchedAt": "2026-08-12T12:08:14.457Z"
+        "revision": "7b63719927992bd7f7fff6b90449bbba2bb94ba3",
+        "fetchedAt": "2026-08-12T16:12:24.201Z"
       },
       "installMode": "mirror",
       "files": {
@@ -161,10 +161,10 @@
         "type": "git",
         "name": "canonical",
         "url": "https://github.com/joeharris76/skill-sync-skills.git",
-        "ref": "78a17e9ea0513aba51663226ef0292a815ac48e3",
+        "ref": "7b63719927992bd7f7fff6b90449bbba2bb94ba3",
         "subdir": "skills",
-        "revision": "78a17e9ea0513aba51663226ef0292a815ac48e3",
-        "fetchedAt": "2026-08-12T12:08:16.284Z"
+        "revision": "7b63719927992bd7f7fff6b90449bbba2bb94ba3",
+        "fetchedAt": "2026-08-12T16:12:25.881Z"
       },
       "installMode": "mirror",
       "files": {
@@ -223,10 +223,10 @@
         "type": "git",
         "name": "canonical",
         "url": "https://github.com/joeharris76/skill-sync-skills.git",
-        "ref": "78a17e9ea0513aba51663226ef0292a815ac48e3",
+        "ref": "7b63719927992bd7f7fff6b90449bbba2bb94ba3",
         "subdir": "skills",
-        "revision": "78a17e9ea0513aba51663226ef0292a815ac48e3",
-        "fetchedAt": "2026-08-12T12:08:17.085Z"
+        "revision": "7b63719927992bd7f7fff6b90449bbba2bb94ba3",
+        "fetchedAt": "2026-08-12T16:12:26.793Z"
       },
       "installMode": "mirror",
       "files": {
@@ -285,10 +285,10 @@
         "type": "git",
         "name": "canonical",
         "url": "https://github.com/joeharris76/skill-sync-skills.git",
-        "ref": "78a17e9ea0513aba51663226ef0292a815ac48e3",
+        "ref": "7b63719927992bd7f7fff6b90449bbba2bb94ba3",
         "subdir": "skills",
-        "revision": "78a17e9ea0513aba51663226ef0292a815ac48e3",
-        "fetchedAt": "2026-08-12T12:08:21.032Z"
+        "revision": "7b63719927992bd7f7fff6b90449bbba2bb94ba3",
+        "fetchedAt": "2026-08-12T16:12:31.026Z"
       },
       "installMode": "mirror",
       "files": {
@@ -345,10 +345,10 @@
         "type": "git",
         "name": "canonical",
         "url": "https://github.com/joeharris76/skill-sync-skills.git",
-        "ref": "78a17e9ea0513aba51663226ef0292a815ac48e3",
+        "ref": "7b63719927992bd7f7fff6b90449bbba2bb94ba3",
         "subdir": "skills",
-        "revision": "78a17e9ea0513aba51663226ef0292a815ac48e3",
-        "fetchedAt": "2026-08-12T12:08:17.914Z"
+        "revision": "7b63719927992bd7f7fff6b90449bbba2bb94ba3",
+        "fetchedAt": "2026-08-12T16:12:27.622Z"
       },
       "installMode": "mirror",
       "files": {
@@ -371,10 +371,10 @@
         "type": "git",
         "name": "canonical",
         "url": "https://github.com/joeharris76/skill-sync-skills.git",
-        "ref": "78a17e9ea0513aba51663226ef0292a815ac48e3",
+        "ref": "7b63719927992bd7f7fff6b90449bbba2bb94ba3",
         "subdir": "skills",
-        "revision": "78a17e9ea0513aba51663226ef0292a815ac48e3",
-        "fetchedAt": "2026-08-12T12:08:15.356Z"
+        "revision": "7b63719927992bd7f7fff6b90449bbba2bb94ba3",
+        "fetchedAt": "2026-08-12T16:12:25.004Z"
       },
       "installMode": "mirror",
       "files": {
@@ -413,10 +413,10 @@
         "type": "git",
         "name": "canonical",
         "url": "https://github.com/joeharris76/skill-sync-skills.git",
-        "ref": "78a17e9ea0513aba51663226ef0292a815ac48e3",
+        "ref": "7b63719927992bd7f7fff6b90449bbba2bb94ba3",
         "subdir": "skills",
-        "revision": "78a17e9ea0513aba51663226ef0292a815ac48e3",
-        "fetchedAt": "2026-08-12T12:08:18.748Z"
+        "revision": "7b63719927992bd7f7fff6b90449bbba2bb94ba3",
+        "fetchedAt": "2026-08-12T16:12:28.479Z"
       },
       "installMode": "mirror",
       "files": {
@@ -435,10 +435,10 @@
         "type": "git",
         "name": "canonical",
         "url": "https://github.com/joeharris76/skill-sync-skills.git",
-        "ref": "78a17e9ea0513aba51663226ef0292a815ac48e3",
+        "ref": "7b63719927992bd7f7fff6b90449bbba2bb94ba3",
         "subdir": "skills",
-        "revision": "78a17e9ea0513aba51663226ef0292a815ac48e3",
-        "fetchedAt": "2026-08-12T12:08:19.571Z"
+        "revision": "7b63719927992bd7f7fff6b90449bbba2bb94ba3",
+        "fetchedAt": "2026-08-12T16:12:29.353Z"
       },
       "installMode": "mirror",
       "files": {

--- a/skill-sync.lock
+++ b/skill-sync.lock
@@ -1,16 +1,16 @@
 {
   "version": 1,
-  "lockedAt": "2026-08-12T03:10:25.919Z",
+  "lockedAt": "2026-08-12T12:08:21.099Z",
   "skills": {
     "blog": {
       "source": {
         "type": "git",
         "name": "canonical",
         "url": "https://github.com/joeharris76/skill-sync-skills.git",
-        "ref": "6ef11c58e61b741b4125b40a553f425973a234e2",
+        "ref": "78a17e9ea0513aba51663226ef0292a815ac48e3",
         "subdir": "skills",
-        "revision": "6ef11c58e61b741b4125b40a553f425973a234e2",
-        "fetchedAt": "2026-08-12T03:10:17.151Z"
+        "revision": "78a17e9ea0513aba51663226ef0292a815ac48e3",
+        "fetchedAt": "2026-08-12T12:08:12.743Z"
       },
       "installMode": "mirror",
       "files": {
@@ -61,10 +61,10 @@
         "type": "git",
         "name": "canonical",
         "url": "https://github.com/joeharris76/skill-sync-skills.git",
-        "ref": "6ef11c58e61b741b4125b40a553f425973a234e2",
+        "ref": "78a17e9ea0513aba51663226ef0292a815ac48e3",
         "subdir": "skills",
-        "revision": "6ef11c58e61b741b4125b40a553f425973a234e2",
-        "fetchedAt": "2026-08-12T03:10:18.267Z"
+        "revision": "78a17e9ea0513aba51663226ef0292a815ac48e3",
+        "fetchedAt": "2026-08-12T12:08:13.586Z"
       },
       "installMode": "mirror",
       "files": {
@@ -115,10 +115,10 @@
         "type": "git",
         "name": "canonical",
         "url": "https://github.com/joeharris76/skill-sync-skills.git",
-        "ref": "6ef11c58e61b741b4125b40a553f425973a234e2",
+        "ref": "78a17e9ea0513aba51663226ef0292a815ac48e3",
         "subdir": "skills",
-        "revision": "6ef11c58e61b741b4125b40a553f425973a234e2",
-        "fetchedAt": "2026-08-12T03:10:19.683Z"
+        "revision": "78a17e9ea0513aba51663226ef0292a815ac48e3",
+        "fetchedAt": "2026-08-12T12:08:14.457Z"
       },
       "installMode": "mirror",
       "files": {
@@ -161,10 +161,10 @@
         "type": "git",
         "name": "canonical",
         "url": "https://github.com/joeharris76/skill-sync-skills.git",
-        "ref": "6ef11c58e61b741b4125b40a553f425973a234e2",
+        "ref": "78a17e9ea0513aba51663226ef0292a815ac48e3",
         "subdir": "skills",
-        "revision": "6ef11c58e61b741b4125b40a553f425973a234e2",
-        "fetchedAt": "2026-08-12T03:10:21.281Z"
+        "revision": "78a17e9ea0513aba51663226ef0292a815ac48e3",
+        "fetchedAt": "2026-08-12T12:08:16.284Z"
       },
       "installMode": "mirror",
       "files": {
@@ -181,8 +181,8 @@
           "size": 1894
         },
         "references/handoff.md": {
-          "sha256": "6b90193cb0411471ba2727baf7d14ef44d6fb4eca65636bc0b3f31bd58af291a",
-          "size": 1704
+          "sha256": "3c35c0001a14dae4c000750de7ccc75f89ee89daee6bd426a1677c894730dfe9",
+          "size": 1657
         },
         "references/ideate.md": {
           "sha256": "00733f03658b2f215eaeebc25739a4ab7d57898fed162045e18f0c389cdc2609",
@@ -209,12 +209,12 @@
           "size": 598
         },
         "SKILL.md": {
-          "sha256": "d45d4c905dcf92985643a0f7b036d45e2fde4fb9bf732f6f6cc2b9a62bac6f23",
-          "size": 4330
+          "sha256": "0adbddfca726a6b0ba61c923fdbb06e50b6518603bce1ef237ca9cda281aa277",
+          "size": 4298
         },
         "skill.yaml": {
-          "sha256": "d29288a7968d6d04ffc07f8b303c881a13aa4d4f6c3cd79dd0d0fcb08aad7628",
-          "size": 243
+          "sha256": "e2c0b40d9935492621e6d21ab216a6227f4bae8f3808ed004d995d0f1b5bbff3",
+          "size": 213
         }
       }
     },
@@ -223,10 +223,10 @@
         "type": "git",
         "name": "canonical",
         "url": "https://github.com/joeharris76/skill-sync-skills.git",
-        "ref": "6ef11c58e61b741b4125b40a553f425973a234e2",
+        "ref": "78a17e9ea0513aba51663226ef0292a815ac48e3",
         "subdir": "skills",
-        "revision": "6ef11c58e61b741b4125b40a553f425973a234e2",
-        "fetchedAt": "2026-08-12T03:10:22.069Z"
+        "revision": "78a17e9ea0513aba51663226ef0292a815ac48e3",
+        "fetchedAt": "2026-08-12T12:08:17.085Z"
       },
       "installMode": "mirror",
       "files": {
@@ -285,10 +285,10 @@
         "type": "git",
         "name": "canonical",
         "url": "https://github.com/joeharris76/skill-sync-skills.git",
-        "ref": "6ef11c58e61b741b4125b40a553f425973a234e2",
+        "ref": "78a17e9ea0513aba51663226ef0292a815ac48e3",
         "subdir": "skills",
-        "revision": "6ef11c58e61b741b4125b40a553f425973a234e2",
-        "fetchedAt": "2026-08-12T03:10:25.856Z"
+        "revision": "78a17e9ea0513aba51663226ef0292a815ac48e3",
+        "fetchedAt": "2026-08-12T12:08:21.032Z"
       },
       "installMode": "mirror",
       "files": {
@@ -322,7 +322,7 @@
         "ref": "6d09682dabe2ff0d68f400d60f8ba8b87f8c02aa",
         "subdir": "skills",
         "revision": "6d09682dabe2ff0d68f400d60f8ba8b87f8c02aa",
-        "fetchedAt": "2026-08-12T01:38:30.666Z"
+        "fetchedAt": "2026-08-12T12:06:11.979Z"
       },
       "installMode": "mirror",
       "files": {
@@ -345,10 +345,10 @@
         "type": "git",
         "name": "canonical",
         "url": "https://github.com/joeharris76/skill-sync-skills.git",
-        "ref": "6ef11c58e61b741b4125b40a553f425973a234e2",
+        "ref": "78a17e9ea0513aba51663226ef0292a815ac48e3",
         "subdir": "skills",
-        "revision": "6ef11c58e61b741b4125b40a553f425973a234e2",
-        "fetchedAt": "2026-08-12T03:10:22.868Z"
+        "revision": "78a17e9ea0513aba51663226ef0292a815ac48e3",
+        "fetchedAt": "2026-08-12T12:08:17.914Z"
       },
       "installMode": "mirror",
       "files": {
@@ -371,10 +371,10 @@
         "type": "git",
         "name": "canonical",
         "url": "https://github.com/joeharris76/skill-sync-skills.git",
-        "ref": "6ef11c58e61b741b4125b40a553f425973a234e2",
+        "ref": "78a17e9ea0513aba51663226ef0292a815ac48e3",
         "subdir": "skills",
-        "revision": "6ef11c58e61b741b4125b40a553f425973a234e2",
-        "fetchedAt": "2026-08-12T03:10:20.500Z"
+        "revision": "78a17e9ea0513aba51663226ef0292a815ac48e3",
+        "fetchedAt": "2026-08-12T12:08:15.356Z"
       },
       "installMode": "mirror",
       "files": {
@@ -413,10 +413,10 @@
         "type": "git",
         "name": "canonical",
         "url": "https://github.com/joeharris76/skill-sync-skills.git",
-        "ref": "6ef11c58e61b741b4125b40a553f425973a234e2",
+        "ref": "78a17e9ea0513aba51663226ef0292a815ac48e3",
         "subdir": "skills",
-        "revision": "6ef11c58e61b741b4125b40a553f425973a234e2",
-        "fetchedAt": "2026-08-12T03:10:23.664Z"
+        "revision": "78a17e9ea0513aba51663226ef0292a815ac48e3",
+        "fetchedAt": "2026-08-12T12:08:18.748Z"
       },
       "installMode": "mirror",
       "files": {
@@ -435,10 +435,10 @@
         "type": "git",
         "name": "canonical",
         "url": "https://github.com/joeharris76/skill-sync-skills.git",
-        "ref": "6ef11c58e61b741b4125b40a553f425973a234e2",
+        "ref": "78a17e9ea0513aba51663226ef0292a815ac48e3",
         "subdir": "skills",
-        "revision": "6ef11c58e61b741b4125b40a553f425973a234e2",
-        "fetchedAt": "2026-08-12T03:10:24.454Z"
+        "revision": "78a17e9ea0513aba51663226ef0292a815ac48e3",
+        "fetchedAt": "2026-08-12T12:08:19.571Z"
       },
       "installMode": "mirror",
       "files": {

--- a/skill-sync.yaml
+++ b/skill-sync.yaml
@@ -3,7 +3,7 @@ sources:
   - name: canonical
     type: git
     url: https://github.com/joeharris76/skill-sync-skills.git
-    ref: 6ef11c58e61b741b4125b40a553f425973a234e2
+    ref: 78a17e9ea0513aba51663226ef0292a815ac48e3
     subdir: skills
   - name: product
     type: git

--- a/skill-sync.yaml
+++ b/skill-sync.yaml
@@ -3,7 +3,7 @@ sources:
   - name: canonical
     type: git
     url: https://github.com/joeharris76/skill-sync-skills.git
-    ref: 78a17e9ea0513aba51663226ef0292a815ac48e3
+    ref: 7b63719927992bd7f7fff6b90449bbba2bb94ba3
     subdir: skills
   - name: product
     type: git

--- a/tests/unit/scripts/test_todo_wrapper.py
+++ b/tests/unit/scripts/test_todo_wrapper.py
@@ -51,6 +51,11 @@ def _declared_standalone_only() -> set[str]:
     return set(declared)
 
 
+def _documented_skill_only_actions(text: str) -> set[str]:
+    """Actions routed by the skill rather than either TODO CLI surface."""
+    return set(re.findall(r"\| `([a-z][a-z-]*)` — skill-only", text))
+
+
 def _unknown_commands(text: str, declared: set[str]) -> set[str]:
     """Referenced `todo <cmd>` forms that are neither wrapper handlers nor declared."""
     referenced = set(re.findall(r"`todo ([a-z][a-z-]*)", text))
@@ -349,6 +354,18 @@ class TestSkillThinness:
         # in either direction; the sets must stay disjoint.
         overlap = _declared_standalone_only() & set(todo_db._HANDLERS)
         assert not overlap, f"standalone_only_commands overlaps wrapper handlers: {sorted(overlap)}"
+
+    def test_skill_only_actions_are_not_cli_commands(self):
+        text = _read_skill_package()
+        skill_only = _documented_skill_only_actions(text)
+        expected = {"prioritize", "batch", "handoff", "closeout"}
+        assert expected <= skill_only
+        assert not (_declared_standalone_only() & skill_only)
+        for action in sorted(skill_only):
+            assert not re.search(rf"_project/scripts/todo\s+{action}\b", text), (
+                f"skill-only `{action}` shown as a project-wrapper invocation"
+            )
+            assert not re.search(rf"`todo {action}\b", text), f"skill-only `{action}` shown as a TODO CLI invocation"
 
     def test_undeclared_unsupported_command_is_flagged(self):
         # Without a declaration the boundary must trip — the declaration is the


### PR DESCRIPTION
## Summary

- classify `prioritize`, `batch`, `handoff`, and `closeout` as skill-only actions
- remove the incorrect standalone CLI declarations for `batch` and `closeout`
- update the handoff wording so it does not present skill actions as `todo <command>` invocations
- make the thin-wrapper contract test cover wrapper CLI, standalone CLI, and skill-only categories
- pin the consumer to the merged canonical skill-sync revision `7b63719927992bd7f7fff6b90449bbba2bb94ba3`
- regenerate the consumer lock metadata

This follow-up corrects the namespace issue identified during review and addresses the publication-order review comment. Canonical source PR: [skill-sync #36](https://github.com/joeharris76/skill-sync-skills/pull/36), merged as `7b63719927992bd7f7fff6b90449bbba2bb94ba3`.

## Verification

- `make pr-preflight` — 27,769 passed, 19 skipped
- `uv run -- python -m pytest -m medium -q tests/unit/scripts/test_todo_wrapper.py` — 25 passed
- `uv run -- ruff check tests/unit/scripts/test_todo_wrapper.py`
- `uv run -- ruff format --check tests/unit/scripts/test_todo_wrapper.py`
- `node /Users/joe/Developer/skill-sync/dist/cli/index.js verify --project .`
