### PR TITLE
chore: pin skill-sync operator to merged lock/pin notes

### DIFF
--- a/.claude/skills/skill-sync/SKILL.md
+++ b/.claude/skills/skill-sync/SKILL.md
@@ -24,6 +24,7 @@ Read the project-root `skill-sync.yaml`, then read
 |---|---|
 | `setup`, `sync`, `status`, `validate`, `verify`, `diff`, `doctor` | `references/operations.md` |
 | `pin`, `unpin`, `prune`, `promote`, `settings` | `references/operations.md` |
+| `agent-config` | `references/operations.md` |
 | `help` | this table |
 
 ## Flags
@@ -31,4 +32,6 @@ Read the project-root `skill-sync.yaml`, then read
 - Global: `--json`/`-j`, `--project`/`-p`, `--help`/`-h`.
 - Sync: `--dry-run`/`-n`, `--force`/`-f`.
 - Validate: `--exit-code`. Settings: `--agent`. Prune: `--dry-run`.
+- Agent config: `capture`, `validate`, or `restore`; supports `--dry-run`,
+  `--force` for restore, and `--json`.
 - Use `--force` only when source and target ownership is known.

--- a/.claude/skills/skill-sync/references/operations.md
+++ b/.claude/skills/skill-sync/references/operations.md
@@ -22,6 +22,9 @@
 - **Pin/unpin:** update config, then validate.
 - **Prune:** dry-run first; remove only known managed content.
 - **Settings:** use `settings generate` to show required agent settings.
+- **Agent config:** use `agent-config capture|validate|restore` for the exact
+  six-file local instruction snapshot. Validate before restore; require
+  `--force` to replace modified destinations.
 
 ## Promote
 
@@ -33,6 +36,19 @@
    checks in the product repository.
 5. Commit, push, or open a PR only when authorized. Publish the source before
    updating downstream pins and mirrors.
+
+## Consumer lock, attributes, and pins
+
+- A git source is cloned `--depth 1` of the default branch. A pin that exists
+  only on a feature branch fails as a missing ref. Land the source change on
+  that default branch before advancing a consumer pin.
+- Sync rewrites `skill-sync.lock` every time. Revert timestamp-only
+  `lockedAt`/`fetchedAt` churn; keep source refs, revisions, and file digests
+  when they change. Unconditional `git checkout skill-sync.lock` discards a
+  real pin or digest update.
+- Sync may move its managed `.gitattributes` block to end-of-file. Sequence
+  that rewrite with any other `.gitattributes` edit rather than landing both
+  in parallel.
 
 ## Deployment and branch tests
 

--- a/skill-sync.lock
+++ b/skill-sync.lock
@@ -319,20 +319,20 @@
         "type": "git",
         "name": "product",
         "url": "https://github.com/joeharris76/skill-sync.git",
-        "ref": "6d09682dabe2ff0d68f400d60f8ba8b87f8c02aa",
+        "ref": "6139085a35455fe90c8d6c94d7567e131a24db96",
         "subdir": "skills",
-        "revision": "6d09682dabe2ff0d68f400d60f8ba8b87f8c02aa",
+        "revision": "6139085a35455fe90c8d6c94d7567e131a24db96",
         "fetchedAt": "2026-08-16T21:50:32.655Z"
       },
       "installMode": "mirror",
       "files": {
         "references/operations.md": {
-          "sha256": "26f661822c7a6be5ac81e68a80827ba4b0bd2a0f375772eb239dd9baa2c8d47a",
-          "size": 1910
+          "sha256": "4835e79ceba1b314be879705cb3b42812fd341486ae0bd1cb2a215b0227b5860",
+          "size": 2776
         },
         "SKILL.md": {
-          "sha256": "0264f64484bd31941fad4cbf09db9e170ac4372916346cd131335705a2914e34",
-          "size": 1259
+          "sha256": "68f73b8880bcf6534e97d2fa1f6b4fb5a6675eb17e8dff7929bd46445717906b",
+          "size": 1421
         },
         "skill.yaml": {
           "sha256": "01ece1a29901cca51c02f6042d087f1053b7e22c3d5102458ec8b8bf13436804",

--- a/skill-sync.yaml
+++ b/skill-sync.yaml
@@ -13,7 +13,7 @@ sources:
   - name: product
     type: git
     url: https://github.com/joeharris76/skill-sync.git
-    ref: 6d09682dabe2ff0d68f400d60f8ba8b87f8c02aa
+    ref: 6139085a35455fe90c8d6c94d7567e131a24db96
     subdir: skills
 skills:
   - blog


### PR DESCRIPTION
Pin the BenchBox product skill-sync source to `6139085a35455fe90c8d6c94d7567e131a24db96` (skill-sync#21 on `main`).

That lands the operator notes for lock timestamp vs digest updates, `--depth 1` pin reachability, and `.gitattributes` block moves. Tracked Claude mirrors and the skill-sync lock digest/ref were updated; unrelated lock timestamps were left alone.

`make skill-sync-check` is clean. Local preflight lint, instruction audit, and fast tests passed.
