### PR TITLE
chore(agents): bind REVIEW-PLAN-RECON-001 in review protocol and instruction audit

### DIFF
--- a/_project/scripts/agent_instruction_audit.py
+++ b/_project/scripts/agent_instruction_audit.py
@@ -28,6 +28,7 @@ REQUIRED_POLICY_IDS = {
     "REVIEW-L2-001",
     "REVIEW-CAPTURE-001",
     "REVIEW-PARITY-001",
+    "REVIEW-PLAN-RECON-001",
     "WRITE-CLOSEOUT-001",
 }
 REVIEW_POLICY_IDS = {policy_id for policy_id in REQUIRED_POLICY_IDS if policy_id.startswith("REVIEW-")}
@@ -45,6 +46,16 @@ CANONICAL_REVIEW_ANCHORS = {
     "REVIEW-L2-001": ("gaps in the review framework", "not defects already found"),
     "REVIEW-CAPTURE-001": ("protocol governs behavior", "governs storage formats"),
     "REVIEW-PARITY-001": ("Missing IDs or contradictory semantics", "skill governs behavior"),
+    "REVIEW-PLAN-RECON-001": (
+        "Claim-against-code checking",
+        "enumerate the recorded decision surfaces",
+        "future-state index and its priority tiers",
+        "migration gates in design docs",
+        "readiness and evidence documents",
+        "open tracker items at the relevant priority",
+        "cite each one or explicitly supersede it",
+        "dropped open gate, is a plan defect",
+    ),
 }
 # The author/committer anchors are load-bearing: the audit previously pinned
 # only the trailer semantics, so the canonical skill could require a human
@@ -69,7 +80,18 @@ PROJECT_COMMIT_ANCHORS = {
         "committer slot behind a human author",
     )
 }
-PROJECT_REVIEW_ANCHORS = {"REVIEW-AUTH-001": ("later user turn", "bundling review and remediation")}
+PROJECT_REVIEW_ANCHORS = {
+    "REVIEW-AUTH-001": ("later user turn", "bundling review and remediation"),
+    "REVIEW-PLAN-RECON-001": (
+        "Enumerate recorded decision",
+        "future-state index/tiers",
+        "migration gates",
+        "readiness docs",
+        "open tracker items",
+        "Cite or supersede each",
+        "dropped open gate is a defect",
+    ),
+}
 AGENT_REVIEW_ANCHORS = {"REVIEW-AUTH-001": ("zero tracked worktree-content changes", "do not review and then edit")}
 AGENT_WRITE_ANCHORS = {
     "WRITE-CLOSEOUT-001": (

--- a/docs/agent/review-protocol.md
+++ b/docs/agent/review-protocol.md
@@ -45,9 +45,10 @@ Do not relocate a defect into L2 (`[REVIEW-L2-001]`).
 - **Extension-cost.** Primary extension-cost metric: files/contracts to add one SQL
   platform, one DataFrame platform, and one benchmark family. McCabe/cloc
   are hygiene (`docs/development/quality-gate-policy.md`).
-- **Prior-decision.** Enumerate recorded decision surfaces (future-state
-  index/tiers, migration gates, readiness docs, open tracker items). Cite or
-  supersede each. Unexplained demotion or a dropped open gate is a defect.
+- **Prior-decision.** `[REVIEW-PLAN-RECON-001]`: Enumerate recorded decision
+  surfaces (future-state index/tiers, migration gates, readiness docs, open
+  tracker items). Cite or supersede each. Unexplained demotion or a dropped open
+  gate is a defect.
 - **CI synchronize fan-out.** For savings/skip/path-filter plans, list every
   same-event workflow, split runner vs wall minutes, and change siblings or
   lower the target. See `docs/operations/repo-admin-settings.md`.

--- a/tests/unit/scripts/test_agent_instruction_audit.py
+++ b/tests/unit/scripts/test_agent_instruction_audit.py
@@ -315,6 +315,22 @@ def test_missing_canonical_review_policy_id_fails(tmp_path: Path) -> None:
     assert any("canonical review skill misses policy IDs: REVIEW-L2-001" in error for error in errors)
 
 
+def test_canonical_plan_reconciliation_policy_drift_fails(tmp_path: Path) -> None:
+    project = _candidate(tmp_path)
+    canonical = project / CANONICAL_REVIEW_SKILL
+    canonical.write_text(canonical.read_text().replace("Claim-against-code checking", "Casual code checking"))
+    _, errors = audit(project, CORPUS)
+    assert any("canonical REVIEW-PLAN-RECON-001 semantics drifted" in error for error in errors)
+
+
+def test_project_plan_reconciliation_policy_drift_fails(tmp_path: Path) -> None:
+    project = _candidate(tmp_path)
+    protocol = project / "docs/agent/review-protocol.md"
+    protocol.write_text(protocol.read_text().replace("Enumerate recorded decision", "Skim prior decision"))
+    _, errors = audit(project, CORPUS)
+    assert any("project REVIEW-PLAN-RECON-001 semantics drifted" in error for error in errors)
+
+
 def test_development_agent_doc_fails(tmp_path: Path) -> None:
     project = _candidate(tmp_path)
     leaked = project / "docs/development/agent-extra.md"


### PR DESCRIPTION
Follow-up addressing Codex review thread on PR #1779.

- Add `REVIEW-PLAN-RECON-001` to `REQUIRED_POLICY_IDS`, `CANONICAL_REVIEW_ANCHORS`, and `PROJECT_REVIEW_ANCHORS` in `_project/scripts/agent_instruction_audit.py`.
- Bind `[REVIEW-PLAN-RECON-001]` to the Prior-decision section in `docs/agent/review-protocol.md`.
- Add parameterized drift detection unit tests in `tests/unit/scripts/test_agent_instruction_audit.py`.