### PR TITLE
ci: require develop ruleset drift evidence

### DIFF
--- a/.github/workflows/develop-ruleset-drift.yml
+++ b/.github/workflows/develop-ruleset-drift.yml
@@ -1,0 +1,45 @@
+name: Develop ruleset drift
+
+on:
+  pull_request_target:
+    branches:
+      - develop
+    types: [opened, synchronize, reopened, ready_for_review]
+
+concurrency:
+  group: develop-ruleset-drift-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  ruleset-drift:
+    name: ruleset-drift
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout trusted develop policy
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.base.sha }}
+          persist-credentials: false
+
+      - name: Compare live governance with the trusted runbook
+        env:
+          RULESET_DRIFT_TOKEN: ${{ secrets.RULESET_DRIFT_TOKEN }}
+        run: |
+          set -euo pipefail
+          python scripts/ruleset_drift_check.py \
+            --token "${RULESET_DRIFT_TOKEN}" \
+            --require-bypass-actor-visibility \
+            --output ruleset-drift.json
+
+      - name: Upload drift evidence
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: develop-ruleset-drift-${{ github.event.pull_request.number }}-${{ github.run_attempt }}
+          path: ruleset-drift.json
+          if-no-files-found: warn
+          retention-days: 30

--- a/_project/decisions/develop-ruleset-drift-required-2026-08-13.md
+++ b/_project/decisions/develop-ruleset-drift-required-2026-08-13.md
@@ -1,0 +1,36 @@
+# Decision: require live ruleset drift evidence on develop PRs
+
+Date: 2026-08-13
+Status: Implemented in repository; live ruleset activation follows this PR.
+
+## Context
+
+The `develop-squash-only` ruleset previously drifted to
+`strict_required_status_checks_policy: false`. The repository corrected the
+live value and added a daily/release canary, but a later admin change could
+still recreate the same stale-base merge window before the next canary.
+
+The drift script needs `RULESET_DRIFT_TOKEN` because the default workflow token
+cannot expose bypass actors. Running pull-request code with that token would be
+unsafe.
+
+## Decision
+
+Add `develop-ruleset-drift.yml` on `pull_request_target` and make its
+`ruleset-drift` job a required context for `develop-squash-only`.
+
+The workflow checks out `github.event.pull_request.base.sha`, never the PR head,
+uses read-only repository permissions, and runs the trusted base copy of the
+existing fail-closed drift script. Evidence is retained for 30 days. The daily
+canary remains an independent release gate.
+
+## Activation sequence
+
+1. Merge the workflow, tests, runbook, and this decision record.
+2. Add `ruleset-drift` to ruleset 15611785's required status checks while
+   preserving strict-base enforcement and every other rule.
+3. Verify the next develop PR reports the required context from trusted base
+   code and that the drift script sees the updated live ruleset.
+
+The context cannot be required before the workflow exists on the base branch;
+doing so would deadlock the introducing PR.

--- a/_project/scripts/fixtures/green_unmerged_fixture.json
+++ b/_project/scripts/fixtures/green_unmerged_fixture.json
@@ -27,6 +27,12 @@
           "status": "completed",
           "conclusion": "success",
           "started_at": "2026-07-23T08:12:00Z"
+        },
+        {
+          "name": "ruleset-drift",
+          "status": "completed",
+          "conclusion": "success",
+          "started_at": "2026-07-23T08:12:00Z"
         }
       ]
     },
@@ -55,6 +61,12 @@
         },
         {
           "name": "Results Explorer browser gate",
+          "status": "completed",
+          "conclusion": "success",
+          "started_at": "2026-07-23T08:12:00Z"
+        },
+        {
+          "name": "ruleset-drift",
           "status": "completed",
           "conclusion": "success",
           "started_at": "2026-07-23T08:12:00Z"
@@ -94,6 +106,12 @@
           "status": "completed",
           "conclusion": "success",
           "started_at": "2026-07-23T08:12:00Z"
+        },
+        {
+          "name": "ruleset-drift",
+          "status": "completed",
+          "conclusion": "success",
+          "started_at": "2026-07-23T08:12:00Z"
         }
       ]
     },
@@ -118,6 +136,12 @@
         },
         {
           "name": "Results Explorer browser gate",
+          "status": "completed",
+          "conclusion": "success",
+          "started_at": "2026-07-23T08:12:00Z"
+        },
+        {
+          "name": "ruleset-drift",
           "status": "completed",
           "conclusion": "success",
           "started_at": "2026-07-23T08:12:00Z"
@@ -152,6 +176,12 @@
           "status": "completed",
           "conclusion": "success",
           "started_at": "2026-07-23T08:12:00Z"
+        },
+        {
+          "name": "ruleset-drift",
+          "status": "completed",
+          "conclusion": "success",
+          "started_at": "2026-07-23T08:12:00Z"
         }
       ]
     },
@@ -180,6 +210,12 @@
         },
         {
           "name": "Results Explorer browser gate",
+          "status": "completed",
+          "conclusion": "success",
+          "started_at": "2026-07-23T08:12:00Z"
+        },
+        {
+          "name": "ruleset-drift",
           "status": "completed",
           "conclusion": "success",
           "started_at": "2026-07-23T08:12:00Z"
@@ -223,6 +259,12 @@
           "status": "completed",
           "conclusion": "success",
           "started_at": "2026-07-23T08:12:00Z"
+        },
+        {
+          "name": "ruleset-drift",
+          "status": "completed",
+          "conclusion": "success",
+          "started_at": "2026-07-23T08:12:00Z"
         }
       ]
     },
@@ -251,6 +293,12 @@
         },
         {
           "name": "Results Explorer browser gate",
+          "status": "completed",
+          "conclusion": "success",
+          "started_at": "2026-07-23T08:12:00Z"
+        },
+        {
+          "name": "ruleset-drift",
           "status": "completed",
           "conclusion": "success",
           "started_at": "2026-07-23T08:12:00Z"
@@ -288,6 +336,12 @@
           "status": "completed",
           "conclusion": "success",
           "started_at": "2026-07-23T08:12:00Z"
+        },
+        {
+          "name": "ruleset-drift",
+          "status": "completed",
+          "conclusion": "success",
+          "started_at": "2026-07-23T08:12:00Z"
         }
       ]
     },
@@ -318,6 +372,12 @@
         },
         {
           "name": "Results Explorer browser gate",
+          "status": "completed",
+          "conclusion": "success",
+          "started_at": "2026-07-23T08:12:00Z"
+        },
+        {
+          "name": "ruleset-drift",
           "status": "completed",
           "conclusion": "success",
           "started_at": "2026-07-23T08:12:00Z"
@@ -376,6 +436,12 @@
           "name": "Results Explorer browser gate",
           "status": "completed",
           "conclusion": "failure",
+          "started_at": "2026-07-23T08:12:00Z"
+        },
+        {
+          "name": "ruleset-drift",
+          "status": "completed",
+          "conclusion": "success",
           "started_at": "2026-07-23T08:12:00Z"
         }
       ]

--- a/_project/scripts/fixtures/soundness_drain_fixture.json
+++ b/_project/scripts/fixtures/soundness_drain_fixture.json
@@ -42,6 +42,12 @@
           "status": "completed",
           "conclusion": "success",
           "completed_at": "2026-07-16T07:55:00Z"
+        },
+        {
+          "name": "ruleset-drift",
+          "status": "completed",
+          "conclusion": "success",
+          "completed_at": "2026-07-16T07:55:00Z"
         }
       ]
     },
@@ -74,6 +80,12 @@
           "status": "completed",
           "conclusion": "success",
           "completed_at": "2026-07-15T08:25:00Z"
+        },
+        {
+          "name": "ruleset-drift",
+          "status": "completed",
+          "conclusion": "success",
+          "completed_at": "2026-07-15T08:25:00Z"
         }
       ]
     },
@@ -100,6 +112,12 @@
         },
         {
           "name": "Results Explorer browser gate",
+          "status": "completed",
+          "conclusion": "success",
+          "completed_at": "2026-07-23T09:40:00Z"
+        },
+        {
+          "name": "ruleset-drift",
           "status": "completed",
           "conclusion": "success",
           "completed_at": "2026-07-23T09:40:00Z"
@@ -132,6 +150,12 @@
           "status": "completed",
           "conclusion": "success",
           "completed_at": "2026-07-18T08:25:00Z"
+        },
+        {
+          "name": "ruleset-drift",
+          "status": "completed",
+          "conclusion": "success",
+          "completed_at": "2026-07-18T08:25:00Z"
         }
       ]
     },
@@ -158,6 +182,12 @@
         },
         {
           "name": "Results Explorer browser gate",
+          "status": "completed",
+          "conclusion": "success",
+          "completed_at": "2026-07-17T08:10:00Z"
+        },
+        {
+          "name": "ruleset-drift",
           "status": "completed",
           "conclusion": "success",
           "completed_at": "2026-07-17T08:10:00Z"
@@ -190,6 +220,12 @@
           "status": "completed",
           "conclusion": "success",
           "completed_at": "2026-07-13T08:25:00Z"
+        },
+        {
+          "name": "ruleset-drift",
+          "status": "completed",
+          "conclusion": "success",
+          "completed_at": "2026-07-13T08:25:00Z"
         }
       ]
     },
@@ -217,6 +253,12 @@
         },
         {
           "name": "Results Explorer browser gate",
+          "status": "completed",
+          "conclusion": "success",
+          "completed_at": "2026-07-18T08:05:00Z"
+        },
+        {
+          "name": "ruleset-drift",
           "status": "completed",
           "conclusion": "success",
           "completed_at": "2026-07-18T08:05:00Z"
@@ -272,6 +314,12 @@
           "status": "completed",
           "conclusion": "failure",
           "completed_at": "2026-07-16T08:05:00Z"
+        },
+        {
+          "name": "ruleset-drift",
+          "status": "completed",
+          "conclusion": "success",
+          "completed_at": "2026-07-16T08:05:00Z"
         }
       ]
     },
@@ -298,6 +346,12 @@
         },
         {
           "name": "Results Explorer browser gate",
+          "status": "completed",
+          "conclusion": "success",
+          "completed_at": "2026-07-23T02:00:00Z"
+        },
+        {
+          "name": "ruleset-drift",
           "status": "completed",
           "conclusion": "success",
           "completed_at": "2026-07-23T02:00:00Z"

--- a/_project/scripts/green_unmerged_sweep.py
+++ b/_project/scripts/green_unmerged_sweep.py
@@ -15,10 +15,11 @@ and alerts only when all of the following hold:
     (a) required-lane green -- EVERY develop-ruleset required status
         context in `REQUIRED_CHECK_NAMES` has its LATEST check run on the
         PR's head SHA completed with conclusion `success`. Today that is
-        both `ci-required-result` and `Results Explorer browser gate`
+        `ci-required-result`, `Results Explorer browser gate`, and
+        `ruleset-drift`
         (docs/operations/repo-admin-settings.md; live ruleset
         develop-squash-only). Partial green (one context success, another
-        missing or red) is NOT required-green. The browser gate always
+        missing or red) is NOT required-green. Every required context
         reports (path-aware skip still concludes success); a missing run
         is fail-closed not-green.
     (b) auto-merge is OFF    -- the PR's own `auto_merge` field is falsy

--- a/_project/scripts/required_lane.py
+++ b/_project/scripts/required_lane.py
@@ -22,6 +22,7 @@ from typing import Any
 REQUIRED_CHECK_NAMES: tuple[str, ...] = (
     "ci-required-result",
     "Results Explorer browser gate",
+    "ruleset-drift",
 )
 
 

--- a/_project/scripts/soundness_drain_report.py
+++ b/_project/scripts/soundness_drain_report.py
@@ -16,7 +16,8 @@ the missing "someone should look at this" signal:
     (a) required-lane green  -- EVERY develop-ruleset required status
         context in ``REQUIRED_CHECK_NAMES`` has its LATEST check run on the
         PR's head SHA completed with conclusion ``success``. Today that is
-        both ``ci-required-result`` and ``Results Explorer browser gate``
+        ``ci-required-result``, ``Results Explorer browser gate``, and
+        ``ruleset-drift``
         (docs/operations/repo-admin-settings.md; live ruleset
         develop-squash-only). Partial green -- one context success, another
         red or never reported -- is NOT required-green; a missing run is

--- a/docs/operations/repo-admin-settings.md
+++ b/docs/operations/repo-admin-settings.md
@@ -54,6 +54,7 @@ Required status checks:
 ```text
 - ci-required-result
 - Results Explorer browser gate
+- ruleset-drift
 ```
 
 `ci-required-result` is the umbrella job in `.github/workflows/pr.yml`
@@ -477,8 +478,12 @@ For the first release that introduces `release-canary.yml`, before GitHub can
 run the workflow from the default branch, `validate-base` runs the same
 non-fast canary suite and ruleset drift check inline as bootstrap evidence.
 
-Ruleset drift is checked by `scripts/ruleset_drift_check.py` inside
-`release-canary.yml`. The script parses this runbook for
+Ruleset drift is checked for every develop PR by
+`develop-ruleset-drift.yml` and independently by `release-canary.yml`. The PR
+workflow uses `pull_request_target`, checks out only the trusted base SHA, and
+never executes pull-request-head code with the admin-visible token. Its
+`ruleset-drift` job is a required `develop-squash-only` context, so drift blocks
+the next merge instead of waiting for the scheduled canary. The script parses this runbook for
 `develop-squash-only` and `release-only`, then compares live GitHub
 rulesets for required status check contexts, strict-base settings, bypass
 actors, linear history, non-fast-forward protection, deletion protection, and
@@ -486,7 +491,7 @@ target refs. For `develop-squash-only`, it also applies the shared
 `review_enforcement_findings` predicate and treats a missing or false
 `require_code_owner_review` as a blocking finding through
 `DEVELOP_REVIEW_RULE_ENFORCED = True`. The
-workflow must use the repository secret `RULESET_DRIFT_TOKEN`
+Both workflows must use the repository secret `RULESET_DRIFT_TOKEN`
 with enough ruleset write/admin visibility for the API to expose
 `bypass_actors`; the default `GITHUB_TOKEN` is intentionally not used for this
 check. If GitHub API access fails, the canary is red; release PRs then fail on

--- a/tests/unit/release/test_ruleset_drift_review_coverage.py
+++ b/tests/unit/release/test_ruleset_drift_review_coverage.py
@@ -83,6 +83,7 @@ def _live_develop_ruleset(*, review_count: int = 0, code_owner_review: bool = Tr
                     "required_status_checks": [
                         {"context": "ci-required-result"},
                         {"context": "Results Explorer browser gate"},
+                        {"context": "ruleset-drift"},
                     ],
                 },
             },

--- a/tests/unit/scripts/test_green_unmerged_sweep.py
+++ b/tests/unit/scripts/test_green_unmerged_sweep.py
@@ -87,7 +87,7 @@ def test_required_lane_picks_latest_started_run() -> None:
     runs = [
         _run("ci-required-result", "failure", "2026-07-23T07:00:00Z"),
         _run("ci-required-result", "success", "2026-07-23T08:00:00Z"),
-        _run("Results Explorer browser gate", "success"),
+        *[_run(name, "success") for name in mod.REQUIRED_CHECK_NAMES if name != "ci-required-result"],
     ]
     assert mod.is_required_lane_green(runs) is True
 
@@ -96,7 +96,7 @@ def test_required_lane_stale_success_does_not_beat_latest_failure() -> None:
     runs = [
         _run("ci-required-result", "success", "2026-07-23T07:00:00Z"),
         _run("ci-required-result", "failure", "2026-07-23T08:00:00Z"),
-        _run("Results Explorer browser gate", "success"),
+        *[_run(name, "success") for name in mod.REQUIRED_CHECK_NAMES if name != "ci-required-result"],
     ]
     assert mod.is_required_lane_green(runs) is False
 

--- a/tests/unit/scripts/test_soundness_drain_report.py
+++ b/tests/unit/scripts/test_soundness_drain_report.py
@@ -95,7 +95,7 @@ def test_required_lane_picks_latest_started_run() -> None:
     runs = [
         _run("ci-required-result", "failure", started_at="2026-07-23T07:00:00Z"),
         _run("ci-required-result", "success", started_at="2026-07-23T08:00:00Z"),
-        _run("Results Explorer browser gate", "success"),
+        *[_run(name, "success") for name in mod.REQUIRED_CHECK_NAMES if name != "ci-required-result"],
     ]
     assert mod.is_required_lane_green(runs) is True
 
@@ -104,7 +104,7 @@ def test_required_lane_stale_success_does_not_beat_latest_failure() -> None:
     runs = [
         _run("ci-required-result", "success", started_at="2026-07-23T07:00:00Z"),
         _run("ci-required-result", "failure", started_at="2026-07-23T08:00:00Z"),
-        _run("Results Explorer browser gate", "success"),
+        *[_run(name, "success") for name in mod.REQUIRED_CHECK_NAMES if name != "ci-required-result"],
     ]
     assert mod.is_required_lane_green(runs) is False
 
@@ -155,18 +155,22 @@ def test_latest_check_run_returns_none_for_unknown_name() -> None:
 def test_green_at_is_the_last_required_context_to_finish() -> None:
     # The lane is green only once every context has finished, so the anchor
     # is the maximum completed_at -- not the first context's.
-    runs = [
-        _run("ci-required-result", "success", completed_at="2026-07-21T08:00:00Z"),
-        _run("Results Explorer browser gate", "success", completed_at="2026-07-23T02:00:00Z"),
-    ]
+    completed_at = {
+        "ci-required-result": "2026-07-21T08:00:00Z",
+        "Results Explorer browser gate": "2026-07-23T02:00:00Z",
+        "ruleset-drift": "2026-07-22T08:00:00Z",
+    }
+    runs = [_run(name, "success", completed_at=completed_at[name]) for name in mod.REQUIRED_CHECK_NAMES]
     assert mod.required_lane_green_at(runs) == "2026-07-23T02:00:00Z"
 
 
 def test_green_at_is_order_independent() -> None:
-    runs = [
-        _run("Results Explorer browser gate", "success", completed_at="2026-07-23T02:00:00Z"),
-        _run("ci-required-result", "success", completed_at="2026-07-21T08:00:00Z"),
-    ]
+    completed_at = {
+        "ci-required-result": "2026-07-21T08:00:00Z",
+        "Results Explorer browser gate": "2026-07-23T02:00:00Z",
+        "ruleset-drift": "2026-07-22T08:00:00Z",
+    }
+    runs = [_run(name, "success", completed_at=completed_at[name]) for name in reversed(mod.REQUIRED_CHECK_NAMES)]
     assert mod.required_lane_green_at(runs) == "2026-07-23T02:00:00Z"
 
 
@@ -195,6 +199,7 @@ def test_park_time_anchors_on_the_last_required_context() -> None:
         "check_runs": [
             _run("ci-required-result", "success", completed_at="2026-07-21T08:00:00Z"),
             _run("Results Explorer browser gate", "success", completed_at="2026-07-23T02:00:00Z"),
+            _run("ruleset-drift", "success", completed_at="2026-07-22T08:00:00Z"),
         ],
     }
     assert mod.park_time_hours(pr, _now(), required_green=True) == pytest.approx(10.0)

--- a/tests/unit/test_ruleset_drift.py
+++ b/tests/unit/test_ruleset_drift.py
@@ -43,6 +43,7 @@ def test_parse_expected_rulesets_from_admin_runbook() -> None:
     assert expected["develop-squash-only"].required_checks == (
         "ci-required-result",
         "Results Explorer browser gate",
+        "ruleset-drift",
     )
     assert expected["develop-squash-only"].strict_required_status_checks_policy is True
     assert expected["release-only"].ref == "refs/heads/release"

--- a/tests/unit/workflows/test_develop_ruleset_drift.py
+++ b/tests/unit/workflows/test_develop_ruleset_drift.py
@@ -1,0 +1,42 @@
+"""Security and required-check contract for per-PR governance drift."""
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+pytestmark = [pytest.mark.unit, pytest.mark.fast]
+
+ROOT = Path(__file__).resolve().parents[3]
+WORKFLOW = ROOT / ".github" / "workflows" / "develop-ruleset-drift.yml"
+
+
+def _workflow() -> dict:
+    return yaml.safe_load(WORKFLOW.read_text(encoding="utf-8"))
+
+
+def test_ruleset_drift_uses_trusted_base_code_with_minimal_permissions() -> None:
+    workflow = _workflow()
+    job = workflow["jobs"]["ruleset-drift"]
+    checkout = job["steps"][0]
+
+    assert workflow["permissions"] == {"contents": "read"}
+    assert checkout["uses"] == "actions/checkout@v4"
+    assert checkout["with"]["ref"] == "${{ github.event.pull_request.base.sha }}"
+    assert checkout["with"]["persist-credentials"] is False
+    assert "head.sha" not in WORKFLOW.read_text(encoding="utf-8")
+
+
+def test_ruleset_drift_fails_closed_and_preserves_evidence() -> None:
+    workflow = _workflow()
+    job = workflow["jobs"]["ruleset-drift"]
+    check = job["steps"][1]
+    upload = job["steps"][2]
+
+    assert job["name"] == "ruleset-drift"
+    assert check["env"] == {"RULESET_DRIFT_TOKEN": "${{ secrets.RULESET_DRIFT_TOKEN }}"}
+    assert "scripts/ruleset_drift_check.py" in check["run"]
+    assert "--require-bypass-actor-visibility" in check["run"]
+    assert "set +e" not in check["run"]
+    assert upload["if"] == "always()"
+    assert upload["with"]["retention-days"] == 30


### PR DESCRIPTION
## Summary
- run the develop ruleset drift check on every PR using trusted base-branch code
- publish a dedicated `ruleset-drift` status context and evidence artifact
- document and test the required-context promotion architecture
- keep green-unmerged and soundness-drain observers synchronized with all three required contexts

## Security architecture
- `pull_request_target` is used only to obtain the repository secret
- checkout is pinned to `github.event.pull_request.base.sha`, never fork/head code
- checkout credentials are disabled and token permissions are read-only
- the existing drift script compares live rulesets with the repository runbook

## Verification
- focused workflow/ruleset/observer suite: 106 passed
- `make pr-preflight`: 27,697 passed, 19 skipped, 52 known warnings, four subtests; artifact hygiene passed
- CI follow-up fixed the deterministic medium-tier failure caused by observer constants and fixtures still modeling two contexts

## Operator follow-up
After this workflow merges, update live ruleset `15611785` to add required context `ruleset-drift` while preserving every existing condition, rule, bypass actor, strict-check setting, code-owner requirement, linear-history rule, deletion protection, and non-fast-forward rule. Adding the requirement before merge would deadlock the PR.
