### PR TITLE
fix(clickhouse): stream server loads without legacy batches

### DIFF
--- a/benchbox/platforms/base/data_loading.py
+++ b/benchbox/platforms/base/data_loading.py
@@ -63,6 +63,27 @@ class DataLoadingError(Exception):
     """Exception raised during data loading operations."""
 
 
+class ClickHouseServerLoadError(DataLoadingError):
+    """Terminal failure while streaming a table into ClickHouse server mode."""
+
+    def __init__(
+        self,
+        table_name: str,
+        source_files: list[Path],
+        rows_attempted: int,
+        cause: BaseException,
+    ) -> None:
+        self.table_name = table_name
+        self.source_files = tuple(source_files)
+        self.rows_attempted = rows_attempted
+        self.cause = cause
+        sources = ", ".join(path.name for path in source_files)
+        super().__init__(
+            f"ClickHouse server load failed for {table_name!r} after {rows_attempted:,} streamed row(s) "
+            f"from {sources}: {cause}"
+        )
+
+
 def validate_sql_identifier(name: str, context: str = "identifier") -> str:
     """Validate that a string is a safe SQL identifier.
 
@@ -1987,6 +2008,23 @@ class ClickHouseNativeHandler(FileFormatHandler):
         """Return whether this handler targets a self-hosted ClickHouse server."""
         return getattr(self.adapter, "deployment_mode", None) == "server"
 
+    def _server_insert_block_size(self) -> int:
+        """Return the bounded clickhouse-driver transport block size.
+
+        The generic :class:`RowBatchProcessor` intentionally remains a 1,000-row
+        helper for other platforms. Server-mode ClickHouse never routes through
+        it: the native driver receives a real generator and owns transport
+        buffering at this explicitly configured size.
+        """
+        value = getattr(self.adapter, "insert_block_size", 65536)
+        if isinstance(value, bool) or not isinstance(value, int) or value <= 0 or value == 1000:
+            raise DataLoadingError("ClickHouse server insert_block_size must be a positive integer other than 1000")
+        return value
+
+    def _server_insert_settings(self) -> dict[str, int]:
+        """Return per-execute settings for a bounded native-driver insert."""
+        return {"insert_block_size": self._server_insert_block_size()}
+
     def _get_csv_loading_config(self, table_name: str) -> dict[str, str]:
         """Get CSV loading configuration for ClickHouse.
 
@@ -2040,8 +2078,10 @@ class ClickHouseNativeHandler(FileFormatHandler):
             if self._uses_server_mode():
                 base_ext = FileFormatRegistry.get_base_data_extension(file_path)
                 if base_ext == ".parquet":
-                    return self._load_parquet_via_client_insert(validated_table, file_path, connection)
-                return self._load_delimited_via_client_insert(validated_table, file_path, connection, benchmark, logger)
+                    return self._load_parquet_via_client_insert(validated_table, [file_path], connection)
+                return self._load_delimited_via_client_insert(
+                    validated_table, [file_path], connection, benchmark, logger
+                )
 
             escaped_path = escape_sql_string_literal(str(file_path))
 
@@ -2089,38 +2129,64 @@ class ClickHouseNativeHandler(FileFormatHandler):
     def _load_delimited_via_client_insert(
         self,
         validated_table: str,
-        file_path: Path,
+        file_paths: list[Path],
         connection: Any,
         benchmark: Any,
         logger: Any,
     ) -> int:
-        """Load host-local delimited files into ClickHouse server via client batches."""
-        compression_handler = FileFormatRegistry.get_compression_handler(file_path)
-
-        with compression_handler.open(file_path) as file_handle:
-            data_start = None
-            if self.has_header:
-                file_handle.readline()
-                data_start = file_handle.tell()
-
-            column_count = SchemaInspector.get_column_count(
-                benchmark, validated_table, file_handle, self.delimiter_char
-            )
+        """Stream host-local delimited files through one native-driver insert."""
+        row_count = 0
+        row_generator: Any | None = None
+        try:
+            first_path = file_paths[0]
+            compression_handler = FileFormatRegistry.get_compression_handler(first_path)
+            with compression_handler.open(first_path) as file_handle:
+                column_count = SchemaInspector.get_column_count(
+                    benchmark, validated_table, file_handle, self.delimiter_char
+                )
             if column_count is None:
                 logger.debug(f"Could not determine column count for {validated_table}")
                 return 0
-            if data_start is not None:
-                file_handle.seek(data_start)
 
-            total_rows = 0
-            processor = RowBatchProcessor()
-            insert_sql = f"INSERT INTO {validated_table} VALUES"
             column_types = self._get_column_type_names(benchmark, validated_table)
-            for batch_data, current_count in processor.process_file(file_handle, self.delimiter_char, column_count):
-                connection.execute(insert_sql, self._convert_rows_for_clickhouse(batch_data, column_types))
-                total_rows = current_count
 
-        return total_rows
+            def rows() -> Iterator[tuple[Any, ...]]:
+                nonlocal row_count
+                for file_path in file_paths:
+                    handler = FileFormatRegistry.get_compression_handler(file_path)
+                    with handler.open(file_path) as file_handle:
+                        if self.has_header:
+                            next(file_handle, None)
+                        for line in file_handle:
+                            line = line.strip()
+                            if not line:
+                                continue
+                            fields = line.split(self.delimiter_char)
+                            fields.extend([""] * max(0, column_count - len(fields)))
+                            fields = fields[:column_count]
+                            row_count += 1
+                            yield tuple(
+                                self._convert_field_for_clickhouse(
+                                    value,
+                                    column_types[index] if index < len(column_types) else None,
+                                )
+                                for index, value in enumerate(fields)
+                            )
+
+            row_generator = rows()
+            connection.execute(
+                f"INSERT INTO {validated_table} VALUES",
+                row_generator,
+                settings=self._server_insert_settings(),
+            )
+            return row_count
+        except ClickHouseServerLoadError:
+            raise
+        except Exception as exc:
+            raise ClickHouseServerLoadError(validated_table, file_paths, row_count, exc) from exc
+        finally:
+            if row_generator is not None:
+                row_generator.close()
 
     def _get_column_type_names(self, benchmark: Any, table_name: str) -> list[str | None]:
         """Return schema type strings for a benchmark table when available."""
@@ -2217,29 +2283,54 @@ class ClickHouseNativeHandler(FileFormatHandler):
             return date.fromisoformat(value)
         return value
 
-    def _load_parquet_via_client_insert(self, validated_table: str, file_path: Path, connection: Any) -> int:
-        """Load host-local Parquet files into ClickHouse server via client batches."""
+    def _load_parquet_via_client_insert(self, validated_table: str, file_paths: list[Path], connection: Any) -> int:
+        """Stream host-local Parquet files through one native-driver insert."""
+        row_count = 0
+        row_generator: Any | None = None
         try:
-            import pyarrow.parquet as pq
-        except ImportError as e:
-            raise RuntimeError("pyarrow is required for Parquet loading") from e
+            try:
+                import pyarrow.parquet as pq
+            except ImportError as exc:
+                raise RuntimeError("pyarrow is required for Parquet loading") from exc
 
-        table = pq.read_table(file_path)
-        if table.num_rows == 0:
-            return 0
+            first_table = pq.ParquetFile(file_paths[0])
+            column_names = first_table.schema.names
+            validated_columns = [validate_sql_identifier(col, "column name") for col in column_names]
+            expected_rows = 0
+            for file_path in file_paths:
+                parquet_file = pq.ParquetFile(file_path)
+                if parquet_file.schema.names != column_names:
+                    raise DataLoadingError(
+                        f"ClickHouse server Parquet shards for {validated_table!r} have different columns: {file_path}"
+                    )
+                expected_rows += parquet_file.metadata.num_rows if parquet_file.metadata is not None else 0
+            if expected_rows == 0:
+                return 0
 
-        column_names = table.schema.names
-        validated_columns = [validate_sql_identifier(col, "column name") for col in column_names]
-        rows = table.to_pylist()
-        insert_sql = f"INSERT INTO {validated_table} ({','.join(validated_columns)}) VALUES"
+            insert_sql = f"INSERT INTO {validated_table} ({','.join(validated_columns)}) VALUES"
+            batch_size = self._server_insert_block_size()
 
-        batch_size = 1000
-        for start in range(0, len(rows), batch_size):
-            batch_rows = rows[start : start + batch_size]
-            batch = [tuple(row[col] for col in column_names) for row in batch_rows]
-            connection.execute(insert_sql, batch)
+            def rows() -> Iterator[tuple[Any, ...]]:
+                nonlocal row_count
+                for file_path in file_paths:
+                    parquet_file = pq.ParquetFile(file_path)
+                    for batch in parquet_file.iter_batches(batch_size=batch_size):
+                        for row in batch.to_pylist():
+                            row_count += 1
+                            yield tuple(row[column_name] for column_name in column_names)
 
-        return table.num_rows
+            row_generator = rows()
+            connection.execute(insert_sql, row_generator, settings=self._server_insert_settings())
+            if row_count != expected_rows:
+                raise DataLoadingError(f"streamed {row_count:,} row(s), expected {expected_rows:,}")
+            return row_count
+        except ClickHouseServerLoadError:
+            raise
+        except Exception as exc:
+            raise ClickHouseServerLoadError(validated_table, file_paths, row_count, exc) from exc
+        finally:
+            if row_generator is not None:
+                row_generator.close()
 
     def load_table_bulk(
         self,
@@ -2258,7 +2349,30 @@ class ClickHouseNativeHandler(FileFormatHandler):
         Falls back to the default per-shard loop only when shards span multiple directories.
         """
         if self._uses_server_mode():
-            return super().load_table_bulk(table_name, file_paths, connection, benchmark, logger)
+            if not file_paths:
+                return 0
+            validated_table = validate_sql_identifier(table_name, "table name")
+            base_extensions = {FileFormatRegistry.get_base_data_extension(path) for path in file_paths}
+            if len(base_extensions) != 1:
+                raise ClickHouseServerLoadError(
+                    validated_table,
+                    file_paths,
+                    0,
+                    DataLoadingError(f"mixed file formats are not supported: {sorted(base_extensions)}"),
+                )
+            if hasattr(self.adapter, "dry_run_mode") and self.adapter.dry_run_mode:
+                if hasattr(self.adapter, "capture_sql"):
+                    extension = next(iter(base_extensions))
+                    sql = (
+                        f"INSERT INTO {validated_table} VALUES"
+                        if extension != ".parquet"
+                        else f"INSERT INTO {validated_table}"
+                    )
+                    self.adapter.capture_sql(sql, "load_data_bulk", validated_table)
+                return 0
+            if next(iter(base_extensions)) == ".parquet":
+                return self._load_parquet_via_client_insert(validated_table, file_paths, connection)
+            return self._load_delimited_via_client_insert(validated_table, file_paths, connection, benchmark, logger)
 
         if len(file_paths) == 1:
             return self.load_table(table_name, file_paths[0], connection, benchmark, logger)
@@ -2704,6 +2818,8 @@ class DataLoader:
             return handler.load_table_bulk(
                 table_name, shard_paths, self.connection, self.benchmark, self.adapter.logger
             )
+        except ClickHouseServerLoadError:
+            raise
         except Exception as e:
             quiet_console.print(f"  ❌ Failed to bulk-load {table_name}: {e}")
             return 0
@@ -2758,6 +2874,8 @@ class DataLoader:
         except (subprocess.CalledProcessError, FileNotFoundError) as e:
             quiet_console.print(f"⚠️  Skipping {file_path.name} - decompression/file error: {e}")
             return 0
+        except ClickHouseServerLoadError:
+            raise
         except Exception as e:
             quiet_console.print(f"  ❌ Failed to load {file_path.name}: {e}")
             return 0
@@ -3019,6 +3137,7 @@ class SchemaHelpersMixin:
 
 __all__ = [
     "DataLoadingError",
+    "ClickHouseServerLoadError",
     "DataSource",
     "CsvDialect",
     "DUCKDB_NO_NULL_CONVERSION_SENTINEL",

--- a/benchbox/platforms/clickhouse/setup.py
+++ b/benchbox/platforms/clickhouse/setup.py
@@ -33,6 +33,13 @@ class ClickHouseSetupMixin:
         self.max_memory_usage = config.get("max_memory_usage", "8GB")  # Sufficient with uncompressed cache disabled
         self.max_execution_time = config.get("max_execution_time", 300)
         self.max_threads = config.get("max_threads", 8)
+        insert_block_size = config.get("insert_block_size", 65536)
+        if isinstance(insert_block_size, bool) or not isinstance(insert_block_size, int):
+            raise ValueError("insert_block_size must be an integer")
+        if insert_block_size <= 0 or insert_block_size == 1000:
+            raise ValueError("insert_block_size must be a positive integer other than 1000")
+        self.insert_block_size = insert_block_size
+        self.send_receive_timeout = config.get("send_receive_timeout", 300)
 
         # Orphaned: max_server_memory_usage_ratio has no live ClickHouse consumer
         # since the session-setting cleanup. Keep as None for backwards compat;
@@ -182,8 +189,8 @@ class ClickHouseSetupMixin:
         return ClickHouseClient(
             **params,
             connect_timeout=30,
-            send_receive_timeout=300,
-            sync_request_timeout=300,
+            send_receive_timeout=self.send_receive_timeout,
+            sync_request_timeout=self.send_receive_timeout,
         )
 
     def _quote_database_identifier(self, database: str) -> str:
@@ -226,8 +233,8 @@ class ClickHouseSetupMixin:
                 database=database,
                 # Connection settings
                 connect_timeout=30,
-                send_receive_timeout=300,
-                sync_request_timeout=300,
+                send_receive_timeout=self.send_receive_timeout,
+                sync_request_timeout=self.send_receive_timeout,
             )
 
             # Test connection

--- a/tests/unit/platforms/base/test_data_loading_operations.py
+++ b/tests/unit/platforms/base/test_data_loading_operations.py
@@ -24,6 +24,8 @@ import pytest
 from benchbox.platforms.base.data_loading import (
     BenchmarkImplTablesSource,
     BenchmarkTablesSource,
+    ClickHouseServerLoadError,
+    DataLoader,
     DataLoadingError,
     DataSource,
     DataSourceResolver,
@@ -39,6 +41,42 @@ from benchbox.platforms.base.data_loading import (
 )
 
 pytestmark = [pytest.mark.unit, pytest.mark.fast]
+
+
+class TestDataLoaderClickHouseFailurePropagation:
+    """Server-mode loader failures must not be swallowed as zero-row success."""
+
+    @staticmethod
+    def _loader(tmp_path: Path, handler: object) -> DataLoader:
+        data_file = tmp_path / "events.tbl"
+        data_file.write_text("1|alpha\n", encoding="utf-8")
+        loader = DataLoader.__new__(DataLoader)
+        loader.handler_factory = lambda file_path, adapter, benchmark, table_name=None, data_source=None: handler
+        loader.connection = MagicMock()
+        loader.benchmark = MagicMock()
+        loader.adapter = MagicMock()
+        loader.adapter.logger = MagicMock()
+        return loader
+
+    def test_sharded_load_rethrows_typed_server_failure(self, tmp_path):
+        failure = ClickHouseServerLoadError("events", [], 0, RuntimeError("timeout"))
+        loader = self._loader(tmp_path, MagicMock(load_table_bulk=MagicMock(side_effect=failure)))
+        data_file = tmp_path / "events.tbl"
+
+        with pytest.raises(ClickHouseServerLoadError) as exc_info:
+            loader._load_sharded_table("events", [data_file])
+
+        assert exc_info.value is failure
+
+    def test_single_file_load_rethrows_typed_server_failure(self, tmp_path):
+        failure = ClickHouseServerLoadError("events", [], 0, RuntimeError("timeout"))
+        loader = self._loader(tmp_path, MagicMock(load_table=MagicMock(side_effect=failure)))
+        data_file = tmp_path / "events.tbl"
+
+        with pytest.raises(ClickHouseServerLoadError) as exc_info:
+            loader._load_single_file("events", data_file)
+
+        assert exc_info.value is failure
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/platforms/test_clickhouse_adapter.py
+++ b/tests/unit/platforms/test_clickhouse_adapter.py
@@ -5,9 +5,10 @@ Copyright 2026 Joe Harris / BenchBox Project
 Licensed under the MIT License. See LICENSE file in the project root for details.
 """
 
+import gzip
 import logging
 from pathlib import Path
-from types import SimpleNamespace
+from types import GeneratorType, SimpleNamespace
 from unittest.mock import Mock, patch
 
 import pytest
@@ -56,6 +57,15 @@ class TestClickHouseAdapter:
             assert adapter.host == "localhost"
             assert adapter.port == 9000
             assert adapter.deployment_mode == "server"
+            assert adapter.insert_block_size == 65536
+
+    def test_server_insert_block_size_rejects_legacy_batch_size(self):
+        """The server path cannot be configured back to the 1,000-row fallback."""
+        with (
+            patch("benchbox.platforms.clickhouse.setup.ClickHouseClient"),
+            pytest.raises(ValueError, match="other than 1000"),
+        ):
+            ClickHouseAdapter(deployment_mode="server", insert_block_size=1000)
 
     def test_initialization_missing_driver(self):
         """Test initialization when ClickHouse driver dependencies are missing (server mode)."""
@@ -90,6 +100,20 @@ class TestClickHouseAdapter:
         assert mock_client_class.call_count == 3
         # Should execute SHOW DATABASES, CREATE DATABASE, and SELECT 1
         assert mock_client.execute.call_count == 3
+        assert mock_client_class.call_args_list[2].kwargs["send_receive_timeout"] == 300
+        assert mock_client_class.call_args_list[2].kwargs["sync_request_timeout"] == 300
+
+    @patch("benchbox.platforms.clickhouse.setup.ClickHouseClient")
+    def test_create_connection_uses_configured_server_timeout(self, mock_client_class):
+        """The configured driver timeout is applied to the scoped server client."""
+        mock_client_class.return_value = Mock()
+        mock_client_class.return_value.execute.side_effect = [[], None, None]
+
+        adapter = ClickHouseAdapter(deployment_mode="server", send_receive_timeout=900)
+        adapter.create_connection()
+
+        assert mock_client_class.call_args_list[2].kwargs["send_receive_timeout"] == 900
+        assert mock_client_class.call_args_list[2].kwargs["sync_request_timeout"] == 900
 
     @patch("benchbox.platforms.clickhouse.setup.ClickHouseClient")
     def test_create_connection_bootstraps_database_before_scoped_client(self, mock_client_class):
@@ -195,10 +219,16 @@ class TestClickHouseAdapter:
         mock_client_class.return_value = mock_client
         # Mock database check to return empty list (database doesn't exist)
         # Mock database creation and SELECT 1 to return None for connection setup
-        # Mock COUNT(*) query to return the row count
-        # Mock: database check, database create, connection test,
-        # COUNT(*) before, INSERT statement, COUNT(*) after
-        mock_client.execute.side_effect = [[], None, None, [[0]], None, [[100]]]
+        # Mock database setup and consume the generator as the real driver does.
+        execute_results = iter([[], None, None])
+
+        def execute(*args, **kwargs):
+            if len(args) > 1 and isinstance(args[1], GeneratorType):
+                list(args[1])
+                return None
+            return next(execute_results)
+
+        mock_client.execute.side_effect = execute
 
         # Create temporary test file first
         import tempfile
@@ -1114,12 +1144,15 @@ class TestClickHouseNativeHandlerBulk:
         handler.adapter.capture_sql.assert_called_once()
 
     def test_server_mode_loads_host_files_with_client_batches(self, tmp_path):
-        """ClickHouse server mode cannot use file() for host-local Docker paths."""
+        """ClickHouse server mode streams host-local Docker files through one insert."""
         shard = tmp_path / "region.tbl"
         shard.write_text("1|AFRICA\n2|AMERICA\n", encoding="utf-8")
 
         handler = self._make_handler(server_mode=True)
         connection = Mock()
+        connection.execute.side_effect = (
+            lambda query, params=None, **kwargs: list(params) if params is not None else None
+        )
         benchmark = Mock()
         benchmark.get_schema.return_value = {
             "region": {
@@ -1130,14 +1163,143 @@ class TestClickHouseNativeHandlerBulk:
             }
         }
 
-        result = handler.load_table_bulk("region", [shard], connection, benchmark, Mock())
+        with patch("benchbox.platforms.base.data_loading.RowBatchProcessor") as batch_processor:
+            result = handler.load_table_bulk("region", [shard], connection, benchmark, Mock())
 
         assert result == 2
-        connection.execute.assert_called_once_with(
-            "INSERT INTO region VALUES",
-            [(1, "AFRICA"), (2, "AMERICA")],
-        )
+        batch_processor.assert_not_called()
+        query, params = connection.execute.call_args.args[:2]
+        assert query == "INSERT INTO region VALUES"
+        assert isinstance(params, GeneratorType)
+        assert connection.execute.call_args.kwargs["settings"]["insert_block_size"] > 1000
         assert "file(" not in connection.execute.call_args[0][0]
+
+    def test_server_mode_uses_one_generator_across_shards(self, tmp_path):
+        """All shards for one table share one bounded native-driver generator."""
+        shards = [tmp_path / "region.tbl.1", tmp_path / "region.tbl.2"]
+        shards[0].write_text("1|AFRICA\n", encoding="utf-8")
+        shards[1].write_text("2|AMERICA\n", encoding="utf-8")
+
+        handler = self._make_handler(server_mode=True)
+        benchmark = Mock()
+        benchmark.get_schema.return_value = {
+            "region": {
+                "columns": [
+                    {"name": "r_regionkey", "type": "INTEGER"},
+                    {"name": "r_name", "type": "CHAR(25)"},
+                ]
+            }
+        }
+        connection = Mock()
+        seen: dict[str, object] = {}
+
+        def execute(query, params=None, **kwargs):
+            seen["query"] = query
+            seen["params_type"] = type(params)
+            seen["generator"] = params
+            seen["rows"] = list(params)
+            seen["settings"] = kwargs["settings"]
+
+        connection.execute.side_effect = execute
+
+        result = handler.load_table_bulk("region", shards, connection, benchmark, Mock())
+
+        assert result == 2
+        assert seen["query"] == "INSERT INTO region VALUES"
+        assert seen["params_type"] is GeneratorType
+        assert seen["rows"] == [(1, "AFRICA"), (2, "AMERICA")]
+        assert seen["settings"] == {"insert_block_size": 65536}
+        assert seen["generator"].gi_frame is None
+
+    def test_server_mode_dry_run_is_explicit_and_not_a_batch_placeholder(self, tmp_path):
+        """Server dry-run records the insert without pretending 1,000 rows were loaded."""
+        shard = tmp_path / "region.tbl"
+        shard.write_text("1|AFRICA\n", encoding="utf-8")
+        handler = self._make_handler(dry_run=True, server_mode=True)
+        connection = Mock()
+
+        result = handler.load_table_bulk("region", [shard], connection, Mock(), Mock())
+
+        assert result == 0
+        assert not connection.execute.called
+        handler.adapter.capture_sql.assert_called_once()
+        assert "INSERT INTO region VALUES" in handler.adapter.capture_sql.call_args.args[0]
+
+    def test_server_mode_preserves_header_blank_and_width_normalization(self, tmp_path):
+        """Streaming parser keeps the established header/blank/pad/truncate contract."""
+        shard = tmp_path / "events.csv.gz"
+        with gzip.open(shard, "wt", encoding="utf-8") as file_handle:
+            file_handle.write("id,name\n\n1,alpha,ignored\n2\n")
+
+        handler = self._make_handler(server_mode=True)
+        handler.delimiter_char = ","
+        handler.has_header = True
+        benchmark = Mock()
+        benchmark.get_schema.return_value = {"events": {"columns": [{"type": "INTEGER"}, {"type": "STRING"}]}}
+        connection = Mock()
+        seen_rows: list[tuple[object, ...]] = []
+
+        def execute(query, params=None, **kwargs):
+            assert isinstance(params, GeneratorType)
+            seen_rows.extend(params)
+
+        connection.execute.side_effect = execute
+
+        result = handler.load_table_bulk("events", [shard], connection, benchmark, Mock())
+
+        assert result == 2
+        assert seen_rows == [(1, "alpha"), (2, "")]
+
+    def test_server_mode_parquet_is_bounded_and_not_materialized(self, tmp_path):
+        """Parquet uses iter_batches and sends a real generator to the driver."""
+        pa = pytest.importorskip("pyarrow")
+        import pyarrow.parquet as pq
+
+        shard = tmp_path / "events.parquet"
+        pq.write_table(pa.table({"id": [1, 2], "name": ["alpha", "beta"]}), shard)
+        handler = self._make_handler(server_mode=True)
+        connection = Mock()
+        seen: dict[str, object] = {}
+
+        def execute(query, params=None, **kwargs):
+            seen["type"] = type(params)
+            seen["rows"] = list(params)
+            seen["settings"] = kwargs["settings"]
+
+        connection.execute.side_effect = execute
+
+        result = handler.load_table_bulk("events", [shard], connection, Mock(), Mock())
+
+        assert result == 2
+        assert seen == {
+            "type": GeneratorType,
+            "rows": [(1, "alpha"), (2, "beta")],
+            "settings": {"insert_block_size": 65536},
+        }
+
+    def test_server_mode_failure_is_typed_and_terminal(self, tmp_path):
+        """A driver failure is surfaced with table/source/partial-row context."""
+        from benchbox.platforms.base.data_loading import ClickHouseServerLoadError
+
+        shard = tmp_path / "events.tbl"
+        shard.write_text("1|alpha\n2|beta\n", encoding="utf-8")
+        handler = self._make_handler(server_mode=True)
+        connection = Mock()
+
+        def execute(query, params=None, **kwargs):
+            list(params)
+            raise RuntimeError("server timed out")
+
+        connection.execute.side_effect = execute
+
+        with pytest.raises(ClickHouseServerLoadError) as exc_info:
+            handler.load_table_bulk("events", [shard], connection, Mock(), Mock())
+
+        error = exc_info.value
+        assert error.table_name == "events"
+        assert error.source_files == (shard,)
+        assert error.rows_attempted == 2
+        assert "server timed out" in str(error)
 
 
 # ===================================================================


### PR DESCRIPTION
## Summary

- Replace ClickHouse server-mode host-file loading with one bounded native-driver `GeneratorType` per table.
- Stream delimited shards and Parquet batches without `pq.read_table()`, full row lists, or the legacy `RowBatchProcessor`.
- Propagate typed terminal load failures through both DataLoader entry points; server dry runs record SQL without a 1,000-row placeholder.
- Make the driver insert block size and send/receive timeout explicit, rejecting `insert_block_size=1000`.

## Guardrails

- ClickHouse local/chDB `file()` loading is unchanged.
- Non-server dry-run placeholders and the global `RowBatchProcessor` remain unchanged.
- A generator is explicitly closed after each execute; partial/failed loads cannot become zero-row success.

## Verification

- `uv run -- python -m pytest tests/unit/platforms/test_clickhouse_adapter.py tests/unit/platforms/base/test_data_loading_operations.py -q` — 224 passed
- `uv run -- ruff check benchbox/platforms/base/data_loading.py benchbox/platforms/clickhouse/setup.py tests/unit/platforms/test_clickhouse_adapter.py tests/unit/platforms/base/test_data_loading_operations.py` — passed
- `make pr-preflight` — passed (27,835 passed, 19 skipped, 52 warnings)

TODO: uat-clickhouse-server-streaming-loader

Downstream memory calibration, compose admission, failure-artifact, and SF1 certification TODOs remain ordered behind this PR and require real ClickHouse UAT measurements.
