### PR TITLE
ci: add pre-merge foreign-platform tpch framing smoke

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -64,9 +64,8 @@ jobs:
           retention-days: 30
 
   # Pre-merge foreign-platform smoke coverage for the bundled TPC-H binaries.
-  # Keep this separate from ci-required-result: the existing required Ubuntu
-  # contract is unchanged, while every code PR gets direct macOS and Windows
-  # execution before merge. Nightly retains the complete three-platform matrix.
+  # Every code PR gets direct macOS and Windows execution before merge, while
+  # nightly retains the complete three-platform matrix.
   tpch-binary-framing:
     name: TPC-H binary framing (${{ matrix.os }})
     needs: ci-paths
@@ -1268,13 +1267,14 @@ jobs:
 
   ci-required-result:
     name: ci-required-result
-    needs: [ci-paths, content-guard, code-lint, code-test, correctness-gate, plan-capture-gate, medium-test, explorer-tokens, site-theme-tokens, explorer-vitest, audit-sha, package-smoke, dependency-audit, parity-check]
+    needs: [ci-paths, tpch-binary-framing, content-guard, code-lint, code-test, correctness-gate, plan-capture-gate, medium-test, explorer-tokens, site-theme-tokens, explorer-vitest, audit-sha, package-smoke, dependency-audit, parity-check]
     if: always()
     runs-on: ubuntu-latest
     steps:
       - name: Aggregate required result
         env:
           CI_PATHS_RESULT: ${{ needs.ci-paths.result }}
+          TPCH_BINARY_FRAMING_RESULT: ${{ needs.tpch-binary-framing.result }}
           CONTENT_RESULT: ${{ needs.content-guard.result }}
           LINT_RESULT: ${{ needs.code-lint.result }}
           TEST_RESULT: ${{ needs.code-test.result }}
@@ -1296,6 +1296,11 @@ jobs:
 
           if [ "$CI_PATHS_RESULT" != "success" ]; then
             echo "ci-paths=$CI_PATHS_RESULT"
+            exit 1
+          fi
+
+          if [ "$NEEDS_CODE_CI" = "true" ] && [ "$TPCH_BINARY_FRAMING_RESULT" != "success" ]; then
+            echo "tpch-binary-framing=$TPCH_BINARY_FRAMING_RESULT"
             exit 1
           fi
 
@@ -1390,6 +1395,7 @@ jobs:
         if: always()
         env:
           CI_PATHS_RESULT: ${{ needs.ci-paths.result }}
+          TPCH_BINARY_FRAMING_RESULT: ${{ needs.tpch-binary-framing.result }}
           CONTENT_RESULT: ${{ needs.content-guard.result }}
           LINT_RESULT: ${{ needs.code-lint.result }}
           TEST_RESULT: ${{ needs.code-test.result }}
@@ -1421,6 +1427,7 @@ jobs:
               "needs_code_ci": os.environ.get("NEEDS_CODE_CI") or "",
               "lanes": {
                   "ci-paths": os.environ.get("CI_PATHS_RESULT") or "",
+                  "tpch-binary-framing": os.environ.get("TPCH_BINARY_FRAMING_RESULT") or "",
                   "content-guard": os.environ.get("CONTENT_RESULT") or "",
                   "code-lint": os.environ.get("LINT_RESULT") or "",
                   "code-test": os.environ.get("TEST_RESULT") or "",

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -63,6 +63,41 @@ jobs:
           path: ci-path-decision.json
           retention-days: 30
 
+  # Pre-merge foreign-platform smoke coverage for the bundled TPC-H binaries.
+  # Keep this separate from ci-required-result: the existing required Ubuntu
+  # contract is unchanged, while every code PR gets direct macOS and Windows
+  # execution before merge. Nightly retains the complete three-platform matrix.
+  tpch-binary-framing:
+    name: TPC-H binary framing (${{ matrix.os }})
+    needs: ci-paths
+    if: ${{ needs.ci-paths.outputs.needs-code-ci == 'true' }}
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 15
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [macos-latest, windows-latest]
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Python 3.12
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v4
+
+      - name: Create virtual environment
+        run: uv venv
+
+      - name: Install dependencies
+        run: uv sync --group dev
+
+      - name: Verify bundled dbgen binaries emit clean framing
+        run: uv run -- python -m pytest tests/unit/core/tpch/test_tpch_dbgen_framing_binaries.py -m 'unit or slow' -v
+
   content-guard:
     name: content-guard
     needs: ci-paths

--- a/tests/unit/workflows/test_pr_workflow_outputs.py
+++ b/tests/unit/workflows/test_pr_workflow_outputs.py
@@ -23,6 +23,7 @@ def test_required_umbrella_jobs_are_unchanged(workflow: dict[str, Any]) -> None:
     needs = workflow["jobs"]["ci-required-result"]["needs"]
     assert needs == [
         "ci-paths",
+        "tpch-binary-framing",
         "content-guard",
         "code-lint",
         "code-test",
@@ -64,3 +65,11 @@ def test_lane_evidence_cannot_fail_the_required_umbrella(workflow: dict[str, Any
     assert evidence.get("continue-on-error") is True
     assert "pr-certification-lanes.json" in record["run"]
     assert evidence["with"]["name"] == "pr-certification-lanes"
+
+
+def test_tpch_binary_framing_is_observed_by_the_required_umbrella(workflow: dict[str, Any]) -> None:
+    aggregate = workflow["jobs"]["ci-required-result"]
+    assert "tpch-binary-framing" in aggregate["needs"]
+    step = next(step for step in aggregate["steps"] if step.get("name") == "Aggregate required result")
+    assert step["env"]["TPCH_BINARY_FRAMING_RESULT"] == "${{ needs.tpch-binary-framing.result }}"
+    assert 'TPCH_BINARY_FRAMING_RESULT" != "success"' in step["run"]

--- a/tests/unit/workflows/test_pr_workflow_path_classifier.py
+++ b/tests/unit/workflows/test_pr_workflow_path_classifier.py
@@ -65,6 +65,7 @@ def _run_ci_required_result(**env_overrides: str) -> subprocess.CompletedProcess
     env = {
         **os.environ,
         "CI_PATHS_RESULT": "success",
+        "TPCH_BINARY_FRAMING_RESULT": "success",
         "CONTENT_RESULT": "skipped",
         "LINT_RESULT": "skipped",
         "TEST_RESULT": "skipped",
@@ -136,6 +137,39 @@ def test_ci_required_result_fails_on_explorer_tokens_failure() -> None:
 
     assert result.returncode == 1
     assert "explorer-tokens=failure" in result.stdout
+
+
+def test_ci_required_result_fails_on_tpch_binary_framing_failure() -> None:
+    result = _run_ci_required_result(
+        NEEDS_CODE_CI="true",
+        SAFE_CONTENT_ONLY="false",
+        TPCH_BINARY_FRAMING_RESULT="failure",
+        LINT_RESULT="success",
+        TEST_RESULT="success",
+        CORRECTNESS_RESULT="success",
+        PLAN_CAPTURE_RESULT="success",
+        MEDIUM_TEST_RESULT="success",
+        EXPLORER_TOKENS_RESULT="success",
+    )
+
+    assert result.returncode == 1
+    assert "tpch-binary-framing=failure" in result.stdout
+
+
+def test_ci_required_result_accepts_tpch_binary_framing_success() -> None:
+    result = _run_ci_required_result(
+        NEEDS_CODE_CI="true",
+        SAFE_CONTENT_ONLY="false",
+        TPCH_BINARY_FRAMING_RESULT="success",
+        LINT_RESULT="success",
+        TEST_RESULT="success",
+        CORRECTNESS_RESULT="success",
+        PLAN_CAPTURE_RESULT="success",
+        MEDIUM_TEST_RESULT="success",
+        EXPLORER_TOKENS_RESULT="success",
+    )
+
+    assert result.returncode == 0
 
 
 def test_ci_required_result_fails_on_explorer_vitest_failure() -> None:


### PR DESCRIPTION
## Summary

- Add a pre-merge macOS and Windows matrix smoke for bundled TPC-H `dbgen` framing.
- Preserve the existing Ubuntu `ci-required-result` contract; nightly retains the complete three-platform matrix.

TODO: `pr-gate-tpch-binary-framing-coverage`

## Verification

- `uv run -- python -m pytest tests/unit/core/tpch/test_tpch_dbgen_framing_binaries.py -m 'unit or slow' -q`
- All workflow YAML parsed successfully.
- Deliberate trailing-delimiter mutation was rejected by the framing assertion.
- `make pr-preflight` passed (27,809 passed, 19 skipped).
