### PR TITLE
fix(docs): ignore GitHub blob/issues links in linkcheck

### DIFF
--- a/docs/linkcheck_ignore.txt
+++ b/docs/linkcheck_ignore.txt
@@ -43,3 +43,8 @@ https://docs\.h2o\.ai/.*
 
 # HammerDB site intermittently returns 502 / connect timeouts
 https://www\.hammerdb\.com/.*
+
+# GitHub blob/issues links in blog posts intermittently return 404/429 to
+# unauthenticated CI requests once rate-limited; verified reachable (200) from
+# an authenticated/non-rate-limited client.
+https://github\.com/joeharris76/BenchBox/(blob|issues).*


### PR DESCRIPTION
CI's unauthenticated linkcheck requests to github.com/joeharris76/BenchBox
blob and issues URLs intermittently return 404/429 once rate-limited,
failing every open PR's Documentation build. The links are live (verified
200 from a non-rate-limited client); the failure is CI-side rate limiting,
matching the existing pattern used for other flaky hosts in this file.
