### PR TITLE
fix/one engine mcp run service adoption

### DIFF
--- a/benchbox/cli/commands/run.py
+++ b/benchbox/cli/commands/run.py
@@ -77,7 +77,7 @@ from benchbox.core.benchmark_registry import (
     presort_capable_benchmarks,
 )
 from benchbox.core.config import DatabaseConfig
-from benchbox.core.constants import QUERY_PHASES, RUN_MODES, VALID_PHASES
+from benchbox.core.constants import RUN_MODES, VALID_PHASES
 from benchbox.core.platform_registry import PlatformRegistry
 from benchbox.core.results.provenance import FUNDING_SOURCES, RESULT_SOURCES
 from benchbox.core.results.status import result_cli_failure_reason, result_non_clean_reason
@@ -511,26 +511,10 @@ class BenchmarkOptionParamType(click.ParamType):
 
 
 def _derive_execution_type(phases: list[str]) -> str:
-    """Derive benchmark execution type from the requested phase list."""
-    query_phases = set(QUERY_PHASES)
-    selected_query_phases = set(phases) & query_phases
-    if selected_query_phases:
-        # Any mixed query-phase request should use combined mode so the adapter
-        # can execute exactly the requested subset of query phases.
-        if len(selected_query_phases) > 1:
-            return "combined"
-        if "power" in selected_query_phases:
-            return "power"
-        if "throughput" in selected_query_phases:
-            return "throughput"
-        if "maintenance" in selected_query_phases:
-            return "maintenance"
-        return "standard"
-    if phases == ["load"] or ("load" in phases and not (set(phases) & query_phases)):
-        return "load_only"
-    if phases == ["generate"] or ("generate" in phases and not (set(phases) & ({"load"} | query_phases))):
-        return "data_only"
-    return "standard"
+    """Derive benchmark execution type through the shared core service."""
+    from benchbox.core.run_service import _map_phases_to_execution_type
+
+    return _map_phases_to_execution_type(phases)
 
 
 def _describe_platform_options(platform_names: Iterable[str]) -> None:

--- a/benchbox/core/run_service.py
+++ b/benchbox/core/run_service.py
@@ -155,6 +155,15 @@ class RunPlan:
     resolved_mode: str | None = None
 
 
+@dataclass(frozen=True)
+class UnsupportedExecutionMode:
+    """Surface-neutral description of an unsupported platform mode."""
+
+    platform: str
+    mode: str
+    supported: tuple[str, ...]
+
+
 def resolve_run_config(
     config: BenchmarkConfig,
     *,
@@ -351,30 +360,14 @@ def execute_run(
 
 
 def _translate_platform_options_for_adapter(platform: str, options: dict) -> dict:
-    """Translate validated MCP-style options to adapter kwargs (duckdb/databricks).
+    """Translate validated platform options to adapter kwargs.
 
-    This is the non-MCP-specific part of the former
-    ``_prepare_adapter_platform_options``. ClickHouse profile resolution stays
-    surface-owned (it needs server config) and is handled by the MCP adapter
-    factory closure; this function handles the generic duckdb/databricks
-    rewrites that are the same regardless of surface.
+    ClickHouse profile resolution stays surface-owned because it needs server
+    configuration. This function handles generic DuckDB and Databricks
+    rewrites that are independent of the calling surface.
     """
-    from benchbox.mcp.schemas import build_databricks_clustering_intent
-
-    # ClickHouse profile is surface-owned but we handle it here for
-    # backwards compatibility with tests that call the core helper directly.
-    # Lazy import avoids hard layering violation at import time.
     normalized = dict(options)
     platform_name = platform.lower().removesuffix("-df")
-    if platform_name in {"clickhouse", "clickhouse-server"} and "connection_profile" in normalized:
-        try:
-            from benchbox.mcp.schemas import resolve_clickhouse_connection_profile
-
-            _profile = resolve_clickhouse_connection_profile(str(normalized.pop("connection_profile")))
-            normalized["port"] = _profile["port"]
-            normalized["secure"] = _profile["secure"]
-        except Exception:
-            pass
     if platform_name == "duckdb" and "threads" in normalized:
         normalized["thread_limit"] = normalized.pop("threads")
     if platform_name == "databricks":
@@ -387,10 +380,38 @@ def _translate_platform_options_for_adapter(platform: str, options: dict) -> dic
     return normalized
 
 
-def _resolve_mode_with_registry(platform: str, mode: str | None):
-    """Validate mode against PlatformRegistry, mirroring former MCP helper."""
-    from benchbox.mcp.errors import make_unsupported_mode_error
+def build_databricks_clustering_intent(options: dict[str, object]):
+    """Build a validated Databricks layout intent without surface coupling."""
+    strategy = options.get("databricks_clustering_strategy")
+    columns = options.get("liquid_clustering_columns")
+    if strategy is None and columns is None:
+        return None
 
+    from benchbox.core.tuning.interface import UnifiedTuningConfiguration
+
+    tuning_config = UnifiedTuningConfiguration()
+    platform_optimizations = tuning_config.platform_optimizations
+    if strategy is not None:
+        strategy = str(strategy).lower()
+        platform_optimizations.databricks_clustering_strategy = strategy
+        platform_optimizations.liquid_clustering_enabled = strategy in {
+            "liquid_clustering",
+            "liquid_clustering_auto",
+        }
+        platform_optimizations.physical_rendering_id = None
+    if columns is not None:
+        parsed_columns = [column.strip() for column in str(columns).split(",") if column.strip()]
+        platform_optimizations.liquid_clustering_columns = parsed_columns
+        platform_optimizations.liquid_clustering_enabled = bool(parsed_columns)
+        if parsed_columns and strategy is None:
+            platform_optimizations.databricks_clustering_strategy = "liquid_clustering"
+
+    platform_optimizations.__post_init__()
+    return tuning_config
+
+
+def _resolve_mode_with_registry(platform: str, mode: str | None):
+    """Resolve a requested mode against the shared platform registry."""
     if mode is not None:
         mode = mode.lower()
         if mode in ("datagen", "generate"):
@@ -410,7 +431,7 @@ def _resolve_mode_with_registry(platform: str, mode: str | None):
     supported.append("data_only")
     if mode is not None:
         if not PlatformRegistry.supports_mode(base_platform, mode):
-            return mode, make_unsupported_mode_error(platform, mode, supported)
+            return mode, UnsupportedExecutionMode(platform, mode, tuple(supported))
         return mode, None
     if platform_lower.endswith("-df"):
         return "dataframe", None
@@ -418,22 +439,23 @@ def _resolve_mode_with_registry(platform: str, mode: str | None):
 
 
 def _map_phases_to_execution_type(phases: list[str]) -> str:
-    """Map phases to test_execution_type (former MCP helper, now core-owned)."""
-    from benchbox.core.constants import QUERY_PHASES
-
+    """Map the requested phases to the shared benchmark execution type."""
     phases_set = set(phases)
     query_phases = set(QUERY_PHASES)
-    if phases_set & query_phases:
-        if "power" in phases_set and "throughput" in phases_set and "maintenance" in phases_set:
+    selected_query_phases = phases_set & query_phases
+    if selected_query_phases:
+        # Any mixed query-phase request must use combined mode so the runner
+        # executes exactly the requested subset instead of silently selecting
+        # the first phase in a priority chain.
+        if len(selected_query_phases) > 1:
             return "combined"
-        elif "power" in phases_set:
+        if "power" in selected_query_phases:
             return "power"
-        elif "throughput" in phases_set:
+        if "throughput" in selected_query_phases:
             return "throughput"
-        elif "maintenance" in phases_set:
+        if "maintenance" in selected_query_phases:
             return "maintenance"
-        else:
-            return "standard"
+        return "standard"
     elif phases == ["load"] or ("load" in phases_set and not phases_set & query_phases):
         return "load_only"
     elif phases == ["generate"] or ("generate" in phases_set and not phases_set & ({"load"} | query_phases)):
@@ -455,6 +477,8 @@ __all__ = [
     "resolve_validation_options",
     "stamp_requested_phases",
     "_translate_platform_options_for_adapter",
+    "build_databricks_clustering_intent",
     "_resolve_mode_with_registry",
+    "UnsupportedExecutionMode",
     "_map_phases_to_execution_type",
 ]

--- a/benchbox/core/run_service.py
+++ b/benchbox/core/run_service.py
@@ -345,6 +345,103 @@ def execute_run(
     return result
 
 
+# ---------------------------------------------------------------------------
+# Helpers migrated from MCP for one-engine (w1)
+# ---------------------------------------------------------------------------
+
+
+def _translate_platform_options_for_adapter(platform: str, options: dict) -> dict:
+    """Translate validated MCP-style options to adapter kwargs (duckdb/databricks).
+
+    This is the non-MCP-specific part of the former
+    ``_prepare_adapter_platform_options``. ClickHouse profile resolution stays
+    surface-owned (it needs server config) and is handled by the MCP adapter
+    factory closure; this function handles the generic duckdb/databricks
+    rewrites that are the same regardless of surface.
+    """
+    from benchbox.mcp.schemas import build_databricks_clustering_intent
+
+    # ClickHouse profile is surface-owned but we handle it here for
+    # backwards compatibility with tests that call the core helper directly.
+    # Lazy import avoids hard layering violation at import time.
+    normalized = dict(options)
+    platform_name = platform.lower().removesuffix("-df")
+    if platform_name in {"clickhouse", "clickhouse-server"} and "connection_profile" in normalized:
+        try:
+            from benchbox.mcp.schemas import resolve_clickhouse_connection_profile
+
+            _profile = resolve_clickhouse_connection_profile(str(normalized.pop("connection_profile")))
+            normalized["port"] = _profile["port"]
+            normalized["secure"] = _profile["secure"]
+        except Exception:
+            pass
+    if platform_name == "duckdb" and "threads" in normalized:
+        normalized["thread_limit"] = normalized.pop("threads")
+    if platform_name == "databricks":
+        tuning_config = build_databricks_clustering_intent(normalized)
+        if tuning_config is not None:
+            normalized.pop("databricks_clustering_strategy", None)
+            normalized.pop("liquid_clustering_columns", None)
+            normalized["tuning_config"] = tuning_config
+            normalized["tuning_enabled"] = True
+    return normalized
+
+
+def _resolve_mode_with_registry(platform: str, mode: str | None):
+    """Validate mode against PlatformRegistry, mirroring former MCP helper."""
+    from benchbox.mcp.errors import make_unsupported_mode_error
+
+    if mode is not None:
+        mode = mode.lower()
+        if mode in ("datagen", "generate"):
+            mode = "data_only"
+    if mode == "data_only":
+        return "data_only", None
+    platform_lower = platform.lower()
+    base_platform = platform_lower.replace("-df", "")
+    caps = PlatformRegistry.get_platform_capabilities(base_platform)
+    if caps is None:
+        return mode or "sql", None
+    supported = []
+    if caps.supports_sql:
+        supported.append("sql")
+    if caps.supports_dataframe:
+        supported.append("dataframe")
+    supported.append("data_only")
+    if mode is not None:
+        if not PlatformRegistry.supports_mode(base_platform, mode):
+            return mode, make_unsupported_mode_error(platform, mode, supported)
+        return mode, None
+    if platform_lower.endswith("-df"):
+        return "dataframe", None
+    return caps.default_mode, None
+
+
+def _map_phases_to_execution_type(phases: list[str]) -> str:
+    """Map phases to test_execution_type (former MCP helper, now core-owned)."""
+    from benchbox.core.constants import QUERY_PHASES
+
+    phases_set = set(phases)
+    query_phases = set(QUERY_PHASES)
+    if phases_set & query_phases:
+        if "power" in phases_set and "throughput" in phases_set and "maintenance" in phases_set:
+            return "combined"
+        elif "power" in phases_set:
+            return "power"
+        elif "throughput" in phases_set:
+            return "throughput"
+        elif "maintenance" in phases_set:
+            return "maintenance"
+        else:
+            return "standard"
+    elif phases == ["load"] or ("load" in phases_set and not phases_set & query_phases):
+        return "load_only"
+    elif phases == ["generate"] or ("generate" in phases_set and not phases_set & ({"load"} | query_phases)):
+        return "data_only"
+    else:
+        return "standard"
+
+
 __all__ = [
     "AdapterFactory",
     "RunPlan",
@@ -357,4 +454,7 @@ __all__ = [
     "resolve_run_config",
     "resolve_validation_options",
     "stamp_requested_phases",
+    "_translate_platform_options_for_adapter",
+    "_resolve_mode_with_registry",
+    "_map_phases_to_execution_type",
 ]

--- a/benchbox/core/runner/runner.py
+++ b/benchbox/core/runner/runner.py
@@ -733,6 +733,10 @@ def _build_run_config_from_options(
         requested_sources=options.get("platform_option_sources"),
         database_options=_database_platform_options(database_config),
     )
+    run_options: dict[str, Any] = {}
+    requested_phases = options.get("requested_phases")
+    if requested_phases:
+        run_options["requested_phases"] = list(requested_phases)
     return RunConfig(
         benchmark=benchmark_config.name,
         query_subset=benchmark_config.queries,
@@ -742,6 +746,7 @@ def _build_run_config_from_options(
         seed=(int(seed_raw) if seed_raw is not None else None),
         platform_options=platform_options or None,
         platform_option_sources=platform_option_sources or None,
+        options=run_options,
         connection={
             "database_path": (platform_config or {}).get("database_path"),
         },

--- a/benchbox/mcp/jobs.py
+++ b/benchbox/mcp/jobs.py
@@ -20,10 +20,6 @@ from mcp.shared.exceptions import MCPError
 from mcp.types import ToolAnnotations
 
 from benchbox.core.benchmark_registry import get_all_benchmarks
-from benchbox.core.platform_config import get_platform_config
-from benchbox.core.run_service import SilentVerbosity, execute_run
-from benchbox.core.schemas import BenchmarkConfig, DatabaseConfig, ExecutionContext
-from benchbox.core.system import SystemProfiler
 from benchbox.mcp.schemas import MCPValidationError, validate_phases, validate_platform_options
 from benchbox.mcp.security import (
     AUTHORIZATION_ERROR,
@@ -33,11 +29,11 @@ from benchbox.mcp.security import (
     authenticated_principal,
 )
 from benchbox.mcp.tools.benchmark import (
-    _attach_summary_charts,
-    _export_and_build_payload,
+    _execute_mcp_run_via_core,
     _generate_data_impl,
+    _resolve_mcp_mode_with_registry,
 )
-from benchbox.utils.clock import elapsed_seconds, mono_time, utc_now
+from benchbox.utils.clock import mono_time, utc_now
 
 logger = logging.getLogger(__name__)
 
@@ -643,43 +639,7 @@ class DurableJobWorker:
         # ``mcp_metadata + data_generation`` shape expected by durable callers.
         # The core ``execute_run`` data_only path produces ``BenchmarkResults``,
         # not this shape, so we keep the surface-owned helper until w3 cleans it.
-        from benchbox.core.platform_registry import PlatformRegistry
-
-        _mode_input = mode
-        if _mode_input is not None:
-            _mode_input = _mode_input.lower()
-            if _mode_input in ("datagen", "generate"):
-                _mode_input = "data_only"
-        if _mode_input == "data_only":
-            resolved_mode, mode_error = "data_only", None
-        else:
-            _pl = platform.lower()
-            _base = _pl.replace("-df", "")
-            _caps = PlatformRegistry.get_platform_capabilities(_base)
-            if _caps is None:
-                resolved_mode, mode_error = _mode_input or "sql", None
-            else:
-                _sup = []
-                if _caps.supports_sql:
-                    _sup.append("sql")
-                if _caps.supports_dataframe:
-                    _sup.append("dataframe")
-                _sup.append("data_only")
-                if _mode_input is not None:
-                    if not PlatformRegistry.supports_mode(_base, _mode_input):
-                        from benchbox.mcp.errors import make_unsupported_mode_error
-
-                        resolved_mode, mode_error = (
-                            _mode_input,
-                            make_unsupported_mode_error(platform, _mode_input, _sup),
-                        )
-                    else:
-                        resolved_mode, mode_error = _mode_input, None
-                else:
-                    if _pl.endswith("-df"):
-                        resolved_mode, mode_error = "dataframe", None
-                    else:
-                        resolved_mode, mode_error = _caps.default_mode, None
+        resolved_mode, mode_error = _resolve_mcp_mode_with_registry(platform, mode)
         if mode_error:
             mode_error["execution_id"] = execution_id
             mode_error["status"] = "failed"
@@ -713,185 +673,46 @@ class DurableJobWorker:
                 bm_lower, bm_class, scale_factor, execution_id, start_time, results_dir=results_dir
             )
 
-        # Normal path: build core configs and delegate to execute_run
-        from benchbox.core.benchmark_registry import get_all_benchmarks, get_public_benchmark_class
+        from benchbox.core.benchmark_registry import get_public_benchmark_class
 
         all_benchmarks = get_all_benchmarks()
-        bm_lower = benchmark.lower()
-        if bm_lower not in all_benchmarks:
+        benchmark_lower = benchmark.lower()
+        if benchmark_lower not in all_benchmarks:
             from benchbox.mcp.errors import make_not_found_error
 
-            resp = make_not_found_error("benchmark", benchmark, available=list(all_benchmarks.keys()))
-            resp["execution_id"] = execution_id
-            resp["status"] = "failed"
-            return resp
-        bm_class = get_public_benchmark_class(bm_lower)
-        if bm_class is None:
+            response = make_not_found_error("benchmark", benchmark, available=list(all_benchmarks.keys()))
+            response["execution_id"] = execution_id
+            response["status"] = "failed"
+            return response
+        benchmark_class = get_public_benchmark_class(benchmark_lower)
+        if benchmark_class is None:
             from benchbox.mcp.errors import ErrorCode, make_error
 
-            resp = make_error(
+            response = make_error(
                 ErrorCode.DEPENDENCY_MISSING,
                 f"Benchmark '{benchmark}' requires additional dependencies",
                 details={"benchmark": benchmark},
             )
-            resp["execution_id"] = execution_id
-            resp["status"] = "failed"
-            return resp
-        benchmark_instance = bm_class(scale_factor=scale_factor)
+            response["execution_id"] = execution_id
+            response["status"] = "failed"
+            return response
 
-        # Translate platform_options for adapter (reuse core helper + clickhouse profile)
-        from benchbox.core.run_service import _translate_platform_options_for_adapter
-
-        try:
-            adapter_options = _translate_platform_options_for_adapter(platform, dict(normalized_platform_options))
-            # ClickHouse profile needs server config; handle here as surface-owned
-            _pname = platform.lower().removesuffix("-df")
-            if _pname in {"clickhouse", "clickhouse-server"} and "connection_profile" in normalized_platform_options:
-                from benchbox.mcp.schemas import resolve_clickhouse_connection_profile
-
-                _prof = resolve_clickhouse_connection_profile(
-                    str(normalized_platform_options.get("connection_profile"))
-                )
-                adapter_options["port"] = _prof["port"]
-                adapter_options["secure"] = _prof["secure"]
-                adapter_options.pop("connection_profile", None)
-        except Exception as exc:
-            from benchbox.mcp.errors import ErrorCode, make_error
-
-            resp = make_error(ErrorCode.VALIDATION_ERROR, str(exc), details={"platform": platform})
-            resp["execution_id"] = execution_id
-            resp["status"] = "failed"
-            return resp
-
-        query_subset = [q.strip() for q in queries.split(",")] if queries else None
-        phases_list = [p.strip() for p in (phases or "load,power").split(",")]
-        execution_context = ExecutionContext(
-            entry_point="mcp",
+        phases_list = [phase.strip() for phase in (phases or "load,power").split(",")]
+        return _execute_mcp_run_via_core(
+            platform=platform,
+            benchmark=benchmark_lower,
+            benchmark_class=benchmark_class,
+            scale_factor=scale_factor,
+            queries=queries,
             phases=phases_list,
-            query_subset=query_subset,
-            mode=resolved_mode if resolved_mode in ("sql", "dataframe") else "sql",
-        )
-
-        # Build core configs
-
-        # BenchmarkConfig
-        meta = all_benchmarks[bm_lower]
-        display_name = meta.get("display_name", bm_lower.upper())
-        # Use query_subset already parsed
-        benchmark_config = BenchmarkConfig(
-            name=bm_lower,
-            display_name=display_name,
-            scale_factor=scale_factor,
-            queries=query_subset,
+            resolved_mode=resolved_mode,
             capture_plans=capture_plans,
+            normalized_platform_options=normalized_platform_options,
+            results_dir=results_dir,
+            execution_id=execution_id,
+            start_time=start_time,
+            anonymize=anonymize,
         )
-        # Map phases to test_execution_type for BenchmarkConfig (kept for harness routing)
-        from benchbox.core.run_service import _map_phases_to_execution_type
-
-        benchmark_config.test_execution_type = _map_phases_to_execution_type(phases_list)
-        if "statistics" in phases_list:
-            benchmark_config.options = dict(benchmark_config.options or {})
-            benchmark_config.options["gather_statistics"] = True
-            benchmark_config.options["statistics_benchmark_name"] = bm_lower
-
-        # DatabaseConfig
-        platform_lower = platform.lower()
-        database_config = DatabaseConfig(
-            type=platform_lower,
-            name=f"mcp_job_{platform_lower}",
-            execution_mode=resolved_mode,
-            options=dict(adapter_options),
-        )
-
-        # SystemProfile
-        profiler = SystemProfiler()
-        system_profile = profiler.get_system_profile()
-
-        # Platform config
-        platform_cfg = get_platform_config(
-            database_config,
-            system_profile,
-            benchmark_name=bm_lower,
-            scale_factor=scale_factor,
-            tuning_config=benchmark_config.options.get("unified_tuning_configuration")
-            if benchmark_config.options
-            else None,
-        )
-
-        # Output root
-        output_root = staging
-
-        # Adapter factory (surface-owned)
-        def _factory(*, execution_mode, output_root, phases):
-            # phases is LifecyclePhases, not used for adapter creation beyond dataframe check
-            if database_config is None or not (phases.load or phases.execute):
-                return None
-            if execution_mode == "dataframe":
-                from benchbox.core.platform_registry import PlatformRegistry as PR
-
-                registered = PR.list_option_specs(database_config.type) if hasattr(PR, "list_option_specs") else []
-                # Fallback: use adapter_options directly filtered
-                df_opts = (
-                    {k: v for k, v in (database_config.options or {}).items() if k in registered}
-                    if registered
-                    else dict(database_config.options or {})
-                )
-                from benchbox.platforms import get_dataframe_adapter
-
-                return get_dataframe_adapter(
-                    database_config.type,
-                    mode="dataframe",
-                    working_dir=output_root,
-                    verbose=False,
-                    very_verbose=False,
-                    tuning_config=benchmark_config.options.get("df_tuning_config"),
-                    **df_opts,
-                )
-            from benchbox.platforms import get_platform_adapter
-
-            adapter = get_platform_adapter(database_config.type, **(platform_cfg or {}))
-            if adapter and benchmark_instance:
-                adapter.benchmark_instance = benchmark_instance
-                adapter.scale_factor = scale_factor
-            return adapter
-
-        # Execute via core
-        result = execute_run(
-            config=benchmark_config,
-            benchmark_instance=benchmark_instance,
-            database_config=database_config,
-            system_profile=system_profile,
-            platform_config=platform_cfg,
-            output_root=output_root,
-            phases_to_run=phases_list,
-            adapter_factory=_factory,
-            verbosity=SilentVerbosity(),
-            monitor=None,
-            execution_context=execution_context,
-        )
-
-        if result is not None:
-            result.execution_context = execution_context.model_dump()
-
-        execution_time = elapsed_seconds(start_time)
-        result_file_path, result_payload = (
-            _export_and_build_payload(result, execution_id, results_dir, anonymize=anonymize)
-            if result
-            else (None, None)
-        )
-        response: dict[str, Any] = result_payload or {}
-        response["mcp_metadata"] = {
-            "execution_id": execution_id,
-            "status": "completed" if result else "no_results",
-            "platform_requested": platform,
-            "benchmark_requested": benchmark,
-            "scale_factor_requested": scale_factor,
-            "execution_mode": resolved_mode,
-            "execution_time_seconds": round(execution_time, 2),
-            "result_file": result_file_path,
-        }
-        _attach_summary_charts(response, result)
-        return response
 
     async def run(self) -> None:
         """Continuously recover and execute shared queued work."""

--- a/benchbox/mcp/jobs.py
+++ b/benchbox/mcp/jobs.py
@@ -19,6 +19,11 @@ from mcp.server.mcpserver import MCPServer
 from mcp.shared.exceptions import MCPError
 from mcp.types import ToolAnnotations
 
+from benchbox.core.benchmark_registry import get_all_benchmarks
+from benchbox.core.platform_config import get_platform_config
+from benchbox.core.run_service import SilentVerbosity, execute_run
+from benchbox.core.schemas import BenchmarkConfig, DatabaseConfig, ExecutionContext
+from benchbox.core.system import SystemProfiler
 from benchbox.mcp.schemas import MCPValidationError, validate_phases, validate_platform_options
 from benchbox.mcp.security import (
     AUTHORIZATION_ERROR,
@@ -27,8 +32,12 @@ from benchbox.mcp.security import (
     TenantWorkspaceProvider,
     authenticated_principal,
 )
-from benchbox.mcp.tools.benchmark import _run_benchmark_impl
-from benchbox.utils.clock import mono_time, utc_now
+from benchbox.mcp.tools.benchmark import (
+    _attach_summary_charts,
+    _export_and_build_payload,
+    _generate_data_impl,
+)
+from benchbox.utils.clock import elapsed_seconds, mono_time, utc_now
 
 logger = logging.getLogger(__name__)
 
@@ -575,22 +584,314 @@ class DurableJobWorker:
 
     @staticmethod
     def _execute_benchmark(job: JobRecord, staging: Path) -> dict[str, Any]:
+        """Execute a durable job via the shared core run service.
+
+        This is the one-engine adoption for the worker path: instead of
+        calling the MCP-private ``_run_benchmark_impl`` helper chain, the
+        worker builds surface-neutral configs and delegates to
+        ``benchbox.core.run_service.execute_run`` with a surface-injected
+        ``AdapterFactory`` and ``SilentVerbosity``. Lease/fencing,
+        idempotency and ``staging→os.replace`` publication remain in
+        ``DurableJobWorker._run_job`` and are untouched.
+        """
+        from benchbox.mcp.errors import ErrorCode, make_error, make_not_found_error
+
         request = job.request
-        return _run_benchmark_impl(
-            str(request["platform"]),
-            str(request["benchmark"]),
-            float(request.get("scale_factor", 0.01)),
-            request.get("queries"),
-            request.get("phases"),
-            request.get("mode"),
-            bool(request.get("capture_plans", False)),
-            platform_options=request.get("platform_options"),
-            results_dir=staging,
-            execution_id=job.execution_id,
-            # Durable jobs only exist under a remote security policy, so the
-            # consumer is always a remote tenant.
-            anonymize=True,
+        platform = str(request["platform"])
+        benchmark = str(request["benchmark"])
+        scale_factor = float(request.get("scale_factor", 0.01))
+        queries = request.get("queries")
+        phases = request.get("phases")
+        mode = request.get("mode")
+        capture_plans = bool(request.get("capture_plans", False))
+        platform_options = request.get("platform_options")
+        results_dir = staging
+        execution_id = job.execution_id
+        anonymize = True
+        start_time = __import__("benchbox.utils.clock", fromlist=["mono_time"]).mono_time()
+
+        # Re-admission: durable store is re-read, so validate again.
+        try:
+            from benchbox.mcp.schemas import validate_platform_options
+
+            normalized_platform_options = validate_platform_options(platform, platform_options)
+        except Exception as exc:
+            from benchbox.mcp.errors import ErrorCode, make_error
+
+            resp = make_error(ErrorCode.VALIDATION_ERROR, str(exc), details={"platform": platform})
+            resp["execution_id"] = execution_id
+            resp["status"] = "failed"
+            return resp
+
+        try:
+            from benchbox.mcp.schemas import validate_phases
+
+            phases = validate_phases(phases)
+        except Exception as exc:
+            from benchbox.core.constants import VALID_PHASES
+            from benchbox.mcp.errors import ErrorCode, make_error
+
+            resp = make_error(
+                ErrorCode.VALIDATION_INVALID_PHASE, str(exc), details={"valid_phases": list(VALID_PHASES)}
+            )
+            resp["execution_id"] = execution_id
+            resp["status"] = "failed"
+            return resp
+
+        # For data_only, delegate to the existing data-gen impl which already
+        # writes to ``results_dir / "datagen"`` and returns the
+        # ``mcp_metadata + data_generation`` shape expected by durable callers.
+        # The core ``execute_run`` data_only path produces ``BenchmarkResults``,
+        # not this shape, so we keep the surface-owned helper until w3 cleans it.
+        from benchbox.core.platform_registry import PlatformRegistry
+
+        _mode_input = mode
+        if _mode_input is not None:
+            _mode_input = _mode_input.lower()
+            if _mode_input in ("datagen", "generate"):
+                _mode_input = "data_only"
+        if _mode_input == "data_only":
+            resolved_mode, mode_error = "data_only", None
+        else:
+            _pl = platform.lower()
+            _base = _pl.replace("-df", "")
+            _caps = PlatformRegistry.get_platform_capabilities(_base)
+            if _caps is None:
+                resolved_mode, mode_error = _mode_input or "sql", None
+            else:
+                _sup = []
+                if _caps.supports_sql:
+                    _sup.append("sql")
+                if _caps.supports_dataframe:
+                    _sup.append("dataframe")
+                _sup.append("data_only")
+                if _mode_input is not None:
+                    if not PlatformRegistry.supports_mode(_base, _mode_input):
+                        from benchbox.mcp.errors import make_unsupported_mode_error
+
+                        resolved_mode, mode_error = (
+                            _mode_input,
+                            make_unsupported_mode_error(platform, _mode_input, _sup),
+                        )
+                    else:
+                        resolved_mode, mode_error = _mode_input, None
+                else:
+                    if _pl.endswith("-df"):
+                        resolved_mode, mode_error = "dataframe", None
+                    else:
+                        resolved_mode, mode_error = _caps.default_mode, None
+        if mode_error:
+            mode_error["execution_id"] = execution_id
+            mode_error["status"] = "failed"
+            return mode_error
+        if resolved_mode == "data_only":
+            # Use surface helper for data_only shape preservation
+            from benchbox.core.benchmark_registry import get_public_benchmark_class
+
+            all_bms = get_all_benchmarks()
+            bm_lower = benchmark.lower()
+            if bm_lower not in all_bms:
+                from benchbox.mcp.errors import make_not_found_error
+
+                resp = make_not_found_error("benchmark", benchmark, available=list(all_bms.keys()))
+                resp["execution_id"] = execution_id
+                resp["status"] = "failed"
+                return resp
+            bm_class = get_public_benchmark_class(bm_lower)
+            if bm_class is None:
+                from benchbox.mcp.errors import ErrorCode, make_error
+
+                resp = make_error(
+                    ErrorCode.DEPENDENCY_MISSING,
+                    f"Benchmark '{benchmark}' requires additional dependencies",
+                    details={"benchmark": benchmark},
+                )
+                resp["execution_id"] = execution_id
+                resp["status"] = "failed"
+                return resp
+            return _generate_data_impl(
+                bm_lower, bm_class, scale_factor, execution_id, start_time, results_dir=results_dir
+            )
+
+        # Normal path: build core configs and delegate to execute_run
+        from benchbox.core.benchmark_registry import get_all_benchmarks, get_public_benchmark_class
+
+        all_benchmarks = get_all_benchmarks()
+        bm_lower = benchmark.lower()
+        if bm_lower not in all_benchmarks:
+            from benchbox.mcp.errors import make_not_found_error
+
+            resp = make_not_found_error("benchmark", benchmark, available=list(all_benchmarks.keys()))
+            resp["execution_id"] = execution_id
+            resp["status"] = "failed"
+            return resp
+        bm_class = get_public_benchmark_class(bm_lower)
+        if bm_class is None:
+            from benchbox.mcp.errors import ErrorCode, make_error
+
+            resp = make_error(
+                ErrorCode.DEPENDENCY_MISSING,
+                f"Benchmark '{benchmark}' requires additional dependencies",
+                details={"benchmark": benchmark},
+            )
+            resp["execution_id"] = execution_id
+            resp["status"] = "failed"
+            return resp
+        benchmark_instance = bm_class(scale_factor=scale_factor)
+
+        # Translate platform_options for adapter (reuse core helper + clickhouse profile)
+        from benchbox.core.run_service import _translate_platform_options_for_adapter
+
+        try:
+            adapter_options = _translate_platform_options_for_adapter(platform, dict(normalized_platform_options))
+            # ClickHouse profile needs server config; handle here as surface-owned
+            _pname = platform.lower().removesuffix("-df")
+            if _pname in {"clickhouse", "clickhouse-server"} and "connection_profile" in normalized_platform_options:
+                from benchbox.mcp.schemas import resolve_clickhouse_connection_profile
+
+                _prof = resolve_clickhouse_connection_profile(
+                    str(normalized_platform_options.get("connection_profile"))
+                )
+                adapter_options["port"] = _prof["port"]
+                adapter_options["secure"] = _prof["secure"]
+                adapter_options.pop("connection_profile", None)
+        except Exception as exc:
+            from benchbox.mcp.errors import ErrorCode, make_error
+
+            resp = make_error(ErrorCode.VALIDATION_ERROR, str(exc), details={"platform": platform})
+            resp["execution_id"] = execution_id
+            resp["status"] = "failed"
+            return resp
+
+        query_subset = [q.strip() for q in queries.split(",")] if queries else None
+        phases_list = [p.strip() for p in (phases or "load,power").split(",")]
+        execution_context = ExecutionContext(
+            entry_point="mcp",
+            phases=phases_list,
+            query_subset=query_subset,
+            mode=resolved_mode if resolved_mode in ("sql", "dataframe") else "sql",
         )
+
+        # Build core configs
+
+        # BenchmarkConfig
+        meta = all_benchmarks[bm_lower]
+        display_name = meta.get("display_name", bm_lower.upper())
+        # Use query_subset already parsed
+        benchmark_config = BenchmarkConfig(
+            name=bm_lower,
+            display_name=display_name,
+            scale_factor=scale_factor,
+            queries=query_subset,
+            capture_plans=capture_plans,
+        )
+        # Map phases to test_execution_type for BenchmarkConfig (kept for harness routing)
+        from benchbox.core.run_service import _map_phases_to_execution_type
+
+        benchmark_config.test_execution_type = _map_phases_to_execution_type(phases_list)
+        if "statistics" in phases_list:
+            benchmark_config.options = dict(benchmark_config.options or {})
+            benchmark_config.options["gather_statistics"] = True
+            benchmark_config.options["statistics_benchmark_name"] = bm_lower
+
+        # DatabaseConfig
+        platform_lower = platform.lower()
+        database_config = DatabaseConfig(
+            type=platform_lower,
+            name=f"mcp_job_{platform_lower}",
+            execution_mode=resolved_mode,
+            options=dict(adapter_options),
+        )
+
+        # SystemProfile
+        profiler = SystemProfiler()
+        system_profile = profiler.get_system_profile()
+
+        # Platform config
+        platform_cfg = get_platform_config(
+            database_config,
+            system_profile,
+            benchmark_name=bm_lower,
+            scale_factor=scale_factor,
+            tuning_config=benchmark_config.options.get("unified_tuning_configuration")
+            if benchmark_config.options
+            else None,
+        )
+
+        # Output root
+        output_root = staging
+
+        # Adapter factory (surface-owned)
+        def _factory(*, execution_mode, output_root, phases):
+            # phases is LifecyclePhases, not used for adapter creation beyond dataframe check
+            if database_config is None or not (phases.load or phases.execute):
+                return None
+            if execution_mode == "dataframe":
+                from benchbox.core.platform_registry import PlatformRegistry as PR
+
+                registered = PR.list_option_specs(database_config.type) if hasattr(PR, "list_option_specs") else []
+                # Fallback: use adapter_options directly filtered
+                df_opts = (
+                    {k: v for k, v in (database_config.options or {}).items() if k in registered}
+                    if registered
+                    else dict(database_config.options or {})
+                )
+                from benchbox.platforms import get_dataframe_adapter
+
+                return get_dataframe_adapter(
+                    database_config.type,
+                    mode="dataframe",
+                    working_dir=output_root,
+                    verbose=False,
+                    very_verbose=False,
+                    tuning_config=benchmark_config.options.get("df_tuning_config"),
+                    **df_opts,
+                )
+            from benchbox.platforms import get_platform_adapter
+
+            adapter = get_platform_adapter(database_config.type, **(platform_cfg or {}))
+            if adapter and benchmark_instance:
+                adapter.benchmark_instance = benchmark_instance
+                adapter.scale_factor = scale_factor
+            return adapter
+
+        # Execute via core
+        result = execute_run(
+            config=benchmark_config,
+            benchmark_instance=benchmark_instance,
+            database_config=database_config,
+            system_profile=system_profile,
+            platform_config=platform_cfg,
+            output_root=output_root,
+            phases_to_run=phases_list,
+            adapter_factory=_factory,
+            verbosity=SilentVerbosity(),
+            monitor=None,
+            execution_context=execution_context,
+        )
+
+        if result is not None:
+            result.execution_context = execution_context.model_dump()
+
+        execution_time = elapsed_seconds(start_time)
+        result_file_path, result_payload = (
+            _export_and_build_payload(result, execution_id, results_dir, anonymize=anonymize)
+            if result
+            else (None, None)
+        )
+        response: dict[str, Any] = result_payload or {}
+        response["mcp_metadata"] = {
+            "execution_id": execution_id,
+            "status": "completed" if result else "no_results",
+            "platform_requested": platform,
+            "benchmark_requested": benchmark,
+            "scale_factor_requested": scale_factor,
+            "execution_mode": resolved_mode,
+            "execution_time_seconds": round(execution_time, 2),
+            "result_file": result_file_path,
+        }
+        _attach_summary_charts(response, result)
+        return response
 
     async def run(self) -> None:
         """Continuously recover and execute shared queued work."""

--- a/benchbox/mcp/schemas.py
+++ b/benchbox/mcp/schemas.py
@@ -597,39 +597,15 @@ def build_databricks_clustering_intent(normalized: Mapping[str, object]):
     Raises:
         MCPValidationError: If the requested layout fields contradict each other.
     """
-    strategy = normalized.get("databricks_clustering_strategy")
-    columns = normalized.get("liquid_clustering_columns")
-    if strategy is None and columns is None:
-        return None
-
-    from benchbox.core.tuning.interface import UnifiedTuningConfiguration
-
-    tuning_config = UnifiedTuningConfiguration()
-    platform_optimizations = tuning_config.platform_optimizations
-
-    if strategy is not None:
-        strategy = str(strategy).lower()
-        platform_optimizations.databricks_clustering_strategy = strategy
-        platform_optimizations.liquid_clustering_enabled = strategy in {
-            "liquid_clustering",
-            "liquid_clustering_auto",
-        }
-        platform_optimizations.physical_rendering_id = None
-    if columns is not None:
-        parsed_columns = [column.strip() for column in str(columns).split(",") if column.strip()]
-        platform_optimizations.liquid_clustering_columns = parsed_columns
-        platform_optimizations.liquid_clustering_enabled = bool(parsed_columns)
-        if parsed_columns and strategy is None:
-            platform_optimizations.databricks_clustering_strategy = "liquid_clustering"
+    from benchbox.core.run_service import build_databricks_clustering_intent as build_core_intent
 
     try:
-        platform_optimizations.__post_init__()
+        return build_core_intent(dict(normalized))
     except ValueError as exc:
         # Surface layout conflicts as a structured validation error at admission
         # instead of an execution failure discovered by a worker.  The message
         # is generated from allow-listed option names, not from caller text.
         raise MCPValidationError(f"Databricks clustering options conflict: {exc}") from exc
-    return tuning_config
 
 
 def validate_query_id(query_id: str) -> str:

--- a/benchbox/mcp/tools/benchmark.py
+++ b/benchbox/mcp/tools/benchmark.py
@@ -26,10 +26,10 @@ from benchbox.core.benchmark_registry import (
     get_benchmark_surface,
     get_public_benchmark_class,
 )
-from benchbox.core.constants import QUERY_PHASES, VALID_PHASES
+from benchbox.core.constants import VALID_PHASES
+from benchbox.core.hooks.platform_hooks import PlatformHookRegistry
 from benchbox.core.results.exporter import ResultExporter
 from benchbox.core.results.schema import build_result_payload
-from benchbox.core.schemas import ExecutionContext
 from benchbox.mcp.errors import (
     ErrorCode,
     make_error,
@@ -39,7 +39,6 @@ from benchbox.mcp.errors import (
 )
 from benchbox.mcp.schemas import (
     MCPValidationError,
-    build_databricks_clustering_intent,
     resolve_clickhouse_connection_profile,
     validate_phases,
     validate_platform_options,
@@ -93,103 +92,6 @@ def _get_platform_adapter(platform: str, mode: str | None = None, **config):
         return get_dataframe_adapter(platform_lower, **df_config)
     else:
         return get_platform_adapter(platform_lower, **config)
-
-
-def _prepare_adapter_platform_options(platform: str, options: Mapping[str, object]) -> dict[str, object]:
-    """Translate MCP option names to the adapter and tuning contracts."""
-    normalized = dict(options)
-    from benchbox.mcp.schemas import resolve_platform_policy_key
-
-    platform_name = resolve_platform_policy_key(platform)
-
-    if platform_name in {"clickhouse", "clickhouse-server"} and "connection_profile" in normalized:
-        # The request carries only a profile name.  Port and TLS policy are read
-        # from server configuration here, at execution time, so a durable retry
-        # re-resolves against current policy instead of replaying a persisted
-        # destination.
-        profile = resolve_clickhouse_connection_profile(str(normalized.pop("connection_profile")))
-        normalized["port"] = profile["port"]
-        normalized["secure"] = profile["secure"]
-
-    if platform_name == "duckdb" and "threads" in normalized:
-        normalized["thread_limit"] = normalized.pop("threads")
-
-    if platform_name == "databricks":
-        # Same translation the admission gate ran, so the object the resolver
-        # consumes is the one that was validated.  `tuning_config` is what
-        # PlatformAdapter turns into `unified_tuning_configuration`, which
-        # `get_effective_tuning_configuration()` returns to the clustering
-        # resolver -- the raw option names would be dropped by `from_config`.
-        tuning_config = build_databricks_clustering_intent(normalized)
-        if tuning_config is not None:
-            normalized.pop("databricks_clustering_strategy", None)
-            normalized.pop("liquid_clustering_columns", None)
-            normalized["tuning_config"] = tuning_config
-            normalized["tuning_enabled"] = True
-
-    return normalized
-
-
-def _validate_and_resolve_mode(platform: str, mode: str | None) -> tuple[str, dict | None]:
-    """Validate mode against platform capabilities, resolve default if not specified."""
-    from benchbox.core.platform_registry import PlatformRegistry
-
-    if mode is not None:
-        mode = mode.lower()
-        if mode in ("datagen", "generate"):
-            mode = "data_only"
-
-    if mode == "data_only":
-        return "data_only", None
-
-    platform_lower = platform.lower()
-    base_platform = platform_lower.replace("-df", "")
-
-    caps = PlatformRegistry.get_platform_capabilities(base_platform)
-    if caps is None:
-        return mode or "sql", None
-
-    supported = []
-    if caps.supports_sql:
-        supported.append("sql")
-    if caps.supports_dataframe:
-        supported.append("dataframe")
-    supported.append("data_only")
-
-    if mode is not None:
-        if not PlatformRegistry.supports_mode(base_platform, mode):
-            return mode, make_unsupported_mode_error(platform, mode, supported)
-        return mode, None
-
-    from benchbox.mcp.schemas import is_dataframe_alias
-
-    if is_dataframe_alias(platform_lower):
-        return "dataframe", None
-    return caps.default_mode, None
-
-
-def _map_phases_to_test_execution_type(phases: list[str]) -> str:
-    """Map benchmark phases to test execution type."""
-    phases_set = set(phases)
-    query_phases = set(QUERY_PHASES)
-
-    if phases_set & query_phases:
-        if "power" in phases_set and "throughput" in phases_set and "maintenance" in phases_set:
-            return "combined"
-        elif "power" in phases_set:
-            return "power"
-        elif "throughput" in phases_set:
-            return "throughput"
-        elif "maintenance" in phases_set:
-            return "maintenance"
-        else:
-            return "standard"
-    elif phases == ["load"] or ("load" in phases_set and not phases_set & query_phases):
-        return "load_only"
-    elif phases == ["generate"] or ("generate" in phases_set and not phases_set & ({"load"} | query_phases)):
-        return "data_only"
-    else:
-        return "standard"
 
 
 def register_benchmark_tools(
@@ -367,6 +269,16 @@ def _make_failed_response(error_response: dict[str, Any], execution_id: str) -> 
     return error_response
 
 
+def _resolve_mcp_mode_with_registry(platform: str, mode: str | None):
+    """Resolve a mode through core and adapt unsupported-mode errors for MCP."""
+    from benchbox.core.run_service import _resolve_mode_with_registry
+
+    resolved_mode, mode_error = _resolve_mode_with_registry(platform, mode)
+    if mode_error is None:
+        return resolved_mode, None
+    return resolved_mode, make_unsupported_mode_error(platform, mode_error.mode, list(mode_error.supported))
+
+
 def _export_and_build_payload(
     result: Any,
     execution_id: str,
@@ -427,6 +339,165 @@ def _attach_summary_charts(response: dict[str, Any], result: Any) -> None:
         logger.debug("Failed to generate post-run summary charts", exc_info=True)
 
 
+def _execute_mcp_run_via_core(
+    *,
+    platform: str,
+    benchmark: str,
+    benchmark_class: Any,
+    scale_factor: float,
+    queries: str | None,
+    phases: list[str],
+    resolved_mode: str,
+    capture_plans: bool,
+    normalized_platform_options: Mapping[str, object],
+    results_dir: Path,
+    execution_id: str,
+    start_time: float,
+    anonymize: bool,
+) -> dict[str, Any]:
+    """Execute a validated MCP run through the shared core run service."""
+    from benchbox.core.run_service import (
+        SilentVerbosity,
+        _map_phases_to_execution_type,
+        _translate_platform_options_for_adapter,
+        execute_run,
+    )
+    from benchbox.core.schemas import BenchmarkConfig, DatabaseConfig, ExecutionContext
+    from benchbox.core.system import SystemProfiler
+
+    benchmark_instance = benchmark_class(scale_factor=scale_factor)
+
+    try:
+        adapter_input = dict(normalized_platform_options)
+        platform_name = platform.lower().removesuffix("-df")
+        if platform_name in {"clickhouse", "clickhouse-server"} and "connection_profile" in normalized_platform_options:
+            profile = resolve_clickhouse_connection_profile(str(normalized_platform_options["connection_profile"]))
+            adapter_input["port"] = profile["port"]
+            adapter_input["secure"] = profile["secure"]
+            adapter_input.pop("connection_profile", None)
+        adapter_options = _translate_platform_options_for_adapter(platform, adapter_input)
+    except MCPValidationError as exc:
+        return _make_failed_response(
+            make_error(ErrorCode.VALIDATION_ERROR, str(exc), details={"platform": platform}),
+            execution_id,
+        )
+
+    query_subset = [query.strip() for query in queries.split(",")] if queries else None
+    execution_context = ExecutionContext(
+        entry_point="mcp",
+        phases=phases,
+        query_subset=query_subset,
+        mode=resolved_mode if resolved_mode in ("sql", "dataframe") else "sql",
+    )
+    all_benchmarks = get_all_benchmarks()
+    metadata = all_benchmarks[benchmark]
+    benchmark_config = BenchmarkConfig(
+        name=benchmark,
+        display_name=metadata.get("display_name", benchmark.upper()),
+        scale_factor=scale_factor,
+        queries=query_subset,
+        capture_plans=capture_plans,
+    )
+    benchmark_config.test_execution_type = _map_phases_to_execution_type(phases)
+    if "statistics" in phases:
+        benchmark_config.options = dict(benchmark_config.options or {})
+        benchmark_config.options["gather_statistics"] = True
+        benchmark_config.options["statistics_benchmark_name"] = benchmark
+
+    database_config = DatabaseConfig(
+        type=platform.lower(),
+        name=f"mcp_{platform.lower()}",
+        execution_mode=resolved_mode,
+        options=dict(adapter_options),
+    )
+    profiler = SystemProfiler()
+    system_profile = profiler.get_system_profile()
+    from benchbox.core.platform_config import get_platform_config
+
+    platform_config = get_platform_config(
+        database_config,
+        system_profile,
+        benchmark_name=benchmark,
+        scale_factor=scale_factor,
+        tuning_config=benchmark_config.options.get("unified_tuning_configuration")
+        if benchmark_config.options
+        else None,
+    )
+
+    def adapter_factory(*, execution_mode, output_root, phases):
+        if not (phases.load or phases.execute):
+            return None
+        if execution_mode == "dataframe":
+            registered = PlatformHookRegistry.list_option_specs(database_config.type)
+            dataframe_options = (
+                {key: value for key, value in database_config.options.items() if key in registered}
+                if registered
+                else dict(database_config.options)
+            )
+            from benchbox.platforms import get_adapter
+
+            return get_adapter(
+                database_config.type,
+                mode="dataframe",
+                working_dir=output_root,
+                verbose=False,
+                very_verbose=False,
+                tuning_config=benchmark_config.options.get("df_tuning_config") if benchmark_config.options else None,
+                **dataframe_options,
+            )
+
+        adapter_kwargs = dict(platform_config or {})
+        adapter_kwargs.update(adapter_options)
+        adapter_kwargs.pop("benchmark", None)
+        adapter_kwargs.pop("scale_factor", None)
+        adapter = _get_platform_adapter(
+            database_config.type,
+            mode=execution_mode,
+            benchmark=benchmark,
+            scale_factor=scale_factor,
+            **adapter_kwargs,
+        )
+        if adapter is not None:
+            adapter.benchmark_instance = benchmark_instance
+            adapter.scale_factor = scale_factor
+        return adapter
+
+    with silence_output(enabled=True):
+        result = execute_run(
+            config=benchmark_config,
+            benchmark_instance=benchmark_instance,
+            database_config=database_config,
+            system_profile=system_profile,
+            platform_config=platform_config,
+            output_root=results_dir,
+            phases_to_run=phases,
+            adapter_factory=adapter_factory,
+            verbosity=SilentVerbosity(),
+            monitor=None,
+            execution_context=execution_context,
+        )
+    if result is not None:
+        result.execution_context = execution_context.model_dump()
+
+    execution_time = elapsed_seconds(start_time)
+    result_file_path, result_payload = (
+        _export_and_build_payload(result, execution_id, results_dir, anonymize=anonymize) if result else (None, None)
+    )
+    response: dict[str, Any] = result_payload or {}
+    response["mcp_metadata"] = {
+        "execution_id": execution_id,
+        "status": "completed" if result else "no_results",
+        "platform_requested": platform,
+        "benchmark_requested": benchmark,
+        "scale_factor_requested": scale_factor,
+        "execution_mode": resolved_mode,
+        "execution_time_seconds": round(execution_time, 2),
+        "result_file": result_file_path,
+    }
+    _attach_summary_charts(response, result)
+    return response
+
+
 def _run_benchmark_impl(
     platform: str,
     benchmark: str,
@@ -481,7 +552,7 @@ def _run_benchmark_impl(
                 execution_id,
             )
 
-        resolved_mode, mode_error = _validate_and_resolve_mode(platform, mode)
+        resolved_mode, mode_error = _resolve_mcp_mode_with_registry(platform, mode)
         if mode_error:
             return _make_failed_response(mode_error, execution_id)
 
@@ -495,102 +566,22 @@ def _run_benchmark_impl(
                 results_dir=results_dir,
             )
 
-        benchmark_instance = benchmark_class(scale_factor=scale_factor)
-
-        # Resolved separately from adapter construction so a policy rejection is
-        # reported as a validation error rather than an unsupported platform.
-        try:
-            adapter_options = _prepare_adapter_platform_options(platform, normalized_platform_options)
-        except MCPValidationError as exc:
-            return _make_failed_response(
-                make_error(ErrorCode.VALIDATION_ERROR, str(exc), details={"platform": platform}),
-                execution_id,
-            )
-
-        try:
-            adapter = _get_platform_adapter(
-                platform,
-                mode=resolved_mode,
-                benchmark=benchmark_lower,
-                scale_factor=scale_factor,
-                **adapter_options,
-            )
-        except (ValueError, ImportError) as e:
-            return _make_failed_response(
-                make_error(ErrorCode.VALIDATION_UNSUPPORTED_PLATFORM, str(e), details={"platform": platform}),
-                execution_id,
-            )
-
-        query_subset = [q.strip() for q in queries.split(",")] if queries else None
         phases_list = [p.strip() for p in (phases or "load,power").split(",")]
-        execution_context = ExecutionContext(
-            entry_point="mcp",
+        return _execute_mcp_run_via_core(
+            platform=platform,
+            benchmark=benchmark_lower,
+            benchmark_class=benchmark_class,
+            scale_factor=scale_factor,
+            queries=queries,
             phases=phases_list,
-            query_subset=query_subset,
-            mode=resolved_mode if resolved_mode in ("sql", "dataframe") else "sql",
+            resolved_mode=resolved_mode,
+            capture_plans=capture_plans,
+            normalized_platform_options=normalized_platform_options,
+            results_dir=results_dir,
+            execution_id=execution_id,
+            start_time=start_time,
+            anonymize=anonymize,
         )
-
-        test_execution_type = _map_phases_to_test_execution_type(phases_list)
-
-        # Opt-in statistics phase (`statistics` in `phases`): threaded independently
-        # of `_map_phases_to_test_execution_type`, which intentionally ignores the
-        # token for execution-type derivation. The base-adapter's
-        # `run_statistics_phase` needs a benchmark slug to resolve the per-benchmark
-        # `supports_statistics_phase` registry gate; omitting it would make the gate
-        # look up an empty slug and always skip.
-        #
-        # Deliberately NOT `benchmark_name`: that run_config key also feeds
-        # `_resolve_benchmark_slug`, which the power/throughput/maintenance/combined
-        # dispatchers use to route TPC benchmarks to specialized harnesses instead of
-        # the generic handler (and, in `run_enhanced_benchmark`, query dialect-family
-        # selection and the row-count-validation `benchmark_type` gate). Setting it
-        # only when `statistics` is requested would make requesting the phase also
-        # change which harness/dialect/validation path runs, so a stats-opt-in MCP
-        # run would no longer be comparable to the same run without it.
-        # `statistics_benchmark_name` is a dedicated key `run_enhanced_benchmark`
-        # reads only for the statistics gate, leaving `benchmark_name` unset (and
-        # routing/dialect/validation behavior identical) whether or not `statistics`
-        # is requested.
-        statistics_run_config: dict[str, Any] = {}
-        if "statistics" in phases_list:
-            statistics_run_config["gather_statistics"] = True
-            statistics_run_config["statistics_benchmark_name"] = benchmark_lower
-
-        with silence_output(enabled=True):
-            result = benchmark_instance.run_with_platform(
-                adapter,
-                query_subset=query_subset,
-                test_execution_type=test_execution_type,
-                capture_plans=capture_plans,
-                **statistics_run_config,
-            )
-
-        if result is not None:
-            result.execution_context = execution_context.model_dump()
-
-        execution_time = elapsed_seconds(start_time)
-
-        result_file_path, result_payload = (
-            _export_and_build_payload(result, execution_id, results_dir, anonymize=anonymize)
-            if result
-            else (None, None)
-        )
-
-        response: dict[str, Any] = result_payload or {}
-        response["mcp_metadata"] = {
-            "execution_id": execution_id,
-            "status": "completed" if result else "no_results",
-            "platform_requested": platform,
-            "benchmark_requested": benchmark,
-            "scale_factor_requested": scale_factor,
-            "execution_mode": resolved_mode,
-            "execution_time_seconds": round(execution_time, 2),
-            "result_file": result_file_path,
-        }
-
-        _attach_summary_charts(response, result)
-
-        return response
 
     except Exception as e:
         logger.error("Benchmark execution failed (%s)", type(e).__name__)

--- a/benchbox/mcp/tools/benchmark.py
+++ b/benchbox/mcp/tools/benchmark.py
@@ -469,7 +469,7 @@ def _execute_mcp_run_via_core(
             database_config=database_config,
             system_profile=system_profile,
             platform_config=platform_config,
-            output_root=results_dir,
+            output_root=benchmark_instance.output_dir,
             phases_to_run=phases,
             adapter_factory=adapter_factory,
             verbosity=SilentVerbosity(),

--- a/tests/integration/mcp/test_durable_jobs.py
+++ b/tests/integration/mcp/test_durable_jobs.py
@@ -100,7 +100,7 @@ def test_normalized_platform_options_survive_repository_round_trip(tmp_path: Pat
 
 def test_durable_replay_applies_duckdb_threads_to_the_real_adapter(tmp_path: Path) -> None:
     """A replayed request must still change DuckDB execution, not just forward a key."""
-    from benchbox.mcp.tools.benchmark import _prepare_adapter_platform_options
+    from benchbox.core.run_service import _translate_platform_options_for_adapter as _prepare_adapter_platform_options
     from benchbox.platforms.duckdb import DuckDBAdapter
 
     repository = DurableJobRepository(tmp_path / "state.sqlite3", JobLimits())

--- a/tests/integration/mcp/test_run_surface_contract.py
+++ b/tests/integration/mcp/test_run_surface_contract.py
@@ -4,8 +4,8 @@ from __future__ import annotations
 
 import pytest
 
+from benchbox.core.run_service import _translate_platform_options_for_adapter as _prepare_adapter_platform_options
 from benchbox.mcp.schemas import MCPValidationError, validate_platform_options
-from benchbox.mcp.tools.benchmark import _prepare_adapter_platform_options
 
 pytestmark = [pytest.mark.integration, pytest.mark.fast]
 

--- a/tests/unit/core/results/test_platform_options_capture.py
+++ b/tests/unit/core/results/test_platform_options_capture.py
@@ -431,6 +431,27 @@ def test_lifecycle_run_config_persists_sanitized_platform_options_with_provenanc
     }
 
 
+def test_lifecycle_run_config_preserves_requested_phases() -> None:
+    benchmark_config = BenchmarkConfig(
+        name="tpch",
+        display_name="TPC-H",
+        options={"requested_phases": ["power", "throughput"]},
+    )
+
+    run_config = _build_run_config_from_options(
+        benchmark_config=benchmark_config,
+        options=benchmark_config.options,
+        platform_config={},
+        database_config=None,
+        validation_opts=ValidationOptions(),
+        verbosity_settings=VerbositySettings.default(),
+        test_type="combined",
+        table_format=None,
+    )
+
+    assert run_config.options == {"requested_phases": ["power", "throughput"]}
+
+
 def test_sanitize_excludes_internal_keys_when_requested() -> None:
     """w1: exported paths must drop internal bookkeeping keys, matching
     ``_iter_public_options`` semantics, instead of publishing them."""

--- a/tests/unit/mcp/test_benchmark_tools.py
+++ b/tests/unit/mcp/test_benchmark_tools.py
@@ -1019,6 +1019,46 @@ class TestPopulateSqlQueryDetails:
             assert response.get("sql_truncated") is False
 
 
+class TestMcpCoreRunOutputRoots:
+    """MCP data generation and result publication use separate roots."""
+
+    def test_core_run_preserves_constructed_datagen_root(self, tmp_path: Path):
+        from benchbox.mcp.tools import benchmark as benchmark_tools
+
+        datagen_root = tmp_path / "benchmark_runs" / "datagen" / "tpch_sf001"
+        results_root = tmp_path / "benchmark_runs" / "results"
+        benchmark_instance = SimpleNamespace(output_dir=datagen_root)
+        result = SimpleNamespace()
+
+        with (
+            patch.object(benchmark_tools, "get_all_benchmarks", return_value={"tpch": {"display_name": "TPC-H"}}),
+            patch("benchbox.core.system.SystemProfiler") as profiler_cls,
+            patch.object(benchmark_tools, "_export_and_build_payload", return_value=("result.json", {})) as export,
+            patch.object(benchmark_tools, "_attach_summary_charts"),
+            patch("benchbox.core.platform_config.get_platform_config", return_value={}),
+            patch("benchbox.core.run_service.execute_run", return_value=result) as execute,
+        ):
+            profiler_cls.return_value.get_system_profile.return_value = None
+            benchmark_tools._execute_mcp_run_via_core(
+                platform="duckdb",
+                benchmark="tpch",
+                benchmark_class=Mock(return_value=benchmark_instance),
+                scale_factor=0.01,
+                queries=None,
+                phases=["load", "power"],
+                resolved_mode="sql",
+                capture_plans=False,
+                normalized_platform_options={},
+                results_dir=results_root,
+                execution_id="exec-1",
+                start_time=100.0,
+                anonymize=False,
+            )
+
+        assert execute.call_args.kwargs["output_root"] == datagen_root
+        assert export.call_args.args[2] == results_root
+
+
 class TestBenchmarkTiming:
     """Tests for monotonic execution timing in benchmark MCP helpers."""
 

--- a/tests/unit/mcp/test_benchmark_tools.py
+++ b/tests/unit/mcp/test_benchmark_tools.py
@@ -397,7 +397,9 @@ class TestRunBenchmarkTool:
         get_adapter.assert_not_called()
 
     def test_databricks_layout_options_build_unified_tuning_config(self):
-        from benchbox.mcp.tools.benchmark import _prepare_adapter_platform_options
+        from benchbox.core.run_service import (
+            _translate_platform_options_for_adapter as _prepare_adapter_platform_options,
+        )
 
         options = _prepare_adapter_platform_options(
             "databricks",
@@ -411,7 +413,9 @@ class TestRunBenchmarkTool:
         assert tuning.platform_optimizations.liquid_clustering_columns == ["event_time", "id"]
 
     def test_databricks_columns_infer_liquid_clustering_strategy(self):
-        from benchbox.mcp.tools.benchmark import _prepare_adapter_platform_options
+        from benchbox.core.run_service import (
+            _translate_platform_options_for_adapter as _prepare_adapter_platform_options,
+        )
 
         options = _prepare_adapter_platform_options("databricks", {"liquid_clustering_columns": "customer_id,order_id"})
 
@@ -425,13 +429,15 @@ class TestRunBenchmarkTool:
         import json
         from unittest.mock import MagicMock, patch
 
+        from benchbox.core.run_service import (
+            _translate_platform_options_for_adapter as _prepare_adapter_platform_options,
+        )
         from benchbox.mcp.schemas import (
             MCP_CLICKHOUSE_PROFILE_ENV,
             MCP_PLATFORM_OPTION_ALLOWLIST,
             MCP_PLATFORM_OPTION_CONTRACT,
             validate_platform_options,
         )
-        from benchbox.mcp.tools.benchmark import _prepare_adapter_platform_options
 
         monkeypatch.setenv(MCP_CLICKHOUSE_PROFILE_ENV, json.dumps({"reviewed": {"port": 9440, "secure": True}}))
 

--- a/tests/unit/mcp/test_benchmark_tools.py
+++ b/tests/unit/mcp/test_benchmark_tools.py
@@ -153,18 +153,14 @@ class TestRunBenchmarkTool:
     def test_platform_options_are_forwarded_only_after_validation(self, tmp_path: Path):
         from benchbox.mcp.tools import benchmark as benchmark_tools
 
-        class DummyBenchmark:
-            def __init__(self, scale_factor: float) -> None:
-                self.scale_factor = scale_factor
-
-            def run_with_platform(self, *_args, **_kwargs):
-                return None
-
-        adapter = Mock()
         with (
             patch.object(benchmark_tools, "get_all_benchmarks", return_value={"tpch": {"name": "tpch"}}),
-            patch.object(benchmark_tools, "get_public_benchmark_class", return_value=DummyBenchmark),
-            patch.object(benchmark_tools, "_get_platform_adapter", return_value=adapter) as get_adapter,
+            patch.object(benchmark_tools, "get_public_benchmark_class", return_value=Mock),
+            patch.object(
+                benchmark_tools,
+                "_execute_mcp_run_via_core",
+                return_value={"mcp_metadata": {"status": "no_results"}},
+            ) as run_core,
         ):
             response = benchmark_tools._run_benchmark_impl(
                 "duckdb",
@@ -179,7 +175,7 @@ class TestRunBenchmarkTool:
             )
 
         assert response["mcp_metadata"]["status"] == "no_results"
-        assert get_adapter.call_args.kwargs["thread_limit"] == 4
+        assert run_core.call_args.kwargs["normalized_platform_options"] == {"threads": 4}
 
     def test_modin_engine_reaches_the_effective_backend(self, tmp_path: Path):
         """Forwarding can succeed while the effective backend is unchanged."""
@@ -262,7 +258,7 @@ class TestRunBenchmarkTool:
 
         with (
             patch.object(benchmark_tools, "get_all_benchmarks", return_value={"tpch": {"name": "tpch"}}),
-            patch.object(benchmark_tools, "get_public_benchmark_class", return_value=DummyBenchmark),
+            patch.object(benchmark_tools, "get_public_benchmark_class", return_value=Mock),
             patch.object(dask_df, "LocalCluster") as local_cluster,
             patch.object(dask_df, "Client"),
         ):
@@ -284,17 +280,14 @@ class TestRunBenchmarkTool:
         """The envelope is a ceiling, not a ban on tuning."""
         from benchbox.mcp.tools import benchmark as benchmark_tools
 
-        class DummyBenchmark:
-            def __init__(self, scale_factor: float) -> None:
-                self.scale_factor = scale_factor
-
-            def run_with_platform(self, *_args, **_kwargs):
-                return None
-
         with (
             patch.object(benchmark_tools, "get_all_benchmarks", return_value={"tpch": {"name": "tpch"}}),
-            patch.object(benchmark_tools, "get_public_benchmark_class", return_value=DummyBenchmark),
-            patch.object(benchmark_tools, "_get_platform_adapter", return_value=Mock()) as get_adapter,
+            patch.object(benchmark_tools, "get_public_benchmark_class", return_value=Mock),
+            patch.object(
+                benchmark_tools,
+                "_execute_mcp_run_via_core",
+                return_value={"mcp_metadata": {"status": "no_results"}},
+            ) as run_core,
         ):
             benchmark_tools._run_benchmark_impl(
                 "dask-df",
@@ -308,10 +301,11 @@ class TestRunBenchmarkTool:
                 anonymize=False,
             )
 
-        kwargs = get_adapter.call_args.kwargs
-        assert kwargs["n_workers"] == 4
-        assert kwargs["threads_per_worker"] == 4
-        assert kwargs["memory_limit"] == "4GB"
+        assert run_core.call_args.kwargs["normalized_platform_options"] == {
+            "n_workers": 4,
+            "threads_per_worker": 4,
+            "memory_limit": "4GB",
+        }
 
     @pytest.mark.parametrize("platform", ["clickhouse", "clickhouse-server"])
     def test_clickhouse_port_override_is_refused_before_any_adapter_is_built(self, platform, tmp_path: Path):
@@ -343,17 +337,14 @@ class TestRunBenchmarkTool:
 
         monkeypatch.setenv(MCP_CLICKHOUSE_PROFILE_ENV, json.dumps({"reviewed": {"port": 9440, "secure": True}}))
 
-        class DummyBenchmark:
-            def __init__(self, scale_factor: float) -> None:
-                self.scale_factor = scale_factor
-
-            def run_with_platform(self, *_args, **_kwargs):
-                return None
-
         with (
             patch.object(benchmark_tools, "get_all_benchmarks", return_value={"tpch": {"name": "tpch"}}),
-            patch.object(benchmark_tools, "get_public_benchmark_class", return_value=DummyBenchmark),
-            patch.object(benchmark_tools, "_get_platform_adapter", return_value=Mock()) as get_adapter,
+            patch.object(benchmark_tools, "get_public_benchmark_class", return_value=Mock),
+            patch.object(
+                benchmark_tools,
+                "_execute_mcp_run_via_core",
+                return_value={"mcp_metadata": {"status": "no_results"}},
+            ) as run_core,
         ):
             benchmark_tools._run_benchmark_impl(
                 "clickhouse-server",
@@ -367,10 +358,7 @@ class TestRunBenchmarkTool:
                 anonymize=False,
             )
 
-        kwargs = get_adapter.call_args.kwargs
-        assert kwargs["port"] == 9440
-        assert kwargs["secure"] is True
-        assert "connection_profile" not in kwargs
+        assert run_core.call_args.kwargs["normalized_platform_options"] == {"connection_profile": "reviewed"}
 
     def test_clickhouse_profile_withdrawn_by_the_operator_fails_closed(self, monkeypatch, tmp_path: Path):
         """A replayed request cannot outlive the profile that authorized it."""
@@ -436,6 +424,7 @@ class TestRunBenchmarkTool:
             MCP_CLICKHOUSE_PROFILE_ENV,
             MCP_PLATFORM_OPTION_ALLOWLIST,
             MCP_PLATFORM_OPTION_CONTRACT,
+            resolve_clickhouse_connection_profile,
             validate_platform_options,
         )
 
@@ -507,6 +496,11 @@ class TestRunBenchmarkTool:
 
                 try:
                     normalized = validate_platform_options(platform, request)
+                    if option_name == "connection_profile":
+                        profile = resolve_clickhouse_connection_profile("reviewed")
+                        normalized = {
+                            key: item for key, item in normalized.items() if key != "connection_profile"
+                        } | profile
                     prepared = _prepare_adapter_platform_options(platform, normalized)
                 except Exception as e:
                     failures.append(f"{platform}.{option_name} prepare failed: {e}")

--- a/tests/unit/mcp/test_mcp_benchmark_stdout_suppression.py
+++ b/tests/unit/mcp/test_mcp_benchmark_stdout_suppression.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import io
 import sys
 from pathlib import Path
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -21,22 +21,14 @@ def test_run_benchmark_impl_suppresses_transitive_stdout() -> None:
     """_run_benchmark_impl should suppress print() leakage from benchmark execution."""
     from benchbox.mcp.tools.benchmark import _run_benchmark_impl
 
-    class DummyBenchmark:
-        def __init__(self, scale_factor: float) -> None:
-            self.scale_factor = scale_factor
-
-        def run_with_platform(self, *_args, **_kwargs):
-            print("LEAK: benchmark run output")
-            return None
-
     captured = io.StringIO()
     original_stdout = sys.stdout
     try:
         sys.stdout = captured
         with (
             patch("benchbox.mcp.tools.benchmark.get_all_benchmarks", return_value={"tpch": {"name": "tpch"}}),
-            patch("benchbox.mcp.tools.benchmark.get_public_benchmark_class", return_value=DummyBenchmark),
-            patch("benchbox.mcp.tools.benchmark._get_platform_adapter", return_value=object()),
+            patch("benchbox.mcp.tools.benchmark.get_public_benchmark_class", return_value=MagicMock),
+            patch("benchbox.core.run_service.execute_run", side_effect=lambda **_: print("LEAK: benchmark run output")),
         ):
             response = _run_benchmark_impl(
                 "duckdb",

--- a/tests/unit/mcp/test_mcp_statistics_phase.py
+++ b/tests/unit/mcp/test_mcp_statistics_phase.py
@@ -57,16 +57,19 @@ def _mock_run(
     phases: str,
     extra_result_kwargs: dict[str, Any] | None = None,
 ) -> tuple[dict[str, Any], dict[str, Any]]:
-    """Call run_benchmark with run_with_platform mocked; return (response, call_kwargs)."""
+    """Call run_benchmark with the shared core service mocked."""
     fn = tool_functions["run_benchmark"]
 
     mock_result = MagicMock()
     mock_result.query_results = []
 
-    mock_instance = MagicMock()
-    mock_instance.run_with_platform.return_value = mock_result
+    captured: dict[str, Any] = {}
 
-    mock_bm_class = MagicMock(return_value=mock_instance)
+    def execute_run(**kwargs):
+        config = kwargs["config"]
+        captured.update(config.options or {})
+        captured["test_execution_type"] = config.test_execution_type
+        return mock_result
 
     result_path = tmp_path / "result.json"
     write_v2_result_file(
@@ -81,17 +84,17 @@ def _mock_run(
 
     with (
         patch("benchbox.mcp.tools.benchmark._get_platform_adapter"),
-        patch("benchbox.mcp.tools.benchmark.get_public_benchmark_class", return_value=mock_bm_class),
+        patch("benchbox.mcp.tools.benchmark.get_public_benchmark_class", return_value=MagicMock),
         patch("benchbox.mcp.tools.benchmark.ResultExporter", return_value=mock_exporter),
+        patch("benchbox.core.run_service.execute_run", side_effect=execute_run),
     ):
         result = fn(platform="duckdb", benchmark="tpch", scale_factor=0.01, phases=phases)
 
-    call_kwargs = mock_instance.run_with_platform.call_args[1]
-    return result, call_kwargs
+    return result, captured
 
 
 class TestStatisticsPhaseFlagThreading:
-    """gather_statistics/statistics_benchmark_name threading into run_with_platform."""
+    """gather_statistics/statistics_benchmark_name threading into core config."""
 
     def test_statistics_in_phases_forwards_gather_statistics_flag(self, tool_functions, tmp_path):
         """`statistics` in phases sets gather_statistics=True and statistics_benchmark_name
@@ -129,7 +132,7 @@ class TestStatisticsPhaseFlagThreading:
 class TestStatisticsPhaseResponsePassThrough:
     """phases.statistics pass-through from the exported result into the MCP response.
 
-    These are deliberately shallow pass-through checks: ``run_with_platform`` is
+    These are deliberately shallow pass-through checks: the core run service is
     mocked and the exported result file is hand-written, so they only prove the MCP
     response carries through whatever ``phases`` the exporter produced. They do NOT
     exercise the ``supports_statistics_phase`` registry gate or ``run_statistics_phase``

--- a/tests/unit/mcp/test_mcp_tool_handlers.py
+++ b/tests/unit/mcp/test_mcp_tool_handlers.py
@@ -1007,7 +1007,7 @@ class TestPhasesMapping:
 
     def test_power_phase_maps_to_power_type(self):
         """Phases containing 'power' should map to power test_execution_type."""
-        from benchbox.mcp.tools.benchmark import _map_phases_to_test_execution_type
+        from benchbox.core.run_service import _map_phases_to_execution_type as _map_phases_to_test_execution_type
 
         assert _map_phases_to_test_execution_type(["power"]) == "power"
         assert _map_phases_to_test_execution_type(["load", "power"]) == "power"
@@ -1015,32 +1015,32 @@ class TestPhasesMapping:
 
     def test_throughput_phase_maps_to_throughput_type(self):
         """Phases containing only 'throughput' should map to throughput type."""
-        from benchbox.mcp.tools.benchmark import _map_phases_to_test_execution_type
+        from benchbox.core.run_service import _map_phases_to_execution_type as _map_phases_to_test_execution_type
 
         assert _map_phases_to_test_execution_type(["throughput"]) == "throughput"
         assert _map_phases_to_test_execution_type(["load", "throughput"]) == "throughput"
 
     def test_combined_phases_map_to_combined_type(self):
         """All three query phases together should map to combined type."""
-        from benchbox.mcp.tools.benchmark import _map_phases_to_test_execution_type
+        from benchbox.core.run_service import _map_phases_to_execution_type as _map_phases_to_test_execution_type
 
         assert _map_phases_to_test_execution_type(["power", "throughput", "maintenance"]) == "combined"
 
     def test_load_only_phase_maps_to_load_only_type(self):
         """Load-only phase should map to load_only type."""
-        from benchbox.mcp.tools.benchmark import _map_phases_to_test_execution_type
+        from benchbox.core.run_service import _map_phases_to_execution_type as _map_phases_to_test_execution_type
 
         assert _map_phases_to_test_execution_type(["load"]) == "load_only"
 
     def test_generate_only_phase_maps_to_data_only_type(self):
         """Generate-only phase should map to data_only type."""
-        from benchbox.mcp.tools.benchmark import _map_phases_to_test_execution_type
+        from benchbox.core.run_service import _map_phases_to_execution_type as _map_phases_to_test_execution_type
 
         assert _map_phases_to_test_execution_type(["generate"]) == "data_only"
 
     def test_empty_phases_maps_to_standard(self):
         """Empty or unrecognized phases should map to standard type."""
-        from benchbox.mcp.tools.benchmark import _map_phases_to_test_execution_type
+        from benchbox.core.run_service import _map_phases_to_execution_type as _map_phases_to_test_execution_type
 
         assert _map_phases_to_test_execution_type([]) == "standard"
         assert _map_phases_to_test_execution_type(["warmup"]) == "standard"

--- a/tests/unit/mcp/test_mcp_tool_handlers.py
+++ b/tests/unit/mcp/test_mcp_tool_handlers.py
@@ -505,28 +505,16 @@ class TestRunBenchmarkToolSuccess:
         assert result["mcp_metadata"]["result_file"] == str(result_path)
 
     def test_query_subset_forwarded(self, tool_functions):
-        """Query subset string is parsed and forwarded."""
+        """Query subset string reaches the shared core run service."""
         fn = tool_functions["run_benchmark"]
 
-        mock_result = MagicMock()
-        mock_result.total_queries = 3
-        mock_result.successful_queries = 3
-        mock_result.failed_queries = 0
-        mock_result.total_execution_time = 1.0
-        mock_result.query_results = []
-
-        mock_instance = MagicMock()
-        mock_instance.run_with_platform.return_value = mock_result
-        mock_bm_class = MagicMock(return_value=mock_instance)
-
-        with (
-            patch("benchbox.mcp.tools.benchmark._get_platform_adapter"),
-            patch("benchbox.mcp.tools.benchmark.get_public_benchmark_class", return_value=mock_bm_class),
-        ):
+        with patch(
+            "benchbox.mcp.tools.benchmark._execute_mcp_run_via_core",
+            return_value={"mcp_metadata": {"status": "completed"}},
+        ) as run_core:
             fn(platform="duckdb", benchmark="tpch", scale_factor=0.01, queries="1,6,17")
 
-            call_kwargs = mock_instance.run_with_platform.call_args[1]
-            assert call_kwargs["query_subset"] == ["1", "6", "17"]
+        assert run_core.call_args.kwargs["queries"] == "1,6,17"
 
     def test_result_exported_with_execution_id(self, tool_functions):
         """Execution ID is set on result before export."""
@@ -539,18 +527,14 @@ class TestRunBenchmarkToolSuccess:
         mock_result.total_execution_time = 1.0
         mock_result.query_results = []
 
-        mock_instance = MagicMock()
-        mock_instance.run_with_platform.return_value = mock_result
-
-        mock_bm_class = MagicMock(return_value=mock_instance)
-
         mock_exporter = MagicMock()
         mock_exporter.export_result.return_value = {"json": Path("/tmp/result.json")}
 
         with (
             patch("benchbox.mcp.tools.benchmark._get_platform_adapter"),
-            patch("benchbox.mcp.tools.benchmark.get_public_benchmark_class", return_value=mock_bm_class),
+            patch("benchbox.mcp.tools.benchmark.get_public_benchmark_class", return_value=MagicMock),
             patch("benchbox.mcp.tools.benchmark.ResultExporter", return_value=mock_exporter),
+            patch("benchbox.core.run_service.execute_run", return_value=mock_result),
         ):
             fn(platform="duckdb", benchmark="tpch", scale_factor=0.01)
 
@@ -638,6 +622,7 @@ class TestRunBenchmarkToolSuccess:
     def test_dataframe_platform_uses_dataframe_runner(self, tool_functions, tmp_path):
         """DataFrame platforms use the dedicated dataframe runner."""
         fn = tool_functions["run_benchmark"]
+        from benchbox.core.runner.runner import LifecyclePhases
 
         mock_df_result = MagicMock()
         mock_df_result.query_results = [
@@ -659,22 +644,23 @@ class TestRunBenchmarkToolSuccess:
         mock_exporter = MagicMock()
         mock_exporter.export_result.return_value = {"json": result_path}
 
-        # Create mock benchmark instance that returns our mock result
-        mock_benchmark_instance = MagicMock()
-        mock_benchmark_instance.run_with_platform.return_value = mock_df_result
-
-        mock_benchmark_class = MagicMock(return_value=mock_benchmark_instance)
+        def execute_run(**kwargs):
+            kwargs["adapter_factory"](
+                execution_mode="dataframe",
+                output_root=tmp_path,
+                phases=LifecyclePhases(load=True, execute=True),
+            )
+            return mock_df_result
 
         with (
-            patch("benchbox.mcp.tools.benchmark._get_platform_adapter"),
-            patch("benchbox.platforms.is_dataframe_platform", return_value=True),
-            patch("benchbox.mcp.tools.benchmark.get_public_benchmark_class", return_value=mock_benchmark_class),
+            patch("benchbox.platforms.get_adapter", return_value=MagicMock()) as get_adapter,
+            patch("benchbox.mcp.tools.benchmark.get_public_benchmark_class", return_value=MagicMock),
             patch("benchbox.mcp.tools.benchmark.ResultExporter", return_value=mock_exporter),
+            patch("benchbox.core.run_service.execute_run", side_effect=execute_run),
         ):
             result = fn(platform="polars-df", benchmark="tpch", scale_factor=0.01)
 
-        # Verify unified run_with_platform was called (DataFrame adapters now use same path)
-        mock_benchmark_instance.run_with_platform.assert_called_once()
+        assert get_adapter.call_args.kwargs["mode"] == "dataframe"
 
         assert result["mcp_metadata"]["status"] == "completed"
         assert result["platform"]["name"] == "polars-df"
@@ -1052,11 +1038,6 @@ class TestPhasesMapping:
         mock_result = MagicMock()
         mock_result.query_results = []
 
-        mock_instance = MagicMock()
-        mock_instance.run_with_platform.return_value = mock_result
-
-        mock_bm_class = MagicMock(return_value=mock_instance)
-
         result_path = tmp_path / "result.json"
         write_v2_result_file(result_path, execution_id="test", timestamp="2026-01-01T00:00:00")
 
@@ -1065,27 +1046,21 @@ class TestPhasesMapping:
 
         with (
             patch("benchbox.mcp.tools.benchmark._get_platform_adapter"),
-            patch("benchbox.mcp.tools.benchmark.get_public_benchmark_class", return_value=mock_bm_class),
+            patch("benchbox.mcp.tools.benchmark.get_public_benchmark_class", return_value=MagicMock),
             patch("benchbox.mcp.tools.benchmark.ResultExporter", return_value=mock_exporter),
+            patch("benchbox.core.run_service.execute_run", return_value=mock_result) as execute_run,
         ):
             fn(platform="duckdb", benchmark="tpch", scale_factor=0.01, phases="power")
 
-        # Verify run_with_platform was called with test_execution_type="power"
-        mock_instance.run_with_platform.assert_called_once()
-        call_kwargs = mock_instance.run_with_platform.call_args[1]
-        assert call_kwargs.get("test_execution_type") == "power"
+        assert execute_run.call_args.kwargs["config"].test_execution_type == "power"
 
     def test_run_benchmark_passes_mode_to_adapter(self, tool_functions, tmp_path):
-        """run_benchmark should pass mode to _get_platform_adapter for correct adapter selection."""
+        """run_benchmark should pass mode to the unified adapter factory."""
         fn = tool_functions["run_benchmark"]
+        from benchbox.core.runner.runner import LifecyclePhases
 
         mock_result = MagicMock()
         mock_result.query_results = []
-
-        mock_instance = MagicMock()
-        mock_instance.run_with_platform.return_value = mock_result
-
-        mock_bm_class = MagicMock(return_value=mock_instance)
 
         result_path = tmp_path / "result.json"
         write_v2_result_file(
@@ -1100,14 +1075,23 @@ class TestPhasesMapping:
 
         mock_get_adapter = MagicMock()
 
+        def execute_run(**kwargs):
+            kwargs["adapter_factory"](
+                execution_mode="dataframe",
+                output_root=tmp_path,
+                phases=LifecyclePhases(load=True, execute=True),
+            )
+            return mock_result
+
         with (
-            patch("benchbox.mcp.tools.benchmark._get_platform_adapter", mock_get_adapter),
-            patch("benchbox.mcp.tools.benchmark.get_public_benchmark_class", return_value=mock_bm_class),
+            patch("benchbox.platforms.get_adapter", mock_get_adapter),
+            patch("benchbox.mcp.tools.benchmark.get_public_benchmark_class", return_value=MagicMock),
             patch("benchbox.mcp.tools.benchmark.ResultExporter", return_value=mock_exporter),
+            patch("benchbox.core.run_service.execute_run", side_effect=execute_run),
         ):
             fn(platform="datafusion", benchmark="tpch", scale_factor=0.01, mode="dataframe")
 
-        # Verify _get_platform_adapter was called with mode="dataframe"
+        # Verify the unified adapter factory was called with mode="dataframe"
         mock_get_adapter.assert_called_once()
         call_kwargs = mock_get_adapter.call_args[1]
         assert call_kwargs.get("mode") == "dataframe"

--- a/tests/unit/mcp/test_schemas.py
+++ b/tests/unit/mcp/test_schemas.py
@@ -288,6 +288,9 @@ class TestPlatformOptionAdmission:
 
     def test_df_suffixed_allowlist_key_resolves_to_itself(self, monkeypatch):
         """A -df-suffixed allow-list key must resolve to itself on both sides."""
+        from benchbox.core.run_service import (
+            _translate_platform_options_for_adapter as _prepare_adapter_platform_options,
+        )
         from benchbox.mcp.schemas import (
             MCP_PLATFORM_OPTION_ALLOWLIST,
             MCP_PLATFORM_OPTION_CONTRACT,
@@ -296,7 +299,6 @@ class TestPlatformOptionAdmission:
             resolve_platform_policy_key,
             validate_platform_options,
         )
-        from benchbox.mcp.tools.benchmark import _prepare_adapter_platform_options
 
         # Inject a synthetic -df allow-list entry that would be shadowed by the base name
         # if the resolver were unconditional.

--- a/tests/unit/mcp/test_surface_defect_regressions.py
+++ b/tests/unit/mcp/test_surface_defect_regressions.py
@@ -172,31 +172,18 @@ class TestRemoteModeAnonymization:
             completed_at=None,
         )
 
-        # New one-engine path delegates to core execute_run and exports with anonymize=True.
-        mock_result = MagicMock()
-        mock_result.query_results = []
+        # New one-engine path delegates to the shared MCP/core execution helper.
         with (
-            patch("benchbox.mcp.jobs.execute_run", return_value=mock_result) as exec_mock,
-            patch("benchbox.mcp.jobs._export_and_build_payload", return_value=(None, {})) as export_mock,
-            patch("benchbox.mcp.jobs.get_public_benchmark_class", return_value=MagicMock(return_value=MagicMock())),
-            patch("benchbox.mcp.jobs.get_all_benchmarks", return_value={"tpch": {"display_name": "TPC-H"}}),
+            patch("benchbox.mcp.jobs._execute_mcp_run_via_core", return_value={}) as run_core,
             patch(
-                "benchbox.mcp.jobs.SystemProfiler",
-                return_value=MagicMock(get_system_profile=MagicMock(return_value=MagicMock())),
+                "benchbox.core.benchmark_registry.get_public_benchmark_class",
+                return_value=MagicMock,
             ),
-            patch("benchbox.mcp.jobs.get_platform_config", return_value={}),
+            patch("benchbox.mcp.jobs.get_all_benchmarks", return_value={"tpch": {"display_name": "TPC-H"}}),
         ):
             DurableJobWorker._execute_benchmark(record, tmp_path)
 
-        # Either the old helper (for data_only) or the new export path must anonymize
-        if export_mock.called:
-            assert (
-                export_mock.call_args.kwargs.get("anonymize") is True
-                or export_mock.call_args[1].get("anonymize") is True
-            )
-        else:
-            # Fallback: old path still used for data_only
-            assert True
+        assert run_core.call_args.kwargs["anonymize"] is True
 
     def test_compare_results_threads_the_anonymization_decision(self, tmp_path: Path):
         from benchbox.mcp.tools import analytics as analytics_module

--- a/tests/unit/mcp/test_surface_defect_regressions.py
+++ b/tests/unit/mcp/test_surface_defect_regressions.py
@@ -149,6 +149,8 @@ class TestRemoteModeAnonymization:
 
     def test_durable_job_execution_anonymizes(self, tmp_path: Path):
         """Durable jobs exist only under a remote policy, so the worker is remote."""
+        from unittest.mock import MagicMock
+
         from benchbox.mcp.jobs import DurableJobWorker, JobRecord
 
         record = JobRecord(
@@ -170,10 +172,31 @@ class TestRemoteModeAnonymization:
             completed_at=None,
         )
 
-        with patch("benchbox.mcp.jobs._run_benchmark_impl", return_value={}) as run_impl:
+        # New one-engine path delegates to core execute_run and exports with anonymize=True.
+        mock_result = MagicMock()
+        mock_result.query_results = []
+        with (
+            patch("benchbox.mcp.jobs.execute_run", return_value=mock_result) as exec_mock,
+            patch("benchbox.mcp.jobs._export_and_build_payload", return_value=(None, {})) as export_mock,
+            patch("benchbox.mcp.jobs.get_public_benchmark_class", return_value=MagicMock(return_value=MagicMock())),
+            patch("benchbox.mcp.jobs.get_all_benchmarks", return_value={"tpch": {"display_name": "TPC-H"}}),
+            patch(
+                "benchbox.mcp.jobs.SystemProfiler",
+                return_value=MagicMock(get_system_profile=MagicMock(return_value=MagicMock())),
+            ),
+            patch("benchbox.mcp.jobs.get_platform_config", return_value={}),
+        ):
             DurableJobWorker._execute_benchmark(record, tmp_path)
 
-        assert run_impl.call_args.kwargs["anonymize"] is True
+        # Either the old helper (for data_only) or the new export path must anonymize
+        if export_mock.called:
+            assert (
+                export_mock.call_args.kwargs.get("anonymize") is True
+                or export_mock.call_args[1].get("anonymize") is True
+            )
+        else:
+            # Fallback: old path still used for data_only
+            assert True
 
     def test_compare_results_threads_the_anonymization_decision(self, tmp_path: Path):
         from benchbox.mcp.tools import analytics as analytics_module

--- a/tests/unit/platforms/test_databricks_liquid_clustering.py
+++ b/tests/unit/platforms/test_databricks_liquid_clustering.py
@@ -289,8 +289,8 @@ def test_mcp_clustering_options_reach_the_effective_resolver(_mock_databricks_sq
     dropped. Only the translated `tuning_config` becomes
     `unified_tuning_configuration`, which is what the resolver reads.
     """
+    from benchbox.core.run_service import _translate_platform_options_for_adapter as _prepare_adapter_platform_options
     from benchbox.mcp.schemas import validate_platform_options
-    from benchbox.mcp.tools.benchmark import _prepare_adapter_platform_options
 
     normalized = validate_platform_options(
         "databricks",
@@ -320,8 +320,8 @@ def test_mcp_clustering_options_reach_the_effective_resolver(_mock_databricks_sq
 
 @patch("benchbox.platforms.databricks.adapter.databricks_sql")
 def test_mcp_columns_alone_infer_liquid_clustering_at_the_resolver(_mock_databricks_sql):
+    from benchbox.core.run_service import _translate_platform_options_for_adapter as _prepare_adapter_platform_options
     from benchbox.mcp.schemas import validate_platform_options
-    from benchbox.mcp.tools.benchmark import _prepare_adapter_platform_options
 
     normalized = validate_platform_options("databricks", {"liquid_clustering_columns": "event_time"})
     prepared = _prepare_adapter_platform_options("databricks", normalized)

--- a/tests/unit/platforms/test_duckdb_adapter.py
+++ b/tests/unit/platforms/test_duckdb_adapter.py
@@ -1644,8 +1644,10 @@ class TestMCPThreadsReachTheEffectiveSetting:
 
     @staticmethod
     def _adapter_from_mcp_request(tmp_path: Path, options: dict):
+        from benchbox.core.run_service import (
+            _translate_platform_options_for_adapter as _prepare_adapter_platform_options,
+        )
         from benchbox.mcp.schemas import validate_platform_options
-        from benchbox.mcp.tools.benchmark import _prepare_adapter_platform_options
 
         normalized = validate_platform_options("duckdb", options)
         prepared = _prepare_adapter_platform_options("duckdb", normalized)

--- a/tests/unit/test_run_orchestration_characterization.py
+++ b/tests/unit/test_run_orchestration_characterization.py
@@ -1,25 +1,13 @@
 """Characterization of run orchestration, ahead of the core run service.
 
-`one-engine-core-run-service` extracts run orchestration into
-`benchbox.core` below both surfaces. Its first work unit is characterization,
-and its anti-patterns require that extractions move code verbatim and that any
-behavior delta be listed explicitly rather than discovered later.
+`one-engine-core-run-service` extracts run orchestration into `benchbox.core`
+below both surfaces. This module pins the shared execution-type behavior so
+both surfaces remain reviewable and cannot silently diverge again.
 
-This module pins what the two surfaces do TODAY, so the extraction can be proven
-behavior-preserving -- or its deltas named. It deliberately does not fix
-anything: the divergence recorded in TestExecutionTypeDivergence is a defect the
-run service is expected to resolve, and pinning it first is what makes that
-resolution reviewable instead of invisible.
-
-Two independent implementations derive a benchmark's execution type from its
-requested phases:
-
-- `benchbox/cli/commands/run.py::_derive_execution_type`
-- `benchbox/mcp/tools/benchmark.py::_map_phases_to_test_execution_type`
-
-They agree on every single-query-phase request and every three-query-phase
-request. They disagree on all 48 combinations that select exactly TWO of the
-three query phases.
+The CLI wrapper and MCP execution both derive a benchmark's execution type from
+`benchbox/core/run_service.py::_map_phases_to_execution_type`. Mixed
+query-phase requests use `combined`, ensuring the runner executes every
+requested query phase.
 """
 
 from __future__ import annotations
@@ -43,9 +31,9 @@ def _cli_derive(phases: list[str]) -> str:
 
 
 def _mcp_derive(phases: list[str]) -> str:
-    from benchbox.mcp.tools.benchmark import _map_phases_to_test_execution_type
+    from benchbox.core.run_service import _map_phases_to_execution_type
 
-    return _map_phases_to_test_execution_type(phases)
+    return _map_phases_to_execution_type(phases)
 
 
 def _all_phase_subsets() -> list[list[str]]:
@@ -95,21 +83,8 @@ class TestExecutionTypeAgreement:
         assert _cli_derive(phases) == _mcp_derive(phases) == "combined"
 
 
-class TestExecutionTypeDivergence:
-    """KNOWN DEFECT, pinned so the run service must resolve it deliberately.
-
-    Selecting exactly two of the three query phases gives different execution
-    types on the two surfaces. The CLI returns `combined`, which its own comment
-    explains is required so the adapter runs exactly the requested subset. MCP
-    returns whichever single phase its if-chain tests first, so the other
-    requested phase is silently dropped: `phases="power,throughput"` over MCP
-    runs the power phase only.
-
-    These tests assert the CURRENT behavior of both surfaces. When the core run
-    service unifies them, these expectations must be updated in the same change,
-    which is the point -- the delta becomes a reviewed edit rather than a silent
-    one.
-    """
+class TestExecutionTypeParity:
+    """Mixed query-phase requests remain combined on both surfaces."""
 
     TWO_QUERY_PHASE_SUBSETS = [list(combo) for combo in itertools.combinations(QUERY_PHASES, 2)]
 
@@ -117,37 +92,21 @@ class TestExecutionTypeDivergence:
     def test_cli_treats_two_query_phases_as_combined(self, phases: list[str]):
         assert _cli_derive(phases) == "combined"
 
-    @pytest.mark.parametrize(
-        ("phases", "mcp_result", "dropped"),
-        [
-            (["power", "throughput"], "power", "throughput"),
-            (["power", "maintenance"], "power", "maintenance"),
-            (["throughput", "maintenance"], "throughput", "maintenance"),
-        ],
-    )
-    def test_mcp_silently_drops_the_second_query_phase(self, phases: list[str], mcp_result: str, dropped: str):
-        derived = _mcp_derive(phases)
+    @pytest.mark.parametrize("phases", TWO_QUERY_PHASE_SUBSETS)
+    def test_mcp_treats_two_query_phases_as_combined(self, phases: list[str]):
+        assert _mcp_derive(phases) == "combined"
 
-        assert derived == mcp_result
-        assert dropped in phases
-        assert derived != "combined", "MCP would have to return combined to honour both phases"
-
-    def test_the_divergence_is_exactly_the_two_query_phase_case(self):
-        """Bounds the defect: 48 of 127 subsets, all of them two-query-phase."""
+    def test_no_phase_subset_diverges(self):
+        """All phase subsets agree across CLI and MCP."""
         diverging = [phases for phases in ALL_SUBSETS if _cli_derive(phases) != _mcp_derive(phases)]
 
         assert len(ALL_SUBSETS) == 127
-        assert len(diverging) == 48
-        for phases in diverging:
-            assert len(set(phases) & set(QUERY_PHASES)) == 2, phases
+        assert diverging == []
 
-    def test_no_agreeing_subset_involves_two_query_phases(self):
-        """The converse, so the bound cannot rot in one direction only."""
+    def test_every_subset_including_two_query_phases_agrees(self):
         agreeing = [phases for phases in ALL_SUBSETS if _cli_derive(phases) == _mcp_derive(phases)]
 
-        assert len(agreeing) == 79
-        for phases in agreeing:
-            assert len(set(phases) & set(QUERY_PHASES)) != 2, phases
+        assert len(agreeing) == len(ALL_SUBSETS)
 
 
 class TestPhaseParsingCharacterization:

--- a/tests/unit/test_runplan_equivalence.py
+++ b/tests/unit/test_runplan_equivalence.py
@@ -1,0 +1,115 @@
+"""Cross-surface RunPlan equivalence: CLI and MCP resolve same inputs identically.
+
+W3 for one-engine-mcp-run-service-adoption. The one-engine contract is that
+all benchmark business logic lives in benchbox.core below both surfaces;
+the two surfaces deliberately expose different subsets but resolve the same
+logical inputs through the same core helpers (resolve_lifecycle_phases,
+_map_phases_to_execution_type, resolve_run_config). This test pins that.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from benchbox.core.run_service import (
+    _map_phases_to_execution_type,
+    resolve_lifecycle_phases,
+)
+
+pytestmark = [pytest.mark.unit, pytest.mark.fast]
+
+
+@pytest.mark.parametrize(
+    "phases, expected_type, expect_execute",
+    [
+        (["load", "power"], "power", True),
+        (["power"], "power", True),
+        (["throughput"], "throughput", True),
+        (["power", "throughput", "maintenance"], "combined", True),
+        (["load"], "load_only", False),
+        (["generate"], "data_only", False),
+        ([], "standard", False),
+        (["warmup"], "standard", False),
+    ],
+)
+def test_runplan_equivalence_phases_map_same_for_cli_and_mcp(phases, expected_type, expect_execute):
+    """Same phases list resolves identically via CLI and MCP (both use core)."""
+    # MCP previously had _map_phases_to_test_execution_type; now core owns it
+    mcp_type = _map_phases_to_execution_type(phases)
+    # CLI uses resolve_lifecycle_phases for the same input
+    lifecycle = resolve_lifecycle_phases(phases if phases else None)
+
+    assert mcp_type == expected_type
+    # Lifecycle and execution_type must agree on whether query execution happens
+    if expected_type in ("power", "throughput", "combined", "standard"):
+        assert lifecycle.execute is True
+    elif expected_type == "load_only":
+        assert lifecycle.load is True and lifecycle.execute is False
+    elif expected_type == "data_only":
+        assert lifecycle.generate is True
+    else:
+        # standard with no phases defaults to generate+load+execute
+        pass
+
+
+def test_runplan_parity_cli_mcp_run_config_resolution(tmp_path):
+    """CLI orchestrator and MCP both delegate RunConfig to core (parity)."""
+    from pathlib import Path
+
+    from benchbox.cli.orchestrator import BenchmarkOrchestrator
+    from benchbox.core.config import BenchmarkConfig
+    from benchbox.core.run_service import SilentVerbosity, resolve_run_config
+
+    cfg = BenchmarkConfig(
+        name="tpch", display_name="TPC-H", scale_factor=0.01, queries=["1"], options={"seed": 5, "power_iterations": 2}
+    )
+    orch = BenchmarkOrchestrator(base_dir=str(tmp_path))
+
+    class _DB:
+        type = "duckdb"
+
+    via_cli = orch._prepare_run_config(cfg, _DB())
+    via_core = resolve_run_config(
+        cfg,
+        database_path=orch.directory_manager.get_database_path(
+            cfg.name, cfg.scale_factor, "duckdb", tuning_config=None
+        ),
+        verbosity=SilentVerbosity(),
+    )
+
+    # CLI uses its own verbosity (quiet False), MCP uses SilentVerbosity (quiet True) — they differ only in verbosity flags
+    # The equivalence is that the non-verbosity fields are identical because both delegate to core
+    cli_dump = via_cli.model_dump()
+    core_dump = via_core.model_dump()
+    for k in ("quiet", "verbose", "verbose_level", "verbose_enabled", "very_verbose"):
+        cli_dump.pop(k, None)
+        core_dump.pop(k, None)
+    assert cli_dump == core_dump
+    assert via_core.quiet is True
+    assert via_cli.quiet is False
+
+
+def test_runplan_equivalence_mcp_parity_with_cli_via_core(tmp_path):
+    """MCP job worker and CLI orchestrator share the same core RunConfig path."""
+    from benchbox.cli.orchestrator import BenchmarkOrchestrator
+    from benchbox.core.config import BenchmarkConfig
+    from benchbox.core.run_service import SilentVerbosity, resolve_run_config
+
+    cfg = BenchmarkConfig(name="tpch", display_name="TPC-H", scale_factor=1.0, options={"power_iterations": 3})
+    orch = BenchmarkOrchestrator(base_dir=str(tmp_path))
+
+    class _DB:
+        type = "duckdb"
+
+    # Simulate what MCP would do for the same logical request (via core)
+    via_mcp = resolve_run_config(
+        cfg,
+        database_path=orch.directory_manager.get_database_path("tpch", 1.0, "duckdb", tuning_config=None),
+        verbosity=SilentVerbosity(),
+    )
+    via_cli = orch._prepare_run_config(cfg, _DB())
+
+    # Same config resolves same iterations via core; quiet differs by surface (MCP silent, CLI not)
+    assert via_mcp.iterations == via_cli.iterations
+    assert via_mcp.quiet is True
+    assert via_cli.quiet is False


### PR DESCRIPTION
## Summary

- route synchronous MCP benchmark execution and durable-job workers through the shared core run service
- keep MCP admission, security, tenancy, anonymization, lease/fencing, and atomic publication at their existing boundaries
- remove MCP-local execution translators and make CLI/MCP phase derivation agree for all 127 phase subsets

## Tracker

- `one-engine-mcp-adoption-not-actually-done`
- `cli-mcp-execution-type-divergence-still-live` (implemented in the same branch; its tracker dependency remains until the first item lands)

## Validation

- focused MCP/core/platform slice: 858 passed
- full fast lane: 27,782 passed, 16 skipped
- Ruff check and format check passed
- import-layer contracts passed
- `make pr-preflight` passed

The external stateless MCP deployment acceptance and final release gate remain separate operator/release gates and are not claimed by this code PR.
