### PR TITLE
docs: align Results Explorer curated preview in v0.4.0 release readiness

### DIFF
--- a/_project/planning/v0.4.0-release-readiness.md
+++ b/_project/planning/v0.4.0-release-readiness.md
@@ -13,7 +13,7 @@ release-branch tree, and the 2026-07-26 tracker export.
 | Package install smoke (v0.3.0 failure class) | COVERED | `test.yml` test-package: isolated wheel install, `import benchbox`, pandas absent, `benchbox --help` |
 | Branch rename main -> release (Decision B) | DONE | `release` branch live; workflows reference it |
 | Nightly | RED (Windows 3.10/3.12 lanes only) | Not on the release-blocking path; active work in #1352 |
-| Results Explorer | OUT OF SCOPE for 0.4.0 | Curation contract unchanged (`check_release_curation.py`); launch checklist is next-cycle work |
+| Results Explorer | CURATED PREVIEW for 0.4.0 | Retained in release curation (Amendment 2026-08-13, PR #1712); built and published to `https://benchbox.dev/results/` on release deploy |
 
 ## Fixed on this branch (needs review + merge to develop BEFORE the cut)
 
@@ -76,9 +76,6 @@ this sandbox; close via `_project/scripts/todo` from a normal environment.
   `uat-clickhouse-server-ddl-compatibility`,
   `uat-certification-rerun-ordering-and-gate`,
   `uat-release-gate-first-evidence-bootstrap` (hard-gates release N+1).
-- Results Explorer launch checklist (tuned-corpus regeneration; trust
-  provenance §2.1; PR #246 evidence closeout; pipeline-script relocation
-  out of `_project/`; curation/decision change).
 - `lxml` PYSEC-2026-87 (blocked on redshift-connector pin; transitive).
 
 ## Cut commands (operator, from a normal environment)
@@ -99,6 +96,10 @@ make release-finalize VERSION=0.4.0
 
 ### New
 
+- **Results Explorer (Curated Preview)** - Interactive in-browser analytics over
+  benchmark runs at `https://benchbox.dev/results/` powered by Preact, Tailwind
+  CSS, and DuckDB-WASM. Includes multi-platform leaderboards, query waterfalls,
+  hardware disclosures, comparison tools, and an embedded SQL query workbench.
 - **DuckLake platform (Beta)** - Run benchmarks against DuckLake (DuckDB
   lakehouse format) via `--platform ducklake`; independent catalog backend
   (`duckdb|sqlite|postgres`) and Parquet `data_path` (local or `s3://`);


### PR DESCRIPTION
## Summary

- Align Results Explorer status in `_project/planning/v0.4.0-release-readiness.md` to Curated Preview per Amendment 2026-08-13 in `_project/decisions/single-repo-migration.md` and PR #1712.
- Draft CHANGELOG section for Results Explorer (Curated Preview) at `https://benchbox.dev/results/`.
- Remove stale explorer launch checklist from open items list.
