### PR TITLE
docs/review protocol axes 20260817

### DIFF
--- a/docs/agent/review-protocol.md
+++ b/docs/agent/review-protocol.md
@@ -1,47 +1,53 @@
 # Agent review protocol
 
-This is the active BenchBox binding for the canonical generated
-`SHARED/review-protocol` skill — the single behavioral authority for
-review-shaped work. It supersedes `docs/agent/review-protocol-legacy.md`,
-retained only as non-authoritative historical rationale. Stable IDs make
-the contract mechanically auditable.
+BenchBox binding for `SHARED/review-protocol`. Supersedes
+`docs/agent/review-protocol-legacy.md`. IDs are auditable.
 
 ## Authority boundary
 
-- `[REVIEW-AUTH-001]`: review-shaped work is read-only. Local capture is the
-  only exception explicitly described below. Remediation, hosted writes,
-  commits, pushes, PRs, and auto-merge require explicit authorization in a
-  later user turn; bundling review and remediation does not satisfy that gate.
-- `[AUTH-PROVENANCE-001]`: label consequential instructions as task authority,
-  repository policy, mechanical constraint, or recommendation. A prior task's
-  requested author identity is not repository policy.
-- `[COMMIT-IDENTITY-001]`: resolve the effective human Git identity and inspect
-  its config origin. Reject stale agent/service identities unless the user
-  explicitly requests that exact identity for the current task.
+- `[REVIEW-AUTH-001]`: reviews are read-only except local capture. Remediation,
+  hosted writes, commits, pushes, PRs, and auto-merge need a later user turn;
+  bundling review and remediation does not. Findings only: zero tracked
+  worktree-content changes; do not review and then edit.
+- `[AUTH-PROVENANCE-001]`: label task, repository, mechanical, or
+  recommendation. A prior task's author identity is not policy.
+- `[COMMIT-IDENTITY-001]`: resolve human Git identity and its origin. Reject
+  stale agent/service authors unless this task names that identity.
 
 ## Finding routing
 
-- `[REVIEW-DEFECT-001]`: an observed correctness, security, or performance
-  failure is a defect and remains an owned review action. It is not a blind
-  spot, assumption, or scope-creep record.
-- `[REVIEW-L2-001]`: L2 records a review dimension the framework failed to ask
-  about. It does not relocate a concrete finding already caught by the review.
-- `[REVIEW-CAPTURE-001]`: review-time finding capture is append-only and local
-  under `~/.benchbox/finding-drafts/`. Hosted `todo finding sync`, commits,
-  pushes, and PRs are separate actions requiring authorization.
+- `[REVIEW-DEFECT-001]`: correctness, security, or performance failures stay
+  owned review actions, not blind spots.
+- `[REVIEW-L2-001]`: L2 is a missed dimension, not a found defect.
+- `[REVIEW-CAPTURE-001]`: append-only under `~/.benchbox/finding-drafts/`.
+  Hosted sync, commits, pushes, and PRs need separate authorization.
 
 ## Project binding
 
-The shared TODO database is the durable work tracker, but a review may not
-write it merely because the database is available. Use `_project/scripts/todo`
-only after the user authorizes tracker writes. The generated canonical skill
-defines cross-project behavior; this file binds it to BenchBox paths and tools
-without duplicating its full prose. `[REVIEW-PARITY-001]` Stable policy IDs and
-their semantics must remain aligned with that canonical skill; wording may be
-shorter here, but a contradiction is drift and the canonical behavior wins.
+Do not write the TODO database just because it exists. Use
+`_project/scripts/todo` only after authorized tracker writes.
+`[REVIEW-PARITY-001]`: IDs and semantics stay aligned with the canonical
+skill; contradiction is drift.
 
 ## Audit evidence provenance
 
-Audit records bind numbers to the tree that produced them through distinct SHA
-fields. `make audit-sha-check` enforces it; the conventions are documented in
-`docs/agent/audit-evidence-provenance.md`.
+Numbers bind to their measurement tree. `make audit-sha-check` enforces it;
+see `docs/agent/audit-evidence-provenance.md`.
+
+## Architecture and plan review axes
+
+Do not relocate a defect into L2 (`[REVIEW-L2-001]`).
+
+- **Operational corpus.** Inventory the operational corpus: test:source
+  ratio, parsed Make API, overlapping docs, explorer/Python contracts, and
+  agent-instruction surface before judging complexity. Simplification plans
+  must name those surfaces.
+- **Extension-cost.** Primary extension-cost metric: files/contracts to add one SQL
+  platform, one DataFrame platform, and one benchmark family. McCabe/cloc
+  are hygiene (`docs/development/quality-gate-policy.md`).
+- **Prior-decision.** Enumerate recorded decision surfaces (future-state
+  index/tiers, migration gates, readiness docs, open tracker items). Cite or
+  supersede each. Unexplained demotion or a dropped open gate is a defect.
+- **CI synchronize fan-out.** For savings/skip/path-filter plans, list every
+  same-event workflow, split runner vs wall minutes, and change siblings or
+  lower the target. See `docs/operations/repo-admin-settings.md`.

--- a/docs/agent/review-protocol.md
+++ b/docs/agent/review-protocol.md
@@ -6,8 +6,8 @@ BenchBox binding for `SHARED/review-protocol`. Supersedes
 ## Authority boundary
 
 - `[REVIEW-AUTH-001]`: reviews are read-only except local capture. Remediation,
-  hosted writes, commits, pushes, PRs, and auto-merge need a later user turn;
-  bundling review and remediation does not. Findings only: zero tracked
+  hosted writes, commits, pushes, PRs, and auto-merge need authorization in a
+  later user turn; bundling review and remediation does not. Findings only: zero tracked
   worktree-content changes; do not review and then edit.
 - `[AUTH-PROVENANCE-001]`: label task, repository, mechanical, or
   recommendation. A prior task's author identity is not policy.

--- a/docs/development/quality-gate-policy.md
+++ b/docs/development/quality-gate-policy.md
@@ -97,6 +97,12 @@ green run.
 
 ## Complexity measurement and exceptions
 
+Per-function McCabe and file cloc are hygiene. They do not measure the
+extension cost of adding one SQL platform, one DataFrame platform, or one
+benchmark family. Architecture reviews treat that extension-cost count as the
+primary complexity metric; this gate remains the hard CC ceiling and advisory
+band only. See `docs/agent/review-protocol.md`.
+
 The former list contained 152 function exclusions. Every entry was remeasured
 against current Ruff C901 output before removal:
 

--- a/docs/operations/repo-admin-settings.md
+++ b/docs/operations/repo-admin-settings.md
@@ -57,6 +57,13 @@ Required status checks:
 - ruleset-drift
 ```
 
+A code-PR `synchronize` is not one Develop PR run. The same head SHA also
+starts Documentation, Results Explorer browser tests, PR base guard,
+auto-merge revocation, and ruleset-drift (plus path-filtered siblings such as
+extension-smoke and gitignore lint). Split runner minutes from wall minutes by
+workflow when judging savings; the next-slowest sibling can dominate remaining
+wall time after `pr.yml` jobs are skipped.
+
 `ci-required-result` is the umbrella job in `.github/workflows/pr.yml`
 that aggregates the required-lane jobs: `ci-paths`, `content-guard`,
 `code-lint`, `code-test`, `correctness-gate`, `plan-capture-gate`,

--- a/docs/operations/repo-admin-settings.md
+++ b/docs/operations/repo-admin-settings.md
@@ -58,11 +58,14 @@ Required status checks:
 ```
 
 A code-PR `synchronize` is not one Develop PR run. The same head SHA also
-starts Documentation, Results Explorer browser tests, PR base guard,
-auto-merge revocation, and ruleset-drift (plus path-filtered siblings such as
-extension-smoke and gitignore lint). Split runner minutes from wall minutes by
-workflow when judging savings; the next-slowest sibling can dominate remaining
-wall time after `pr.yml` jobs are skipped.
+starts Results Explorer browser tests, PR base guard, auto-merge revocation,
+the unconditional `develop-refresh-shadow` observational workflow, and
+ruleset-drift (plus path-filtered siblings such as extension-smoke and
+gitignore lint). Documentation (`docs.yml`) only starts when the diff touches
+its own path filter (`benchbox/**`, `docs/**`, `examples/**`, and similar) —
+for example a `tests/**`-only PR does not start it. Split runner minutes from
+wall minutes by workflow when judging savings; the next-slowest sibling can
+dominate remaining wall time after `pr.yml` jobs are skipped.
 
 `ci-required-result` is the umbrella job in `.github/workflows/pr.yml`
 that aggregates the required-lane jobs: `ci-paths`, `content-guard`,


### PR DESCRIPTION
- **docs: add architecture and plan review axes**
- **docs: restore REVIEW-AUTH later-turn wording for the audit fixture**
