### PR TITLE
docs(agents): state the write close-out policy and enforce via instruction audit

### DIFF
--- a/.claude/commands/pr.md
+++ b/.claude/commands/pr.md
@@ -12,46 +12,22 @@ description: BenchBox PR workflow - path-aware preflight, push, open PR vs devel
 
 ## Your task
 
-This is the BenchBox-specific PR workflow. `develop` is PR-gated through
-`ci-required-result`; linear history and squash-only merging are enforced. The
-umbrella uses `.github/path-filters.yml`: content-only PRs run content
-validation and skip Python fast tests, while code/infra/unknown-path PRs run the
-post-Step-3 lint/type + Ubuntu 3.12 fast-test gate. The goal is to land a green
-PR with one command and walk away - auto-merge handles the rest.
+BenchBox PR workflow targeting `develop` with linear history and squash-only merging.
 
 Execute the following in order, stopping on the first failure:
 
-1. **Run `make agent-write-preflight`.** If it refuses because this is the
-   BenchBox primary clone, stop and tell the user to create a disposable
-   worktree with `make worktree-create BRANCH=<name> WORKTREE_PATH=<path>`. Do not commit, push, or open a PR from
-   the primary clone unless the user explicitly set
-   `BENCHBOX_ALLOW_MAIN_CLONE_WRITE=1`.
+1. **Run `make agent-write-preflight`.** If it refuses (BenchBox primary clone), stop and tell
+   the user to create a worktree (`make worktree-create BRANCH=<name> WORKTREE_PATH=<path>`).
+   Do not commit, push, or open a PR from the primary clone without `BENCHBOX_ALLOW_MAIN_CLONE_WRITE=1`.
 
-2. **Refuse if on `develop` or `main`.** If `git branch --show-current` returns
-   one of those, stop and tell the user to switch to a feature branch worktree
-   (offer `make worktree-create BRANCH=<name> WORKTREE_PATH=<path>`).
+2. **Refuse if on `develop` or `main`.** Stop and switch to a feature branch worktree if needed.
 
-3. **If there are authorized uncommitted changes**, inspect the diff and refuse
-   to sweep unrelated or ambiguous files into the commit. Stage each authorized
-   path explicitly — never `git add -A` — and create a conventional commit
-   (`feat:`/`fix:`/`docs:`/`test:`/`chore:`/`ci:`/`refactor:` prefix). Run
-   `make agent-identity-check`: repository-local values override the user's
-   global identity but may be stale. Reject agent/service identities unless the
-   user explicitly requested that exact identity for this task. Add a co-author
-   trailer only when explicitly requested.
-   If pre-commit hooks rewrite files, re-stage and commit again (do NOT use
-   `--amend`; create a new commit).
+3. **Stage authorized changes and commit.** Stage authorized paths explicitly (never `git add -A`),
+   verify `make agent-identity-check`, and create a conventional commit.
 
-4. **Run `make pr-preflight`** to mirror the CI gate locally. If it fails, fix
-   the root cause and loop back to step 3. Do NOT bypass with `--no-verify`.
+4. **Run `make pr-preflight`** to mirror CI locally. Fix root causes if failing; do not use `--no-verify`.
 
-5. **Run `make pr-open`** — pushes the branch, opens a PR vs `develop` with
-   `gh pr create --fill`, and enables `gh pr merge --auto --squash`.
+5. **Run `make pr-open`** — pushes branch and opens a PR vs `develop`. Note: auto-merge stays withheld
+   unless `READY=1` (`make pr-open READY=1` or `make pr-ready`).
 
-6. **Print the PR URL** and a one-line summary of what auto-merge will do
-   ("will squash-merge once `ci-required-result` goes green").
-   Do NOT poll for CI completion — auto-merge handles it.
-
-You have the capability to call multiple tools in a single response. Call them
-all in one message wherever the calls are independent. Do not narrate
-intermediate steps unless you hit a blocker that needs the user's input.
+6. **Print the PR URL** and reported auto-merge status. Do not poll CI: pending is terminal.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -51,8 +51,9 @@ implementation workflow, not unrelated cleanup or external actions.
 `[WRITE-CLOSEOUT-001]` An authorized write workflow closes at a named branch, a
 commit, and `make pr-open`; auto-merge stays withheld until `make pr-ready`. These
 are required close-out steps of write authorization, not separate permissions.
-Do not stop before `make pr-open` unless the prompt explicitly forbids publication
-or requests local-only work, or a gate fails (keep commit and report blocker).
+Within an authorized write workflow, do not stop before `make pr-open` unless the
+prompt explicitly forbids publication or requests local-only work, or a gate fails
+(keep commit and report blocker).
 
 `[REVIEW-DEFECT-001]` Keep concrete correctness, security, or performance
 defects in the review/action path; do not relabel them as blind spots.
@@ -76,39 +77,49 @@ make agent-write-preflight
 ```
 
 `worktree-create` pins identity via `git config --worktree`, so later writes cannot reauthor it.
-Stop if `git rev-parse --show-toplevel` is primary clone; emergency writes need explicit approval
-plus `BENCHBOX_ALLOW_MAIN_CLONE_WRITE=1`. Preserve unrelated dirty work; never use destructive
-Git/filesystem commands without approval. Use `rg`; stage only authorized paths; never `git add -A`.
-Disposable clones declare `BENCHBOX_EPHEMERAL_CLONE=1`; local sessions must use linked worktrees.
-Never run `git worktree prune` or `gc` inside container mounting `.git` (pruning destroys host
-registrations). Unlock only for safe removal after confirming mount is inactive.
+
+Stop if `git rev-parse --show-toplevel` is the primary clone; emergency writes
+there need explicit user authorization plus `BENCHBOX_ALLOW_MAIN_CLONE_WRITE=1`.
+Preserve unrelated dirty work; never use destructive Git/filesystem commands
+without approval. Use `rg`; stage only authorized paths; never `git add -A`.
+
+A disposable clone (remote agent session, CI runner) has no canonical clone;
+it declares `BENCHBOX_EPHEMERAL_CLONE=1` instead of the emergency override.
+Local agent sessions must use linked worktrees.
+
+Never run `git worktree prune` or `gc` inside a container mounting `.git` (pruning destroys
+host registrations). Unlock only for safe removal after confirming mount is inactive.
 
 ## Tooling and implementation
 
 - Prefer repository `make` targets and existing helpers.
 - Python tooling is `uv` only: `uv run -- ...`, `uv add`, `uv sync`, `uv lock`.
-- Research affected paths; make narrowest coherent changes preserving performance/compatibility.
-  Search existing helpers before writing new ones (`make duplicate-check-verbose` / `duplicate-check-delta`).
-- Use Python 3.10+, four spaces, 120 columns, Ruff, public API type hints.
-- No credentials in Git; redact logs; live cloud tests/destructive cleanup require approval.
+- Research the affected path, make the narrowest coherent change, and preserve
+  compatibility and critical-path performance. Before writing a new helper,
+  search for an existing equivalent (`make duplicate-check-verbose` / `duplicate-check-delta`).
+- Use Python 3.10+, four spaces, 120 columns, Ruff, and public API type hints.
+- No credentials in Git; redact logs and use environment variables.
+- Live cloud tests and broad/destructive cleanup require explicit approval.
 
-For long output, write `/tmp/<slug>.log` (report status + short tail). UAT runs use
-`BENCHBOX_OUTPUT_DIR=~/Developer/benchmark_runs` (announce command, runtime, log, stop condition).
-Do not commit raw logs, screenshots, reports, or generated binaries without a durable consumer.
+For long output, write `/tmp/<slug>.log` (report status + short tail). UAT/stress runs use
+`BENCHBOX_OUTPUT_DIR=~/Developer/benchmark_runs` (announce command, maximum runtime, log path,
+and stop condition). Do not commit raw logs, screenshots, browser reports, or generated binaries.
 
 ## Verification and close-out
 
-Read a claimed TODO's `verification` ladder and run narrowest proof first.
-Local checks: `uv run -- python -m pytest -m fast -q`, `uv run -- ruff check .`, `uv run -- ruff format --check .`.
+Read a claimed TODO's `verification` ladder and run the narrowest proof first.
+Useful local checks: `uv run -- python -m pytest -m fast -q`,
+`uv run -- ruff check .`, `uv run -- ruff format --check .`, `uv run -- ty check`.
 
-Before publication, self-review with `code` skill's review action and fix all issues/considerations/nits
-unless user opts out. Run `make pr-preflight` once, then `make pr-open`. Boilerplate gates may go to
-low-effort subagent; you still choose command and interpret failures. Do not poll CI: pending is terminal.
+Before publication, self-review with the `code` skill's review action and fix all
+issues, considerations, and nits unless the user explicitly opts out. Run `make pr-preflight`
+once, then `make pr-open`. Boilerplate gates may go to a low-effort subagent; you still
+choose the command and interpret failures. Do not poll CI: pending is a valid terminal state.
 
-Dev PRs target `develop` (or `release` / `published-results`), squash merge, never direct-push protected
-branches. Force-push only feature branches with `--force-with-lease`. Soundness paths listed by
-`_project/scripts/auto_merge_soundness_paths.py` require maintainer review; excluded from auto-merge.
-A drift/pinning guard and required-CI wiring must land in same PR.
+Dev PRs target `develop` (or `release` / `published-results`), use squash merge, and never direct-push
+protected branches. Force-push only feature branches with `--force-with-lease`. Soundness paths listed
+by `_project/scripts/auto_merge_soundness_paths.py` require maintainer review; excluded from auto-merge.
+A drift/pinning guard and its required-CI wiring must land in the same PR.
 ## PR base branch (stacked PRs unsupported)
 Stacked/feature-base PRs unsupported: zero CI by filters; `pr-base-guard.yml` fails loud — retarget/rebase onto
 `develop` after parent squash-merge (`docs/development/pr-base-branch-policy.md`). Bad-base empty checks ≠
@@ -116,12 +127,13 @@ Stacked/feature-base PRs unsupported: zero CI by filters; `pr-base-guard.yml` fa
 
 ## TODO tracker
 
-Shared database is only TODO record. `_project/scripts/todo` is only write path; global `--db`/`--actor`
-flags precede subcommand. Tracker writes follow worktree policy (`_project/todo-db-export/` public;
-no recovered plaintext). `todo claim <id>` prints binding work order; follow scope, preserve rules,
-anti-patterns, dependencies, verification. Exit 2 means fix cause, never bypass. `todo ready` and `todo stats`
-print untriaged-findings banner on stderr when open findings/drafts exist; triage via `todo finding candidates`
-(finding commands are read-only; findings are review blind spots, never claimable).
+The shared database is the only TODO record. `_project/scripts/todo` is the only write path;
+global `--db`/`--actor` flags precede subcommand. Tracker writes follow worktree policy
+(`_project/todo-db-export/` public; no recovered plaintext). `todo claim <id>` prints binding work order;
+follow scope, preserve rules, anti-patterns, dependencies, verification. Exit 2 means fix cause, never bypass.
+`todo ready` and `todo stats` print untriaged-findings banner on stderr when open findings or unsynced drafts exist;
+triage via `todo finding candidates` (`finding list`/`show`/`candidates` are read-only; findings are review blind spots,
+never claimable items).
 
 ## BenchBox invariants
 
@@ -132,21 +144,25 @@ print untriaged-findings banner on stderr when open findings/drafts exist; triag
 - CLI dry runs must propagate explicit phases; deterministic runs use a seed.
 - Green focused/fast tests are not UAT or production certification.
 
-Apple/macOS notes: `make test-correctness-gate` uses Linux digests; use `make ci-linux` for parity.
+Apple/macOS notes: `make test-correctness-gate` uses Linux-generated digests; use `make ci-linux` for parity.
 Mocker is local-only, never CI: databend needs docker (its `minio` service exits under mocker),
 doris/starrocks are single-container. See `docs/operations/uat-framework.md` ("Mocker validation status") for
-lifecycle, cleanup, caveats. Never globally prune without approval.
+lifecycle, cleanup, and caveats. Never globally prune without approval.
 
 ## Skills and generated mirrors
 
-Stable wrappers: `code`, `test`, `todo`, `todo-db`, `blog`, `benchbox`, `skill-sync`, `tidy-perms`.
+Stable wrappers are `code`, `test`, `todo`, `todo-db`, `blog`, `benchbox`, `skill-sync`, and `tidy-perms`.
 `todo` authors ideas/specs; `todo-db` owns tracker actions. Skill source is `/Users/joe/.skill-sync/skills`;
 `.claude/skills`, `.codex/skills`, `.gemini/skills`, and `.antigravity/skills` are generated mirrors.
 Run `make skill-sync` to regenerate mirrors, never hand-edit one. Integrity comes from PR review of mirror diff
-plus untracked-mirror drift guard (`scripts/check_untracked_skill_mirrors.sh`), not lock-verify step.
+plus untracked-mirror drift guard (`scripts/check_untracked_skill_mirrors.sh`), not a lock-verify step.
 
 ## Operational references
 
-- Operations: `docs/operations/` — `repo-admin-settings.md` (PR/admin policy), `uat-framework.md`, `release-guide.md`, `agent-instruction-evaluation.md`
-- Agent: unpublished `docs/agent/` (`review-protocol.md`). Development: `docs/development/` — `adding-new-platforms.md`, `pr-base-branch-policy.md`
-- SQL compatibility: `benchbox/sql_compat/README.md`; tests: `tests/README.md`; Dev-loop status (as of 2026-08-10): REASSESS — P95 PR-to-merged 22.6 hours; post-merge red rate 8.21% aggregate, but not sustained above 5% of days.
+- Operations: `docs/operations/` — `repo-admin-settings.md` (PR/admin policy),
+  `uat-framework.md`, `release-guide.md`, `agent-instruction-evaluation.md`
+- Agent: unpublished `docs/agent/` (`review-protocol.md`). Development:
+  `docs/development/` — `adding-new-platforms.md`, `pr-base-branch-policy.md`
+- SQL compatibility: `benchbox/sql_compat/README.md`; tests: `tests/README.md`;
+  Dev-loop status (as of 2026-08-10): REASSESS — P95 PR-to-merged 22.6 hours; post-merge red rate 8.21% aggregate,
+  but not sustained above 5% of days.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -52,8 +52,8 @@ implementation workflow, not unrelated cleanup or external actions.
 commit, and `make pr-open`; auto-merge stays withheld until `make pr-ready`. These
 are required close-out steps of write authorization, not separate permissions.
 Within an authorized write workflow, do not stop before `make pr-open` unless the
-prompt explicitly forbids publication or requests local-only work, or a gate fails
-(keep commit and report blocker).
+prompt explicitly forbids publication, authorizes only a local commit, or a gate
+fails (in which case keep the commit and report the blocker).
 
 `[REVIEW-DEFECT-001]` Keep concrete correctness, security, or performance
 defects in the review/action path; do not relabel them as blind spots.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -48,6 +48,12 @@ only, with zero tracked worktree-content changes; do not review and then edit
 locally in the same turn. Implementation requests authorize the narrow
 implementation workflow, not unrelated cleanup or external actions.
 
+`[WRITE-CLOSEOUT-001]` An authorized write workflow closes at a named branch, a
+commit, and `make pr-open`; auto-merge stays withheld until `make pr-ready`. These
+are required close-out steps of write authorization, not separate permissions.
+Do not stop before `make pr-open` unless the prompt explicitly forbids publication
+or requests local-only work, or a gate fails (keep commit and report blocker).
+
 `[REVIEW-DEFECT-001]` Keep concrete correctness, security, or performance
 defects in the review/action path; do not relabel them as blind spots.
 `[REVIEW-L2-001]` L2 captures missed review dimensions, not defects already
@@ -69,53 +75,40 @@ cd <WORKTREE_PATH>
 make agent-write-preflight
 ```
 
-`worktree-create` pins identity via `git config --worktree`, so later writes
-cannot reauthor it.
-
-Stop if `git rev-parse --show-toplevel` is the primary clone; emergency writes
-there need explicit user authorization plus `BENCHBOX_ALLOW_MAIN_CLONE_WRITE=1`.
-Preserve unrelated dirty work; never use destructive Git/filesystem commands
-without approval. Use `rg`; stage only authorized paths; never `git add -A`.
-
-A disposable clone (remote agent session, CI runner) has no canonical clone;
-it declares `BENCHBOX_EPHEMERAL_CLONE=1` instead of the emergency override.
-Local agent sessions must use linked worktrees.
-
-Never run `git worktree prune` or `gc` inside a container mounting `.git` —
-host registrations read prunable there and pruning destroys them. Unlock only
-for safe removal after confirming the mount is inactive.
+`worktree-create` pins identity via `git config --worktree`, so later writes cannot reauthor it.
+Stop if `git rev-parse --show-toplevel` is primary clone; emergency writes need explicit approval
+plus `BENCHBOX_ALLOW_MAIN_CLONE_WRITE=1`. Preserve unrelated dirty work; never use destructive
+Git/filesystem commands without approval. Use `rg`; stage only authorized paths; never `git add -A`.
+Disposable clones declare `BENCHBOX_EPHEMERAL_CLONE=1`; local sessions must use linked worktrees.
+Never run `git worktree prune` or `gc` inside container mounting `.git` (pruning destroys host
+registrations). Unlock only for safe removal after confirming mount is inactive.
 
 ## Tooling and implementation
 
 - Prefer repository `make` targets and existing helpers.
 - Python tooling is `uv` only: `uv run -- ...`, `uv add`, `uv sync`, `uv lock`.
-- Research the affected path, make the narrowest coherent change, and preserve
-  compatibility and critical-path performance. Before writing a new helper,
-  search for an existing equivalent (`make duplicate-check-verbose` / `duplicate-check-delta`).
-- Use Python 3.10+, four spaces, 120 columns, Ruff, and public API type hints.
-- No credentials in Git; redact logs and use environment variables.
-- Live cloud tests and broad/destructive cleanup require explicit approval.
+- Research affected paths; make narrowest coherent changes preserving performance/compatibility.
+  Search existing helpers before writing new ones (`make duplicate-check-verbose` / `duplicate-check-delta`).
+- Use Python 3.10+, four spaces, 120 columns, Ruff, public API type hints.
+- No credentials in Git; redact logs; live cloud tests/destructive cleanup require approval.
 
-For long output, write `/tmp/<slug>.log` and report status plus a short tail.
-UAT/stress runs use `BENCHBOX_OUTPUT_DIR=~/Developer/benchmark_runs`; announce
-command, maximum runtime, log path, and stop condition. Do not commit raw logs,
-screenshots, browser reports, or generated binaries without a durable consumer.
+For long output, write `/tmp/<slug>.log` (report status + short tail). UAT runs use
+`BENCHBOX_OUTPUT_DIR=~/Developer/benchmark_runs` (announce command, runtime, log, stop condition).
+Do not commit raw logs, screenshots, reports, or generated binaries without a durable consumer.
 
 ## Verification and close-out
 
-Read a claimed TODO's `verification` ladder and run the narrowest proof first.
-Useful local checks: `uv run -- python -m pytest -m fast -q`,
-`uv run -- ruff check .`, `uv run -- ruff format --check .`, `uv run -- ty check`.
+Read a claimed TODO's `verification` ladder and run narrowest proof first.
+Local checks: `uv run -- python -m pytest -m fast -q`, `uv run -- ruff check .`, `uv run -- ruff format --check .`.
 
-Before publication, self-review with the `code` skill's review action and fix all
-issues, considerations, and nits unless the user explicitly opts out. Run `make pr-preflight`
-once, then `make pr-open`. Boilerplate gates may go to a low-effort subagent; you still
-choose the command and interpret failures. Do not poll CI: pending is a valid terminal state.
+Before publication, self-review with `code` skill's review action and fix all issues/considerations/nits
+unless user opts out. Run `make pr-preflight` once, then `make pr-open`. Boilerplate gates may go to
+low-effort subagent; you still choose command and interpret failures. Do not poll CI: pending is terminal.
 
-Dev PRs target `develop` (or `release` / `published-results`), use squash merge, and never direct-push protected
+Dev PRs target `develop` (or `release` / `published-results`), squash merge, never direct-push protected
 branches. Force-push only feature branches with `--force-with-lease`. Soundness paths listed by
-`_project/scripts/auto_merge_soundness_paths.py` require maintainer review and remain excluded from auto-merge.
-A drift/pinning guard and its required-CI wiring must land in the same PR.
+`_project/scripts/auto_merge_soundness_paths.py` require maintainer review; excluded from auto-merge.
+A drift/pinning guard and required-CI wiring must land in same PR.
 ## PR base branch (stacked PRs unsupported)
 Stacked/feature-base PRs unsupported: zero CI by filters; `pr-base-guard.yml` fails loud — retarget/rebase onto
 `develop` after parent squash-merge (`docs/development/pr-base-branch-policy.md`). Bad-base empty checks ≠
@@ -123,48 +116,37 @@ Stacked/feature-base PRs unsupported: zero CI by filters; `pr-base-guard.yml` fa
 
 ## TODO tracker
 
-The shared database is the only TODO record. `_project/scripts/todo` is the
-only write path; global `--db`/`--actor` flags precede the subcommand. Tracker
-writes follow the same worktree policy (`_project/todo-db-export/` is public; no recovered plaintext). `todo claim <id>` prints the binding
-work order; follow its scope, preserve rules, anti-patterns, dependencies, and
-verification. Exit 2 means fix the cause, never bypass it. `todo ready` and
-`todo stats` print an untriaged-findings banner on stderr when open findings or
-unsynced drafts exist; triage via `todo finding candidates` (`finding
-list`/`show`/`candidates` are read-only; findings are review blind spots, never
-claimable items).
+Shared database is only TODO record. `_project/scripts/todo` is only write path; global `--db`/`--actor`
+flags precede subcommand. Tracker writes follow worktree policy (`_project/todo-db-export/` public;
+no recovered plaintext). `todo claim <id>` prints binding work order; follow scope, preserve rules,
+anti-patterns, dependencies, verification. Exit 2 means fix cause, never bypass. `todo ready` and `todo stats`
+print untriaged-findings banner on stderr when open findings/drafts exist; triage via `todo finding candidates`
+(finding commands are read-only; findings are review blind spots, never claimable).
 
 ## BenchBox invariants
 
-- Timing durations use `benchbox.utils.clock.mono_time()` and
-  `elapsed_seconds()`; wall clocks are only for event/audit timestamps.
-- Adapter SDK imports stay lazy. New SQL platforms subclass `PlatformAdapter`
-  and register with `@register_platform`.
-- CREATE TABLE rewrites are registered under `Phase.DDL_OPTIMIZE`; run
-  `make compat-docs-check` and the DDL drift inventory check.
-- Dependency upper bounds are exceptional. Current high-risk caps are
-  `sqlglot<31`, `click<9`, `pydantic<3`, `pyarrow<24`, and `duckdb<2`.
+- Timing durations use `benchbox.utils.clock.mono_time()` and `elapsed_seconds()`; wall clocks are event/audit only.
+- Adapter SDK imports stay lazy. New SQL platforms subclass `PlatformAdapter` and register with `@register_platform`.
+- CREATE TABLE rewrites are registered under `Phase.DDL_OPTIMIZE`; run `make compat-docs-check` and DDL drift check.
+- Dependency upper bounds exceptional. Current caps: `sqlglot<31`, `click<9`, `pydantic<3`, `pyarrow<24`, `duckdb<2`.
 - CLI dry runs must propagate explicit phases; deterministic runs use a seed.
 - Green focused/fast tests are not UAT or production certification.
 
-Apple/macOS notes: `make test-correctness-gate` uses Linux-generated digests; use `make ci-linux` for parity.
+Apple/macOS notes: `make test-correctness-gate` uses Linux digests; use `make ci-linux` for parity.
 Mocker is local-only, never CI: databend needs docker (its `minio` service exits under mocker),
 doris/starrocks are single-container. See `docs/operations/uat-framework.md` ("Mocker validation status") for
-lifecycle, cleanup, and caveats. Never globally prune without approval.
+lifecycle, cleanup, caveats. Never globally prune without approval.
 
 ## Skills and generated mirrors
 
-Stable wrappers are `code`, `test`, `todo`, `todo-db`, `blog`, `benchbox`,
-`skill-sync`, and `tidy-perms`. `todo` authors ideas/specs; `todo-db` owns tracker
-actions. Skill source is `/Users/joe/.skill-sync/skills`; `.claude/skills`, `.codex/skills`,
-`.gemini/skills`, and `.antigravity/skills` are generated mirrors. Run `make skill-sync` to
-regenerate mirrors, never hand-edit one. Integrity comes from PR review of the mirror diff
-plus the untracked-mirror drift guard (`scripts/check_untracked_skill_mirrors.sh`), not a
-lock-verify step.
+Stable wrappers: `code`, `test`, `todo`, `todo-db`, `blog`, `benchbox`, `skill-sync`, `tidy-perms`.
+`todo` authors ideas/specs; `todo-db` owns tracker actions. Skill source is `/Users/joe/.skill-sync/skills`;
+`.claude/skills`, `.codex/skills`, `.gemini/skills`, and `.antigravity/skills` are generated mirrors.
+Run `make skill-sync` to regenerate mirrors, never hand-edit one. Integrity comes from PR review of mirror diff
+plus untracked-mirror drift guard (`scripts/check_untracked_skill_mirrors.sh`), not lock-verify step.
 
 ## Operational references
 
-- Operations: `docs/operations/` — `repo-admin-settings.md` (PR/admin policy),
-  `uat-framework.md`, `release-guide.md`, `agent-instruction-evaluation.md`
-- Agent: unpublished `docs/agent/` (`review-protocol.md`). Development:
-  `docs/development/` — `adding-new-platforms.md`, `pr-base-branch-policy.md`
+- Operations: `docs/operations/` — `repo-admin-settings.md` (PR/admin policy), `uat-framework.md`, `release-guide.md`, `agent-instruction-evaluation.md`
+- Agent: unpublished `docs/agent/` (`review-protocol.md`). Development: `docs/development/` — `adding-new-platforms.md`, `pr-base-branch-policy.md`
 - SQL compatibility: `benchbox/sql_compat/README.md`; tests: `tests/README.md`; Dev-loop status (as of 2026-08-10): REASSESS — P95 PR-to-merged 22.6 hours; post-merge red rate 8.21% aggregate, but not sustained above 5% of days.

--- a/_project/scripts/agent_instruction_audit.py
+++ b/_project/scripts/agent_instruction_audit.py
@@ -28,6 +28,7 @@ REQUIRED_POLICY_IDS = {
     "REVIEW-L2-001",
     "REVIEW-CAPTURE-001",
     "REVIEW-PARITY-001",
+    "WRITE-CLOSEOUT-001",
 }
 REVIEW_POLICY_IDS = {policy_id for policy_id in REQUIRED_POLICY_IDS if policy_id.startswith("REVIEW-")}
 CANONICAL_REVIEW_ANCHORS = {
@@ -70,6 +71,14 @@ PROJECT_COMMIT_ANCHORS = {
 }
 PROJECT_REVIEW_ANCHORS = {"REVIEW-AUTH-001": ("later user turn", "bundling review and remediation")}
 AGENT_REVIEW_ANCHORS = {"REVIEW-AUTH-001": ("zero tracked worktree-content changes", "do not review and then edit")}
+AGENT_WRITE_ANCHORS = {
+    "WRITE-CLOSEOUT-001": (
+        "named branch",
+        "make pr-open",
+        "make pr-ready",
+        "close-out steps",
+    )
+}
 CODE_REVIEW_RULE_ANCHORS = (
     "Do not report commit identity.",
     "Review sandboxes may use synthetic identities.",
@@ -251,6 +260,13 @@ def audit_commit_policy(project: Path) -> list[str]:
             errors.append(f"project commit policy misses policy ID: {policy_id}")
         elif missing_anchors:
             errors.append(f"project {policy_id} semantics drifted; missing anchors: {', '.join(missing_anchors)}")
+    for policy_id, anchors in AGENT_WRITE_ANCHORS.items():
+        section = _policy_section(agents, policy_id)
+        missing_anchors = _missing_anchors(section, anchors)
+        if not section:
+            errors.append(f"AGENTS.md write policy misses policy ID: {policy_id}")
+        elif missing_anchors:
+            errors.append(f"AGENTS.md {policy_id} semantics drifted; missing anchors: {', '.join(missing_anchors)}")
     return errors
 
 

--- a/_project/scripts/agent_instruction_audit.py
+++ b/_project/scripts/agent_instruction_audit.py
@@ -79,6 +79,9 @@ AGENT_WRITE_ANCHORS = {
         "make pr-ready",
         "required close-out steps of write authorization, not separate permissions",
         "do not stop before",
+        "explicitly forbids publication",
+        "authorizes only a local commit",
+        "gate fails",
     )
 }
 CODE_REVIEW_RULE_ANCHORS = (

--- a/_project/scripts/agent_instruction_audit.py
+++ b/_project/scripts/agent_instruction_audit.py
@@ -73,10 +73,12 @@ PROJECT_REVIEW_ANCHORS = {"REVIEW-AUTH-001": ("later user turn", "bundling revie
 AGENT_REVIEW_ANCHORS = {"REVIEW-AUTH-001": ("zero tracked worktree-content changes", "do not review and then edit")}
 AGENT_WRITE_ANCHORS = {
     "WRITE-CLOSEOUT-001": (
-        "named branch",
+        "authorized write workflow closes at a named branch",
         "make pr-open",
+        "auto-merge stays withheld until",
         "make pr-ready",
-        "close-out steps",
+        "required close-out steps of write authorization, not separate permissions",
+        "do not stop before",
     )
 }
 CODE_REVIEW_RULE_ANCHORS = (
@@ -174,7 +176,8 @@ def _policy_section(text: str, policy_id: str) -> str:
     if marker not in text:
         return ""
     section = text.split(marker, 1)[1]
-    return section.split("\n## ", 1)[0]
+    parts = re.split(r"\n\s*(?:##\s+|`?\[[A-Z0-9_-]+\])", section, maxsplit=1)
+    return parts[0]
 
 
 def _missing_anchors(text: str, anchors: Iterable[str]) -> list[str]:

--- a/docs/operations/release-guide.md
+++ b/docs/operations/release-guide.md
@@ -35,7 +35,7 @@ Before a release PR can merge, the `release-only` ruleset must require:
   generate/load/execute with EXACT stored answer-set row-count validation of the
   18 answer-stable TPC-H queries; Q11/Q16/Q18/Q20 are excluded for answer-set
   boundary sensitivity, and validation is cardinality-level, not value-level).
-  The stored digests are Linux-generated, so on Apple silicon and macOS run
+  The stored digests are Linux-generated, so on Apple silicon with macOS 26 or newer run
   `make ci-linux` for parity rather than reading a local mismatch as a defect;
 - the credential-free integration-not-slow suite:
   `tests/integration -m "integration and not (slow or stress or resource_heavy or live_integration)"`;

--- a/docs/operations/release-guide.md
+++ b/docs/operations/release-guide.md
@@ -34,7 +34,9 @@ Before a release PR can merge, the `release-only` ruleset must require:
   (`DuckDB x TPC-H` at SF=1 with the pinned reference qgen seed, through
   generate/load/execute with EXACT stored answer-set row-count validation of the
   18 answer-stable TPC-H queries; Q11/Q16/Q18/Q20 are excluded for answer-set
-  boundary sensitivity, and validation is cardinality-level, not value-level);
+  boundary sensitivity, and validation is cardinality-level, not value-level).
+  The stored digests are Linux-generated, so on Apple silicon and macOS run
+  `make ci-linux` for parity rather than reading a local mismatch as a defect;
 - the credential-free integration-not-slow suite:
   `tests/integration -m "integration and not (slow or stress or resource_heavy or live_integration)"`;
 - isolated exact-one-wheel package build/install smoke;

--- a/tests/unit/scripts/test_agent_instruction_audit.py
+++ b/tests/unit/scripts/test_agent_instruction_audit.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import importlib.util
 import json
 import os
+import re
 import shutil
 import subprocess
 import sys
@@ -124,6 +125,27 @@ def test_project_write_closeout_drift_fails(tmp_path: Path) -> None:
             "optional suggestions that require separate user approval",
         )
     )
+    _, errors = audit(project, CORPUS)
+    assert any("AGENTS.md WRITE-CLOSEOUT-001 semantics drifted" in error for error in errors)
+
+
+@pytest.mark.parametrize(
+    "phrase",
+    [
+        "explicitly forbids publication",
+        "authorizes only a local commit",
+        "gate fails",
+        "do not stop before",
+    ],
+)
+def test_project_write_closeout_exception_drift_fails(tmp_path: Path, phrase: str) -> None:
+    project = _candidate(tmp_path)
+    agents = project / "AGENTS.md"
+    content = agents.read_text()
+    pattern = re.compile(r"\s+".join(re.escape(w) for w in phrase.split()))
+    new_content, count = pattern.subn("deleted constraint", content)
+    assert count > 0, f"Pattern {phrase} was not found in AGENTS.md"
+    agents.write_text(new_content)
     _, errors = audit(project, CORPUS)
     assert any("AGENTS.md WRITE-CLOSEOUT-001 semantics drifted" in error for error in errors)
 

--- a/tests/unit/scripts/test_agent_instruction_audit.py
+++ b/tests/unit/scripts/test_agent_instruction_audit.py
@@ -118,7 +118,12 @@ def test_project_commit_coauthor_consent_drift_fails(tmp_path: Path) -> None:
 def test_project_write_closeout_drift_fails(tmp_path: Path) -> None:
     project = _candidate(tmp_path)
     agents = project / "AGENTS.md"
-    agents.write_text(agents.read_text().replace("make pr-open", "ask for confirmation"))
+    agents.write_text(
+        agents.read_text().replace(
+            "required close-out steps of write authorization, not separate permissions",
+            "optional suggestions that require separate user approval",
+        )
+    )
     _, errors = audit(project, CORPUS)
     assert any("AGENTS.md WRITE-CLOSEOUT-001 semantics drifted" in error for error in errors)
 

--- a/tests/unit/scripts/test_agent_instruction_audit.py
+++ b/tests/unit/scripts/test_agent_instruction_audit.py
@@ -115,6 +115,14 @@ def test_project_commit_coauthor_consent_drift_fails(tmp_path: Path) -> None:
     assert any("project COMMIT-IDENTITY-001 semantics drifted" in error for error in errors)
 
 
+def test_project_write_closeout_drift_fails(tmp_path: Path) -> None:
+    project = _candidate(tmp_path)
+    agents = project / "AGENTS.md"
+    agents.write_text(agents.read_text().replace("make pr-open", "ask for confirmation"))
+    _, errors = audit(project, CORPUS)
+    assert any("AGENTS.md WRITE-CLOSEOUT-001 semantics drifted" in error for error in errors)
+
+
 def test_project_commit_anchor_reflow_passes(tmp_path: Path) -> None:
     project = _candidate(tmp_path)
     agents = project / "AGENTS.md"


### PR DESCRIPTION
AGENTS.md carried five prohibited publication actions under REVIEW-AUTH-001 with
no counterpart stating that publication is the standard close-out for authorized
write tasks.

Add [WRITE-CLOSEOUT-001] to AGENTS.md specifying that an authorized write
workflow closes at a named branch, commit, and `make pr-open` (with auto-merge
withheld until `make pr-ready`), which are required close-out steps rather than
separate permissions.

Anchor [WRITE-CLOSEOUT-001] in _project/scripts/agent_instruction_audit.py under
REQUIRED_POLICY_IDS and AGENT_WRITE_ANCHORS, and add test coverage in
tests/unit/scripts/test_agent_instruction_audit.py.

Fund the 170-line and 16,000-byte budgets by compressing verbose wording across
AGENTS.md while preserving essential Apple/macOS and Mocker operational guidance.
Net AGENTS.md length: 152/170 lines; active instruction bytes: 15762/16000.
