### PR TITLE
chore: remove stale token refresh in todo skill and update tracker spec

### DIFF
--- a/.claude/skills/todo/SKILL.md
+++ b/.claude/skills/todo/SKILL.md
@@ -23,8 +23,8 @@ If one request combines review or validation with close-out, perform the read-on
 ### Failures and claims
 
 - Exit code 2 means a general failure.
-- Exit code 4 means the hosted database rejected the credentials. Stop writes, run `todo doctor`, and show the error;
-  the wrapper may first try one token refresh.
+- Exit code 4 means the hosted database rejected the credentials (missing or rejected). Stop writes, run `todo doctor`,
+  and follow the remediation in `docs/operations/hosted-credentials.md` (provision or rotate the credential via `TODO_DB_CREDENTIAL_COMMAND`).
 - Only the holder can run `todo release`; it exits 2 for another actor's claim, and checking `claimed_by` can race.
   `complete` and `drop` may clear any claim. `--actor` prevents mistakes, not impersonation.
 

--- a/.claude/skills/todo/references/bootstrap.md
+++ b/.claude/skills/todo/references/bootstrap.md
@@ -63,10 +63,10 @@ TODO_DB_AUTH_TOKEN=... todo-db init-project \
   across worktrees.
 - Hosted `todo verify --run` requires `TODO_DB_ALLOW_HOSTED_VERIFY_RUN=1`
   because stored verification commands can execute other people's code.
-- Use `todo doctor` to check config, identity, database access, and Turso CLI
-  authentication. Use `--json` for automation. Exit code 4 means
-  authentication failed: stop writes, refresh the token, and show the error.
-  Wrappers try one refresh first.
+- Use `todo doctor` to check config, identity, database access, and credential
+  resolution. Use `--json` for automation. Exit code 4 means authentication
+  failed: stop writes, run `todo doctor`, and rotate or provision the credential
+  via `TODO_DB_CREDENTIAL_COMMAND` (see `docs/operations/hosted-credentials.md`).
 - Install hosted adapters with `uv sync --extra hosted --extra audit` in the
   tool checkout.
 - `scripts/turso_acceptance.sh` creates a temporary live database, runs the

--- a/.claude/skills/todo/references/prioritize.md
+++ b/.claude/skills/todo/references/prioritize.md
@@ -8,8 +8,8 @@ Rank open items by topic without changing tracker state. There is no
 1. Run `_project/scripts/todo --help` and confirm `doctor`, `stats`, `ready`,
    `list`, `show`, and `deps`.
 2. Run `todo doctor`. Use the production database:
-   - Hosted: `TODO_DB_URL` and `TODO_DB_AUTH_TOKEN`; the wrapper may refresh the
-     token once.
+   - Hosted: `TODO_DB_URL` and credentials resolved via `TODO_DB_CREDENTIAL_COMMAND`
+     (or explicit `TODO_DB_RO_AUTH_TOKEN` / `TODO_DB_AUTH_TOKEN`).
    - Read-only fallback: an explicit `--db <git-root>/.todo-db/replica.db` or
      `TODO_DB_REPLICA`, but only when `doctor` approves its schema and shows a
      non-trivial item count.

--- a/_project/specs/todo-db-tracker.md
+++ b/_project/specs/todo-db-tracker.md
@@ -1,6 +1,6 @@
 # TODO Tracker on a Shared Database — Design Spec
 
-Status: proposed (decision-ready; not yet implemented).
+Status: implemented (live in production at schema v7; todo-db v0.4.3).
 Author: agent session, 2026-07-18, from the TODO-infrastructure review.
 Decision owner: maintainer.
 

--- a/_project/specs/todo-db-tracker.md
+++ b/_project/specs/todo-db-tracker.md
@@ -1,8 +1,18 @@
 # TODO Tracker on a Shared Database — Design Spec
 
-Status: implemented (live in production at schema v7; todo-db v0.4.3).
+Status: historical design spec (implemented; live in production at schema v7, todo-db v0.4.3).
 Author: agent session, 2026-07-18, from the TODO-infrastructure review.
 Decision owner: maintainer.
+
+> **Architecture & Operational Evolution:**
+> This document records the original 2026-07-18 design specification for the shared database tracker.
+> The core system (SQLite/libSQL backend, constraint-enforcing CLI, and structured guardrails) is
+> implemented and active. Operational contracts that evolved during deployment—including external
+> credential resolution via `TODO_DB_CREDENTIAL_COMMAND`, removal of in-process token minting/auto-provisioning,
+> and wrapper isolation—are canonically governed by:
+> - [`docs/operations/todo-db-benchbox-extraction.md`](../docs/operations/todo-db-benchbox-extraction.md)
+> - [`docs/operations/hosted-credentials.md`](../docs/operations/hosted-credentials.md)
+> - [`_project/decisions/`](../_project/decisions/)
 
 ## Problem statement
 
@@ -604,12 +614,13 @@ Clones discover the production tracker without embedding secrets:
 
    Turso CLI accepts day-granularity expirations or `never`; sub-day values
    like `30m` are rejected. Prefer 1d session tokens over long-lived ones.
-3. **Auto-provision (no config, no env).** When no `--db` / `TODO_DB_PATH` /
-   `TODO_DB_URL` / config URL is set and `turso` is on PATH and logged in,
-   `_try_turso_auto_provision` mints both URL and a 1d token in-process
-   (never written to disk or printed) and selects the hosted backend as
-   auto-provisioned. This is the zero-config path for a logged-in operator
-   on a machine that has not yet pulled `config.json`.
+3. **Auto-provision (historical prototype; superseded).** *Historical note:* When
+   no `--db` / `TODO_DB_PATH` / `TODO_DB_URL` / config URL was set, early prototype
+   experiments tested in-process token minting via `_try_turso_auto_provision`.
+   This was subsequently removed during security hardening in favor of external
+   credential resolution (`TODO_DB_CREDENTIAL_COMMAND` pointing to the OS keychain
+   or secret store) and explicit environment credentials; the wrapper and CLI
+   never mint or refresh tokens in-process. See `docs/operations/hosted-credentials.md`.
 4. **Precedence reminder.** Config supplies the URL the way `TODO_DB_URL`
    would; it does **not** mint a token. A selected hosted backend with a
    missing token fails at connect / `doctor` auth (exit 4), never by silently
@@ -877,26 +888,13 @@ TODO tree from an untrusted source would plant shell commands; do not.
     environment. Local access authenticated via the maintainer's
     logged-in `turso` CLI, minting short-lived DB tokens per invocation
     (`turso db tokens create benchbox-todo`), never stored or echoed.
-    **Local auto-provisioning now exists** (`_project/scripts/todo_db.py`,
-    `_resolve_backend`/`_try_turso_auto_provision`): when none of --db,
-    `TODO_DB_PATH`, `TODO_DB_URL`, or a `.todo-db/config.json` URL is set,
-    the CLI shells out to the logged-in `turso` CLI itself
-    (`turso db show <name> --url` + `turso db tokens create <name>
-    --expiration 1d` (Turso CLI requires day granularity or ``never``;
-    sub-day values are rejected), db name from `TODO_DB_TURSO_DB`, default
-    `benchbox-todo`) and uses the hosted backend transparently, falling
-    back to the local implicit DB (with a refusal-on-write pointing at
-    `turso auth login` / `TODO_DB_URL`+`TODO_DB_AUTH_TOKEN` /
-    `--db`/`TODO_DB_PATH`/config) if turso is absent, not logged in, or the
-    mint fails. When turso is on PATH but mint fails, a short reason class
-    (`db-show-failed`, `token-create-failed`, etc. — never stderr/URL/token)
-    is surfaced via stderr WARN, the doctor `turso-provision` check, and the
-    write-refusal message, so the fallthrough is not silent. Tracked
-    credential-free config discovery (`.todo-db/config.json` with URL only)
-    is the clone-default path for selecting the production hosted URL;
-    session tokens still mint as above or via `TODO_DB_AUTH_TOKEN`. This
-    closes the former open provisioning item without requiring the two
-    variables in local `.env`.
+    **Local auto-provisioning (historical prototype note):** Early prototype
+    implementations explored shelling out to the logged-in `turso` CLI in-process.
+    During production extraction and security hardening (ADR 0004/0005), in-process
+    minting and refreshing were removed entirely; credentials are provided externally
+    via `TODO_DB_CREDENTIAL_COMMAND` (pointing to the OS keychain or secret store) or
+    explicit environment variables. See `docs/operations/hosted-credentials.md` and
+    `docs/operations/todo-db-benchbox-extraction.md`.
 - **G2 — CLI MVP:** schema DDL + `create/show/claim/start/done/defer/
   promote/dismiss/complete/ready/list/stats/export` + tests. No repo changes
   to the YAML system yet.

--- a/docs/operations/hosted-credentials.md
+++ b/docs/operations/hosted-credentials.md
@@ -1,0 +1,164 @@
+# Hosted credential operations
+
+This runbook covers database-scoped Turso credentials for BenchBox's todo tracker.
+Keep bearer tokens out of the repository, command arguments, logs, tracker
+evidence, and configuration files.
+
+## Mint a bounded token
+
+Choose the shortest practical lifetime.
+
+```sh
+# Developer or headless writer: 90 days.
+export TODO_DB_AUTH_TOKEN="$(turso db tokens create benchbox-todo --expiration 90d)"
+
+# Scheduled audit/export: server-enforced read-only, 180 days.
+export TODO_DB_RO_AUTH_TOKEN="$(turso db tokens create benchbox-todo --read-only --expiration 180d)"
+```
+
+Inject the result with an OS keychain, password manager, process supervisor, or
+CI secret store. Point `TODO_DB_CREDENTIAL_COMMAND` at that store so sessions
+retrieve it without an interactive step; see Provision once below. Do not save it
+in `.todo-db/config.json` or a wrapper-managed cache. Record the database, capability,
+issue date, expiry date, owner, and replacement reminder in the external secret
+inventory—never the token value in tracker evidence.
+
+Do not use group-scoped tokens with this runbook. If an operator deliberately
+uses one, the owner must document group-level invalidation and every database
+that shares its blast radius.
+
+## Provision once
+
+Do this one time per machine and capability. Afterwards no shell, agent session,
+or CI worker needs an interactive step until the token is rotated.
+
+1. Mint the bounded token as shown above and pipe it straight into your secret
+   store, never into a file or the shell history.
+
+   ```sh
+   security add-generic-password -U -a "$USER" -s benchbox-todo-rw \
+     -w "$(turso db tokens create benchbox-todo --expiration 90d)"
+   ```
+
+   1Password, `pass`, `gopass`, and a CI secret store are equally valid; the
+   store only has to print one token on standard output.
+
+2. Point todo-db at the store. Put this in the shell profile or process
+   supervisor that starts your sessions, so every later shell and agent
+   inherits it:
+
+   ```sh
+   export TODO_DB_CREDENTIAL_COMMAND="security find-generic-password -w -s benchbox-todo-rw"
+   ```
+
+   For a read-only consumer, store a `--read-only` token under its own service
+   name (e.g. `benchbox-todo-ro`) and point the variable at that entry instead.
+
+3. Confirm it resolves without any injected credential:
+
+   ```sh
+   env -u TODO_DB_AUTH_TOKEN -u TODO_DB_RO_AUTH_TOKEN \
+     _project/scripts/todo doctor --json
+   ```
+
+   The `database` check must report `"source": "TODO_DB_CREDENTIAL_COMMAND"`.
+
+The command is never run through a shell, so it must be a plain program and its
+arguments. Put any pipeline or conditional logic in a small script and name that
+script instead. Arguments are passed through unchanged; todo-db appends
+nothing. When a provider must serve both capabilities from one entry-point, have
+that script read `TODO_DB_CREDENTIAL_CAPABILITY`, which todo-db sets to
+`read-only` or `read-write` in the command's environment:
+
+```sh
+#!/bin/sh
+# Exit 0 with no output means "absent", which is the only condition that lets a
+# read-only request fall back to read-write. A missing entry makes `security`
+# exit 44, and a non-zero exit is an error that stops resolution, so the absent
+# case has to be handled deliberately.
+case "$TODO_DB_CREDENTIAL_CAPABILITY" in
+  read-only)
+    security find-generic-password -w -s benchbox-todo-ro 2>/dev/null || exit 0
+    ;;
+  *)
+    exec security find-generic-password -w -s benchbox-todo-rw
+    ;;
+esac
+```
+
+If your store holds one entry serving both capabilities, point the variable
+straight at it and skip the script. `doctor` will then report
+`capability: requested:read-write` even for a read-only operation, because the
+capability records what todo-db asked for, not what the token can do.
+
+## Validate
+
+Run a read-only preflight before a batch:
+
+```sh
+TODO_DB_RO_AUTH_TOKEN=... _project/scripts/todo doctor --json
+```
+
+A mutation worker validates its read-write credential explicitly:
+
+```sh
+TODO_DB_AUTH_TOKEN=... _project/scripts/todo doctor --rw --json
+```
+
+Read-only mode is server-enforced only when the supplied token was created with
+`--read-only`. Never place `TODO_DB_AUTH_TOKEN` in the scheduled audit job.
+
+## Rotate: routine replacement
+
+For a provider-backed credential this is the only recurring interactive step,
+at most once per lifetime maximum for that capability: mint the replacement,
+overwrite the store entry in place (`security add-generic-password -U` updates
+rather than duplicates), start a fresh process, and re-run the validation check.
+`TODO_DB_CREDENTIAL_COMMAND` still names the same entry, so no session,
+wrapper, or CI job needs an update.
+
+For directly injected credentials:
+
+1. The named owner mints a bounded replacement before the current expiry.
+2. Update one external consumer or secret store.
+3. Run `doctor` and the consumer's normal read or mutation smoke check.
+4. Update the remaining consumers.
+5. Confirm the old token is no longer injected and let it expire naturally.
+
+Do not run database-wide invalidation for routine replacement: it revokes other
+healthy credentials in the same database scope.
+
+## Expired or rejected credential
+
+Stop database-dependent work. Mint a bounded replacement outside todo-db,
+update the external injector, start a fresh process so it receives the new
+environment, and run `doctor` again. A child process cannot repair its parent
+shell's environment.
+
+Do not retry a rejected read-only token with a read-write credential. That can
+hide an incorrect permission or an accidental write path.
+
+## Suspected compromise
+
+1. Identify whether the token is database- or group-scoped.
+2. For a database-scoped token, immediately run:
+
+   ```sh
+   turso db tokens invalidate benchbox-todo --yes
+   ```
+
+3. Assume every database-scoped token is invalid, including read-only tokens.
+4. Mint new bounded read-write and read-only credentials as required.
+5. Redistribute them through the external secret stores and restart consumers.
+6. Run `doctor`, audit verification, and the relevant smoke checks.
+7. Record the incident without recording any bearer value.
+
+A group-scoped token requires `turso group tokens invalidate` and a separate
+inventory-driven response. Database invalidation alone may not cover it.
+
+## Scheduled audit ownership
+
+The repository/workflow owner maintains `TODO_DB_PROD_RO_TOKEN`, its issue and
+expiry dates, and a replacement reminder. The workflow environment must contain
+`TODO_DB_RO_AUTH_TOKEN` and must not contain `TODO_DB_AUTH_TOKEN`. CI never
+mints credentials and never receives Turso account credentials.

--- a/skill-sync.lock
+++ b/skill-sync.lock
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "lockedAt": "2026-08-16T22:49:47.409Z",
+  "lockedAt": "2026-08-19T18:29:01.833Z",
   "skills": {
     "blog": {
       "source": {
@@ -10,7 +10,7 @@
         "ref": "7b63719927992bd7f7fff6b90449bbba2bb94ba3",
         "subdir": "skills",
         "revision": "7b63719927992bd7f7fff6b90449bbba2bb94ba3",
-        "fetchedAt": "2026-08-16T21:51:16.794Z"
+        "fetchedAt": "2026-08-19T18:28:53.115Z"
       },
       "installMode": "mirror",
       "files": {
@@ -64,7 +64,7 @@
         "ref": "7b63719927992bd7f7fff6b90449bbba2bb94ba3",
         "subdir": "skills",
         "revision": "7b63719927992bd7f7fff6b90449bbba2bb94ba3",
-        "fetchedAt": "2026-08-16T21:51:17.479Z"
+        "fetchedAt": "2026-08-19T18:28:53.886Z"
       },
       "installMode": "mirror",
       "files": {
@@ -161,10 +161,10 @@
         "type": "git",
         "name": "todo-context-efficiency",
         "url": "https://github.com/joeharris76/skill-sync-skills.git",
-        "ref": "e0af1fe8b6751ee7cae42fa7a9adc374d96dd690",
+        "ref": "77ab905fe66cc86a8d8a11fdc4b3500e28d8e0d0",
         "subdir": "skills",
-        "revision": "e0af1fe8b6751ee7cae42fa7a9adc374d96dd690",
-        "fetchedAt": "2026-08-16T22:49:43.374Z"
+        "revision": "77ab905fe66cc86a8d8a11fdc4b3500e28d8e0d0",
+        "fetchedAt": "2026-08-19T18:28:56.180Z"
       },
       "installMode": "mirror",
       "files": {
@@ -173,8 +173,8 @@
           "size": 6430
         },
         "references/bootstrap.md": {
-          "sha256": "7b3fbbe13006548df81be94aa7b6d38b177ee1f883b0f5770111c5700f8fa334",
-          "size": 3031
+          "sha256": "09c2b8f49d617b4319c8fe004184a9e7b4e83e6f13223bccd7f532049c15199d",
+          "size": 3095
         },
         "references/closeout.md": {
           "sha256": "d2bd9ba6965e76020f2184d3aca1434c067bbfaa6dfcb43e1f6f51078af01773",
@@ -193,8 +193,8 @@
           "size": 1166
         },
         "references/prioritize.md": {
-          "sha256": "b64e5834547f26e34b1269cadb7d4d04cac7784fddc0c69e20ae97eb9a131529",
-          "size": 4494
+          "sha256": "0fd22f6a8cc0f51841fea3745559132ede4be39a27b5a01cdec3dacd98913c69",
+          "size": 4548
         },
         "references/queries.md": {
           "sha256": "11ae465326ec08c012ea7beb5aadbd3d5faeee90ad2140a7f8d3a46fd022f724",
@@ -209,8 +209,8 @@
           "size": 463
         },
         "SKILL.md": {
-          "sha256": "4f039e8b410b0150748a2da619bacc07d7020ac86c163bfe8fc038bdef17bf4e",
-          "size": 3844
+          "sha256": "b2fae7c4bea44a0a6e9605f44ad480924ec0a20821e079a398585c5d1ed62589",
+          "size": 3942
         },
         "skill.yaml": {
           "sha256": "e2c0b40d9935492621e6d21ab216a6227f4bae8f3808ed004d995d0f1b5bbff3",
@@ -226,7 +226,7 @@
         "ref": "7b63719927992bd7f7fff6b90449bbba2bb94ba3",
         "subdir": "skills",
         "revision": "7b63719927992bd7f7fff6b90449bbba2bb94ba3",
-        "fetchedAt": "2026-08-16T21:51:20.232Z"
+        "fetchedAt": "2026-08-19T18:28:57.006Z"
       },
       "installMode": "mirror",
       "files": {
@@ -322,7 +322,7 @@
         "ref": "6139085a35455fe90c8d6c94d7567e131a24db96",
         "subdir": "skills",
         "revision": "6139085a35455fe90c8d6c94d7567e131a24db96",
-        "fetchedAt": "2026-08-16T21:50:32.655Z"
+        "fetchedAt": "2026-08-19T18:29:00.955Z"
       },
       "installMode": "mirror",
       "files": {
@@ -348,7 +348,7 @@
         "ref": "7b63719927992bd7f7fff6b90449bbba2bb94ba3",
         "subdir": "skills",
         "revision": "7b63719927992bd7f7fff6b90449bbba2bb94ba3",
-        "fetchedAt": "2026-08-16T21:51:20.932Z"
+        "fetchedAt": "2026-08-19T18:28:58.767Z"
       },
       "installMode": "mirror",
       "files": {
@@ -374,7 +374,7 @@
         "ref": "7b63719927992bd7f7fff6b90449bbba2bb94ba3",
         "subdir": "skills",
         "revision": "7b63719927992bd7f7fff6b90449bbba2bb94ba3",
-        "fetchedAt": "2026-08-16T21:51:18.835Z"
+        "fetchedAt": "2026-08-19T18:28:55.408Z"
       },
       "installMode": "mirror",
       "files": {

--- a/skill-sync.yaml
+++ b/skill-sync.yaml
@@ -8,7 +8,7 @@ sources:
   - name: todo-context-efficiency
     type: git
     url: https://github.com/joeharris76/skill-sync-skills.git
-    ref: e0af1fe8b6751ee7cae42fa7a9adc374d96dd690
+    ref: 77ab905fe66cc86a8d8a11fdc4b3500e28d8e0d0
     subdir: skills
   - name: product
     type: git


### PR DESCRIPTION
## Summary
Addresses remaining follow-ups after todo-db 0.4.3 upgrade:

1. **Remove stale wrapper token refresh references in todo skill**: Synced from upstream `skill-sync-skills` (commit `77ab905`), updating `.claude/skills/todo/SKILL.md`, `bootstrap.md`, and `prioritize.md` to point to `TODO_DB_CREDENTIAL_COMMAND` and `docs/operations/hosted-credentials.md`.
2. **Update skill-sync pin & lock**: Updated `skill-sync.yaml` and `skill-sync.lock` to record the new skill revision.
3. **Update tracker spec status**: Updated `_project/specs/todo-db-tracker.md` header from `proposed` to `implemented (live in production at schema v7; todo-db v0.4.3)`.