### PR TITLE
Add structural oracle for vector search results

### DIFF
--- a/benchbox/core/benchmark_mixins.py
+++ b/benchbox/core/benchmark_mixins.py
@@ -254,6 +254,7 @@ class CursorValidationQueryExecutionMixin:
                 actual_row_count=actual_row_count,
                 first_row=result[0] if result else None,
                 validation_result=validation_result,
+                materialized_rows=result,
             )
             self._attach_query_stats(result_dict, query_stats)
             return result_dict

--- a/benchbox/core/vector_search/benchmark.py
+++ b/benchbox/core/vector_search/benchmark.py
@@ -194,6 +194,16 @@ class VectorSearchBenchmark(GeneratorOutputDirMixin, TranslatableQueryMixin, Dat
     # Query execution
     # ------------------------------------------------------------------
 
+    def validate_query_result(self, query_id: Union[int, str], rows: Any) -> None:
+        """Validate materialized rows returned by a platform adapter.
+
+        The generic adapter execution path does not call this benchmark's
+        ``run_benchmark`` method. Adapters use this opt-in hook after their
+        timed query execution to apply the same structural oracle to the
+        production CLI/MCP path.
+        """
+        validate_search_result(str(query_id), rows)
+
     def execute_query(
         self,
         query_id: Union[int, str],
@@ -309,8 +319,8 @@ class VectorSearchBenchmark(GeneratorOutputDirMixin, TranslatableQueryMixin, Dat
                         dialect=dialect,
                         platform_version=platform_version,
                     )
-                    validate_search_result(query_id, result)
                     duration = elapsed_seconds(start)
+                    self.validate_query_result(query_id, result)
                     query_results["iterations"].append(
                         {
                             "iteration": i + 1,

--- a/benchbox/core/vector_search/benchmark.py
+++ b/benchbox/core/vector_search/benchmark.py
@@ -26,6 +26,7 @@ from benchbox.core.benchmark_mixins import DataGenerationMixin
 from benchbox.core.query_catalog_base import QuerySkippedError, TranslatableQueryMixin
 from benchbox.core.utils.tuning import extract_constraint_flags
 from benchbox.core.vector_search.generator import VectorSearchDataGenerator
+from benchbox.core.vector_search.metrics import validate_search_result
 from benchbox.core.vector_search.queries import VectorSearchQueryManager
 from benchbox.core.vector_search.schema import TABLES, get_all_create_table_sql
 from benchbox.utils.clock import elapsed_seconds, mono_time
@@ -308,6 +309,7 @@ class VectorSearchBenchmark(GeneratorOutputDirMixin, TranslatableQueryMixin, Dat
                         dialect=dialect,
                         platform_version=platform_version,
                     )
+                    validate_search_result(query_id, result)
                     duration = elapsed_seconds(start)
                     query_results["iterations"].append(
                         {

--- a/benchbox/core/vector_search/benchmark.py
+++ b/benchbox/core/vector_search/benchmark.py
@@ -18,6 +18,7 @@ Licensed under the MIT License. See LICENSE file in the project root for details
 
 from __future__ import annotations
 
+from collections.abc import Sequence
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Optional, Union
 
@@ -194,7 +195,7 @@ class VectorSearchBenchmark(GeneratorOutputDirMixin, TranslatableQueryMixin, Dat
     # Query execution
     # ------------------------------------------------------------------
 
-    def validate_query_result(self, query_id: Union[int, str], rows: Any) -> None:
+    def validate_query_result(self, query_id: Union[int, str], rows: Sequence[Sequence[object]]) -> None:
         """Validate materialized rows returned by a platform adapter.
 
         The generic adapter execution path does not call this benchmark's

--- a/benchbox/core/vector_search/metrics.py
+++ b/benchbox/core/vector_search/metrics.py
@@ -46,8 +46,8 @@ def validate_search_result(query_id: str, rows: Sequence[Sequence[object]]) -> N
     seen_ids: set[object] = set()
     metrics: list[float] = []
     for index, row in enumerate(rows):
-        if len(row) < 2:
-            raise ValueError(f"{normalized_query_id} row {index} has no metric column")
+        if len(row) != 2:
+            raise ValueError(f"{normalized_query_id} row {index} must contain exactly id and metric columns")
         row_id = row[0]
         if row_id in seen_ids:
             raise ValueError(f"{normalized_query_id} returned duplicate id {row_id!r}")

--- a/benchbox/core/vector_search/metrics.py
+++ b/benchbox/core/vector_search/metrics.py
@@ -10,10 +10,60 @@ Licensed under the MIT License. See LICENSE file in the project root for details
 
 from __future__ import annotations
 
+import math
 import statistics
 from typing import Sequence
 
 from benchbox.core.results.metrics import percentile_ms
+
+_QUERY_LIMITS = {"Q1": 10, "Q2": 10, "Q3": 10, "Q4": 100, "Q5": 10, "Q6": 20}
+_DISTANCE_QUERY = "Q2"
+
+
+def validate_search_result(query_id: str, rows: Sequence[Sequence[object]]) -> None:
+    """Validate the engine-independent shape and ordering contract of a search result.
+
+    This is a structural oracle for the vector-search benchmark.  It does not
+    assert engine-specific nearest-neighbour IDs; it catches result-shape,
+    duplicate-ID, non-finite-metric, and ordering regressions that a timing-only
+    benchmark would otherwise report as successful.
+
+    Args:
+        query_id: One of Q1-Q6.
+        rows: Rows returned by the query, with ``(id, metric)`` in that order.
+
+    Raises:
+        ValueError: If the result violates the query's published contract.
+    """
+    if query_id not in _QUERY_LIMITS:
+        raise ValueError(f"Unknown vector-search query: {query_id}")
+
+    limit = _QUERY_LIMITS[query_id]
+    if len(rows) > limit:
+        raise ValueError(f"{query_id} returned {len(rows)} rows; expected at most {limit}")
+
+    seen_ids: set[object] = set()
+    metrics: list[float] = []
+    for index, row in enumerate(rows):
+        if len(row) < 2:
+            raise ValueError(f"{query_id} row {index} has no metric column")
+        row_id = row[0]
+        if row_id in seen_ids:
+            raise ValueError(f"{query_id} returned duplicate id {row_id!r}")
+        seen_ids.add(row_id)
+        try:
+            metric = float(row[1])
+        except (TypeError, ValueError) as exc:
+            raise ValueError(f"{query_id} row {index} has a non-numeric metric") from exc
+        if not math.isfinite(metric):
+            raise ValueError(f"{query_id} row {index} has a non-finite metric")
+        metrics.append(metric)
+
+    for previous, current in zip(metrics, metrics[1:]):
+        if query_id == _DISTANCE_QUERY and previous > current:
+            raise ValueError(f"{query_id} distance results are not ascending")
+        if query_id != _DISTANCE_QUERY and previous < current:
+            raise ValueError(f"{query_id} similarity results are not descending")
 
 
 def recall_at_k(ground_truth: Sequence[int], approximate: Sequence[int], k: int) -> float:

--- a/benchbox/core/vector_search/metrics.py
+++ b/benchbox/core/vector_search/metrics.py
@@ -35,35 +35,36 @@ def validate_search_result(query_id: str, rows: Sequence[Sequence[object]]) -> N
     Raises:
         ValueError: If the result violates the query's published contract.
     """
-    if query_id not in _QUERY_LIMITS:
+    normalized_query_id = str(query_id).strip().upper()
+    if normalized_query_id not in _QUERY_LIMITS:
         raise ValueError(f"Unknown vector-search query: {query_id}")
 
-    limit = _QUERY_LIMITS[query_id]
+    limit = _QUERY_LIMITS[normalized_query_id]
     if len(rows) > limit:
-        raise ValueError(f"{query_id} returned {len(rows)} rows; expected at most {limit}")
+        raise ValueError(f"{normalized_query_id} returned {len(rows)} rows; expected at most {limit}")
 
     seen_ids: set[object] = set()
     metrics: list[float] = []
     for index, row in enumerate(rows):
         if len(row) < 2:
-            raise ValueError(f"{query_id} row {index} has no metric column")
+            raise ValueError(f"{normalized_query_id} row {index} has no metric column")
         row_id = row[0]
         if row_id in seen_ids:
-            raise ValueError(f"{query_id} returned duplicate id {row_id!r}")
+            raise ValueError(f"{normalized_query_id} returned duplicate id {row_id!r}")
         seen_ids.add(row_id)
         try:
             metric = float(row[1])
         except (TypeError, ValueError) as exc:
-            raise ValueError(f"{query_id} row {index} has a non-numeric metric") from exc
+            raise ValueError(f"{normalized_query_id} row {index} has a non-numeric metric") from exc
         if not math.isfinite(metric):
-            raise ValueError(f"{query_id} row {index} has a non-finite metric")
+            raise ValueError(f"{normalized_query_id} row {index} has a non-finite metric")
         metrics.append(metric)
 
     for previous, current in zip(metrics, metrics[1:]):
-        if query_id == _DISTANCE_QUERY and previous > current:
-            raise ValueError(f"{query_id} distance results are not ascending")
-        if query_id != _DISTANCE_QUERY and previous < current:
-            raise ValueError(f"{query_id} similarity results are not descending")
+        if normalized_query_id == _DISTANCE_QUERY and previous > current:
+            raise ValueError(f"{normalized_query_id} distance results are not ascending")
+        if normalized_query_id != _DISTANCE_QUERY and previous < current:
+            raise ValueError(f"{normalized_query_id} similarity results are not descending")
 
 
 def recall_at_k(ground_truth: Sequence[int], approximate: Sequence[int], k: int) -> float:

--- a/benchbox/platforms/athena.py
+++ b/benchbox/platforms/athena.py
@@ -1237,6 +1237,7 @@ class AthenaAdapter(PlatformAdapter):
                 actual_row_count=actual_row_count,
                 first_row=result[0] if result else None,
                 validation_result=validation_result,
+                materialized_rows=result,
             )
 
             # Add Athena-specific fields

--- a/benchbox/platforms/azure_synapse.py
+++ b/benchbox/platforms/azure_synapse.py
@@ -1023,6 +1023,7 @@ class AzureSynapseAdapter(PlatformAdapter):
                 actual_row_count=actual_row_count,
                 first_row=result[0] if result else None,
                 validation_result=validation_result,
+                materialized_rows=result,
             )
 
             self.log_verbose(f"Query {query_id} completed: {actual_row_count} rows in {execution_time:.3f}s")

--- a/benchbox/platforms/base/execution.py
+++ b/benchbox/platforms/base/execution.py
@@ -1053,7 +1053,21 @@ class TestDriversMixin:
             return self._execute_operation_query(benchmark, connection, query_id)
 
         scale_factor = getattr(benchmark, "scale_factor", None)
-        result = self.execute_query(
+        validator = getattr(benchmark, "validate_query_result", None)
+        if callable(validator):
+            from benchbox.platforms.base.result_capture import materialized_result_validation
+
+            with materialized_result_validation(validator):
+                return self.execute_query(
+                    connection,
+                    query_sql,
+                    query_id,
+                    benchmark_type=benchmark_type,
+                    scale_factor=scale_factor,
+                    validate_row_count=self.enable_validation,
+                )
+
+        return self.execute_query(
             connection,
             query_sql,
             query_id,
@@ -1061,72 +1075,6 @@ class TestDriversMixin:
             scale_factor=scale_factor,
             validate_row_count=self.enable_validation,
         )
-        return self._apply_benchmark_result_validation(benchmark, connection, query_id, query_sql, result)
-
-    @staticmethod
-    def _materialize_query_rows_for_validation(connection: Any, query_sql: str) -> Any:
-        """Materialize rows for an opt-in post-execution benchmark oracle.
-
-        Platform ``execute_query`` implementations intentionally return compact
-        result dictionaries, so the generic driver cannot inspect the full row
-        set from the timed call. An opt-in benchmark hook therefore gets a
-        second, untimed read of the same rendered SQL. This keeps oracle work
-        out of ``execution_time_seconds`` while preserving the adapter's normal
-        execution and result-building path for every benchmark without a hook.
-        """
-        execute = getattr(connection, "execute", None)
-        if callable(execute):
-            cursor = execute(query_sql)
-            fetchall = getattr(cursor, "fetchall", None)
-            if callable(fetchall):
-                return fetchall()
-            if cursor is not None and not hasattr(cursor, "fetchall"):
-                return cursor
-            connection_fetchall = getattr(connection, "fetchall", None)
-            if callable(connection_fetchall):
-                return connection_fetchall()
-
-        cursor_factory = getattr(connection, "cursor", None)
-        if not callable(cursor_factory):
-            raise TypeError(f"Connection cannot materialize validation rows: {type(connection)!r}")
-        cursor = cursor_factory()
-        try:
-            cursor.execute(query_sql)
-            return cursor.fetchall()
-        finally:
-            close = getattr(cursor, "close", None)
-            if callable(close):
-                close()
-
-    def _apply_benchmark_result_validation(
-        self,
-        benchmark: Any,
-        connection: Any,
-        query_id: str,
-        query_sql: str,
-        result: dict[str, Any],
-    ) -> dict[str, Any]:
-        """Apply an opt-in benchmark oracle and route failures as query failures."""
-        # Inspect the class as well as the instance so test doubles and other
-        # dynamic objects that fabricate arbitrary attributes do not opt into a
-        # second query execution accidentally.
-        validator = getattr(benchmark, "validate_query_result", None)
-        if getattr(type(benchmark), "validate_query_result", None) is None:
-            validator = None
-        if not callable(validator) or result.get("status") != "SUCCESS":
-            return result
-
-        try:
-            rows = self._materialize_query_rows_for_validation(connection, query_sql)
-            validator(query_id, rows)
-        except Exception as exc:
-            failed_result = dict(result)
-            failed_result["status"] = "FAILED"
-            failed_result["validation_passed"] = False
-            failed_result["error"] = f"result validation failed: {exc}"
-            return failed_result
-
-        return result
 
     def _execute_operation_query(self, benchmark, connection: Any, query_id: str) -> dict[str, Any]:
         """Execute a benchmark operation (INSERT/UPDATE/DELETE) and return result dict."""

--- a/benchbox/platforms/base/execution.py
+++ b/benchbox/platforms/base/execution.py
@@ -1053,7 +1053,7 @@ class TestDriversMixin:
             return self._execute_operation_query(benchmark, connection, query_id)
 
         scale_factor = getattr(benchmark, "scale_factor", None)
-        return self.execute_query(
+        result = self.execute_query(
             connection,
             query_sql,
             query_id,
@@ -1061,6 +1061,72 @@ class TestDriversMixin:
             scale_factor=scale_factor,
             validate_row_count=self.enable_validation,
         )
+        return self._apply_benchmark_result_validation(benchmark, connection, query_id, query_sql, result)
+
+    @staticmethod
+    def _materialize_query_rows_for_validation(connection: Any, query_sql: str) -> Any:
+        """Materialize rows for an opt-in post-execution benchmark oracle.
+
+        Platform ``execute_query`` implementations intentionally return compact
+        result dictionaries, so the generic driver cannot inspect the full row
+        set from the timed call. An opt-in benchmark hook therefore gets a
+        second, untimed read of the same rendered SQL. This keeps oracle work
+        out of ``execution_time_seconds`` while preserving the adapter's normal
+        execution and result-building path for every benchmark without a hook.
+        """
+        execute = getattr(connection, "execute", None)
+        if callable(execute):
+            cursor = execute(query_sql)
+            fetchall = getattr(cursor, "fetchall", None)
+            if callable(fetchall):
+                return fetchall()
+            if cursor is not None and not hasattr(cursor, "fetchall"):
+                return cursor
+            connection_fetchall = getattr(connection, "fetchall", None)
+            if callable(connection_fetchall):
+                return connection_fetchall()
+
+        cursor_factory = getattr(connection, "cursor", None)
+        if not callable(cursor_factory):
+            raise TypeError(f"Connection cannot materialize validation rows: {type(connection)!r}")
+        cursor = cursor_factory()
+        try:
+            cursor.execute(query_sql)
+            return cursor.fetchall()
+        finally:
+            close = getattr(cursor, "close", None)
+            if callable(close):
+                close()
+
+    def _apply_benchmark_result_validation(
+        self,
+        benchmark: Any,
+        connection: Any,
+        query_id: str,
+        query_sql: str,
+        result: dict[str, Any],
+    ) -> dict[str, Any]:
+        """Apply an opt-in benchmark oracle and route failures as query failures."""
+        # Inspect the class as well as the instance so test doubles and other
+        # dynamic objects that fabricate arbitrary attributes do not opt into a
+        # second query execution accidentally.
+        validator = getattr(benchmark, "validate_query_result", None)
+        if getattr(type(benchmark), "validate_query_result", None) is None:
+            validator = None
+        if not callable(validator) or result.get("status") != "SUCCESS":
+            return result
+
+        try:
+            rows = self._materialize_query_rows_for_validation(connection, query_sql)
+            validator(query_id, rows)
+        except Exception as exc:
+            failed_result = dict(result)
+            failed_result["status"] = "FAILED"
+            failed_result["validation_passed"] = False
+            failed_result["error"] = f"result validation failed: {exc}"
+            return failed_result
+
+        return result
 
     def _execute_operation_query(self, benchmark, connection: Any, query_id: str) -> dict[str, Any]:
         """Execute a benchmark operation (INSERT/UPDATE/DELETE) and return result dict."""

--- a/benchbox/platforms/base/result_capture.py
+++ b/benchbox/platforms/base/result_capture.py
@@ -36,7 +36,9 @@ import re
 import statistics
 import threading
 import time
-from collections.abc import Mapping
+from collections.abc import Callable, Iterator, Mapping, Sequence
+from contextlib import contextmanager
+from contextvars import ContextVar
 from dataclasses import replace
 from datetime import datetime
 from pathlib import Path
@@ -71,6 +73,58 @@ from benchbox.platforms.base.utils import is_non_interactive
 from benchbox.utils.clock import elapsed_seconds
 from benchbox.utils.printing import quiet_console
 from benchbox.utils.timeout_manager import run_with_timeout
+
+MaterializedRows = Sequence[Sequence[object]]
+MaterializedRowsSource = MaterializedRows | Callable[[], MaterializedRows]
+MaterializedResultValidator = Callable[[str, MaterializedRows], None]
+
+_MATERIALIZED_RESULT_VALIDATOR: ContextVar[MaterializedResultValidator | None] = ContextVar(
+    "benchbox_materialized_result_validator",
+    default=None,
+)
+
+
+@contextmanager
+def materialized_result_validation(validator: MaterializedResultValidator) -> Iterator[None]:
+    """Apply a benchmark-local full-result oracle to one adapter execution.
+
+    A context variable keeps concurrent throughput streams isolated while
+    avoiding a public ``execute_query`` signature change across every adapter.
+    Platform implementations pass their already-materialized rows to the
+    shared result builder; the oracle runs after the adapter has captured the
+    measured execution duration.
+    """
+    token = _MATERIALIZED_RESULT_VALIDATOR.set(validator)
+    try:
+        yield
+    finally:
+        _MATERIALIZED_RESULT_VALIDATOR.reset(token)
+
+
+def materialized_result_validation_active() -> bool:
+    """Return whether the current adapter execution needs its full result rows."""
+    return _MATERIALIZED_RESULT_VALIDATOR.get() is not None
+
+
+def apply_materialized_result_validation(
+    result: dict[str, Any],
+    query_id: str,
+    materialized_rows: MaterializedRowsSource | None,
+) -> None:
+    """Apply the active benchmark-local oracle to a successful result in place."""
+    materialized_validator = _MATERIALIZED_RESULT_VALIDATOR.get()
+    if materialized_validator is None or result["status"] != "SUCCESS":
+        return
+
+    try:
+        if materialized_rows is None:
+            raise RuntimeError("platform adapter did not expose materialized rows for structural validation")
+        rows = materialized_rows if isinstance(materialized_rows, Sequence) else materialized_rows()
+        materialized_validator(str(query_id), rows)
+    except Exception as exc:
+        result["status"] = "FAILED"
+        result["error"] = str(exc) or type(exc).__name__
+
 
 try:
     from benchbox.core.results.models import ExecutionPhases, QueryDefinition
@@ -1265,6 +1319,7 @@ class ResultCaptureMixin:
         validation_result: Any = None,
         error: str | None = None,
         result_digest: str | None = None,
+        materialized_rows: MaterializedRowsSource | None = None,
     ) -> dict[str, Any]:
         """Build query result dictionary with consistent validation field mapping.
 
@@ -1281,6 +1336,8 @@ class ResultCaptureMixin:
             result_digest: Gate-only full-result value digest (optional). Present
                 only when BENCHBOX_EMIT_RESULT_DIGEST armed the value oracle; absent
                 on a normal run so the payload shape is unchanged.
+            materialized_rows: Full rows, or a lazy row supplier, for an active
+                benchmark-local structural oracle. Ignored when no oracle is active.
 
         Returns:
             Dictionary with standardized query result fields
@@ -1326,6 +1383,8 @@ class ResultCaptureMixin:
                 result_dict["error"] = validation_result.error_message
 
             result_dict["row_count_validation"] = row_count_validation
+
+        apply_materialized_result_validation(result_dict, query_id, materialized_rows)
 
         execution = query_execution_from_legacy_dict(result_dict)
         compatibility_result = query_execution_to_legacy_dict(

--- a/benchbox/platforms/base/spark_execution_mixin.py
+++ b/benchbox/platforms/base/spark_execution_mixin.py
@@ -564,6 +564,7 @@ class SparkQueryExecutionMixin:
                 actual_row_count=actual_row_count,
                 first_row=tuple(result[0]) if result else None,
                 validation_result=validation_result,
+                materialized_rows=result,
             )
 
             result_dict["query_statistics"] = query_stats

--- a/benchbox/platforms/base/sql_execution.py
+++ b/benchbox/platforms/base/sql_execution.py
@@ -100,6 +100,7 @@ def execute_sql_query(
             first_row=results[0] if results else None,
             validation_result=validation_result,
             result_digest=result_digest,
+            materialized_rows=results,
         )
 
     except Exception as exc:

--- a/benchbox/platforms/bigquery.py
+++ b/benchbox/platforms/bigquery.py
@@ -1556,6 +1556,7 @@ class BigQueryAdapter(PlatformAdapter):
                 actual_row_count=actual_row_count,
                 first_row=result[0] if result else None,
                 validation_result=validation_result,
+                materialized_rows=result,
             )
 
             # Include BigQuery-specific fields

--- a/benchbox/platforms/clickhouse/workload.py
+++ b/benchbox/platforms/clickhouse/workload.py
@@ -837,17 +837,18 @@ class ClickHouseWorkloadMixin:
                         "translated_query": None,
                     }
 
-            # Build successful result
+            # Preserve ClickHouse's historical row-count metadata semantics: a
+            # warning can accompany a successful validation result without the
+            # expected-results ValidationMode enum used by the shared builder.
             result_dict = {
                 "query_id": query_id,
                 "status": "SUCCESS",
                 "execution_time_seconds": execution_time,
                 "rows_returned": actual_row_count,
                 "first_row": result[0] if result else None,
-                "translated_query": None,  # Translation handled by base adapter
+                "translated_query": None,
             }
 
-            # Include validation metadata if validation was performed
             if validation_result:
                 row_count_validation = {
                     "expected": validation_result.expected_row_count,
@@ -857,6 +858,10 @@ class ClickHouseWorkloadMixin:
                 if validation_result.warning_message:
                     row_count_validation["warning"] = validation_result.warning_message
                 result_dict["row_count_validation"] = row_count_validation
+
+            from benchbox.platforms.base.result_capture import apply_materialized_result_validation
+
+            apply_materialized_result_validation(result_dict, query_id, result)
 
         except Exception as e:
             execution_time = elapsed_seconds(start_time)

--- a/benchbox/platforms/cudf.py
+++ b/benchbox/platforms/cudf.py
@@ -544,6 +544,12 @@ class CuDFAdapter(NoConstraintEnforcementMixin, PlatformAdapter):
             actual_row_count = result.rowcount
             # Get first row efficiently (only transfers one row)
             first_row = result.fetchone()
+            materialized_rows = None
+            from benchbox.platforms.base.result_capture import materialized_result_validation_active
+
+            if materialized_result_validation_active():
+                materialized_rows = ([first_row] if first_row is not None else []) + list(result.fetchall())
+                actual_row_count = len(materialized_rows)
 
             logger.debug(f"Query {query_id} completed in {execution_time:.3f}s, returned {actual_row_count} rows")
 
@@ -579,6 +585,7 @@ class CuDFAdapter(NoConstraintEnforcementMixin, PlatformAdapter):
                 actual_row_count=actual_row_count,
                 first_row=first_row,
                 validation_result=validation_result,
+                materialized_rows=materialized_rows,
             )
 
             # Add GPU-specific metrics

--- a/benchbox/platforms/databend/adapter.py
+++ b/benchbox/platforms/databend/adapter.py
@@ -560,6 +560,7 @@ class DatabendAdapter(PlatformAdapter):
                 actual_row_count=actual_row_count,
                 first_row=result[0] if result else None,
                 validation_result=validation_result,
+                materialized_rows=result,
             )
 
             result_dict["query_statistics"] = query_stats

--- a/benchbox/platforms/databricks/adapter.py
+++ b/benchbox/platforms/databricks/adapter.py
@@ -2007,6 +2007,7 @@ class DatabricksAdapter(PlatformAdapter):
                 actual_row_count=actual_row_count,
                 first_row=result[0] if result else None,
                 validation_result=validation_result,
+                materialized_rows=result,
             )
 
             # Include Databricks-specific fields

--- a/benchbox/platforms/databricks/dataframe_adapter.py
+++ b/benchbox/platforms/databricks/dataframe_adapter.py
@@ -342,6 +342,7 @@ class DatabricksDataFrameAdapter(DatabricksAdapter):
                 actual_row_count=actual_row_count,
                 first_row=tuple(result[0]) if result else None,
                 validation_result=validation_result,
+                materialized_rows=result,
             )
 
             # Add DataFrame mode metadata

--- a/benchbox/platforms/datafusion.py
+++ b/benchbox/platforms/datafusion.py
@@ -1621,6 +1621,16 @@ class DataFusionAdapter(NoConstraintEnforcementMixin, PlatformAdapter):
                 actual_row_count=actual_row_count,
                 first_row=first_row,
                 validation_result=validation_result,
+                materialized_rows=lambda: [
+                    tuple(
+                        batch.column(column_index)[row_index].as_py()
+                        if hasattr(batch.column(column_index)[row_index], "as_py")
+                        else batch.column(column_index)[row_index]
+                        for column_index in range(batch.num_columns)
+                    )
+                    for batch in result_batches
+                    for row_index in range(batch.num_rows)
+                ],
             )
 
             # Display plan in console when --show-query-plans is active.

--- a/benchbox/platforms/duckdb.py
+++ b/benchbox/platforms/duckdb.py
@@ -1163,6 +1163,7 @@ class DuckDBAdapter(PlatformAdapter):
                 first_row=rows[0] if rows else None,
                 validation_result=validation_result,
                 result_digest=result_digest,
+                materialized_rows=rows,
             )
 
             # Capture and merge structured query plan (SUCCESS-guarded in the helper)

--- a/benchbox/platforms/redshift.py
+++ b/benchbox/platforms/redshift.py
@@ -2107,6 +2107,7 @@ class RedshiftAdapter(PlatformAdapter):
                 actual_row_count=actual_row_count,
                 first_row=result[0] if result else None,
                 validation_result=validation_result,
+                materialized_rows=result,
             )
 
             # Include Redshift-specific fields

--- a/benchbox/platforms/snowflake.py
+++ b/benchbox/platforms/snowflake.py
@@ -1211,6 +1211,7 @@ class SnowflakeAdapter(PlatformAdapter):
                 actual_row_count=actual_row_count,
                 first_row=result[0] if result else None,
                 validation_result=validation_result,
+                materialized_rows=result,
             )
 
             # Include Snowflake-specific fields

--- a/benchbox/platforms/snowpark_connect.py
+++ b/benchbox/platforms/snowpark_connect.py
@@ -429,6 +429,7 @@ class SnowparkConnectAdapter(SparkTuningMixin, PlatformAdapter):
                 execution_time=elapsed,
                 actual_row_count=len(rows),
                 first_row=rows[0] if rows else None,
+                materialized_rows=result,
             )
             result_dict["stream_id"] = stream_id
             result_dict["results"] = rows

--- a/benchbox/platforms/sqlite.py
+++ b/benchbox/platforms/sqlite.py
@@ -567,6 +567,7 @@ class SQLiteAdapter(PlatformAdapter):
                 actual_row_count=actual_row_count,
                 first_row=results[0] if results else None,
                 validation_result=validation_result,
+                materialized_rows=results,
             )
             # Include full results for SQLite compatibility
             result["results"] = results

--- a/benchbox/vector_search.py
+++ b/benchbox/vector_search.py
@@ -112,6 +112,10 @@ class VectorSearch(BaseBenchmark):
         """Return all queries in the default (DuckDB) dialect."""
         return self._impl.get_all_queries()
 
+    def validate_query_result(self, query_id: Union[int, str], rows: Any) -> None:
+        """Validate materialized rows returned by a platform adapter."""
+        self._impl.validate_query_result(query_id, rows)
+
     def get_schema(self, dialect: str = "duckdb") -> dict[str, dict]:
         """Return the schema table definitions."""
         return self._impl.get_schema(dialect)

--- a/benchbox/vector_search.py
+++ b/benchbox/vector_search.py
@@ -8,6 +8,7 @@ Copyright 2026 Joe Harris / BenchBox Project
 Licensed under the MIT License. See LICENSE file in the project root for details.
 """
 
+from collections.abc import Sequence
 from pathlib import Path
 from typing import Any, Optional, Union
 
@@ -112,7 +113,7 @@ class VectorSearch(BaseBenchmark):
         """Return all queries in the default (DuckDB) dialect."""
         return self._impl.get_all_queries()
 
-    def validate_query_result(self, query_id: Union[int, str], rows: Any) -> None:
+    def validate_query_result(self, query_id: Union[int, str], rows: Sequence[Sequence[object]]) -> None:
         """Validate materialized rows returned by a platform adapter."""
         self._impl.validate_query_result(query_id, rows)
 

--- a/tests/unit/core/vector_search/test_vector_benchmark.py
+++ b/tests/unit/core/vector_search/test_vector_benchmark.py
@@ -450,6 +450,25 @@ class TestVectorSearchSchema:
 class TestVectorSearchMetrics:
     """Tests for recall@k, latency percentiles, and QPS utilities."""
 
+    def test_search_result_oracle_accepts_ordered_rows(self):
+        from benchbox.core.vector_search.metrics import validate_search_result
+
+        validate_search_result("Q1", [(1, 0.9), (2, 0.8)])
+
+    def test_search_result_oracle_rejects_planted_ordering_defect(self):
+        from benchbox.core.vector_search.metrics import validate_search_result
+
+        with pytest.raises(ValueError, match="similarity results are not descending"):
+            validate_search_result("Q1", [(1, 0.8), (2, 0.9)])
+
+    def test_search_result_oracle_rejects_duplicate_ids_and_excess_rows(self):
+        from benchbox.core.vector_search.metrics import validate_search_result
+
+        with pytest.raises(ValueError, match="duplicate id"):
+            validate_search_result("Q2", [(1, 0.1), (1, 0.2)])
+        with pytest.raises(ValueError, match="at most 10"):
+            validate_search_result("Q2", [(index, float(index)) for index in range(11)])
+
     def test_perfect_recall(self):
         from benchbox.core.vector_search.metrics import recall_at_k
 
@@ -623,6 +642,24 @@ class TestVectorSearchBenchmark:
         )
         assert results["queries"]["Q2"]["status"] == "SKIPPED"
         assert "l2_distance requires StarRocks" in results["queries"]["Q2"]["skip_reason"]
+
+    def test_run_benchmark_applies_structural_result_oracle(self, tmp_path):
+        from benchbox.core.vector_search import VectorSearchBenchmark
+
+        class Cursor:
+            def fetchall(self):
+                return [(1, 0.8), (2, 0.9)]
+
+        class Connection:
+            def execute(self, _sql):
+                return Cursor()
+
+        benchmark = VectorSearchBenchmark(scale_factor=0.01, output_dir=tmp_path)
+        results = benchmark.run_benchmark(connection=Connection(), queries=["Q1"])
+
+        iteration = results["queries"]["Q1"]["iterations"][0]
+        assert iteration["success"] is False
+        assert "similarity results are not descending" in iteration["error"]
 
     def test_get_create_tables_sql_duckdb(self, tmp_path):
         from benchbox.core.vector_search import VectorSearchBenchmark

--- a/tests/unit/core/vector_search/test_vector_benchmark.py
+++ b/tests/unit/core/vector_search/test_vector_benchmark.py
@@ -454,6 +454,8 @@ class TestVectorSearchMetrics:
         from benchbox.core.vector_search.metrics import validate_search_result
 
         validate_search_result("Q1", [(1, 0.9), (2, 0.8)])
+        validate_search_result("q1", [(1, 0.9), (2, 0.8)])
+        validate_search_result(" q2 ", [(1, 0.1), (2, 0.2)])
 
     def test_search_result_oracle_rejects_planted_ordering_defect(self):
         from benchbox.core.vector_search.metrics import validate_search_result
@@ -660,6 +662,35 @@ class TestVectorSearchBenchmark:
         iteration = results["queries"]["Q1"]["iterations"][0]
         assert iteration["success"] is False
         assert "similarity results are not descending" in iteration["error"]
+
+    def test_run_benchmark_times_query_before_structural_oracle(self, tmp_path, monkeypatch):
+        from benchbox.core.vector_search import benchmark as vector_benchmark_module
+
+        events: list[str] = []
+
+        class Cursor:
+            def fetchall(self):
+                return [(1, 0.9)]
+
+        class Connection:
+            def execute(self, _sql):
+                return Cursor()
+
+        monkeypatch.setattr(
+            vector_benchmark_module,
+            "elapsed_seconds",
+            lambda _start: events.append("duration") or 0.25,
+        )
+        monkeypatch.setattr(
+            vector_benchmark_module,
+            "validate_search_result",
+            lambda _query_id, _rows: events.append("oracle"),
+        )
+
+        benchmark = vector_benchmark_module.VectorSearchBenchmark(scale_factor=0.01, output_dir=tmp_path)
+        benchmark.run_benchmark(connection=Connection(), queries=["Q1"])
+
+        assert events == ["duration", "oracle"]
 
     def test_get_create_tables_sql_duckdb(self, tmp_path):
         from benchbox.core.vector_search import VectorSearchBenchmark

--- a/tests/unit/core/vector_search/test_vector_benchmark.py
+++ b/tests/unit/core/vector_search/test_vector_benchmark.py
@@ -470,6 +470,8 @@ class TestVectorSearchMetrics:
             validate_search_result("Q2", [(1, 0.1), (1, 0.2)])
         with pytest.raises(ValueError, match="at most 10"):
             validate_search_result("Q2", [(index, float(index)) for index in range(11)])
+        with pytest.raises(ValueError, match="exactly id and metric columns"):
+            validate_search_result("Q1", [(1, 0.9, "extra")])
 
     def test_perfect_recall(self):
         from benchbox.core.vector_search.metrics import recall_at_k

--- a/tests/unit/core/vector_search/test_vector_benchmark.py
+++ b/tests/unit/core/vector_search/test_vector_benchmark.py
@@ -665,34 +665,36 @@ class TestVectorSearchBenchmark:
         assert iteration["success"] is False
         assert "similarity results are not descending" in iteration["error"]
 
-    def test_run_benchmark_times_query_before_structural_oracle(self, tmp_path, monkeypatch):
-        from benchbox.core.vector_search import benchmark as vector_benchmark_module
+    def test_run_benchmark_excludes_structural_validation_from_latency(self, tmp_path, monkeypatch):
+        from benchbox.core.vector_search import VectorSearchBenchmark, benchmark as benchmark_module
 
         events: list[str] = []
 
         class Cursor:
             def fetchall(self):
-                return [(1, 0.9)]
+                return [(1, 0.9), (2, 0.8)]
 
         class Connection:
             def execute(self, _sql):
                 return Cursor()
 
+        benchmark = VectorSearchBenchmark(scale_factor=0.01, output_dir=tmp_path)
+        monkeypatch.setattr(benchmark_module, "mono_time", lambda: 10.0)
         monkeypatch.setattr(
-            vector_benchmark_module,
+            benchmark_module,
             "elapsed_seconds",
-            lambda _start: events.append("duration") or 0.25,
+            lambda _start: events.append("elapsed") or 0.25,
         )
         monkeypatch.setattr(
-            vector_benchmark_module,
-            "validate_search_result",
-            lambda _query_id, _rows: events.append("oracle"),
+            benchmark,
+            "validate_query_result",
+            lambda _query_id, _rows: events.append("validate"),
         )
 
-        benchmark = vector_benchmark_module.VectorSearchBenchmark(scale_factor=0.01, output_dir=tmp_path)
-        benchmark.run_benchmark(connection=Connection(), queries=["Q1"])
+        results = benchmark.run_benchmark(connection=Connection(), queries=["q1"])
 
-        assert events == ["duration", "oracle"]
+        assert events == ["elapsed", "validate"]
+        assert results["queries"]["q1"]["iterations"][0]["time"] == 0.25
 
     def test_get_create_tables_sql_duckdb(self, tmp_path):
         from benchbox.core.vector_search import VectorSearchBenchmark
@@ -748,6 +750,13 @@ class TestVectorSearchWrapper:
 
         b = VectorSearch(scale_factor=0.01, output_dir=tmp_path)
         assert len(b.get_all_queries()) == 6
+
+    def test_wrapper_exposes_structural_result_oracle(self, tmp_path):
+        from benchbox.vector_search import VectorSearch
+
+        benchmark = VectorSearch(scale_factor=0.01, output_dir=tmp_path)
+        with pytest.raises(ValueError, match="not descending"):
+            benchmark.validate_query_result("q1", [(1, 0.8), (2, 0.9)])
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/platforms/test_base_adapter.py
+++ b/tests/unit/platforms/test_base_adapter.py
@@ -364,6 +364,47 @@ class TestPlatformAdapter:
         assert adapter.connection_pool is None
         assert adapter.dialect is None
 
+    def test_execute_single_query_applies_benchmark_result_oracle(self):
+        """The production adapter path must route opt-in benchmark oracles."""
+
+        class Cursor:
+            def fetchall(self):
+                return [(1, 0.8), (2, 0.9)]
+
+        class Connection:
+            def __init__(self):
+                self.executed_sql: list[str] = []
+
+            def execute(self, sql):
+                self.executed_sql.append(sql)
+                return Cursor()
+
+        class Benchmark:
+            scale_factor = 0.01
+
+            def validate_query_result(self, query_id, rows):
+                assert query_id == "Q1"
+                assert rows == [(1, 0.8), (2, 0.9)]
+                raise ValueError("similarity results are not descending")
+
+        adapter = MockPlatformAdapter()
+        adapter.execute_query = Mock(
+            return_value={
+                "query_id": "Q1",
+                "status": "SUCCESS",
+                "execution_time_seconds": 0.1,
+                "rows_returned": 2,
+            }
+        )
+        connection = Connection()
+
+        result = adapter._execute_single_query(Benchmark(), connection, "Q1", "SELECT ...")
+
+        assert result["status"] == "FAILED"
+        assert result["validation_passed"] is False
+        assert "similarity results are not descending" in result["error"]
+        assert connection.executed_sql == ["SELECT ..."]
+
     def test_external_table_capability_defaults_disabled(self):
         """Base adapter defaults to native tables unless subclasses opt in."""
         adapter = MockPlatformAdapter()

--- a/tests/unit/platforms/test_base_adapter.py
+++ b/tests/unit/platforms/test_base_adapter.py
@@ -364,47 +364,6 @@ class TestPlatformAdapter:
         assert adapter.connection_pool is None
         assert adapter.dialect is None
 
-    def test_execute_single_query_applies_benchmark_result_oracle(self):
-        """The production adapter path must route opt-in benchmark oracles."""
-
-        class Cursor:
-            def fetchall(self):
-                return [(1, 0.8), (2, 0.9)]
-
-        class Connection:
-            def __init__(self):
-                self.executed_sql: list[str] = []
-
-            def execute(self, sql):
-                self.executed_sql.append(sql)
-                return Cursor()
-
-        class Benchmark:
-            scale_factor = 0.01
-
-            def validate_query_result(self, query_id, rows):
-                assert query_id == "Q1"
-                assert rows == [(1, 0.8), (2, 0.9)]
-                raise ValueError("similarity results are not descending")
-
-        adapter = MockPlatformAdapter()
-        adapter.execute_query = Mock(
-            return_value={
-                "query_id": "Q1",
-                "status": "SUCCESS",
-                "execution_time_seconds": 0.1,
-                "rows_returned": 2,
-            }
-        )
-        connection = Connection()
-
-        result = adapter._execute_single_query(Benchmark(), connection, "Q1", "SELECT ...")
-
-        assert result["status"] == "FAILED"
-        assert result["validation_passed"] is False
-        assert "similarity results are not descending" in result["error"]
-        assert connection.executed_sql == ["SELECT ..."]
-
     def test_external_table_capability_defaults_disabled(self):
         """Base adapter defaults to native tables unless subclasses opt in."""
         adapter = MockPlatformAdapter()
@@ -538,6 +497,39 @@ class TestPlatformAdapter:
         assert "dialect" not in kwargs
         assert isinstance(results, list)
         assert all(r.get("run_type") == "measurement" for r in results)
+
+    def test_execute_single_query_applies_benchmark_materialized_result_oracle(self):
+        class MaterializedAdapter(MockPlatformAdapter):
+            def execute_query(self, connection, query, query_id, **kwargs):
+                rows = [(1, 0.8), (2, 0.9)]
+                return self._build_query_result_with_validation(
+                    query_id=query_id,
+                    execution_time=0.125,
+                    actual_row_count=len(rows),
+                    first_row=rows[0],
+                    materialized_rows=rows,
+                )
+
+        class Benchmark:
+            scale_factor = 0.01
+
+            @staticmethod
+            def validate_query_result(query_id, rows):
+                from benchbox.core.vector_search.metrics import validate_search_result
+
+                validate_search_result(query_id, rows)
+
+        result = MaterializedAdapter()._execute_single_query(
+            Benchmark(),
+            connection=object(),
+            query_id="q1",
+            query_sql="SELECT 1",
+            benchmark_type="vector_search",
+        )
+
+        assert result["status"] == "FAILED"
+        assert result["execution_time_seconds"] == 0.125
+        assert "not descending" in result["error"]
 
     def test_execute_all_queries_benchmark_no_dialect_parameter(self):
         """Test _execute_all_queries when benchmark doesn't support dialect parameter."""


### PR DESCRIPTION
## Summary
- add an additive vector-search structural oracle for result shape, row limits, unique IDs, finite metrics, and ORDER BY direction
- apply it during benchmark execution so a malformed result is recorded as a failed query
- add planted-defect and run-path regression coverage

## Validation
- `make oracle-coverage-map-check`
- `uv run -- python -m pytest -p no:cacheprovider -n 0 tests/unit/test_oracle_coverage_map.py tests/unit/core/vector_search/test_vector_benchmark.py -q` (106 passed)
- Ruff, format, diff checks, and pre-commit hooks pass

This is intentionally a structural oracle; it does not claim engine-specific nearest-neighbour IDs.