### PR TITLE
docs(adr): correct tracking claim and record that Linux SF1 placement is ungated

### DIFF
--- a/docs/development/adr/adr-clickhouse-server-containerization.md
+++ b/docs/development/adr/adr-clickhouse-server-containerization.md
@@ -10,7 +10,9 @@ the rung ladder or the admission arithmetic in
 
 ## Date
 
-2026-08-19
+2026-08-19. Amended 2026-08-20 to correct the tracking claim in
+"Follow-up ownership", record that this decision is documented but not
+enforced, and mark the superseded remediation text in the w2 evidence artifact.
 
 ## Context
 
@@ -112,12 +114,44 @@ certifies.
 - The container remains the only place the memory envelope is externally
   enforced, so compose stays authoritative for `CLICKHOUSE_MEMORY_LIMIT` and the
   no-default contract documented in `docs/operations/uat-framework.md` stands.
+- **This decision is documented, not enforced.** No preflight check refuses SF1
+  certification on darwin. `check_memory_headroom` blocks the current host on
+  available memory alone, which is a coincidence of this machine's size: a macOS
+  host with enough RAM would clear admission and emit an SF1 certification
+  result that this ADR considers invalid, because the VM layer and the absent
+  cgroup contract do not appear in the admission arithmetic. Treat a darwin SF1
+  result as unqualified until a gate exists.
+
+## Evidence and superseded records
+
+`~/Developer/benchmark_runs/clickhouse-certification-20260818/sf1-admission-8g-blocked-20260818.json`
+is the admission-denial evidence for work unit w2 and remains valid as a
+measurement. Its `operator_remediation_required` narrative predates this ADR
+and is superseded: it offers "reboot this host and run the SF1 sweep with no
+interactive agent session competing" as a first remedy, which this decision
+rejects. Freeing memory on the macOS host does not make it a certification
+host, because the objection is the virtualization layer and the missing cgroup
+contract, not the byte count on any given day. Read that field as history.
 
 ## Follow-up ownership
 
-Per-query `max_memory_usage` defaults to `"8GB"` in
-`benchbox/platforms/clickhouse/setup.py:33`, equal to the container limit, which
-permits a single query to claim the entire cgroup with nothing left for merges,
-caches, or page cache. That is a tuning question in platform code, out of scope
-for the certification item, and is tracked separately. It is a candidate lever if
-the goal ever becomes lowering the admission bar rather than satisfying it.
+Two follow-ups are open. **Neither is filed in the hosted tracker**, because
+`todo doctor` fails `E_AUTH_MISSING` and no `TODO_DB_*` credential is present on
+this host. Recording them here is the only durable record; file them when
+credentials are restored.
+
+**Per-query `max_memory_usage` equals the container limit.** It defaults to
+`"8GB"` in `benchbox/platforms/clickhouse/setup.py:33`, matching
+`clickhouse_memory_limit` in `tests/uat/config.py:122`, so a single query may
+claim the entire cgroup with nothing left for merges, caches, or page cache. The
+two values are configured independently and do not track each other. Whether
+this is a defect or an intentional ceiling is undecided. Draft at
+`~/.todo-db/finding-drafts/benchbox/clickhouse-per-query-memory-equals-container-limit-2026-08-19.md`;
+rename with the `.merged-to-todo` suffix once filed. It is a candidate lever if
+the goal ever becomes lowering the admission bar rather than satisfying it, but
+it must not be used to unblock SF1 on an unqualified host.
+
+**No gate enforces the Linux requirement.** Making it real means a platform
+check in the UAT admission path that fails SF1 certification on darwin
+regardless of available memory, rather than relying on this document being read.
+That is platform-code work, unscoped and unauthorized here.

--- a/docs/operations/uat-framework.md
+++ b/docs/operations/uat-framework.md
@@ -895,6 +895,11 @@ double the engine's actual need. SF1 certification therefore runs on Linux;
 macOS keeps the SF0.01 smoke at `baseline-1g`. See
 [ADR: `clickhouse-server` Containerization and Linux SF1 Certification](../development/adr/adr-clickhouse-server-containerization.md).
 
+That placement is a documented requirement, not a gate. Admission checks
+available memory and does not check the platform, so a macOS host with enough
+RAM will pass and produce an SF1 result the ADR does not consider valid. Do not
+treat a darwin SF1 certification as qualified.
+
 For a direct operator compose check, export the selected rung explicitly:
 
 ```bash


### PR DESCRIPTION
The ADR stated the per-query max_memory_usage follow-up "is tracked
separately". It is not. It is an unfiled draft in the zero-credential
drafts directory, because todo-db filing fails E_AUTH_MISSING and no
TODO_DB_* credential exists on this host. The wording implied a tracker
item a reader could look up. Both open follow-ups now name their draft
path and the reason they are unfiled.

Record a second learning the original ADR missed: the decision that SF1
certification runs on Linux is documented prose, not a gate. Admission
checks available memory and never checks platform, so a macOS host with
enough RAM would clear the bar and emit an SF1 result the ADR does not
consider valid, with nothing in the artifact to reveal it. Added as a
Consequences bullet and as an operator caveat in uat-framework.md.

Mark the w2 evidence artifact's remediation text superseded. It offers
"reboot this host" as a first remedy, written before the container
evaluation; the objection to macOS is the virtualization layer, not the
byte count, so freeing memory does not qualify the host. The artifact is
left byte-identical with a sibling note beside it.

No change to the rung ladder, the admission arithmetic, the no-fallback
loader contract, or any platform code.
