### PR TITLE
docs: decide fast-lane wall-clock policy

### DIFF
--- a/_project/scripts/dev_loop_pr_metrics.py
+++ b/_project/scripts/dev_loop_pr_metrics.py
@@ -57,6 +57,7 @@ import re
 import shutil
 import statistics
 import subprocess
+import time
 import urllib.error
 import urllib.request
 from collections.abc import Callable
@@ -130,23 +131,31 @@ def _gh_available() -> bool:
 
 
 def _gh_api(path: str) -> object | None:
-    """GET *path* via the `gh api` CLI. Returns None on any failure."""
-    try:
-        proc = subprocess.run(
-            ["gh", "api", path],
-            capture_output=True,
-            text=True,
-            timeout=30,
-            check=False,
-        )
-    except (OSError, subprocess.TimeoutExpired):
-        return None
-    if proc.returncode != 0:
-        return None
-    try:
-        return json.loads(proc.stdout)
-    except json.JSONDecodeError:
-        return None
+    """GET *path* via the `gh api` CLI, retrying transient CLI/API failures."""
+    for attempt in range(API_RETRY_ATTEMPTS):
+        try:
+            proc = subprocess.run(
+                ["gh", "api", path],
+                capture_output=True,
+                text=True,
+                timeout=30,
+                check=False,
+            )
+        except (OSError, subprocess.TimeoutExpired):
+            proc = None
+
+        if proc is not None and proc.returncode == 0:
+            try:
+                return json.loads(proc.stdout)
+            except json.JSONDecodeError:
+                pass
+
+        if attempt + 1 < API_RETRY_ATTEMPTS:
+            # Keep retries bounded while allowing transient 5xx, transport,
+            # and CLI startup failures to recover before the collector fails
+            # closed rather than publishing understated metrics.
+            time.sleep(0.5 * (attempt + 1))
+    return None
 
 
 def _urllib_api(path: str, token: str) -> object | None:
@@ -239,9 +248,36 @@ class GitHubClient:
         return items
 
 
+def _gh_auth_token() -> str | None:
+    """Read the authenticated gh token without writing it to output or disk."""
+    if not _gh_available():
+        return None
+    try:
+        proc = subprocess.run(
+            ["gh", "auth", "token"],
+            capture_output=True,
+            text=True,
+            timeout=30,
+            check=False,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return None
+    token = proc.stdout.strip() if proc.returncode == 0 else ""
+    return token or None
+
+
 def make_client(repo: str) -> GitHubClient | None:
     """Return a usable GitHubClient, or None if no API access is available."""
     if _gh_available():
+        # Prefer one token lookup plus direct GETs over spawning `gh api` for
+        # every paginated request. The latter is correct but too slow for the
+        # event-fanout window and can fail closed on an isolated subprocess
+        # startup/transport hiccup. The token remains in memory only.
+        gh_token = _gh_auth_token()
+        if gh_token:
+            probe = _urllib_api(f"/repos/{repo}", gh_token)
+            if probe is not None:
+                return GitHubClient(repo, use_gh=False, token=gh_token)
         probe = _gh_api(f"/repos/{repo}")
         if probe is not None:
             return GitHubClient(repo, use_gh=True, token=None)

--- a/docs/operations/fast-lane-budget.md
+++ b/docs/operations/fast-lane-budget.md
@@ -155,6 +155,37 @@ nightly ratchet signal above starts accumulating exactly that data (each
 fired/cleared cycle is a headroom-vs-time data point). Revisit after
 roughly 4 weeks of that signal running, per the TODO's guidance.
 
+## Wall-clock decision record (2026-08-15)
+
+The four-week decision sample is now available. The read-only metrics
+collection covered **491 merged develop PRs** from 2026-07-18 through
+2026-08-14. It contained **395 completed-success fast-test job durations**:
+
+| Measure | Fast-test job wall time |
+| --- | ---: |
+| Median | 675 seconds (11.25 minutes) |
+| P95 | 752 seconds (12.53 minutes) |
+| P99 | 778 seconds (12.97 minutes) |
+| Maximum observed successful job | 797 seconds (13.28 minutes) |
+
+The remaining 96 PRs are censored or absent observations: failed, cancelled,
+missing, or otherwise non-successful jobs do not expose a completed duration in
+this dataset. They are not evidence that the lane stayed below any budget.
+
+**Decision: retain the count regime.** Do not replace the absolute
+`max_fast_tests` ceiling or the per-PR delta guard with a wall-clock failure
+at this time. The observed successful tail leaves useful room below a
+candidate 15-minute cap, while the censored failures mean this sample cannot
+calibrate a hard timeout's failure behavior. The count ceiling remains the
+cheap fail-closed structural backstop, and the delta guard still catches a
+single PR's runaway test growth before it consumes shared runway.
+
+Reconsider this decision after another complete 28-day sample, or sooner if a
+completed fast-test job approaches 15 minutes or the censored-job rate changes
+materially. Any future wall-clock gate must publish its timeout, cancellation
+handling, and rollback behavior alongside a fresh uncensored sample; it must
+not silently demote the count guards.
+
 ## medium-test wall-clock budget (distinct from w6 above)
 
 Not to be confused with w6: that gate is about *replacing* the fast lane's

--- a/tests/unit/scripts/test_dev_loop_pr_metrics.py
+++ b/tests/unit/scripts/test_dev_loop_pr_metrics.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import importlib.util
 import sys
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 
@@ -44,6 +45,23 @@ class _FakeClient:
             return self.jobs
         assert item_key == "check_runs"
         return self.checks
+
+
+def test_gh_api_retries_transient_failures(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls = 0
+
+    def fake_run(*_args, **_kwargs):
+        nonlocal calls
+        calls += 1
+        if calls < 3:
+            return SimpleNamespace(returncode=1, stdout="", stderr="temporary failure")
+        return SimpleNamespace(returncode=0, stdout='{"ok": true}', stderr="")
+
+    monkeypatch.setattr(metrics.subprocess, "run", fake_run)
+    monkeypatch.setattr(metrics.time, "sleep", lambda _seconds: None)
+
+    assert metrics._gh_api("/repos/example/project") == {"ok": True}
+    assert calls == 3
 
 
 def test_empty_first_pass_run_returns_all_metric_slots() -> None:


### PR DESCRIPTION
## Summary

- Record the four-week fast-lane wall-clock decision: retain the count ceiling and delta guard.
- Add durable evidence: 491 merged PRs, 395 completed fast-job samples, P95 752 seconds.
- Make read-only GitHub metrics collection resilient to transient API failures and avoid spawning `gh api` for every request.

TODO: `fast-lane-wallclock-budget-decision`

## Verification

- Metrics collection produced complete 28-day JSON evidence.
- `tests/unit/scripts/test_dev_loop_pr_metrics.py` and `test_timing_policy_modes.py`: 35 passed.
- `timing_policy_check.py --strict` passed.
- `make pr-preflight` passed: 27,809 passed, 19 skipped.
