### PR TITLE
ci: guard releases with a UAT charter

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,6 +41,32 @@ jobs:
           fi
           echo "OK: $target_sha is origin/release or an ancestor of it."
 
+  verify-uat-charter:
+    needs: verify-tag-on-release
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Require a committed UAT charter or pointer
+        shell: bash
+        run: |
+          set -euo pipefail
+          candidates=(
+            tests/uat/CHARTER.md
+            _project/release-evidence/README.md
+          )
+          found=0
+          for path in "${candidates[@]}"; do
+            if git ls-files --error-unmatch "$path" >/dev/null 2>&1 && test -s "$path"; then
+              echo "Found committed UAT charter or pointer: $path"
+              found=1
+            fi
+          done
+          if [ "$found" -eq 0 ]; then
+            echo "::error::Release ref contains neither a committed UAT charter nor a release-evidence pointer."
+            exit 1
+          fi
+
   dependency-bounds:
     needs: verify-tag-on-release
     runs-on: ubuntu-latest
@@ -79,7 +105,7 @@ jobs:
           retention-days: 90
 
   build:
-    needs: [verify-tag-on-release, dependency-bounds]
+    needs: [verify-tag-on-release, verify-uat-charter, dependency-bounds]
     runs-on: ubuntu-latest
     outputs:
       version: ${{ steps.version.outputs.version }}

--- a/tests/unit/workflows/test_release_uat_charter_guard.py
+++ b/tests/unit/workflows/test_release_uat_charter_guard.py
@@ -1,0 +1,50 @@
+"""Contract tests for the release workflow's UAT charter guard."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+import yaml
+
+pytestmark = [pytest.mark.unit, pytest.mark.fast]
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+RELEASE_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "release.yml"
+
+
+def _workflow() -> dict[str, Any]:
+    return yaml.safe_load(RELEASE_WORKFLOW.read_text(encoding="utf-8"))
+
+
+def _needs(job: dict[str, Any]) -> list[str]:
+    needs = job.get("needs", [])
+    return [needs] if isinstance(needs, str) else needs
+
+
+def test_release_build_requires_the_uat_charter_guard() -> None:
+    jobs = _workflow()["jobs"]
+
+    assert "verify-uat-charter" in jobs
+    assert "verify-uat-charter" in _needs(jobs["build"])
+    assert "verify-tag-on-release" in _needs(jobs["verify-uat-charter"])
+
+
+def test_uat_charter_guard_is_fail_closed_and_uses_committed_candidates() -> None:
+    jobs = _workflow()["jobs"]
+    steps = jobs["verify-uat-charter"]["steps"]
+    run = next(step["run"] for step in steps if step.get("name") == "Require a committed UAT charter or pointer")
+
+    assert "tests/uat/CHARTER.md" in run
+    assert "_project/release-evidence/README.md" in run
+    assert "git ls-files --error-unmatch" in run
+    assert 'test -s "$path"' in run
+    assert "found=0" in run
+    assert 'if [ "$found" -eq 0 ]' in run
+    assert "exit 1" in run
+
+
+def test_canonical_uat_charter_candidates_exist_on_develop() -> None:
+    assert (REPO_ROOT / "tests/uat/CHARTER.md").is_file()
+    assert (REPO_ROOT / "_project/release-evidence/README.md").is_file()

--- a/tests/unit/workflows/test_release_uat_charter_guard.py
+++ b/tests/unit/workflows/test_release_uat_charter_guard.py
@@ -47,4 +47,8 @@ def test_uat_charter_guard_is_fail_closed_and_uses_committed_candidates() -> Non
 
 def test_canonical_uat_charter_candidates_exist_on_develop() -> None:
     assert (REPO_ROOT / "tests/uat/CHARTER.md").is_file()
-    assert (REPO_ROOT / "_project/release-evidence/README.md").is_file()
+    # release-cut intentionally removes the development-only _project tree;
+    # the release workflow still accepts this path when it is present on
+    # develop, but release-tree fast tests must not require it.
+    if (REPO_ROOT / "_project" / "decisions").is_dir():
+        assert (REPO_ROOT / "_project/release-evidence/README.md").is_file()


### PR DESCRIPTION
## Summary

- Add a fail-closed `verify-uat-charter` job to the release workflow.
- Require a committed UAT charter or release-evidence pointer before release builds and publication.
- Add workflow contract tests covering the candidate paths and failure branch.

TODO: `add-a-ci-check-that-the-uat-charter-or-pointer-exists-on-the`

## Verification

- `uv run -- python -m pytest tests/unit/workflows/test_release_uat_charter_guard.py -q`
- `uv run -- python -m pytest tests/unit/workflows -q`
- `make pr-preflight` passed: 27,812 passed, 19 skipped.
