### PR TITLE
fix: close recent PR review follow-ups

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -125,7 +125,7 @@ repos:
       # preflight cover authorized primary-clone and disposable-clone commits.
       - id: agent-write-preflight
         name: agent write location and identity preflight
-        entry: sh scripts/agent_write_preflight.sh
+        entry: sh scripts/agent_pre_commit_guard.sh
         language: system
         pass_filenames: false
         always_run: true

--- a/Makefile
+++ b/Makefile
@@ -968,9 +968,7 @@ RELEASE_REQUIRED_CONTEXTS := validate-base release-required-result
 	fi; \
 	if [ ! -d "$(BENCHBOX_MAKEFILE_ROOT)_project/decisions" ]; then \
 		BRANCH=$$(git rev-parse --abbrev-ref HEAD 2>/dev/null || true); \
-		if [ "$$BRANCH" != "v$(VERSION)" ] \
-				|| ! git rev-parse --verify --quiet refs/heads/develop >/dev/null \
-				|| ! git merge-base --is-ancestor develop HEAD; then \
+		if [ "$$BRANCH" != "v$(VERSION)" ]; then \
 			echo "Error: release-cut requires the BenchBox development tree unless resuming v$(VERSION) after curation." >&2; \
 			exit 2; \
 		fi; \

--- a/_project/decisions/auto-merge-policy-consolidation-2026-08-06.md
+++ b/_project/decisions/auto-merge-policy-consolidation-2026-08-06.md
@@ -1,9 +1,9 @@
 # Auto-merge policy: adversarial evaluation and consolidation
 
 **Date**: 2026-08-06
-**Status**: historical evaluation; decisions D1–D7 were later accepted and
-dispositioned below. At the time of this evaluation, no mechanism had yet been
-modified.
+**Status**: historical evaluation; D1–D4 and D6 were later implemented.
+D5 and D7 remain recommendations pending explicit authorization. At the time
+of this evaluation, no mechanism had yet been modified.
 **Related**: PRs #1567, #1592, #1622, #1623, #1624 (policy lineage);
 #1568/#1569 (live arm-on-open failure); #1503/#1521/#1531 (stranded review
 fixes); #1512 (anonymization auto-merge escape); #1543 (red-develop revert);
@@ -185,9 +185,9 @@ the mechanism set.
 
 ## Decisions and disposition (D1–D7)
 
-The recommendations below are no longer merely proposed. The merge of PR
-#1636 authorized and implemented D1–D4; PR #1634 implemented D6. D5 and D7
-remain accepted policy decisions rather than code changes. This record
+The recommendations below are not all accepted. The merge of PR #1636
+authorized and implemented D1–D4; PR #1634 implemented D6. D5 and D7 remain
+proposed policy recommendations and are not authorized by this record. This record
 preserves the evaluation and rationale; the current source and operational
 runbook are the operative implementation record.
 

--- a/_project/decisions/strict-base-refresh-merge-queue-2026-08-14.md
+++ b/_project/decisions/strict-base-refresh-merge-queue-2026-08-14.md
@@ -52,7 +52,7 @@ Queried 2026-08-14. Names only; secret values were not read.
 | HTTPS | certificate approved, expires 2026-10-29; HTTPS enforced | Re-issue after domain re-association |
 | Actions secret names | `CODECOV_TOKEN`, `RULESET_DRIFT_TOKEN`, `TODO_DB_RO_AUTH_TOKEN`, `TODO_DB_URL`, `TODO_EXPORT_PR_TOKEN` | Recreate in the destination; `RULESET_DRIFT_TOKEN` is required for bypass-actor visibility |
 | Actions variable | none | Low |
-| Ruleset | `15611785` develop-squash-only; `19149459` release-only; `15611787` v-release-branches-minimal; `15611787`/`18774756` tag | Re-bind IDs and required contexts after transfer |
+| Ruleset | `15611785` develop-squash-only; `19149459` release-only; `15611787` v-release-branches-minimal; `18774756` tag | Re-bind IDs and required contexts after transfer |
 | Environment | `github-pages` (branch policy); `pypi` (required reviewers); `test-pypi` | Reviewer IDs and environment protection must be rebuilt |
 | Webhook / app hook | none listed | Low today; re-check at transfer time |
 | Package API | not readable with the current token (`read:packages` missing) | Operator must inventory GHCR/npm packages before transfer |

--- a/_project/scripts/todo_db_standalone_compat.py
+++ b/_project/scripts/todo_db_standalone_compat.py
@@ -96,9 +96,7 @@ def _command_index_from(argv: list[str], commands: frozenset[str]) -> tuple[int,
         if any(value.startswith(f"{option}=") for option in GLOBAL_VALUE_OPTIONS):
             index += 1
             continue
-        if value in commands:
-            return index, value
-        index += 1
+        return (index, value) if value in commands else None
     return None
 
 

--- a/benchbox/platforms/base/data_loading.py
+++ b/benchbox/platforms/base/data_loading.py
@@ -2138,12 +2138,15 @@ class ClickHouseNativeHandler(FileFormatHandler):
         row_count = 0
         row_generator: Any | None = None
         try:
-            first_path = file_paths[0]
-            compression_handler = FileFormatRegistry.get_compression_handler(first_path)
-            with compression_handler.open(first_path) as file_handle:
-                column_count = SchemaInspector.get_column_count(
-                    benchmark, validated_table, file_handle, self.delimiter_char
-                )
+            column_count = None
+            for file_path in file_paths:
+                compression_handler = FileFormatRegistry.get_compression_handler(file_path)
+                with compression_handler.open(file_path) as file_handle:
+                    column_count = SchemaInspector.get_column_count(
+                        benchmark, validated_table, file_handle, self.delimiter_char
+                    )
+                if column_count is not None:
+                    break
             if column_count is None:
                 logger.debug(f"Could not determine column count for {validated_table}")
                 return 0
@@ -2294,12 +2297,12 @@ class ClickHouseNativeHandler(FileFormatHandler):
                 raise RuntimeError("pyarrow is required for Parquet loading") from exc
 
             first_table = pq.ParquetFile(file_paths[0])
-            column_names = first_table.schema.names
+            column_names = first_table.schema_arrow.names
             validated_columns = [validate_sql_identifier(col, "column name") for col in column_names]
             expected_rows = 0
             for file_path in file_paths:
                 parquet_file = pq.ParquetFile(file_path)
-                if parquet_file.schema.names != column_names:
+                if parquet_file.schema_arrow.names != column_names:
                     raise DataLoadingError(
                         f"ClickHouse server Parquet shards for {validated_table!r} have different columns: {file_path}"
                     )

--- a/docs/operations/uat-framework.md
+++ b/docs/operations/uat-framework.md
@@ -885,13 +885,16 @@ insufficient: the gate rejects a missing, extra, or differently-sized table.
 ```bash
 uv run -- python -m tests.uat.clickhouse_certification \
   --manifest "$BENCHBOX_OUTPUT_DIR/datagen/tpch_sf1/_datagen_manifest.json" \
+  --table-format tbl \
   --result "$BENCHBOX_OUTPUT_DIR/results/tpch_sf1_clickhouse_server_sql_<id>.json"
 ```
 
 The command prints `PASS` only when every manifest table has an exact result
-count. A manifest whose shard metadata does not describe the files actually
-loaded is a certification failure and must be regenerated or corrected before
-the memory and query gates can be considered complete.
+count, the result identifies ClickHouse Server, and its benchmark and scale
+factor match the manifest. `--table-format` must name the format actually
+loaded; a manifest whose shard metadata does not describe those files is a
+certification failure and must be regenerated or corrected before the memory
+and query gates can be considered complete.
 
 ## Troubleshooting
 

--- a/make/inventory.json
+++ b/make/inventory.json
@@ -1,5 +1,5 @@
 {
-  "contract_sha256": "254edcbac7f63f2347951c5627ed8edd2d06d619a76ed38908923cf473bc71eb",
+  "contract_sha256": "5f423e6e69ccde0cb2e560645626bacc3eec13f8c27a077a20caa301624ecdb2",
   "default_goal": "test",
   "include_order": [
     "make/platform-tests.mk",
@@ -360,8 +360,8 @@
     ".release-cut-tree-required": [
       {
         "header": ".release-cut-tree-required:",
-        "recipe": "\t@if [ -z \"$(VERSION)\" ]; then \\\n\t\techo \"Usage: make release-cut VERSION=X.Y.Z\" >&2; \\\n\t\texit 1; \\\n\tfi; \\\n\tif [ ! -d \"$(BENCHBOX_MAKEFILE_ROOT)_project/decisions\" ]; then \\\n\t\tBRANCH=$$(git rev-parse --abbrev-ref HEAD 2>/dev/null || true); \\\n\t\tif [ \"$$BRANCH\" != \"v$(VERSION)\" ] \\\n\t\t\t\t|| ! git rev-parse --verify --quiet refs/heads/develop >/dev/null \\\n\t\t\t\t|| ! git merge-base --is-ancestor develop HEAD; then \\\n\t\t\techo \"Error: release-cut requires the BenchBox development tree unless resuming v$(VERSION) after curation.\" >&2; \\\n\t\t\texit 2; \\\n\t\tfi; \\\n\tfi",
-        "recipe_sha256": "70be74f63f6153e366734b8a086faa019b3c34e8fc777e43cf9ad754bbc7f29a"
+        "recipe": "\t@if [ -z \"$(VERSION)\" ]; then \\\n\t\techo \"Usage: make release-cut VERSION=X.Y.Z\" >&2; \\\n\t\texit 1; \\\n\tfi; \\\n\tif [ ! -d \"$(BENCHBOX_MAKEFILE_ROOT)_project/decisions\" ]; then \\\n\t\tBRANCH=$$(git rev-parse --abbrev-ref HEAD 2>/dev/null || true); \\\n\t\tif [ \"$$BRANCH\" != \"v$(VERSION)\" ]; then \\\n\t\t\techo \"Error: release-cut requires the BenchBox development tree unless resuming v$(VERSION) after curation.\" >&2; \\\n\t\t\texit 2; \\\n\t\tfi; \\\n\tfi",
+        "recipe_sha256": "a04c5612862d7dc287bf74b3b064e60a5d12110c33a24f242cb62fb976555ce9"
       }
     ],
     "agent-commit-range-check": [
@@ -1870,7 +1870,7 @@
     ]
   },
   "schema_version": 2,
-  "semantic_sha256": "a8b3fc85e825fa51a91fab98a014651ee1ea3c545b9e84768b1145da983b83e9",
+  "semantic_sha256": "ff69a160c2a35250e3888221263206d89c3c0ae52db84f74de7b19d7326fcf85",
   "semantic_statements": [
     {
       "body": "override BENCHBOX_MAKEFILE_ROOT := $(dir $(realpath $(lastword $(MAKEFILE_LIST))))",
@@ -3370,9 +3370,9 @@
       ]
     },
     {
-      "body": ".release-cut-tree-required:\n\t@if [ -z \"$(VERSION)\" ]; then \\\n\t\techo \"Usage: make release-cut VERSION=X.Y.Z\" >&2; \\\n\t\texit 1; \\\n\tfi; \\\n\tif [ ! -d \"$(BENCHBOX_MAKEFILE_ROOT)_project/decisions\" ]; then \\\n\t\tBRANCH=$$(git rev-parse --abbrev-ref HEAD 2>/dev/null || true); \\\n\t\tif [ \"$$BRANCH\" != \"v$(VERSION)\" ] \\\n\t\t\t\t|| ! git rev-parse --verify --quiet refs/heads/develop >/dev/null \\\n\t\t\t\t|| ! git merge-base --is-ancestor develop HEAD; then \\\n\t\t\techo \"Error: release-cut requires the BenchBox development tree unless resuming v$(VERSION) after curation.\" >&2; \\\n\t\t\texit 2; \\\n\t\tfi; \\\n\tfi",
+      "body": ".release-cut-tree-required:\n\t@if [ -z \"$(VERSION)\" ]; then \\\n\t\techo \"Usage: make release-cut VERSION=X.Y.Z\" >&2; \\\n\t\texit 1; \\\n\tfi; \\\n\tif [ ! -d \"$(BENCHBOX_MAKEFILE_ROOT)_project/decisions\" ]; then \\\n\t\tBRANCH=$$(git rev-parse --abbrev-ref HEAD 2>/dev/null || true); \\\n\t\tif [ \"$$BRANCH\" != \"v$(VERSION)\" ]; then \\\n\t\t\techo \"Error: release-cut requires the BenchBox development tree unless resuming v$(VERSION) after curation.\" >&2; \\\n\t\t\texit 2; \\\n\t\tfi; \\\n\tfi",
       "kind": "rule",
-      "sha256": "5301261cd9ecb0bc1d71d8b544fc31958fe4aeb32911e6d2f22ee8e8c2859a84",
+      "sha256": "4cf3f94c9586016f3d89d1e40d5f91555123a3cbc9b13bd74b331afb4c9b7d86",
       "targets": [
         ".release-cut-tree-required"
       ]

--- a/scripts/agent_pre_commit_guard.sh
+++ b/scripts/agent_pre_commit_guard.sh
@@ -1,12 +1,20 @@
 #!/bin/sh
 set -eu
 
-# The linked-worktree guard is an agent-session safeguard. A human contributor
-# may intentionally commit from the primary clone, so the pre-commit hook must
-# not apply the agent-only location policy unconditionally.
+# The linked-worktree guard is an agent-session safeguard. Git hooks cannot
+# reliably distinguish an agent using a human Git identity from a human
+# contributor, so an unmarked primary-clone commit must fail closed. Humans
+# who have explicitly authorized a primary-clone commit may use the same
+# declaration accepted by agent_write_preflight.sh; linked worktrees need no
+# declaration.
 configured=$(git config --bool --get benchbox.agent-write-preflight 2>/dev/null || true)
 if [ "$configured" = "true" ] || [ "${BENCHBOX_AGENT_SESSION:-}" = "1" ]; then
   exec sh scripts/agent_write_preflight.sh
 fi
 
-exit 0
+allow_main=${BENCHBOX_ALLOW_MAIN_CLONE_WRITE:-${ALLOW_MAIN_CLONE_WRITE:-}}
+if [ "$allow_main" = "1" ] || [ "${BENCHBOX_EPHEMERAL_CLONE:-}" = "1" ]; then
+  exit 0
+fi
+
+exec sh scripts/agent_write_preflight.sh

--- a/scripts/agent_pre_commit_guard.sh
+++ b/scripts/agent_pre_commit_guard.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+set -eu
+
+# The linked-worktree guard is an agent-session safeguard. A human contributor
+# may intentionally commit from the primary clone, so the pre-commit hook must
+# not apply the agent-only location policy unconditionally.
+configured=$(git config --bool --get benchbox.agent-write-preflight 2>/dev/null || true)
+if [ "$configured" = "true" ] || [ "${BENCHBOX_AGENT_SESSION:-}" = "1" ]; then
+  exec sh scripts/agent_write_preflight.sh
+fi
+
+exit 0

--- a/scripts/set_worktree_identity.sh
+++ b/scripts/set_worktree_identity.sh
@@ -89,6 +89,11 @@ if [ "$(git_wt config --get extensions.worktreeConfig 2>/dev/null || true)" != "
   git_wt config extensions.worktreeConfig true
 fi
 
+# Mark worktrees created through the agent-safe lifecycle so the pre-commit
+# hook applies the location guard there while leaving normal human commits in
+# the primary clone alone.
+git_wt config --worktree benchbox.agent-write-preflight true
+
 # Enabling the extension moves any pre-existing common-config [user] block out
 # of this worktree's precedence path only if we write our own. Write both keys
 # unconditionally-but-idempotently so a partially-set worktree converges.

--- a/tests/uat/clickhouse_certification.py
+++ b/tests/uat/clickhouse_certification.py
@@ -10,6 +10,8 @@ from __future__ import annotations
 
 import argparse
 import json
+import math
+import re
 import sys
 from dataclasses import dataclass
 from pathlib import Path
@@ -69,8 +71,8 @@ def _non_negative_count(value: Any, *, path: Path, table: str, field: str) -> in
     return value
 
 
-def manifest_table_rows(path: Path) -> dict[str, int]:
-    """Aggregate the selected manifest format into exact table row counts."""
+def manifest_table_rows(path: Path, table_format: str) -> dict[str, int]:
+    """Aggregate the format that the ClickHouse run was instructed to load."""
     payload = _read_json(path)
     tables = payload.get("tables")
     if not isinstance(tables, dict) or not tables:
@@ -83,17 +85,9 @@ def manifest_table_rows(path: Path) -> dict[str, int]:
         format_block = raw_formats.get("formats", raw_formats)
         if not isinstance(format_block, dict):
             raise CertificationArtifactError(f"{path}: {table} has invalid format data")
-        preferred = payload.get("format_preference")
-        formats = list(preferred) if isinstance(preferred, list) else []
-        formats.extend(name for name in format_block if name not in formats)
-        selected_entries: list[Any] | None = None
-        for format_name in formats:
-            candidate = format_block.get(format_name)
-            if isinstance(candidate, list) and candidate:
-                selected_entries = candidate
-                break
-        if selected_entries is None:
-            raise CertificationArtifactError(f"{path}: {table} has no usable manifest entries")
+        selected_entries = format_block.get(table_format)
+        if not isinstance(selected_entries, list) or not selected_entries:
+            raise CertificationArtifactError(f"{path}: {table} has no usable {table_format!r} manifest entries")
         total = 0
         for index, entry in enumerate(selected_entries):
             if not isinstance(entry, dict) or "row_count" not in entry:
@@ -118,10 +112,35 @@ def result_table_rows(path: Path) -> dict[str, int]:
     return actual
 
 
-def validate_exact_manifest_rows(manifest_path: Path, result_path: Path) -> ExactRowValidation:
-    """Compare manifest and result counts without accepting aggregate-only proof."""
+def validate_exact_manifest_rows(manifest_path: Path, result_path: Path, table_format: str) -> ExactRowValidation:
+    """Compare the loaded ClickHouse workload with its exact manifest format."""
+    manifest = _read_json(Path(manifest_path))
+    benchmark = manifest.get("benchmark")
+    scale_factor = manifest.get("scale_factor")
+    if not isinstance(benchmark, str) or not benchmark:
+        raise CertificationArtifactError(f"{manifest_path}: manifest lacks benchmark identity")
+    if isinstance(scale_factor, bool) or not isinstance(scale_factor, (int, float)) or not math.isfinite(scale_factor):
+        raise CertificationArtifactError(f"{manifest_path}: manifest lacks a finite scale_factor")
+
+    result = _read_json(Path(result_path))
+    platform = result.get("platform")
+    benchmark_payload = result.get("benchmark")
+    platform_name = platform.get("name") if isinstance(platform, dict) else None
+    benchmark_id = benchmark_payload.get("id") if isinstance(benchmark_payload, dict) else None
+    result_scale = benchmark_payload.get("scale_factor") if isinstance(benchmark_payload, dict) else None
+    normalized_platform = re.sub(r"[^a-z0-9]+", "-", str(platform_name or "").lower()).strip("-")
+    if normalized_platform != "clickhouse-server":
+        raise CertificationArtifactError(f"{result_path}: result platform must be ClickHouse Server")
+    if benchmark_id != benchmark:
+        raise CertificationArtifactError(
+            f"{result_path}: result benchmark {benchmark_id!r} does not match manifest {benchmark!r}"
+        )
+    if isinstance(result_scale, bool) or not isinstance(result_scale, (int, float)) or result_scale != scale_factor:
+        raise CertificationArtifactError(
+            f"{result_path}: result scale_factor {result_scale!r} does not match manifest {scale_factor!r}"
+        )
     validation = ExactRowValidation(
-        expected=manifest_table_rows(Path(manifest_path)),
+        expected=manifest_table_rows(Path(manifest_path), table_format),
         actual=result_table_rows(Path(result_path)),
     )
     validation.require_pass()
@@ -132,9 +151,12 @@ def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--manifest", type=Path, required=True)
     parser.add_argument("--result", type=Path, required=True)
+    parser.add_argument(
+        "--table-format", required=True, help="Exact manifest format loaded by ClickHouse (for example tbl)"
+    )
     args = parser.parse_args(argv)
     try:
-        validation = validate_exact_manifest_rows(args.manifest, args.result)
+        validation = validate_exact_manifest_rows(args.manifest, args.result, args.table_format)
     except CertificationArtifactError as exc:
         print(f"FAIL {exc}", file=sys.stderr)
         return 2

--- a/tests/uat/clickhouse_memory.py
+++ b/tests/uat/clickhouse_memory.py
@@ -63,12 +63,23 @@ _MEMORY_UNITS = {
 _DECIMAL_GIB_EQUIVALENCE = 1000**3
 
 
-def runtime_limit_matches_rung(runtime_limit_bytes: int, requested_memory_gib: float) -> bool:
-    """Return whether a runtime cap is the requested rung in either unit system."""
+def runtime_limit_matches_rung(
+    runtime_limit_bytes: int, requested_memory_gib: float, *, requested_bytes: int | None = None
+) -> bool:
+    """Return whether a runtime cap is the requested rung in either unit system.
 
+    The trace format stores a nominal GiB rung, so it accepts the exact decimal
+    or binary spelling of that nominal value. Runtime admission also has the
+    original parsed byte count available; passing it switches to an exact
+    comparison and avoids converting a decimal request into a smaller binary
+    nominal value.
+    """
+
+    if requested_bytes is not None:
+        return runtime_limit_bytes == requested_bytes
     lower_limit = int(requested_memory_gib * _DECIMAL_GIB_EQUIVALENCE)
     upper_limit = int(requested_memory_gib * GIB)
-    return lower_limit <= runtime_limit_bytes <= upper_limit
+    return runtime_limit_bytes in {lower_limit, upper_limit}
 
 
 # These are the metrics that make a trace evidence rather than a host/engine

--- a/tests/uat/clickhouse_memory.py
+++ b/tests/uat/clickhouse_memory.py
@@ -62,6 +62,15 @@ _MEMORY_UNITS = {
 # cannot be relabelled as the requested rung.
 _DECIMAL_GIB_EQUIVALENCE = 1000**3
 
+
+def runtime_limit_matches_rung(runtime_limit_bytes: int, requested_memory_gib: float) -> bool:
+    """Return whether a runtime cap is the requested rung in either unit system."""
+
+    lower_limit = int(requested_memory_gib * _DECIMAL_GIB_EQUIVALENCE)
+    upper_limit = int(requested_memory_gib * GIB)
+    return lower_limit <= runtime_limit_bytes <= upper_limit
+
+
 # These are the metrics that make a trace evidence rather than a host/engine
 # health sample. Optional asynchronous metrics such as OSMemoryFree are not
 # required, but a response from the wrong metric or a partially failed query
@@ -175,8 +184,6 @@ class ClickHouseMemoryTrace:
             sample.responsiveness_ms is None or not math.isfinite(sample.responsiveness_ms) for sample in self.samples
         ):
             return False
-        lower_limit = int(self.rung.requested_memory_gib * _DECIMAL_GIB_EQUIVALENCE)
-        upper_limit = int(self.rung.requested_memory_gib * GIB)
         engine_samples = [sample.engine for sample in self.samples]
         for sample in self.samples:
             if (
@@ -195,7 +202,7 @@ class ClickHouseMemoryTrace:
                 return False
             if sample.engine.oom_killed is not False or sample.engine.running is not True:
                 return False
-            if not lower_limit <= sample.engine.limit_bytes <= upper_limit:
+            if not runtime_limit_matches_rung(sample.engine.limit_bytes, self.rung.requested_memory_gib):
                 return False
         if any(sample.oom_killed is True for sample in engine_samples):
             return False
@@ -539,6 +546,10 @@ class MemoryTraceCollector:
         if self._thread is not None:
             raise RuntimeError("memory trace collector already started")
         self._started_mono = time.monotonic()
+        # Replace any prior passing artifact before the child command starts.
+        # If the process is interrupted before stop(), a stale success must not
+        # be mistaken for evidence from this run.
+        write_trace(self.output_path, self.trace)
         self._sample_once()
         self._thread = threading.Thread(target=self._run, name="clickhouse-memory-trace", daemon=True)
         self._thread.start()

--- a/tests/uat/config.py
+++ b/tests/uat/config.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import math
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
@@ -354,8 +355,8 @@ def _require_nonnegative_float(payload: dict[str, Any], key: str, *, default: fl
         coerced = float(value)
     except (TypeError, ValueError) as exc:
         raise ConfigError(f"`{section}.{key}` must be a number, got {type(value).__name__}={value!r}") from exc
-    if coerced < 0:
-        raise ConfigError(f"`{section}.{key}` must be >= 0")
+    if not math.isfinite(coerced) or coerced < 0:
+        raise ConfigError(f"`{section}.{key}` must be a finite number >= 0")
     return coerced
 
 

--- a/tests/uat/phases/execute.py
+++ b/tests/uat/phases/execute.py
@@ -27,6 +27,7 @@ from pathlib import Path
 
 from tests.uat import docker_assets
 from tests.uat.cleanup import CellKey, can_prune, prune_database_dir, source_reuse_graph
+from tests.uat.clickhouse_memory import runtime_limit_matches_rung
 from tests.uat.config import OutputConfig, UATConfig
 from tests.uat.ladder import LadderRung, plan_ladder
 from tests.uat.matrix import (
@@ -728,7 +729,7 @@ def _check_clickhouse_runtime_memory(
             f"ClickHouse runtime memory admission failed for {project_name}: stats did not report a memory limit; "
             "refusing to infer one from host RAM or an engine default"
         )
-    if runtime_limit != selected_bytes:
+    if not runtime_limit_matches_rung(runtime_limit, selected_bytes / (1024**3)):
         return (
             f"ClickHouse runtime memory admission failed for {project_name}: requested {selected_value} "
             f"({selected_bytes} bytes), runtime reported {runtime_limit} bytes"

--- a/tests/uat/phases/execute.py
+++ b/tests/uat/phases/execute.py
@@ -729,7 +729,7 @@ def _check_clickhouse_runtime_memory(
             f"ClickHouse runtime memory admission failed for {project_name}: stats did not report a memory limit; "
             "refusing to infer one from host RAM or an engine default"
         )
-    if not runtime_limit_matches_rung(runtime_limit, selected_bytes / (1024**3)):
+    if not runtime_limit_matches_rung(runtime_limit, selected_bytes / (1024**3), requested_bytes=selected_bytes):
         return (
             f"ClickHouse runtime memory admission failed for {project_name}: requested {selected_value} "
             f"({selected_bytes} bytes), runtime reported {runtime_limit} bytes"

--- a/tests/uat/runner.py
+++ b/tests/uat/runner.py
@@ -149,6 +149,25 @@ def _extract_load_failure(log_text: str) -> dict[str, object] | None:
     return None
 
 
+def _extract_load_failure_from_path(log_path: Path) -> dict[str, object] | None:
+    """Scan a cell log incrementally for its structured load-failure marker."""
+
+    try:
+        with log_path.open("r", encoding="utf-8") as handle:
+            for line in handle:
+                if not line.startswith(LOAD_FAILURE_MARKER):
+                    continue
+                raw_payload = line[len(LOAD_FAILURE_MARKER) :].strip()
+                try:
+                    payload = json.loads(raw_payload)
+                except (TypeError, ValueError):
+                    return None
+                return payload if isinstance(payload, dict) else None
+    except (OSError, UnicodeDecodeError):
+        return None
+    return None
+
+
 def _write_load_failure_sidecar(
     *,
     log_path: Path,
@@ -194,7 +213,7 @@ def _materialize_load_failure_sidecar(
 ) -> tuple[Path | None, Path | None]:
     """Persist a marker payload and return its optional result and sidecar paths."""
 
-    payload = _extract_load_failure(log_path.read_text(encoding="utf-8"))
+    payload = _extract_load_failure_from_path(log_path)
     if payload is None:
         return result_path, None
 

--- a/tests/uat/test_clickhouse_certification.py
+++ b/tests/uat/test_clickhouse_certification.py
@@ -23,10 +23,18 @@ def _write_artifacts(tmp_path: Path, *, lineitem_manifest: int = 3, lineitem_res
         json.dumps(
             {
                 "version": 2,
+                "benchmark": "tpch",
+                "scale_factor": 1.0,
                 "format_preference": ["tbl"],
                 "tables": {
-                    "customer": {"tbl": [{"path": "customer.tbl", "row_count": 2}]},
-                    "lineitem": {"tbl": [{"path": "lineitem.tbl", "row_count": lineitem_manifest}]},
+                    "customer": {
+                        "tbl": [{"path": "customer.tbl", "row_count": 2}],
+                        "parquet": [{"path": "customer.parquet", "row_count": 4}],
+                    },
+                    "lineitem": {
+                        "tbl": [{"path": "lineitem.tbl", "row_count": lineitem_manifest}],
+                        "parquet": [{"path": "lineitem.parquet", "row_count": lineitem_manifest + 1}],
+                    },
                 },
             }
         ),
@@ -34,7 +42,13 @@ def _write_artifacts(tmp_path: Path, *, lineitem_manifest: int = 3, lineitem_res
     )
     result = tmp_path / "result.json"
     result.write_text(
-        json.dumps({"tables": {"customer": {"rows": 2}, "lineitem": {"rows": lineitem_result}}}),
+        json.dumps(
+            {
+                "benchmark": {"id": "tpch", "scale_factor": 1.0},
+                "platform": {"name": "ClickHouse (Server)"},
+                "tables": {"customer": {"rows": 2}, "lineitem": {"rows": lineitem_result}},
+            }
+        ),
         encoding="utf-8",
     )
     return manifest, result
@@ -42,7 +56,7 @@ def _write_artifacts(tmp_path: Path, *, lineitem_manifest: int = 3, lineitem_res
 
 def test_exact_row_gate_compares_each_table(tmp_path: Path):
     manifest, result = _write_artifacts(tmp_path)
-    validation = validate_exact_manifest_rows(manifest, result)
+    validation = validate_exact_manifest_rows(manifest, result, "tbl")
     assert validation.passed
     assert validation.expected == {"customer": 2, "lineitem": 3}
 
@@ -50,7 +64,7 @@ def test_exact_row_gate_compares_each_table(tmp_path: Path):
 def test_exact_row_gate_rejects_table_mismatch(tmp_path: Path):
     manifest, result = _write_artifacts(tmp_path, lineitem_result=4)
     with pytest.raises(CertificationArtifactError, match="lineitem: expected=3 actual=4"):
-        validate_exact_manifest_rows(manifest, result)
+        validate_exact_manifest_rows(manifest, result, "tbl")
 
 
 def test_exact_row_gate_rejects_missing_or_extra_table(tmp_path: Path):
@@ -60,7 +74,7 @@ def test_exact_row_gate_rejects_missing_or_extra_table(tmp_path: Path):
     payload["tables"]["supplier"] = {"rows": 1}
     result.write_text(json.dumps(payload), encoding="utf-8")
     with pytest.raises(CertificationArtifactError, match="customer: expected=2 actual=None"):
-        validate_exact_manifest_rows(manifest, result)
+        validate_exact_manifest_rows(manifest, result, "tbl")
 
 
 def test_artifact_readers_fail_closed_on_missing_counts(tmp_path: Path):
@@ -69,8 +83,25 @@ def test_artifact_readers_fail_closed_on_missing_counts(tmp_path: Path):
     del payload["tables"]["lineitem"]["tbl"][0]["row_count"]
     manifest.write_text(json.dumps(payload), encoding="utf-8")
     with pytest.raises(CertificationArtifactError, match="lacks row_count"):
-        manifest_table_rows(manifest)
+        manifest_table_rows(manifest, "tbl")
 
     result.write_text(json.dumps({"tables": {"lineitem": {}}}), encoding="utf-8")
     with pytest.raises(CertificationArtifactError, match="lacks a table row count"):
         result_table_rows(result)
+
+
+def test_certification_uses_explicit_loaded_format(tmp_path: Path):
+    manifest, result = _write_artifacts(tmp_path, lineitem_manifest=4, lineitem_result=5)
+    payload = json.loads(result.read_text(encoding="utf-8"))
+    payload["tables"]["customer"]["rows"] = 4
+    result.write_text(json.dumps(payload), encoding="utf-8")
+    assert validate_exact_manifest_rows(manifest, result, "parquet").expected == {"customer": 4, "lineitem": 5}
+
+
+def test_certification_rejects_a_result_from_another_platform(tmp_path: Path):
+    manifest, result = _write_artifacts(tmp_path)
+    payload = json.loads(result.read_text(encoding="utf-8"))
+    payload["platform"]["name"] = "DuckDB"
+    result.write_text(json.dumps(payload), encoding="utf-8")
+    with pytest.raises(CertificationArtifactError, match="platform must be ClickHouse Server"):
+        validate_exact_manifest_rows(manifest, result, "tbl")

--- a/tests/uat/test_clickhouse_memory.py
+++ b/tests/uat/test_clickhouse_memory.py
@@ -324,6 +324,7 @@ def test_collector_records_injected_engine_stats_without_live_daemon(monkeypatch
         command_runner=command_runner,
     )
     collector.start()
+    assert json.loads((tmp_path / "trace.json").read_text(encoding="utf-8"))["outcome"] == "running"
     collector.stop(outcome="passed")
     assert trace.samples
     assert trace.samples[0].engine.usage_bytes == clickhouse_memory.GIB

--- a/tests/uat/test_clickhouse_memory.py
+++ b/tests/uat/test_clickhouse_memory.py
@@ -177,6 +177,25 @@ def test_trace_accepts_decimal_runtime_spelling_for_named_gib_rung():
     assert trace.valid_for_calibration is True
 
 
+@pytest.mark.parametrize(
+    ("runtime_limit", "requested_bytes", "expected"),
+    [
+        (8_000_000_000, 8_000_000_000, True),
+        (8 * clickhouse_memory.GIB, 8_000_000_000, False),
+        (7_500_000_000, 8_000_000_000, False),
+    ],
+)
+def test_runtime_admission_compares_the_resolved_byte_count(runtime_limit, requested_bytes, expected):
+    assert (
+        clickhouse_memory.runtime_limit_matches_rung(
+            runtime_limit,
+            requested_bytes / clickhouse_memory.GIB,
+            requested_bytes=requested_bytes,
+        )
+        is expected
+    )
+
+
 @pytest.mark.parametrize("missing", ["usage", "oom", "running", "host", "metrics"])
 def test_trace_fails_closed_on_required_telemetry_gaps(missing):
     trace = _trace()

--- a/tests/uat/test_config.py
+++ b/tests/uat/test_config.py
@@ -220,6 +220,12 @@ def test_validate_config_rejects_negative_docker_memory_reserve():
         config.validate_config({"name": "smoke", "preflight": {"docker_memory_reserve_gib": -0.1}})
 
 
+@pytest.mark.parametrize("value", [float("nan"), float("inf"), "nan", "inf"])
+def test_validate_config_rejects_non_finite_docker_memory_reserve(value):
+    with pytest.raises(config.ConfigError, match="finite"):
+        config.validate_config({"name": "smoke", "preflight": {"docker_memory_reserve_gib": value}})
+
+
 @pytest.mark.parametrize(
     ("field", "cleanup"),
     [

--- a/tests/uat/test_runner.py
+++ b/tests/uat/test_runner.py
@@ -285,6 +285,29 @@ def test_run_cell_writes_clickhouse_load_failure_sidecar(tmp_path: Path):
     assert artifact["log_path"] == str(result.log_path)
 
 
+def test_load_failure_sidecar_scans_large_log_incrementally(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    log_path = tmp_path / "cell.log"
+    payload = {"table": "lineitem", "rows_attempted": 1, "result_json": None}
+    log_path.write_text("noise\n" * 10_000 + runner.LOAD_FAILURE_MARKER + json.dumps(payload) + "\n", encoding="utf-8")
+
+    def fail_full_read(*_args, **_kwargs):
+        raise AssertionError("load-failure extraction must not read the complete log")
+
+    monkeypatch.setattr(Path, "read_text", fail_full_read)
+    _result_path, sidecar = runner._materialize_load_failure_sidecar(
+        log_path=log_path,
+        platform="clickhouse-server",
+        benchmark="tpch",
+        scale=1.0,
+        runs_dir=tmp_path,
+        result_path=None,
+    )
+
+    assert sidecar is not None
+    monkeypatch.undo()
+    assert json.loads(sidecar.read_text(encoding="utf-8"))["table"] == "lineitem"
+
+
 def test_run_cell_diagnostic_rerun_fires_for_empty_stdout_failure(tmp_path: Path):
     captured_quiet = []
 

--- a/tests/unit/platforms/base/test_data_loading_operations.py
+++ b/tests/unit/platforms/base/test_data_loading_operations.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 import gzip
 import io
 import json
+import logging
 from pathlib import Path
 from typing import Any
 from unittest.mock import MagicMock
@@ -24,6 +25,7 @@ import pytest
 from benchbox.platforms.base.data_loading import (
     BenchmarkImplTablesSource,
     BenchmarkTablesSource,
+    ClickHouseNativeHandler,
     ClickHouseServerLoadError,
     DataLoader,
     DataLoadingError,
@@ -77,6 +79,52 @@ class TestDataLoaderClickHouseFailurePropagation:
             loader._load_single_file("events", data_file)
 
         assert exc_info.value is failure
+
+
+class _ServerConnection:
+    def __init__(self) -> None:
+        self.rows: list[tuple] = []
+        self.query: str | None = None
+
+    def execute(self, query: str, rows=None, **_kwargs):
+        self.query = query
+        if rows is not None:
+            self.rows.extend(rows)
+
+
+class _ServerAdapter:
+    deployment_mode = "server"
+    insert_block_size = 16
+
+
+def test_clickhouse_delimited_loader_skips_empty_first_shard(tmp_path: Path) -> None:
+    empty = tmp_path / "part-0.tbl"
+    populated = tmp_path / "part-1.tbl"
+    empty.write_text("", encoding="utf-8")
+    populated.write_text("1|alpha\n", encoding="utf-8")
+    connection = _ServerConnection()
+    handler = ClickHouseNativeHandler("|", _ServerAdapter(), object())
+
+    assert (
+        handler._load_delimited_via_client_insert(
+            "events", [empty, populated], connection, object(), logging.getLogger()
+        )
+        == 1
+    )
+    assert connection.rows == [("1", "alpha")]
+
+
+def test_clickhouse_parquet_loader_uses_logical_nested_names(tmp_path: Path) -> None:
+    pa = pytest.importorskip("pyarrow")
+    pq = pytest.importorskip("pyarrow.parquet")
+    path = tmp_path / "events.parquet"
+    pq.write_table(pa.table({"embedding": [[1, 2]], "event_id": [1]}), path)
+    connection = _ServerConnection()
+    handler = ClickHouseNativeHandler("|", _ServerAdapter(), object())
+
+    assert handler._load_parquet_via_client_insert("events", [path], connection) == 1
+    assert "embedding,event_id" in (connection.query or "")
+    assert connection.rows == [([1, 2], 1)]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/scripts/test_check_release_curation.py
+++ b/tests/unit/scripts/test_check_release_curation.py
@@ -173,6 +173,11 @@ def test_curated_release_cut_guard_allows_only_the_matching_develop_descendant(t
     subprocess.run(["git", "add", "Makefile", "make"], cwd=tmp_path, check=True)
     subprocess.run(["git", "commit", "-m", "fixture"], cwd=tmp_path, check=True, capture_output=True)
     subprocess.run(["git", "checkout", "-b", "v9.9.9"], cwd=tmp_path, check=True, capture_output=True)
+    subprocess.run(["git", "checkout", "develop"], cwd=tmp_path, check=True, capture_output=True)
+    (tmp_path / "README.md").write_text("develop advanced\n", encoding="utf-8")
+    subprocess.run(["git", "add", "README.md"], cwd=tmp_path, check=True)
+    subprocess.run(["git", "commit", "-m", "advance develop"], cwd=tmp_path, check=True, capture_output=True)
+    subprocess.run(["git", "checkout", "v9.9.9"], cwd=tmp_path, check=True, capture_output=True)
 
     allowed = subprocess.run(
         ["make", "--no-print-directory", ".release-cut-tree-required", "VERSION=9.9.9"],

--- a/tests/unit/scripts/test_todo_db_standalone_compat.py
+++ b/tests/unit/scripts/test_todo_db_standalone_compat.py
@@ -162,6 +162,28 @@ def test_option_values_that_match_commands_are_not_parsed_as_commands() -> None:
     assert compat._command_index(["--actor", "audit", "show", "item"]) == (2, "show")
 
 
+def test_recovery_verb_cannot_be_hidden_by_a_later_wrapper_option_value(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    args = [
+        "--db",
+        str(tmp_path / "todo.sqlite"),
+        "--project-id",
+        "benchbox",
+        "--repository",
+        "https://example.invalid/repo",
+        "restore",
+        "--input",
+        "show",
+        "--replace",
+    ]
+    assert compat._command_index(args) is None
+    assert compat._command_index_from(args, compat.STANDALONE_ONLY_COMMANDS) == (6, "restore")
+    monkeypatch.setattr(compat, "_delegate", lambda *args, **kwargs: pytest.fail("must not delegate"))
+    assert compat.main(args) == 2
+    assert "does not expose standalone-only" in capsys.readouterr().err
+
+
 @pytest.mark.parametrize("command", sorted(compat.STANDALONE_ONLY_COMMANDS))
 def test_destructive_standalone_only_commands_are_not_routable(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str], command: str

--- a/tests/unit/test_agent_write_preflight.py
+++ b/tests/unit/test_agent_write_preflight.py
@@ -140,7 +140,7 @@ def test_preflight_allows_non_primary_worktree(tmp_path: Path) -> None:
     assert "BenchBox write preflight OK" in result.stdout
 
 
-def test_configured_hook_allows_human_primary_commit_and_preserves_declarations(tmp_path: Path) -> None:
+def test_configured_hook_requires_primary_clone_declaration_and_preserves_escape_hatches(tmp_path: Path) -> None:
     repo = _init_clone(tmp_path / "BenchBox")
     _install_configured_write_hook(repo)
     before = subprocess.run(
@@ -158,16 +158,9 @@ def test_configured_hook_allows_human_primary_commit_and_preserves_declarations(
         check=False,
     )
 
-    assert human_commit.returncode == 0, human_commit.stdout + human_commit.stderr
-    assert (
-        subprocess.run(
-            ["git", "rev-parse", "HEAD"], cwd=repo, check=True, capture_output=True, text=True
-        ).stdout.strip()
-        != before
-    )
+    assert human_commit.returncode != 0
+    assert "Refusing BenchBox write preflight in the primary clone" in human_commit.stderr
 
-    (repo / "README.md").write_text("authorized primary\n", encoding="utf-8")
-    subprocess.run(["git", "add", "README.md"], cwd=repo, check=True)
     allowed = subprocess.run(
         ["git", "commit", "-m", "authorized primary"],
         cwd=repo,
@@ -177,6 +170,12 @@ def test_configured_hook_allows_human_primary_commit_and_preserves_declarations(
         check=False,
     )
     assert allowed.returncode == 0, allowed.stdout + allowed.stderr
+    assert (
+        subprocess.run(
+            ["git", "rev-parse", "HEAD"], cwd=repo, check=True, capture_output=True, text=True
+        ).stdout.strip()
+        != before
+    )
 
     (repo / "README.md").write_text("ephemeral change\n", encoding="utf-8")
     subprocess.run(["git", "add", "README.md"], cwd=repo, check=True)

--- a/tests/unit/test_agent_write_preflight.py
+++ b/tests/unit/test_agent_write_preflight.py
@@ -44,6 +44,8 @@ def _install_configured_write_hook(repo: Path) -> None:
     scripts = repo / "scripts"
     scripts.mkdir()
     (scripts / SCRIPT.name).write_text(SCRIPT.read_text(encoding="utf-8"), encoding="utf-8")
+    guard = Path("scripts/agent_pre_commit_guard.sh")
+    (scripts / guard.name).write_text(guard.read_text(encoding="utf-8"), encoding="utf-8")
     (repo / ".pre-commit-config.yaml").write_text(
         "repos:\n"
         "  - repo: local\n"
@@ -138,7 +140,7 @@ def test_preflight_allows_non_primary_worktree(tmp_path: Path) -> None:
     assert "BenchBox write preflight OK" in result.stdout
 
 
-def test_configured_hook_refuses_primary_commit_before_object_and_preserves_declarations(tmp_path: Path) -> None:
+def test_configured_hook_allows_human_primary_commit_and_preserves_declarations(tmp_path: Path) -> None:
     repo = _init_clone(tmp_path / "BenchBox")
     _install_configured_write_hook(repo)
     before = subprocess.run(
@@ -147,8 +149,8 @@ def test_configured_hook_refuses_primary_commit_before_object_and_preserves_decl
     (repo / "README.md").write_text("primary change\n", encoding="utf-8")
     subprocess.run(["git", "add", "README.md", ".pre-commit-config.yaml", "scripts"], cwd=repo, check=True)
 
-    refused = subprocess.run(
-        ["git", "commit", "-m", "must refuse primary"],
+    human_commit = subprocess.run(
+        ["git", "commit", "-m", "human primary"],
         cwd=repo,
         env={**os.environ, **HUMAN_IDENTITY},
         capture_output=True,
@@ -156,15 +158,16 @@ def test_configured_hook_refuses_primary_commit_before_object_and_preserves_decl
         check=False,
     )
 
-    assert refused.returncode != 0
-    assert "Refusing BenchBox write preflight in the primary clone" in refused.stdout + refused.stderr
+    assert human_commit.returncode == 0, human_commit.stdout + human_commit.stderr
     assert (
         subprocess.run(
             ["git", "rev-parse", "HEAD"], cwd=repo, check=True, capture_output=True, text=True
         ).stdout.strip()
-        == before
+        != before
     )
 
+    (repo / "README.md").write_text("authorized primary\n", encoding="utf-8")
+    subprocess.run(["git", "add", "README.md"], cwd=repo, check=True)
     allowed = subprocess.run(
         ["git", "commit", "-m", "authorized primary"],
         cwd=repo,


### PR DESCRIPTION
## Summary
- close actionable review findings from recent open and merged PRs
- harden release, UAT certification, ClickHouse loading, and agent-write guards
- add regression coverage for each fix

## Validation
- `uv run -- python -m pytest tests/unit/ -x -q` — 27289 passed, 24 skipped
- focused follow-up tests — 438 passed
- Ruff, formatting, Makefile inventory, commit hooks, and push fast-lane checks passed

The repository PR preflight reached its lint-marker check but was blocked by another worktree holding the shared test lock; the full preflight log is retained locally.