### PR TITLE
fix: close merged-PR review follow-ups in replay, attribution, and audits

### DIFF
--- a/.github/workflows/develop-refresh-shadow.yml
+++ b/.github/workflows/develop-refresh-shadow.yml
@@ -241,7 +241,21 @@ jobs:
                       if name == "pr-certification-identity" and artifact.get("id"):
                           identity = load_identity_artifact(int(artifact["id"]))
               run_head = str(run.get("head_sha") or "")
+              # A `pull_request_target` run is dispatched from the trusted base,
+              # so GitHub records the BASE tip as its head_sha - never the PR
+              # head. Binding certification by that value cannot match, which
+              # left a required run (e.g. `ruleset-drift`) without a
+              # certification_kind and forced `prior_check_unbound`, so an
+              # otherwise valid exact refresh could never be shadow-eligible.
+              # GitHub carries the PR association on the run itself; keep it as
+              # a secondary key used only when the direct head match fails, so
+              # no run that already bound can bind differently.
+              associated = run.get("pull_requests") or []
+              assoc_head = ""
+              if isinstance(associated, list) and associated and isinstance(associated[0], dict):
+                  assoc_head = str(((associated[0].get("head") or {}).get("sha")) or "")
               run_meta[run_id] = {
+                  "assoc_head_sha": assoc_head,
                   "id": run.get("id") or run_id,
                   "name": run.get("name") or "",
                   "path": run.get("path") or "",
@@ -261,19 +275,23 @@ jobs:
           for run_id in sorted(run_meta):
               info = run_meta[run_id]
               identity = identity_by_head.get(info["head_sha"])
+              if not identity and info.get("assoc_head_sha"):
+                  identity = identity_by_head.get(info["assoc_head_sha"])
               if identity:
                   kind = "full"
                   run_fingerprint = identity["workflow_fingerprint"]
                   run_base = identity["base_sha"]
+                  run_head = identity.get("pr_head_sha") or info.get("assoc_head_sha") or info["head_sha"]
               else:
                   kind = ""
                   run_fingerprint = ""
                   run_base = ""
+                  run_head = info["head_sha"]
               actions_runs.append({
                   "id": info["id"],
                   "name": info["name"],
                   "path": info["path"],
-                  "head_sha": info["head_sha"],
+                  "head_sha": run_head,
                   "event": info["event"],
                   "certification_kind": kind,
                   "workflow_fingerprint": run_fingerprint,

--- a/_project/audits/behind-pr-occurrence-throughput-2026-08-16.md
+++ b/_project/audits/behind-pr-occurrence-throughput-2026-08-16.md
@@ -21,8 +21,12 @@ Observed tip: `origin/develop` `360cd918756597b298af3f0d18434f35387b0fe1`
 
 ## Sample
 
-- Develop merges: 33 squash-merges to `develop` from 2026-08-14T00:15:10Z
-  through 2026-08-17T00:49:53Z (`#1721` … `#1753`). 32 interarrival gaps.
+- Develop merges: 34 squash-merges to `develop` from 2026-08-14T00:15:09Z
+  through 2026-08-17T00:49:53Z (`#1721` … `#1753`). 33 interarrival gaps.
+  Counted with `git log --first-parent`; an earlier revision of this audit
+  reported 33 merges / 32 gaps because it omitted `#1711`, which landed at
+  2026-08-14T00:36:32Z between `#1721` and `#1719`. No exclusion criterion
+  justified dropping it, so the table below is recomputed over every merge.
 - Required-gate wall: reuse profile #1734 (2026-08-14 code refreshes
   `#1717`/`#1718`/`#1719`) plus #1751 first `ci-required-result`
   (22:54:12Z–23:13:53Z = 19.7 min).
@@ -34,13 +38,15 @@ Observed tip: `origin/develop` `360cd918756597b298af3f0d18434f35387b0fe1`
 | Stat | Minutes |
 |---|---:|
 | min | 4.3 |
-| p50 | 31.3 |
-| p75 | 66.2 |
-| p95 | 634.0 |
-| mean | 136.1 |
+| p50 | 27.5 |
+| p75 | 44.9 |
+| p95 | 802.5 |
+| mean | 132.0 |
 | max | 1361.8 |
 
-18.8% of gaps are under 20 min. **50% of gaps are under 31 min**, the
+Percentiles use the repo-wide nearest-rank definition (`percentile_ms`).
+
+18.2% of gaps are under 20 min. **51.5% of gaps are under 31 min**, the
 #1734 `medium-test` merge-unblock wall.
 
 ## Required-gate duration
@@ -52,9 +58,17 @@ Observed tip: `origin/develop` `360cd918756597b298af3f0d18434f35387b0fe1`
 | #1734 `#1719` | 27.0 min; medium-test 26.6 |
 | #1751 first `ci-required-result` | 19.7 min |
 
-Gate duration is a material fraction of interarrival. A PR that opens
-current still has about even odds of seeing another develop merge before
-a 31-minute gate finishes, in this window.
+Gate duration is a material fraction of interarrival. For a PR that opens
+*immediately after a merge*, this window puts the odds of another develop
+merge landing inside a 31-minute gate at about even.
+
+That bound does not generalize to a PR opening at an arbitrary moment. The
+share of *gaps* shorter than the gate is not the probability an arbitrary
+PR is overtaken: that depends on where within a gap PRs actually open, and
+arbitrary-time sampling lands in long gaps more often than their count
+suggests (length-biased sampling). This sample records merge times only,
+with no PR-open distribution, so the stronger claim is not supported here -
+measuring current PR open times would be needed to make it.
 
 Open-time currency (`behind-pr-occurrence-01-pr-open-currency`) removes
 the open-stale residual. It does not remove this in-flight residual.
@@ -87,7 +101,7 @@ earned.
 
 ## Refresh-storm cost
 
-If every one of N open develop PRs auto-refreshed on each of the 32 gaps,
+If every one of N open develop PRs auto-refreshed on each of the 33 gaps,
 that is N full required gates per merge. At 27–31 min/gate and 50% of
 gaps under 31 min, the first refresh to land re-stales the rest. That is
 why bulk update is rejected.

--- a/_project/audits/strict-base-refresh-replay-2026-08-14.md
+++ b/_project/audits/strict-base-refresh-replay-2026-08-14.md
@@ -49,19 +49,20 @@ Required contexts across the window: `ci-required-result`,
 ## Replay result
 
 Normalized fixtures under `tests/fixtures/ci/pr-refresh-replay/` replay
-through the classifier. The eligible fixture is `shadow_eligible`. Historical
+through the classifier. The eligible fixture is `shadow_eligible`. Synthetic control
 and negative fixtures are `full_required`.
 
 | Class | Decision | Full-only failure? |
 |---|---|---|
 | Eligible exact refresh | `shadow_eligible` | no |
-| Historical cancelled medium (no identity artifacts) | `full_required` (`prior_check_unbound`) | no |
+| Synthetic cancelled medium control (no identity artifacts) | `full_required` (`prior_check_unbound`) | no |
 | Fork, chained refresh, self-change, merge-driver, semantic schema, head-drift race, malformed | `full_required` | no |
 
 `full-only` means the classifier would have waived long lanes while those
-lanes actually failed on the recorded full run. This window has **zero**
-full-only failures: the cancelled refreshes are not `shadow_eligible`
-because prior full-certification artifacts were absent.
+lanes actually failed on the recorded full run. The fixture set holds **zero**
+recorded historical observations (the cancelled-medium fixture is a synthetic
+control carrying the eligible template's payload); populating recorded GitHub
+payloads is needed before citing historical full-only rates.
 
 Hit rate on the fixture set is not an activation number. Discarding
 fallback reasons from the denominator would make a classifier that always

--- a/_project/decisions/behind-pr-occurrence-2026-08-16.md
+++ b/_project/decisions/behind-pr-occurrence-2026-08-16.md
@@ -70,7 +70,7 @@ refreshing several PRs at once is self-defeating.
 | `make pr-refresh` (one PR at a time) | **reuse** | Intended absorb. Policy-blessed. |
 | Fail `pr-open` when `origin/develop` is not an ancestor of `HEAD` | **accept for 01** | Would have absorbed `#1749`. Does not keep a PR current for the whole gate. Must not silently merge inside `pr-open` (that would turn `pr-fanout` into a refresh storm). |
 | Flip `allow_update_branch` | **reject** | Suggestion affordance, not an updater. Would absorb neither intervening commit. |
-| Update every open develop PR when `develop` moves | **reject** | Refresh storm. `Makefile` `pr-refresh` already forbids this. |
+| Update every open develop PR when `develop` moves | **reject** | Refresh storm. `Makefile` `pr-refresh` acts on the current worktree's branch only and refuses to run on `develop`/`main`/`release`; it holds no lock against concurrent invocation from other worktrees, so avoiding bulk refresh is convention here, not enforcement. |
 | Arm auto-merge at `pr-open` | **reject as the fix for this class** | Would not have saved #1751 (already behind). Reintroduces merge-before-follow-up (`#1503`/`#1521`/`#1531`). `make pr-ready` stays the only local arm path. |
 | Unblock `07a` or `07b` from this item | **reject** | `06` selected `SHADOW_ONLY`. Measurement lives in 02; a later activation, not this record, may unblock one path. |
 | `refresh-shadow` as a branch updater | **reject** | Observational only. Not a required context. Cannot skip lanes or update heads. |

--- a/_project/decisions/skill-integrity-ci-lane-validation-2026-08-18.md
+++ b/_project/decisions/skill-integrity-ci-lane-validation-2026-08-18.md
@@ -120,8 +120,19 @@ refresh-shadow observations, revocation, orphan detection, browser umbrella,
 and post-merge work where present; do not report only the skill job.
 
 Cancelled and incomplete jobs never enter successful completed runner-minutes.
-They remain visible in the cancelled/incomplete buckets, including superseded
-synchronize attempts, so concurrency cancellation cannot flatter savings.
+They remain visible in the cancelled/incomplete buckets, so concurrency
+cancellation cannot flatter savings *on the head that was measured*.
+
+Superseded synchronize attempts are a stated prerequisite, not something the
+current collector already does. `event_fanout_for_pr` reads only the merged
+PR's `pr.head.sha` and queries runs, jobs, and check-runs for that single SHA
+(`_project/scripts/dev_loop_pr_metrics.py`), so jobs cancelled on a prior head
+- exactly what a refresh or fix-forward push produces - are omitted rather
+than bucketed, which understates runner cost and flatters the savings. Before
+this protocol's accounting is published, either extend the collector to
+enumerate every recorded synchronize head, or run it once per recorded head
+and sum the per-head buckets. Reporting a single-head fan-out as if it covered
+the PR's whole synchronize history is not a valid substitute.
 Reruns use the collector's existing same-named/latest-success behavior, and a
 missing required context is a failure rather than a zero-duration result.
 

--- a/_project/decisions/strict-base-refresh-activation-2026-08-14.md
+++ b/_project/decisions/strict-base-refresh-activation-2026-08-14.md
@@ -57,8 +57,11 @@ No sample-size or calendar threshold is used as the sole gate.
   stay `full_required`.
 - Kill switch: disable or delete `develop-refresh-shadow.yml`. There is no
   skip path to unwind.
-- rollback: checkout the parent of this decision; no GitHub setting
-  changes to reverse.
+- rollback: `git revert` the commit that landed this decision, on a branch,
+  through the normal PR flow. Checking out its parent only detaches a local
+  HEAD - once merged it neither removes the decision from `develop` nor leaves
+  a reviewable record, and rewriting history is not an option on a protected
+  branch. No GitHub setting changes to reverse.
 - Operator: no settings mutation, no repository transfer, no custom merge
   steward.
 

--- a/benchbox/cli/commands/run.py
+++ b/benchbox/cli/commands/run.py
@@ -2493,6 +2493,12 @@ def _finalize_normal_interactive_plan(s: types.SimpleNamespace) -> None:
     s.resolved_run_plan = _capture_resolved_run_plan(s)
 
     plan: ResolvedRunPlan = s.resolved_run_plan
+    # The wizard can turn official mode ON after `select_benchmark()` already
+    # built this config with `official=False` - `_interactive_collect_flags`
+    # updates only `s.official`. Without this copy `compliance_mode_kwargs()`
+    # reads the stale config value, so a run the wizard reported as official
+    # classifies as `unofficial_nonstandard` and `benchbox submit` refuses it.
+    s.benchmark_config.official = bool(getattr(s, "official", False))
     s.benchmark_config.scale_factor = plan.scale
     s.benchmark_config.queries = list(plan.queries) if plan.queries is not None else None
     s.benchmark_config.compress_data = plan.compression_enabled

--- a/scripts/post_merge_signature.py
+++ b/scripts/post_merge_signature.py
@@ -202,6 +202,14 @@ def imported_module_paths(test_path: str, repo_root: Path) -> list[str]:
                 # more directory.
                 climb = node.level - 1
                 anchor = test_dir_parts[: len(test_dir_parts) - climb] if climb else test_dir_parts
+                if anchor:
+                    # The anchor package itself, not only what is imported from
+                    # it. `from . import VALUE` where VALUE lives in the package
+                    # initializer resolves to no alias file at all, and even a
+                    # sibling import executes that initializer - so a merge that
+                    # broke `__init__.py` was scored as non-owning and downgraded
+                    # to advisory, skipping the revert.
+                    module_names.add(".".join(anchor))
                 if node.module:
                     module_names.add(".".join([*anchor, node.module]))
                 elif anchor:

--- a/scripts/pr_refresh_replay.py
+++ b/scripts/pr_refresh_replay.py
@@ -8,7 +8,6 @@ Actions-run data so unit tests do not touch the network.
 
 import argparse
 import json
-import statistics
 import sys
 from dataclasses import asdict, dataclass, field
 from datetime import datetime, timezone
@@ -21,6 +20,27 @@ from pr_refresh_certification import (
     classify,
     request_from_mapping,
 )
+
+from benchbox.core.results.metrics import percentile_ms
+
+# GitHub check-run conclusions that represent a settled outcome. A lane whose
+# recorded value is absent, null, empty, "pending", or an unrecognized string has
+# no terminal result yet, so completeness must reject it rather than accept the
+# key's mere presence - `_failed_lanes` reads such a value as "not failed", which
+# would report a shadow-eligible record as having no full-only failure before the
+# lane actually finished.
+TERMINAL_LANE_CONCLUSIONS = frozenset(
+    {"success", "failure", "neutral", "cancelled", "timed_out", "action_required", "skipped", "stale"}
+)
+
+# Synthetic fixtures (the eligible template and the negative controls) exist to
+# pin classifier behaviour, and carry placeholder durations - 100 seconds, 20
+# runner-minutes. They are legitimate classification records but are not
+# measurements, so performance aggregates must exclude them or the published p50
+# / p95 / runner-minute totals describe the fixtures rather than the historical
+# window. Records without an explicit kind are treated as observations.
+RECORD_KIND_CONTROL = "control"
+RECORD_KIND_OBSERVATION = "observation"
 
 FULL_LANE_NAMES = (
     "code-lint",
@@ -42,6 +62,7 @@ class ReplayResult:
     required_gate_seconds: float | None = None
     all_workflow_seconds: float | None = None
     runner_minutes: float | None = None
+    kind: str = RECORD_KIND_OBSERVATION
 
 
 @dataclass
@@ -56,6 +77,8 @@ class ReplaySummary:
     required_gate_p95: float | None
     all_workflow_p50: float | None
     runner_minutes_total: float | None
+    observations: int
+    controls: int
 
 
 def _as_float(value: object) -> float | None:
@@ -65,6 +88,12 @@ def _as_float(value: object) -> float | None:
         return float(value)
     except (TypeError, ValueError):
         return None
+
+
+def _record_kind(raw: Mapping[str, Any]) -> str:
+    """Classify a record as a synthetic control or a real observation."""
+    kind = str(raw.get("kind") or "").strip().lower()
+    return RECORD_KIND_CONTROL if kind == RECORD_KIND_CONTROL else RECORD_KIND_OBSERVATION
 
 
 def _failed_lanes(raw: Mapping[str, Any]) -> list[str]:
@@ -99,6 +128,7 @@ def replay_record(raw: Mapping[str, Any]) -> ReplayResult:
             pr_number=int(raw["pr_number"]) if raw.get("pr_number") else None,
             decision=DECISION_FULL,
             reasons=["malformed_payload"],
+            kind=_record_kind(raw),
         )
     failed = _failed_lanes(raw)
     return ReplayResult(
@@ -111,16 +141,23 @@ def replay_record(raw: Mapping[str, Any]) -> ReplayResult:
         required_gate_seconds=_as_float(raw.get("required_gate_seconds")),
         all_workflow_seconds=_as_float(raw.get("all_workflow_seconds")),
         runner_minutes=_as_float(raw.get("runner_minutes")),
+        kind=_record_kind(raw),
     )
 
 
 def _percentile(values: list[float], pct: float) -> float | None:
+    """Percentile via the repo-wide nearest-rank definition.
+
+    The previous index arithmetic - `ordered[int(n * pct / 100)]` - degenerated
+    to `max()` for any sample of 20 or fewer values, which is every realistic
+    replay history, so `required_gate_p95` tracked a single outlier. Delegating
+    to `percentile_ms` also keeps one percentile definition across the repo; note
+    it takes `p` as a fraction, and passing 95 instead of 0.95 is exactly the
+    silent max() this replaced.
+    """
     if not values:
         return None
-    if len(values) == 1:
-        return values[0]
-    ordered = sorted(values)
-    return statistics.median(ordered) if pct == 50 else ordered[min(len(ordered) - 1, int(len(ordered) * pct / 100))]
+    return percentile_ms(sorted(values), pct / 100)
 
 
 def summarize(results: list[ReplayResult]) -> ReplaySummary:
@@ -130,9 +167,13 @@ def summarize(results: list[ReplayResult]) -> ReplaySummary:
     for item in results:
         for reason in item.reasons or ["(none)"]:
             reasons[reason] = reasons.get(reason, 0) + 1
-    gate = [item.required_gate_seconds for item in results if item.required_gate_seconds is not None]
-    whole = [item.all_workflow_seconds for item in results if item.all_workflow_seconds is not None]
-    minutes = [item.runner_minutes for item in results if item.runner_minutes is not None]
+    # Classification counts cover every record; timing aggregates cover only
+    # observations. Both counts are reported so an excluded control is visible
+    # rather than silently dropped.
+    observed = [item for item in results if item.kind != RECORD_KIND_CONTROL]
+    gate = [item.required_gate_seconds for item in observed if item.required_gate_seconds is not None]
+    whole = [item.all_workflow_seconds for item in observed if item.all_workflow_seconds is not None]
+    minutes = [item.runner_minutes for item in observed if item.runner_minutes is not None]
     total = len(results)
     return ReplaySummary(
         records=total,
@@ -145,6 +186,8 @@ def summarize(results: list[ReplayResult]) -> ReplaySummary:
         required_gate_p95=_percentile(gate, 95),
         all_workflow_p50=_percentile(whole, 50),
         runner_minutes_total=sum(minutes) if minutes else None,
+        observations=len(observed),
+        controls=total - len(observed),
     )
 
 
@@ -173,6 +216,13 @@ def completeness_errors(records: list[Mapping[str, Any]], results: list[ReplayRe
         missing = [name for name in FULL_LANE_NAMES if name not in lanes]
         if missing:
             errors.append(f"{record_id}: missing lane outcomes {missing}")
+        invalid = sorted(
+            f"{name}={lanes.get(name)!r}"
+            for name in FULL_LANE_NAMES
+            if name in lanes and str(lanes.get(name) or "").lower() not in TERMINAL_LANE_CONCLUSIONS
+        )
+        if invalid:
+            errors.append(f"{record_id}: non-terminal lane conclusions {invalid}")
     return errors
 
 

--- a/tests/fixtures/ci/pr-refresh-replay/eligible-refresh.json
+++ b/tests/fixtures/ci/pr-refresh-replay/eligible-refresh.json
@@ -116,5 +116,6 @@
     "correctness-gate": "success",
     "plan-capture-gate": "success",
     "medium-test": "success"
-  }
+  },
+  "kind": "control"
 }

--- a/tests/fixtures/ci/pr-refresh-replay/historical-cancelled-medium.json
+++ b/tests/fixtures/ci/pr-refresh-replay/historical-cancelled-medium.json
@@ -116,5 +116,7 @@
   },
   "required_gate_seconds": 900,
   "all_workflow_seconds": 2100,
-  "runner_minutes": 40
+  "runner_minutes": 40,
+  "kind": "control",
+  "note": "Synthetic, despite the historical-* name: the nested `request` this record feeds the classifier is copied from the eligible template - it identifies PR 1717, not 1732, with placeholder head/base SHAs and a null run id. Marked control so its durations stay out of the performance aggregates. Replaying the real #1732 event requires populating `request` from the recorded GitHub payload; until then this directory holds no historical observations and the replay summary must not be cited as historical evidence."
 }

--- a/tests/fixtures/ci/pr-refresh-replay/negative-chained.json
+++ b/tests/fixtures/ci/pr-refresh-replay/negative-chained.json
@@ -117,5 +117,6 @@
   },
   "required_gate_seconds": 100,
   "all_workflow_seconds": 400,
-  "runner_minutes": 20
+  "runner_minutes": 20,
+  "kind": "control"
 }

--- a/tests/fixtures/ci/pr-refresh-replay/negative-fork.json
+++ b/tests/fixtures/ci/pr-refresh-replay/negative-fork.json
@@ -116,5 +116,6 @@
   },
   "required_gate_seconds": 100,
   "all_workflow_seconds": 400,
-  "runner_minutes": 20
+  "runner_minutes": 20,
+  "kind": "control"
 }

--- a/tests/fixtures/ci/pr-refresh-replay/negative-malformed.json
+++ b/tests/fixtures/ci/pr-refresh-replay/negative-malformed.json
@@ -13,5 +13,6 @@
   },
   "required_gate_seconds": 0,
   "all_workflow_seconds": 0,
-  "runner_minutes": 0
+  "runner_minutes": 0,
+  "kind": "control"
 }

--- a/tests/fixtures/ci/pr-refresh-replay/negative-merge-driver.json
+++ b/tests/fixtures/ci/pr-refresh-replay/negative-merge-driver.json
@@ -116,5 +116,6 @@
   },
   "required_gate_seconds": 100,
   "all_workflow_seconds": 400,
-  "runner_minutes": 20
+  "runner_minutes": 20,
+  "kind": "control"
 }

--- a/tests/fixtures/ci/pr-refresh-replay/negative-race-head-drift.json
+++ b/tests/fixtures/ci/pr-refresh-replay/negative-race-head-drift.json
@@ -116,5 +116,6 @@
   },
   "required_gate_seconds": 100,
   "all_workflow_seconds": 400,
-  "runner_minutes": 20
+  "runner_minutes": 20,
+  "kind": "control"
 }

--- a/tests/fixtures/ci/pr-refresh-replay/negative-self-change.json
+++ b/tests/fixtures/ci/pr-refresh-replay/negative-self-change.json
@@ -116,5 +116,6 @@
   },
   "required_gate_seconds": 100,
   "all_workflow_seconds": 400,
-  "runner_minutes": 20
+  "runner_minutes": 20,
+  "kind": "control"
 }

--- a/tests/fixtures/ci/pr-refresh-replay/negative-semantic-schema.json
+++ b/tests/fixtures/ci/pr-refresh-replay/negative-semantic-schema.json
@@ -116,5 +116,6 @@
   },
   "required_gate_seconds": 100,
   "all_workflow_seconds": 400,
-  "runner_minutes": 20
+  "runner_minutes": 20,
+  "kind": "control"
 }

--- a/tests/unit/cli/test_run_resolution.py
+++ b/tests/unit/cli/test_run_resolution.py
@@ -694,3 +694,64 @@ def test_normal_interactive_finalization_refreshes_plan_when_selectors_and_phase
     ) == (plan.compression_enabled, plan.compression_type, plan.compression_level)
     assert execution_context.mode == plan.resolved_mode
     assert execution_context.tuning_mode == plan.canonical_tuning_mode
+
+
+def test_finalization_propagates_the_wizard_official_choice_into_the_config() -> None:
+    """The wizard's official-mode answer must reach `benchmark_config.official`.
+
+    `select_benchmark()` builds the config before the prompt runs, so it starts
+    `official=False` and `_interactive_collect_flags` updates only `s.official`.
+    Without the copy, `compliance_mode_kwargs()` reads the stale config value and
+    the run classifies as `unofficial_nonstandard`, which `benchbox submit`
+    refuses - even though the wizard reported official mode as enabled.
+    """
+    compression = CompressionConfig(enabled=False, type="none", level=None)
+    state = SimpleNamespace(
+        official=True,
+        platform="duckdb",
+        platform_key="duckdb",
+        benchmark="tpcds",
+        scale=1.0,
+        phases="load,power",
+        phases_to_run=["load", "power"],
+        queries=None,
+        queries_to_run=None,
+        tuning="tuned",
+        table_mode="native",
+        output=None,
+        mode=None,
+        seed=11,
+        compression=compression,
+        comp_config=compression,
+        compress_data=compression.enabled,
+        compression_type=compression.type,
+        compression_level=compression.level,
+        compression_cli_set=True,
+        concurrency=1,
+        test_execution_type="power",
+        execution_mode="power",
+        resolved_mode="sql",
+        tuning_resolution=SimpleNamespace(canonical_mode="tuned"),
+        tuning_enabled=True,
+        tuning_config_file=None,
+        use_auto_tuning=False,
+        loaded_unified_config=None,
+        data_organization_payload=None,
+        df_tuning_config=None,
+        benchmark_config=BenchmarkConfig(
+            name="tpcds",
+            display_name="TPC-DS",
+            scale_factor=1.0,
+            queries=None,
+            concurrency=1,
+            official=False,
+        ),
+        database_config=SimpleNamespace(type="duckdb", execution_mode="sql"),
+        stats_reset=None,
+        stats_per_table_timing=False,
+    )
+    assert state.benchmark_config.official is False
+
+    _run_module._finalize_normal_interactive_plan(state)
+
+    assert state.benchmark_config.official is True

--- a/tests/unit/scripts/test_pr_refresh_replay.py
+++ b/tests/unit/scripts/test_pr_refresh_replay.py
@@ -8,6 +8,8 @@ from pathlib import Path
 import pytest
 from pr_refresh_certification import DECISION_FULL, DECISION_SHADOW
 from pr_refresh_replay import (
+    _percentile,
+    completeness_errors,
     load_records,
     main,
     replay_record,
@@ -124,3 +126,46 @@ def test_check_completeness_fails_when_lane_outcomes_missing(tmp_path: Path) -> 
     del record["actual_lane_conclusions"]
     (source / "bad.json").write_text(json.dumps(record), encoding="utf-8")
     assert main(["--fixtures", str(source), "--check-completeness"]) == 1
+
+
+def test_percentile_uses_nearest_rank_not_an_off_by_one_index() -> None:
+    """p95 must be the nearest-rank value, not one position past it.
+
+    The previous arithmetic indexed `int(n * pct / 100)` where nearest-rank is
+    `ceil(n * p) - 1`, so it overshot by one and clamped to `max()` at the top
+    of the sample: p95 of 1..20 came back 20 rather than 19, making
+    `required_gate_p95` track a single outlier. A 5-element sample cannot show
+    this - there nearest-rank p95 genuinely *is* the maximum.
+    """
+    assert _percentile([float(n) for n in range(1, 21)], 95) == 19.0
+    assert _percentile([float(n) for n in range(1, 101)], 95) == 95.0
+    assert _percentile([1.0, 2.0, 3.0, 4.0, 100.0], 50) == 3.0
+    assert _percentile([], 95) is None
+    assert _percentile([7.0], 95) == 7.0
+
+
+def test_synthetic_controls_are_excluded_from_performance_aggregates() -> None:
+    """Control fixtures carry placeholder durations and must not be measured."""
+    observation = _eligible_record(id="obs")
+    observation["required_gate_seconds"] = 900
+    observation["runner_minutes"] = 40
+    control = _eligible_record(id="ctl")
+    control["kind"] = "control"
+    control["required_gate_seconds"] = 100
+    control["runner_minutes"] = 20
+
+    summary = summarize([replay_record(observation), replay_record(control)])
+
+    assert summary.records == 2
+    assert summary.observations == 1
+    assert summary.controls == 1
+    assert summary.required_gate_p50 == 900
+    assert summary.runner_minutes_total == 40
+
+
+def test_completeness_rejects_non_terminal_lane_conclusions() -> None:
+    """A key whose value is null/pending is not a settled outcome."""
+    record = _eligible_record(id="pending")
+    record["actual_lane_conclusions"]["medium-test"] = None
+    errors = completeness_errors([record], [replay_record(record)])
+    assert any("non-terminal lane conclusions" in error for error in errors)

--- a/tests/unit/test_post_merge_signature.py
+++ b/tests/unit/test_post_merge_signature.py
@@ -574,3 +574,36 @@ def test_attribution_stays_advisory_when_import_analysis_also_clears_sha(tmp_pat
     changed = ["docs/operations/uat-framework.md"]
 
     assert attribution_action(failure_ids, changed, repo_root=tmp_path) == "advisory"
+
+
+def test_imported_module_paths_keeps_the_anchor_package(tmp_path: Path) -> None:
+    """`from . import VALUE` must record the package initializer that defines it.
+
+    Recording only alias-derived paths dropped `tests/pkg/__init__.py`, so a
+    merge that broke the initializer looked non-owning and was downgraded to
+    advisory - skipping the revert the workflow gates on.
+    """
+    pkg = tmp_path / "tests" / "pkg"
+    pkg.mkdir(parents=True)
+    (pkg / "__init__.py").write_text("VALUE = 1\n", encoding="utf-8")
+    (pkg / "test_it.py").write_text(
+        "def test_it():\n    from . import VALUE\n    assert VALUE == 1\n",
+        encoding="utf-8",
+    )
+
+    found = imported_module_paths("tests/pkg/test_it.py", tmp_path)
+    assert "tests/pkg/__init__.py" in found
+
+
+def test_attribution_reverts_when_the_package_initializer_changed(tmp_path: Path) -> None:
+    """The anchor-package signal must reach `attribution_action`, not just the finder."""
+    pkg = tmp_path / "tests" / "pkg"
+    pkg.mkdir(parents=True)
+    (pkg / "__init__.py").write_text("VALUE = 1\n", encoding="utf-8")
+    (pkg / "test_it.py").write_text(
+        "def test_it():\n    from . import VALUE\n    assert VALUE == 1\n",
+        encoding="utf-8",
+    )
+
+    failure_ids = ["tests/pkg/test_it.py::test_it"]
+    assert attribution_action(failure_ids, ["tests/pkg/__init__.py"], repo_root=tmp_path) == "revert"


### PR DESCRIPTION
Third sweep of unresolved `chatgpt-codex-connector` threads on merged PRs. Scanned the 100 most recently updated merged PRs (#1516-#1773) and found 23 unresolved threads, all in #1738-#1769 — everything the previous sweep closed has stayed closed. **No identity findings this round**, down from 15 last sweep.

This PR actions the 11 that need a code change. Of the rest, 7 were already fixed on `develop`, 2 target guidance that never merged, 2 already carry maintainer replies, and 1 needs an upstream change.

## Refresh-replay CLI (#1739)

- **Nearest-rank percentile.** `int(n * pct / 100)` overshoots nearest-rank by one and clamps to `max()` at the top of the sample: p95 of 1..20 returned 20 instead of 19, so `required_gate_p95` tracked a single outlier. Now delegates to `percentile_ms`, the repo-wide definition. (The review's `range(1, 101)` example actually returns 96, not 100 — the off-by-one is the real defect, and a 5-element sample cannot show it, since there nearest-rank p95 genuinely *is* the max.)
- **Controls excluded from performance aggregates.** The eligible template and negative controls carry placeholder durations (100s, 20 runner-minutes) and were averaged into published totals. Records now carry an explicit `kind`; controls are excluded from timing only, classification counts still cover everything, and both counts are reported so an exclusion is visible.
- **Non-terminal lane conclusions rejected** under `--check-completeness`. A key whose value was null, empty, or unrecognized counted as complete while `_failed_lanes` read it as not-failed.
- **`historical-cancelled-medium` marked as a control.** Verified the review's claim: the nested `request` fed to the classifier is a verbatim copy of the eligible template — PR 1717 not 1732, placeholder SHAs, null run id. So there were **zero** real observations, not one. The summary now reports `observations: 0` with null percentiles rather than presenting synthetic values as historical evidence. Populating the real #1732 event needs the recorded GitHub payload; I have not fabricated it.

## Post-merge attribution (#1769)

**Anchor package retained** when resolving relative imports. `from . import VALUE` recorded only alias-derived paths, so a merge breaking the `__init__.py` that defines VALUE looked non-owning, returned `advisory`, and skipped the revert. Both new tests fail without the fix.

## Shadow certification (#1738)

**`pull_request_target` runs bound through their PR association.** GitHub records the base tip as such a run's `head_sha`, so certification lookup by that value never matched, leaving `ruleset-drift` unbound and forcing `prior_check_unbound`. The association is consulted only as a fallback when the direct head match fails, so no run that already bound can bind differently — this cannot fail open.

## Audits and decisions

- **Interarrival table recomputed over all 34 merges (#1756).** Verified with `git log --first-parent`: #1711 does land at 2026-08-14T00:36:32Z between #1721 and #1719, and the old figures match exactly the sample that omits it. p50 27.5 / mean 132.0 replace 31.3 / 136.1 — matching the review's independently computed values. Also limited the even-odds conclusion to a PR opening immediately after a merge, since the share of gaps under the gate is not the probability an arbitrarily-timed PR is overtaken (length-biased sampling).
- **#1753** — `pr-refresh` now described as warning against bulk refresh, not forbidding it. Confirmed the target only refuses to run *on* develop/main/release and holds no lock against concurrent invocation from other worktrees.
- **#1740** — rollback is now a `git revert` through the normal PR flow; checking out the parent only detaches a local HEAD once merged.
- **#1768** — superseded-head collection stated as a prerequisite rather than existing behaviour. Confirmed `event_fanout_for_pr` reads only `pr.head.sha`, so cancellations on prior heads are omitted rather than bucketed.

## Already fixed on develop — resolved, no change

#1763 (all three: import-analysis attribution, advisory-issue reuse, `revert-suppressed` finalize), #1749's `pull_request_target` note in the base-branch policy, and both #1747 findings (`lookupFailed` is reset on a successful listing; the capture matrix already has a 240s describe-level timeout). **#1767** is moot: the only protected baseline was created 2026-08-19, two days *after* #1767 merged, so it already uses the new normalization and there is no legacy baseline to migrate.

## Not actionable here

- **#1749's two skill-sync findings** target `docs/development/skill-sync-operations.md`, which was dropped from PR #1749 before merge and is not on `develop` — nor did the guidance land anywhere else. Both are correct critiques of guidance that does not exist in the tree.
- **#1764** needs the canonical `todo` skill source, which lives in the external pinned skill-sync repo; the `.claude/skills` copy is generated and would be overwritten. Unlike `code.review_checklist`, the todo review reference exposes no project config hook, so there is no in-repo injection point.
- **#1759's two threads** already carry maintainer replies pointing at #1760 — resolved only, per the sweep's triage rules.

## Verification

- `uv run -- python -m pytest tests/unit/ -x -q` — 27471 passed, 24 skipped
- `ruff check` / `ruff format --check` — clean
- Workflow YAML parses; replay CLI re-run end to end