### PR TITLE
fix(ci): do not auto-revert a SHA that missed the failing test

### DIFF
--- a/.github/workflows/develop-post-merge.yml
+++ b/.github/workflows/develop-post-merge.yml
@@ -619,9 +619,32 @@ jobs:
             echo "EOF_NEW_IDS"
           } >> "${GITHUB_OUTPUT}"
 
+      - name: Attribute new failures to the blamed SHA
+        id: attribute
+        if: steps.signature-decision.outputs.should-revert == 'true'
+        shell: bash
+        env:
+          NEW_FAILURE_IDS: ${{ steps.signature-decision.outputs.new-failure-ids }}
+        run: |
+          set -euo pipefail
+          # Fail-open comparisons have empty/unusable new IDs: keep revert.
+          if [ -z "${NEW_FAILURE_IDS}" ] || [ "${NEW_FAILURE_IDS}" = "null" ]; then
+            echo "action=revert" >> "${GITHUB_OUTPUT}"
+            echo "Attribution skipped (no new-failure-id payload); keeping revert."
+            exit 0
+          fi
+          printf '%s\n' "${NEW_FAILURE_IDS}" > new-failure-ids.json
+          python3 scripts/post_merge_signature.py attribute \
+            --sha "${FAILING_SHA}" \
+            --failure-ids new-failure-ids.json \
+            --out attribution.json
+          action="$(jq -r '.action' attribution.json)"
+          echo "action=${action}" >> "${GITHUB_OUTPUT}"
+          echo "Attribution action: ${action}"
+
       - name: Open revert PR or conflict issue
         id: open-revert
-        if: steps.signature-decision.outputs.should-revert == 'true'
+        if: steps.signature-decision.outputs.should-revert == 'true' && steps.attribute.outputs.action != 'advisory'
         shell: bash
         env:
           FAIL_OPEN_REASON: ${{ steps.signature-decision.outputs.fail-open-reason }}
@@ -811,6 +834,24 @@ jobs:
               "Auto-revert conflict for develop red at ${short_sha}" \
               "The automatic \`git revert ${FAILING_SHA}\` conflicted."
           fi
+
+      - name: Comment advisory instead of reverting
+        id: advisory-comment
+        if: steps.signature-decision.outputs.should-revert == 'true' && steps.attribute.outputs.action == 'advisory'
+        shell: bash
+        env:
+          NEW_FAILURE_IDS: ${{ steps.signature-decision.outputs.new-failure-ids }}
+        run: |
+          set -euo pipefail
+          body="Post-merge is red with new failure IDs, but blamed SHA \`${FAILING_SHA}\` did not touch the failing test file(s) or a matching code-under-test basename. Skipping auto-revert; fix-forward the latent break.
+
+          Failing run: ${RUN_URL}
+          New failure IDs: ${NEW_FAILURE_IDS}"
+          echo "${body}"
+          gh issue create \
+            --title "Auto-revert advisory: ${FAILING_SHA:0:12} did not own the failing test" \
+            --label incident:develop-red \
+            --body "${body}" || true
 
       - name: Upsert develop-red incident issue
         id: upsert-incident

--- a/.github/workflows/develop-post-merge.yml
+++ b/.github/workflows/develop-post-merge.yml
@@ -458,7 +458,7 @@ jobs:
       auto-revert-pr-opened-at: ${{ steps.open-revert.outputs.auto-revert-pr-opened-at }}
       auto-revert-pr-url: ${{ steps.open-revert.outputs.auto-revert-pr-url }}
       conflict-issue-url: ${{ steps.open-revert.outputs.conflict-issue-url }}
-      revert-suppressed: ${{ steps.signature-decision.outputs.revert-suppressed }}
+      revert-suppressed: ${{ steps.revert-outcome.outputs.revert-suppressed }}
       new-failure-ids: ${{ steps.signature-decision.outputs.new-failure-ids }}
       incident-issue-url: ${{ steps.upsert-incident.outputs.incident-issue-url }}
     permissions:
@@ -641,6 +641,24 @@ jobs:
           action="$(jq -r '.action' attribution.json)"
           echo "action=${action}" >> "${GITHUB_OUTPUT}"
           echo "Attribution action: ${action}"
+
+      - name: Finalize revert-suppressed for metrics
+        id: revert-outcome
+        # Always runs (even when the attribute step above was skipped) so the
+        # job output below has a value in every case: the signature-decision
+        # step's revert-suppressed is computed before attribution runs, so it
+        # is still "false" for an advisory run even though this job's
+        # "Open revert PR or conflict issue" step explicitly skips the revert.
+        # Metrics consuming revert-suppressed must see that suppression.
+        if: always()
+        shell: bash
+        run: |
+          set -euo pipefail
+          revert_suppressed="${{ steps.signature-decision.outputs.revert-suppressed }}"
+          if [ "${{ steps.attribute.outputs.action }}" = "advisory" ]; then
+            revert_suppressed="true"
+          fi
+          echo "revert-suppressed=${revert_suppressed}" >> "${GITHUB_OUTPUT}"
 
       - name: Open revert PR or conflict issue
         id: open-revert
@@ -843,6 +861,24 @@ jobs:
           NEW_FAILURE_IDS: ${{ steps.signature-decision.outputs.new-failure-ids }}
         run: |
           set -euo pipefail
+
+          # Idempotency: if a re-run of this workflow lands on the advisory
+          # path again for the same SHA (workflow re-run, retry), reuse the
+          # existing open issue instead of opening a duplicate. Match by SHA
+          # in the body via the GitHub search index, scoped to this label -
+          # mirrors open_manual_action_issue's search-before-create pattern
+          # above.
+          existing_issue_url="$(gh issue list \
+            --state open \
+            --label incident:develop-red \
+            --search "${FAILING_SHA} in:body" \
+            --json url \
+            --jq '.[0].url // ""')"
+          if [ -n "${existing_issue_url}" ]; then
+            echo "Advisory issue already exists: ${existing_issue_url}"
+            exit 0
+          fi
+
           body="Post-merge is red with new failure IDs, but blamed SHA \`${FAILING_SHA}\` did not touch the failing test file(s) or a matching code-under-test basename. Skipping auto-revert; fix-forward the latent break.
 
           Failing run: ${RUN_URL}

--- a/scripts/post_merge_signature.py
+++ b/scripts/post_merge_signature.py
@@ -17,6 +17,13 @@ auto-revert-on-failure attribute a red develop run to the merge that actually
 introduced a new failure, instead of blaming whichever commit merged last
 while develop was already red for an unrelated reason.
 
+Blame rule today: revert ``github.sha`` of the first post-merge run whose
+signature has new failure IDs. Residual: a latent environment-dependent
+break can still make that SHA the first red run even when the blamed commit
+did not touch the failing test. ``attribute`` downgrades that case to an
+advisory when every extractable failing test path is outside the SHA's diff.
+Job-level failures (lint, missing junit paths) stay fail-closed (revert).
+
 Stdlib-only by design (see scripts/path_filter_decision.py for the same
 precedent): this runs in a bare `python` step with no dependency sync.
 """
@@ -25,6 +32,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import subprocess
 import sys
 import xml.etree.ElementTree as ET
 from pathlib import Path
@@ -110,6 +118,61 @@ def load_signature(path: Path) -> dict[str, object]:
     return data
 
 
+def failure_id_test_paths(failure_ids: list[object]) -> list[str]:
+    """Extract repository test paths from junit-style failure IDs.
+
+    ``tests/unit/foo.py::test_bar`` yields ``tests/unit/foo.py``. Job-level
+    IDs such as ``lint:Run CI lint mirror`` yield nothing.
+    """
+    paths: list[str] = []
+    seen: set[str] = set()
+    for raw in failure_ids:
+        if not isinstance(raw, str):
+            continue
+        candidate = raw.split("::", 1)[0].strip()
+        if not candidate.endswith(".py"):
+            continue
+        if "/" not in candidate and not candidate.startswith("tests"):
+            continue
+        if candidate not in seen:
+            seen.add(candidate)
+            paths.append(candidate)
+    return paths
+
+
+def paths_related_to_test(test_path: str) -> list[str]:
+    """Return the test path plus a conservative code-under-test stem match.
+
+    ``tests/unit/test_foo.py`` also matches a changed ``foo.py`` basename so a
+    PR that edits the module under test still reverts. This is not a full
+    import graph.
+    """
+    related = [test_path]
+    name = Path(test_path).name
+    if name.startswith("test_") and name.endswith(".py"):
+        related.append(name[len("test_") :])
+    return related
+
+
+def attribution_action(failure_ids: list[object], changed_paths: list[str]) -> str:
+    """Return ``revert`` or ``advisory`` for a blamed SHA's changed paths.
+
+    Advisory only when every extractable failing test path (and its stem
+    match) is absent from ``changed_paths``. No extractable test path keeps
+    revert so lint/job failures stay fail-closed.
+    """
+    test_paths = failure_id_test_paths(failure_ids)
+    if not test_paths:
+        return "revert"
+    changed = set(changed_paths)
+    changed_names = {Path(path).name for path in changed_paths}
+    for test_path in test_paths:
+        for related in paths_related_to_test(test_path):
+            if related in changed or Path(related).name in changed_names:
+                return "revert"
+    return "advisory"
+
+
 def diff_signatures(previous: dict[str, object], current: dict[str, object]) -> list[str]:
     """Return the failure IDs present in `current` but absent from `previous`.
 
@@ -148,6 +211,51 @@ def _build_command(args: argparse.Namespace) -> int:
     text = json.dumps(signature, indent=2, sort_keys=True) + "\n"
     args.out.parent.mkdir(parents=True, exist_ok=True)
     args.out.write_text(text, encoding="utf-8")
+    print(text, end="")
+    return 0
+
+
+def changed_paths_for_sha(sha: str) -> list[str]:
+    """List paths changed by ``sha`` (stdlib git, no shell)."""
+    result = subprocess.run(
+        ["git", "diff-tree", "--no-commit-id", "--name-only", "-r", sha],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        raise SignatureError(result.stderr.strip() or f"git diff-tree failed for {sha}")
+    return [line for line in result.stdout.splitlines() if line]
+
+
+def _attribute_command(args: argparse.Namespace) -> int:
+    try:
+        payload = json.loads(Path(args.failure_ids).read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        print(f"error: could not read failure ids: {exc}", file=sys.stderr)
+        return 1
+    if isinstance(payload, dict):
+        failure_ids = payload.get("new_failure_ids", payload.get("failure_ids", []))
+    else:
+        failure_ids = payload
+    if not isinstance(failure_ids, list):
+        print("error: failure id payload must be a list or signature object", file=sys.stderr)
+        return 1
+    try:
+        changed_paths = changed_paths_for_sha(args.sha)
+    except SignatureError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 1
+    action = attribution_action(failure_ids, changed_paths)
+    result = {
+        "action": action,
+        "test_paths": failure_id_test_paths(failure_ids),
+        "changed_paths": changed_paths,
+    }
+    text = json.dumps(result, indent=2, sort_keys=True) + "\n"
+    if args.out:
+        args.out.parent.mkdir(parents=True, exist_ok=True)
+        args.out.write_text(text, encoding="utf-8")
     print(text, end="")
     return 0
 
@@ -201,6 +309,20 @@ def main(argv: list[str] | None = None) -> int:
     diff_parser.add_argument("--current", type=Path, required=True, help="Path to the current run's signature JSON")
     diff_parser.add_argument("--out", type=Path, help="Path to write {new_failure_ids: [...]}")
     diff_parser.set_defaults(func=_diff_command)
+
+    attribute_parser = subparsers.add_parser(
+        "attribute",
+        help="Decide revert vs advisory from new failure IDs and the blamed SHA diff.",
+    )
+    attribute_parser.add_argument("--sha", required=True, help="Blamed commit SHA")
+    attribute_parser.add_argument(
+        "--failure-ids",
+        type=Path,
+        required=True,
+        help="JSON list or {new_failure_ids: [...]} from diff",
+    )
+    attribute_parser.add_argument("--out", type=Path, help="Path to write the attribution JSON")
+    attribute_parser.set_defaults(func=_attribute_command)
 
     args = parser.parse_args(argv)
     return args.func(args)

--- a/scripts/post_merge_signature.py
+++ b/scripts/post_merge_signature.py
@@ -31,6 +31,7 @@ precedent): this runs in a bare `python` step with no dependency sync.
 from __future__ import annotations
 
 import argparse
+import ast
 import json
 import subprocess
 import sys
@@ -154,21 +155,100 @@ def paths_related_to_test(test_path: str) -> list[str]:
     return related
 
 
-def attribution_action(failure_ids: list[object], changed_paths: list[str]) -> str:
+def _dotted_module_to_candidate_paths(module: str) -> list[str]:
+    """Return the repo-relative file path candidates for a dotted module name."""
+    base = "/".join(module.split("."))
+    return [f"{base}.py", f"{base}/__init__.py"]
+
+
+def imported_module_paths(test_path: str, repo_root: Path) -> list[str]:
+    """Return repo-relative paths ``test_path`` actually imports, via its AST.
+
+    Real import/dependency analysis rather than basename matching: parses
+    every ``import``/``from ... import`` statement anywhere in the test file
+    (module-level or nested inside functions - most of these tests import
+    lazily), resolves each dotted module name (relative imports included) to
+    a candidate file path, and keeps only paths that exist on disk. This is
+    what lets a merge that breaks a same-package dependency the test imports
+    under an unrelated basename (e.g. a test file exercising
+    ``throughput_test.py`` via ``from benchbox.core.tpcds.throughput_test
+    import ...``) still be attributed correctly, instead of relying on
+    filename overlap.
+
+    Best-effort: returns ``[]`` if the test file cannot be read or parsed.
+    Callers must not treat an empty result as proof the blamed SHA is
+    innocent - only as "this signal found nothing", since it is not a full
+    transitive import graph (only direct imports of the test file itself are
+    resolved).
+    """
+    full_path = repo_root / test_path
+    try:
+        source = full_path.read_text(encoding="utf-8")
+        tree = ast.parse(source, filename=str(full_path))
+    except (OSError, SyntaxError, UnicodeDecodeError):
+        return []
+
+    test_dir_parts = Path(test_path).parent.parts
+    module_names: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                module_names.add(alias.name)
+        elif isinstance(node, ast.ImportFrom):
+            if node.level:
+                # Relative import: resolve against the test file's own
+                # package directory. level=1 is "from . import x" (same
+                # package as the test file); each extra level climbs one
+                # more directory.
+                climb = node.level - 1
+                anchor = test_dir_parts[: len(test_dir_parts) - climb] if climb else test_dir_parts
+                if node.module:
+                    module_names.add(".".join([*anchor, node.module]))
+                elif anchor:
+                    module_names.add(".".join(anchor))
+            elif node.module:
+                module_names.add(node.module)
+
+    paths: list[str] = []
+    seen: set[str] = set()
+    for module in sorted(module_names):
+        for candidate in _dotted_module_to_candidate_paths(module):
+            if candidate in seen:
+                continue
+            seen.add(candidate)
+            if (repo_root / candidate).is_file():
+                paths.append(candidate)
+    return paths
+
+
+def attribution_action(
+    failure_ids: list[object],
+    changed_paths: list[str],
+    repo_root: Path | None = None,
+) -> str:
     """Return ``revert`` or ``advisory`` for a blamed SHA's changed paths.
 
-    Advisory only when every extractable failing test path (and its stem
-    match) is absent from ``changed_paths``. No extractable test path keeps
+    Checks two signals before downgrading to advisory: the test path/stem
+    heuristic (``paths_related_to_test``) and, since that heuristic misses a
+    dependency whose basename differs from the test file, real import
+    analysis (``imported_module_paths``) - a changed path the test file
+    actually imports still triggers revert even when neither its name nor
+    its stem matches. Advisory only when both signals clear the blamed SHA
+    for every extractable failing test path. No extractable test path keeps
     revert so lint/job failures stay fail-closed.
     """
     test_paths = failure_id_test_paths(failure_ids)
     if not test_paths:
         return "revert"
+    root = repo_root or Path.cwd()
     changed = set(changed_paths)
     changed_names = {Path(path).name for path in changed_paths}
     for test_path in test_paths:
         for related in paths_related_to_test(test_path):
             if related in changed or Path(related).name in changed_names:
+                return "revert"
+        for imported in imported_module_paths(test_path, root):
+            if imported in changed:
                 return "revert"
     return "advisory"
 

--- a/tests/unit/test_post_merge_signature.py
+++ b/tests/unit/test_post_merge_signature.py
@@ -18,9 +18,11 @@ if _SCRIPTS_DIR not in sys.path:
 
 from post_merge_signature import (  # noqa: E402
     SignatureError,
+    attribution_action,
     build_signature_from_job_failure,
     build_signature_from_junit,
     diff_signatures,
+    failure_id_test_paths,
     load_signature,
     main,
 )
@@ -455,3 +457,34 @@ def test_cli_diff_prints_new_ids_to_stdout(tmp_path: Path, capsys: pytest.Captur
     assert exit_code == 0
     captured = capsys.readouterr()
     assert captured.out.strip() == "tests/a.py::test_a"
+
+
+def test_failure_id_test_paths_extracts_junit_paths_only() -> None:
+    paths = failure_id_test_paths(
+        [
+            "tests/unit/test_query_generation_preflight.py::test_tpcds_throughput_preflight_detects_generation_failures",
+            "lint:Run CI lint mirror",
+            12,
+        ]
+    )
+    assert paths == ["tests/unit/test_query_generation_preflight.py"]
+
+
+def test_attribution_advisory_when_blamed_sha_misses_failing_test() -> None:
+    failure_ids = [
+        "tests/unit/test_query_generation_preflight.py::test_tpcds_throughput_preflight_detects_generation_failures"
+    ]
+    changed = ["benchbox/platforms/ducklake.py", "docs/operations/uat-framework.md"]
+    assert attribution_action(failure_ids, changed) == "advisory"
+
+
+def test_attribution_reverts_when_blamed_sha_touches_code_under_test() -> None:
+    failure_ids = [
+        "tests/unit/test_post_merge_signature.py::test_build_signature_from_junit_extracts_failures_and_errors"
+    ]
+    changed = ["scripts/post_merge_signature.py"]
+    assert attribution_action(failure_ids, changed) == "revert"
+
+
+def test_attribution_reverts_job_level_failures() -> None:
+    assert attribution_action(["lint:Run CI lint mirror"], ["README.md"]) == "revert"

--- a/tests/unit/test_post_merge_signature.py
+++ b/tests/unit/test_post_merge_signature.py
@@ -23,6 +23,7 @@ from post_merge_signature import (  # noqa: E402
     build_signature_from_junit,
     diff_signatures,
     failure_id_test_paths,
+    imported_module_paths,
     load_signature,
     main,
 )
@@ -488,3 +489,74 @@ def test_attribution_reverts_when_blamed_sha_touches_code_under_test() -> None:
 
 def test_attribution_reverts_job_level_failures() -> None:
     assert attribution_action(["lint:Run CI lint mirror"], ["README.md"]) == "revert"
+
+
+# ---------------------------------------------------------------------------
+# imported_module_paths / real dependency attribution (finding #1)
+# ---------------------------------------------------------------------------
+
+
+def test_imported_module_paths_finds_lazy_function_local_imports(tmp_path: Path) -> None:
+    (tmp_path / "pkg").mkdir()
+    (tmp_path / "pkg" / "dep.py").write_text("VALUE = 1\n", encoding="utf-8")
+    test_dir = tmp_path / "tests"
+    test_dir.mkdir()
+    test_file = test_dir / "test_thing.py"
+    test_file.write_text(
+        "def test_it():\n    from pkg.dep import VALUE\n    assert VALUE == 1\n",
+        encoding="utf-8",
+    )
+
+    paths = imported_module_paths("tests/test_thing.py", tmp_path)
+
+    assert "pkg/dep.py" in paths
+
+
+def test_imported_module_paths_skips_nonexistent_modules(tmp_path: Path) -> None:
+    test_dir = tmp_path / "tests"
+    test_dir.mkdir()
+    (test_dir / "test_thing.py").write_text("import os\nimport totally.missing.module\n", encoding="utf-8")
+
+    paths = imported_module_paths("tests/test_thing.py", tmp_path)
+
+    assert paths == []
+
+
+def test_imported_module_paths_missing_file_returns_empty(tmp_path: Path) -> None:
+    assert imported_module_paths("tests/does_not_exist.py", tmp_path) == []
+
+
+def test_attribution_reverts_via_real_import_when_basename_differs(tmp_path: Path) -> None:
+    # The finding #1 repro: a test imports a module whose basename does not
+    # match the test's own basename or its `test_` stem, so the old
+    # basename-only heuristic wrongly returned advisory. Real import
+    # analysis must still catch it.
+    (tmp_path / "benchbox").mkdir()
+    (tmp_path / "benchbox" / "throughput_test.py").write_text("def run():\n    pass\n", encoding="utf-8")
+    tests_dir = tmp_path / "tests"
+    tests_dir.mkdir()
+    (tests_dir / "test_query_generation_preflight.py").write_text(
+        "def test_it():\n    from benchbox.throughput_test import run\n    run()\n",
+        encoding="utf-8",
+    )
+
+    failure_ids = ["tests/test_query_generation_preflight.py::test_it"]
+    changed = ["benchbox/throughput_test.py"]
+
+    assert attribution_action(failure_ids, changed, repo_root=tmp_path) == "revert"
+
+
+def test_attribution_stays_advisory_when_import_analysis_also_clears_sha(tmp_path: Path) -> None:
+    (tmp_path / "benchbox").mkdir()
+    (tmp_path / "benchbox" / "unrelated.py").write_text("def run():\n    pass\n", encoding="utf-8")
+    tests_dir = tmp_path / "tests"
+    tests_dir.mkdir()
+    (tests_dir / "test_query_generation_preflight.py").write_text(
+        "def test_it():\n    from benchbox.unrelated import run\n    run()\n",
+        encoding="utf-8",
+    )
+
+    failure_ids = ["tests/test_query_generation_preflight.py::test_it"]
+    changed = ["docs/operations/uat-framework.md"]
+
+    assert attribution_action(failure_ids, changed, repo_root=tmp_path) == "advisory"


### PR DESCRIPTION
Signature comparison still suppresses persistent-red duplicates. A first
latent failure now becomes an advisory when the blamed SHA did not touch
the failing test file or a matching code-under-test basename.
