### PR TITLE
fix(todo): close package runtime recovery bypass

### DIFF
--- a/.github/workflows/todo-db-export.yml
+++ b/.github/workflows/todo-db-export.yml
@@ -142,8 +142,11 @@ jobs:
             todo-db --db "${restore_dir}/restore.sqlite" \
             --project-id "${TODO_DB_PROJECT_ID}" --repository "${TODO_DB_REPOSITORY}" \
             export --output "${restore_dir}/restored.json"
-          uv run --project _project/scripts --locked -- \
-            python -c 'import json, pathlib; source=json.loads(pathlib.Path("'"${LOSSLESS_DIR}"'/todo-db.json").read_text()); restored=json.loads(pathlib.Path("'"${restore_dir}"'/restored.json").read_text()); assert source == restored'
+          cmp -s "${LOSSLESS_DIR}/todo-db.json" "${restore_dir}/restored.json" || {
+            echo "Restored export is not byte-identical to the source recovery artifact" >&2
+            sha256sum "${LOSSLESS_DIR}/todo-db.json" "${restore_dir}/restored.json" >&2
+            exit 1
+          }
 
       - name: Write directory README
         run: |

--- a/_project/scripts/todo_db_standalone_compat.py
+++ b/_project/scripts/todo_db_standalone_compat.py
@@ -60,6 +60,8 @@ COMMANDS = frozenset(
     }
 )
 
+STANDALONE_ONLY_COMMANDS = frozenset({"init-project", "restore", "restore-legacy"})
+
 GLOBAL_VALUE_OPTIONS = frozenset({"--actor", "--db", "--project-id", "--replica", "--repository"})
 OFFLINE_FINDING_SUBCOMMANDS = frozenset({"create", "candidates"})
 PACKAGE_COMMAND_TRANSLATIONS = {"scope-update": "update"}
@@ -81,6 +83,10 @@ def _repo_root() -> Path:
 
 
 def _command_index(argv: list[str]) -> tuple[int, str] | None:
+    return _command_index_from(argv, COMMANDS)
+
+
+def _command_index_from(argv: list[str], commands: frozenset[str]) -> tuple[int, str] | None:
     index = 0
     while index < len(argv):
         value = argv[index]
@@ -90,10 +96,39 @@ def _command_index(argv: list[str]) -> tuple[int, str] | None:
         if any(value.startswith(f"{option}=") for option in GLOBAL_VALUE_OPTIONS):
             index += 1
             continue
-        if value in COMMANDS:
+        if value in commands:
             return index, value
         index += 1
     return None
+
+
+def _is_root_help(argv: list[str]) -> bool:
+    saw_help = False
+    index = 0
+    while index < len(argv):
+        value = argv[index]
+        if value in GLOBAL_VALUE_OPTIONS:
+            index += 2
+            continue
+        if any(value.startswith(f"{option}=") for option in GLOBAL_VALUE_OPTIONS):
+            index += 1
+            continue
+        if value in {"-h", "--help"}:
+            saw_help = True
+            index += 1
+            continue
+        return False
+    return saw_help
+
+
+def _print_root_help() -> None:
+    commands = ",".join(sorted(COMMANDS))
+    print(
+        f"usage: todo [GLOBAL OPTIONS] {{{commands}}} ...\n\n"
+        "BenchBox compatibility wrapper for the locked todo-db package.\n"
+        "Run 'todo <command> --help' for command-specific options.\n\n"
+        "Standalone recovery commands are intentionally unavailable through this wrapper."
+    )
 
 
 def _has_option(argv: Iterable[str], name: str) -> bool:
@@ -453,11 +488,6 @@ def _canonical_json(value: Any) -> str:
     return json.dumps(value, sort_keys=True) + "\n"
 
 
-def _canonical_lossless_json(value: Any) -> str:
-    """Match the locked package's lossless export serialization exactly."""
-    return json.dumps(value, sort_keys=True, separators=(",", ":"), ensure_ascii=False) + "\n"
-
-
 def _atomic_write(path: Path, content: str) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
     with tempfile.NamedTemporaryFile("w", encoding="utf-8", dir=path.parent, delete=False) as handle:
@@ -466,8 +496,16 @@ def _atomic_write(path: Path, content: str) -> None:
     temporary.replace(path)
 
 
+def _atomic_write_bytes(path: Path, content: bytes) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with tempfile.NamedTemporaryFile("wb", dir=path.parent, delete=False) as handle:
+        handle.write(content)
+        temporary = Path(handle.name)
+    temporary.replace(path)
+
+
 def _write_legacy_export(
-    output_dir: Path, envelope: dict[str, Any], lossless_dir: Path | None = None
+    output_dir: Path, envelope: dict[str, Any], lossless_content: bytes, lossless_dir: Path | None = None
 ) -> tuple[Path, Path, Path, Path]:
     """Write the committed items-domain views, plus the lossless envelope.
 
@@ -496,7 +534,7 @@ def _write_legacy_export(
     events_path = output_dir / "events.jsonl"
     index_path = output_dir / "index.md"
     items = _item_rows(envelope)
-    _atomic_write(lossless_path, _canonical_lossless_json(envelope))
+    _atomic_write_bytes(lossless_path, lossless_content)
     _atomic_write(items_path, "".join(_canonical_json(item) for item in items))
     events = sorted((dict(row) for row in envelope.get("events") or []), key=lambda row: row["seq"])
     _atomic_write(events_path, "".join(_canonical_json(event) for event in events))
@@ -551,8 +589,9 @@ def _export(argv: list[str], cwd: Path) -> int:
             sys.stderr.write(_redact(result.stderr, secrets))
         if result.returncode:
             return result.returncode
-        envelope = json.loads(standalone_output.read_text(encoding="utf-8"))
-        lossless, items, events, index = _write_legacy_export(output_dir, envelope, lossless_dir)
+        lossless_content = standalone_output.read_bytes()
+        envelope = json.loads(lossless_content)
+        lossless, items, events, index = _write_legacy_export(output_dir, envelope, lossless_content, lossless_dir)
         print(f"wrote {items}, {events} and {index} (lossless envelope: {lossless})")
         return 0
 
@@ -561,6 +600,17 @@ def _main(argv: list[str] | None = None) -> int:
     args = list(sys.argv[1:] if argv is None else argv)
     located = _command_index(args)
     if located is None:
+        standalone_only = _command_index_from(args, STANDALONE_ONLY_COMMANDS)
+        if standalone_only is not None:
+            print(
+                f"error: BenchBox compatibility wrapper does not expose standalone-only "
+                f"'{standalone_only[1]}'; use the locked todo-db package directly in an approved recovery workflow",
+                file=sys.stderr,
+            )
+            return 2
+        if not args or _is_root_help(args):
+            _print_root_help()
+            return 0
         return _forward_result(_delegate(args, command="", cwd=_repo_root()))
     command_index, command = located
     root = _repo_root()

--- a/tests/integration/test_todo_db_standalone_compat_real.py
+++ b/tests/integration/test_todo_db_standalone_compat_real.py
@@ -11,30 +11,80 @@ import pytest
 pytestmark = [pytest.mark.integration, pytest.mark.medium]
 
 
-def test_real_locked_wrapper_accepts_pinned_database_and_identity(tmp_path: Path) -> None:
-    repo_root = Path(__file__).resolve().parents[2]
-    wrapper = repo_root / "_project" / "scripts" / "todo"
-    database = tmp_path / "standalone.sqlite"
+def _run_wrapper(
+    repo_root: Path, database: Path, *args: str, todo_db_path: Path | None = None
+) -> subprocess.CompletedProcess[str]:
     environment = os.environ.copy()
-    environment.update(
-        {
-            "BENCHBOX_REPO_ROOT": str(repo_root),
-            "TODO_DB_PATH": str(tmp_path / "must-not-win.sqlite"),
-        }
-    )
-    result = subprocess.run(
-        [
-            str(wrapper),
-            "--db",
-            str(database),
-            "init",
-        ],
+    environment.update({"BENCHBOX_REPO_ROOT": str(repo_root), "TODO_DB_PATH": str(todo_db_path or database)})
+    return subprocess.run(
+        [str(repo_root / "_project" / "scripts" / "todo"), "--db", str(database), *args],
         cwd=repo_root,
         env=environment,
         text=True,
         capture_output=True,
         check=False,
     )
+
+
+def test_real_locked_wrapper_accepts_pinned_database_and_identity(tmp_path: Path) -> None:
+    repo_root = Path(__file__).resolve().parents[2]
+    database = tmp_path / "standalone.sqlite"
+    result = _run_wrapper(repo_root, database, "init", todo_db_path=tmp_path / "must-not-win.sqlite")
     assert result.returncode == 0, result.stderr
     assert database.is_file()
     assert not (tmp_path / "must-not-win.sqlite").exists()
+
+
+@pytest.mark.parametrize("command", ["init-project", "restore", "restore-legacy"])
+def test_real_locked_wrapper_rejects_standalone_only_destructive_commands(tmp_path: Path, command: str) -> None:
+    repo_root = Path(__file__).resolve().parents[2]
+    result = _run_wrapper(repo_root, tmp_path / "standalone.sqlite", command)
+
+    assert result.returncode == 2
+    assert "does not expose standalone-only" in result.stderr
+
+
+def test_real_locked_wrapper_preserves_package_export_bytes(tmp_path: Path) -> None:
+    repo_root = Path(__file__).resolve().parents[2]
+    database = tmp_path / "standalone.sqlite"
+    assert _run_wrapper(repo_root, database, "init").returncode == 0
+    compatibility_dir = tmp_path / "compatibility"
+    lossless_dir = tmp_path / "lossless"
+    wrapper_export = _run_wrapper(
+        repo_root,
+        database,
+        "export",
+        "--out",
+        str(compatibility_dir),
+        "--lossless-out",
+        str(lossless_dir),
+    )
+    assert wrapper_export.returncode == 0, wrapper_export.stderr
+
+    direct_export = tmp_path / "direct.json"
+    direct = subprocess.run(
+        [
+            "uv",
+            "run",
+            "--project",
+            str(repo_root / "_project" / "scripts"),
+            "--locked",
+            "--",
+            "todo-db",
+            "--db",
+            str(database),
+            "--project-id",
+            "benchbox",
+            "--repository",
+            "https://github.com/joeharris76/BenchBox",
+            "export",
+            "--output",
+            str(direct_export),
+        ],
+        cwd=repo_root,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    assert direct.returncode == 0, direct.stderr
+    assert (lossless_dir / "todo-db.json").read_bytes() == direct_export.read_bytes()

--- a/tests/unit/scripts/test_todo_db_export_workflow.py
+++ b/tests/unit/scripts/test_todo_db_export_workflow.py
@@ -15,7 +15,7 @@ def test_workflow_uses_only_the_locked_package_runtime() -> None:
 
     assert text.count("uv sync --project _project/scripts --locked") == 1
     assert "_project/scripts/todo export" in text
-    assert text.count("uv run --project _project/scripts --locked") == 5
+    assert text.count("uv run --project _project/scripts --locked") == 4
     for forbidden in (
         "todo_db.py",
         "BENCHBOX_TODO_DB_STANDALONE",
@@ -27,11 +27,12 @@ def test_workflow_uses_only_the_locked_package_runtime() -> None:
         assert forbidden not in text
 
 
-def test_restore_validation_compares_the_complete_export_envelope() -> None:
+def test_restore_validation_compares_the_exact_recovery_artifact_bytes() -> None:
     text = WORKFLOW.read_text()
 
-    assert "assert source == restored" in text
-    assert 'k not in {"schema_migrations", "audit_head"}' not in text
+    assert 'cmp -s "${LOSSLESS_DIR}/todo-db.json" "${restore_dir}/restored.json"' in text
+    assert "sha256sum" in text
+    assert "assert source == restored" not in text
 
 
 def test_versioned_recovery_artifacts_have_bounded_retention() -> None:

--- a/tests/unit/scripts/test_todo_db_standalone_compat.py
+++ b/tests/unit/scripts/test_todo_db_standalone_compat.py
@@ -65,6 +65,11 @@ def _envelope() -> dict:
     }
 
 
+def _package_export_bytes(envelope: dict) -> bytes:
+    """A deliberately non-canonical package payload used to prove byte preservation."""
+    return (json.dumps(envelope, ensure_ascii=False, indent=2) + "\n").encode()
+
+
 def test_lifecycle_commands_receive_identity_and_actor(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     calls: list[tuple[list[str], str]] = []
 
@@ -157,9 +162,45 @@ def test_option_values_that_match_commands_are_not_parsed_as_commands() -> None:
     assert compat._command_index(["--actor", "audit", "show", "item"]) == (2, "show")
 
 
-def test_destructive_standalone_only_commands_are_not_routable() -> None:
-    assert compat._command_index(["restore", "--input", "backup.json"]) is None
+@pytest.mark.parametrize("command", sorted(compat.STANDALONE_ONLY_COMMANDS))
+def test_destructive_standalone_only_commands_are_not_routable(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str], command: str
+) -> None:
+    monkeypatch.setenv("BENCHBOX_REPO_ROOT", str(tmp_path))
+    monkeypatch.setattr(compat, "_delegate", lambda *args, **kwargs: pytest.fail("must not delegate"))
+
+    assert compat.main(["--db", str(tmp_path / "todo.sqlite"), command]) == 2
+    assert "does not expose standalone-only" in capsys.readouterr().err
     assert compat._command_index(["audit", "verify"]) == (0, "audit")
+
+
+def test_root_help_describes_only_the_compatibility_commands(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    monkeypatch.setenv("BENCHBOX_REPO_ROOT", str(tmp_path))
+    monkeypatch.setattr(compat, "_delegate", lambda *args, **kwargs: pytest.fail("help must not delegate"))
+
+    assert compat.main(["--help"]) == 0
+
+    output = capsys.readouterr().out
+    assert "scope-update" in output
+    assert "freeze" in output
+    for command in compat.STANDALONE_ONLY_COMMANDS:
+        assert command not in output
+
+
+def test_unknown_command_help_is_left_for_the_package_parser(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    calls: list[list[str]] = []
+
+    def fake_delegate(argv: list[str], *, command: str, cwd: Path, capture: bool = True) -> CompletedProcess[str]:
+        calls.append(argv)
+        return CompletedProcess(argv, 2, stdout="", stderr="invalid command\n")
+
+    monkeypatch.setenv("BENCHBOX_REPO_ROOT", str(tmp_path))
+    monkeypatch.setattr(compat, "_delegate", fake_delegate)
+
+    assert compat.main(["frobnicate", "--help"]) == 2
+    assert calls == [["frobnicate", "--help"]]
 
 
 def test_missing_db_refuses_implicit_fork_database(
@@ -227,7 +268,9 @@ def test_broken_pipe_is_a_clean_exit(monkeypatch: pytest.MonkeyPatch, tmp_path: 
     assert compat.main(["--db", str(tmp_path / "todo.sqlite"), "show", "item"]) == 0
 
 
-def test_no_command_output_redacts_both_token_names(monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys) -> None:
+def test_unknown_command_output_redacts_both_token_names(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys
+) -> None:
     monkeypatch.setenv("TODO_DB_AUTH_TOKEN", "rw-secret")
     monkeypatch.setenv("TODO_DB_RO_AUTH_TOKEN", "ro-secret")
     monkeypatch.setattr(compat, "_repo_root", lambda: tmp_path)
@@ -238,7 +281,7 @@ def test_no_command_output_redacts_both_token_names(monkeypatch: pytest.MonkeyPa
         return CompletedProcess(command, 2, stdout="rw-secret ro-secret\n", stderr="rw-secret ro-secret\n")
 
     monkeypatch.setattr(compat.subprocess, "run", fake_run)
-    assert compat.main(["--help"]) == 2
+    assert compat.main(["frobnicate"]) == 2
     captured = capsys.readouterr()
     assert "rw-secret" not in captured.out + captured.err
     assert "ro-secret" not in captured.out + captured.err
@@ -246,10 +289,12 @@ def test_no_command_output_redacts_both_token_names(monkeypatch: pytest.MonkeyPa
 
 def test_export_writes_lossless_envelope_and_legacy_views(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     envelope = _envelope()
+    envelope["metadata"]["label"] = "Café"
+    package_export = _package_export_bytes(envelope)
 
     def fake_delegate(argv: list[str], *, command: str, cwd: Path, capture: bool = True) -> CompletedProcess[str]:
         output = Path(argv[argv.index("--output") + 1])
-        output.write_text(json.dumps(envelope), encoding="utf-8")
+        output.write_bytes(package_export)
         return CompletedProcess(argv, 0, stdout="export complete\n", stderr="")
 
     monkeypatch.setattr(compat, "_delegate", fake_delegate)
@@ -275,10 +320,11 @@ def test_export_writes_lossless_envelope_and_legacy_views(monkeypatch: pytest.Mo
 
     # The lossless envelope is the recovery artifact -- complete, and OUTSIDE the
     # committed snapshot directory.
-    lossless_text = (lossless_dir / "todo-db.json").read_text(encoding="utf-8")
+    lossless_path = lossless_dir / "todo-db.json"
+    lossless_text = lossless_path.read_text(encoding="utf-8")
     lossless = json.loads(lossless_text)
     assert lossless == envelope
-    assert lossless_text == json.dumps(envelope, sort_keys=True, separators=(",", ":"), ensure_ascii=False) + "\n"
+    assert lossless_path.read_bytes() == package_export
     assert not (output_dir / "todo-db.json").exists()
     item = json.loads((output_dir / "items.jsonl").read_text(encoding="utf-8").splitlines()[0])
     assert item["work"][0]["wid"] == "w0"
@@ -344,13 +390,13 @@ def test_export_rerun_removes_legacy_in_tree_envelope(tmp_path: Path) -> None:
     output_dir = tmp_path / "snapshot"
     lossless_dir = tmp_path / "lossless"
     envelope = _envelope()
-    compat._write_legacy_export(output_dir, envelope, lossless_dir)
+    compat._write_legacy_export(output_dir, envelope, _package_export_bytes(envelope), lossless_dir)
 
     legacy_envelope = output_dir / "todo-db.json"
     legacy_envelope.write_text('{"legacy": true}\n', encoding="utf-8")
     updated = {**envelope, "metadata": {"rerun": True}}
 
-    compat._write_legacy_export(output_dir, updated, lossless_dir)
+    compat._write_legacy_export(output_dir, updated, _package_export_bytes(updated), lossless_dir)
 
     assert not legacy_envelope.exists()
     assert json.loads((lossless_dir / "todo-db.json").read_text(encoding="utf-8")) == updated
@@ -410,7 +456,7 @@ def test_export_never_commits_findings_domain_prose(monkeypatch: pytest.MonkeyPa
 def test_export_views_are_byte_identical_to_legacy_format(tmp_path: Path) -> None:
     envelope = _envelope()
     envelope["tables"]["items"][0]["title"] = "Café | table"
-    compat._write_legacy_export(tmp_path / "out", envelope, tmp_path / "lossless")
+    compat._write_legacy_export(tmp_path / "out", envelope, _package_export_bytes(envelope), tmp_path / "lossless")
     tmp_path = tmp_path / "out"
     item = compat._item_rows(envelope)[0]
     assert (tmp_path / "items.jsonl").read_text(encoding="utf-8") == json.dumps(item, sort_keys=True) + "\n"


### PR DESCRIPTION
## Summary

- fail closed when the BenchBox compatibility wrapper receives package-only destructive recovery commands
- keep root help scoped to commands the wrapper can safely enforce
- preserve the locked package's raw recovery bytes instead of duplicating its serializer
- require byte-identical restore/export evidence in the scheduled workflow

## Root cause

PR #1710 removed the embedded runtime, but unknown package commands still fell through directly to `todo-db`. That let `restore --replace` bypass the compatibility freeze guard. A non-holder could replace a frozen database with an older snapshot, removing the freeze and its later audit history.

PR #1715 also reconstructed the package's lossless JSON locally. The bytes matched todo-db 0.3.2 but could silently drift after a package-format change because tests and CI compared duplicated formatting or parsed JSON equality.

## Negative controls

- wrapper `restore`, `restore-legacy`, and `init-project` now return exit 2 without delegation
- an explicit local database export is byte-identical to direct locked-package export
- workflow restore validation uses `cmp` and reports both SHA-256 values on mismatch

## Validation

- focused adapter, workflow, and real-wrapper suite: 76 passed
- `make pr-preflight`: 27,693 passed, 19 skipped, 52 known warnings, four subtests
- `todo check-scope certify-benchbox-package-only-todo-runtime-gated`: scope OK, five files
- artifact hygiene passed
