### PR TITLE
docs: record accepted auto-merge review decisions

### DIFF
--- a/_project/decisions/auto-merge-policy-consolidation-2026-08-06.md
+++ b/_project/decisions/auto-merge-policy-consolidation-2026-08-06.md
@@ -1,8 +1,9 @@
 # Auto-merge policy: adversarial evaluation and consolidation
 
 **Date**: 2026-08-06
-**Status**: evaluation recorded; decisions D1–D7 proposed, **not yet authorized**
-(read-only investigation; no mechanism was modified).
+**Status**: historical evaluation; decisions D1–D7 were later accepted and
+dispositioned below. At the time of this evaluation, no mechanism had yet been
+modified.
 **Related**: PRs #1567, #1592, #1622, #1623, #1624 (policy lineage);
 #1568/#1569 (live arm-on-open failure); #1503/#1521/#1531 (stranded review
 fixes); #1512 (anonymization auto-merge escape); #1543 (red-develop revert);
@@ -182,7 +183,13 @@ the mechanism set.
 | (d) **Recommended**: status quo − dead code + label made real + generated-file fix; tiers unchanged | 4 | 4 | 4 | 4 | 4 | 20 | Same ceremony as (c); removes the multi-agent failure modes actually observed. |
 | (e) Tighten: require completed bot review before arm | 2 | 2 | 4 | 3 | 3 | 14 | The 08-06 batch shows this deadlocks on third-party outages (every Codex review failed on limits); couples merge availability to an external quota. |
 
-## Recommendation (D1–D7)
+## Decisions and disposition (D1–D7)
+
+The recommendations below are no longer merely proposed. The merge of PR
+#1636 authorized and implemented D1–D4; PR #1634 implemented D6. D5 and D7
+remain accepted policy decisions rather than code changes. This record
+preserves the evaluation and rationale; the current source and operational
+runbook are the operative implementation record.
 
 | ID | Decision | Choice |
 |---|---|---|


### PR DESCRIPTION
## Summary
- Update the auto-merge policy decision record to distinguish its historical evaluation from the later accepted dispositions.
- Record that PR #1636 implemented D1–D4 and PR #1634 implemented D6; D5 and D7 remain accepted policy decisions.

## Validation
- `uv run -- python -m pytest tests/unit/ -x -q` — 27,695 passed, 24 skipped, 4 subtests passed.
- Targeted auto-merge tests — 23 passed.
- Push preflight hooks passed.