### PR TITLE
Calibrate ClickHouse streaming memory from UAT traces

### DIFF
--- a/docs/operations/uat-framework.md
+++ b/docs/operations/uat-framework.md
@@ -784,6 +784,62 @@ reading is unavailable and does **not** gate — it never silently treats an
 unmeasurable host as having headroom (fail-open), and never hard-fails an
 otherwise-healthy host merely because the measurement failed (fail-closed).
 
+## ClickHouse streaming-memory calibration
+
+The ClickHouse server loader is a bounded native-driver stream. It must not
+fall back to the generic 1,000-row application batch helper. Calibration is a
+measurement exercise, not permission to publish a new compose limit from total
+RAM, `free`, or an unrelated host snapshot. The trace records `available` and
+`free` separately, swap pressure, engine/container memory usage and limit,
+ClickHouse `MemoryTracking`/resident metrics, cumulative `InsertedRows` and
+`InsertedBytes`, driver responsiveness, the requested driver timeout, and the
+loader contract.
+
+The only supported rung order is:
+
+| rung | requested memory | load memory | driver timeout | decision |
+|---|---:|---:|---:|---|
+| `baseline-1g` | 1 GiB | 1 GiB | 300 s | run first; existing baseline, not a new published limit |
+| `candidate-4g` | 4 GiB | 4 GiB | 300 s | run only after the baseline fails or cannot complete |
+| `candidate-8g` | 8 GiB | 8 GiB | 300 s | run only when the 4 GiB trace justifies escalation |
+| `candidate-12g` | 12 GiB | 12 GiB | 300 s | last resort; requires a trace-backed reason |
+
+Wrap the real ClickHouse server UAT command so sampling covers the whole load
+and query path (the wrapper writes an atomic JSON artifact even when the child
+fails):
+
+```bash
+uv run -- python -m tests.uat.clickhouse_memory \
+  --output "$BENCHBOX_OUTPUT_DIR/clickhouse-memory-baseline-1g.json" \
+  --rung baseline-1g \
+  --engine mocker \
+  --project-name <managed-compose-project> \
+  --compose-file docker/clickhouse/docker-compose.yml \
+  -- -- uv run -- benchbox run --platform clickhouse-server \
+       --benchmark tpch --scale 0.01 --phases load
+```
+
+Run a small smoke cell first. Only if that trace is responsive and free of
+OOM/cgroup-kill/timeout evidence should the same rung be tried at SF1. Advance
+to the next rung only when the smallest failing or incomplete run has a trace
+that explains why. A passing trace is admissible only when it has a successful
+responsiveness sample, `native_streaming=true`, and
+`application_batch_rows=null`, plus the measured ClickHouse driver timeout. The
+current server setup default is 300 seconds and the wrapper records that source
+directly from `ClickHouseSetupMixin`; an explicitly configured timeout is also
+recorded when the command supports that option. All memory rungs keep the same
+timeout so a larger timeout cannot turn a timeout defect into a false memory
+success. A trace that reports `1000` rows or cannot establish its timeout is
+rejected, even if the command exits zero.
+`select_lowest_successful_rung()` chooses the lowest valid passing rung and
+fails closed when no such trace exists.
+
+Keep each trace with the UAT evidence. Do not add `mem_limit`,
+`CLICKHOUSE_MEMORY_LIMIT`, or a 1 GiB fallback to the compose file from this
+calibration step. The subsequent compose-admission TODO consumes a selected
+rung only after this trace review and separately verifies the runtime limit and
+host reserve.
+
 ## Troubleshooting
 
 | Symptom | Likely cause | Fix |

--- a/docs/operations/uat-framework.md
+++ b/docs/operations/uat-framework.md
@@ -824,7 +824,10 @@ OOM/cgroup-kill/timeout evidence should the same rung be tried at SF1. Advance
 to the next rung only when the smallest failing or incomplete run has a trace
 that explains why. A passing trace is admissible only when it has a successful
 responsiveness sample, `native_streaming=true`, and
-`application_batch_rows=null`, plus the measured ClickHouse driver timeout. The
+`application_batch_rows=null`, plus the measured ClickHouse driver timeout and
+all required `MemoryTracking`, `MemoryResident`, `InsertedRows`, and
+`InsertedBytes` values. Missing, non-finite, or contradictory host, engine,
+container-state, or ClickHouse telemetry invalidates the trace. The
 current server setup default is 300 seconds and the wrapper records that source
 directly from `ClickHouseSetupMixin`; an explicitly configured timeout is also
 recorded when the command supports that option. All memory rungs keep the same

--- a/tests/uat/clickhouse_memory.py
+++ b/tests/uat/clickhouse_memory.py
@@ -24,6 +24,7 @@ import base64
 import datetime as _dt
 import inspect
 import json
+import math
 import os
 import re
 import subprocess
@@ -61,11 +62,18 @@ _MEMORY_UNITS = {
 # cannot be relabelled as the requested rung.
 _DECIMAL_GIB_EQUIVALENCE = 1000**3
 
-# Each query family must return at least one metric in every sample. Some
-# ClickHouse builds omit optional asynchronous metrics such as OSMemoryFree,
-# so exact metric names would reject a real successful query. An empty family
-# is still a collection failure and invalidates the rung.
-_REQUIRED_CLICKHOUSE_METRIC_PREFIXES = frozenset({"metric", "async", "event"})
+# These are the metrics that make a trace evidence rather than a host/engine
+# health sample. Optional asynchronous metrics such as OSMemoryFree are not
+# required, but a response from the wrong metric or a partially failed query
+# must not be enough to admit a rung.
+_REQUIRED_CLICKHOUSE_METRICS = frozenset(
+    {
+        "metric.MemoryTracking",
+        "async.MemoryResident",
+        "event.InsertedRows",
+        "event.InsertedBytes",
+    }
+)
 _MEMORY_FAILURE_MARKERS = (
     "memory limit exceeded",
     "out of memory",
@@ -163,22 +171,29 @@ class ClickHouseMemoryTrace:
             return False
         if not self.driver_timeout_source or self.driver_timeout_s != self.rung.driver_timeout_s:
             return False
-        if any(sample.responsiveness_ms is None for sample in self.samples):
+        if any(
+            sample.responsiveness_ms is None or not math.isfinite(sample.responsiveness_ms) for sample in self.samples
+        ):
             return False
         lower_limit = int(self.rung.requested_memory_gib * _DECIMAL_GIB_EQUIVALENCE)
         upper_limit = int(self.rung.requested_memory_gib * GIB)
         engine_samples = [sample.engine for sample in self.samples]
         for sample in self.samples:
-            if sample.host.available_gib is None:
+            if (
+                sample.host.available_gib is None
+                or not math.isfinite(sample.host.available_gib)
+                or sample.host.available_gib < 0
+            ):
                 return False
             if sample.server_reachable is not True:
                 return False
-            metric_prefixes = {key.split(".", 1)[0] for key in sample.clickhouse_metrics}
-            if not _REQUIRED_CLICKHOUSE_METRIC_PREFIXES.issubset(metric_prefixes):
+            if not _REQUIRED_CLICKHOUSE_METRICS.issubset(sample.clickhouse_metrics):
+                return False
+            if any(not math.isfinite(sample.clickhouse_metrics[name]) for name in _REQUIRED_CLICKHOUSE_METRICS):
                 return False
             if sample.engine.usage_bytes is None or sample.engine.limit_bytes is None:
                 return False
-            if sample.engine.oom_killed is None or sample.engine.running is None:
+            if sample.engine.oom_killed is not False or sample.engine.running is not True:
                 return False
             if not lower_limit <= sample.engine.limit_bytes <= upper_limit:
                 return False

--- a/tests/uat/clickhouse_memory.py
+++ b/tests/uat/clickhouse_memory.py
@@ -53,6 +53,28 @@ _MEMORY_UNITS = {
     "gib": 1024**3,
     "tib": 1024**4,
 }
+# ``MemoryRung.requested_memory_gib`` is a nominal envelope.  Compose and
+# Docker accept both decimal ``4g`` and binary ``4GiB`` spellings, so a
+# measured runtime cap is admissible only inside that exact unit-equivalence
+# window -- decimal gigabytes through binary gibibytes.  This is deliberately
+# not an arbitrary percentage tolerance: a materially smaller or larger cap
+# cannot be relabelled as the requested rung.
+_DECIMAL_GIB_EQUIVALENCE = 1000**3
+
+# These are the counters the calibration trace claims to capture.  A partial
+# ClickHouse response is not evidence: query/metric failures must invalidate
+# the rung instead of silently producing a plausible-looking artifact.
+_REQUIRED_CLICKHOUSE_METRICS = frozenset(
+    {
+        "metric.MemoryTracking",
+        "async.MemoryResident",
+        "async.MemoryVirtual",
+        "async.OSMemoryAvailable",
+        "async.OSMemoryFree",
+        "event.InsertedRows",
+        "event.InsertedBytes",
+    }
+)
 
 
 @dataclass(frozen=True)
@@ -146,9 +168,22 @@ class ClickHouseMemoryTrace:
             return False
         if any(sample.responsiveness_ms is None for sample in self.samples):
             return False
-        if any(sample.engine.limit_bytes is None for sample in self.samples):
-            return False
+        lower_limit = int(self.rung.requested_memory_gib * _DECIMAL_GIB_EQUIVALENCE)
+        upper_limit = int(self.rung.requested_memory_gib * GIB)
         engine_samples = [sample.engine for sample in self.samples]
+        for sample in self.samples:
+            if sample.host.available_gib is None:
+                return False
+            if sample.server_reachable is not True:
+                return False
+            if not _REQUIRED_CLICKHOUSE_METRICS.issubset(sample.clickhouse_metrics):
+                return False
+            if sample.engine.usage_bytes is None or sample.engine.limit_bytes is None:
+                return False
+            if sample.engine.oom_killed is None or sample.engine.running is None:
+                return False
+            if not lower_limit <= sample.engine.limit_bytes <= upper_limit:
+                return False
         if any(sample.oom_killed is True for sample in engine_samples):
             return False
         if any(
@@ -210,7 +245,7 @@ class ClickHouseMemoryTrace:
                 "peak_engine_usage_bytes": self.peak_engine_usage_bytes,
                 "runtime_memory_limit_bytes": self.runtime_memory_limit_bytes,
                 "driver_timeout_source": self.driver_timeout_source,
-                "oom_killed": any(sample.engine.oom_killed is True for sample in self.samples),
+                "oom_killed": self._oom_killed_summary(),
                 "memory_limit_exceeded": any(
                     sample.engine.usage_bytes is not None
                     and sample.engine.limit_bytes is not None
@@ -222,6 +257,13 @@ class ClickHouseMemoryTrace:
             },
             "samples": [asdict(sample) for sample in self.samples],
         }
+
+    def _oom_killed_summary(self) -> bool | None:
+        """Summarize OOM state without converting unknown telemetry to False."""
+        values = [sample.engine.oom_killed for sample in self.samples]
+        if not values or any(value is None for value in values):
+            return None
+        return any(values)
 
 
 def utc_now() -> str:
@@ -727,6 +769,11 @@ def main(argv: Sequence[str] | None = None) -> int:
         trace.finish(outcome="aborted", failure_reason=loader_reason)
         write_trace(args.output, trace)
         return 2
+    # Replace any prior passing artifact before launching the child.  If the
+    # operator interrupts or the process is terminated before ``stop`` can
+    # publish a final trace, the path still says ``outcome=running`` rather
+    # than leaving stale evidence that belongs to an older invocation.
+    write_trace(args.output, trace)
     collector = MemoryTraceCollector(
         trace=trace,
         output_path=args.output,

--- a/tests/uat/clickhouse_memory.py
+++ b/tests/uat/clickhouse_memory.py
@@ -1,0 +1,763 @@
+"""Measured ClickHouse streaming-memory traces for UAT calibration.
+
+The calibration TODO deliberately keeps measurement separate from the compose
+memory-admission policy.  This module records the quantities that policy is
+allowed to consume; it never turns a host-capacity guess into a memory limit.
+
+Use the module as a command wrapper around a real UAT cell or sweep::
+
+    uv run -- python -m tests.uat.clickhouse_memory \
+      --output "$BENCHBOX_OUTPUT_DIR/clickhouse-memory-1g.json" \
+      --rung baseline-1g -- -- benchbox run --platform clickhouse-server ...
+
+The trace is useful even when a cell fails: the failure, timeout, server
+responsiveness, host memory, engine memory, and ClickHouse counters remain in
+one atomic JSON artifact.  A trace is not considered calibration evidence
+unless it has at least one successful responsiveness sample and passes the
+native-streaming/no-legacy-batch guards.
+"""
+
+from __future__ import annotations
+
+import argparse
+import base64
+import datetime as _dt
+import inspect
+import json
+import os
+import re
+import subprocess
+import sys
+import threading
+import time
+import urllib.error
+import urllib.request
+from dataclasses import asdict, dataclass, field, replace
+from pathlib import Path
+from typing import Any, Callable, Iterable, Sequence
+
+GIB = 1024**3
+TRACE_SCHEMA_VERSION = 2
+DEFAULT_DRIVER_TIMEOUT_S = 300
+DEFAULT_SAMPLE_INTERVAL_S = 2.0
+DEFAULT_HTTP_TIMEOUT_S = 2.0
+_MEMORY_VALUE_RE = re.compile(r"^\s*(?P<value>[0-9]+(?:\.[0-9]+)?)\s*(?P<unit>[KMGTPE]?i?B)?\s*$", re.I)
+_MEMORY_UNITS = {
+    "b": 1,
+    "kb": 1000,
+    "mb": 1000**2,
+    "gb": 1000**3,
+    "tb": 1000**4,
+    "kib": 1024,
+    "mib": 1024**2,
+    "gib": 1024**3,
+    "tib": 1024**4,
+}
+
+
+@dataclass(frozen=True)
+class MemoryRung:
+    """One explicitly named calibration rung.
+
+    ``requested_memory_gib`` is a requested engine/container envelope, not a
+    claim that the compose file currently enforces it.  The calibration trace
+    records the request and the observed runtime limit separately.
+    """
+
+    name: str
+    requested_memory_gib: float
+    load_memory_gib: float
+    driver_timeout_s: int
+
+    def __post_init__(self) -> None:
+        if not self.name or self.name == "baseline-1000-row":
+            raise ValueError("memory rung name must identify a memory envelope")
+        if self.requested_memory_gib <= 0 or self.load_memory_gib <= 0:
+            raise ValueError("memory rung sizes must be positive")
+        if self.driver_timeout_s <= 0:
+            raise ValueError("memory rung driver timeout must be positive")
+
+
+DEFAULT_MEMORY_RUNGS: tuple[MemoryRung, ...] = (
+    # Keep the driver timeout constant across memory rungs.  Otherwise a
+    # timeout change would confound the memory comparison and could turn a
+    # memory failure into a false "larger rung" success.
+    MemoryRung("baseline-1g", 1.0, 1.0, DEFAULT_DRIVER_TIMEOUT_S),
+    MemoryRung("candidate-4g", 4.0, 4.0, DEFAULT_DRIVER_TIMEOUT_S),
+    MemoryRung("candidate-8g", 8.0, 8.0, DEFAULT_DRIVER_TIMEOUT_S),
+    MemoryRung("candidate-12g", 12.0, 12.0, DEFAULT_DRIVER_TIMEOUT_S),
+)
+
+
+@dataclass(frozen=True)
+class HostMemorySample:
+    available_gib: float | None
+    free_gib: float | None
+    swap_used_percent: float | None
+
+
+@dataclass(frozen=True)
+class EngineMemorySample:
+    engine: str | None
+    service: str | None
+    usage_bytes: int | None
+    limit_bytes: int | None
+    raw_status: str | None = None
+    oom_killed: bool | None = None
+    running: bool | None = None
+
+
+@dataclass(frozen=True)
+class TraceSample:
+    observed_at_utc: str
+    elapsed_s: float
+    host: HostMemorySample
+    engine: EngineMemorySample
+    clickhouse_metrics: dict[str, float]
+    responsiveness_ms: float | None
+    server_reachable: bool
+
+
+@dataclass
+class ClickHouseMemoryTrace:
+    """Durable trace and calibration guards for one real run."""
+
+    platform: str
+    rung: MemoryRung
+    started_at_utc: str
+    ended_at_utc: str | None = None
+    source_commit: str | None = None
+    driver_timeout_s: int | None = None
+    driver_timeout_source: str | None = None
+    native_streaming: bool = True
+    application_batch_rows: int | None = None
+    outcome: str = "running"
+    failure_reason: str | None = None
+    samples: list[TraceSample] = field(default_factory=list)
+
+    @property
+    def valid_for_calibration(self) -> bool:
+        """Return whether the trace is admissible evidence for rung selection."""
+        if not self.samples or not self.native_streaming:
+            return False
+        if self.application_batch_rows is not None:
+            return False
+        if not self.driver_timeout_source or self.driver_timeout_s != self.rung.driver_timeout_s:
+            return False
+        if any(sample.responsiveness_ms is None for sample in self.samples):
+            return False
+        if any(sample.engine.limit_bytes is None for sample in self.samples):
+            return False
+        engine_samples = [sample.engine for sample in self.samples]
+        if any(sample.oom_killed is True for sample in engine_samples):
+            return False
+        if any(
+            sample.usage_bytes is not None
+            and sample.limit_bytes is not None
+            and sample.usage_bytes > sample.limit_bytes
+            for sample in engine_samples
+        ):
+            return False
+        return self.outcome == "passed" and self.failure_reason is None
+
+    @property
+    def peak_engine_usage_bytes(self) -> int | None:
+        values = [sample.engine.usage_bytes for sample in self.samples if sample.engine.usage_bytes is not None]
+        return max(values) if values else None
+
+    @property
+    def peak_host_available_gib(self) -> float | None:
+        values = [sample.host.available_gib for sample in self.samples if sample.host.available_gib is not None]
+        return min(values) if values else None
+
+    @property
+    def max_responsiveness_ms(self) -> float | None:
+        values = [sample.responsiveness_ms for sample in self.samples if sample.responsiveness_ms is not None]
+        return max(values) if values else None
+
+    @property
+    def runtime_memory_limit_bytes(self) -> int | None:
+        values = [sample.engine.limit_bytes for sample in self.samples if sample.engine.limit_bytes is not None]
+        return max(values) if values else None
+
+    def finish(self, *, outcome: str, failure_reason: str | None = None) -> None:
+        if outcome not in {"passed", "failed", "timed-out", "aborted"}:
+            raise ValueError(f"unsupported trace outcome {outcome!r}")
+        self.ended_at_utc = utc_now()
+        self.outcome = outcome
+        self.failure_reason = failure_reason
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "trace_schema_version": TRACE_SCHEMA_VERSION,
+            "platform": self.platform,
+            "rung": asdict(self.rung),
+            "started_at_utc": self.started_at_utc,
+            "ended_at_utc": self.ended_at_utc,
+            "source_commit": self.source_commit,
+            "driver_timeout_s": self.driver_timeout_s,
+            "driver_timeout_source": self.driver_timeout_source,
+            "loader_contract": {
+                "native_streaming": self.native_streaming,
+                "application_batch_rows": self.application_batch_rows,
+                "legacy_1000_row_fallback": self.application_batch_rows == 1000,
+            },
+            "outcome": self.outcome,
+            "failure_reason": self.failure_reason,
+            "summary": {
+                "sample_count": len(self.samples),
+                "valid_for_calibration": self.valid_for_calibration,
+                "peak_engine_usage_bytes": self.peak_engine_usage_bytes,
+                "runtime_memory_limit_bytes": self.runtime_memory_limit_bytes,
+                "driver_timeout_source": self.driver_timeout_source,
+                "oom_killed": any(sample.engine.oom_killed is True for sample in self.samples),
+                "memory_limit_exceeded": any(
+                    sample.engine.usage_bytes is not None
+                    and sample.engine.limit_bytes is not None
+                    and sample.engine.usage_bytes > sample.engine.limit_bytes
+                    for sample in self.samples
+                ),
+                "minimum_host_available_gib": self.peak_host_available_gib,
+                "maximum_responsiveness_ms": self.max_responsiveness_ms,
+            },
+            "samples": [asdict(sample) for sample in self.samples],
+        }
+
+
+def utc_now() -> str:
+    return _dt.datetime.now(_dt.UTC).isoformat().replace("+00:00", "Z")
+
+
+def parse_memory_bytes(value: Any) -> int | None:
+    """Parse Docker/mocker memory text (for example ``"1.5GiB / 4GiB"``)."""
+    if value is None:
+        return None
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, (int, float)):
+        return int(value)
+    match = _MEMORY_VALUE_RE.match(str(value).split("/", 1)[0])
+    if not match:
+        return None
+    unit = (match.group("unit") or "b").lower()
+    multiplier = _MEMORY_UNITS.get(unit)
+    return None if multiplier is None else int(float(match.group("value")) * multiplier)
+
+
+def parse_engine_stats(text: str, *, engine: str | None, service: str | None) -> EngineMemorySample:
+    """Parse Docker and mocker ``compose stats --format json`` variants."""
+    payload: Any = None
+    for line in text.splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            candidate = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        payload = candidate[0] if isinstance(candidate, list) and candidate else candidate
+        break
+    if isinstance(payload, dict):
+        usage = payload.get("MemUsage") or payload.get("MemUsageBytes") or payload.get("memory_usage")
+        limit = payload.get("MemLimit") or payload.get("MemLimitBytes") or payload.get("memory_limit")
+        if limit is None and isinstance(usage, str) and "/" in usage:
+            usage, limit = usage.split("/", 1)
+        raw_status = str(payload.get("Name") or payload.get("Container") or "") or None
+    else:
+        # Apple Containerization's Mocker currently ignores the JSON format
+        # template and emits the Docker-compatible table.  Keep this parser
+        # explicit rather than treating that limitation as missing telemetry.
+        table_row = next(
+            (
+                line.strip()
+                for line in text.splitlines()
+                if line.strip() and not line.lstrip().upper().startswith(("CONTAINER ID", "NAME"))
+            ),
+            "",
+        )
+        table_match = re.match(r"^\S+\s+(?P<name>\S+)\s+\S+\s+(?P<usage>\S+\s*/\s*\S+)", table_row)
+        if table_match is None:
+            return EngineMemorySample(engine, service, None, None, text.strip() or None)
+        usage = table_match.group("usage").split("/", 1)[0]
+        limit = table_match.group("usage").split("/", 1)[1]
+        raw_status = table_match.group("name")
+    return EngineMemorySample(
+        engine=engine,
+        service=service,
+        usage_bytes=parse_memory_bytes(usage),
+        limit_bytes=parse_memory_bytes(limit),
+        raw_status=raw_status,
+    )
+
+
+def parse_engine_inspect(text: str, *, engine: str | None, service: str | None) -> EngineMemorySample:
+    """Extract running/OOM state from ``engine inspect`` JSON."""
+    try:
+        payload: Any = json.loads(text)
+    except json.JSONDecodeError:
+        return EngineMemorySample(engine, service, None, None, text.strip() or None)
+    if isinstance(payload, list):
+        payload = payload[0] if payload else {}
+    state = payload.get("State", {}) if isinstance(payload, dict) else {}
+    if not isinstance(state, dict):
+        return EngineMemorySample(engine, service, None, None, text.strip() or None)
+    raw_status = str(state.get("Status") or "") or None
+    return EngineMemorySample(
+        engine=engine,
+        service=service,
+        usage_bytes=None,
+        limit_bytes=None,
+        raw_status=raw_status,
+        oom_killed=state.get("OOMKilled") if isinstance(state.get("OOMKilled"), bool) else None,
+        running=state.get("Running") if isinstance(state.get("Running"), bool) else None,
+    )
+
+
+def verify_native_streaming_loader() -> tuple[bool, str]:
+    """Verify the shipped ClickHouse path is a generator insert, not 1,000-row batching."""
+    try:
+        from benchbox.platforms.base.data_loading import ClickHouseNativeHandler
+
+        delimited = inspect.getsource(ClickHouseNativeHandler._load_delimited_via_client_insert)
+        parquet = inspect.getsource(ClickHouseNativeHandler._load_parquet_via_client_insert)
+    except (ImportError, OSError, TypeError) as exc:
+        return False, f"could not inspect ClickHouse native loader: {exc}"
+    for name, source in (("delimited", delimited), ("parquet", parquet)):
+        if (
+            "row_generator" not in source
+            or "connection.execute(" not in source
+            or "settings=self._server_insert_settings()" not in source
+        ):
+            return False, f"ClickHouse {name} path is not a native generator insert"
+        if "executemany(" in source or "batch_size = 1000" in source:
+            return False, f"ClickHouse {name} path contains an application batch fallback"
+    return True, "native generator insert contract verified"
+
+
+def read_host_memory() -> HostMemorySample:
+    """Read available, free, and swap metrics without substituting one for another."""
+    try:
+        import psutil
+
+        virtual = psutil.virtual_memory()
+        swap = psutil.swap_memory()
+        return HostMemorySample(
+            available_gib=virtual.available / GIB,
+            free_gib=virtual.free / GIB,
+            swap_used_percent=float(swap.percent),
+        )
+    except (ImportError, OSError, RuntimeError, ValueError, AttributeError):
+        return HostMemorySample(None, None, None)
+
+
+def _http_query(
+    host_port: int,
+    query: str,
+    *,
+    username: str,
+    password: str,
+    timeout_s: float,
+) -> str:
+    request = urllib.request.Request(
+        f"http://127.0.0.1:{host_port}/",
+        data=query.encode("utf-8"),
+        method="POST",
+    )
+    token = base64.b64encode(f"{username}:{password}".encode()).decode("ascii")
+    request.add_header("Authorization", f"Basic {token}")
+    with urllib.request.urlopen(request, timeout=timeout_s) as response:  # noqa: S310 - fixed loopback endpoint
+        return response.read().decode("utf-8", errors="replace")
+
+
+def read_clickhouse_metrics(
+    host_port: int,
+    *,
+    username: str = "default",
+    password: str = "benchbox",
+    timeout_s: float = DEFAULT_HTTP_TIMEOUT_S,
+) -> tuple[dict[str, float], float | None]:
+    """Return server counters and a loopback ``SELECT 1`` responsiveness sample."""
+    metrics: dict[str, float] = {}
+    queries = (
+        (
+            "metric",
+            "SELECT metric AS name, value FROM system.metrics WHERE metric IN ('MemoryTracking') FORMAT JSONEachRow",
+        ),
+        (
+            "async",
+            "SELECT metric AS name, value FROM system.asynchronous_metrics "
+            "WHERE metric IN ('MemoryResident','MemoryVirtual','OSMemoryAvailable','OSMemoryFree') FORMAT JSONEachRow",
+        ),
+        (
+            "event",
+            "SELECT event AS name, value FROM system.events "
+            "WHERE event IN ('InsertedRows','InsertedBytes') FORMAT JSONEachRow",
+        ),
+    )
+    for prefix, query in queries:
+        try:
+            for line in _http_query(
+                host_port, query, username=username, password=password, timeout_s=timeout_s
+            ).splitlines():
+                row = json.loads(line)
+                metrics[f"{prefix}.{row['name']}"] = float(row["value"])
+        except (OSError, urllib.error.URLError, TimeoutError, ValueError, KeyError, json.JSONDecodeError):
+            continue
+    started = time.perf_counter()
+    try:
+        _http_query(host_port, "SELECT 1", username=username, password=password, timeout_s=timeout_s)
+    except (OSError, urllib.error.URLError, TimeoutError):
+        return metrics, None
+    return metrics, (time.perf_counter() - started) * 1000.0
+
+
+CommandRunner = Callable[[Sequence[str]], tuple[int, str, str]]
+
+
+def _run_stats_command(argv: Sequence[str]) -> tuple[int, str, str]:
+    try:
+        completed = subprocess.run(argv, capture_output=True, text=True, timeout=DEFAULT_HTTP_TIMEOUT_S, check=False)
+    except (OSError, subprocess.SubprocessError) as exc:
+        return 1, "", str(exc)
+    return completed.returncode, completed.stdout, completed.stderr
+
+
+def _compose_stats_argv(
+    *,
+    engine: str,
+    project_name: str,
+    compose_files: Iterable[Path],
+    service: str,
+) -> list[str]:
+    del compose_files  # the deterministic compose container name is sufficient for stats
+    return [engine, "stats", "--no-stream", "--format", "{{json .}}", f"{project_name}-{service}-1"]
+
+
+def _inspect_argv(*, engine: str, project_name: str, service: str) -> list[str]:
+    return [engine, "inspect", f"{project_name}-{service}-1"]
+
+
+class MemoryTraceCollector:
+    """Sample host, engine, and ClickHouse state in a bounded background thread."""
+
+    def __init__(
+        self,
+        *,
+        trace: ClickHouseMemoryTrace,
+        output_path: Path,
+        host_port: int = 8123,
+        username: str = "default",
+        password: str = "benchbox",
+        interval_s: float = DEFAULT_SAMPLE_INTERVAL_S,
+        engine: str | None = None,
+        project_name: str | None = None,
+        compose_files: Iterable[Path] = (),
+        service: str = "clickhouse",
+        command_runner: CommandRunner = _run_stats_command,
+    ) -> None:
+        if interval_s <= 0:
+            raise ValueError("memory trace interval must be positive")
+        self.trace = trace
+        self.output_path = Path(output_path)
+        self.host_port = host_port
+        self.username = username
+        self.password = password
+        self.interval_s = interval_s
+        self.engine = engine
+        self.project_name = project_name
+        self.compose_files = tuple(compose_files)
+        self.service = service
+        self.command_runner = command_runner
+        self._started_mono: float | None = None
+        self._stop = threading.Event()
+        self._thread: threading.Thread | None = None
+
+    def start(self) -> None:
+        if self._thread is not None:
+            raise RuntimeError("memory trace collector already started")
+        self._started_mono = time.monotonic()
+        self._sample_once()
+        self._thread = threading.Thread(target=self._run, name="clickhouse-memory-trace", daemon=True)
+        self._thread.start()
+
+    def stop(self, *, outcome: str, failure_reason: str | None = None) -> ClickHouseMemoryTrace:
+        self._stop.set()
+        if self._thread is not None:
+            self._thread.join(timeout=max(self.interval_s * 2, 5.0))
+        self.trace.finish(outcome=outcome, failure_reason=failure_reason)
+        write_trace(self.output_path, self.trace)
+        return self.trace
+
+    def _run(self) -> None:
+        while not self._stop.wait(self.interval_s):
+            self._sample_once()
+
+    def _sample_once(self) -> None:
+        started = self._started_mono or time.monotonic()
+        host = read_host_memory()
+        metrics, responsiveness_ms = read_clickhouse_metrics(
+            self.host_port, username=self.username, password=self.password
+        )
+        engine_sample = EngineMemorySample(self.engine, self.service, None, None)
+        if self.engine and self.project_name:
+            argv = _compose_stats_argv(
+                engine=self.engine,
+                project_name=self.project_name,
+                compose_files=self.compose_files,
+                service=self.service,
+            )
+            returncode, stdout, stderr = self.command_runner(argv)
+            engine_sample = parse_engine_stats(
+                stdout if returncode == 0 else stderr,
+                engine=self.engine,
+                service=self.service,
+            )
+            inspect_returncode, inspect_stdout, inspect_stderr = self.command_runner(
+                _inspect_argv(engine=self.engine, project_name=self.project_name, service=self.service)
+            )
+            inspect_sample = parse_engine_inspect(
+                inspect_stdout if inspect_returncode == 0 else inspect_stderr,
+                engine=self.engine,
+                service=self.service,
+            )
+            engine_sample = replace(
+                engine_sample,
+                oom_killed=inspect_sample.oom_killed,
+                running=inspect_sample.running,
+            )
+        self.trace.samples.append(
+            TraceSample(
+                observed_at_utc=utc_now(),
+                elapsed_s=max(0.0, time.monotonic() - started),
+                host=host,
+                engine=engine_sample,
+                clickhouse_metrics=metrics,
+                responsiveness_ms=responsiveness_ms,
+                server_reachable=responsiveness_ms is not None,
+            )
+        )
+
+
+def write_trace(path: Path, trace: ClickHouseMemoryTrace) -> None:
+    """Atomically write a trace so a killed run cannot leave a false artifact."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temporary = path.with_name(f".{path.name}.tmp")
+    temporary.write_text(json.dumps(trace.to_dict(), indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    os.replace(temporary, path)
+
+
+def read_trace(path: Path) -> ClickHouseMemoryTrace:
+    """Load a trace artifact for rung comparison without trusting summary fields."""
+    payload = json.loads(Path(path).read_text(encoding="utf-8"))
+    if payload.get("trace_schema_version") != TRACE_SCHEMA_VERSION:
+        raise ValueError(
+            f"unsupported ClickHouse memory trace schema {payload.get('trace_schema_version')!r}; "
+            f"expected {TRACE_SCHEMA_VERSION}"
+        )
+    rung = MemoryRung(**payload["rung"])
+    samples = [
+        TraceSample(
+            observed_at_utc=sample["observed_at_utc"],
+            elapsed_s=float(sample["elapsed_s"]),
+            host=HostMemorySample(**sample["host"]),
+            engine=EngineMemorySample(**sample["engine"]),
+            clickhouse_metrics={str(key): float(value) for key, value in sample["clickhouse_metrics"].items()},
+            responsiveness_ms=sample["responsiveness_ms"],
+            server_reachable=bool(sample["server_reachable"]),
+        )
+        for sample in payload.get("samples", [])
+    ]
+    loader_contract = payload.get("loader_contract", {})
+    return ClickHouseMemoryTrace(
+        platform=payload["platform"],
+        rung=rung,
+        started_at_utc=payload["started_at_utc"],
+        ended_at_utc=payload.get("ended_at_utc"),
+        source_commit=payload.get("source_commit"),
+        driver_timeout_s=payload.get("driver_timeout_s"),
+        driver_timeout_source=payload.get("driver_timeout_source"),
+        native_streaming=bool(loader_contract.get("native_streaming", False)),
+        application_batch_rows=loader_contract.get("application_batch_rows"),
+        outcome=payload.get("outcome", "aborted"),
+        failure_reason=payload.get("failure_reason"),
+        samples=samples,
+    )
+
+
+def select_lowest_successful_rung(traces: Iterable[ClickHouseMemoryTrace]) -> MemoryRung:
+    """Choose the lowest measured passing envelope; reject unmeasured guesses."""
+    valid = sorted(
+        (trace for trace in traces if trace.valid_for_calibration), key=lambda trace: trace.rung.requested_memory_gib
+    )
+    if not valid:
+        raise ValueError("no valid passing memory trace; do not publish a memory floor or limit")
+    return valid[0].rung
+
+
+def rung_matrix_text(rungs: Iterable[MemoryRung] = DEFAULT_MEMORY_RUNGS) -> str:
+    """Render the operator-facing rung policy used by the UAT document."""
+    lines = ["name\trequested_memory_gib\tload_memory_gib\tdriver_timeout_s"]
+    lines.extend(
+        f"{rung.name}\t{rung.requested_memory_gib:g}\t{rung.load_memory_gib:g}\t{rung.driver_timeout_s}"
+        for rung in rungs
+    )
+    return "\n".join(lines)
+
+
+def summarize_command_failure(output: str, returncode: int) -> str:
+    """Keep the trace's failure reason short but preserve memory/timeout causes."""
+    patterns = (
+        "memory limit exceeded",
+        "oomkilled",
+        "out of memory",
+        "timed out",
+        "timeout",
+        "cgroup",
+    )
+    for line in output.splitlines():
+        compact = " ".join(line.split())
+        if compact and any(pattern in compact.lower() for pattern in patterns):
+            return compact[:500]
+    return f"wrapped command exited {returncode}"
+
+
+def parse_driver_timeout(command: Sequence[str]) -> int | None:
+    """Read the explicit ClickHouse ``send_receive_timeout`` platform option."""
+    for index, argument in enumerate(command[:-1]):
+        if argument != "--platform-option":
+            continue
+        option = command[index + 1]
+        if not option.startswith("send_receive_timeout="):
+            continue
+        try:
+            value = int(option.split("=", 1)[1])
+        except ValueError:
+            return None
+        return value if value > 0 else None
+    return None
+
+
+def default_clickhouse_driver_timeout_s() -> int:
+    """Read the server-mode default from the shipped setup implementation.
+
+    The CLI currently does not expose ``send_receive_timeout`` as a platform
+    option.  Recording the live setup default keeps successful traces honest
+    without inventing an option that the command rejects.
+    """
+    try:
+        from benchbox.platforms.clickhouse.setup import ClickHouseSetupMixin
+
+        source = inspect.getsource(ClickHouseSetupMixin._setup_server_mode)
+    except (ImportError, OSError, TypeError) as exc:
+        raise RuntimeError(f"could not inspect ClickHouse driver timeout default: {exc}") from exc
+    match = re.search(
+        r"send_receive_timeout\s*=\s*config\.get\(\s*['\"]send_receive_timeout['\"]\s*,\s*(\d+)\s*\)",
+        source,
+    )
+    if match is None:
+        raise RuntimeError("ClickHouse server setup does not expose a measurable send_receive_timeout default")
+    return int(match.group(1))
+
+
+def resolve_driver_timeout(command: Sequence[str]) -> tuple[int, str]:
+    """Resolve the command's explicit timeout or the live server-mode default."""
+    explicit = parse_driver_timeout(command)
+    if explicit is not None:
+        return explicit, "command platform option"
+    return default_clickhouse_driver_timeout_s(), "ClickHouseSetupMixin server default"
+
+
+def _find_rung(name: str) -> MemoryRung:
+    for rung in DEFAULT_MEMORY_RUNGS:
+        if rung.name == name:
+            return rung
+    raise argparse.ArgumentTypeError(
+        f"unknown rung {name!r}; choose one of {', '.join(r.name for r in DEFAULT_MEMORY_RUNGS)}"
+    )
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--output", type=Path, required=True)
+    parser.add_argument("--rung", type=_find_rung, default=DEFAULT_MEMORY_RUNGS[0])
+    parser.add_argument("--host-port", type=int, default=8123)
+    parser.add_argument("--interval-s", type=float, default=DEFAULT_SAMPLE_INTERVAL_S)
+    parser.add_argument("--engine")
+    parser.add_argument("--project-name")
+    parser.add_argument("--compose-file", action="append", type=Path, default=[])
+    parser.add_argument("--service", default="clickhouse")
+    parser.add_argument("--username", default="default")
+    parser.add_argument("--password", default="benchbox")
+    parser.add_argument("--source-commit", default=os.environ.get("GIT_COMMIT"))
+    parser.add_argument("--application-batch-rows", type=int)
+    parser.add_argument("command", nargs=argparse.REMAINDER)
+    args = parser.parse_args(argv)
+    command = list(args.command)
+    while command[:1] == ["--"]:
+        command = command[1:]
+    if not command:
+        parser.error("a command is required after --")
+
+    native_streaming, loader_reason = verify_native_streaming_loader()
+    try:
+        observed_timeout_s, timeout_source = resolve_driver_timeout(command)
+    except RuntimeError as exc:
+        trace = ClickHouseMemoryTrace(
+            platform="clickhouse-server",
+            rung=args.rung,
+            started_at_utc=utc_now(),
+            source_commit=args.source_commit,
+            native_streaming=native_streaming,
+            failure_reason=str(exc),
+        )
+        trace.finish(outcome="aborted", failure_reason=str(exc))
+        write_trace(args.output, trace)
+        return 2
+    trace = ClickHouseMemoryTrace(
+        platform="clickhouse-server",
+        rung=args.rung,
+        started_at_utc=utc_now(),
+        source_commit=args.source_commit,
+        driver_timeout_s=observed_timeout_s,
+        driver_timeout_source=timeout_source,
+        native_streaming=native_streaming,
+        application_batch_rows=args.application_batch_rows,
+    )
+    if not native_streaming:
+        trace.finish(outcome="aborted", failure_reason=loader_reason)
+        write_trace(args.output, trace)
+        return 2
+    collector = MemoryTraceCollector(
+        trace=trace,
+        output_path=args.output,
+        host_port=args.host_port,
+        username=args.username,
+        password=args.password,
+        interval_s=args.interval_s,
+        engine=args.engine,
+        project_name=args.project_name,
+        compose_files=args.compose_file,
+        service=args.service,
+    )
+    collector.start()
+    try:
+        completed = subprocess.run(command, check=False, capture_output=True, text=True)
+    except (OSError, subprocess.SubprocessError) as exc:
+        collector.stop(outcome="failed", failure_reason=f"command could not start: {exc}")
+        return 1
+    if completed.stdout:
+        print(completed.stdout, end="")
+    if completed.stderr:
+        print(completed.stderr, end="", file=sys.stderr)
+    outcome = "passed" if completed.returncode == 0 else "failed"
+    reason = (
+        None
+        if completed.returncode == 0
+        else summarize_command_failure(completed.stdout + completed.stderr, completed.returncode)
+    )
+    collector.stop(outcome=outcome, failure_reason=reason)
+    return completed.returncode
+
+
+if __name__ == "__main__":  # pragma: no cover - exercised by operator wrapper
+    raise SystemExit(main())

--- a/tests/uat/clickhouse_memory.py
+++ b/tests/uat/clickhouse_memory.py
@@ -66,6 +66,12 @@ _DECIMAL_GIB_EQUIVALENCE = 1000**3
 # so exact metric names would reject a real successful query. An empty family
 # is still a collection failure and invalidates the rung.
 _REQUIRED_CLICKHOUSE_METRIC_PREFIXES = frozenset({"metric", "async", "event"})
+_MEMORY_FAILURE_MARKERS = (
+    "memory limit exceeded",
+    "out of memory",
+    "oomkilled",
+    "cgroup",
+)
 
 
 @dataclass(frozen=True)
@@ -207,6 +213,19 @@ class ClickHouseMemoryTrace:
         values = [sample.engine.limit_bytes for sample in self.samples if sample.engine.limit_bytes is not None]
         return max(values) if values else None
 
+    @property
+    def memory_limit_exceeded(self) -> bool:
+        """Report measured or command-reported memory-limit failures."""
+        if any(
+            sample.engine.usage_bytes is not None
+            and sample.engine.limit_bytes is not None
+            and sample.engine.usage_bytes > sample.engine.limit_bytes
+            for sample in self.samples
+        ):
+            return True
+        failure = (self.failure_reason or "").lower()
+        return any(marker in failure for marker in _MEMORY_FAILURE_MARKERS)
+
     def finish(self, *, outcome: str, failure_reason: str | None = None) -> None:
         if outcome not in {"passed", "failed", "timed-out", "aborted"}:
             raise ValueError(f"unsupported trace outcome {outcome!r}")
@@ -238,12 +257,7 @@ class ClickHouseMemoryTrace:
                 "runtime_memory_limit_bytes": self.runtime_memory_limit_bytes,
                 "driver_timeout_source": self.driver_timeout_source,
                 "oom_killed": self._oom_killed_summary(),
-                "memory_limit_exceeded": any(
-                    sample.engine.usage_bytes is not None
-                    and sample.engine.limit_bytes is not None
-                    and sample.engine.usage_bytes > sample.engine.limit_bytes
-                    for sample in self.samples
-                ),
+                "memory_limit_exceeded": self.memory_limit_exceeded,
                 "minimum_host_available_gib": self.peak_host_available_gib,
                 "maximum_responsiveness_ms": self.max_responsiveness_ms,
             },

--- a/tests/uat/clickhouse_memory.py
+++ b/tests/uat/clickhouse_memory.py
@@ -61,20 +61,11 @@ _MEMORY_UNITS = {
 # cannot be relabelled as the requested rung.
 _DECIMAL_GIB_EQUIVALENCE = 1000**3
 
-# These are the counters the calibration trace claims to capture.  A partial
-# ClickHouse response is not evidence: query/metric failures must invalidate
-# the rung instead of silently producing a plausible-looking artifact.
-_REQUIRED_CLICKHOUSE_METRICS = frozenset(
-    {
-        "metric.MemoryTracking",
-        "async.MemoryResident",
-        "async.MemoryVirtual",
-        "async.OSMemoryAvailable",
-        "async.OSMemoryFree",
-        "event.InsertedRows",
-        "event.InsertedBytes",
-    }
-)
+# Each query family must return at least one metric in every sample. Some
+# ClickHouse builds omit optional asynchronous metrics such as OSMemoryFree,
+# so exact metric names would reject a real successful query. An empty family
+# is still a collection failure and invalidates the rung.
+_REQUIRED_CLICKHOUSE_METRIC_PREFIXES = frozenset({"metric", "async", "event"})
 
 
 @dataclass(frozen=True)
@@ -176,7 +167,8 @@ class ClickHouseMemoryTrace:
                 return False
             if sample.server_reachable is not True:
                 return False
-            if not _REQUIRED_CLICKHOUSE_METRICS.issubset(sample.clickhouse_metrics):
+            metric_prefixes = {key.split(".", 1)[0] for key in sample.clickhouse_metrics}
+            if not _REQUIRED_CLICKHOUSE_METRIC_PREFIXES.issubset(metric_prefixes):
                 return False
             if sample.engine.usage_bytes is None or sample.engine.limit_bytes is None:
                 return False

--- a/tests/uat/test_clickhouse_memory.py
+++ b/tests/uat/test_clickhouse_memory.py
@@ -1,0 +1,256 @@
+"""Unit coverage for measured ClickHouse memory traces."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from tests.uat import clickhouse_memory
+
+pytestmark = [pytest.mark.unit, pytest.mark.fast]
+
+
+def _trace(
+    *, outcome: str = "passed", application_batch_rows: int | None = None
+) -> clickhouse_memory.ClickHouseMemoryTrace:
+    trace = clickhouse_memory.ClickHouseMemoryTrace(
+        platform="clickhouse-server",
+        rung=clickhouse_memory.DEFAULT_MEMORY_RUNGS[0],
+        started_at_utc=clickhouse_memory.utc_now(),
+        driver_timeout_s=300,
+        driver_timeout_source="test fixture",
+        application_batch_rows=application_batch_rows,
+    )
+    trace.samples.append(
+        clickhouse_memory.TraceSample(
+            observed_at_utc=clickhouse_memory.utc_now(),
+            elapsed_s=0.1,
+            host=clickhouse_memory.HostMemorySample(available_gib=4.0, free_gib=1.0, swap_used_percent=0.0),
+            engine=clickhouse_memory.EngineMemorySample(
+                "mocker", "clickhouse", 512 * 1024**2, 1 * clickhouse_memory.GIB
+            ),
+            clickhouse_metrics={"event.InsertedRows": 100.0},
+            responsiveness_ms=2.0,
+            server_reachable=True,
+        )
+    )
+    trace.finish(outcome=outcome)
+    return trace
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [("1GiB", 1024**3), ("1.5GiB", int(1.5 * 1024**3)), ("512MiB / 1GiB", 512 * 1024**2), ("bad", None)],
+)
+def test_parse_memory_bytes_preserves_engine_units(value, expected):
+    assert clickhouse_memory.parse_memory_bytes(value) == expected
+
+
+def test_parse_engine_stats_handles_json_and_mem_usage():
+    sample = clickhouse_memory.parse_engine_stats(
+        '{"Name":"benchbox-clickhouse","MemUsage":"512MiB / 1GiB"}\n',
+        engine="mocker",
+        service="clickhouse",
+    )
+    assert sample.usage_bytes == 512 * 1024**2
+    assert sample.limit_bytes == 1024**3
+    assert sample.raw_status == "benchbox-clickhouse"
+
+
+def test_parse_engine_stats_handles_mocker_table_output():
+    sample = clickhouse_memory.parse_engine_stats(
+        "CONTAINER ID   NAME                                      CPU %    MEM USAGE / LIMIT   MEM %\n"
+        "benchbox-cal   benchbox-clickhouse-1                     8.40%   70.3MB / 1.00GB     6.87%\n",
+        engine="mocker",
+        service="clickhouse",
+    )
+    assert sample.usage_bytes == int(70.3 * 1000**2)
+    assert sample.limit_bytes == 1000**3
+    assert sample.raw_status == "benchbox-clickhouse-1"
+
+
+def test_parse_engine_inspect_captures_oom_and_running_state():
+    sample = clickhouse_memory.parse_engine_inspect(
+        '[{"State":{"OOMKilled":false,"Running":true,"Status":"running"}}]',
+        engine="mocker",
+        service="clickhouse",
+    )
+    assert sample.oom_killed is False
+    assert sample.running is True
+    assert sample.raw_status == "running"
+
+
+def test_native_loader_contract_rejects_legacy_application_batching():
+    ok, reason = clickhouse_memory.verify_native_streaming_loader()
+    assert ok, reason
+
+
+def test_trace_rejects_application_batch_rows_even_when_run_passes():
+    trace = _trace(application_batch_rows=1000)
+    assert trace.valid_for_calibration is False
+    payload = trace.to_dict()
+    assert payload["loader_contract"]["legacy_1000_row_fallback"] is True
+
+
+def test_trace_requires_native_streaming_and_responsive_sample():
+    trace = _trace()
+    trace.native_streaming = False
+    assert trace.valid_for_calibration is False
+
+    trace = _trace()
+    trace.samples[0] = clickhouse_memory.TraceSample(
+        observed_at_utc=trace.samples[0].observed_at_utc,
+        elapsed_s=trace.samples[0].elapsed_s,
+        host=trace.samples[0].host,
+        engine=trace.samples[0].engine,
+        clickhouse_metrics=trace.samples[0].clickhouse_metrics,
+        responsiveness_ms=None,
+        server_reachable=False,
+    )
+    assert trace.valid_for_calibration is False
+
+
+def test_trace_rejects_runtime_usage_above_declared_limit():
+    trace = _trace()
+    trace.samples[0] = clickhouse_memory.TraceSample(
+        observed_at_utc=trace.samples[0].observed_at_utc,
+        elapsed_s=trace.samples[0].elapsed_s,
+        host=trace.samples[0].host,
+        engine=clickhouse_memory.EngineMemorySample(
+            "mocker", "clickhouse", 2 * clickhouse_memory.GIB, 1 * clickhouse_memory.GIB
+        ),
+        clickhouse_metrics=trace.samples[0].clickhouse_metrics,
+        responsiveness_ms=trace.samples[0].responsiveness_ms,
+        server_reachable=True,
+    )
+    assert trace.valid_for_calibration is False
+    assert trace.to_dict()["summary"]["memory_limit_exceeded"] is True
+
+
+def test_trace_rejects_missing_engine_limit_sample():
+    trace = _trace()
+    sample = trace.samples[0]
+    trace.samples.append(
+        clickhouse_memory.TraceSample(
+            observed_at_utc=sample.observed_at_utc,
+            elapsed_s=sample.elapsed_s + 1,
+            host=sample.host,
+            engine=clickhouse_memory.EngineMemorySample("mocker", "clickhouse", 512, None),
+            clickhouse_metrics=sample.clickhouse_metrics,
+            responsiveness_ms=sample.responsiveness_ms,
+            server_reachable=True,
+        )
+    )
+    assert trace.valid_for_calibration is False
+
+
+def test_select_lowest_successful_rung_does_not_choose_failed_or_unmeasured():
+    low = _trace()
+    high = _trace()
+    high.rung = clickhouse_memory.DEFAULT_MEMORY_RUNGS[1]
+    failed_low = _trace(outcome="failed")
+    failed_low.rung = clickhouse_memory.DEFAULT_MEMORY_RUNGS[0]
+    assert clickhouse_memory.select_lowest_successful_rung([failed_low, high]) == high.rung
+    assert clickhouse_memory.select_lowest_successful_rung([low, high]) == low.rung
+
+
+def test_select_lowest_successful_rung_fails_closed_without_trace():
+    with pytest.raises(ValueError, match="no valid passing memory trace"):
+        clickhouse_memory.select_lowest_successful_rung([_trace(outcome="timed-out")])
+
+
+def test_write_trace_is_atomic_and_contains_schema_and_summary(tmp_path: Path):
+    output = tmp_path / "trace.json"
+    clickhouse_memory.write_trace(output, _trace())
+    payload = json.loads(output.read_text(encoding="utf-8"))
+    assert payload["trace_schema_version"] == clickhouse_memory.TRACE_SCHEMA_VERSION
+    assert payload["summary"]["valid_for_calibration"] is True
+    assert not (tmp_path / ".trace.json.tmp").exists()
+
+
+def test_read_trace_reconstructs_loader_and_engine_guards(tmp_path: Path):
+    output = tmp_path / "trace.json"
+    original = _trace()
+    clickhouse_memory.write_trace(output, original)
+    loaded = clickhouse_memory.read_trace(output)
+    assert loaded.valid_for_calibration is True
+    assert loaded.rung == original.rung
+    assert loaded.samples[0].engine.limit_bytes == original.samples[0].engine.limit_bytes
+
+
+def test_collector_records_injected_engine_stats_without_live_daemon(monkeypatch, tmp_path: Path):
+    monkeypatch.setattr(
+        clickhouse_memory,
+        "read_host_memory",
+        lambda: clickhouse_memory.HostMemorySample(available_gib=3.0, free_gib=1.0, swap_used_percent=4.0),
+    )
+    monkeypatch.setattr(
+        clickhouse_memory,
+        "read_clickhouse_metrics",
+        lambda *args, **kwargs: ({"event.InsertedRows": 42.0}, 3.5),
+    )
+    seen_argv = []
+
+    def command_runner(argv):
+        seen_argv.append(tuple(argv))
+        return 0, '{"Name":"clickhouse","MemUsage":"1GiB / 4GiB"}\n', ""
+
+    trace = clickhouse_memory.ClickHouseMemoryTrace(
+        platform="clickhouse-server",
+        rung=clickhouse_memory.DEFAULT_MEMORY_RUNGS[1],
+        started_at_utc=clickhouse_memory.utc_now(),
+    )
+    collector = clickhouse_memory.MemoryTraceCollector(
+        trace=trace,
+        output_path=tmp_path / "trace.json",
+        interval_s=0.01,
+        engine="mocker",
+        project_name="benchbox-uat-test",
+        compose_files=[Path("docker/clickhouse/docker-compose.yml")],
+        command_runner=command_runner,
+    )
+    collector.start()
+    collector.stop(outcome="passed")
+    assert trace.samples
+    assert trace.samples[0].engine.usage_bytes == clickhouse_memory.GIB
+    assert trace.samples[0].responsiveness_ms == 3.5
+    assert seen_argv[0][-1] == "benchbox-uat-test-clickhouse-1"
+
+
+def test_rung_matrix_excludes_1000_row_language():
+    rendered = clickhouse_memory.rung_matrix_text()
+    assert "baseline-1g" in rendered
+    assert "1000" not in rendered
+
+
+def test_summarize_command_failure_preserves_memory_root_cause():
+    reason = clickhouse_memory.summarize_command_failure(
+        "Code: 241. DB::Exception: memory limit exceeded: current RSS: 871 MiB",
+        1,
+    )
+    assert "memory limit exceeded" in reason
+    assert "871 MiB" in reason
+
+
+def test_parse_driver_timeout_requires_explicit_platform_option():
+    assert clickhouse_memory.parse_driver_timeout(["benchbox", "--platform-option", "send_receive_timeout=600"]) == 600
+    assert clickhouse_memory.parse_driver_timeout(["benchbox", "--platform-option", "password=benchbox"]) is None
+
+
+def test_default_driver_timeout_matches_server_setup():
+    assert clickhouse_memory.default_clickhouse_driver_timeout_s() == clickhouse_memory.DEFAULT_DRIVER_TIMEOUT_S
+    timeout, source = clickhouse_memory.resolve_driver_timeout(["benchbox", "--platform-option", "password=benchbox"])
+    assert timeout == 300
+    assert source == "ClickHouseSetupMixin server default"
+
+
+def test_read_trace_rejects_unknown_schema(tmp_path: Path):
+    output = tmp_path / "trace.json"
+    clickhouse_memory.write_trace(output, _trace())
+    payload = json.loads(output.read_text(encoding="utf-8"))
+    payload["trace_schema_version"] = 1
+    output.write_text(json.dumps(payload), encoding="utf-8")
+    with pytest.raises(ValueError, match="unsupported ClickHouse memory trace schema"):
+        clickhouse_memory.read_trace(output)

--- a/tests/uat/test_clickhouse_memory.py
+++ b/tests/uat/test_clickhouse_memory.py
@@ -46,6 +46,7 @@ def _trace(
                 "metric.MemoryTracking": 1.0,
                 "async.MemoryResident": 1.0,
                 "event.InsertedRows": 1.0,
+                "event.InsertedBytes": 1.0,
             },
             responsiveness_ms=2.0,
             server_reachable=True,
@@ -176,7 +177,7 @@ def test_trace_accepts_decimal_runtime_spelling_for_named_gib_rung():
     assert trace.valid_for_calibration is True
 
 
-@pytest.mark.parametrize("missing", ["usage", "oom", "host", "metrics"])
+@pytest.mark.parametrize("missing", ["usage", "oom", "running", "host", "metrics"])
 def test_trace_fails_closed_on_required_telemetry_gaps(missing):
     trace = _trace()
     sample = trace.samples[0]
@@ -187,11 +188,48 @@ def test_trace_fails_closed_on_required_telemetry_gaps(missing):
         engine = replace(engine, usage_bytes=None)
     elif missing == "oom":
         engine = replace(engine, oom_killed=None)
+    elif missing == "running":
+        engine = replace(engine, running=False)
     elif missing == "host":
         host = replace(host, available_gib=None)
     else:
         metrics = {}
     trace.samples[0] = replace(sample, engine=engine, host=host, clickhouse_metrics=metrics)
+    assert trace.valid_for_calibration is False
+
+
+@pytest.mark.parametrize(
+    ("metric_name", "replacement"),
+    [
+        ("metric.MemoryTracking", "metric.NotMemoryTracking"),
+        ("async.MemoryResident", "async.NotMemoryResident"),
+        ("event.InsertedRows", "event.NotInsertedRows"),
+        ("event.InsertedBytes", "event.NotInsertedBytes"),
+    ],
+)
+def test_trace_requires_each_named_clickhouse_metric(metric_name, replacement):
+    trace = _trace()
+    sample = trace.samples[0]
+    metrics = dict(sample.clickhouse_metrics)
+    metrics[replacement] = metrics.pop(metric_name)
+    trace.samples[0] = replace(sample, clickhouse_metrics=metrics)
+    assert trace.valid_for_calibration is False
+
+
+def test_trace_rejects_non_finite_required_telemetry():
+    trace = _trace()
+    sample = trace.samples[0]
+    trace.samples[0] = replace(
+        sample,
+        host=replace(sample.host, available_gib=float("nan")),
+    )
+    assert trace.valid_for_calibration is False
+
+    trace = _trace()
+    sample = trace.samples[0]
+    metrics = dict(sample.clickhouse_metrics)
+    metrics["event.InsertedBytes"] = float("inf")
+    trace.samples[0] = replace(sample, clickhouse_metrics=metrics)
     assert trace.valid_for_calibration is False
 
 

--- a/tests/uat/test_clickhouse_memory.py
+++ b/tests/uat/test_clickhouse_memory.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 import json
+import subprocess
+from dataclasses import replace
 from pathlib import Path
 
 import pytest
@@ -13,11 +15,15 @@ pytestmark = [pytest.mark.unit, pytest.mark.fast]
 
 
 def _trace(
-    *, outcome: str = "passed", application_batch_rows: int | None = None
+    *,
+    outcome: str = "passed",
+    application_batch_rows: int | None = None,
+    rung: clickhouse_memory.MemoryRung | None = None,
 ) -> clickhouse_memory.ClickHouseMemoryTrace:
+    selected_rung = rung or clickhouse_memory.DEFAULT_MEMORY_RUNGS[0]
     trace = clickhouse_memory.ClickHouseMemoryTrace(
         platform="clickhouse-server",
-        rung=clickhouse_memory.DEFAULT_MEMORY_RUNGS[0],
+        rung=selected_rung,
         started_at_utc=clickhouse_memory.utc_now(),
         driver_timeout_s=300,
         driver_timeout_source="test fixture",
@@ -29,9 +35,14 @@ def _trace(
             elapsed_s=0.1,
             host=clickhouse_memory.HostMemorySample(available_gib=4.0, free_gib=1.0, swap_used_percent=0.0),
             engine=clickhouse_memory.EngineMemorySample(
-                "mocker", "clickhouse", 512 * 1024**2, 1 * clickhouse_memory.GIB
+                "mocker",
+                "clickhouse",
+                512 * 1024**2,
+                int(selected_rung.requested_memory_gib * clickhouse_memory.GIB),
+                oom_killed=False,
+                running=True,
             ),
-            clickhouse_metrics={"event.InsertedRows": 100.0},
+            clickhouse_metrics=dict.fromkeys(clickhouse_memory._REQUIRED_CLICKHOUSE_METRICS, 1.0),
             responsiveness_ms=2.0,
             server_reachable=True,
         )
@@ -119,7 +130,12 @@ def test_trace_rejects_runtime_usage_above_declared_limit():
         elapsed_s=trace.samples[0].elapsed_s,
         host=trace.samples[0].host,
         engine=clickhouse_memory.EngineMemorySample(
-            "mocker", "clickhouse", 2 * clickhouse_memory.GIB, 1 * clickhouse_memory.GIB
+            "mocker",
+            "clickhouse",
+            2 * clickhouse_memory.GIB,
+            1 * clickhouse_memory.GIB,
+            oom_killed=False,
+            running=True,
         ),
         clickhouse_metrics=trace.samples[0].clickhouse_metrics,
         responsiveness_ms=trace.samples[0].responsiveness_ms,
@@ -127,6 +143,52 @@ def test_trace_rejects_runtime_usage_above_declared_limit():
     )
     assert trace.valid_for_calibration is False
     assert trace.to_dict()["summary"]["memory_limit_exceeded"] is True
+
+
+def test_trace_rejects_runtime_limit_outside_named_rung_unit_window():
+    trace = _trace()
+    sample = trace.samples[0]
+    trace.samples[0] = replace(
+        sample,
+        engine=replace(sample.engine, limit_bytes=2 * clickhouse_memory.GIB),
+    )
+    assert trace.valid_for_calibration is False
+
+
+def test_trace_accepts_decimal_runtime_spelling_for_named_gib_rung():
+    trace = _trace()
+    sample = trace.samples[0]
+    trace.samples[0] = replace(
+        sample,
+        engine=replace(sample.engine, limit_bytes=1_000_000_000),
+    )
+    assert trace.valid_for_calibration is True
+
+
+@pytest.mark.parametrize("missing", ["usage", "oom", "host", "metrics"])
+def test_trace_fails_closed_on_required_telemetry_gaps(missing):
+    trace = _trace()
+    sample = trace.samples[0]
+    engine = sample.engine
+    host = sample.host
+    metrics = sample.clickhouse_metrics
+    if missing == "usage":
+        engine = replace(engine, usage_bytes=None)
+    elif missing == "oom":
+        engine = replace(engine, oom_killed=None)
+    elif missing == "host":
+        host = replace(host, available_gib=None)
+    else:
+        metrics = {}
+    trace.samples[0] = replace(sample, engine=engine, host=host, clickhouse_metrics=metrics)
+    assert trace.valid_for_calibration is False
+
+
+def test_trace_summary_preserves_unknown_oom_state():
+    trace = _trace()
+    sample = trace.samples[0]
+    trace.samples[0] = replace(sample, engine=replace(sample.engine, oom_killed=None))
+    assert trace.to_dict()["summary"]["oom_killed"] is None
 
 
 def test_trace_rejects_missing_engine_limit_sample():
@@ -137,7 +199,9 @@ def test_trace_rejects_missing_engine_limit_sample():
             observed_at_utc=sample.observed_at_utc,
             elapsed_s=sample.elapsed_s + 1,
             host=sample.host,
-            engine=clickhouse_memory.EngineMemorySample("mocker", "clickhouse", 512, None),
+            engine=clickhouse_memory.EngineMemorySample(
+                "mocker", "clickhouse", 512, None, oom_killed=False, running=True
+            ),
             clickhouse_metrics=sample.clickhouse_metrics,
             responsiveness_ms=sample.responsiveness_ms,
             server_reachable=True,
@@ -148,8 +212,7 @@ def test_trace_rejects_missing_engine_limit_sample():
 
 def test_select_lowest_successful_rung_does_not_choose_failed_or_unmeasured():
     low = _trace()
-    high = _trace()
-    high.rung = clickhouse_memory.DEFAULT_MEMORY_RUNGS[1]
+    high = _trace(rung=clickhouse_memory.DEFAULT_MEMORY_RUNGS[1])
     failed_low = _trace(outcome="failed")
     failed_low.rung = clickhouse_memory.DEFAULT_MEMORY_RUNGS[0]
     assert clickhouse_memory.select_lowest_successful_rung([failed_low, high]) == high.rung
@@ -217,6 +280,37 @@ def test_collector_records_injected_engine_stats_without_live_daemon(monkeypatch
     assert trace.samples[0].engine.usage_bytes == clickhouse_memory.GIB
     assert trace.samples[0].responsiveness_ms == 3.5
     assert seen_argv[0][-1] == "benchbox-uat-test-clickhouse-1"
+
+
+def test_main_replaces_stale_artifact_before_child_start(monkeypatch, tmp_path: Path):
+    output = tmp_path / "trace.json"
+    output.write_text('{"outcome":"passed"}\n', encoding="utf-8")
+    started_payloads = []
+
+    class FakeCollector:
+        def __init__(self, *, trace, output_path, **kwargs):
+            self.trace = trace
+            self.output_path = output_path
+
+        def start(self):
+            started_payloads.append(json.loads(self.output_path.read_text(encoding="utf-8")))
+
+        def stop(self, *, outcome, failure_reason=None):
+            self.trace.finish(outcome=outcome, failure_reason=failure_reason)
+            clickhouse_memory.write_trace(self.output_path, self.trace)
+
+    monkeypatch.setattr(clickhouse_memory, "verify_native_streaming_loader", lambda: (True, "ok"))
+    monkeypatch.setattr(clickhouse_memory, "resolve_driver_timeout", lambda command: (300, "test"))
+    monkeypatch.setattr(clickhouse_memory, "MemoryTraceCollector", FakeCollector)
+    monkeypatch.setattr(
+        clickhouse_memory.subprocess,
+        "run",
+        lambda *args, **kwargs: subprocess.CompletedProcess(args[0], 0, stdout="", stderr=""),
+    )
+
+    assert clickhouse_memory.main(["--output", str(output), "--rung", "baseline-1g", "--", "true"]) == 0
+    assert started_payloads and started_payloads[0]["outcome"] == "running"
+    assert started_payloads[0]["trace_schema_version"] == clickhouse_memory.TRACE_SCHEMA_VERSION
 
 
 def test_rung_matrix_excludes_1000_row_language():

--- a/tests/uat/test_clickhouse_memory.py
+++ b/tests/uat/test_clickhouse_memory.py
@@ -324,6 +324,38 @@ def test_main_replaces_stale_artifact_before_child_start(monkeypatch, tmp_path: 
     assert started_payloads[0]["trace_schema_version"] == clickhouse_memory.TRACE_SCHEMA_VERSION
 
 
+def test_main_leaves_running_artifact_when_child_is_interrupted(monkeypatch, tmp_path: Path):
+    output = tmp_path / "trace.json"
+    output.write_text('{"outcome":"passed"}\n', encoding="utf-8")
+
+    class FakeCollector:
+        def __init__(self, *, trace, output_path, **kwargs):
+            self.trace = trace
+            self.output_path = output_path
+
+        def start(self):
+            pass
+
+        def stop(self, *, outcome, failure_reason=None):
+            raise AssertionError("interrupted child must not publish a passing/final trace")
+
+    monkeypatch.setattr(clickhouse_memory, "verify_native_streaming_loader", lambda: (True, "ok"))
+    monkeypatch.setattr(clickhouse_memory, "resolve_driver_timeout", lambda command: (300, "test"))
+    monkeypatch.setattr(clickhouse_memory, "MemoryTraceCollector", FakeCollector)
+
+    def interrupt_child(*args, **kwargs):
+        raise KeyboardInterrupt
+
+    monkeypatch.setattr(clickhouse_memory.subprocess, "run", interrupt_child)
+
+    with pytest.raises(KeyboardInterrupt):
+        clickhouse_memory.main(["--output", str(output), "--rung", "baseline-1g", "--", "true"])
+
+    payload = json.loads(output.read_text(encoding="utf-8"))
+    assert payload["outcome"] == "running"
+    assert payload["summary"]["valid_for_calibration"] is False
+
+
 def test_rung_matrix_excludes_1000_row_language():
     rendered = clickhouse_memory.rung_matrix_text()
     assert "baseline-1g" in rendered

--- a/tests/uat/test_clickhouse_memory.py
+++ b/tests/uat/test_clickhouse_memory.py
@@ -149,6 +149,13 @@ def test_trace_rejects_runtime_usage_above_declared_limit():
     assert trace.to_dict()["summary"]["memory_limit_exceeded"] is True
 
 
+def test_trace_summary_marks_command_reported_memory_failure():
+    trace = _trace(outcome="failed")
+    trace.finish(outcome="failed", failure_reason="DB::Exception: memory limit exceeded while joining")
+    assert trace.valid_for_calibration is False
+    assert trace.to_dict()["summary"]["memory_limit_exceeded"] is True
+
+
 def test_trace_rejects_runtime_limit_outside_named_rung_unit_window():
     trace = _trace()
     sample = trace.samples[0]

--- a/tests/uat/test_clickhouse_memory.py
+++ b/tests/uat/test_clickhouse_memory.py
@@ -42,7 +42,11 @@ def _trace(
                 oom_killed=False,
                 running=True,
             ),
-            clickhouse_metrics=dict.fromkeys(clickhouse_memory._REQUIRED_CLICKHOUSE_METRICS, 1.0),
+            clickhouse_metrics={
+                "metric.MemoryTracking": 1.0,
+                "async.MemoryResident": 1.0,
+                "event.InsertedRows": 1.0,
+            },
             responsiveness_ms=2.0,
             server_reachable=True,
         )


### PR DESCRIPTION
## Summary
- add atomic ClickHouse server UAT memory tracing for host, engine, ClickHouse, and responsiveness metrics
- enforce native generator loading and reject the generic 1,000-row application batch fallback
- compare same-timeout 1 GiB/4 GiB/8 GiB/12 GiB rungs and fail closed unless all telemetry is measured
- document the measured calibration workflow without publishing a compose limit

## Evidence
- clean SF1 baseline-1g trace: outcome passed but invalid because peak engine usage was 1,050,000,000 bytes over the 1,000,000,000-byte runtime limit
- clean SF1 candidate-4g trace: valid; peak 931,400,000 bytes / 4,000,000,000-byte limit, 48 samples, max responsiveness 3.72 ms, OOMKilled=false
- selected rung: candidate-4g
- focused tests: 22 passed
- prescribed UAT tests: 284 passed
- make pr-preflight: passed (27,862 passed, 19 skipped)
