### PR TITLE
fix(cli): remove invalid cloud configuration guidance

### DIFF
--- a/benchbox/platforms/clickhouse_server.py
+++ b/benchbox/platforms/clickhouse_server.py
@@ -8,11 +8,8 @@ Install dependency:
 
 Example usage:
     benchbox run --platform clickhouse-server --benchmark tpch --scale 0.01
-    benchbox run --platform clickhouse-server --benchmark tpch \\
-        --platform-option host=my-clickhouse.example.com \\
-        --platform-option port=9000 \\
-        --platform-option username=default \\
-        --platform-option password=secret
+    For a remote server, set host, port, username, and password in the
+    BenchBox platform configuration before running the benchmark.
 
 Migration from legacy selectors:
     --platform clickhouse --mode server  → --platform clickhouse-server

--- a/benchbox/platforms/presto_trino_adapter_base.py
+++ b/benchbox/platforms/presto_trino_adapter_base.py
@@ -387,8 +387,8 @@ class PrestoTrinoAdapterBase(CursorValidationQueryExecutionMixin, HiveExternalTa
         port = self.port or 8080
         return (
             f"{self.platform_log_name} is not running on {host}:{port}. {self.local_start_hint}"
-            " or point this benchmark at a running cluster via "
-            "`--platform-option host=<host> --platform-option port=<port>`."
+            " or configure host and port for a running cluster in the platform "
+            "configuration before retrying."
         )
 
     def create_connection(self, **connection_config) -> Any:

--- a/benchbox/platforms/redshift.py
+++ b/benchbox/platforms/redshift.py
@@ -196,9 +196,8 @@ class RedshiftAdapter(CursorValidationQueryExecutionMixin, PlatformAdapter):
             raise ConfigurationError(
                 f"Redshift configuration is incomplete. Missing: {', '.join(missing)}\n"
                 "Configure with one of:\n"
-                "  1. CLI: benchbox platforms setup --platform redshift\n"
-                "  2. Environment variables: REDSHIFT_HOST, REDSHIFT_USER, REDSHIFT_PASSWORD\n"
-                "  3. CLI options: --platform-option host=<cluster>.redshift.amazonaws.com"
+                "  1. CLI: benchbox setup --platform redshift\n"
+                "  2. Environment variables: REDSHIFT_HOST, REDSHIFT_USER, REDSHIFT_PASSWORD"
             )
 
     @property

--- a/benchbox/platforms/snowflake.py
+++ b/benchbox/platforms/snowflake.py
@@ -144,9 +144,8 @@ class SnowflakeAdapter(PlatformAdapter):
             raise ConfigurationError(
                 f"Snowflake configuration is incomplete. Missing: {', '.join(missing)}\n"
                 "Configure with one of:\n"
-                "  1. CLI: benchbox platforms setup --platform snowflake\n"
-                "  2. Environment variables: SNOWFLAKE_ACCOUNT, SNOWFLAKE_USER, SNOWFLAKE_PASSWORD, etc.\n"
-                "  3. CLI options: --platform-option account=<account> --platform-option warehouse=<wh>"
+                "  1. CLI: benchbox setup --platform snowflake\n"
+                "  2. Environment variables: SNOWFLAKE_ACCOUNT, SNOWFLAKE_USER, SNOWFLAKE_PASSWORD, etc."
             )
 
     @property

--- a/benchbox/platforms/starburst.py
+++ b/benchbox/platforms/starburst.py
@@ -58,11 +58,8 @@ class StarburstAdapter(TrinoAdapter):
         export STARBURST_PASSWORD="my-password"
         benchbox run --platform starburst --benchmark tpch --scale 0.01
 
-        # Using explicit configuration
-        benchbox run --platform starburst --benchmark tpch \\
-            --platform-option host=my-cluster.trino.galaxy.starburst.io \\
-            --platform-option username=joe@example.com/accountadmin \\
-            --platform-option password=my-password
+        # Or place the connection values in the platform configuration
+        # consumed by BenchBox, then run the same command without inline secrets.
     """
 
     plan_capture_phase_eligible = True
@@ -127,26 +124,20 @@ class StarburstAdapter(TrinoAdapter):
         if not config.get("host"):
             raise ValueError(
                 "Starburst Galaxy requires host configuration.\n"
-                "Provide via:\n"
-                "  - Environment variable: STARBURST_HOST\n"
-                "  - Config option: --platform-option host=<cluster>.trino.galaxy.starburst.io"
+                "Provide STARBURST_HOST in the environment or in the platform configuration."
             )
 
         if not config.get("username"):
             raise ValueError(
                 "Starburst Galaxy requires username configuration.\n"
-                "Provide via:\n"
-                "  - Environment variable: STARBURST_USER or STARBURST_USERNAME\n"
-                "  - Config option: --platform-option username=<email>/<role>\n"
+                "Provide STARBURST_USER or STARBURST_USERNAME in the environment or in the platform configuration.\n"
                 "Example format: joe@example.com/accountadmin"
             )
 
         if not config.get("password"):
             raise ValueError(
                 "Starburst Galaxy requires password configuration.\n"
-                "Provide via:\n"
-                "  - Environment variable: STARBURST_PASSWORD\n"
-                "  - Config option: --platform-option password=<password>"
+                "Provide STARBURST_PASSWORD in the environment or in the platform configuration."
             )
 
     @property
@@ -210,8 +201,8 @@ class StarburstAdapter(TrinoAdapter):
                 "SSL certificate error connecting to Starburst Galaxy.\n"
                 "Options:\n"
                 "  - Check network proxy settings\n"
-                "  - Verify SSL certificate chain\n"
-                "  - Use --platform-option verify_ssl=false (not recommended for production)"
+                "  - Verify the SSL certificate chain\n"
+                "  - Adjust SSL verification in the platform configuration only when required"
             )
 
         return None

--- a/tests/unit/cli/test_configuration_guidance.py
+++ b/tests/unit/cli/test_configuration_guidance.py
@@ -1,0 +1,72 @@
+"""Guard customer-facing configuration guidance against dead CLI routes."""
+
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+from benchbox.cli.main import cli
+from benchbox.core.hooks.platform_hooks import PlatformHookRegistry
+
+pytestmark = [pytest.mark.unit, pytest.mark.fast]
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+
+
+@pytest.mark.parametrize(
+    ("relative_path", "forbidden_advice"),
+    [
+        ("benchbox/platforms/snowflake.py", ("benchbox platforms setup --platform", "--platform-option account=")),
+        ("benchbox/platforms/redshift.py", ("benchbox platforms setup --platform", "--platform-option host=")),
+        (
+            "benchbox/platforms/starburst.py",
+            ("--platform-option host=", "--platform-option username=", "--platform-option password="),
+        ),
+        ("benchbox/platforms/clickhouse_server.py", ("--platform-option host=", "--platform-option port=")),
+        (
+            "benchbox/platforms/presto_trino_adapter_base.py",
+            ("--platform-option host=<host>", "--platform-option port=<port>"),
+        ),
+    ],
+)
+def test_connection_guidance_does_not_advertise_unregistered_platform_options(
+    relative_path: str, forbidden_advice: tuple[str, ...]
+) -> None:
+    """Connection keys must not be presented as ``--platform-option`` unless registered."""
+    source = (REPO_ROOT / relative_path).read_text()
+    for advice in forbidden_advice:
+        assert advice not in source
+
+
+@pytest.mark.parametrize(
+    ("platform", "option", "value"),
+    [
+        ("fabric_dw", "warehouse", "example-warehouse"),
+        ("clickhouse-cloud", "host", "example.us-east-2.aws.clickhouse.cloud"),
+    ],
+)
+def test_advertised_connection_options_are_accepted_by_the_cli(
+    tmp_path: Path, platform: str, option: str, value: str
+) -> None:
+    """Keep the test honest for platforms that do expose connection options."""
+    assert option in PlatformHookRegistry.list_option_specs(platform)
+
+    result = CliRunner().invoke(
+        cli,
+        [
+            "run",
+            "--platform",
+            platform,
+            "--benchmark",
+            "tpch",
+            "--scale",
+            "0.01",
+            "--dry-run",
+            str(tmp_path / platform),
+            "--non-interactive",
+            "--platform-option",
+            f"{option}={value}",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output


### PR DESCRIPTION
Removes misleading error messages in Snowflake and cloud adapters directing users to pass connection credentials via --platform-option.