### PR TITLE
fix(todo): enforce skill action taxonomy

### DIFF
--- a/.claude/skills/todo/SKILL.md
+++ b/.claude/skills/todo/SKILL.md
@@ -20,7 +20,7 @@ Use `_project/scripts/todo`. Check that the wrapper supports the command you nee
 * Run `_project/scripts/todo --help` and confirm the subcommand appears.
 * If the subcommand is missing, report the gap and stop.
 
-`prioritize` has no CLI command. It is a skill-only analysis. Follow `references/prioritize.md` and use only the inspect commands it lists.
+Skill-only actions: `prioritize`, `batch`, `handoff`, and `closeout`; follow their guides, not the CLI.
 
 If one request combines review or validation with close-out, perform the
 read-only review and stop at findings under `SHARED/review-protocol/SKILL.md`.
@@ -54,7 +54,7 @@ The `--help` output for the command you chose is the full contract.
 | `prioritize` — skill-only, no CLI command | You rank open items and group by topic | `references/prioritize.md` |
 | `lint` | You review an item | `references/review.md` |
 | `finding candidates`, `finding triage`, `finding import`, `finding sync`, `finding promote` | You triage findings | `references/implement.md` |
-| `batch` — a set of related TODOs | You implement several TODOs in order | `references/batch.md` |
+| `batch` — skill-only, no CLI command | You implement several TODOs in order | `references/batch.md` |
 | `handoff` — skill-only, no CLI command | You create a self-contained batch handoff | `references/handoff.md` |
 | `closeout` — skill-only, no CLI command | You remediate a separately reviewed batch and close its items | `references/closeout.md` |
 | `help` | You need the action list | This table |

--- a/.claude/skills/todo/references/handoff.md
+++ b/.claude/skills/todo/references/handoff.md
@@ -6,8 +6,8 @@ reviewed batch. Assume the next session knows only what the prompt states.
 Include these sections in order:
 
 1. **Objective and item set** — batch label, every TODO id, and whether the
-   next action is the standalone skill action `todo batch` or the standalone
-   skill action `todo closeout`; neither is a project-wrapper command.
+   next action is the Todo skill's `batch` action or `closeout` action; neither
+   is a CLI command.
 2. **Tracker preflight** — how to reach the tracker and confirm the intended
    backend before any write.
 3. **Current state** — live PR states, branch names, required checks, and the

--- a/.claude/skills/todo/skill.yaml
+++ b/.claude/skills/todo/skill.yaml
@@ -9,6 +9,4 @@ category: workflow
 targets:
   claude: true
   codex: true
-standalone_only_commands:
-  batch: 0.9.0
-  closeout: 0.9.0
+standalone_only_commands: {}

--- a/skill-sync.lock
+++ b/skill-sync.lock
@@ -1,16 +1,16 @@
 {
   "version": 1,
-  "lockedAt": "2026-08-12T03:10:25.919Z",
+  "lockedAt": "2026-08-12T16:16:45.555Z",
   "skills": {
     "blog": {
       "source": {
         "type": "git",
         "name": "canonical",
         "url": "https://github.com/joeharris76/skill-sync-skills.git",
-        "ref": "6ef11c58e61b741b4125b40a553f425973a234e2",
+        "ref": "7b63719927992bd7f7fff6b90449bbba2bb94ba3",
         "subdir": "skills",
-        "revision": "6ef11c58e61b741b4125b40a553f425973a234e2",
-        "fetchedAt": "2026-08-12T03:10:17.151Z"
+        "revision": "7b63719927992bd7f7fff6b90449bbba2bb94ba3",
+        "fetchedAt": "2026-08-12T16:16:37.555Z"
       },
       "installMode": "mirror",
       "files": {
@@ -61,10 +61,10 @@
         "type": "git",
         "name": "canonical",
         "url": "https://github.com/joeharris76/skill-sync-skills.git",
-        "ref": "6ef11c58e61b741b4125b40a553f425973a234e2",
+        "ref": "7b63719927992bd7f7fff6b90449bbba2bb94ba3",
         "subdir": "skills",
-        "revision": "6ef11c58e61b741b4125b40a553f425973a234e2",
-        "fetchedAt": "2026-08-12T03:10:18.267Z"
+        "revision": "7b63719927992bd7f7fff6b90449bbba2bb94ba3",
+        "fetchedAt": "2026-08-12T16:16:38.359Z"
       },
       "installMode": "mirror",
       "files": {
@@ -115,10 +115,10 @@
         "type": "git",
         "name": "canonical",
         "url": "https://github.com/joeharris76/skill-sync-skills.git",
-        "ref": "6ef11c58e61b741b4125b40a553f425973a234e2",
+        "ref": "7b63719927992bd7f7fff6b90449bbba2bb94ba3",
         "subdir": "skills",
-        "revision": "6ef11c58e61b741b4125b40a553f425973a234e2",
-        "fetchedAt": "2026-08-12T03:10:19.683Z"
+        "revision": "7b63719927992bd7f7fff6b90449bbba2bb94ba3",
+        "fetchedAt": "2026-08-12T16:16:39.137Z"
       },
       "installMode": "mirror",
       "files": {
@@ -161,10 +161,10 @@
         "type": "git",
         "name": "canonical",
         "url": "https://github.com/joeharris76/skill-sync-skills.git",
-        "ref": "6ef11c58e61b741b4125b40a553f425973a234e2",
+        "ref": "7b63719927992bd7f7fff6b90449bbba2bb94ba3",
         "subdir": "skills",
-        "revision": "6ef11c58e61b741b4125b40a553f425973a234e2",
-        "fetchedAt": "2026-08-12T03:10:21.281Z"
+        "revision": "7b63719927992bd7f7fff6b90449bbba2bb94ba3",
+        "fetchedAt": "2026-08-12T16:16:40.706Z"
       },
       "installMode": "mirror",
       "files": {
@@ -181,8 +181,8 @@
           "size": 1894
         },
         "references/handoff.md": {
-          "sha256": "6b90193cb0411471ba2727baf7d14ef44d6fb4eca65636bc0b3f31bd58af291a",
-          "size": 1704
+          "sha256": "3c35c0001a14dae4c000750de7ccc75f89ee89daee6bd426a1677c894730dfe9",
+          "size": 1657
         },
         "references/ideate.md": {
           "sha256": "00733f03658b2f215eaeebc25739a4ab7d57898fed162045e18f0c389cdc2609",
@@ -209,12 +209,12 @@
           "size": 598
         },
         "SKILL.md": {
-          "sha256": "d45d4c905dcf92985643a0f7b036d45e2fde4fb9bf732f6f6cc2b9a62bac6f23",
-          "size": 4330
+          "sha256": "0adbddfca726a6b0ba61c923fdbb06e50b6518603bce1ef237ca9cda281aa277",
+          "size": 4298
         },
         "skill.yaml": {
-          "sha256": "d29288a7968d6d04ffc07f8b303c881a13aa4d4f6c3cd79dd0d0fcb08aad7628",
-          "size": 243
+          "sha256": "e2c0b40d9935492621e6d21ab216a6227f4bae8f3808ed004d995d0f1b5bbff3",
+          "size": 213
         }
       }
     },
@@ -223,10 +223,10 @@
         "type": "git",
         "name": "canonical",
         "url": "https://github.com/joeharris76/skill-sync-skills.git",
-        "ref": "6ef11c58e61b741b4125b40a553f425973a234e2",
+        "ref": "7b63719927992bd7f7fff6b90449bbba2bb94ba3",
         "subdir": "skills",
-        "revision": "6ef11c58e61b741b4125b40a553f425973a234e2",
-        "fetchedAt": "2026-08-12T03:10:22.069Z"
+        "revision": "7b63719927992bd7f7fff6b90449bbba2bb94ba3",
+        "fetchedAt": "2026-08-12T16:16:41.534Z"
       },
       "installMode": "mirror",
       "files": {
@@ -285,10 +285,10 @@
         "type": "git",
         "name": "canonical",
         "url": "https://github.com/joeharris76/skill-sync-skills.git",
-        "ref": "6ef11c58e61b741b4125b40a553f425973a234e2",
+        "ref": "7b63719927992bd7f7fff6b90449bbba2bb94ba3",
         "subdir": "skills",
-        "revision": "6ef11c58e61b741b4125b40a553f425973a234e2",
-        "fetchedAt": "2026-08-12T03:10:25.856Z"
+        "revision": "7b63719927992bd7f7fff6b90449bbba2bb94ba3",
+        "fetchedAt": "2026-08-12T16:16:45.321Z"
       },
       "installMode": "mirror",
       "files": {
@@ -322,7 +322,7 @@
         "ref": "6d09682dabe2ff0d68f400d60f8ba8b87f8c02aa",
         "subdir": "skills",
         "revision": "6d09682dabe2ff0d68f400d60f8ba8b87f8c02aa",
-        "fetchedAt": "2026-08-12T01:38:30.666Z"
+        "fetchedAt": "2026-08-12T16:16:44.535Z"
       },
       "installMode": "mirror",
       "files": {
@@ -345,10 +345,10 @@
         "type": "git",
         "name": "canonical",
         "url": "https://github.com/joeharris76/skill-sync-skills.git",
-        "ref": "6ef11c58e61b741b4125b40a553f425973a234e2",
+        "ref": "7b63719927992bd7f7fff6b90449bbba2bb94ba3",
         "subdir": "skills",
-        "revision": "6ef11c58e61b741b4125b40a553f425973a234e2",
-        "fetchedAt": "2026-08-12T03:10:22.868Z"
+        "revision": "7b63719927992bd7f7fff6b90449bbba2bb94ba3",
+        "fetchedAt": "2026-08-12T16:16:42.353Z"
       },
       "installMode": "mirror",
       "files": {
@@ -371,10 +371,10 @@
         "type": "git",
         "name": "canonical",
         "url": "https://github.com/joeharris76/skill-sync-skills.git",
-        "ref": "6ef11c58e61b741b4125b40a553f425973a234e2",
+        "ref": "7b63719927992bd7f7fff6b90449bbba2bb94ba3",
         "subdir": "skills",
-        "revision": "6ef11c58e61b741b4125b40a553f425973a234e2",
-        "fetchedAt": "2026-08-12T03:10:20.500Z"
+        "revision": "7b63719927992bd7f7fff6b90449bbba2bb94ba3",
+        "fetchedAt": "2026-08-12T16:16:39.938Z"
       },
       "installMode": "mirror",
       "files": {
@@ -413,10 +413,10 @@
         "type": "git",
         "name": "canonical",
         "url": "https://github.com/joeharris76/skill-sync-skills.git",
-        "ref": "6ef11c58e61b741b4125b40a553f425973a234e2",
+        "ref": "7b63719927992bd7f7fff6b90449bbba2bb94ba3",
         "subdir": "skills",
-        "revision": "6ef11c58e61b741b4125b40a553f425973a234e2",
-        "fetchedAt": "2026-08-12T03:10:23.664Z"
+        "revision": "7b63719927992bd7f7fff6b90449bbba2bb94ba3",
+        "fetchedAt": "2026-08-12T16:16:43.133Z"
       },
       "installMode": "mirror",
       "files": {
@@ -435,10 +435,10 @@
         "type": "git",
         "name": "canonical",
         "url": "https://github.com/joeharris76/skill-sync-skills.git",
-        "ref": "6ef11c58e61b741b4125b40a553f425973a234e2",
+        "ref": "7b63719927992bd7f7fff6b90449bbba2bb94ba3",
         "subdir": "skills",
-        "revision": "6ef11c58e61b741b4125b40a553f425973a234e2",
-        "fetchedAt": "2026-08-12T03:10:24.454Z"
+        "revision": "7b63719927992bd7f7fff6b90449bbba2bb94ba3",
+        "fetchedAt": "2026-08-12T16:16:43.886Z"
       },
       "installMode": "mirror",
       "files": {

--- a/skill-sync.yaml
+++ b/skill-sync.yaml
@@ -3,7 +3,7 @@ sources:
   - name: canonical
     type: git
     url: https://github.com/joeharris76/skill-sync-skills.git
-    ref: 6ef11c58e61b741b4125b40a553f425973a234e2
+    ref: 7b63719927992bd7f7fff6b90449bbba2bb94ba3
     subdir: skills
   - name: product
     type: git

--- a/tests/unit/scripts/test_todo_wrapper.py
+++ b/tests/unit/scripts/test_todo_wrapper.py
@@ -6,7 +6,7 @@ a command contract. These tests pin that contract:
 
 - the `todo` shim is the single entry point and works from any cwd;
 - the root skill is genuinely thin (line budget) and carries no schema prose;
-- the skill package covers the mandatory workflow verbs and mentions only real commands.
+- the skill package separates wrapper commands, standalone CLI commands, and skill-only actions.
 
 Marked medium (not fast) deliberately: subprocess-driven and the fast lane is
 budget-gated.
@@ -43,7 +43,7 @@ def _read_skill_package() -> str:
     return "\n".join(path.read_text(encoding="utf-8") for path in (SKILL_PATH, *reference_paths))
 
 
-def _declared_standalone_only() -> set[str]:
+def _declared_standalone_cli_commands() -> set[str]:
     """Commands the skill declares as standalone `todo` CLI only (never wrapper)."""
     meta = yaml.safe_load((SKILL_PATH.parent / "skill.yaml").read_text(encoding="utf-8")) or {}
     declared = meta.get("standalone_only_commands") or {}
@@ -51,15 +51,29 @@ def _declared_standalone_only() -> set[str]:
     return set(declared)
 
 
-def _unknown_commands(text: str, declared: set[str]) -> set[str]:
-    """Referenced `todo <cmd>` forms that are neither wrapper handlers nor declared."""
+def _declared_skill_only_actions() -> set[str]:
+    """Skill orchestration actions explicitly marked as having no CLI command."""
+    text = SKILL_PATH.read_text(encoding="utf-8")
+    return set(re.findall(r"\| `([a-z][a-z-]*)` — skill-only, no CLI command \|", text))
+
+
+def _critical_rule_skill_only_actions() -> set[str]:
+    """Skill-only actions exempted from the wrapper-help requirement."""
+    text = SKILL_PATH.read_text(encoding="utf-8")
+    match = re.search(r"Skill-only actions: ([^;]+);", text)
+    assert match, "skill package must exempt skill-only actions from the wrapper-help rule"
+    return set(re.findall(r"`([a-z][a-z-]*)`", match.group(1)))
+
+
+def _unknown_cli_commands(text: str, standalone: set[str]) -> set[str]:
+    """Referenced `todo <cmd>` forms that are neither wrapper nor standalone CLI commands."""
     referenced = set(re.findall(r"`todo ([a-z][a-z-]*)", text))
     # `finding` is dispatched by name (not via _HANDLERS) so todo_db never
     # references a todo_findings symbol at load time. `doctor` is also outside
     # _HANDLERS: main routes it before open/dispatch so it can diagnose an
     # unreachable backend. Both are real CLI verbs consumers may document.
     real = set(todo_db._HANDLERS) | {"finding", "doctor"}
-    return referenced - real - declared
+    return referenced - real - standalone
 
 
 def _load_script():
@@ -334,35 +348,45 @@ class TestSkillThinness:
             "rules belong in the CLI/DB, not the skill"
         )
 
-    def test_skill_references_only_real_or_declared_commands(self):
+    def test_skill_references_only_real_or_declared_cli_commands(self):
         text = _read_skill_package()
         referenced = set(re.findall(r"`todo ([a-z][a-z-]*)", text))
         assert referenced, "skill package must reference `todo <command>` forms"
-        unknown = _unknown_commands(text, _declared_standalone_only())
+        unknown = _unknown_cli_commands(text, _declared_standalone_cli_commands())
         assert not unknown, (
-            "skill package references commands that are neither wrapper handlers "
-            f"nor declared standalone-only: {sorted(unknown)}"
+            "skill package presents actions as CLI commands that are neither wrapper handlers "
+            f"nor declared standalone CLI commands: {sorted(unknown)}"
         )
 
-    def test_declared_standalone_commands_are_not_wrapper_handlers(self):
-        # Declaring a wrapper-supported verb standalone-only would mask drift
-        # in either direction; the sets must stay disjoint.
-        overlap = _declared_standalone_only() & set(todo_db._HANDLERS)
-        assert not overlap, f"standalone_only_commands overlaps wrapper handlers: {sorted(overlap)}"
+    def test_action_capability_classes_are_disjoint(self):
+        wrapper_commands = set(todo_db._HANDLERS) | {"finding", "doctor"}
+        standalone_commands = _declared_standalone_cli_commands()
+        skill_actions = _declared_skill_only_actions()
+        assert skill_actions, "skill package must declare its skill-only actions"
+        assert not (wrapper_commands & standalone_commands), "standalone CLI commands overlap wrapper handlers"
+        assert not (wrapper_commands & skill_actions), "skill-only actions overlap wrapper handlers"
+        assert not (standalone_commands & skill_actions), "skill-only actions overlap standalone CLI commands"
+
+    def test_skill_only_actions_are_exempted_from_wrapper_help(self):
+        assert _critical_rule_skill_only_actions() == _declared_skill_only_actions()
 
     def test_undeclared_unsupported_command_is_flagged(self):
         # Without a declaration the boundary must trip — the declaration is the
-        # only sanctioned way to document a wrapper-unsupported verb.
-        assert _unknown_commands("run `todo frobnicate` then stop", set()) == {"frobnicate"}
+        # only sanctioned way to document a wrapper-unsupported CLI verb.
+        assert _unknown_cli_commands("run `todo frobnicate` then stop", set()) == {"frobnicate"}
         # update is a real wrapper handler; it must not be flagged as unknown
         # when the declared standalone set is empty.
-        assert _unknown_commands("`todo update <id>` corrects items", set()) == set()
+        assert _unknown_cli_commands("`todo update <id>` corrects items", set()) == set()
 
-    def test_standalone_only_commands_never_presented_as_wrapper_invocations(self):
+    def test_skill_only_action_presented_as_cli_command_is_flagged(self):
+        assert "batch" in _declared_skill_only_actions()
+        assert _unknown_cli_commands("run `todo batch`", set()) == {"batch"}
+
+    def test_standalone_cli_commands_never_presented_as_wrapper_invocations(self):
         # A declared verb must never appear as a project-wrapper invocation and
         # every documented use must carry standalone gating language nearby.
         text = _read_skill_package()
-        for command in sorted(_declared_standalone_only()):
+        for command in sorted(_declared_standalone_cli_commands()):
             assert not re.search(rf"_project/scripts/todo\s+{command}\b", text), (
                 f"standalone-only `{command}` shown as a project-wrapper invocation"
             )
@@ -374,6 +398,13 @@ class TestSkillThinness:
                 assert "standalone" in window, (
                     f"`todo {command}` reference at package line {index + 1} lacks standalone gating language"
                 )
+
+    def test_skill_only_actions_never_presented_as_cli_commands(self):
+        text = _read_skill_package()
+        for action in sorted(_declared_skill_only_actions()):
+            assert not re.search(rf"\btodo\s+{action}\b", text), (
+                f"skill-only action `{action}` is presented as a CLI command"
+            )
 
     def test_skill_covers_required_workflow(self):
         text = _read_skill_package()


### PR DESCRIPTION
## Summary

- bump the canonical skill pin to merged skill-sync-skills PR #36 and regenerate the tracked Todo mirror
- keep `standalone_only_commands` reserved for executable standalone CLI verbs
- model wrapper commands, standalone CLI commands, and skill-only orchestration actions as disjoint capability classes
- reject skill-only actions presented as `todo <action>` CLI commands and require the critical-rule exemption to match the action table

## Root cause

The existing contract inferred every backticked `todo <word>` phrase was executable and offered only two classifications: project-wrapper commands or standalone CLI commands. Skill-only actions such as `batch` and `closeout` were therefore temporarily forced into false standalone-CLI metadata to satisfy the test.

## Validation

- `uv run -- python -m pytest tests/unit/scripts/test_todo_wrapper.py -q -n 0` — 27 passed
- `uv run -- ruff check tests/unit/scripts/test_todo_wrapper.py`
- `uv run -- ruff format --check tests/unit/scripts/test_todo_wrapper.py`
- `make skill-sync-check`
- `make agent-instructions-check`
- `make pr-preflight` — passed with 647 existing `ty` diagnostics
- `git diff --check`

Follow-up to joeharris76/skill-sync-skills#36. Supersedes duplicate BenchBox PR #1690 with complete
category-disjointness, critical-rule consistency, and negative-control coverage.
