### PR TITLE
fix(e2e): make public-site visual capture deterministic against fade-in animation

### DIFF
--- a/results-explorer/e2e/captures/public-site-pages.spec.ts
+++ b/results-explorer/e2e/captures/public-site-pages.spec.ts
@@ -46,6 +46,21 @@ test("captures the public route and viewport matrix", async ({ browser }) => {
       await page.goto(route.path, { waitUntil: "networkidle" });
       await expect(page.locator("body")).toContainText(route.heading);
       if ("ready" in route) await waitForDataLoaded(page, route.ready);
+      // The landing page fades in `.feature-card`/`.benchmark-card`/`.install-step`
+      // via an IntersectionObserver (landing/script.js) independent of
+      // `networkidle`, so capture timing races the fade-in transition and
+      // produces a non-deterministic screenshot digest at viewports where
+      // those elements start in view. Force the settled end state before
+      // every capture so the digest reflects layout, not animation timing.
+      await page.addStyleTag({
+        content: `
+          .feature-card, .benchmark-card, .install-step {
+            opacity: 1 !important;
+            transform: none !important;
+            transition: none !important;
+          }
+        `,
+      });
       const overflow = await page.evaluate(() => document.documentElement.scrollWidth > window.innerWidth + 1);
       expect(overflow, `${route.path} overflows at ${width}px`).toBe(false);
 


### PR DESCRIPTION
landing/script.js fades .feature-card/.benchmark-card/.install-step in via
an IntersectionObserver independent of the page's networkidle/data-ready
signals, so the capture screenshot races the fade-in transition. At
viewports where those elements start in the initial viewport (observed:
1280px), the screenshot digest was non-deterministic, intermittently
failing the visual-baseline gate on unrelated PRs with no landing-page
content change. Force the settled end state via an injected style before
every capture so the digest reflects layout, not animation timing.
