### PR TITLE
feat(ci): replay refresh history and prove classifier fail-closed

### DIFF
--- a/_project/audits/strict-base-refresh-replay-2026-08-14.md
+++ b/_project/audits/strict-base-refresh-replay-2026-08-14.md
@@ -1,0 +1,103 @@
+---
+date: 2026-08-14
+develop_sha: c72ee4efd5a73ed86e07bef3731c657067f330eb
+measured_at_sha: c72ee4efd5a73ed86e07bef3731c657067f330eb
+checked_sha: c72ee4efd5a73ed86e07bef3731c657067f330eb
+---
+
+# Strict-base refresh replay and negative controls
+
+This report is evidence for
+`strict-base-refresh-03-historical-replay-and-negative-controls`.
+It does not authorize skip behavior. Activation remains
+`strict-base-refresh-06-activation-decision-and-selected-path-handoff`.
+
+Observed tip: `origin/develop` `c72ee4efd5a73ed86e07bef3731c657067f330eb`
+(#1738, shadow workflows on `develop`).
+
+## Window and method
+
+- Window: merged `develop` PRs since 2026-08-13 (strict current-base lock, #1708).
+- Refresh-like event: a PR commit with exactly two parents.
+- Replay: `scripts/pr_refresh_replay.py` over normalized fixtures. No hosted
+  workflow was rerun, cancelled, or altered.
+- Required-gate and all-workflow measures are reported separately.
+- Identity artifacts did not exist before #1738, so live historical requests
+  fail closed. That fallback stays in the denominator.
+
+## Inventory
+
+27 merged PRs in the window. 6 PRs contained 10 two-parent commits.
+
+Every sampled synchronize fanned out at least: Auto-merge revocation,
+Develop PR, Documentation, Orphaned Commit Detector, PR base guard, and
+Results Explorer browser tests. `Develop ruleset drift` appears after #1722
+and is a required context.
+
+Required contexts across the window: `ci-required-result`,
+`Results Explorer browser gate`, and later `ruleset-drift`.
+
+| PR | Two-parent commits | Required umbrella |
+|---|---|---|
+| 1732 | 4 | 3 success; 1 cancelled `medium-test` / failed umbrella |
+| 1721 | 1 | success |
+| 1719 | 1 | success |
+| 1712 | 1 | cancelled `test` and `medium-test` / failed umbrella |
+| 1711 | 1 | success; lint/test/medium skipped (docs) |
+| 1708 | 2 | 1 cancelled `medium-test`; 1 success |
+
+## Replay result
+
+Normalized fixtures under `tests/fixtures/ci/pr-refresh-replay/` replay
+through the classifier. The eligible fixture is `shadow_eligible`. Historical
+and negative fixtures are `full_required`.
+
+| Class | Decision | Full-only failure? |
+|---|---|---|
+| Eligible exact refresh | `shadow_eligible` | no |
+| Historical cancelled medium (no identity artifacts) | `full_required` (`prior_check_unbound`) | no |
+| Fork, chained refresh, self-change, merge-driver, semantic schema, head-drift race, malformed | `full_required` | no |
+
+`full-only` means the classifier would have waived long lanes while those
+lanes actually failed on the recorded full run. This window has **zero**
+full-only failures: the cancelled refreshes are not `shadow_eligible`
+because prior full-certification artifacts were absent.
+
+Hit rate on the fixture set is not an activation number. Discarding
+fallback reasons from the denominator would make a classifier that always
+returns full look useful. Every fallback reason above stays counted.
+
+## Latency and runner-minute split
+
+`pr.yml` required-gate time is not whole-event cost. A synchronize also
+starts Documentation, browser tests, ruleset-drift, PR base guard,
+orphaned-commit detection, and auto-merge revocation.
+
+- Required-gate: the merge-unblock wall is still `medium-test` on code PRs
+  (about 26–31 minutes on recent #1732 / #1734 / #1738 refreshes).
+- All-workflow: the same event also spends Documentation and other
+  non-required runner-minutes. Those minutes are not saved by skipping
+  `medium-test` alone.
+- Cancelled refreshes waste runner-minutes without producing a certified
+  tree. They are not skip-safety evidence.
+
+## Confidence and limitation
+
+This sample is small (10 refresh-like commits, one week). No sample-size
+threshold alone authorizes activation. Shadow parity after #1738 will
+observe live classify decisions; it still does not prove skipped-lane
+safety. Semantic, metadata, merge-driver, chained-refresh, fork, race,
+self-change, and malformed-evidence controls are fixture-proven, not
+production-incident-proven.
+
+Limitation: pre-#1738 history cannot produce `shadow_eligible` because
+`pr-certification-identity` / `pr-certification-lanes` did not exist.
+Post-#1738 shadow records are the next evidence layer, not this item's
+activation gate.
+
+## Activation implication
+
+Keep `SHADOW_ONLY` available. Do not treat this replay as permission to
+skip lint, typecheck, or long test lanes. A later decision may choose
+`SHADOW_ONLY`, `REDUCED_FAST_REFRESH`, or `NATIVE_MERGE_QUEUE` only after
+live shadow yield and any full-only failures are re-measured.

--- a/scripts/pr_refresh_replay.py
+++ b/scripts/pr_refresh_replay.py
@@ -1,0 +1,221 @@
+#!/usr/bin/env python3
+"""Deterministic replay of recorded refresh events through the classifier.
+
+Evidence generation only. This module never skips a CI job and never
+publishes a required status. Callers inject recorded PR, check-run, and
+Actions-run data so unit tests do not touch the network.
+"""
+
+import argparse
+import json
+import statistics
+import sys
+from dataclasses import asdict, dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Mapping
+
+from pr_refresh_certification import (
+    DECISION_FULL,
+    DECISION_SHADOW,
+    classify,
+    request_from_mapping,
+)
+
+FULL_LANE_NAMES = (
+    "code-lint",
+    "code-test",
+    "correctness-gate",
+    "plan-capture-gate",
+    "medium-test",
+)
+
+
+@dataclass
+class ReplayResult:
+    record_id: str
+    pr_number: int | None
+    decision: str
+    reasons: list[str] = field(default_factory=list)
+    actual_full_lanes_failed: list[str] = field(default_factory=list)
+    full_only_failure: bool = False
+    required_gate_seconds: float | None = None
+    all_workflow_seconds: float | None = None
+    runner_minutes: float | None = None
+
+
+@dataclass
+class ReplaySummary:
+    records: int
+    shadow_eligible: int
+    full_required: int
+    eligibility_yield: float
+    full_only_failures: int
+    reason_counts: dict[str, int]
+    required_gate_p50: float | None
+    required_gate_p95: float | None
+    all_workflow_p50: float | None
+    runner_minutes_total: float | None
+
+
+def _as_float(value: object) -> float | None:
+    if value is None or value == "":
+        return None
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _failed_lanes(raw: Mapping[str, Any]) -> list[str]:
+    lanes = raw.get("actual_lane_conclusions") or {}
+    if not isinstance(lanes, Mapping):
+        return []
+    failed: list[str] = []
+    for name in FULL_LANE_NAMES:
+        conclusion = str(lanes.get(name) or "").lower()
+        if conclusion in {"failure", "timed_out", "cancelled"}:
+            failed.append(name)
+    return failed
+
+
+def normalize_record(raw: Mapping[str, Any]) -> dict[str, Any]:
+    """Copy a recorded event into the classifier request shape."""
+
+    request = raw.get("request") if isinstance(raw.get("request"), Mapping) else raw
+    if not isinstance(request, Mapping):
+        raise TypeError("record must be a mapping or contain a request mapping")
+    return dict(request)
+
+
+def replay_record(raw: Mapping[str, Any]) -> ReplayResult:
+    record_id = str(raw.get("id") or raw.get("record_id") or raw.get("pr_number") or "unknown")
+    try:
+        request = request_from_mapping(normalize_record(raw))
+        decision = classify(request)
+    except (AttributeError, TypeError, ValueError, KeyError):
+        return ReplayResult(
+            record_id=record_id,
+            pr_number=int(raw["pr_number"]) if raw.get("pr_number") else None,
+            decision=DECISION_FULL,
+            reasons=["malformed_payload"],
+        )
+    failed = _failed_lanes(raw)
+    return ReplayResult(
+        record_id=record_id,
+        pr_number=decision.pr_number,
+        decision=decision.decision,
+        reasons=list(decision.reasons),
+        actual_full_lanes_failed=failed,
+        full_only_failure=bool(failed) and decision.decision == DECISION_SHADOW,
+        required_gate_seconds=_as_float(raw.get("required_gate_seconds")),
+        all_workflow_seconds=_as_float(raw.get("all_workflow_seconds")),
+        runner_minutes=_as_float(raw.get("runner_minutes")),
+    )
+
+
+def _percentile(values: list[float], pct: float) -> float | None:
+    if not values:
+        return None
+    if len(values) == 1:
+        return values[0]
+    ordered = sorted(values)
+    if pct >= 95 and len(ordered) >= 2:
+        return ordered[-1]
+    return statistics.median(ordered) if pct == 50 else ordered[min(len(ordered) - 1, int(len(ordered) * pct / 100))]
+
+
+def summarize(results: list[ReplayResult]) -> ReplaySummary:
+    shadow = [item for item in results if item.decision == DECISION_SHADOW]
+    full = [item for item in results if item.decision == DECISION_FULL]
+    reasons: dict[str, int] = {}
+    for item in results:
+        for reason in item.reasons or ["(none)"]:
+            reasons[reason] = reasons.get(reason, 0) + 1
+    gate = [item.required_gate_seconds for item in results if item.required_gate_seconds is not None]
+    whole = [item.all_workflow_seconds for item in results if item.all_workflow_seconds is not None]
+    minutes = [item.runner_minutes for item in results if item.runner_minutes is not None]
+    total = len(results)
+    return ReplaySummary(
+        records=total,
+        shadow_eligible=len(shadow),
+        full_required=len(full),
+        eligibility_yield=(len(shadow) / total) if total else 0.0,
+        full_only_failures=sum(1 for item in results if item.full_only_failure),
+        reason_counts=dict(sorted(reasons.items())),
+        required_gate_p50=_percentile(gate, 50),
+        required_gate_p95=_percentile(gate, 95),
+        all_workflow_p50=_percentile(whole, 50),
+        runner_minutes_total=sum(minutes) if minutes else None,
+    )
+
+
+def load_records(path: Path) -> list[dict[str, Any]]:
+    if path.is_dir():
+        files = sorted(p for p in path.glob("*.json") if p.is_file())
+        records = [json.loads(item.read_text(encoding="utf-8")) for item in files]
+    else:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+        records = payload if isinstance(payload, list) else [payload]
+    return [item for item in records if isinstance(item, dict)]
+
+
+def completeness_errors(records: list[Mapping[str, Any]], results: list[ReplayResult]) -> list[str]:
+    errors: list[str] = []
+    if len(records) != len(results):
+        errors.append(f"record/result count mismatch: {len(records)} vs {len(results)}")
+    for raw, result in zip(records, results):
+        record_id = str(raw.get("id") or result.record_id)
+        if result.decision not in {DECISION_SHADOW, DECISION_FULL}:
+            errors.append(f"{record_id}: unclassified decision {result.decision!r}")
+        lanes = raw.get("actual_lane_conclusions")
+        if not isinstance(lanes, Mapping):
+            errors.append(f"{record_id}: missing actual_lane_conclusions")
+            continue
+        missing = [name for name in FULL_LANE_NAMES if name not in lanes]
+        if missing:
+            errors.append(f"{record_id}: missing lane outcomes {missing}")
+    return errors
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--input", type=Path, help="Record JSON file or directory")
+    parser.add_argument("--fixtures", type=Path, help="Alias for --input")
+    parser.add_argument("--json-out", type=Path, help="Write replay summary JSON")
+    parser.add_argument(
+        "--check-completeness",
+        action="store_true",
+        help="Fail unless every record has a decision and full-lane outcomes",
+    )
+    args = parser.parse_args(argv)
+    source = args.fixtures or args.input
+    if source is None:
+        parser.error("one of --input or --fixtures is required")
+    records = load_records(source)
+    results = [replay_record(item) for item in records]
+    summary = summarize(results)
+    payload = {
+        "summary": asdict(summary),
+        "results": [asdict(item) for item in results],
+        "generated_at": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+    }
+    if args.check_completeness:
+        errors = completeness_errors(records, results)
+        payload["completeness_errors"] = errors
+        if errors:
+            sys.stderr.write("unclassified or incomplete records:\n")
+            for error in errors:
+                sys.stderr.write(f"  {error}\n")
+            if args.json_out:
+                args.json_out.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+            return 1
+    text = json.dumps(payload, indent=2, sort_keys=True) + "\n"
+    if args.json_out:
+        args.json_out.write_text(text, encoding="utf-8")
+    sys.stdout.write(text)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/fixtures/ci/pr-refresh-replay/eligible-refresh.json
+++ b/tests/fixtures/ci/pr-refresh-replay/eligible-refresh.json
@@ -1,0 +1,120 @@
+{
+  "id": "fixture-eligible-refresh",
+  "pr_number": 1717,
+  "request": {
+    "action": "synchronize",
+    "before": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    "after": "dddddddddddddddddddddddddddddddddddddddd",
+    "head_sha": "dddddddddddddddddddddddddddddddddddddddd",
+    "base_sha": "cccccccccccccccccccccccccccccccccccccccc",
+    "current_head_sha": "dddddddddddddddddddddddddddddddddddddddd",
+    "current_base_sha": "cccccccccccccccccccccccccccccccccccccccc",
+    "head_repo_id": 1,
+    "base_repo_id": 1,
+    "is_fork": false,
+    "pr_number": 1717,
+    "synthetic_merge_sha": "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
+    "required_contexts": [
+      "ci-required-result",
+      "Results Explorer browser gate",
+      "ruleset-drift"
+    ],
+    "commits": {
+      "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa": {
+        "sha": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "parents": [
+          "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+        ],
+        "tree": "1111111111111111111111111111111111111111"
+      },
+      "dddddddddddddddddddddddddddddddddddddddd": {
+        "sha": "dddddddddddddddddddddddddddddddddddddddd",
+        "parents": [
+          "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+          "cccccccccccccccccccccccccccccccccccccccc"
+        ],
+        "tree": "2222222222222222222222222222222222222222"
+      }
+    },
+    "merge_tree": "2222222222222222222222222222222222222222",
+    "merge_tree_error": null,
+    "check_runs": [
+      {
+        "id": 101,
+        "name": "ci-required-result",
+        "status": "completed",
+        "conclusion": "success",
+        "started_at": "2026-08-14T00:00:00Z",
+        "head_sha": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "run_id": 201
+      },
+      {
+        "id": 102,
+        "name": "Results Explorer browser gate",
+        "status": "completed",
+        "conclusion": "success",
+        "started_at": "2026-08-14T00:00:01Z",
+        "head_sha": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "run_id": 202
+      },
+      {
+        "id": 103,
+        "name": "ruleset-drift",
+        "status": "completed",
+        "conclusion": "success",
+        "started_at": "2026-08-14T00:00:02Z",
+        "head_sha": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "run_id": 203
+      }
+    ],
+    "actions_runs": [
+      {
+        "id": 201,
+        "name": "Develop PR",
+        "path": ".github/workflows/pr.yml",
+        "head_sha": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "event": "pull_request",
+        "certification_kind": "full",
+        "workflow_fingerprint": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+        "base_sha": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+      },
+      {
+        "id": 202,
+        "name": "Results Explorer browser tests",
+        "path": ".github/workflows/results-explorer-browser.yml",
+        "head_sha": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "event": "pull_request",
+        "certification_kind": "full",
+        "workflow_fingerprint": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+        "base_sha": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+      },
+      {
+        "id": 203,
+        "name": "Develop ruleset drift",
+        "path": ".github/workflows/develop-ruleset-drift.yml",
+        "head_sha": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "event": "pull_request_target",
+        "certification_kind": "full",
+        "workflow_fingerprint": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+        "base_sha": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+      }
+    ],
+    "current_workflow_fingerprint": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+    "authored_paths": [
+      "benchbox/core/runner.py"
+    ],
+    "intervening_paths": [
+      "docs/operations/repo-admin-settings.md"
+    ]
+  },
+  "required_gate_seconds": 1800,
+  "all_workflow_seconds": 2400,
+  "runner_minutes": 90,
+  "actual_lane_conclusions": {
+    "code-lint": "success",
+    "code-test": "success",
+    "correctness-gate": "success",
+    "plan-capture-gate": "success",
+    "medium-test": "success"
+  }
+}

--- a/tests/fixtures/ci/pr-refresh-replay/historical-cancelled-medium.json
+++ b/tests/fixtures/ci/pr-refresh-replay/historical-cancelled-medium.json
@@ -1,0 +1,120 @@
+{
+  "id": "historical-1732-612814e681",
+  "pr_number": 1732,
+  "request": {
+    "action": "synchronize",
+    "before": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    "after": "dddddddddddddddddddddddddddddddddddddddd",
+    "head_sha": "dddddddddddddddddddddddddddddddddddddddd",
+    "base_sha": "cccccccccccccccccccccccccccccccccccccccc",
+    "current_head_sha": "dddddddddddddddddddddddddddddddddddddddd",
+    "current_base_sha": "cccccccccccccccccccccccccccccccccccccccc",
+    "head_repo_id": 1,
+    "base_repo_id": 1,
+    "is_fork": false,
+    "pr_number": 1717,
+    "synthetic_merge_sha": "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
+    "required_contexts": [
+      "ci-required-result",
+      "Results Explorer browser gate",
+      "ruleset-drift"
+    ],
+    "commits": {
+      "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa": {
+        "sha": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "parents": [
+          "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+        ],
+        "tree": "1111111111111111111111111111111111111111"
+      },
+      "dddddddddddddddddddddddddddddddddddddddd": {
+        "sha": "dddddddddddddddddddddddddddddddddddddddd",
+        "parents": [
+          "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+          "cccccccccccccccccccccccccccccccccccccccc"
+        ],
+        "tree": "2222222222222222222222222222222222222222"
+      }
+    },
+    "merge_tree": "2222222222222222222222222222222222222222",
+    "merge_tree_error": null,
+    "check_runs": [
+      {
+        "id": 101,
+        "name": "ci-required-result",
+        "status": "completed",
+        "conclusion": "success",
+        "started_at": "2026-08-14T00:00:00Z",
+        "head_sha": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "run_id": 201
+      },
+      {
+        "id": 102,
+        "name": "Results Explorer browser gate",
+        "status": "completed",
+        "conclusion": "success",
+        "started_at": "2026-08-14T00:00:01Z",
+        "head_sha": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "run_id": 202
+      },
+      {
+        "id": 103,
+        "name": "ruleset-drift",
+        "status": "completed",
+        "conclusion": "success",
+        "started_at": "2026-08-14T00:00:02Z",
+        "head_sha": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "run_id": 203
+      }
+    ],
+    "actions_runs": [
+      {
+        "id": 201,
+        "name": "Develop PR",
+        "path": ".github/workflows/pr.yml",
+        "head_sha": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "event": "pull_request",
+        "certification_kind": "",
+        "workflow_fingerprint": "",
+        "base_sha": ""
+      },
+      {
+        "id": 202,
+        "name": "Results Explorer browser tests",
+        "path": ".github/workflows/results-explorer-browser.yml",
+        "head_sha": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "event": "pull_request",
+        "certification_kind": "",
+        "workflow_fingerprint": "",
+        "base_sha": ""
+      },
+      {
+        "id": 203,
+        "name": "Develop ruleset drift",
+        "path": ".github/workflows/develop-ruleset-drift.yml",
+        "head_sha": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "event": "pull_request_target",
+        "certification_kind": "",
+        "workflow_fingerprint": "",
+        "base_sha": ""
+      }
+    ],
+    "current_workflow_fingerprint": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+    "authored_paths": [
+      "benchbox/core/runner.py"
+    ],
+    "intervening_paths": [
+      "docs/operations/repo-admin-settings.md"
+    ]
+  },
+  "actual_lane_conclusions": {
+    "code-lint": "success",
+    "code-test": "success",
+    "correctness-gate": "success",
+    "plan-capture-gate": "success",
+    "medium-test": "cancelled"
+  },
+  "required_gate_seconds": 900,
+  "all_workflow_seconds": 2100,
+  "runner_minutes": 40
+}

--- a/tests/fixtures/ci/pr-refresh-replay/negative-chained.json
+++ b/tests/fixtures/ci/pr-refresh-replay/negative-chained.json
@@ -1,0 +1,121 @@
+{
+  "id": "negative-chained",
+  "pr_number": 10,
+  "request": {
+    "action": "synchronize",
+    "before": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    "after": "dddddddddddddddddddddddddddddddddddddddd",
+    "head_sha": "dddddddddddddddddddddddddddddddddddddddd",
+    "base_sha": "cccccccccccccccccccccccccccccccccccccccc",
+    "current_head_sha": "dddddddddddddddddddddddddddddddddddddddd",
+    "current_base_sha": "cccccccccccccccccccccccccccccccccccccccc",
+    "head_repo_id": 1,
+    "base_repo_id": 1,
+    "is_fork": false,
+    "pr_number": 1717,
+    "synthetic_merge_sha": "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
+    "required_contexts": [
+      "ci-required-result",
+      "Results Explorer browser gate",
+      "ruleset-drift"
+    ],
+    "commits": {
+      "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa": {
+        "sha": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "parents": [
+          "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+          "ffffffffffffffffffffffffffffffffffffffff"
+        ],
+        "tree": "1111111111111111111111111111111111111111"
+      },
+      "dddddddddddddddddddddddddddddddddddddddd": {
+        "sha": "dddddddddddddddddddddddddddddddddddddddd",
+        "parents": [
+          "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+          "cccccccccccccccccccccccccccccccccccccccc"
+        ],
+        "tree": "2222222222222222222222222222222222222222"
+      }
+    },
+    "merge_tree": "2222222222222222222222222222222222222222",
+    "merge_tree_error": null,
+    "check_runs": [
+      {
+        "id": 101,
+        "name": "ci-required-result",
+        "status": "completed",
+        "conclusion": "success",
+        "started_at": "2026-08-14T00:00:00Z",
+        "head_sha": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "run_id": 201
+      },
+      {
+        "id": 102,
+        "name": "Results Explorer browser gate",
+        "status": "completed",
+        "conclusion": "success",
+        "started_at": "2026-08-14T00:00:01Z",
+        "head_sha": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "run_id": 202
+      },
+      {
+        "id": 103,
+        "name": "ruleset-drift",
+        "status": "completed",
+        "conclusion": "success",
+        "started_at": "2026-08-14T00:00:02Z",
+        "head_sha": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "run_id": 203
+      }
+    ],
+    "actions_runs": [
+      {
+        "id": 201,
+        "name": "Develop PR",
+        "path": ".github/workflows/pr.yml",
+        "head_sha": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "event": "pull_request",
+        "certification_kind": "full",
+        "workflow_fingerprint": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+        "base_sha": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+      },
+      {
+        "id": 202,
+        "name": "Results Explorer browser tests",
+        "path": ".github/workflows/results-explorer-browser.yml",
+        "head_sha": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "event": "pull_request",
+        "certification_kind": "full",
+        "workflow_fingerprint": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+        "base_sha": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+      },
+      {
+        "id": 203,
+        "name": "Develop ruleset drift",
+        "path": ".github/workflows/develop-ruleset-drift.yml",
+        "head_sha": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "event": "pull_request_target",
+        "certification_kind": "full",
+        "workflow_fingerprint": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+        "base_sha": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+      }
+    ],
+    "current_workflow_fingerprint": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+    "authored_paths": [
+      "benchbox/core/runner.py"
+    ],
+    "intervening_paths": [
+      "docs/operations/repo-admin-settings.md"
+    ]
+  },
+  "actual_lane_conclusions": {
+    "code-lint": "success",
+    "code-test": "success",
+    "correctness-gate": "success",
+    "plan-capture-gate": "success",
+    "medium-test": "success"
+  },
+  "required_gate_seconds": 100,
+  "all_workflow_seconds": 400,
+  "runner_minutes": 20
+}

--- a/tests/fixtures/ci/pr-refresh-replay/negative-fork.json
+++ b/tests/fixtures/ci/pr-refresh-replay/negative-fork.json
@@ -1,0 +1,120 @@
+{
+  "id": "negative-fork",
+  "pr_number": 9,
+  "request": {
+    "action": "synchronize",
+    "before": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    "after": "dddddddddddddddddddddddddddddddddddddddd",
+    "head_sha": "dddddddddddddddddddddddddddddddddddddddd",
+    "base_sha": "cccccccccccccccccccccccccccccccccccccccc",
+    "current_head_sha": "dddddddddddddddddddddddddddddddddddddddd",
+    "current_base_sha": "cccccccccccccccccccccccccccccccccccccccc",
+    "head_repo_id": 1,
+    "base_repo_id": 1,
+    "is_fork": true,
+    "pr_number": 1717,
+    "synthetic_merge_sha": "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
+    "required_contexts": [
+      "ci-required-result",
+      "Results Explorer browser gate",
+      "ruleset-drift"
+    ],
+    "commits": {
+      "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa": {
+        "sha": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "parents": [
+          "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+        ],
+        "tree": "1111111111111111111111111111111111111111"
+      },
+      "dddddddddddddddddddddddddddddddddddddddd": {
+        "sha": "dddddddddddddddddddddddddddddddddddddddd",
+        "parents": [
+          "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+          "cccccccccccccccccccccccccccccccccccccccc"
+        ],
+        "tree": "2222222222222222222222222222222222222222"
+      }
+    },
+    "merge_tree": "2222222222222222222222222222222222222222",
+    "merge_tree_error": null,
+    "check_runs": [
+      {
+        "id": 101,
+        "name": "ci-required-result",
+        "status": "completed",
+        "conclusion": "success",
+        "started_at": "2026-08-14T00:00:00Z",
+        "head_sha": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "run_id": 201
+      },
+      {
+        "id": 102,
+        "name": "Results Explorer browser gate",
+        "status": "completed",
+        "conclusion": "success",
+        "started_at": "2026-08-14T00:00:01Z",
+        "head_sha": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "run_id": 202
+      },
+      {
+        "id": 103,
+        "name": "ruleset-drift",
+        "status": "completed",
+        "conclusion": "success",
+        "started_at": "2026-08-14T00:00:02Z",
+        "head_sha": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "run_id": 203
+      }
+    ],
+    "actions_runs": [
+      {
+        "id": 201,
+        "name": "Develop PR",
+        "path": ".github/workflows/pr.yml",
+        "head_sha": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "event": "pull_request",
+        "certification_kind": "full",
+        "workflow_fingerprint": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+        "base_sha": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+      },
+      {
+        "id": 202,
+        "name": "Results Explorer browser tests",
+        "path": ".github/workflows/results-explorer-browser.yml",
+        "head_sha": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "event": "pull_request",
+        "certification_kind": "full",
+        "workflow_fingerprint": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+        "base_sha": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+      },
+      {
+        "id": 203,
+        "name": "Develop ruleset drift",
+        "path": ".github/workflows/develop-ruleset-drift.yml",
+        "head_sha": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "event": "pull_request_target",
+        "certification_kind": "full",
+        "workflow_fingerprint": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+        "base_sha": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+      }
+    ],
+    "current_workflow_fingerprint": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+    "authored_paths": [
+      "benchbox/core/runner.py"
+    ],
+    "intervening_paths": [
+      "docs/operations/repo-admin-settings.md"
+    ]
+  },
+  "actual_lane_conclusions": {
+    "code-lint": "success",
+    "code-test": "success",
+    "correctness-gate": "success",
+    "plan-capture-gate": "success",
+    "medium-test": "success"
+  },
+  "required_gate_seconds": 100,
+  "all_workflow_seconds": 400,
+  "runner_minutes": 20
+}

--- a/tests/fixtures/ci/pr-refresh-replay/negative-malformed.json
+++ b/tests/fixtures/ci/pr-refresh-replay/negative-malformed.json
@@ -1,0 +1,17 @@
+{
+  "id": "negative-malformed",
+  "pr_number": 15,
+  "request": {
+    "pr_number": "nope"
+  },
+  "actual_lane_conclusions": {
+    "code-lint": "success",
+    "code-test": "success",
+    "correctness-gate": "success",
+    "plan-capture-gate": "success",
+    "medium-test": "success"
+  },
+  "required_gate_seconds": 0,
+  "all_workflow_seconds": 0,
+  "runner_minutes": 0
+}

--- a/tests/fixtures/ci/pr-refresh-replay/negative-merge-driver.json
+++ b/tests/fixtures/ci/pr-refresh-replay/negative-merge-driver.json
@@ -1,0 +1,120 @@
+{
+  "id": "negative-merge-driver",
+  "pr_number": 12,
+  "request": {
+    "action": "synchronize",
+    "before": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    "after": "dddddddddddddddddddddddddddddddddddddddd",
+    "head_sha": "dddddddddddddddddddddddddddddddddddddddd",
+    "base_sha": "cccccccccccccccccccccccccccccccccccccccc",
+    "current_head_sha": "dddddddddddddddddddddddddddddddddddddddd",
+    "current_base_sha": "cccccccccccccccccccccccccccccccccccccccc",
+    "head_repo_id": 1,
+    "base_repo_id": 1,
+    "is_fork": false,
+    "pr_number": 1717,
+    "synthetic_merge_sha": "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
+    "required_contexts": [
+      "ci-required-result",
+      "Results Explorer browser gate",
+      "ruleset-drift"
+    ],
+    "commits": {
+      "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa": {
+        "sha": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "parents": [
+          "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+        ],
+        "tree": "1111111111111111111111111111111111111111"
+      },
+      "dddddddddddddddddddddddddddddddddddddddd": {
+        "sha": "dddddddddddddddddddddddddddddddddddddddd",
+        "parents": [
+          "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+          "cccccccccccccccccccccccccccccccccccccccc"
+        ],
+        "tree": "2222222222222222222222222222222222222222"
+      }
+    },
+    "merge_tree": "2222222222222222222222222222222222222222",
+    "merge_tree_error": null,
+    "check_runs": [
+      {
+        "id": 101,
+        "name": "ci-required-result",
+        "status": "completed",
+        "conclusion": "success",
+        "started_at": "2026-08-14T00:00:00Z",
+        "head_sha": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "run_id": 201
+      },
+      {
+        "id": 102,
+        "name": "Results Explorer browser gate",
+        "status": "completed",
+        "conclusion": "success",
+        "started_at": "2026-08-14T00:00:01Z",
+        "head_sha": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "run_id": 202
+      },
+      {
+        "id": 103,
+        "name": "ruleset-drift",
+        "status": "completed",
+        "conclusion": "success",
+        "started_at": "2026-08-14T00:00:02Z",
+        "head_sha": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "run_id": 203
+      }
+    ],
+    "actions_runs": [
+      {
+        "id": 201,
+        "name": "Develop PR",
+        "path": ".github/workflows/pr.yml",
+        "head_sha": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "event": "pull_request",
+        "certification_kind": "full",
+        "workflow_fingerprint": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+        "base_sha": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+      },
+      {
+        "id": 202,
+        "name": "Results Explorer browser tests",
+        "path": ".github/workflows/results-explorer-browser.yml",
+        "head_sha": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "event": "pull_request",
+        "certification_kind": "full",
+        "workflow_fingerprint": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+        "base_sha": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+      },
+      {
+        "id": 203,
+        "name": "Develop ruleset drift",
+        "path": ".github/workflows/develop-ruleset-drift.yml",
+        "head_sha": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "event": "pull_request_target",
+        "certification_kind": "full",
+        "workflow_fingerprint": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+        "base_sha": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+      }
+    ],
+    "current_workflow_fingerprint": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+    "authored_paths": [
+      ".gitattributes"
+    ],
+    "intervening_paths": [
+      "docs/operations/repo-admin-settings.md"
+    ]
+  },
+  "actual_lane_conclusions": {
+    "code-lint": "success",
+    "code-test": "success",
+    "correctness-gate": "success",
+    "plan-capture-gate": "success",
+    "medium-test": "success"
+  },
+  "required_gate_seconds": 100,
+  "all_workflow_seconds": 400,
+  "runner_minutes": 20
+}

--- a/tests/fixtures/ci/pr-refresh-replay/negative-race-head-drift.json
+++ b/tests/fixtures/ci/pr-refresh-replay/negative-race-head-drift.json
@@ -1,0 +1,120 @@
+{
+  "id": "negative-race-head-drift",
+  "pr_number": 14,
+  "request": {
+    "action": "synchronize",
+    "before": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    "after": "dddddddddddddddddddddddddddddddddddddddd",
+    "head_sha": "dddddddddddddddddddddddddddddddddddddddd",
+    "base_sha": "cccccccccccccccccccccccccccccccccccccccc",
+    "current_head_sha": "1111111111111111111111111111111111111111",
+    "current_base_sha": "cccccccccccccccccccccccccccccccccccccccc",
+    "head_repo_id": 1,
+    "base_repo_id": 1,
+    "is_fork": false,
+    "pr_number": 1717,
+    "synthetic_merge_sha": "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
+    "required_contexts": [
+      "ci-required-result",
+      "Results Explorer browser gate",
+      "ruleset-drift"
+    ],
+    "commits": {
+      "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa": {
+        "sha": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "parents": [
+          "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+        ],
+        "tree": "1111111111111111111111111111111111111111"
+      },
+      "dddddddddddddddddddddddddddddddddddddddd": {
+        "sha": "dddddddddddddddddddddddddddddddddddddddd",
+        "parents": [
+          "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+          "cccccccccccccccccccccccccccccccccccccccc"
+        ],
+        "tree": "2222222222222222222222222222222222222222"
+      }
+    },
+    "merge_tree": "2222222222222222222222222222222222222222",
+    "merge_tree_error": null,
+    "check_runs": [
+      {
+        "id": 101,
+        "name": "ci-required-result",
+        "status": "completed",
+        "conclusion": "success",
+        "started_at": "2026-08-14T00:00:00Z",
+        "head_sha": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "run_id": 201
+      },
+      {
+        "id": 102,
+        "name": "Results Explorer browser gate",
+        "status": "completed",
+        "conclusion": "success",
+        "started_at": "2026-08-14T00:00:01Z",
+        "head_sha": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "run_id": 202
+      },
+      {
+        "id": 103,
+        "name": "ruleset-drift",
+        "status": "completed",
+        "conclusion": "success",
+        "started_at": "2026-08-14T00:00:02Z",
+        "head_sha": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "run_id": 203
+      }
+    ],
+    "actions_runs": [
+      {
+        "id": 201,
+        "name": "Develop PR",
+        "path": ".github/workflows/pr.yml",
+        "head_sha": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "event": "pull_request",
+        "certification_kind": "full",
+        "workflow_fingerprint": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+        "base_sha": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+      },
+      {
+        "id": 202,
+        "name": "Results Explorer browser tests",
+        "path": ".github/workflows/results-explorer-browser.yml",
+        "head_sha": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "event": "pull_request",
+        "certification_kind": "full",
+        "workflow_fingerprint": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+        "base_sha": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+      },
+      {
+        "id": 203,
+        "name": "Develop ruleset drift",
+        "path": ".github/workflows/develop-ruleset-drift.yml",
+        "head_sha": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "event": "pull_request_target",
+        "certification_kind": "full",
+        "workflow_fingerprint": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+        "base_sha": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+      }
+    ],
+    "current_workflow_fingerprint": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+    "authored_paths": [
+      "benchbox/core/runner.py"
+    ],
+    "intervening_paths": [
+      "docs/operations/repo-admin-settings.md"
+    ]
+  },
+  "actual_lane_conclusions": {
+    "code-lint": "success",
+    "code-test": "success",
+    "correctness-gate": "success",
+    "plan-capture-gate": "success",
+    "medium-test": "success"
+  },
+  "required_gate_seconds": 100,
+  "all_workflow_seconds": 400,
+  "runner_minutes": 20
+}

--- a/tests/fixtures/ci/pr-refresh-replay/negative-self-change.json
+++ b/tests/fixtures/ci/pr-refresh-replay/negative-self-change.json
@@ -1,0 +1,120 @@
+{
+  "id": "negative-self-change",
+  "pr_number": 11,
+  "request": {
+    "action": "synchronize",
+    "before": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    "after": "dddddddddddddddddddddddddddddddddddddddd",
+    "head_sha": "dddddddddddddddddddddddddddddddddddddddd",
+    "base_sha": "cccccccccccccccccccccccccccccccccccccccc",
+    "current_head_sha": "dddddddddddddddddddddddddddddddddddddddd",
+    "current_base_sha": "cccccccccccccccccccccccccccccccccccccccc",
+    "head_repo_id": 1,
+    "base_repo_id": 1,
+    "is_fork": false,
+    "pr_number": 1717,
+    "synthetic_merge_sha": "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
+    "required_contexts": [
+      "ci-required-result",
+      "Results Explorer browser gate",
+      "ruleset-drift"
+    ],
+    "commits": {
+      "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa": {
+        "sha": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "parents": [
+          "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+        ],
+        "tree": "1111111111111111111111111111111111111111"
+      },
+      "dddddddddddddddddddddddddddddddddddddddd": {
+        "sha": "dddddddddddddddddddddddddddddddddddddddd",
+        "parents": [
+          "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+          "cccccccccccccccccccccccccccccccccccccccc"
+        ],
+        "tree": "2222222222222222222222222222222222222222"
+      }
+    },
+    "merge_tree": "2222222222222222222222222222222222222222",
+    "merge_tree_error": null,
+    "check_runs": [
+      {
+        "id": 101,
+        "name": "ci-required-result",
+        "status": "completed",
+        "conclusion": "success",
+        "started_at": "2026-08-14T00:00:00Z",
+        "head_sha": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "run_id": 201
+      },
+      {
+        "id": 102,
+        "name": "Results Explorer browser gate",
+        "status": "completed",
+        "conclusion": "success",
+        "started_at": "2026-08-14T00:00:01Z",
+        "head_sha": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "run_id": 202
+      },
+      {
+        "id": 103,
+        "name": "ruleset-drift",
+        "status": "completed",
+        "conclusion": "success",
+        "started_at": "2026-08-14T00:00:02Z",
+        "head_sha": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "run_id": 203
+      }
+    ],
+    "actions_runs": [
+      {
+        "id": 201,
+        "name": "Develop PR",
+        "path": ".github/workflows/pr.yml",
+        "head_sha": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "event": "pull_request",
+        "certification_kind": "full",
+        "workflow_fingerprint": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+        "base_sha": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+      },
+      {
+        "id": 202,
+        "name": "Results Explorer browser tests",
+        "path": ".github/workflows/results-explorer-browser.yml",
+        "head_sha": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "event": "pull_request",
+        "certification_kind": "full",
+        "workflow_fingerprint": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+        "base_sha": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+      },
+      {
+        "id": 203,
+        "name": "Develop ruleset drift",
+        "path": ".github/workflows/develop-ruleset-drift.yml",
+        "head_sha": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "event": "pull_request_target",
+        "certification_kind": "full",
+        "workflow_fingerprint": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+        "base_sha": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+      }
+    ],
+    "current_workflow_fingerprint": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+    "authored_paths": [
+      "scripts/pr_refresh_certification.py"
+    ],
+    "intervening_paths": [
+      "docs/operations/repo-admin-settings.md"
+    ]
+  },
+  "actual_lane_conclusions": {
+    "code-lint": "success",
+    "code-test": "success",
+    "correctness-gate": "success",
+    "plan-capture-gate": "success",
+    "medium-test": "success"
+  },
+  "required_gate_seconds": 100,
+  "all_workflow_seconds": 400,
+  "runner_minutes": 20
+}

--- a/tests/fixtures/ci/pr-refresh-replay/negative-semantic-schema.json
+++ b/tests/fixtures/ci/pr-refresh-replay/negative-semantic-schema.json
@@ -1,0 +1,120 @@
+{
+  "id": "negative-semantic-schema",
+  "pr_number": 13,
+  "request": {
+    "action": "synchronize",
+    "before": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    "after": "dddddddddddddddddddddddddddddddddddddddd",
+    "head_sha": "dddddddddddddddddddddddddddddddddddddddd",
+    "base_sha": "cccccccccccccccccccccccccccccccccccccccc",
+    "current_head_sha": "dddddddddddddddddddddddddddddddddddddddd",
+    "current_base_sha": "cccccccccccccccccccccccccccccccccccccccc",
+    "head_repo_id": 1,
+    "base_repo_id": 1,
+    "is_fork": false,
+    "pr_number": 1717,
+    "synthetic_merge_sha": "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
+    "required_contexts": [
+      "ci-required-result",
+      "Results Explorer browser gate",
+      "ruleset-drift"
+    ],
+    "commits": {
+      "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa": {
+        "sha": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "parents": [
+          "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+        ],
+        "tree": "1111111111111111111111111111111111111111"
+      },
+      "dddddddddddddddddddddddddddddddddddddddd": {
+        "sha": "dddddddddddddddddddddddddddddddddddddddd",
+        "parents": [
+          "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+          "cccccccccccccccccccccccccccccccccccccccc"
+        ],
+        "tree": "2222222222222222222222222222222222222222"
+      }
+    },
+    "merge_tree": "2222222222222222222222222222222222222222",
+    "merge_tree_error": null,
+    "check_runs": [
+      {
+        "id": 101,
+        "name": "ci-required-result",
+        "status": "completed",
+        "conclusion": "success",
+        "started_at": "2026-08-14T00:00:00Z",
+        "head_sha": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "run_id": 201
+      },
+      {
+        "id": 102,
+        "name": "Results Explorer browser gate",
+        "status": "completed",
+        "conclusion": "success",
+        "started_at": "2026-08-14T00:00:01Z",
+        "head_sha": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "run_id": 202
+      },
+      {
+        "id": 103,
+        "name": "ruleset-drift",
+        "status": "completed",
+        "conclusion": "success",
+        "started_at": "2026-08-14T00:00:02Z",
+        "head_sha": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "run_id": 203
+      }
+    ],
+    "actions_runs": [
+      {
+        "id": 201,
+        "name": "Develop PR",
+        "path": ".github/workflows/pr.yml",
+        "head_sha": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "event": "pull_request",
+        "certification_kind": "full",
+        "workflow_fingerprint": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+        "base_sha": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+      },
+      {
+        "id": 202,
+        "name": "Results Explorer browser tests",
+        "path": ".github/workflows/results-explorer-browser.yml",
+        "head_sha": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "event": "pull_request",
+        "certification_kind": "full",
+        "workflow_fingerprint": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+        "base_sha": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+      },
+      {
+        "id": 203,
+        "name": "Develop ruleset drift",
+        "path": ".github/workflows/develop-ruleset-drift.yml",
+        "head_sha": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "event": "pull_request_target",
+        "certification_kind": "full",
+        "workflow_fingerprint": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+        "base_sha": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+      }
+    ],
+    "current_workflow_fingerprint": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+    "authored_paths": [
+      "benchbox/schema/registry.py"
+    ],
+    "intervening_paths": [
+      "docs/operations/repo-admin-settings.md"
+    ]
+  },
+  "actual_lane_conclusions": {
+    "code-lint": "success",
+    "code-test": "success",
+    "correctness-gate": "success",
+    "plan-capture-gate": "success",
+    "medium-test": "success"
+  },
+  "required_gate_seconds": 100,
+  "all_workflow_seconds": 400,
+  "runner_minutes": 20
+}

--- a/tests/unit/scripts/test_pr_refresh_replay.py
+++ b/tests/unit/scripts/test_pr_refresh_replay.py
@@ -1,0 +1,126 @@
+"""Deterministic replay and negative controls for refresh certification."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from pr_refresh_certification import DECISION_FULL, DECISION_SHADOW
+from pr_refresh_replay import (
+    load_records,
+    main,
+    replay_record,
+    summarize,
+)
+
+pytestmark = [pytest.mark.unit, pytest.mark.fast]
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+ELIGIBLE = REPO_ROOT / "tests" / "fixtures" / "ci" / "pr-refresh" / "eligible.json"
+REPLAY_FIXTURES = REPO_ROOT / "tests" / "fixtures" / "ci" / "pr-refresh-replay"
+
+
+def _eligible_record(**overrides: object) -> dict:
+    request = json.loads(ELIGIBLE.read_text(encoding="utf-8"))
+    record = {
+        "id": "eligible-refresh",
+        "pr_number": 1717,
+        "request": request,
+        "actual_lane_conclusions": {
+            "code-lint": "success",
+            "code-test": "success",
+            "correctness-gate": "success",
+            "plan-capture-gate": "success",
+            "medium-test": "success",
+        },
+        "required_gate_seconds": 1800,
+        "all_workflow_seconds": 2400,
+        "runner_minutes": 90,
+    }
+    record.update(overrides)
+    return record
+
+
+def test_eligible_refresh_replays_as_shadow_without_full_only_failure() -> None:
+    result = replay_record(_eligible_record())
+    assert result.decision == DECISION_SHADOW
+    assert result.full_only_failure is False
+    assert result.actual_full_lanes_failed == []
+
+
+def test_shadow_eligible_with_failed_medium_is_full_only_failure() -> None:
+    record = _eligible_record()
+    record["actual_lane_conclusions"]["medium-test"] = "failure"
+    result = replay_record(record)
+    assert result.decision == DECISION_SHADOW
+    assert result.full_only_failure is True
+    assert result.actual_full_lanes_failed == ["medium-test"]
+
+
+def test_chained_refresh_is_full_required() -> None:
+    record = _eligible_record()
+    request = record["request"]
+    parent1 = request["commits"][request["before"]]
+    parent1["parents"] = [parent1["parents"][0], "f" * 40]
+    result = replay_record(record)
+    assert result.decision == DECISION_FULL
+    assert "chained_refresh" in result.reasons
+
+
+def test_fork_and_self_change_and_malformed_are_full_required() -> None:
+    fork = _eligible_record()
+    fork["request"]["is_fork"] = True
+    assert replay_record(fork).reasons == ["fork_head"]
+
+    self_change = _eligible_record()
+    self_change["request"]["authored_paths"] = ["scripts/pr_refresh_certification.py"]
+    assert "self_change" in replay_record(self_change).reasons
+
+    malformed = {"id": "bad", "request": {"pr_number": "nope"}}
+    result = replay_record(malformed)
+    assert result.decision == DECISION_FULL
+    assert result.reasons == ["malformed_payload"]
+
+
+def test_summary_reports_yield_and_reason_distribution() -> None:
+    results = [
+        replay_record(_eligible_record()),
+        replay_record(_eligible_record(id="docs")),
+    ]
+    fork = _eligible_record(id="fork")
+    fork["request"]["is_fork"] = True
+    results.append(replay_record(fork))
+    summary = summarize(results)
+    assert summary.records == 3
+    assert summary.shadow_eligible == 2
+    assert summary.full_required == 1
+    assert summary.eligibility_yield == pytest.approx(2 / 3)
+    assert summary.reason_counts["fork_head"] == 1
+    assert summary.required_gate_p50 == 1800
+
+
+def test_cli_reads_fixture_directory(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    if REPLAY_FIXTURES.is_dir() and any(REPLAY_FIXTURES.glob("*.json")):
+        source = REPLAY_FIXTURES
+    else:
+        source = tmp_path / "records"
+        source.mkdir()
+        (source / "one.json").write_text(json.dumps(_eligible_record()), encoding="utf-8")
+    out = tmp_path / "summary.json"
+    assert main(["--fixtures", str(source), "--json-out", str(out), "--check-completeness"]) == 0
+    payload = json.loads(out.read_text(encoding="utf-8"))
+    assert payload["summary"]["records"] >= 1
+    assert payload["completeness_errors"] == []
+    printed = json.loads(capsys.readouterr().out)
+    assert printed["summary"]["records"] == payload["summary"]["records"]
+    assert load_records(source)
+
+
+def test_check_completeness_fails_when_lane_outcomes_missing(tmp_path: Path) -> None:
+    source = tmp_path / "records"
+    source.mkdir()
+    record = _eligible_record()
+    del record["actual_lane_conclusions"]
+    (source / "bad.json").write_text(json.dumps(record), encoding="utf-8")
+    assert main(["--fixtures", str(source), "--check-completeness"]) == 1


### PR DESCRIPTION
Add a fixture-driven replay of exact-merge events and negative
controls. Historical pre-identity refreshes stay full_required.
This report does not authorize skip behavior.
