### PR TITLE
fix(todo): align export recovery contract

### DIFF
--- a/_project/scripts/todo_db_standalone_compat.py
+++ b/_project/scripts/todo_db_standalone_compat.py
@@ -453,6 +453,11 @@ def _canonical_json(value: Any) -> str:
     return json.dumps(value, sort_keys=True) + "\n"
 
 
+def _canonical_lossless_json(value: Any) -> str:
+    """Match the locked package's lossless export serialization exactly."""
+    return json.dumps(value, sort_keys=True, separators=(",", ":"), ensure_ascii=False) + "\n"
+
+
 def _atomic_write(path: Path, content: str) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
     with tempfile.NamedTemporaryFile("w", encoding="utf-8", dir=path.parent, delete=False) as handle:
@@ -491,7 +496,7 @@ def _write_legacy_export(
     events_path = output_dir / "events.jsonl"
     index_path = output_dir / "index.md"
     items = _item_rows(envelope)
-    _atomic_write(lossless_path, _canonical_json(envelope))
+    _atomic_write(lossless_path, _canonical_lossless_json(envelope))
     _atomic_write(items_path, "".join(_canonical_json(item) for item in items))
     events = sorted((dict(row) for row in envelope.get("events") or []), key=lambda row: row["seq"])
     _atomic_write(events_path, "".join(_canonical_json(event) for event in events))
@@ -503,8 +508,26 @@ def _write_legacy_export(
 
 
 def _export(argv: list[str], cwd: Path) -> int:
-    if any(value in {"-h", "--help", "--version"} for value in argv):
+    if any(value in {"-h", "--help"} for value in argv):
+        print(
+            "usage: todo export [-h] [--out DIRECTORY] [--lossless-out DIRECTORY]\n\n"
+            "Write deterministic compatibility views and a separate lossless recovery envelope.\n\n"
+            "options:\n"
+            "  -h, --help            show this help message and exit\n"
+            "  --out DIRECTORY       compatibility-view directory (default: .todo-db/export)\n"
+            "  --lossless-out DIRECTORY\n"
+            "                        lossless recovery-envelope directory"
+        )
+        return 0
+    if "--version" in argv:
         return _forward_result(_delegate(argv, command="export", cwd=cwd))
+    if _has_option(argv, "--output"):
+        print(
+            "error: BenchBox compatibility export uses --out DIRECTORY; "
+            "use --lossless-out DIRECTORY to place the recovery envelope",
+            file=sys.stderr,
+        )
+        return 2
     out_dir, without_out = _option_value(argv, "--out")
     # The lossless envelope is written outside --out (the committed snapshot);
     # --lossless-out relocates it, e.g. to a CI artifact staging directory.

--- a/tests/unit/scripts/test_todo_db_standalone_compat.py
+++ b/tests/unit/scripts/test_todo_db_standalone_compat.py
@@ -275,8 +275,10 @@ def test_export_writes_lossless_envelope_and_legacy_views(monkeypatch: pytest.Mo
 
     # The lossless envelope is the recovery artifact -- complete, and OUTSIDE the
     # committed snapshot directory.
-    lossless = json.loads((lossless_dir / "todo-db.json").read_text(encoding="utf-8"))
+    lossless_text = (lossless_dir / "todo-db.json").read_text(encoding="utf-8")
+    lossless = json.loads(lossless_text)
     assert lossless == envelope
+    assert lossless_text == json.dumps(envelope, sort_keys=True, separators=(",", ":"), ensure_ascii=False) + "\n"
     assert not (output_dir / "todo-db.json").exists()
     item = json.loads((output_dir / "items.jsonl").read_text(encoding="utf-8").splitlines()[0])
     assert item["work"][0]["wid"] == "w0"
@@ -285,6 +287,36 @@ def test_export_writes_lossless_envelope_and_legacy_views(monkeypatch: pytest.Mo
     # leftover from a separate main-path export.
     events = [json.loads(line) for line in (output_dir / "events.jsonl").read_text(encoding="utf-8").splitlines()]
     assert events == envelope["events"]
+
+
+def test_export_help_describes_the_compatibility_contract(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys
+) -> None:
+    monkeypatch.setenv("BENCHBOX_REPO_ROOT", str(tmp_path))
+    monkeypatch.setattr(
+        compat,
+        "_delegate",
+        lambda *args, **kwargs: pytest.fail("export help must not delegate to the package contract"),
+    )
+
+    assert compat.main(["export", "--help"]) == 0
+
+    captured = capsys.readouterr()
+    assert "--out DIRECTORY" in captured.out
+    assert "--lossless-out DIRECTORY" in captured.out
+    assert "--output" not in captured.out
+
+
+def test_export_rejects_the_package_output_option_with_compatibility_guidance(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys
+) -> None:
+    monkeypatch.setenv("BENCHBOX_REPO_ROOT", str(tmp_path))
+
+    assert compat.main(["--db", str(tmp_path / "todo.sqlite"), "export", "--output", "snapshot.json"]) == 2
+
+    captured = capsys.readouterr()
+    assert "uses --out DIRECTORY" in captured.err
+    assert "--lossless-out DIRECTORY" in captured.err
 
 
 def test_export_lossless_envelope_defaults_outside_the_committed_snapshot(


### PR DESCRIPTION
## Summary

- show the BenchBox compatibility export contract instead of forwarding misleading package help
- reject `--output` with guidance to the established `--out` and `--lossless-out` directory contract
- serialize the lossless recovery envelope exactly like locked `todo-db` 0.3.2 while preserving legacy JSONL and Markdown view formatting

## Certification evidence

- clean `develop` clone with no global `todo-db`: locked package resolved to 0.3.2 and nested wrapper invocation passed
- wrapper boundary suite: 65 passed, no skips
- non-holder release negative control: exit 2; holder claim remained intact
- hosted audit: SHA-256 chain verified at 8,865 events
- clean restore: 2,178 items; identical audit head; byte-identical re-export SHA-256 `54e06f655e2cc0277fd9365a422ddc1b921c0d018ab7187a919f850079cd128a`
- full scripts suite: 1,252 passed
- `make pr-preflight`: 27,693 passed, 19 skipped, 4 subtests passed; artifact hygiene passed

## Design choice

Keeping package `--output FILE` semantics in this adapter would conflict with BenchBox export compatibility views and recovery-artifact separation. The wrapper therefore documents and enforces its directory contract explicitly; direct locked-package commands remain available for package-native lossless export and restore.

Tracker: `certify-benchbox-package-only-todo-runtime-gated`
