### PR TITLE
ci: add protected public-site visual baselines

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -3,21 +3,6 @@ name: Documentation
 on:
   push:
     branches: [release, develop]
-    paths:
-      - "benchbox/**"
-      - "docs/**"
-      - "examples/**"
-      - "landing/**"
-      - "_project/scripts/explorer_pipeline/**"
-      - "_project/scripts/explorer_publish.py"
-      - "_project/scripts/results_explorer_snapshot_invariants.py"
-      - "results-data/**"
-      - "results-explorer/**"
-      - "scripts/**"
-      - ".github/workflows/docs.yml"
-      - "Makefile"
-      - "README.md"
-      - "pyproject.toml"
   pull_request:
     branches: [release, develop]
     paths:
@@ -214,6 +199,7 @@ jobs:
     name: Public-site visual regression
     if: >-
       (github.event_name == 'push' && github.ref == 'refs/heads/develop') ||
+      (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/develop') ||
       (github.event_name == 'pull_request' && github.base_ref == 'develop')
     needs: build
     runs-on: ubuntu-latest
@@ -277,7 +263,7 @@ jobs:
           E2E_PAGES_SHAPED: "1"
           E2E_SITE_DIR: ${{ github.workspace }}/site
           PUBLIC_SITE_VISUAL_OUTPUT: ${{ runner.temp }}/public-site-visual-current
-          PUBLIC_SITE_VISUAL_BASELINE: ${{ runner.temp }}/public-site-visual-baseline
+          PUBLIC_SITE_VISUAL_BASELINE: ${{ steps.baseline-mode.outputs.require == '1' && format('{0}/public-site-visual-baseline', runner.temp) || '' }}
           PUBLIC_SITE_VISUAL_BASE_SHA: ${{ github.event.pull_request.base.sha }}
           PUBLIC_SITE_VISUAL_REQUIRE_BASELINE: ${{ steps.baseline-mode.outputs.require }}
           PUBLIC_SITE_VISUAL_SOURCE_SHA: ${{ github.sha }}
@@ -285,7 +271,9 @@ jobs:
         working-directory: results-explorer
 
       - name: Upload protected-develop visual baseline
-        if: github.event_name == 'push' && github.ref == 'refs/heads/develop'
+        if: >-
+          (github.event_name == 'push' && github.ref == 'refs/heads/develop') ||
+          (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/develop')
         uses: actions/upload-artifact@v4
         with:
           name: public-site-visual-baseline

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -2,7 +2,7 @@ name: Documentation
 
 on:
   push:
-    branches: [release]
+    branches: [release, develop]
     paths:
       - "benchbox/**"
       - "docs/**"
@@ -39,6 +39,7 @@ on:
 
 permissions:
   contents: read
+  actions: read
   pages: write
   id-token: write
 
@@ -199,6 +200,109 @@ jobs:
         uses: actions/upload-pages-artifact@v3
         with:
           path: site
+
+      # The visual job consumes the exact assembled tree without rebuilding it.
+      # This is a short-lived transport artifact, not a publication baseline.
+      - name: Upload assembled site for visual acceptance
+        uses: actions/upload-artifact@v4
+        with:
+          name: public-site-assembled-${{ github.run_id }}
+          path: site
+          retention-days: 3
+
+  public-site-visual-regression:
+    name: Public-site visual regression
+    if: >-
+      (github.event_name == 'push' && github.ref == 'refs/heads/develop') ||
+      (github.event_name == 'pull_request' && github.base_ref == 'develop')
+    needs: build
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: "npm"
+          cache-dependency-path: results-explorer/package-lock.json
+
+      - name: Download assembled site
+        uses: actions/download-artifact@v4
+        with:
+          name: public-site-assembled-${{ github.run_id }}
+          path: site
+
+      - name: Install explorer dependencies
+        run: npm ci
+        working-directory: results-explorer
+
+      - name: Install Playwright Chromium
+        run: npx playwright install --with-deps chromium
+        working-directory: results-explorer
+
+      - name: Download exact base visual baseline
+        id: baseline
+        if: github.event_name == 'pull_request'
+        continue-on-error: true
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          PUBLIC_SITE_VISUAL_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          PUBLIC_SITE_VISUAL_BASELINE: ${{ runner.temp }}/public-site-visual-baseline
+        run: node scripts/download-public-site-visual-baseline.mjs
+        working-directory: results-explorer
+
+      - name: Determine baseline mode
+        id: baseline-mode
+        env:
+          BASELINE_OUTCOME: ${{ steps.baseline.outcome }}
+          BOOTSTRAP: ${{ steps.baseline.outputs.bootstrap || 'false' }}
+        shell: bash
+        run: |
+          if [ -f "$RUNNER_TEMP/public-site-visual-baseline/manifest.json" ]; then
+            echo "require=1" >> "$GITHUB_OUTPUT"
+            echo "Exact base-SHA baseline found; comparison is blocking."
+          elif [ "$BASELINE_OUTCOME" = "failure" ] && [ "$BOOTSTRAP" != "true" ]; then
+            echo "::error::A protected baseline exists, but none is bound to this exact base SHA."
+            exit 1
+          else
+            echo "require=0" >> "$GITHUB_OUTPUT"
+            echo "No protected baseline exists yet; running the one-time bootstrap capture."
+          fi
+
+      - name: Capture and compare public site
+        env:
+          E2E_PAGES_SHAPED: "1"
+          E2E_SITE_DIR: ${{ github.workspace }}/site
+          PUBLIC_SITE_VISUAL_OUTPUT: ${{ runner.temp }}/public-site-visual-current
+          PUBLIC_SITE_VISUAL_BASELINE: ${{ runner.temp }}/public-site-visual-baseline
+          PUBLIC_SITE_VISUAL_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          PUBLIC_SITE_VISUAL_REQUIRE_BASELINE: ${{ steps.baseline-mode.outputs.require }}
+          PUBLIC_SITE_VISUAL_SOURCE_SHA: ${{ github.sha }}
+        run: npm run test:e2e:public-site
+        working-directory: results-explorer
+
+      - name: Upload protected-develop visual baseline
+        if: github.event_name == 'push' && github.ref == 'refs/heads/develop'
+        uses: actions/upload-artifact@v4
+        with:
+          name: public-site-visual-baseline
+          path: ${{ runner.temp }}/public-site-visual-current
+          retention-days: 30
+
+      - name: Upload visual diagnostics
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: public-site-visual-diagnostics-${{ github.run_id }}
+          path: |
+            ${{ runner.temp }}/public-site-visual-current
+            results-explorer/test-results
+            results-explorer/playwright-report
+          if-no-files-found: ignore
+          retention-days: 3
 
   # Deploy to GitHub Pages (release pushes only)
   # Isolated as its own job so the github-pages environment protection

--- a/_project/audits/public-site-visual-baseline-policy-2026-08-15.md
+++ b/_project/audits/public-site-visual-baseline-policy-2026-08-15.md
@@ -1,0 +1,62 @@
+---
+date: 2026-08-15
+develop_sha: e03c75382be312c1368ef98fd53f1e5ac68fe4bc
+measured_at_sha: e03c75382be312c1368ef98fd53f1e5ac68fe4bc
+checked_sha: e03c75382be312c1368ef98fd53f1e5ac68fe4bc
+verdict: policy
+---
+
+# Public-site visual baseline policy — 2026-08-15
+
+## Decision
+
+The public-site visual suite uses **protected-develop CI artifacts** as its
+baseline. Raw screenshots are never committed to Git. A baseline is valid only
+when all of the following are true:
+
+- it was produced by the protected `develop` push workflow after the complete
+  visual suite passed;
+- its manifest binds the source commit SHA, route, viewport, browser project,
+  fixture/read-model identity, and screenshot digest;
+- a pull request compares against the exact base SHA's artifact, never against
+  a mutable live site or an arbitrary latest run;
+- a missing, stale, or unverifiable baseline fails the relevant visual gate
+  rather than silently becoming a new baseline; the one-time bootstrap
+  exception applies only while no protected baseline artifact exists at all,
+  and that run may capture but cannot compare;
+- baseline refresh occurs only from a successful protected `develop` run after
+  review, and the previous artifact remains available for rollback.
+
+PR failures may upload screenshots, traces, and a diff report as short-lived
+review artifacts. Those artifacts are diagnostic only and must not become the
+next baseline without the protected-develop refresh path.
+
+## Current implementation boundary
+
+The repository now provides the route/viewport capture and digest-comparison
+harness in `results-explorer/e2e/captures/public-site-pages.spec.ts`. It still
+does not provide the protected-develop baseline upload or exact-base artifact
+retrieval. The implementation work must add those two pieces before calling
+the suite blocking. Until then, existing Chromium functional coverage remains
+the only blocking browser gate.
+
+## Required matrix
+
+The initial matrix is Chromium at 390, 768, 1280, and 1600 CSS pixels across
+stable public landing, documentation/blog, and Results Explorer routes. Dynamic
+content must use the deterministic fixture/read-model inputs already used by
+the Explorer harness. Fonts, animation, clock, and network-dependent content
+must be controlled or excluded from the comparison.
+
+## Retention and rollback
+
+- Protected baseline artifacts: retain for at least 30 days and bind to the
+  source SHA in the manifest.
+- PR diagnostic artifacts: retain for 3 days, matching the existing browser
+  workflow reports.
+- Rollback: select the preceding successful protected-develop artifact whose
+  manifest matches the base SHA; never overwrite a baseline in place.
+
+The bootstrap exception is closed automatically after the first protected
+`develop` push uploads `public-site-visual-baseline`. From then on, an exact
+base-SHA lookup failure is a hard visual-gate error.

--- a/_project/audits/public-site-visual-regression-bootstrap-2026-08-15.md
+++ b/_project/audits/public-site-visual-regression-bootstrap-2026-08-15.md
@@ -1,0 +1,51 @@
+---
+date: 2026-08-15
+develop_sha: e03c75382be312c1368ef98fd53f1e5ac68fe4bc
+measured_at_sha: e03c75382be312c1368ef98fd53f1e5ac68fe4bc
+checked_sha: e03c75382be312c1368ef98fd53f1e5ac68fe4bc
+verdict: green-bootstrap
+---
+
+# Public-site visual regression bootstrap — 2026-08-15
+
+## Matrix
+
+The assembled Pages-shaped site was built from the checked SHA and served by
+`results-explorer/scripts/serve-browser-tests.mjs`. The new public-site capture
+harness passed **16 captures**:
+
+- landing page `/`
+- documentation `/docs/usage/getting-started.html`
+- blog `/blog/2026-05-18-v0-3-0-release-overview.html`
+- Results Explorer `/results/`
+- Chromium viewports 390, 768, 1280, and 1600 CSS pixels
+
+Every capture passed its route heading and horizontal-overflow contract. The
+harness emitted a SHA-256 manifest and screenshots to a temporary local
+artifact directory; no browser artifacts were committed.
+
+## Existing Explorer regression coverage
+
+The existing blocking Chromium suite also passed: 109 functional tests,
+9 failure-regression tests, and 1 performance test. Twelve tests were skipped
+by existing opt-in conditions.
+
+## Baseline status
+
+This was the bootstrap capture: no protected-develop baseline artifact existed
+for the current base SHA, so no pixel-digest comparison was claimed. The
+workflow now uploads `public-site-visual-baseline` from protected `develop` and
+will require an exact base-SHA artifact for subsequent develop pull requests.
+
+## Reproduction
+
+```bash
+make docs-build
+cd results-explorer
+npm run typecheck:e2e
+E2E_PAGES_SHAPED=1 E2E_SITE_DIR=<assembled-site> \
+  PUBLIC_SITE_VISUAL_OUTPUT=<temporary-output> \
+  PUBLIC_SITE_VISUAL_SOURCE_SHA=e03c75382be312c1368ef98fd53f1e5ac68fe4bc \
+  npm run test:e2e:public-site
+npm run test:e2e:chromium
+```

--- a/docs/development/results-explorer-browser-testing.md
+++ b/docs/development/results-explorer-browser-testing.md
@@ -64,6 +64,19 @@ Failure artifacts (traces, screenshots, video, HTML report) land under
 `results-explorer/test-results/` and `results-explorer/playwright-report/`
 and are both gitignored.
 
+## Public-site visual baseline policy
+
+The full public-site visual suite is broader than the Explorer's current
+functional gate. Its baseline policy is recorded in
+`_project/audits/public-site-visual-baseline-policy-2026-08-15.md`:
+raw screenshots stay out of Git, protected `develop` produces SHA-bound
+baseline artifacts, and pull requests compare against the exact base-SHA
+artifact. Missing or unverifiable baselines fail closed; a PR diagnostic
+artifact is never promoted directly to a baseline. The capture harness at `results-explorer/e2e/captures/public-site-pages.spec.ts`
+and Pages-shaped server are now reusable building blocks. The protected
+baseline upload and exact-base retrieval jobs must land before this suite is
+made blocking.
+
 ## What CI gates
 
 [`.github/workflows/results-explorer-browser.yml`](../../.github/workflows/results-explorer-browser.yml)

--- a/docs/operations/develop-push-drop-inventory.md
+++ b/docs/operations/develop-push-drop-inventory.md
@@ -43,6 +43,7 @@ Re-run the method when adding a new develop-push workflow.
 | `submission-validator-drift-check.yml` | `develop` + validator path filter | weekly Mon `0 6 * * 1` | yes | Safety-critical integrity — develop vs `published-results` validator copy | Weekly schedule + dispatch bound drift even if path-matched push is dropped | **Covered** — schedule present; path filter already limits push volume |
 | `sync-results-data-to-published.yml` | `develop` + `results-data/**` (and related validator paths) | **none** | yes | Safety-critical — only automated mirror of develop corpus → `published-results` | Dropped path-matched push leaves public corpus stale until human recovery | **Accepted risk** — daily `corpus-drift-check.yml` canary detects develop-ahead drift and recommends `gh workflow run sync-results-data-to-published.yml`; workflow retains write-heavy mirror on push/dispatch only (no schedule mutation of public branch) |
 | `results-explorer-browser.yml` | `release` + `develop` + explorer/`results-data` path filter | **none** | yes | Mixed — required PR gate (`Results Explorer browser gate`); develop push is post-merge tip re-build for path-matched merges | Dropped develop push can leave tip without a post-merge browser rebuild until the next matching push or dispatch | **Accepted risk** — pre-merge required check on every PR into develop is the primary safety property; develop push is additive tip verification; suite is expensive (Chromium full + smoke browsers) so no hourly schedule; recover with `gh workflow run results-explorer-browser.yml --ref develop` |
+| `docs.yml` | `develop` + public-site/docs path filter | **none** | yes | Mixed — assembles the Pages-shaped site and produces the SHA-bound public-site visual baseline | A dropped push delays baseline refresh; exact-base PR comparison fails closed once any baseline exists | **Accepted risk** — the develop PR visual job remains the review gate; the protected push is an additive baseline producer; recover with `gh workflow run docs.yml --ref develop` |
 
 ### Explicit non-entries (push, but not develop)
 
@@ -51,7 +52,7 @@ inventory's risk class:
 
 | Workflow | Why excluded |
 | --- | --- |
-| `docs.yml` | `push.branches: [release]` only (develop is PR-only) |
+| `docs.yml` | Pages deployment occurs only on `release`; the `develop` push is baseline production and is included above |
 | `lint.yml` / `test.yml` | `push.branches: [release]` only |
 | `release.yml` | tag push `v*` only |
 
@@ -163,7 +164,7 @@ PY
 ```
 
 Expected subject set (names only):
-`develop-post-merge.yml`, `orphaned-commit-detector.yml`,
+`develop-post-merge.yml`, `docs.yml`, `orphaned-commit-detector.yml`,
 `results-explorer-browser.yml`, `submission-validator-drift-check.yml`,
 `sync-results-data-to-published.yml`.
 

--- a/results-explorer/e2e/captures/public-site-pages.spec.ts
+++ b/results-explorer/e2e/captures/public-site-pages.spec.ts
@@ -60,17 +60,27 @@ test("captures the public route and viewport matrix", async ({ browser }) => {
   };
   await writeFile(MANIFEST, `${JSON.stringify(manifest, null, 2)}\n`, "utf8");
 
-  if (!BASELINE) {
+  if (!REQUIRE_BASELINE) {
     expect(REQUIRE_BASELINE, "PUBLIC_SITE_VISUAL_BASELINE is required for comparison").toBe(false);
     return;
   }
 
+  if (!BASELINE) {
+    throw new Error("PUBLIC_SITE_VISUAL_BASELINE is required when comparison is enabled");
+  }
   const baseline = JSON.parse(await readFile(path.join(BASELINE, "manifest.json"), "utf8")) as typeof manifest;
   expect(baseline.browser).toBe("chromium");
   if (process.env.PUBLIC_SITE_VISUAL_BASE_SHA) {
     expect(baseline.source_sha).toBe(process.env.PUBLIC_SITE_VISUAL_BASE_SHA);
   }
   const expected = new Map(baseline.captures.map((capture) => [`${capture.route}@${capture.viewport_width}`, capture.digest]));
+  const actualKeys = new Set(captures.map((capture) => `${capture.route}@${capture.viewport_width}`));
+  const missing = [...expected.keys()].filter((key) => !actualKeys.has(key));
+  const unexpected = [...actualKeys].filter((key) => !expected.has(key));
+  expect(
+    { missing, unexpected },
+    "visual baseline route/viewport matrix must match exactly",
+  ).toEqual({ missing: [], unexpected: [] });
   const changed = captures
     .filter((capture) => expected.get(`${capture.route}@${capture.viewport_width}`) !== capture.digest)
     .map((capture) => `${capture.route}@${capture.viewport_width}`);

--- a/results-explorer/e2e/captures/public-site-pages.spec.ts
+++ b/results-explorer/e2e/captures/public-site-pages.spec.ts
@@ -1,0 +1,78 @@
+import { createHash } from "node:crypto";
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import path from "node:path";
+
+import { expect, test } from "@playwright/test";
+
+const OUTPUT = path.resolve(
+  process.env.PUBLIC_SITE_VISUAL_OUTPUT ?? path.join("test-results", "public-site-visual"),
+);
+const BASELINE = process.env.PUBLIC_SITE_VISUAL_BASELINE
+  ? path.resolve(process.env.PUBLIC_SITE_VISUAL_BASELINE)
+  : undefined;
+const REQUIRE_BASELINE = process.env.PUBLIC_SITE_VISUAL_REQUIRE_BASELINE === "1";
+const SOURCE_SHA = process.env.PUBLIC_SITE_VISUAL_SOURCE_SHA ?? "unknown";
+const VIEWPORTS = [390, 768, 1280, 1600] as const;
+const ROUTES = [
+  { slug: "landing", path: "/", heading: /benchbox/i },
+  { slug: "getting-started", path: "/docs/usage/getting-started.html", heading: /getting started/i },
+  {
+    slug: "release-overview",
+    path: "/blog/2026-05-18-v0-3-0-release-overview.html",
+    heading: /v0\.3\.0/i,
+  },
+  { slug: "results", path: "/results/", heading: /results/i },
+] as const;
+const MANIFEST = path.join(OUTPUT, "manifest.json");
+
+test.describe.configure({ mode: "serial" });
+// The public-site suite requires the assembled Pages-shaped site. Keep it out
+// of the Explorer-only blocking command unless that site is explicitly mounted.
+test.skip(!process.env.E2E_PAGES_SHAPED || !process.env.E2E_SITE_DIR, "requires E2E_PAGES_SHAPED and E2E_SITE_DIR");
+
+test("captures the public route and viewport matrix", async ({ browser }) => {
+  await mkdir(OUTPUT, { recursive: true });
+  const captures: Array<Record<string, unknown>> = [];
+
+  for (const width of VIEWPORTS) {
+    for (const route of ROUTES) {
+      const context = await browser.newContext({ viewport: { width, height: 900 } });
+      const page = await context.newPage();
+      await page.goto(route.path, { waitUntil: "networkidle" });
+      await expect(page.locator("body")).toContainText(route.heading);
+      const overflow = await page.evaluate(() => document.documentElement.scrollWidth > window.innerWidth + 1);
+      expect(overflow, `${route.path} overflows at ${width}px`).toBe(false);
+
+      const filename = `${route.slug}-${width}.png`;
+      const screenshotPath = path.join(OUTPUT, filename);
+      await page.screenshot({ path: screenshotPath, fullPage: true });
+      const digest = createHash("sha256").update(await readFile(screenshotPath)).digest("hex");
+      captures.push({ digest, filename, route: route.path, viewport_width: width });
+      await context.close();
+    }
+  }
+
+  const manifest = {
+    browser: "chromium",
+    captures,
+    source_sha: SOURCE_SHA,
+    viewports: VIEWPORTS,
+  };
+  await writeFile(MANIFEST, `${JSON.stringify(manifest, null, 2)}\n`, "utf8");
+
+  if (!BASELINE) {
+    expect(REQUIRE_BASELINE, "PUBLIC_SITE_VISUAL_BASELINE is required for comparison").toBe(false);
+    return;
+  }
+
+  const baseline = JSON.parse(await readFile(path.join(BASELINE, "manifest.json"), "utf8")) as typeof manifest;
+  expect(baseline.browser).toBe("chromium");
+  if (process.env.PUBLIC_SITE_VISUAL_BASE_SHA) {
+    expect(baseline.source_sha).toBe(process.env.PUBLIC_SITE_VISUAL_BASE_SHA);
+  }
+  const expected = new Map(baseline.captures.map((capture) => [`${capture.route}@${capture.viewport_width}`, capture.digest]));
+  const changed = captures
+    .filter((capture) => expected.get(`${capture.route}@${capture.viewport_width}`) !== capture.digest)
+    .map((capture) => `${capture.route}@${capture.viewport_width}`);
+  expect(changed, `visual baseline mismatch; changed captures: ${changed.join(", ")}`).toEqual([]);
+});

--- a/results-explorer/package.json
+++ b/results-explorer/package.json
@@ -25,6 +25,7 @@
     "test:e2e:fixtures": "node scripts/generate-browser-fixtures.mjs && node scripts/verify-browser-fixtures.mjs",
     "test:e2e:serve": "node scripts/serve-browser-tests.mjs",
     "test:e2e:webkit": "npm run test:e2e:fixtures && npm run build && playwright test --project=webkit --workers=1",
+    "test:e2e:public-site": "playwright test --project=chromium --workers=1 e2e/captures/public-site-pages.spec.ts",
     "uat-external-corpus-smoke": "npm run build && playwright test --grep @uat-external-corpus"
   },
   "dependencies": {

--- a/results-explorer/scripts/download-public-site-visual-baseline.mjs
+++ b/results-explorer/scripts/download-public-site-visual-baseline.mjs
@@ -1,0 +1,48 @@
+#!/usr/bin/env node
+/** Download the baseline artifact produced by the exact protected-develop SHA. */
+
+import { execFile } from "node:child_process";
+import { appendFile, mkdir, writeFile } from "node:fs/promises";
+import { promisify } from "node:util";
+
+const execFileAsync = promisify(execFile);
+const token = process.env.GITHUB_TOKEN;
+const repository = process.env.GITHUB_REPOSITORY;
+const baseSha = process.env.PUBLIC_SITE_VISUAL_BASE_SHA;
+const output = process.env.PUBLIC_SITE_VISUAL_BASELINE;
+const apiUrl = process.env.GITHUB_API_URL ?? "https://api.github.com";
+
+if (!token || !repository || !baseSha || !output) {
+  throw new Error("GITHUB_TOKEN, GITHUB_REPOSITORY, PUBLIC_SITE_VISUAL_BASE_SHA, and PUBLIC_SITE_VISUAL_BASELINE are required");
+}
+
+const headers = {
+  Accept: "application/vnd.github+json",
+  Authorization: `Bearer ${token}`,
+  "X-GitHub-Api-Version": "2022-11-28",
+};
+
+async function github(path) {
+  const response = await fetch(`${apiUrl}${path}`, { headers });
+  if (!response.ok) throw new Error(`GitHub API ${response.status} for ${path}`);
+  return response.json();
+}
+
+const data = await github(`/repos/${repository}/actions/artifacts?name=public-site-visual-baseline&per_page=100`);
+const validArtifacts = (data.artifacts ?? []).filter((candidate) => !candidate.expired);
+const artifact = validArtifacts.find((candidate) => candidate.workflow_run?.head_sha === baseSha);
+if (!artifact) {
+  if (validArtifacts.length === 0) {
+    if (process.env.GITHUB_OUTPUT) await appendFile(process.env.GITHUB_OUTPUT, "bootstrap=true\n");
+    throw new Error(`No protected public-site visual baseline exists yet; bootstrap from the next protected develop push (base SHA ${baseSha})`);
+  }
+  throw new Error(`No unexpired public-site visual baseline is bound to base SHA ${baseSha}`);
+}
+
+const response = await fetch(artifact.archive_download_url, { headers });
+if (!response.ok) throw new Error(`Baseline artifact download failed with HTTP ${response.status}`);
+await mkdir(output, { recursive: true });
+const archive = `${output}.zip`;
+await writeFile(archive, Buffer.from(await response.arrayBuffer()));
+await execFileAsync("unzip", ["-q", archive, "-d", output]);
+console.log(`Downloaded baseline artifact ${artifact.id} for ${baseSha} to ${output}`);

--- a/tests/unit/workflows/test_develop_post_merge_gaps.py
+++ b/tests/unit/workflows/test_develop_post_merge_gaps.py
@@ -239,6 +239,7 @@ def test_push_drop_inventory_subject_set_matches_workflows() -> None:
 
     expected = {
         "develop-post-merge.yml",
+        "docs.yml",
         "orphaned-commit-detector.yml",
         "results-explorer-browser.yml",
         "submission-validator-drift-check.yml",

--- a/tests/unit/workflows/test_public_site_visual_workflow.py
+++ b/tests/unit/workflows/test_public_site_visual_workflow.py
@@ -1,0 +1,68 @@
+"""Contract tests for the public-site visual baseline workflow."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+import yaml
+
+pytestmark = [pytest.mark.unit, pytest.mark.fast]
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+DOCS_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "docs.yml"
+
+
+def _workflow() -> dict[str, Any]:
+    return yaml.safe_load(DOCS_WORKFLOW.read_text(encoding="utf-8"))
+
+
+def test_develop_pushes_produce_a_public_site_visual_baseline() -> None:
+    workflow = _workflow()
+    assert "develop" in workflow[True]["push"]["branches"]
+    assert workflow["permissions"]["actions"] == "read"
+
+    build_steps = workflow["jobs"]["build"]["steps"]
+    upload = next(step for step in build_steps if step.get("name") == "Upload assembled site for visual acceptance")
+    assert upload["with"]["name"] == "public-site-assembled-${{ github.run_id }}"
+    assert upload["with"]["retention-days"] == 3
+
+    visual = workflow["jobs"]["public-site-visual-regression"]
+    assert visual["needs"] == "build"
+    assert "refs/heads/develop" in visual["if"]
+    assert "base_ref == 'develop'" in visual["if"]
+
+    baseline_upload = next(
+        step for step in visual["steps"] if step.get("name") == "Upload protected-develop visual baseline"
+    )
+    assert "refs/heads/develop" in baseline_upload["if"]
+    assert baseline_upload["with"]["name"] == "public-site-visual-baseline"
+    assert baseline_upload["with"]["retention-days"] == 30
+
+
+def test_pull_requests_compare_exact_base_sha_or_run_bootstrap_capture() -> None:
+    visual = _workflow()["jobs"]["public-site-visual-regression"]
+    steps = visual["steps"]
+    download = next(step for step in steps if step.get("name") == "Download exact base visual baseline")
+    run = next(step for step in steps if step.get("name") == "Capture and compare public site")
+
+    assert download["env"]["PUBLIC_SITE_VISUAL_BASE_SHA"] == "${{ github.event.pull_request.base.sha }}"
+    assert "download-public-site-visual-baseline.mjs" in download["run"]
+    assert "PUBLIC_SITE_VISUAL_REQUIRE_BASELINE" in run["env"]
+    assert run["env"]["E2E_PAGES_SHAPED"] == "1"
+    assert "public-site-visual" in run["env"]["PUBLIC_SITE_VISUAL_OUTPUT"]
+
+    baseline_mode = next(step for step in steps if step.get("name") == "Determine baseline mode")
+    assert "protected baseline exists" in baseline_mode["run"]
+    assert "BOOTSTRAP" in baseline_mode["env"]
+
+
+def test_visual_baseline_script_and_capture_command_are_tracked() -> None:
+    script = REPO_ROOT / "results-explorer" / "scripts" / "download-public-site-visual-baseline.mjs"
+    package = __import__("json").loads((REPO_ROOT / "results-explorer" / "package.json").read_text(encoding="utf-8"))
+
+    assert script.is_file()
+    assert "bootstrap=true" in script.read_text(encoding="utf-8")
+    assert "test:e2e:public-site" in package["scripts"]
+    assert "e2e/captures/public-site-pages.spec.ts" in package["scripts"]["test:e2e:public-site"]

--- a/tests/unit/workflows/test_public_site_visual_workflow.py
+++ b/tests/unit/workflows/test_public_site_visual_workflow.py
@@ -21,6 +21,7 @@ def _workflow() -> dict[str, Any]:
 def test_develop_pushes_produce_a_public_site_visual_baseline() -> None:
     workflow = _workflow()
     assert "develop" in workflow[True]["push"]["branches"]
+    assert "paths" not in workflow[True]["push"]
     assert workflow["permissions"]["actions"] == "read"
 
     build_steps = workflow["jobs"]["build"]["steps"]
@@ -31,12 +32,14 @@ def test_develop_pushes_produce_a_public_site_visual_baseline() -> None:
     visual = workflow["jobs"]["public-site-visual-regression"]
     assert visual["needs"] == "build"
     assert "refs/heads/develop" in visual["if"]
+    assert "workflow_dispatch" in visual["if"]
     assert "base_ref == 'develop'" in visual["if"]
 
     baseline_upload = next(
         step for step in visual["steps"] if step.get("name") == "Upload protected-develop visual baseline"
     )
     assert "refs/heads/develop" in baseline_upload["if"]
+    assert "workflow_dispatch" in baseline_upload["if"]
     assert baseline_upload["with"]["name"] == "public-site-visual-baseline"
     assert baseline_upload["with"]["retention-days"] == 30
 
@@ -50,6 +53,7 @@ def test_pull_requests_compare_exact_base_sha_or_run_bootstrap_capture() -> None
     assert download["env"]["PUBLIC_SITE_VISUAL_BASE_SHA"] == "${{ github.event.pull_request.base.sha }}"
     assert "download-public-site-visual-baseline.mjs" in download["run"]
     assert "PUBLIC_SITE_VISUAL_REQUIRE_BASELINE" in run["env"]
+    assert "steps.baseline-mode.outputs.require" in run["env"]["PUBLIC_SITE_VISUAL_BASELINE"]
     assert run["env"]["E2E_PAGES_SHAPED"] == "1"
     assert "public-site-visual" in run["env"]["PUBLIC_SITE_VISUAL_OUTPUT"]
 


### PR DESCRIPTION
## Summary

- Add a deterministic 16-capture Chromium public-site matrix across landing, docs, blog, and Results Explorer at four viewports.
- Produce SHA-bound visual manifests and compare PRs against the exact protected-develop baseline artifact.
- Add one-time bootstrap handling, fail-closed exact-base lookup after bootstrap, diagnostics retention, and develop-push inventory coverage.

TODO: `full-public-site-visual-regression-suite`

## Verification

- Public-site matrix: 16 captures passed.
- Existing Chromium Explorer suite: 109 functional + 9 failure-regression + 1 performance passed.
- Workflow contract tests and YAML parsing passed.
- `make docs-validate` passed.
- `make pr-preflight` passed: 27,812 passed, 19 skipped.
