### PR TITLE
fix(ci): shard release canary non-fast tests

### DIFF
--- a/.github/workflows/release-canary.yml
+++ b/.github/workflows/release-canary.yml
@@ -16,18 +16,16 @@ permissions:
 
 env:
   RELEASE_CANARY_REF: develop
+  RELEASE_CANARY_SHARD_COUNT: 4
 
 jobs:
-  credential-free-non-fast:
-    name: credential-free non-fast canary
+  collect-credential-free-non-fast:
+    name: collect credential-free non-fast canary
     runs-on: ubuntu-latest
-    # This suite is intentionally single-threaded. Leave headroom for hosted
-    # runner variance without changing the canary's test coverage.
-    timeout-minutes: 120
+    timeout-minutes: 15
     outputs:
       checked_sha: ${{ steps.checked-ref.outputs.checked_sha }}
       collected_count: ${{ steps.collect.outputs.collected_count }}
-      pytest_exit_code: ${{ steps.run-tests.outputs.pytest_exit_code }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -54,79 +52,167 @@ jobs:
         id: collect
         shell: bash
         run: |
-          set -euo pipefail
+          set -o pipefail
           mkdir -p release-canary-artifacts
+          rc=0
           uv run -- python -m pytest \
             --collect-only \
             -q \
             -n 0 \
             -m "(slow or resource_heavy) and not (stress or live_integration)" \
             | tee release-canary-artifacts/non-fast-collect.txt
+          pipeline_status=("${PIPESTATUS[@]}")
+          rc=${pipeline_status[0]}
+          tee_rc=${pipeline_status[1]}
+          if [ "$rc" != "0" ] || [ "$tee_rc" != "0" ]; then
+            echo "::error::Credential-free non-fast test collection or log capture failed."
+            exit 1
+          fi
           count=$(grep -Eo '^[0-9]+/[0-9]+ tests collected' release-canary-artifacts/non-fast-collect.txt | tail -1 | cut -d/ -f1)
           if [ -z "$count" ]; then
             echo "::error::Could not parse collected non-fast canary count."
             exit 1
           fi
-          echo "collected_count=$count" >> "$GITHUB_OUTPUT"
-
-      - name: Run credential-free non-fast tests
-        id: run-tests
-        shell: bash
-        run: |
-          rc=0
-          uv run -- python -m pytest \
-            -m "(slow or resource_heavy) and not (stress or live_integration)" \
-            -n 0 \
-            --tb=short \
-            --maxfail=5 \
-            2>&1 | tee release-canary-artifacts/non-fast-pytest.log \
-            || rc=${PIPESTATUS[0]}
-          echo "pytest_exit_code=$rc" >> "$GITHUB_OUTPUT"
-
-      - name: Write non-fast canary summary
-        if: always()
+          uv run -- python scripts/release_canary_sharding.py collect \
+            --input release-canary-artifacts/non-fast-collect.txt \
+            --nodeids-output release-canary-artifacts/non-fast-nodeids.txt \
+            --summary-output release-canary-artifacts/non-fast-collection-summary.json \
+            --expected-count "$count" \
+            --shard-count "$RELEASE_CANARY_SHARD_COUNT" \
+            --checked-ref develop \
+            --checked-sha "${CHECKED_SHA}" \
+            --github-output "$GITHUB_OUTPUT"
         env:
           CHECKED_SHA: ${{ steps.checked-ref.outputs.checked_sha }}
-          COLLECTED_COUNT: ${{ steps.collect.outputs.collected_count }}
-          PYTEST_EXIT_CODE: ${{ steps.run-tests.outputs.pytest_exit_code }}
-        run: |
-          uv run -- python - <<'PY'
-          import json
-          import os
-          from datetime import datetime, timezone
-          from pathlib import Path
-
-          payload = {
-              "workflow": "release-canary.yml",
-              "job": "credential-free-non-fast",
-              "checked_ref": "develop",
-              "commit_sha": os.environ["CHECKED_SHA"],
-              "run_id": os.environ["GITHUB_RUN_ID"],
-              "completed_at": datetime.now(timezone.utc).isoformat(),
-              "suite_families": ["slow", "resource_heavy"],
-              "excluded_families": ["stress", "live_integration"],
-              "marker_expression": "(slow or resource_heavy) and not (stress or live_integration)",
-              "collected_count": os.environ.get("COLLECTED_COUNT", ""),
-              "pytest_exit_code": os.environ.get("PYTEST_EXIT_CODE", ""),
-          }
-          out = Path("release-canary-artifacts/non-fast-summary.json")
-          out.parent.mkdir(exist_ok=True)
-          out.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
-          PY
 
       - name: Upload non-fast canary artifacts
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: release-canary-non-fast
+          name: release-canary-nodeids
           path: release-canary-artifacts/
           retention-days: 30
 
-      - name: Fail if non-fast canary failed
-        if: steps.run-tests.outputs.pytest_exit_code != '0'
+  credential-free-non-fast:
+    name: credential-free non-fast canary (shard ${{ matrix.shard_number }}/4)
+    runs-on: ubuntu-latest
+    needs: [collect-credential-free-non-fast]
+    timeout-minutes: 45
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - shard_index: 0
+            shard_number: 1
+          - shard_index: 1
+            shard_number: 2
+          - shard_index: 2
+            shard_number: 3
+          - shard_index: 3
+            shard_number: 4
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.collect-credential-free-non-fast.outputs.checked_sha }}
+          fetch-depth: 0
+
+      - name: Download collected node IDs
+        uses: actions/download-artifact@v4
+        with:
+          name: release-canary-nodeids
+          path: release-canary-artifacts
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v4
+
+      - name: Install dependencies
+        run: uv sync --group dev
+
+      - name: Partition node IDs
+        shell: bash
+        env:
+          SHARD_INDEX: ${{ matrix.shard_index }}
         run: |
-          echo "::error::Credential-free non-fast canary failed."
-          exit 1
+          uv run -- python scripts/release_canary_sharding.py shard \
+            --input release-canary-artifacts/non-fast-nodeids.txt \
+            --nodeids-output "release-canary-artifacts/shard-${SHARD_INDEX}-nodeids.txt" \
+            --summary-output "release-canary-artifacts/shard-${SHARD_INDEX}-summary.json" \
+            --shard-index "$SHARD_INDEX" \
+            --shard-count "$RELEASE_CANARY_SHARD_COUNT"
+
+      - name: Run credential-free non-fast shard
+        id: run-tests
+        shell: bash
+        env:
+          SHARD_INDEX: ${{ matrix.shard_index }}
+        run: |
+          set -o pipefail
+          mapfile -t node_ids < "release-canary-artifacts/shard-${SHARD_INDEX}-nodeids.txt"
+          rc=0
+          if [ "${#node_ids[@]}" -eq 0 ]; then
+            echo "No tests assigned to shard ${SHARD_INDEX}." | tee "release-canary-artifacts/shard-${SHARD_INDEX}-pytest.log"
+          else
+            uv run -- python -m pytest \
+              -m "(slow or resource_heavy) and not (stress or live_integration)" \
+              -n 0 \
+              --tb=short \
+              --maxfail=5 \
+              "${node_ids[@]}" \
+              2>&1 | tee "release-canary-artifacts/shard-${SHARD_INDEX}-pytest.log"
+            pipeline_status=("${PIPESTATUS[@]}")
+            rc=${pipeline_status[0]}
+            tee_rc=${pipeline_status[1]}
+            if [ "$tee_rc" != "0" ]; then
+              rc="$tee_rc"
+            fi
+          fi
+          echo "pytest_exit_code=$rc" >> "$GITHUB_OUTPUT"
+          exit "$rc"
+
+      - name: Write shard summary
+        if: always()
+        shell: bash
+        env:
+          SHARD_INDEX: ${{ matrix.shard_index }}
+          SHARD_COUNT: ${{ env.RELEASE_CANARY_SHARD_COUNT }}
+          CHECKED_SHA: ${{ needs.collect-credential-free-non-fast.outputs.checked_sha }}
+          COLLECTED_COUNT: ${{ needs.collect-credential-free-non-fast.outputs.collected_count }}
+          PYTEST_EXIT_CODE: ${{ steps.run-tests.outputs.pytest_exit_code }}
+        run: |
+          assigned_count=""
+          shard_nodeids="release-canary-artifacts/shard-${SHARD_INDEX}-nodeids.txt"
+          if [ -f "$shard_nodeids" ]; then
+            assigned_count=$(wc -l < "$shard_nodeids" | tr -d ' ')
+          fi
+          cat > "release-canary-artifacts/shard-${SHARD_INDEX}-summary.json" <<EOF
+          {
+            "workflow": "release-canary.yml",
+            "job": "credential-free-non-fast",
+            "checked_ref": "develop",
+            "commit_sha": "${CHECKED_SHA}",
+            "run_id": "${GITHUB_RUN_ID}",
+            "shard_index": ${SHARD_INDEX},
+            "shard_count": ${SHARD_COUNT},
+            "marker_expression": "(slow or resource_heavy) and not (stress or live_integration)",
+            "collected_count": "${COLLECTED_COUNT}",
+            "assigned_count": "${assigned_count}",
+            "pytest_exit_code": "${PYTEST_EXIT_CODE}"
+          }
+          EOF
+
+      - name: Upload shard artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: release-canary-non-fast-shard-${{ matrix.shard_index }}
+          path: release-canary-artifacts/
+          retention-days: 30
 
   ruleset-drift:
     name: ruleset drift
@@ -219,16 +305,24 @@ jobs:
   release-canary-result:
     name: release-canary-result
     runs-on: ubuntu-latest
-    needs: [credential-free-non-fast, ruleset-drift, pypi-latest-installability]
+    needs:
+      [
+        collect-credential-free-non-fast,
+        credential-free-non-fast,
+        ruleset-drift,
+        pypi-latest-installability,
+      ]
     if: always()
     steps:
       - name: Write release canary summary
         env:
-          CHECKED_SHA: ${{ needs.credential-free-non-fast.outputs.checked_sha }}
+          COLLECTION_RESULT: ${{ needs.collect-credential-free-non-fast.result }}
+          CHECKED_SHA: ${{ needs.collect-credential-free-non-fast.outputs.checked_sha }}
           NON_FAST_RESULT: ${{ needs.credential-free-non-fast.result }}
           RULESET_DRIFT_RESULT: ${{ needs.ruleset-drift.result }}
           PYPI_LATEST_RESULT: ${{ needs.pypi-latest-installability.result }}
-          NON_FAST_COUNT: ${{ needs.credential-free-non-fast.outputs.collected_count }}
+          NON_FAST_COUNT: ${{ needs.collect-credential-free-non-fast.outputs.collected_count }}
+          SHARD_COUNT: ${{ env.RELEASE_CANARY_SHARD_COUNT }}
         run: |
           mkdir -p release-canary-artifacts
           cat > release-canary-artifacts/release-canary-summary.json <<EOF
@@ -239,11 +333,14 @@ jobs:
             "run_id": "${GITHUB_RUN_ID}",
             "suite_families": ["slow", "resource_heavy"],
             "excluded_families": ["stress", "live_integration"],
+            "marker_expression": "(slow or resource_heavy) and not (stress or live_integration)",
             "freshness_contract_hours": 48,
+            "collection_result": "${COLLECTION_RESULT}",
             "non_fast_result": "${NON_FAST_RESULT}",
             "ruleset_drift_result": "${RULESET_DRIFT_RESULT}",
             "pypi_latest_installability_result": "${PYPI_LATEST_RESULT}",
-            "non_fast_collected_count": "${NON_FAST_COUNT}"
+            "non_fast_collected_count": "${NON_FAST_COUNT}",
+            "non_fast_shard_count": "${SHARD_COUNT}"
           }
           EOF
 
@@ -256,6 +353,7 @@ jobs:
 
       - name: Aggregate release canary result
         env:
+          COLLECTION_RESULT: ${{ needs.collect-credential-free-non-fast.result }}
           NON_FAST_RESULT: ${{ needs.credential-free-non-fast.result }}
           RULESET_DRIFT_RESULT: ${{ needs.ruleset-drift.result }}
           PYPI_LATEST_RESULT: ${{ needs.pypi-latest-installability.result }}
@@ -263,6 +361,7 @@ jobs:
           set -euo pipefail
           failed=0
           for pair in \
+            "collect-credential-free-non-fast=$COLLECTION_RESULT" \
             "credential-free-non-fast=$NON_FAST_RESULT" \
             "ruleset-drift=$RULESET_DRIFT_RESULT" \
             "pypi-latest-installability=$PYPI_LATEST_RESULT"; do

--- a/scripts/release_canary_sharding.py
+++ b/scripts/release_canary_sharding.py
@@ -1,0 +1,202 @@
+"""Collect and deterministically partition release-canary pytest node IDs."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import sys
+from collections.abc import Iterable, Sequence
+from pathlib import Path
+from typing import Any
+
+MARKER_EXPRESSION = "(slow or resource_heavy) and not (stress or live_integration)"
+DEFAULT_SHARD_COUNT = 4
+
+
+def _canonical_node_ids(node_ids: Iterable[str]) -> list[str]:
+    """Validate node IDs and return them in a stable order."""
+    values = list(node_ids)
+    if not values:
+        raise ValueError("node-id input is empty")
+    if any(not isinstance(node_id, str) or not node_id.strip() for node_id in values):
+        raise ValueError("node-id input contains an empty or non-string value")
+    if len(set(values)) != len(values):
+        raise ValueError("node-id input contains duplicates")
+    return sorted(values)
+
+
+def parse_collection_output(output: str) -> list[str]:
+    """Extract pytest node IDs from ``--collect-only -q`` output."""
+    node_ids = []
+    for line in output.splitlines():
+        candidate = line.strip()
+        if candidate.startswith("tests/") and "::" in candidate:
+            node_ids.append(candidate)
+    return _canonical_node_ids(node_ids)
+
+
+def read_node_ids(path: Path) -> list[str]:
+    """Read and validate a newline-delimited node-id file."""
+    return _canonical_node_ids(path.read_text(encoding="utf-8").splitlines())
+
+
+def partition_node_ids(node_ids: Sequence[str], shard_index: int, shard_count: int) -> list[str]:
+    """Return one deterministic, disjoint shard of ``node_ids``.
+
+    Sorting before round-robin assignment makes the result independent of
+    pytest's collection order while spreading adjacent test modules across
+    shards. Invalid parameters and duplicate input fail closed.
+    """
+    if isinstance(shard_count, bool) or not isinstance(shard_count, int) or shard_count < 1:
+        raise ValueError("shard_count must be a positive integer")
+    if isinstance(shard_index, bool) or not isinstance(shard_index, int) or not 0 <= shard_index < shard_count:
+        raise ValueError("shard_index must be an integer in [0, shard_count)")
+    ordered = _canonical_node_ids(node_ids)
+    return ordered[shard_index::shard_count]
+
+
+def _node_ids_sha256(node_ids: Sequence[str]) -> str:
+    payload = "\n".join(node_ids) + "\n"
+    return hashlib.sha256(payload.encode("utf-8")).hexdigest()
+
+
+def _write_json(path: Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+
+
+def _write_node_ids(path: Path, node_ids: Sequence[str]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    payload = "\n".join(node_ids) + "\n" if node_ids else ""
+    path.write_text(payload, encoding="utf-8")
+
+
+def collect_node_ids(
+    input_path: Path,
+    nodeids_output: Path,
+    summary_output: Path,
+    *,
+    expected_count: int,
+    shard_count: int,
+    checked_ref: str = "",
+    checked_sha: str = "",
+    github_output: Path | None = None,
+) -> int:
+    """Create the canonical node-id artifact and collection manifest."""
+    if expected_count < 1:
+        raise ValueError("expected_count must be a positive integer")
+    if isinstance(shard_count, bool) or not isinstance(shard_count, int) or shard_count < 1:
+        raise ValueError("shard_count must be a positive integer")
+
+    node_ids = parse_collection_output(input_path.read_text(encoding="utf-8"))
+    if len(node_ids) != expected_count:
+        raise ValueError(f"collected node-id count {len(node_ids)} does not match expected count {expected_count}")
+
+    shard_counts = [len(partition_node_ids(node_ids, index, shard_count)) for index in range(shard_count)]
+    if sum(shard_counts) != len(node_ids):
+        raise ValueError("shard count conservation check failed")
+
+    _write_node_ids(nodeids_output, node_ids)
+    _write_json(
+        summary_output,
+        {
+            "workflow": "release-canary.yml",
+            "job": "collect-credential-free-non-fast",
+            "checked_ref": checked_ref,
+            "commit_sha": checked_sha,
+            "marker_expression": MARKER_EXPRESSION,
+            "total_count": len(node_ids),
+            "shard_count": shard_count,
+            "shard_counts": shard_counts,
+            "node_ids_sha256": _node_ids_sha256(node_ids),
+        },
+    )
+    if github_output is not None:
+        with github_output.open("a", encoding="utf-8") as handle:
+            handle.write(f"collected_count={len(node_ids)}\n")
+    return len(node_ids)
+
+
+def write_shard(
+    input_path: Path,
+    nodeids_output: Path,
+    summary_output: Path,
+    *,
+    shard_index: int,
+    shard_count: int,
+) -> int:
+    """Write one shard file and its manifest from the collection artifact."""
+    node_ids = read_node_ids(input_path)
+    shard_node_ids = partition_node_ids(node_ids, shard_index, shard_count)
+    _write_node_ids(nodeids_output, shard_node_ids)
+    _write_json(
+        summary_output,
+        {
+            "workflow": "release-canary.yml",
+            "job": "credential-free-non-fast",
+            "marker_expression": MARKER_EXPRESSION,
+            "shard_index": shard_index,
+            "shard_count": shard_count,
+            "assigned_count": len(shard_node_ids),
+            "total_count": len(node_ids),
+            "source_node_ids_sha256": _node_ids_sha256(node_ids),
+            "node_ids_sha256": _node_ids_sha256(shard_node_ids),
+        },
+    )
+    return len(shard_node_ids)
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    collect_parser = subparsers.add_parser("collect", help="create the canonical node-id artifact")
+    collect_parser.add_argument("--input", type=Path, required=True)
+    collect_parser.add_argument("--nodeids-output", type=Path, required=True)
+    collect_parser.add_argument("--summary-output", type=Path, required=True)
+    collect_parser.add_argument("--expected-count", type=int, required=True)
+    collect_parser.add_argument("--shard-count", type=int, default=DEFAULT_SHARD_COUNT)
+    collect_parser.add_argument("--checked-ref", default="")
+    collect_parser.add_argument("--checked-sha", default="")
+    collect_parser.add_argument("--github-output", type=Path)
+
+    shard_parser = subparsers.add_parser("shard", help="write one deterministic node-id shard")
+    shard_parser.add_argument("--input", type=Path, required=True)
+    shard_parser.add_argument("--nodeids-output", type=Path, required=True)
+    shard_parser.add_argument("--summary-output", type=Path, required=True)
+    shard_parser.add_argument("--shard-index", type=int, required=True)
+    shard_parser.add_argument("--shard-count", type=int, required=True)
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _build_parser().parse_args(argv)
+    try:
+        if args.command == "collect":
+            collect_node_ids(
+                args.input,
+                args.nodeids_output,
+                args.summary_output,
+                expected_count=args.expected_count,
+                shard_count=args.shard_count,
+                checked_ref=args.checked_ref,
+                checked_sha=args.checked_sha,
+                github_output=args.github_output,
+            )
+        else:
+            write_shard(
+                args.input,
+                args.nodeids_output,
+                args.summary_output,
+                shard_index=args.shard_index,
+                shard_count=args.shard_count,
+            )
+    except (OSError, ValueError, json.JSONDecodeError) as exc:
+        print(f"release-canary sharding error: {exc}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/unit/test_release_canary_sharding.py
+++ b/tests/unit/test_release_canary_sharding.py
@@ -1,0 +1,175 @@
+"""Tests for deterministic release-canary collection and sharding."""
+
+from __future__ import annotations
+
+import itertools
+from pathlib import Path
+
+import pytest
+import yaml
+
+from scripts.release_canary_sharding import (
+    DEFAULT_SHARD_COUNT,
+    MARKER_EXPRESSION,
+    collect_node_ids,
+    parse_collection_output,
+    partition_node_ids,
+    write_shard,
+)
+
+pytestmark = [pytest.mark.unit, pytest.mark.fast]
+
+REPO_ROOT = Path(__file__).parents[2]
+
+
+def _workflow() -> dict:
+    return yaml.safe_load((REPO_ROOT / ".github" / "workflows" / "release-canary.yml").read_text(encoding="utf-8"))
+
+
+def _run_text(job_name: str) -> str:
+    workflow = _workflow()
+    return "\n".join(str(step.get("run", "")) for step in workflow["jobs"][job_name]["steps"])
+
+
+def test_parse_collection_output_sorts_and_rejects_duplicate_node_ids():
+    output = """
+    Using CPython 3.12.13
+    tests/unit/test_b.py::test_two
+    tests/unit/test_a.py::test_one
+    2/10 tests collected (8 deselected) in 0.1s
+    """
+
+    assert parse_collection_output(output) == [
+        "tests/unit/test_a.py::test_one",
+        "tests/unit/test_b.py::test_two",
+    ]
+    with pytest.raises(ValueError, match="duplicates"):
+        parse_collection_output("tests/unit/test_a.py::test_one\ntests/unit/test_a.py::test_one\n")
+
+
+def test_partition_is_deterministic_disjoint_and_complete():
+    node_ids = [f"tests/unit/test_{index:02d}.py::test_case" for index in range(11, -1, -1)]
+
+    first = [partition_node_ids(node_ids, index, DEFAULT_SHARD_COUNT) for index in range(DEFAULT_SHARD_COUNT)]
+    second = [
+        partition_node_ids(list(reversed(node_ids)), index, DEFAULT_SHARD_COUNT) for index in range(DEFAULT_SHARD_COUNT)
+    ]
+
+    assert first == second
+    assigned = list(itertools.chain.from_iterable(first))
+    assert len(assigned) == len(set(assigned)) == len(node_ids)
+    assert sorted(assigned) == sorted(node_ids)
+
+
+@pytest.mark.parametrize(
+    ("shard_index", "shard_count"),
+    [(-1, 4), (4, 4), (0, 0), (0, -1), (0, True), (True, 4)],
+)
+def test_invalid_shard_parameters_fail_closed(shard_index, shard_count):
+    with pytest.raises(ValueError):
+        partition_node_ids(["tests/unit/test_a.py::test_one"], shard_index, shard_count)
+
+
+def test_collection_and_shard_manifests_conserve_node_ids(tmp_path: Path):
+    raw = tmp_path / "collect.txt"
+    nodeids = tmp_path / "nodeids.txt"
+    collection_summary = tmp_path / "collection-summary.json"
+    raw.write_text(
+        "\n".join(f"tests/unit/test_{index}.py::test_case" for index in range(7))
+        + "\n7/100 tests collected (93 deselected)\n",
+        encoding="utf-8",
+    )
+
+    assert (
+        collect_node_ids(
+            raw,
+            nodeids,
+            collection_summary,
+            expected_count=7,
+            shard_count=4,
+            checked_ref="develop",
+            checked_sha="abc123",
+        )
+        == 7
+    )
+    collection_payload = collection_summary.read_text(encoding="utf-8")
+    assert '"total_count": 7' in collection_payload
+    assert '"checked_ref": "develop"' in collection_payload
+
+    shard_paths = []
+    for index in range(4):
+        shard_path = tmp_path / f"shard-{index}.txt"
+        write_shard(
+            nodeids,
+            shard_path,
+            tmp_path / f"shard-{index}.json",
+            shard_index=index,
+            shard_count=4,
+        )
+        shard_paths.append(shard_path)
+
+    assigned = list(
+        itertools.chain.from_iterable(path.read_text(encoding="utf-8").splitlines() for path in shard_paths)
+    )
+    assert len(assigned) == len(set(assigned)) == 7
+    assert sorted(assigned) == sorted(nodeids.read_text(encoding="utf-8").splitlines())
+
+
+def test_release_canary_workflow_uses_collection_artifact_and_four_single_threaded_shards():
+    workflow = _workflow()
+    jobs = workflow["jobs"]
+
+    assert set(jobs) == {
+        "collect-credential-free-non-fast",
+        "credential-free-non-fast",
+        "ruleset-drift",
+        "pypi-latest-installability",
+        "release-canary-result",
+    }
+
+    collection = jobs["collect-credential-free-non-fast"]
+    assert collection["timeout-minutes"] == 15
+    assert collection["steps"][0]["with"]["ref"] == "${{ env.RELEASE_CANARY_REF }}"
+    collection_text = _run_text("collect-credential-free-non-fast")
+    assert collection_text.count(MARKER_EXPRESSION) == 1
+    assert "--collect-only" in collection_text
+    assert "release-canary-nodeids" in "\n".join(str(step) for step in collection["steps"])
+    assert "release_canary_sharding.py" in collection_text
+
+    shards = jobs["credential-free-non-fast"]
+    assert shards["needs"] == ["collect-credential-free-non-fast"]
+    assert shards["strategy"]["fail-fast"] is False
+    assert [entry["shard_index"] for entry in shards["strategy"]["matrix"]["include"]] == [0, 1, 2, 3]
+    assert shards["timeout-minutes"] == 45
+    shard_text = _run_text("credential-free-non-fast")
+    assert shard_text.count(f'-m "{MARKER_EXPRESSION}"') == 1
+    assert "actions/download-artifact@v4" in "\n".join(str(step) for step in shards["steps"])
+    assert "release_canary_sharding.py" in shard_text
+    assert "mapfile -t node_ids" in shard_text
+    assert "-n 0" in shard_text
+
+
+def test_release_canary_aggregation_fails_closed_and_preserves_summary_contract():
+    workflow = _workflow()
+    result_job = workflow["jobs"]["release-canary-result"]
+    assert result_job["if"] == "always()"
+    assert set(result_job["needs"]) == {
+        "collect-credential-free-non-fast",
+        "credential-free-non-fast",
+        "ruleset-drift",
+        "pypi-latest-installability",
+    }
+    result_text = _run_text("release-canary-result")
+    for field in (
+        '"checked_ref": "develop"',
+        '"commit_sha": "${CHECKED_SHA}"',
+        '"non_fast_result": "${NON_FAST_RESULT}"',
+        '"ruleset_drift_result": "${RULESET_DRIFT_RESULT}"',
+        '"pypi_latest_installability_result": "${PYPI_LATEST_RESULT}"',
+        '"non_fast_collected_count": "${NON_FAST_COUNT}"',
+    ):
+        assert field in result_text
+    for result_name in ("COLLECTION_RESULT", "NON_FAST_RESULT", "RULESET_DRIFT_RESULT", "PYPI_LATEST_RESULT"):
+        assert f"${result_name}" in result_text
+    assert 'if [ "$result" != "success" ]' in result_text
+    assert "Release canary passed." in result_text

--- a/tests/unit/test_release_infrastructure.py
+++ b/tests/unit/test_release_infrastructure.py
@@ -358,16 +358,21 @@ class TestReleaseInfrastructure:
 
         jobs = workflow["jobs"]
         assert set(jobs) == {
+            "collect-credential-free-non-fast",
             "credential-free-non-fast",
             "ruleset-drift",
             "pypi-latest-installability",
             "release-canary-result",
         }
-        assert jobs["credential-free-non-fast"]["steps"][0]["with"]["ref"] == "${{ env.RELEASE_CANARY_REF }}"
+        collection_job = jobs["collect-credential-free-non-fast"]
+        assert collection_job["steps"][0]["with"]["ref"] == "${{ env.RELEASE_CANARY_REF }}"
         assert jobs["ruleset-drift"]["steps"][0]["with"]["ref"] == "${{ env.RELEASE_CANARY_REF }}"
-        # The non-fast lane is deliberately single-threaded; keep a bounded
-        # amount of headroom for hosted-runner variance.
-        assert jobs["credential-free-non-fast"]["timeout-minutes"] == 120
+        # Each shard is deliberately single-threaded; process-level sharding
+        # keeps the timeout bounded without enabling unsafe xdist concurrency.
+        non_fast_job = jobs["credential-free-non-fast"]
+        assert non_fast_job["timeout-minutes"] == 45
+        assert non_fast_job["strategy"]["fail-fast"] is False
+        assert len(non_fast_job["strategy"]["matrix"]["include"]) == 4
 
         # pypi-latest-installability must not gate on (or be gated by) the
         # other canary jobs, and must not check out the repo (it installs
@@ -380,16 +385,22 @@ class TestReleaseInfrastructure:
         assert "importlib.util.find_spec('pandas') is None" in pypi_latest_text
         assert "mktemp -d" in pypi_latest_text
 
+        collection_text = _workflow_job_run_text("release-canary.yml", "collect-credential-free-non-fast")
+        assert RELEASE_CANARY_NON_FAST_EXPRESSION in collection_text
+        assert "--collect-only" in collection_text
+        assert "release-canary-artifacts/non-fast-collection-summary.json" in collection_text
+        assert "--checked-ref develop" in collection_text
+        assert "--checked-sha" in collection_text
+        assert "raw" not in collection_text.lower()
+        assert "set +e" not in collection_text
+
         non_fast_text = _workflow_job_run_text("release-canary.yml", "credential-free-non-fast")
         assert RELEASE_CANARY_NON_FAST_EXPRESSION in non_fast_text
-        assert "--collect-only" in non_fast_text
-        assert "release-canary-artifacts/non-fast-summary.json" in non_fast_text
-        assert '"checked_ref": "develop"' in non_fast_text
-        assert '"commit_sha": os.environ["CHECKED_SHA"]' in non_fast_text
-        assert "raw" not in non_fast_text.lower()
-        # Exit code must propagate via rc= variable, not be swallowed by set+e/exit 0.
-        assert "set +e" not in non_fast_text
-        assert "exit 0" not in non_fast_text
+        assert "release-canary-artifacts/shard-${SHARD_INDEX}-summary.json" in non_fast_text
+        assert "actions/download-artifact@v4" not in non_fast_text
+        assert "mapfile -t node_ids" in non_fast_text
+        assert "-n 0" in non_fast_text
+        assert 'exit "$rc"' in non_fast_text
 
         ruleset_text = _workflow_job_run_text("release-canary.yml", "ruleset-drift")
         assert "scripts/ruleset_drift_check.py" in ruleset_text
@@ -402,6 +413,7 @@ class TestReleaseInfrastructure:
         result_job = jobs["release-canary-result"]
         assert result_job["name"] == "release-canary-result"
         assert set(result_job["needs"]) == {
+            "collect-credential-free-non-fast",
             "credential-free-non-fast",
             "ruleset-drift",
             "pypi-latest-installability",
@@ -409,12 +421,13 @@ class TestReleaseInfrastructure:
         result_text = _workflow_job_run_text("release-canary.yml", "release-canary-result")
         assert '"checked_ref": "develop"' in result_text
         assert '"commit_sha": "${CHECKED_SHA}"' in result_text
+        assert '"collection_result": "${COLLECTION_RESULT}"' in result_text
         assert '"freshness_contract_hours": 48' in result_text
         assert "Release canary passed." in result_text
 
     def test_canary_collect_count_regex_matches_pytest_deselect_format(self):
         """The canary collect-step grep regex must match the actual pytest --collect-only output format."""
-        collect_text = _workflow_job_run_text("release-canary.yml", "credential-free-non-fast")
+        collect_text = _workflow_job_run_text("release-canary.yml", "collect-credential-free-non-fast")
         assert "'^[0-9]+/[0-9]+ tests collected'" in collect_text
 
         # Verify the regex semantics using Python re (same logic as the grep ERE pattern).


### PR DESCRIPTION
## Summary

- collect the develop canary node IDs once and record the checked SHA and total count
- run the existing marker-selected suite in four deterministic process-level shards with pytest -n 0
- upload shard evidence and fail the release summary on collection, shard, drift, or PyPI gate failures

## Verification

- uv run -- python -m pytest tests/unit/test_release_infrastructure.py tests/unit/test_release_canary_sharding.py -q -n 0
- uv run ruff check .
- uv run ruff format --check .
- make pr-preflight

Targets develop. The fresh develop-owned release-canary run is the required post-merge evidence for the remaining TODO.