### PR TITLE
fix: address adversarial-review findings from PRs #1737-#1767

### DIFF
--- a/benchbox/core/run_service.py
+++ b/benchbox/core/run_service.py
@@ -464,11 +464,7 @@ def map_phases_to_execution_type(phases: list[str]) -> str:
 # Sorted so that additions land in one obvious place and a missing export is
 # visible on inspection rather than by grepping the call sites.
 __all__ = [
-    "TPC_ALLOWED_SCALE_FACTORS",
     "AdapterFactory",
-    "SilentVerbosity",
-    "UnsupportedExecutionMode",
-    "VerbosityLike",
     "build_databricks_clustering_intent",
     "execute_run",
     "get_execution_mode",
@@ -479,8 +475,12 @@ __all__ = [
     "resolve_mode_with_registry",
     "resolve_run_config",
     "resolve_validation_options",
+    "SilentVerbosity",
     "stamp_requested_phases",
+    "TPC_ALLOWED_SCALE_FACTORS",
     "translate_platform_options_for_adapter",
+    "UnsupportedExecutionMode",
     "validate_stream_count",
     "validate_tpc_scale_factor",
+    "VerbosityLike",
 ]

--- a/results-explorer/e2e/captures/public-site-pages.spec.ts
+++ b/results-explorer/e2e/captures/public-site-pages.spec.ts
@@ -52,6 +52,10 @@ test("captures the public route and viewport matrix", async ({ browser }) => {
       // produces a non-deterministic screenshot digest at viewports where
       // those elements start in view. Force the settled end state before
       // every capture so the digest reflects layout, not animation timing.
+      // Trade-off: this also means a real CSS regression that leaves one of
+      // these elements permanently mis-transformed or invisible can no
+      // longer be caught here, since the override always paints the
+      // settled state regardless of what the page actually renders.
       await page.addStyleTag({
         content: `
           .feature-card, .benchmark-card, .install-step {

--- a/scripts/post_merge_signature.py
+++ b/scripts/post_merge_signature.py
@@ -205,7 +205,11 @@ def imported_module_paths(test_path: str, repo_root: Path) -> list[str]:
                 if node.module:
                     module_names.add(".".join([*anchor, node.module]))
                 elif anchor:
-                    module_names.add(".".join(anchor))
+                    # "from . import sibling[, other]": each imported name is
+                    # itself a candidate module (e.g. a same-package helper
+                    # file), not just the anchor package.
+                    for alias in node.names:
+                        module_names.add(".".join([*anchor, alias.name]))
             elif node.module:
                 module_names.add(node.module)
 

--- a/scripts/pr_refresh_replay.py
+++ b/scripts/pr_refresh_replay.py
@@ -120,8 +120,6 @@ def _percentile(values: list[float], pct: float) -> float | None:
     if len(values) == 1:
         return values[0]
     ordered = sorted(values)
-    if pct >= 95 and len(ordered) >= 2:
-        return ordered[-1]
     return statistics.median(ordered) if pct == 50 else ordered[min(len(ordered) - 1, int(len(ordered) * pct / 100))]
 
 

--- a/tests/unit/core/test_platform_config_required_from_config.py
+++ b/tests/unit/core/test_platform_config_required_from_config.py
@@ -21,12 +21,23 @@ def test_from_config_required_keys_are_forwarded_by_shared_helper() -> None:
         assert built[key] == payload[key]
 
 
-def test_from_config_required_key_missing_from_helper_fails_the_contract() -> None:
-    """Negative control: a required key omitted by the helper is a contract break."""
-    helper_keys = frozenset(TUNING_FORWARD_KEYS)
-    assert "not_a_real_required_field" not in helper_keys
-    leaked = frozenset({"not_a_real_required_field"})
-    assert not leaked <= helper_keys
+def test_from_config_required_key_missing_from_helper_fails_the_contract(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Negative control: a required key dropped from the forwarding set is silently lost.
+
+    Simulates the exact break this contract guards against: if a required key
+    were ever removed from ``TUNING_FORWARD_KEYS``, ``build_adapter_config``
+    would stop forwarding it with no error, rather than raising.
+    """
+    key = next(iter(REQUIRED_FROM_CONFIG_KEYS))
+    reduced_keys = tuple(k for k in TUNING_FORWARD_KEYS if k != key)
+    monkeypatch.setattr("benchbox.platforms.base.config_utils.TUNING_FORWARD_KEYS", reduced_keys)
+
+    payload = {k: f"value-{k}" for k in REQUIRED_FROM_CONFIG_KEYS}
+    payload["benchmark"] = "tpch"
+    payload["scale_factor"] = 1.0
+    built = build_adapter_config(payload, platform="sqlite", generated_key=None)
+
+    assert key not in built
 
 
 def test_from_config_required_get_platform_config_emits_tuning_config() -> None:

--- a/tests/unit/test_post_merge_signature.py
+++ b/tests/unit/test_post_merge_signature.py
@@ -526,6 +526,20 @@ def test_imported_module_paths_missing_file_returns_empty(tmp_path: Path) -> Non
     assert imported_module_paths("tests/does_not_exist.py", tmp_path) == []
 
 
+def test_imported_module_paths_finds_same_package_import_without_module(tmp_path: Path) -> None:
+    test_dir = tmp_path / "tests" / "foo"
+    test_dir.mkdir(parents=True)
+    (test_dir / "helpers.py").write_text("def run():\n    return 1\n", encoding="utf-8")
+    (test_dir / "test_thing.py").write_text(
+        "from . import helpers\n\ndef test_it():\n    assert helpers.run() == 1\n",
+        encoding="utf-8",
+    )
+
+    paths = imported_module_paths("tests/foo/test_thing.py", tmp_path)
+
+    assert "tests/foo/helpers.py" in paths
+
+
 def test_attribution_reverts_via_real_import_when_basename_differs(tmp_path: Path) -> None:
     # The finding #1 repro: a test imports a module whose basename does not
     # match the test's own basename or its `test_` stem, so the old


### PR DESCRIPTION
Fixes the Required and low-risk Consider/Nit findings from an adversarial
five-axis review of the last 4 days of merged PRs (~/.benchbox/finding-drafts/
BenchBox/2026-08-17-215900-adversarial-review-pr-1737-1767.md):

- post_merge_signature.py: imported_module_paths() dropped imported names for
  `from . import sibling` (module=None relative imports), only recording the
  anchor package. Reproduced the false-negative class PR #1763 was written to
  fix, just via a different import syntax. Adds a regression test.
- pr_refresh_replay.py: _percentile() hardcoded p95+ to the sample max instead
  of interpolating, misleading for a field named required_gate_p95 as sample
  sizes grow. Removed the special case; p95 now uses the same nearest-rank
  formula as every other percentile.
- public-site-pages.spec.ts: documents the coverage trade-off from PR #1767's
  CSS override (forced settled end-state also hides a real transform/opacity
  regression in the same elements).
- run_service.py: __all__ claimed to be sorted but wasn't; alphabetized.
- test_platform_config_required_from_config.py: the "negative control" test
  never exercised build_adapter_config, so it couldn't actually catch a
  required key silently dropped from the forwarding set. Rewritten to
  monkeypatch TUNING_FORWARD_KEYS and assert on real runtime behavior.

Not fixed: skill_sync_ci_policy.py's `compare` CLI subcommand looked unused
by grep, but compare_repository_manifest() is used directly (imported) by
path_filter_decision.py:333 - not dead code, no change needed.
