### PR TITLE
feat(ci): collect trusted refresh-shadow evidence without skipping CI

### DIFF
--- a/.github/workflows/develop-refresh-shadow.yml
+++ b/.github/workflows/develop-refresh-shadow.yml
@@ -1,0 +1,392 @@
+name: Develop refresh shadow
+
+# Observational only. Never a required context. Never skips another workflow.
+# pull_request_target so the classifier script comes from the trusted base.
+# PR commits are fetched as Git objects only; they are never checked out.
+
+on:
+  pull_request_target:
+    branches:
+      - develop
+    types: [opened, reopened, synchronize, ready_for_review]
+
+concurrency:
+  group: develop-refresh-shadow-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  actions: read
+  pull-requests: read
+
+jobs:
+  refresh-shadow:
+    name: refresh-shadow
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout trusted base
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.base.sha }}
+          persist-credentials: false
+          fetch-depth: 0
+
+      - name: Fetch PR commits as Git objects
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          set -euo pipefail
+          git fetch --no-tags origin "pull/${PR_NUMBER}/head:refs/shadow/pr-head"
+          git fetch --no-tags origin "${{ github.event.pull_request.base.sha }}"
+
+      - name: Classify refresh in shadow mode
+        env:
+          GH_TOKEN: ${{ github.token }}
+          EVENT_ACTION: ${{ github.event.action }}
+          EVENT_BEFORE: ${{ github.event.before }}
+          EVENT_AFTER: ${{ github.event.after }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_REPO_ID: ${{ github.event.pull_request.head.repo.id }}
+          BASE_REPO_ID: ${{ github.event.pull_request.base.repo.id }}
+          IS_FORK: ${{ github.event.pull_request.head.repo.fork }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          set -euo pipefail
+          python - <<'PY'
+          import hashlib
+          import io
+          import json
+          import os
+          import subprocess
+          import time
+          import urllib.error
+          import urllib.request
+          import zipfile
+          from datetime import datetime, timezone
+          from pathlib import Path
+
+          started = time.monotonic()
+          collected_at = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+          def git(*args: str) -> str:
+              return subprocess.check_output(["git", *args], text=True).strip()
+
+          def api(path: str, accept: str = "application/vnd.github+json"):
+              req = urllib.request.Request(
+                  f"https://api.github.com{path}",
+                  headers={
+                      "Accept": accept,
+                      "Authorization": f"Bearer {os.environ['GH_TOKEN']}",
+                      "X-GitHub-Api-Version": "2022-11-28",
+                  },
+              )
+              try:
+                  with urllib.request.urlopen(req, timeout=30) as resp:
+                      return json.loads(resp.read().decode("utf-8"))
+              except (urllib.error.URLError, TimeoutError, OSError, json.JSONDecodeError):
+                  return {"_error": "request-failed"}
+
+          def is_git_sha(value: object) -> bool:
+              if not isinstance(value, str) or len(value) not in {40, 64}:
+                  return False
+              allowed = set("0123456789abcdefABCDEF")
+              return all(ch in allowed for ch in value) and set(value) != {"0"}
+
+          def commit_info(sha: str):
+              if not sha:
+                  return None
+              try:
+                  parents = [line for line in git("rev-parse", f"{sha}^@").splitlines() if line]
+                  tree = git("rev-parse", f"{sha}^{{tree}}")
+              except subprocess.CalledProcessError:
+                  return None
+              return {"sha": sha, "parents": parents, "tree": tree}
+
+          def parse_identity(raw):
+              if not isinstance(raw, dict):
+                  return None
+              kind = raw.get("certification_kind")
+              fingerprint = raw.get("workflow_fingerprint")
+              base = raw.get("base_sha")
+              head = raw.get("pr_head_sha")
+              if kind != "full":
+                  return None
+              if not isinstance(fingerprint, str) or len(fingerprint) != 64:
+                  return None
+              hex_digits = set("0123456789abcdefABCDEF")
+              if any(ch not in hex_digits for ch in fingerprint):
+                  return None
+              if not is_git_sha(base) or not is_git_sha(head):
+                  return None
+              return {
+                  "certification_kind": "full",
+                  "workflow_fingerprint": fingerprint.lower(),
+                  "base_sha": base,
+                  "pr_head_sha": head,
+              }
+
+          def load_identity_artifact(artifact_id: int):
+              # gh follows the artifact zip redirect and drops Authorization
+              # on the signed URL. urllib would forward the token and fail.
+              completed = subprocess.run(
+                  [
+                      "gh",
+                      "api",
+                      "-H",
+                      "Accept: application/vnd.github+json",
+                      f"repos/{repo}/actions/artifacts/{artifact_id}/zip",
+                  ],
+                  check=False,
+                  capture_output=True,
+              )
+              if completed.returncode != 0 or not completed.stdout.startswith(b"PK"):
+                  return None
+              try:
+                  with zipfile.ZipFile(io.BytesIO(completed.stdout)) as archive:
+                      for name in archive.namelist():
+                          if name.endswith(".json"):
+                              return parse_identity(json.loads(archive.read(name).decode("utf-8")))
+              except (zipfile.BadZipFile, json.JSONDecodeError, UnicodeDecodeError, OSError, ValueError):
+                  return None
+              return None
+
+          repo = os.environ["GITHUB_REPOSITORY"]
+          ruleset = api("/repos/{0}/rulesets/15611785".format(repo))
+          contexts = []
+          if isinstance(ruleset, dict) and "_error" not in ruleset:
+              for rule in ruleset.get("rules") or []:
+                  if rule.get("type") == "required_status_checks":
+                      for check in (rule.get("parameters") or {}).get("required_status_checks") or []:
+                          if check.get("context"):
+                              contexts.append(str(check["context"]))
+
+          head = os.environ.get("HEAD_SHA") or ""
+          before = os.environ.get("EVENT_BEFORE") or ""
+          base = os.environ.get("BASE_SHA") or ""
+          after = os.environ.get("EVENT_AFTER") or ""
+          commits = {}
+          for sha in (head, before, base):
+              info = commit_info(sha)
+              if info:
+                  commits[sha] = info
+
+          merge_tree = None
+          merge_tree_error = None
+          if before and base:
+              completed = subprocess.run(
+                  ["git", "merge-tree", "--write-tree", before, base],
+                  check=False,
+                  text=True,
+                  capture_output=True,
+              )
+              if completed.returncode == 0:
+                  merge_tree = completed.stdout.strip() or None
+              else:
+                  merge_tree_error = "merge-tree-failed"
+
+          check_payload = api(f"/repos/{repo}/commits/{before}/check-runs?per_page=100") if before else {}
+          raw_checks = check_payload.get("check_runs") if isinstance(check_payload, dict) else None
+          check_runs = []
+          run_ids = set()
+          if isinstance(raw_checks, list):
+              for item in raw_checks:
+                  html = str(item.get("html_url") or "")
+                  run_id = None
+                  if "/actions/runs/" in html:
+                      try:
+                          run_id = int(html.split("/actions/runs/")[1].split("/")[0])
+                          run_ids.add(run_id)
+                      except (IndexError, ValueError):
+                          run_id = None
+                  check_runs.append({
+                      "id": item.get("id") or 0,
+                      "name": item.get("name") or "",
+                      "status": item.get("status") or "",
+                      "conclusion": item.get("conclusion") or "",
+                      "started_at": item.get("started_at") or "",
+                      "head_sha": item.get("head_sha") or "",
+                      "run_id": run_id,
+                  })
+
+          wf_files = [
+              ".github/workflows/pr.yml",
+              ".github/workflows/results-explorer-browser.yml",
+              ".github/workflows/develop-ruleset-drift.yml",
+          ]
+          entries = {}
+          for path in wf_files:
+              data = Path(path).read_bytes() if Path(path).is_file() else b""
+              entries[path] = hashlib.sha256(data).hexdigest()
+          fingerprint = hashlib.sha256(
+              "\n".join(f"{path}={entries[path]}" for path in sorted(entries)).encode()
+          ).hexdigest()
+
+          run_meta = {}
+          identity_by_head = {}
+          for run_id in sorted(run_ids):
+              run = api(f"/repos/{repo}/actions/runs/{run_id}")
+              if not isinstance(run, dict) or run.get("_error"):
+                  continue
+              arts = api(f"/repos/{repo}/actions/runs/{run_id}/artifacts")
+              artifacts = arts.get("artifacts") if isinstance(arts, dict) else None
+              names = []
+              identity = None
+              if isinstance(artifacts, list):
+                  for artifact in artifacts:
+                      name = artifact.get("name")
+                      if name:
+                          names.append(name)
+                      if name == "pr-certification-identity" and artifact.get("id"):
+                          identity = load_identity_artifact(int(artifact["id"]))
+              run_head = str(run.get("head_sha") or "")
+              run_meta[run_id] = {
+                  "id": run.get("id") or run_id,
+                  "name": run.get("name") or "",
+                  "path": run.get("path") or "",
+                  "head_sha": run_head,
+                  "event": run.get("event") or "",
+                  "artifact_names": names,
+                  "identity": identity,
+              }
+              if (
+                  identity
+                  and "pr-certification-identity" in names
+                  and "pr-certification-lanes" in names
+              ):
+                  identity_by_head[identity["pr_head_sha"]] = identity
+
+          actions_runs = []
+          for run_id in sorted(run_meta):
+              info = run_meta[run_id]
+              identity = identity_by_head.get(info["head_sha"])
+              if identity:
+                  kind = "full"
+                  run_fingerprint = identity["workflow_fingerprint"]
+                  run_base = identity["base_sha"]
+              else:
+                  kind = ""
+                  run_fingerprint = ""
+                  run_base = ""
+              actions_runs.append({
+                  "id": info["id"],
+                  "name": info["name"],
+                  "path": info["path"],
+                  "head_sha": info["head_sha"],
+                  "event": info["event"],
+                  "certification_kind": kind,
+                  "workflow_fingerprint": run_fingerprint,
+                  "base_sha": run_base,
+              })
+
+          pr = api(f"/repos/{repo}/pulls/{os.environ['PR_NUMBER']}")
+          current_head = ""
+          current_base = ""
+          if isinstance(pr, dict) and "_error" not in pr:
+              current_head = str((pr.get("head") or {}).get("sha") or "")
+              current_base = str((pr.get("base") or {}).get("sha") or "")
+
+          authored = None
+          intervening = None
+          try:
+              if base and head:
+                  authored = [line for line in git("diff", "--name-only", f"{base}...{head}").splitlines() if line]
+              if before and base:
+                  intervening = [line for line in git("diff", "--name-only", f"{before}...{base}").splitlines() if line]
+          except subprocess.CalledProcessError:
+              authored = None
+              intervening = None
+
+          request = {
+              "action": os.environ.get("EVENT_ACTION") or "",
+              "before": before,
+              "after": after,
+              "head_sha": head,
+              "base_sha": base,
+              "current_head_sha": current_head or head,
+              "current_base_sha": current_base or base,
+              "head_repo_id": int(os.environ["HEAD_REPO_ID"]) if os.environ.get("HEAD_REPO_ID") else None,
+              "base_repo_id": int(os.environ["BASE_REPO_ID"]) if os.environ.get("BASE_REPO_ID") else None,
+              "is_fork": os.environ.get("IS_FORK") == "true",
+              "pr_number": int(os.environ["PR_NUMBER"]),
+              "synthetic_merge_sha": "",
+              "required_contexts": contexts,
+              "commits": commits,
+              "merge_tree": merge_tree,
+              "merge_tree_error": merge_tree_error,
+              "check_runs": check_runs,
+              "actions_runs": actions_runs,
+              "current_workflow_fingerprint": fingerprint,
+              "authored_paths": authored,
+              "intervening_paths": intervening,
+          }
+          Path("/tmp/shadow-request.json").write_text(json.dumps(request), encoding="utf-8")
+          duration_ms = int((time.monotonic() - started) * 1000)
+          Path("/tmp/shadow-timing.json").write_text(
+              json.dumps({"collected_at": collected_at, "duration_ms": duration_ms}),
+              encoding="utf-8",
+          )
+          PY
+          if [ ! -f scripts/pr_refresh_certification.py ]; then
+            printf '%s\n' '{"decision":"full_required","reasons":["missing_path_evidence"],"version":1}' > shadow-decision.json
+          else
+            python scripts/pr_refresh_certification.py --input /tmp/shadow-request.json --json-out shadow-decision.json
+          fi
+          python - <<'PY'
+          import json
+          import os
+          from pathlib import Path
+
+          decision = json.loads(Path("shadow-decision.json").read_text(encoding="utf-8"))
+          timing = {}
+          timing_path = Path("/tmp/shadow-timing.json")
+          if timing_path.is_file():
+              timing = json.loads(timing_path.read_text(encoding="utf-8"))
+          record = {
+              "decision": decision.get("decision"),
+              "reasons": decision.get("reasons") or [],
+              "pr_number": decision.get("pr_number"),
+              "feature_head": decision.get("feature_head"),
+              "tested_base_sha": decision.get("tested_base_sha"),
+              "parent1": decision.get("parent1"),
+              "parent2": decision.get("parent2"),
+              "required_contexts": decision.get("required_contexts") or [],
+              "check_run_ids": decision.get("check_run_ids") or {},
+              "actions_run_ids": decision.get("actions_run_ids") or {},
+              "workflow_fingerprint": decision.get("workflow_fingerprint"),
+              "certification_kind": decision.get("certification_kind"),
+              "version": decision.get("version"),
+              "event_action": os.environ.get("EVENT_ACTION") or "",
+              "collected_at": timing.get("collected_at"),
+              "duration_ms": timing.get("duration_ms"),
+          }
+          Path("shadow-decision.json").write_text(
+              json.dumps(record, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+          )
+          summary = os.environ.get("GITHUB_STEP_SUMMARY")
+          if summary:
+              reasons = ",".join(record["reasons"]) or "(none)"
+              Path(summary).open("a", encoding="utf-8").write(
+                  "\n".join(
+                      [
+                          "### Refresh shadow classification",
+                          "",
+                          f"- Decision: `{record['decision']}`",
+                          f"- Reasons: `{reasons}`",
+                          f"- Duration: `{record.get('duration_ms')} ms`",
+                          "- This record is not a required check and cannot skip CI.",
+                          "",
+                      ]
+                  )
+              )
+          PY
+
+      - name: Upload shadow decision
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: refresh-shadow-${{ github.event.pull_request.number }}-${{ github.run_attempt }}
+          path: shadow-decision.json
+          if-no-files-found: warn
+          retention-days: 30

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1164,6 +1164,73 @@ jobs:
             make audit-sha-check FILE="$audit_path" AUDIT_SHA_TARGET_REF="origin/${{ github.base_ref }}"
           done < /tmp/changed-audits.txt
 
+  certification-identity:
+    name: certification-identity
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Record certification identity
+        env:
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          SYNTHETIC_MERGE_SHA: ${{ github.sha }}
+          RUN_ID: ${{ github.run_id }}
+        run: |
+          set -euo pipefail
+          python - <<'PY'
+          import hashlib
+          import json
+          import os
+          import subprocess
+          from pathlib import Path
+
+          def git(*args: str) -> str:
+              return subprocess.check_output(["git", *args], text=True).strip()
+
+          head = os.environ["HEAD_SHA"]
+          base = os.environ["BASE_SHA"]
+          merge = os.environ["SYNTHETIC_MERGE_SHA"]
+          files = [
+              ".github/workflows/pr.yml",
+              ".github/workflows/results-explorer-browser.yml",
+              ".github/workflows/develop-ruleset-drift.yml",
+          ]
+          entries = {}
+          for path in files:
+              data = Path(path).read_bytes() if Path(path).is_file() else b""
+              entries[path] = hashlib.sha256(data).hexdigest()
+          fingerprint = hashlib.sha256(
+              "\n".join(f"{path}={entries[path]}" for path in sorted(entries)).encode()
+          ).hexdigest()
+          record = {
+              "pr_head_sha": head,
+              "base_sha": base,
+              "synthetic_merge_sha": merge,
+              "synthetic_merge_tree": git("rev-parse", "HEAD^{tree}"),
+              "workflow_fingerprint": fingerprint,
+              "run_id": int(os.environ["RUN_ID"]),
+              "certification_kind": "full",
+          }
+          Path("pr-certification-identity.json").write_text(
+              json.dumps(record, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+          )
+          PY
+
+      - name: Upload certification identity
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: pr-certification-identity
+          path: pr-certification-identity.json
+          if-no-files-found: warn
+          retention-days: 30
+
   ci-required-result:
     name: ci-required-result
     needs: [ci-paths, content-guard, code-lint, code-test, correctness-gate, plan-capture-gate, medium-test, explorer-tokens, site-theme-tokens, explorer-vitest, audit-sha, package-smoke, dependency-audit, parity-check]
@@ -1283,3 +1350,68 @@ jobs:
 
           echo "code-lint=$LINT_RESULT code-test=$TEST_RESULT correctness-gate=$CORRECTNESS_RESULT plan-capture-gate=$PLAN_CAPTURE_RESULT medium-test=$MEDIUM_TEST_RESULT"
           exit 1
+
+      - name: Record certification lane evidence
+        if: always()
+        env:
+          CI_PATHS_RESULT: ${{ needs.ci-paths.result }}
+          CONTENT_RESULT: ${{ needs.content-guard.result }}
+          LINT_RESULT: ${{ needs.code-lint.result }}
+          TEST_RESULT: ${{ needs.code-test.result }}
+          CORRECTNESS_RESULT: ${{ needs.correctness-gate.result }}
+          PLAN_CAPTURE_RESULT: ${{ needs.plan-capture-gate.result }}
+          MEDIUM_TEST_RESULT: ${{ needs.medium-test.result }}
+          EXPLORER_TOKENS_RESULT: ${{ needs.explorer-tokens.result }}
+          SITE_THEME_TOKENS_RESULT: ${{ needs.site-theme-tokens.result }}
+          EXPLORER_VITEST_RESULT: ${{ needs.explorer-vitest.result }}
+          AUDIT_SHA_RESULT: ${{ needs.audit-sha.result }}
+          PACKAGE_SMOKE_RESULT: ${{ needs.package-smoke.result }}
+          DEPENDENCY_AUDIT_RESULT: ${{ needs.dependency-audit.result }}
+          PARITY_CHECK_RESULT: ${{ needs.parity-check.result }}
+          NEEDS_CODE_CI: ${{ needs.ci-paths.outputs.needs-code-ci }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          RUN_ID: ${{ github.run_id }}
+        run: |
+          set -euo pipefail
+          python - <<'PY'
+          import json
+          import os
+          from pathlib import Path
+
+          record = {
+              "run_id": int(os.environ["RUN_ID"]),
+              "pr_head_sha": os.environ.get("HEAD_SHA") or "",
+              "base_sha": os.environ.get("BASE_SHA") or "",
+              "needs_code_ci": os.environ.get("NEEDS_CODE_CI") or "",
+              "lanes": {
+                  "ci-paths": os.environ.get("CI_PATHS_RESULT") or "",
+                  "content-guard": os.environ.get("CONTENT_RESULT") or "",
+                  "code-lint": os.environ.get("LINT_RESULT") or "",
+                  "code-test": os.environ.get("TEST_RESULT") or "",
+                  "correctness-gate": os.environ.get("CORRECTNESS_RESULT") or "",
+                  "plan-capture-gate": os.environ.get("PLAN_CAPTURE_RESULT") or "",
+                  "medium-test": os.environ.get("MEDIUM_TEST_RESULT") or "",
+                  "explorer-tokens": os.environ.get("EXPLORER_TOKENS_RESULT") or "",
+                  "site-theme-tokens": os.environ.get("SITE_THEME_TOKENS_RESULT") or "",
+                  "explorer-vitest": os.environ.get("EXPLORER_VITEST_RESULT") or "",
+                  "audit-sha": os.environ.get("AUDIT_SHA_RESULT") or "",
+                  "package-smoke": os.environ.get("PACKAGE_SMOKE_RESULT") or "",
+                  "dependency-audit": os.environ.get("DEPENDENCY_AUDIT_RESULT") or "",
+                  "parity-check": os.environ.get("PARITY_CHECK_RESULT") or "",
+              },
+          }
+          Path("pr-certification-lanes.json").write_text(
+              json.dumps(record, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+          )
+          PY
+
+      - name: Upload certification lane evidence
+        if: always()
+        continue-on-error: true
+        uses: actions/upload-artifact@v4
+        with:
+          name: pr-certification-lanes
+          path: pr-certification-lanes.json
+          if-no-files-found: warn
+          retention-days: 30

--- a/docs/operations/repo-admin-settings.md
+++ b/docs/operations/repo-admin-settings.md
@@ -97,6 +97,17 @@ two PRs can each pass against the same older base and exceed an invariant when
 merged in sequence. The tradeoff is deliberate: when `develop` advances, an
 otherwise-green PR must refresh its required checks before it can merge.
 
+`refresh-shadow` (added with the strict-base refresh shadow rollout) is the
+observational job in `.github/workflows/develop-refresh-shadow.yml`. It is
+**not a required** context. It classifies exact `develop` refreshes using the
+trusted base copy of `scripts/pr_refresh_certification.py` and publishes a
+bounded artifact. It cannot skip Develop PR lanes, cannot satisfy
+`ci-required-result`, and does not change auto-merge or ruleset 15611785.
+`.github/workflows/pr.yml` also uploads `pr-certification-identity` and
+`pr-certification-lanes` artifacts so a later activation gate can bind a full
+run to a specific head, base, merge tree, workflow fingerprint, and lane
+set. Missing artifacts fail closed to `full_required`.
+
 Verify:
 
 ```bash

--- a/tests/unit/workflows/test_pr_refresh_shadow_workflow.py
+++ b/tests/unit/workflows/test_pr_refresh_shadow_workflow.py
@@ -1,0 +1,112 @@
+"""Trust and permission contracts for the refresh-shadow workflow."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+import yaml
+
+pytestmark = [pytest.mark.unit, pytest.mark.fast]
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+SHADOW = REPO_ROOT / ".github" / "workflows" / "develop-refresh-shadow.yml"
+PR_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "pr.yml"
+ADMIN = REPO_ROOT / "docs" / "operations" / "repo-admin-settings.md"
+
+
+def _triggers(workflow: dict[str, Any]) -> dict[str, Any]:
+    triggers = workflow.get("on", workflow.get(True))
+    assert triggers is not None
+    return triggers
+
+
+@pytest.fixture(scope="module")
+def workflow() -> dict[str, Any]:
+    return yaml.safe_load(SHADOW.read_text(encoding="utf-8"))
+
+
+def test_shadow_uses_pull_request_target_and_is_not_required(workflow: dict[str, Any]) -> None:
+    triggers = _triggers(workflow)
+    assert "pull_request_target" in triggers
+    assert triggers["pull_request_target"]["branches"] == ["develop"]
+    text = SHADOW.read_text(encoding="utf-8")
+    assert "ci-required-result" not in text
+    assert "Results Explorer browser gate" not in text
+    admin = ADMIN.read_text(encoding="utf-8")
+    assert "refresh-shadow" in admin
+    assert "not a required" in admin.lower() or "observational" in admin.lower()
+    required_block = admin.split("Required status checks:", 1)[1].split("```text", 1)[1].split("```", 1)[0]
+    assert "refresh-shadow" not in required_block
+
+
+def test_shadow_permissions_are_read_only(workflow: dict[str, Any]) -> None:
+    perms = workflow["permissions"]
+    assert perms == {
+        "contents": "read",
+        "actions": "read",
+        "pull-requests": "read",
+    }
+    assert "write" not in yaml.safe_dump(perms)
+
+
+def test_shadow_checks_out_trusted_base_only(workflow: dict[str, Any]) -> None:
+    job = workflow["jobs"]["refresh-shadow"]
+    checkout = next(step for step in job["steps"] if str(step.get("uses", "")).startswith("actions/checkout@"))
+    assert checkout["with"]["ref"] == "${{ github.event.pull_request.base.sha }}"
+    assert checkout["with"]["persist-credentials"] is False
+    text = SHADOW.read_text(encoding="utf-8")
+    checkout_region = text.split("actions/checkout", 1)[-1].split("Fetch PR commits", 1)[0]
+    assert "pull_request.head.sha" not in checkout_region
+    assert "ref: ${{ github.event.pull_request.head.sha }}" not in text
+    assert "ref: ${{ github.sha }}" not in text
+
+
+def test_shadow_does_not_skip_or_replace_required_pr_lanes() -> None:
+    pr = yaml.safe_load(PR_WORKFLOW.read_text(encoding="utf-8"))
+    required = pr["jobs"]["ci-required-result"]["needs"]
+    for name in (
+        "ci-paths",
+        "content-guard",
+        "code-lint",
+        "code-test",
+        "correctness-gate",
+        "plan-capture-gate",
+        "medium-test",
+    ):
+        assert name in required
+    lint_if = pr["jobs"]["code-lint"]["if"]
+    test_if = pr["jobs"]["code-test"]["if"]
+    assert "refresh" not in lint_if
+    assert "refresh" not in test_if
+    assert "shadow" not in lint_if
+    assert "shadow" not in test_if
+
+
+def test_shadow_collector_fail_closes_without_inventing_prior_identity(workflow: dict[str, Any]) -> None:
+    text = SHADOW.read_text(encoding="utf-8")
+    assert "pr-certification-identity" in text
+    assert "pr-certification-lanes" in text
+    assert "actions/artifacts/" in text
+    assert "gh" in text and "api" in text
+    assert "scripts/pr_refresh_certification.py" in text
+    assert "missing_path_evidence" in text
+    classify = next(
+        step
+        for step in workflow["jobs"]["refresh-shadow"]["steps"]
+        if step.get("name") == "Classify refresh in shadow mode"
+    )
+    assert "contents: write" not in yaml.safe_dump(classify)
+
+
+def test_shadow_uploads_bounded_decision_artifact(workflow: dict[str, Any]) -> None:
+    upload = next(
+        step for step in workflow["jobs"]["refresh-shadow"]["steps"] if step.get("name") == "Upload shadow decision"
+    )
+    assert upload["if"] == "always()"
+    assert upload["with"]["path"] == "shadow-decision.json"
+    assert "refresh-shadow-" in str(upload["with"]["name"])
+    text = SHADOW.read_text(encoding="utf-8")
+    assert "duration_ms" in text
+    assert "This record is not a required check" in text

--- a/tests/unit/workflows/test_pr_workflow_outputs.py
+++ b/tests/unit/workflows/test_pr_workflow_outputs.py
@@ -1,0 +1,66 @@
+"""Pin Develop PR required-lane outputs after shadow evidence was added."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+import yaml
+
+pytestmark = [pytest.mark.unit, pytest.mark.fast]
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+PR_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "pr.yml"
+
+
+@pytest.fixture(scope="module")
+def workflow() -> dict[str, Any]:
+    return yaml.safe_load(PR_WORKFLOW.read_text(encoding="utf-8"))
+
+
+def test_required_umbrella_jobs_are_unchanged(workflow: dict[str, Any]) -> None:
+    needs = workflow["jobs"]["ci-required-result"]["needs"]
+    assert needs == [
+        "ci-paths",
+        "content-guard",
+        "code-lint",
+        "code-test",
+        "correctness-gate",
+        "plan-capture-gate",
+        "medium-test",
+        "explorer-tokens",
+        "site-theme-tokens",
+        "explorer-vitest",
+        "audit-sha",
+        "package-smoke",
+        "dependency-audit",
+        "parity-check",
+    ]
+
+
+def test_code_lanes_still_path_gated_only(workflow: dict[str, Any]) -> None:
+    expected = "${{ needs.ci-paths.outputs.needs-code-ci == 'true' }}"
+    for job_id in ("code-lint", "code-test", "correctness-gate", "plan-capture-gate", "medium-test"):
+        assert workflow["jobs"][job_id]["if"] == expected
+
+
+def test_certification_identity_is_observational(workflow: dict[str, Any]) -> None:
+    job = workflow["jobs"]["certification-identity"]
+    assert "if" not in job
+    assert "certification-identity" not in workflow["jobs"]["ci-required-result"]["needs"]
+    names = [step.get("name") for step in job["steps"]]
+    assert "Record certification identity" in names
+    checkout = next(step for step in job["steps"] if str(step.get("uses", "")).startswith("actions/checkout@"))
+    assert checkout["with"]["persist-credentials"] is False
+
+
+def test_lane_evidence_cannot_fail_the_required_umbrella(workflow: dict[str, Any]) -> None:
+    steps = workflow["jobs"]["ci-required-result"]["steps"]
+    record = next(step for step in steps if step.get("name") == "Record certification lane evidence")
+    evidence = next(step for step in steps if step.get("name") == "Upload certification lane evidence")
+    assert record.get("if") == "always()"
+    assert evidence.get("if") == "always()"
+    assert evidence.get("continue-on-error") is True
+    assert "pr-certification-lanes.json" in record["run"]
+    assert evidence["with"]["name"] == "pr-certification-lanes"


### PR DESCRIPTION
Add a pull_request_target shadow classifier and full-run identity
artifacts. Required contexts and lane if-conditions stay unchanged.
Missing prior artifacts fail closed to full_required.
