### PR TITLE
chore(skills): sync bounded todo batches

### DIFF
--- a/.claude/skills/todo/SKILL.md
+++ b/.claude/skills/todo/SKILL.md
@@ -11,36 +11,30 @@ tools: Bash, Read, Edit, Write, Task
 
 After bootstrap, use `_project/scripts/todo` for every tracker command.
 
-- Run `_project/scripts/todo --help` and confirm the chosen subcommand.
-- Treat that subcommand's `--help` output as its full contract.
+- Run `_project/scripts/todo --help`; treat the chosen subcommand's help as its full contract.
 - If the subcommand is missing, report the gap and stop.
 - Put global flags before it: `todo --db <path> --actor <name> <command>`.
 
 Skill-only actions: `prioritize`, `batch`, `handoff`, and `closeout`; follow their guides, not the CLI.
 
-If one request combines review or validation with close-out, perform the
-read-only review and stop at findings under `SHARED/review-protocol/SKILL.md`.
-A later user message may authorize `closeout`.
+If one request combines review or validation with close-out, perform the read-only review and stop at findings under
+`SHARED/review-protocol/SKILL.md`. A later user message may authorize `closeout`.
 
 ### Failures and claims
 
 - Exit code 2 means a general failure.
-- Exit code 4 means the hosted database rejected the credentials. Stop writes,
-  run `todo doctor`, and show the error. The wrapper may first try one token
-  refresh.
-- Only the holder can run `todo release`. It exits 2 for another actor's claim;
-  checking `claimed_by` can still race. `complete` and `drop` may clear any
-  claim. `--actor` prevents mistakes, not impersonation.
+- Exit code 4 means the hosted database rejected the credentials. Stop writes, run `todo doctor`, and show the error;
+  the wrapper may first try one token refresh.
+- Only the holder can run `todo release`; it exits 2 for another actor's claim, and checking `claimed_by` can race.
+  `complete` and `drop` may clear any claim. `--actor` prevents mistakes, not impersonation.
 
 ### Lifecycle rules
 
 - Read the selected action guide before acting.
-- When the user approves a specification and asks to track it, create its item
-  with `todo create` or the supported create-from-spec command.
+- After specification approval, track it with `todo create` or the supported create-from-spec command.
 - Store tracker state only in the database; do not create tracker files by hand.
 - Commit through `SHARED/change-framework/SKILL.md`.
-- `TODO_DB_URL` may select the hosted database. The CLI never prints its
-  connection string.
+- `TODO_DB_URL` may select the hosted database; the CLI never prints its connection string.
 
 ## Actions
 
@@ -59,6 +53,5 @@ A later user message may authorize `closeout`.
 | `closeout` — skill-only, no CLI command | You remediate a separately reviewed batch and close its items | `references/closeout.md` |
 | `help` | You need the action list | This table |
 
-`todo ready` and `todo stats` may warn on stderr about open findings or unsynced
-drafts without changing stdout. Run `todo finding candidates` when warned; no
-warning appears when there are no findings.
+`todo ready` and `todo stats` may warn on stderr about open findings or unsynced drafts without changing stdout. Run
+`todo finding candidates` when warned; no warning appears when there are no findings.

--- a/.claude/skills/todo/SKILL.md
+++ b/.claude/skills/todo/SKILL.md
@@ -7,18 +7,14 @@ tools: Bash, Read, Edit, Write, Task
 
 # Todo — Idea to Done
 
-## Purpose
-
-Use this skill to turn a rough idea into a clear specification and manage its
-TODO items through the full lifecycle: idea, specification, creation,
-implementation, and completion.
-
 ## Critical rules
 
-Use `_project/scripts/todo`. Check that the wrapper supports the command you need:
+After bootstrap, use `_project/scripts/todo` for every tracker command.
 
-* Run `_project/scripts/todo --help` and confirm the subcommand appears.
-* If the subcommand is missing, report the gap and stop.
+- Run `_project/scripts/todo --help` and confirm the chosen subcommand.
+- Treat that subcommand's `--help` output as its full contract.
+- If the subcommand is missing, report the gap and stop.
+- Put global flags before it: `todo --db <path> --actor <name> <command>`.
 
 Skill-only actions: `prioritize`, `batch`, `handoff`, and `closeout`; follow their guides, not the CLI.
 
@@ -26,20 +22,24 @@ If one request combines review or validation with close-out, perform the
 read-only review and stop at findings under `SHARED/review-protocol/SKILL.md`.
 A later user message may authorize `closeout`.
 
-Put global flags before the subcommand: `todo --db <path> --actor <name> <command>`.
+### Failures and claims
 
-Exit code 2 means a general failure. Exit code 4 means the hosted database rejected your credentials. When you get exit code 4, stop all writes, run `todo doctor`, and show the error. Some wrappers try once to refresh the token before they return exit code 4.
+- Exit code 2 means a general failure.
+- Exit code 4 means the hosted database rejected the credentials. Stop writes,
+  run `todo doctor`, and show the error. The wrapper may first try one token
+  refresh.
+- Only the holder can run `todo release`. It exits 2 for another actor's claim;
+  checking `claimed_by` can still race. `complete` and `drop` may clear any
+  claim. `--actor` prevents mistakes, not impersonation.
 
-Only the holder can release a claim. `todo release` fails with exit 2 if another actor holds it. Checking `claimed_by` with `todo show --json` can still race. `complete` and `drop` can still clear any claim. The actor comes from `--actor`, so this prevents mistakes, not impersonation.
+### Lifecycle rules
 
-The `--help` output for the command you chose is the full contract.
-
-* Read the selected action guide before acting.
-* When the user agrees to a specification, create its item with `todo create`
-  or the supported create-from-spec command.
-* Store tracker state only in the database. Do not write it to files by hand.
-* Commit only through `SHARED/change-framework/SKILL.md`.
-* `TODO_DB_URL` may select the hosted database. The CLI never prints its
+- Read the selected action guide before acting.
+- When the user approves a specification and asks to track it, create its item
+  with `todo create` or the supported create-from-spec command.
+- Store tracker state only in the database; do not create tracker files by hand.
+- Commit through `SHARED/change-framework/SKILL.md`.
+- `TODO_DB_URL` may select the hosted database. The CLI never prints its
   connection string.
 
 ## Actions
@@ -59,4 +59,6 @@ The `--help` output for the command you chose is the full contract.
 | `closeout` — skill-only, no CLI command | You remediate a separately reviewed batch and close its items | `references/closeout.md` |
 | `help` | You need the action list | This table |
 
-`todo ready` and `todo stats` may print a one-line warning on stderr when there are untriaged findings (open findings or unsynced drafts). The warning does not affect stdout. When you see it, run `todo finding candidates` to triage. The warning is silent when there are no findings.
+`todo ready` and `todo stats` may warn on stderr about open findings or unsynced
+drafts without changing stdout. Run `todo finding candidates` when warned; no
+warning appears when there are no findings.

--- a/.claude/skills/todo/references/batch.md
+++ b/.claude/skills/todo/references/batch.md
@@ -1,98 +1,139 @@
 # Batch Implementation
 
-Use `batch` to implement a related set of TODOs in order. For each item,
-implement, verify, complete, review, fix findings, commit, and open one PR. Use
-the `code` skill review when available. Otherwise, apply the same five-axis
-review by hand.
+Use `batch` to implement an explicit named TODO set in dependency order. It
+authorizes implementation, branches, commits, and PRs only for that set;
+auto-merge is allowed only when CI, not human approval, is the integration gate.
+It does not bypass repository, tracker, review, or publication gates.
 
-One `batch` call over an explicit named set authorizes implementation, commits,
-PRs, and conditional auto-merge only for those TODOs. It does not authorize
-work outside their work orders or bypass repository approval gates. Do not ask
-again for the same authority per item.
+A batch coordinates bounded contexts, not one long conversation. The tracker,
+Git, PR service, CI, artifacts, and human decisions remain authoritative.
 
 ## Before you start
 
-Run `todo doctor` through `_project/scripts/todo`. If the wrapper does not support `doctor`, report that you skipped the preflight. Fix any failure before you claim the first item.
+1. Read repository instructions, `references/implement.md`,
+   `SHARED/change-framework/SKILL.md`, and `SHARED/review-protocol/SKILL.md` as
+   required for the next action; do not copy their rules into the ledger.
+2. Run required tracker `--help` checks and `todo doctor`, using the wrapper and
+   global-flag ordering from `SKILL.md`. Fix or report any failure and stop
+   before claiming or editing; follow that contract on authentication failure.
+3. Confirm the exact TODO set, dependencies, integration branch, and existing
+   claims, branches, worktrees, and PRs. Reconcile rather than duplicate work.
+4. Run any required repository write preflight; fix or report failure and stop.
 
-If a command that documents the exit-code contract returns exit code 4, stop
-the batch. The wrapper may already have tried to refresh the token once.
+## Local handoff ledger
 
-1. Record each stale tracker item and its blocker in the local ledger.
-2. Show the authentication error and its documented recovery command.
-3. Do not implement more work or open PRs while tracker writes fail.
-4. After authentication is restored, replay missed tracker writes before
-   taking another item.
+Keep one ledger at a stable ignored path outside disposable worktrees, such as
+`.todo-batch/<slug>.txt` in the orchestration worktree. Verify it once with
+`git check-ignore`; use `.git/info/exclude`, not a committed rule. Never commit it.
 
-## Tracker commands
+Before the first claim or source mutation, initialize the exact named TODO IDs.
+Store one latest envelope per item, separated by `---`, and atomically replace
+the complete file. Only the serial controller writes it; concurrency is unsupported.
 
-Use `_project/scripts/todo` for claims and leases (`claim`), per-unit worktrees
-and branches (`start`/`done`), and completion and PRs (`complete --pr`). Rebuild
-progress with `todo list`, `todo stats`, and `todo deps <id>`.
-
-## Local ledger — batch bookkeeping only
-
-`batch` spans many TODOs, PRs, and CI waits. Keep one small local ledger for the facts the database does not track:
-
-* the batch set and order after you remove duplicates and sort by dependencies;
-* each item's batch-local status (`pending`, `waiting`, `in_progress`, `in_review`, `pr_open`, `done`, `blocked`) — this is local to the ledger, not the tracker's own state;
-* the blocker or wait reason.
-
-Per-item worktree, branch, and PR already live in the database (`start`/`complete`). Do not duplicate them. Put the ledger on an ignored local path (for example, an existing scratch dir or `.todo-batch/<slug>.yaml`). If that path is visible to git, add `.todo-batch/` to `.git/info/exclude` — not to the committed `.gitignore`. Never commit the ledger. On resume, read it first.
-
-```yaml
-batch: <slug>
-order: [todo-a, todo-b]
-items:
-  todo-a: {status: pending, note: ""}
+```text
+TODO: <id>
+STATUS: pending|in_progress|pr_open|waiting|done|blocked
+TRACKER_STATE: <observed state>
+BRANCH: <branch or none>
+WORKTREE: <path or none>
+PR: <number or none>
+PR_STATE: <open|merged|closed|none>
+HEAD: <sha or none>
+VERIFICATION: <concise result>
+GATE_SNAPSHOT: <gate, concise result/link, or none>
+BLOCKER: <owner/reason or none>
+NEXT_ACTION: <exact action>
+---
 ```
 
-The ledger preserves only the temporary orchestration state needed to resume
-this batch.
+These are cached observations, not authority for a mutation. Before acting,
+revalidate the facts required by `NEXT_ACTION` under the implementation guide,
+change framework, and repository policy.
 
-## Setup
+## Schedule bounded work
 
-1. Remove exact duplicate ids. Confirm each one with `todo show <id>`.
-2. Read each item's work order (`todo claim` shows scope, must-preserve, anti-patterns, verification steps, ready units, and deferrals) or preview with `todo show <id> --json` and `todo deps <id>`.
-3. Sort by in-batch dependencies (`deps.needs`). Items in a cycle are `blocked`. Continue with the rest.
+Run serially. A substantial TODO needs its own implementation, verification,
+and review cycle; give it a fresh worker context when supported. Tightly coupled
+trivial items may share a context while their combined history remains small.
 
-## Scheduler
+At each scheduler boundary:
 
-After a failed attempt, make one focused retry. If the retry fails, mark the
-item `blocked` and continue with other TODOs.
+1. Read the ledger once and refresh only state needed to select the next item.
+2. Mark missing, malformed, or cyclic items `blocked` with a reason. Record a
+   hard tracker blocker through the documented tracker command.
+3. Select an item only when its dependencies, including required integration
+   merges, are satisfied, tracker state permits claim or resume, and no existing
+   branch, worktree, or PR must be reconciled first.
+4. Start or resume it with `references/implement.md` in a fresh isolated linked
+   worktree from the current integration branch. Refresh after dependency merges
+   and remove that clean worktree after merge under repository policy.
+5. After one focused retry, classify externally resolvable failures as waiting
+   and non-resolvable failures as blocked; record the owner and next action.
 
-Repeat until every item is `done` or `blocked`:
+If no item is eligible and the remainder waits on external gates, checkpoint,
+report, and end the batch invocation. Resumption is a new invocation; do not
+turn repeated invocations into an implicit polling loop.
 
-1. Re-read the ledger. Refresh readiness with `todo ready` and `todo deps`. `ready`/`stats` may print a warning on stderr about untriaged findings — triage with `todo finding candidates`. Findings are not batch items and never enter the ready queue.
-2. Classify each non-terminal item (`ready` is derived, not stored):
-   * `ready`: ledger status is `pending`, every in-batch dependency is `done` (its PR is merged into the integration branch), and external deps are clear per `todo ready`.
-   * `waiting`: a dependency PR, external dep, CI check, or merge is pending and can still resolve this session.
-   * `blocked`: missing or malformed item, dependency cycle, the failed-retry rule above, or a wait with no resolution path this session. Record the reason. If it is a hard tracker blocker, run `todo block <id> --reason ...`.
-3. If a TODO is ready, implement it (see below).
-4. If none are ready: mark ordinary pending CI as `waiting`. Use bounded, announced monitoring (command, max time, log path, stop condition — for example, `gh pr checks` or the project PR-status target) only for a dependency gate that blocks another TODO. You can delegate a deterministic gate check to a subagent for run-and-report. Apply the failed-retry rule to red batch-owned PRs. Being not-ready is `waiting`, not `blocked`.
+## Worker closeout
 
-## For each ready TODO
+Follow implementation, verification, commit, PR, deferral, and completion
+contracts by reference. Before commit or PR, run the required internal review,
+resolve Critical and Required findings, disposition optional findings under
+repository policy, and re-verify substantive fixes.
 
-1. Mark `in_progress` in the ledger.
-2. For implementation work, create and use a fresh linked worktree off the integration branch before editing. Keep the work isolated there, and after the PR or PRs merge, verify the tree is clean and remove that exact linked worktree according to repository policy. Do not assume a retained slot or worktree pool. If a dependency PR merged since you created the worktree, refresh onto the updated branch first.
-3. Run `todo claim <id>` and follow the work order. For each work unit, run
-   `todo start`, apply `SHARED/change-framework/SKILL.md` Section 1 before
-   source-code edits, implement, then record evidence with `todo done`. Defer
-   out-of-scope work with `todo defer`.
-4. Run `todo check-scope <id>` and `todo verify <id> --run`.
-5. Mark `in_review`. As internal implementation verification under
-   `SHARED/review-protocol/SKILL.md` [REVIEW-AUTH-001], run the `code` skill
-   review on the diff or apply the same five-axis review. Fix every Critical or
-   Required finding unless you can prove it is invalid. Apply Nit or Consider
-   only when it is in scope. List every skipped finding in the PR body.
-   Re-verify and re-review after non-trivial fixes.
-6. Commit only explicit paths (never `git add -A`) through `SHARED/change-framework`, then open the PR.
-7. Run `todo complete <id> --pr <n>` — but first resolve deferrals with `promote` or `dismiss`, or it will refuse.
-8. If a later TODO in the batch needs this PR merged: mark `pr_open`, enable auto-merge only when the integration branch gate is CI checks (not required human approval), then monitor until merged and mark `done`. Else mark `done` after you open the PR and complete the item.
+Do not return full work orders, diffs, logs, or source dumps. Keep long output
+in a temporary artifact and return only its result, short tail, link, or digest.
+Return the envelope above:
 
-## Workers
+- after successful item closeout;
+- before intentionally ending or compacting a worker context; or
+- after a failure that requires later resumption.
 
-Run one item at a time by default. Parallel workers increase churn for little gain. Use one worker per TODO only when you have worker sessions. The orchestrator still owns order, ledger, monitors, and the final report. Each worker must return: `TODO`, `STATUS: done|pr_open|blocked`, `PR`, `WORKTREE`, `BRANCH`, `NOTES`.
+Store the envelope before selecting more work; add no per-operation
+acknowledgements. After an unexpected end, inspect authoritative live state
+before retrying an operation with an unknown outcome.
+
+When another item depends on the PR, leave it `pr_open` or `waiting` until
+verified merged. Otherwise use the terminal tracker state after PR creation and
+completion. An open or green PR is not proof of merge.
+
+## CI and external waits
+
+Before querying a gate, reuse its snapshot from this invocation. Take at most
+one concise snapshot per gate, store it in the item envelope, and do not query it
+again before the invocation ends. Use bounded fields; keep verbose output
+outside context and retain only pending/failing names, links, and next action.
+
+If a gate remains pending, record `waiting`, follow the documented claim
+lifecycle, checkpoint, and end the worker. Continue independent eligible work
+without retaining that history; if all work waits, end the invocation. Never
+sleep or poll in an implementation context.
+
+## Context rotation and resume
+
+At every substantial-item boundary, persist the envelope and discard the worker
+transcript. Rotate or compact the controller too; its handoff preserves the
+exact TODO set and ledger path, not logs, readiness output, or discussion.
+
+If fresh contexts are unavailable, checkpoint and compact at a safe item or
+work-unit boundary. Do not measure occupancy or compact uncheckpointed work. If
+neither option exists and history grows large, stop with the ledger and resume action.
+
+A resumed context must:
+
+1. confirm that the requested TODO set exactly matches the ledger;
+2. read the ledger once and select its current item and `NEXT_ACTION`;
+3. revalidate only the live facts required by that action; and
+4. continue without replaying completed work orders, logs, or discussion.
 
 ## Final report
 
-Report `TODO | PR # | status | note`. List blockers with unblock steps and the ledger path. If the session ends before every item is terminal, state the ledger path and the resume command (run `batch` again with the same inputs — the ledger plus the database resumes progress).
+Report one concise row per item:
+
+```text
+TODO | tracker state | PR/state | head | verification | blocker | next action
+```
+
+Include the ledger path and distinguish open, merged, tracker-complete, waiting,
+and blocked work. If anything remains non-terminal, provide the exact resume
+action rather than waiting in the current context.

--- a/.claude/skills/todo/references/bootstrap.md
+++ b/.claude/skills/todo/references/bootstrap.md
@@ -1,6 +1,7 @@
 # Bootstrap the Tracker
 
-Use this guide to add the `todo-db` tracker to a project that does not yet have it. The CLI contract is authoritative — only use what `todo --help` shows. You must provide a project id and a repository URL. There is no default. If you run `init` without them, it fails.
+Use the commands shown by `todo --help`. Initialization requires a project ID
+and repository URL; neither has a default.
 
 ## 1. Scaffold with `init-project` — the normal path
 
@@ -13,13 +14,22 @@ todo-db init-project \
   --wrapper
 ```
 
-This one command sets the identity and creates the scaffolding:
+This command sets identity and creates:
 
-* `.todo-db/config.json` — committed. The tool finds it by walking up from your working directory, or from `TODO_DB_CONFIG` if you set it. It holds the identity and the database location so later commands need no flags. Priority: explicit flags first, then `TODO_DB_*` env vars, then the config file.
-* `.todo-db/.gitignore` — keeps the database files untracked but keeps `config.json` tracked. Do not add a bare `.todo-db/` line to the repository `.gitignore`. It would hide the committed config. The command warns you if the config is ignored.
-* `_project/scripts/todo` (created by `--wrapper`) — a wrapper that finds the tool as `TODO_DB_TOOL` env var, then `todo-db` on PATH, then a sibling `../todo-db` checkout. It sets `TODO_DB_CONFIG` so it works from any directory. It does not hard-code an identity.
+- `.todo-db/config.json`, which is committed. The tool finds it through
+  `TODO_DB_CONFIG` or by walking up from the working directory. Configuration
+  precedence is explicit flags, `TODO_DB_*` environment variables, then this
+  file.
+- `.todo-db/.gitignore`, which ignores database files but tracks `config.json`.
+  Do not add `.todo-db/` to the repository `.gitignore`; that would hide the
+  committed configuration. The command warns if the config is ignored.
+- `_project/scripts/todo` when `--wrapper` is set. It resolves `TODO_DB_TOOL`,
+  then `todo-db` on `PATH`, then `../todo-db`. It sets `TODO_DB_CONFIG`, works
+  from any directory, and does not hard-code identity.
 
-`--db` stores a local path (default `.todo-db/standalone.sqlite`) or a `libsql://` URL in the config. The command never overwrites existing scaffolding unless you pass `--force`. Commit `config.json`, `.todo-db/.gitignore`, and the wrapper.
+`--db` stores a local path, defaulting to `.todo-db/standalone.sqlite`, or a
+`libsql://` URL. Existing scaffolding requires `--force` to overwrite. Commit
+`config.json`, `.todo-db/.gitignore`, and the wrapper.
 
 **Minimal fallback — no scaffolding (for throwaway databases):**
 
@@ -27,13 +37,15 @@ This one command sets the identity and creates the scaffolding:
 todo-db --db <path> init --project-id <id> --repository <url>
 ```
 
-Then pass the identity and database on every call, or through `TODO_DB_PROJECT_ID`, `TODO_DB_REPOSITORY`, and `TODO_DB_PATH`. The audit actor comes from `--actor` or from `TODO_ACTOR`, `CLAUDE_SESSION_ID`, `CODEX_SESSION_ID`, or `AGENT_SESSION_ID`.
+Then pass identity and database on each call or set `TODO_DB_PROJECT_ID`,
+`TODO_DB_REPOSITORY`, and `TODO_DB_PATH`. The audit actor comes from `--actor`,
+`TODO_ACTOR`, `CLAUDE_SESSION_ID`, `CODEX_SESSION_ID`, or `AGENT_SESSION_ID`.
 
 ## 2. Hosted backend (Turso/libSQL) — when you use `TODO_DB_URL`
 
-This section is part of the main guide. Use it when you store the tracker in a hosted database.
-
-You must create the hosted database before you run `todo-db`. Create it and mint tokens with the Turso CLI (`turso db create ...` and token minting). The tracker CLI never creates the remote database. If the database does not exist, the first connection fails.
+Create the hosted database and mint tokens with the Turso CLI, such as
+`turso db create ...`, before running `todo-db`. The tracker CLI does not create
+remote databases.
 
 Example:
 
@@ -43,11 +55,20 @@ TODO_DB_AUTH_TOKEN=... todo-db init-project \
   --project-id <project-id> --repository <repository-url>
 ```
 
-What you need to know:
-
-* Tokens live only in env vars. `TODO_DB_AUTH_TOKEN` is for read-write. `TODO_DB_RO_AUTH_TOKEN` is for read-only use (for example, `export`). The CLI refuses plaintext `http://` URLs.
-* Hosted read-write use needs a per-worktree replica: `--replica .todo-db/replica.db`. The scaffold git-ignores it. Do not share one replica path across worktrees.
-* `todo verify --run` on a hosted database refuses to run unless you set `TODO_DB_ALLOW_HOSTED_VERIFY_RUN=1`. Stored verification commands were written by other people. Running them is a code-execution risk.
-* Preflight check: `todo doctor` is a safe health check. It checks config, identity, database reachability, and Turso CLI auth. Use `--json` for automation. Exit code 4 means auth failed — stop writes, refresh the token, and show the error. Wrappers from `todo-db` try once to refresh the token before they return exit code 4.
-* Hosted adapters are optional extras of the `todo-db` package. Install them in the tool checkout with `uv sync --extra hosted --extra audit`.
-* Live validation: `scripts/turso_acceptance.sh` in the `todo-db` checkout creates a temporary database, runs the full lifecycle, and destroys it. It uses real resources, so run it on purpose only.
+- Keep tokens in environment variables. `TODO_DB_AUTH_TOKEN` grants read-write
+  access; `TODO_DB_RO_AUTH_TOKEN` is read-only. The CLI rejects plaintext
+  `http://` URLs.
+- Give each read-write worktree its own replica with
+  `--replica .todo-db/replica.db`. The scaffold ignores it; never share the path
+  across worktrees.
+- Hosted `todo verify --run` requires `TODO_DB_ALLOW_HOSTED_VERIFY_RUN=1`
+  because stored verification commands can execute other people's code.
+- Use `todo doctor` to check config, identity, database access, and Turso CLI
+  authentication. Use `--json` for automation. Exit code 4 means
+  authentication failed: stop writes, refresh the token, and show the error.
+  Wrappers try one refresh first.
+- Install hosted adapters with `uv sync --extra hosted --extra audit` in the
+  tool checkout.
+- `scripts/turso_acceptance.sh` creates a temporary live database, runs the
+  lifecycle, and destroys it. Run it deliberately because it uses real
+  resources.

--- a/.claude/skills/todo/references/ideate.md
+++ b/.claude/skills/todo/references/ideate.md
@@ -8,4 +8,6 @@ Use this guide to refine a rough idea.
 4. Stress-test assumptions.
 5. Recommend a minimal viable scope, what you will not do, and open questions.
 
-Before you recommend, apply `SHARED/review-protocol/SKILL.md` (Planning-Depth Layers) L3 and the L2 missed-dimension question. Note any reframe. Save only after the user confirms.
+Before recommending, apply Layers 2 and 3 of
+`SHARED/review-protocol/SKILL.md`. Record any reframe and save only after the
+user confirms.

--- a/.claude/skills/todo/references/implement.md
+++ b/.claude/skills/todo/references/implement.md
@@ -2,14 +2,24 @@
 
 ## Steps
 
-1. Pick the next item: `todo ready` shows the top ready item. `todo claim <id>` prints the full work order — scope, must-preserve notes, anti-patterns, verification steps, ready units, and deferrals. Treat it as the complete briefing. If `ready` prints a warning on stderr about untriaged findings, run `todo finding candidates` and `todo finding triage <id> ...` to clear them before you pick new work. Findings are review blind spots, not claimable items.
+1. Run `todo ready`, then `todo claim <id>` for the full work order: scope,
+   must-preserve notes, anti-patterns, verification, ready units, and deferrals.
+   If `ready` warns about findings, run `todo finding candidates` and
+   `todo finding triage <id> ...` before choosing new work. Findings are not
+   claimable items.
 2. For each work unit: run `todo start <id> <wid>` (optional), apply
    `SHARED/change-framework/SKILL.md` Section 1 before source-code edits,
    implement the unit, then run `todo done <id> <wid> --evidence "<command or commit or PR>"`.
-3. Defer out-of-scope work at once: `todo defer <id> --summary "..." --reason "..."`.
-4. Before you commit: run `todo check-scope <id>` and `todo verify <id> --run [seq]`.
-5. Complete: `todo complete <id> --pr <n>` — but first resolve every deferral with `todo promote <deferral-id> --to-item <slug>` or `todo dismiss <deferral-id> --reason "..."`. The command refuses if deferrals remain.
+3. Defer out-of-scope work immediately with
+   `todo defer <id> --summary "..." --reason "..."`.
+4. Before committing, run `todo check-scope <id>` and
+   `todo verify <id> --run [seq]`.
+5. Resolve every deferral with `todo promote <deferral-id> --to-item <slug>` or
+   `todo dismiss <deferral-id> --reason "..."`. Then run
+   `todo complete <id> --pr <n>`; it refuses unresolved deferrals.
 
 ## Findings
 
-Triage through `todo finding candidates`, `todo finding triage`, `todo finding sync`, and `todo finding promote`. See the finding commands in the tracker help. Findings never enter the ready queue.
+Use `todo finding candidates`, `todo finding triage`, `todo finding sync`, and
+`todo finding promote` as documented in tracker help. Findings never enter the
+ready queue.

--- a/.claude/skills/todo/references/prioritize.md
+++ b/.claude/skills/todo/references/prioritize.md
@@ -1,17 +1,22 @@
 # Prioritize TODOs
 
-Rank open items and group them by topic. Do not change tracker state unless the user asks you to. This is a skill-only analysis. There is no `prioritize` CLI command.
-
-Use it when the user says: "prioritize TODOs", "top N most important", "what should we work on", "rank the backlog", or "group ready work by topic".
+Rank open items by topic without changing tracker state. There is no
+`prioritize` CLI command.
 
 ## Before you start
 
-1. Confirm the wrapper supports the inspect commands you need. Run `_project/scripts/todo --help` and check for at least `doctor`, `stats`, `ready`, `list`, `show`, and `deps`.
+1. Run `_project/scripts/todo --help` and confirm `doctor`, `stats`, `ready`,
+   `list`, `show`, and `deps`.
 2. Run `todo doctor`. Use the production database:
-   * Hosted: `TODO_DB_URL` plus `TODO_DB_AUTH_TOKEN` (the wrapper may refresh the token once).
-   * Acceptable fallback for reads: an explicit replica path (`--db <git-root>/.todo-db/replica.db` or `TODO_DB_REPLICA`) — only if `doctor` reports the schema is OK and shows a non-trivial item count.
-   * Do not use a silent local fallback database when `doctor` warns it is not the production tracker, unless the user explicitly asks for analysis on that file. Never run `todo migrate` to make a stale local copy readable.
-3. If `doctor` fails on schema, auth, or identity, stop and report the gap. Do not build a backlog from `_project/TODO`, the committed snapshot at `_project/todo-db-export/`, or chat history.
+   - Hosted: `TODO_DB_URL` and `TODO_DB_AUTH_TOKEN`; the wrapper may refresh the
+     token once.
+   - Read-only fallback: an explicit `--db <git-root>/.todo-db/replica.db` or
+     `TODO_DB_REPLICA`, but only when `doctor` approves its schema and shows a
+     non-trivial item count.
+3. Stop on schema, authentication, or identity failure. Use a non-production
+   file only when the user explicitly requests analysis of that file. Never run
+   `todo migrate` on a stale copy or build the backlog from `_project/TODO`,
+   `_project/todo-db-export/`, or chat history.
 
 ## Inputs
 
@@ -23,7 +28,7 @@ Use it when the user says: "prioritize TODOs", "top N most important", "what sho
 
 ## Workflow
 
-Collect the live picture first. Always start here:
+Start with the live picture:
 
 ```sh
 todo doctor
@@ -35,20 +40,25 @@ todo list --priority medium-high
 todo list --state active
 ```
 
-When `N` is large or medium-high matters, also list `medium`. Always surface the stderr warning from `ready`/`stats` about untriaged findings as a side note — triage with `todo finding candidates`. Findings are not ranked items.
+When `N` is large or medium-high matters, also list `medium`. Report any
+findings warning from `ready` or `stats`; findings are not ranked items.
 
-Use `todo show <id>` and `todo deps <id>` for any item you cannot classify from the list line.
+Use `todo show <id>` and `todo deps <id>` when list output is insufficient.
 
-If the open set is small (about 15 or fewer) or you can answer from the CLI lists, you can stop here. Pick up to `N` items by hand using severity, then ready, then unlock value, then keyword risk (see signals below). Group by `category` or worktree from the list lines.
+For about 15 or fewer open items, rank up to `N` directly by severity,
+readiness, unlock value, and keyword risk. Group by category or worktree.
 
 ### When you need a structured ranking
 
-Use this branch when the open high-priority set is large (more than about 15) or the user asked for topic groups. You need a bulk view.
+Use a bulk view for more than about 15 high-priority items or requested topic
+groups.
 
 Choose one source, in this order:
 
-1. `todo export` output (the CLI command) — only if it is fresh enough for the question.
-2. Read-only SQL on the explicit replica or local path that `doctor` already approved. Never query a file you guessed. The tracker tables are `items`, `item_deps`, and optionally `findings`. Check column names with `PRAGMA table_info` and a sample row first.
+1. Fresh `todo export` output.
+2. Read-only SQL against a path approved by `doctor`. Never guess the file.
+   Inspect `items`, `item_deps`, and optional `findings` columns with
+   `PRAGMA table_info` and a sample row before querying.
 
 For each open candidate, compute:
 
@@ -58,8 +68,8 @@ For each open candidate, compute:
 | Ready | unblocked (`blocked_reason` empty) and no open dependency edges |
 | Unlock value | count of open items that depend on this id |
 | In-flight | `active` or currently claimed — small boost only |
-| Risk keywords | words in title or category that suggest privacy, security, or correctness risk (for example, leak, secret, credential, egress, provenance, silent) |
-| Human-only | maintainer or admin work — demote out of the agent-actionable top N (still note it in a footnote when it is critical) |
+| Risk keywords | Title/category terms suggesting privacy, security, or correctness risk, such as leak, secret, credential, egress, provenance, or silent |
+| Human-only | Maintainer/admin work; demote from the agent-actionable top N but note critical items |
 
 Default order:
 
@@ -70,42 +80,43 @@ Default order:
 5. active or claimed
 6. stable tie-break on `id`
 
-Do not treat "claimed by me" as rank 1 when a higher-severity ready item is unclaimed.
+A claim gives only a small boost; it never outranks a higher-severity ready item.
 
 ### Topic groups
 
 Give each ranked item exactly one topic.
 
-1. Use `category` when it is stable and meaningful.
-2. Else use worktree when it names a real program (not a catch-all like `main`).
-3. Else use keyword buckets from the title or description. Reuse buckets you already saw in the inventory. Keep 4 to 8 groups for a top-25. Merge singletons into the nearest group or an "Other high-priority" group.
+1. Prefer a stable, meaningful `category`.
+2. Otherwise use a worktree that names a real program, not `main` or another
+   catch-all.
+3. Otherwise reuse keyword buckets from titles or descriptions. For a top 25,
+   keep four to eight groups and merge singletons into the nearest group or
+   "Other high-priority."
 
 ### Report
 
 Include:
 
-1. Method line — which database you used (hosted or replica path), open counts by priority, `N`, and that write-back is off.
-2. Tables per topic — rank, id, priority, state, ready, unlocks, one-line reason.
-3. Suggested order — a short, dependency-aware sequence across groups. Put privacy, security, and tracker-reliability before product work.
-4. Demotions — high or critical items you left out of the top N, with reason (blocked, human-only, narrow risk, waiting on deps).
-5. Side notes — open findings warning, stale-replica caveat, blocked criticals the user still owns.
+1. Method: database identity, open counts by priority, `N`, and write-back off.
+2. Topic tables: rank, id, priority, state, readiness, unlocks, and one-line
+   reason.
+3. Suggested dependency-aware order across groups, with privacy, security, and
+   tracker reliability before product work.
+4. High or critical demotions and their reasons.
+5. Findings warnings, replica caveats, and user-owned blocked criticals.
 
-These ranks are recommendations for this session. They do not change the database.
+Ranks are session recommendations and do not change the database.
 
 ### Write-back — only when the user asks
 
-Only when the user says to apply the ranking (for example, "write these priorities back"):
+Only when the user asks to apply the ranking:
 
-1. Confirm the wrapper supports `update` (`todo update --help` returns 0). If it does not, report the gap. Do not drop and recreate to change priority.
+1. Confirm `todo update --help` succeeds. Report a missing command; do not drop
+   and recreate items.
 2. Update only items whose stored priority differs from the recommended band.
 3. Give a one-line reason per update. Prefer band moves (`medium` → `high`) over invented ranks the schema cannot store.
 4. Re-run `todo stats` and show before/after counts.
 
-Do not do these even when ranking:
-
-* Use a silent local fallback database after `doctor` warned it is not production.
-* Run `todo migrate` on a local copy to make ranking work.
-* Treat the committed snapshot at `_project/todo-db-export/` or `_project/TODO` trees as the live backlog.
-* Change priorities, block, or claim as a side effect of a read-only ranking request.
-* Dump all open medium items when the user asked for the top 25.
-* Make one topic per item or one flat list when groups were requested.
+Never change priorities, block, or claim during read-only ranking. Respect `N`
+and requested grouping; do not dump all medium items, create one topic per item,
+or return a flat list when groups were requested.

--- a/.claude/skills/todo/references/queries.md
+++ b/.claude/skills/todo/references/queries.md
@@ -2,8 +2,18 @@
 
 ## Create and update
 
-* Create: `todo create --title ... --worktree ... --priority ...`, or `--from -` with JSON. Items that involve code need scope rules, must-preserve notes, anti-patterns, and verification steps.
-* Update: `todo update <id>` changes an item after you create it. You can change `--title`, `--description`, `--priority`, `--worktree`, `--add-work`, `--edit-work` (only for work units that are still pending; done units are immutable because they carry evidence), `--add-verify`, and `--drop-verify SEQ --reason ...`. Each update creates one audit event with before/after diffs. You must give `--reason` when you edit items that are done or dropped. The id, state, and identity never change through `update` — use lifecycle commands to change state. Prefer `update` over dropping and recreating. It keeps history and links.
+- Create with `todo create --title ... --worktree ... --priority ...` or JSON
+  through `--from -`. Code items need scope rules, must-preserve notes,
+  anti-patterns, and verification steps.
+- Update with `todo update <id>`. It accepts `--title`, `--description`,
+  `--priority`, `--worktree`, `--add-work`, `--edit-work`, `--add-verify`, and
+  `--drop-verify SEQ --reason ...`.
+- Edit work units only while pending. Done units are immutable because they
+  carry evidence.
+- Each update records one audit event with before-and-after differences. Give
+  `--reason` when editing done or dropped items.
+- `update` cannot change an item's id, state, or identity. Use lifecycle
+  commands for state and prefer updates over dropping and recreating items.
 
 ## Inspect
 
@@ -11,16 +21,21 @@
 * `todo show <id> [--json]` — show one item
 * `todo stats` — counts by state, priority, worktree, and deferral
 * `todo deps <id>` — show dependencies
-* `todo export` — write a deterministic snapshot (JSONL plus a markdown index). This is the CLI command. It is different from the committed snapshot at `_project/todo-db-export/` (written by `write_export`). Prefer live commands (`list`, `show`, `stats`) for day-to-day work. Use the committed snapshot only for offline review.
+- `todo export` — write a deterministic JSONL snapshot and Markdown index. This
+  CLI output differs from `_project/todo-db-export/`, which `write_export`
+  commits. Prefer live `list`, `show`, and `stats`; use the committed snapshot
+  only for offline review.
 
 ## Rank and group
 
-Ranking and grouping open work is a skill-only analysis. It has no CLI command. Follow `references/prioritize.md`. Do not invent a `prioritize` command.
+Follow `references/prioritize.md`; there is no `prioritize` CLI command.
 
 ## Block, release, and drop
 
 * `todo block <id> --reason ...` — mark blocked
 * `todo unblock <id>` — clear the blocked flag
-* `todo release <id>` — release your claim. Fails with exit 2 if another actor holds it. Checking `claimed_by` with `todo show --json` can still race. You cannot release another actor's expired claim. Use `todo claim` (may take it over if expired) or `todo sweep-stale`. Does nothing if unclaimed.
+- `todo release <id>` — release your claim. It does nothing when unclaimed and
+  exits 2 for another actor's claim. `todo show --json` can race. For another
+  actor's expired claim, use `todo claim` to take it over or `todo sweep-stale`.
 * `todo sweep-stale` — release expired claims
 * `todo drop <id> --reason ...` — drop an item

--- a/.claude/skills/todo/references/review.md
+++ b/.claude/skills/todo/references/review.md
@@ -1,3 +1,7 @@
 # TODO Review
 
-Run `todo lint <id>` or `todo lint --all`. It checks verification steps (with commands), code scope rules, `prior_art` for new modules, env vars, and file conventions, and runnable evidence for pinned upstream behavior. Check clarity and whether premises are still current from `todo show <id>`, then apply `SHARED/review-protocol/SKILL.md` L2.
+Run `todo lint <id>` or `todo lint --all`. It checks command-based verification,
+code scope, `prior_art` for new modules, environment variables, file
+conventions, and runnable evidence for pinned upstream behavior. Use
+`todo show <id>` to check clarity and current premises, then apply Layer 2 of
+`SHARED/review-protocol/SKILL.md`.

--- a/.claude/skills/todo/references/spec.md
+++ b/.claude/skills/todo/references/spec.md
@@ -1,9 +1,11 @@
 # Write a Specification
 
-State the assumptions, objective, commands, structure, style, tests, boundaries, success criteria, and review gate. Before you finalize, apply `SHARED/review-protocol/SKILL.md` (Planning-Depth Layers) L3 and include a reframe only if it changes the spec. Save only after the user confirms.
-
-If the spec covers new infrastructure, list existing patterns by file path. For each pattern, say whether you will extend it, supersede it, or add something genuinely new.
+State assumptions, objective, commands, structure, style, tests, boundaries,
+success criteria, and review gate. Before finalizing, apply Layer 3 of
+`SHARED/review-protocol/SKILL.md`. Include a reframe only if it changes the
+specification. Save only after the user confirms.
 
 ## Prior art
 
-List the relevant existing patterns and why the proposal extends, supersedes, or adds to them.
+For new infrastructure, list relevant patterns by file path. Explain whether
+the proposal extends or supersedes each pattern, or adds something new.

--- a/skill-sync.lock
+++ b/skill-sync.lock
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "lockedAt": "2026-08-16T21:51:23.750Z",
+  "lockedAt": "2026-08-16T22:49:47.409Z",
   "skills": {
     "blog": {
       "source": {
@@ -161,10 +161,10 @@
         "type": "git",
         "name": "todo-context-efficiency",
         "url": "https://github.com/joeharris76/skill-sync-skills.git",
-        "ref": "740eeab3a585af162523c5b5e653fea18fae19f1",
+        "ref": "e0af1fe8b6751ee7cae42fa7a9adc374d96dd690",
         "subdir": "skills",
-        "revision": "740eeab3a585af162523c5b5e653fea18fae19f1",
-        "fetchedAt": "2026-08-16T21:51:19.533Z"
+        "revision": "e0af1fe8b6751ee7cae42fa7a9adc374d96dd690",
+        "fetchedAt": "2026-08-16T22:49:43.374Z"
       },
       "installMode": "mirror",
       "files": {
@@ -209,8 +209,8 @@
           "size": 463
         },
         "SKILL.md": {
-          "sha256": "428de89b09cbd538890152e547a30a2828a190c3f8689bc8d1979ea878a39941",
-          "size": 3933
+          "sha256": "4f039e8b410b0150748a2da619bacc07d7020ac86c163bfe8fc038bdef17bf4e",
+          "size": 3844
         },
         "skill.yaml": {
           "sha256": "e2c0b40d9935492621e6d21ab216a6227f4bae8f3808ed004d995d0f1b5bbff3",

--- a/skill-sync.lock
+++ b/skill-sync.lock
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "lockedAt": "2026-08-12T16:16:45.555Z",
+  "lockedAt": "2026-08-16T21:51:23.750Z",
   "skills": {
     "blog": {
       "source": {
@@ -10,7 +10,7 @@
         "ref": "7b63719927992bd7f7fff6b90449bbba2bb94ba3",
         "subdir": "skills",
         "revision": "7b63719927992bd7f7fff6b90449bbba2bb94ba3",
-        "fetchedAt": "2026-08-12T16:16:37.555Z"
+        "fetchedAt": "2026-08-16T21:51:16.794Z"
       },
       "installMode": "mirror",
       "files": {
@@ -64,7 +64,7 @@
         "ref": "7b63719927992bd7f7fff6b90449bbba2bb94ba3",
         "subdir": "skills",
         "revision": "7b63719927992bd7f7fff6b90449bbba2bb94ba3",
-        "fetchedAt": "2026-08-12T16:16:38.359Z"
+        "fetchedAt": "2026-08-16T21:51:17.479Z"
       },
       "installMode": "mirror",
       "files": {
@@ -118,7 +118,7 @@
         "ref": "7b63719927992bd7f7fff6b90449bbba2bb94ba3",
         "subdir": "skills",
         "revision": "7b63719927992bd7f7fff6b90449bbba2bb94ba3",
-        "fetchedAt": "2026-08-12T16:16:39.137Z"
+        "fetchedAt": "2026-08-16T21:51:18.143Z"
       },
       "installMode": "mirror",
       "files": {
@@ -159,22 +159,22 @@
     "todo": {
       "source": {
         "type": "git",
-        "name": "canonical",
+        "name": "todo-context-efficiency",
         "url": "https://github.com/joeharris76/skill-sync-skills.git",
-        "ref": "7b63719927992bd7f7fff6b90449bbba2bb94ba3",
+        "ref": "740eeab3a585af162523c5b5e653fea18fae19f1",
         "subdir": "skills",
-        "revision": "7b63719927992bd7f7fff6b90449bbba2bb94ba3",
-        "fetchedAt": "2026-08-12T16:16:40.706Z"
+        "revision": "740eeab3a585af162523c5b5e653fea18fae19f1",
+        "fetchedAt": "2026-08-16T21:51:19.533Z"
       },
       "installMode": "mirror",
       "files": {
         "references/batch.md": {
-          "sha256": "0edc7a9dfff97583d26c61a83a519111bf6e56ec3031151d96753bcafb27fa1c",
-          "size": 6712
+          "sha256": "25a1a8ae5b9d70d4644a1ad87ff7b47f0d2426afcf532d2aa498195bd590a4ee",
+          "size": 6430
         },
         "references/bootstrap.md": {
-          "sha256": "ea29918ad420016d5f65adf5777c8fe3f6c86311045bcdc3c45fae5ada05bf39",
-          "size": 3853
+          "sha256": "7b3fbbe13006548df81be94aa7b6d38b177ee1f883b0f5770111c5700f8fa334",
+          "size": 3031
         },
         "references/closeout.md": {
           "sha256": "d2bd9ba6965e76020f2184d3aca1434c067bbfaa6dfcb43e1f6f51078af01773",
@@ -185,32 +185,32 @@
           "size": 1657
         },
         "references/ideate.md": {
-          "sha256": "00733f03658b2f215eaeebc25739a4ab7d57898fed162045e18f0c389cdc2609",
-          "size": 461
+          "sha256": "119d827f10d4978518265dbf37fafbe57ae5830518f25b083913ed25ff6a8f5e",
+          "size": 419
         },
         "references/implement.md": {
-          "sha256": "e1ce08e4f015ae43d481d4567ce8a4635c868fe2115a9f519a8f9179a1c86ce3",
-          "size": 1331
+          "sha256": "5c3fa90df411bd52d82238e1734a4ea1d8aa2783b76d7071be73a54ff75cf5bd",
+          "size": 1166
         },
         "references/prioritize.md": {
-          "sha256": "24720a9f300a081e893ebc3052855d8081e1cafa67eb3a710ad095a55e2975c9",
-          "size": 6015
+          "sha256": "b64e5834547f26e34b1269cadb7d4d04cac7784fddc0c69e20ae97eb9a131529",
+          "size": 4494
         },
         "references/queries.md": {
-          "sha256": "0f3b137373ccf90468cdc593c1f2cfdc77934a2fc582a1af66e9509bd2067e60",
-          "size": 2108
+          "sha256": "11ae465326ec08c012ea7beb5aadbd3d5faeee90ad2140a7f8d3a46fd022f724",
+          "size": 1829
         },
         "references/review.md": {
-          "sha256": "09296f7252cb92f53e99d06344f82d2b7d842abe5f7bad58e36cb4137c427e6f",
-          "size": 360
+          "sha256": "939b1e48cb66346f929d3d538362b252f0f00f689ca4299c64733c22f2621b0a",
+          "size": 347
         },
         "references/spec.md": {
-          "sha256": "b8eb188d006cdc4caa926430eb93b7fcc98a5034d2954b6776fef15f7a27582d",
-          "size": 598
+          "sha256": "3f0e3bd1c1a061c399bdd75b51cdde2c90c9f9fbc3394a0d0aeff14258c12474",
+          "size": 463
         },
         "SKILL.md": {
-          "sha256": "0adbddfca726a6b0ba61c923fdbb06e50b6518603bce1ef237ca9cda281aa277",
-          "size": 4298
+          "sha256": "428de89b09cbd538890152e547a30a2828a190c3f8689bc8d1979ea878a39941",
+          "size": 3933
         },
         "skill.yaml": {
           "sha256": "e2c0b40d9935492621e6d21ab216a6227f4bae8f3808ed004d995d0f1b5bbff3",
@@ -226,7 +226,7 @@
         "ref": "7b63719927992bd7f7fff6b90449bbba2bb94ba3",
         "subdir": "skills",
         "revision": "7b63719927992bd7f7fff6b90449bbba2bb94ba3",
-        "fetchedAt": "2026-08-12T16:16:41.534Z"
+        "fetchedAt": "2026-08-16T21:51:20.232Z"
       },
       "installMode": "mirror",
       "files": {
@@ -288,7 +288,7 @@
         "ref": "7b63719927992bd7f7fff6b90449bbba2bb94ba3",
         "subdir": "skills",
         "revision": "7b63719927992bd7f7fff6b90449bbba2bb94ba3",
-        "fetchedAt": "2026-08-12T16:16:45.321Z"
+        "fetchedAt": "2026-08-16T21:51:23.647Z"
       },
       "installMode": "mirror",
       "files": {
@@ -322,7 +322,7 @@
         "ref": "6d09682dabe2ff0d68f400d60f8ba8b87f8c02aa",
         "subdir": "skills",
         "revision": "6d09682dabe2ff0d68f400d60f8ba8b87f8c02aa",
-        "fetchedAt": "2026-08-12T16:16:44.535Z"
+        "fetchedAt": "2026-08-16T21:50:32.655Z"
       },
       "installMode": "mirror",
       "files": {
@@ -348,7 +348,7 @@
         "ref": "7b63719927992bd7f7fff6b90449bbba2bb94ba3",
         "subdir": "skills",
         "revision": "7b63719927992bd7f7fff6b90449bbba2bb94ba3",
-        "fetchedAt": "2026-08-12T16:16:42.353Z"
+        "fetchedAt": "2026-08-16T21:51:20.932Z"
       },
       "installMode": "mirror",
       "files": {
@@ -374,7 +374,7 @@
         "ref": "7b63719927992bd7f7fff6b90449bbba2bb94ba3",
         "subdir": "skills",
         "revision": "7b63719927992bd7f7fff6b90449bbba2bb94ba3",
-        "fetchedAt": "2026-08-12T16:16:39.938Z"
+        "fetchedAt": "2026-08-16T21:51:18.835Z"
       },
       "installMode": "mirror",
       "files": {
@@ -416,7 +416,7 @@
         "ref": "7b63719927992bd7f7fff6b90449bbba2bb94ba3",
         "subdir": "skills",
         "revision": "7b63719927992bd7f7fff6b90449bbba2bb94ba3",
-        "fetchedAt": "2026-08-12T16:16:43.133Z"
+        "fetchedAt": "2026-08-16T21:51:21.683Z"
       },
       "installMode": "mirror",
       "files": {
@@ -438,7 +438,7 @@
         "ref": "7b63719927992bd7f7fff6b90449bbba2bb94ba3",
         "subdir": "skills",
         "revision": "7b63719927992bd7f7fff6b90449bbba2bb94ba3",
-        "fetchedAt": "2026-08-12T16:16:43.886Z"
+        "fetchedAt": "2026-08-16T21:51:22.355Z"
       },
       "installMode": "mirror",
       "files": {

--- a/skill-sync.yaml
+++ b/skill-sync.yaml
@@ -8,7 +8,7 @@ sources:
   - name: todo-context-efficiency
     type: git
     url: https://github.com/joeharris76/skill-sync-skills.git
-    ref: 740eeab3a585af162523c5b5e653fea18fae19f1
+    ref: e0af1fe8b6751ee7cae42fa7a9adc374d96dd690
     subdir: skills
   - name: product
     type: git

--- a/skill-sync.yaml
+++ b/skill-sync.yaml
@@ -5,6 +5,11 @@ sources:
     url: https://github.com/joeharris76/skill-sync-skills.git
     ref: 7b63719927992bd7f7fff6b90449bbba2bb94ba3
     subdir: skills
+  - name: todo-context-efficiency
+    type: git
+    url: https://github.com/joeharris76/skill-sync-skills.git
+    ref: 740eeab3a585af162523c5b5e653fea18fae19f1
+    subdir: skills
   - name: product
     type: git
     url: https://github.com/joeharris76/skill-sync.git
@@ -34,6 +39,8 @@ install_mode: mirror
 overrides:
   skill-sync:
     source_name: product
+  todo:
+    source_name: todo-context-efficiency
 config:
   code:
     lint: "uv run ruff check ."


### PR DESCRIPTION
## Summary
- source the `todo` skill from merged skill-sync-skills commit `e0af1fe`
- regenerate the tracked Claude TODO mirror and all local managed targets
- keep unrelated catalog skills on BenchBox's existing canonical pin
- adopt bounded TODO batch contexts while preserving the 40-line thin-wrapper budget

## Validation
- `make agent-write-preflight`
- `make skill-sync`
- `make skill-sync-check`
- `make agent-identity-check`
- `uv run -- python -m pytest -q tests/unit/scripts/test_todo_wrapper.py::TestSkillThinness::test_skill_body_is_thin` (passed)
- prior `make pr-preflight` completed all gates except a concurrent pytest-lock collision; its safe single-threaded collection equivalent passed

## Source
- skill-sync-skills PR #41 — bounded batch contexts
- skill-sync-skills PR #43 — thin-wrapper compatibility
- merged source commit: `e0af1fe8b6751ee7cae42fa7a9adc374d96dd690`
