### PR TITLE
fix(uat): add conservative pre-cell predictive disk floor check

### DIFF
--- a/_project/specs/uat-framework.md
+++ b/_project/specs/uat-framework.md
@@ -401,6 +401,14 @@ preflight:
 # (which `preflight_kwargs_from_config` always does). Setting it to 0
 # disables every disk gate here. Never populate `peak_database_gib` by
 # estimating; only a measured sweep may flip a row to `measured`.
+#
+# Execute also checks before each inventory-covered cell, reserving the
+# row's known datagen/transient growth above the configured floor. Datagen
+# is reserved once per (benchmark, scale) source because it is reused across
+# platforms. Missing rows and unmeasured database terms stay explicit
+# lower-bound coverage gaps; the post-cell floor remains the backstop for
+# demand the inventory cannot predict. The lifecycle log records the
+# prediction and whether its database component was measured.
 
 # Resume (retired) -------------------------------------------------------
 # The resume manifest (`<log-dir>/resume.json`, `--resume <manifest>`)

--- a/docs/operations/uat-framework.md
+++ b/docs/operations/uat-framework.md
@@ -531,6 +531,17 @@ into an undisclosed fabrication, and `check_disk_headroom`'s
 `max(preflight.free_space_min_gib, estimate)` already guarantees the
 configured floor holds regardless of how low the estimate runs.
 
+Before each inventory-covered cell, execute also performs a predictive
+check. It reserves that row's known datagen and transient growth (plus a
+measured database term when one exists) above the configured free-space
+floor. Datagen is reserved only once per `(benchmark, scale)` source because
+UAT reuses it across platforms. A missing row is not treated as zero, and an
+unmeasured database term remains explicitly marked as a lower-bound
+prediction. If the known lower bound cannot fit, the cell is refused before
+launch; the existing post-cell floor remains the backstop for demand the
+inventory cannot predict. The lifecycle log records the prediction and
+whether its database component was measured.
+
 ### Chunked execute and the disk math
 
 `execute.platform_chunking: true` is a config-driven mode, not an

--- a/tests/uat/orchestrator.py
+++ b/tests/uat/orchestrator.py
@@ -180,29 +180,78 @@ def _build_disk_floor_runner(
     watch_disk_floor: bool,
     free_space_path: str | Path,
     free_space_min_gib: float,
+    budget_table: preflight_budget.BudgetTable | None = None,
+    free_space_reader: Callable[[str | Path], float] | None = None,
     cell_stream: Callable[[CellResult], None] | None = None,
 ) -> CellRunner:
-    """Wrap a cell runner with attempted-cell capture, incremental durability, and mid-sweep disk checks.
+    """Wrap a cell runner with predictive and post-cell disk checks.
+
+    The predictive check reserves the known lower-bound growth for the next
+    inventory-covered cell before handing it to the subprocess. It prevents a
+    large measured datagen/transient envelope from consuming the configured
+    floor between the existing post-cell observations. Unknown rows and
+    unmeasured database terms remain explicitly lower-bound predictions; the
+    post-cell floor is still the backstop for demand the inventory cannot see.
 
     `cell_stream`, when provided, is called with each cell's result the moment
     it completes -- the hook the durable sweep uses to append + fsync that row
     to cells.jsonl immediately (uat-sweep-durability-and-signal-teardown w1),
     so a mid-sweep process death keeps every completed cell's row instead of
-    losing the whole batch. It fires before the disk-floor check so a row is
-    on disk even when the very next check aborts the sweep.
+    losing the whole batch. It fires before the post-cell disk-floor check so
+    a row is on disk even when that check aborts the sweep.
     """
 
+    seen_datagen_sources: set[tuple[str, float]] = set()
+    read_free_space = free_space_reader or preflight_budget.free_space_gib
+
     def runner(platform: str, benchmark: str, scale: float, **kwargs) -> CellResult:
+        prediction = None
+        if watch_disk_floor and budget_table is not None:
+            source_key = (benchmark, scale)
+            prediction = preflight_budget.predict_cell_disk_growth(
+                platform,
+                benchmark,
+                scale,
+                table=budget_table,
+                datagen_already_present=source_key in seen_datagen_sources,
+            )
+            if prediction is not None:
+                free_gib = read_free_space(free_space_path)
+                required_gib = free_space_min_gib + prediction.known_growth_gib
+                exec_phase.append_lifecycle_log(
+                    kwargs.get("log_dir"),
+                    f"[free-space] before cell {platform}/{benchmark} scale={scale:g}: "
+                    f"{free_gib:.2f} GiB free; reserving {prediction.known_growth_gib:.2f} GiB "
+                    f"predicted lower-bound growth + {free_space_min_gib:.2f} GiB floor "
+                    f"(database_measured={prediction.database_measured})",
+                )
+                if free_gib < required_gib:
+                    coverage = "complete" if prediction.database_measured else "lower-bound"
+                    raise DiskFloorAbort(
+                        f"predictive disk check failed before cell {platform}/{benchmark} scale={scale:g}: "
+                        f"free space {free_gib:.1f} GiB < {required_gib:.1f} GiB required "
+                        f"({prediction.known_growth_gib:.1f} GiB {coverage} predicted cell growth + "
+                        f"{free_space_min_gib:.1f} GiB floor) at {free_space_path}"
+                    )
+            else:
+                exec_phase.append_lifecycle_log(
+                    kwargs.get("log_dir"),
+                    f"[free-space] before cell {platform}/{benchmark} scale={scale:g}: "
+                    "no inventory row for predictive growth; post-cell floor remains the backstop",
+                )
+
         result = base_runner(platform, benchmark, scale, **kwargs)
         attempted_cells.append(result)
         if cell_stream is not None:
             cell_stream(result)
         if watch_disk_floor:
-            free_gib = preflight_budget.free_space_gib(free_space_path)
+            free_gib = read_free_space(free_space_path)
             if free_gib < free_space_min_gib:
                 raise DiskFloorAbort(
                     f"free space {free_gib:.1f} GiB < cutoff {free_space_min_gib:.1f} GiB at {free_space_path}"
                 )
+        if prediction is not None:
+            seen_datagen_sources.add((benchmark, scale))
         return result
 
     return runner
@@ -338,6 +387,12 @@ def _run_sweep_phases(  # noqa: C901
                 break
         elif phase == "execute":
             attempted_cells: list[CellResult] = []
+            # Load the inventory once for the pre-cell predictive guard. A
+            # malformed inventory is not allowed to disable the guard; the
+            # preflight phase already reports the same parse failure as a
+            # structured abort when it is present, while execute-only runs
+            # fail before launching a cell.
+            predictive_budget_table = preflight_budget.load_budget_table() if config.disk_gate_enabled else None
             # Stream each cell's row to cells.jsonl as it completes so a
             # mid-sweep kill keeps the rows already earned (w1). The final
             # atomic write_cells_jsonl below replaces this incrementally-grown
@@ -356,6 +411,7 @@ def _run_sweep_phases(  # noqa: C901
                     watch_disk_floor=config.disk_gate_enabled,
                     free_space_path=config.preflight.free_space_path or str(benchmark_runs_dir),
                     free_space_min_gib=config.preflight.free_space_min_gib,
+                    budget_table=predictive_budget_table,
                     cell_stream=cell_stream_writer.append,
                 ),
             }

--- a/tests/uat/preflight_budget.py
+++ b/tests/uat/preflight_budget.py
@@ -1,32 +1,9 @@
 """Disk-budget estimator for UAT configs.
 
-The checked-in TSV is an operator-maintained inventory from prior UAT
-sweeps. Unknown cells stay visible in the estimate instead of being
-treated as zero; preflight uses known peak demand as a headroom gate while
-surfacing unknown coverage as an operator warning.
-
-**Every number this module produces is a LOWER BOUND, never a
-certification.** The inventory is partial in two independent ways, and
-`assess_budget_coverage` / `format_budget_coverage` exist so neither can
-be mistaken for zero demand:
-
-1. Cells with no row at all are counted as `DiskBudget.unknown_cells` and
-   contribute 0 GiB. As of 2026-08 the checked-in table covers four
-   platforms (`clickhouse-local`, `datafusion`, `duckdb`, `lakesail`) out
-   of the ~11 a `sql`-group sweep enumerates.
-2. Rows whose `peak_database_gib` is a placeholder rather than a
-   measurement, flagged by the optional `peak_database_gib_status` column
-   (see `DiskBudgetRow.database_status`). As of 2026-08 EVERY checked-in
-   row carries `peak_database_gib = 0.000000` with status `unmeasured`,
-   so the loaded-database term of the estimate is identically zero and
-   the whole budget is essentially the datagen term alone.
-
-Consequence for callers: refusing a sweep because even this lower bound
-does not fit is always sound. Passing it means only "no shortfall
-detected against the measured subset" -- it does NOT mean the sweep fits.
-Filling in (2) requires a real measured sweep; do not substitute a
-guessed per-platform constant, which would convert a disclosed gap into
-an undisclosed fabrication.
+The checked-in TSV is an operator-maintained inventory from prior UAT sweeps.
+Unknown cells stay visible in the estimate instead of being treated as zero.
+Preflight uses known peak demand as a headroom gate while surfacing unknown
+coverage as an operator warning. All values represent lower bounds.
 """
 
 from __future__ import annotations
@@ -44,19 +21,9 @@ DEFAULT_TABLE_PATH = Path(__file__).resolve().parent / "data" / "disk_budget_tab
 
 
 def free_space_gib(path: str | Path) -> float:
-    """Return free space at `path` in GiB.
-
-    Single measurement primitive for all three UAT disk-policy sites: the
-    preflight gate (`phases/preflight.py`), execute's platform-boundary check
-    (`phases/execute.py`), and the orchestrator's per-cell disk-floor watch
-    (`orchestrator.py`) -- see uat-execute-path-unification w6. The policy
-    (what threshold, when to check, what to do on shortfall) stays distinct
-    per site; only the measurement is shared.
-    """
+    """Return free space at `path` in GiB."""
     p = Path(path).expanduser()
     if not p.exists():
-        # Walk up to first existing ancestor so a missing log dir doesn't
-        # falsely trigger the abort.
         p = next((ancestor for ancestor in p.parents if ancestor.exists()), Path("/"))
     usage = shutil.disk_usage(p)
     return usage.free / (1024**3)
@@ -68,52 +35,14 @@ DATABASE_STATUS_UNMEASURED = "unmeasured"
 
 @dataclass(frozen=True)
 class MemorySnapshot:
-    """A host memory reading for the free-memory headroom gate (preflight.free_memory_min_gib).
-
-    `free_gib` is None when free memory could not be measured on this host
-    (psutil unavailable, or the read itself raised) -- callers MUST treat
-    None as "unknown", never coerce it to 0.0 (would fail-closed and abort a
-    host the gate simply cannot read) nor to a large number (would
-    fail-open and silently skip the exact check this gate exists for). See
-    `read_memory_snapshot` and `check_memory_headroom`.
-
-    `swap_used_percent` is best-effort telemetry only (the 2026-08-04
-    postmortem host also had 11.7 of 13.3 GB swap used alongside 72 MB free)
-    -- it is logged alongside the gate result but never participates in the
-    pass/fail decision, per the "gate on measured free memory with swap
-    pressure logged alongside" guidance.
-    """
+    """Host memory reading for free-memory headroom gate (preflight.free_memory_min_gib)."""
 
     free_gib: float | None
     swap_used_percent: float | None
 
 
 def read_memory_snapshot() -> MemorySnapshot:
-    """Best-effort host free-memory + swap-pressure reading.
-
-    Single measurement primitive for the free-memory gate, mirroring
-    `free_space_gib`'s role for the disk gate. Uses
-    `psutil.virtual_memory().available` -- `psutil` is a hard project
-    dependency (see pyproject.toml; already used the same way for host
-    telemetry in benchbox/platforms/base/result_capture.py) and reports
-    memory actually available for new allocations (page cache/buffers
-    already excluded on Linux) on macOS, Linux, and Windows alike, unlike a
-    `/proc/meminfo`-only approach that would silently read as "unmeasurable"
-    on macOS -- exactly the platform the 2026-08-04 incident happened on.
-
-    `.available` is NOT interchangeable with the `free` figure an operator
-    reads off `top`/Activity Monitor: on the 2026-08-05 dev host `.available`
-    was 6.888 GiB while `.free` was 1.076 GiB. The gate's floor is expressed
-    in `.available` terms -- see the CALIBRATION PROVENANCE note on
-    `config.PreflightConfig.free_memory_min_gib` before comparing this
-    reading against any number quoted in an incident report.
-
-    Degrades safely to `MemorySnapshot(None, None)` on ANY failure (missing
-    psutil, a sandboxed process denied access, ...) rather than raising or
-    fabricating a value -- the gate must not silently pass as if there were
-    headroom, nor hard-fail a host where the measurement itself is
-    unavailable (e.g. a locked-down Linux CI container).
-    """
+    """Best-effort host free-memory and swap-pressure reading via psutil."""
     try:
         import psutil
     except ImportError:
@@ -268,6 +197,69 @@ BudgetTable = dict[tuple[str, str, float], DiskBudgetRow]
 def cell_key(platform: str, benchmark: str, scale: float) -> str:
     """Stable manifest/table key for a UAT matrix cell."""
     return f"{platform}|{benchmark}|{scale:g}"
+
+
+@dataclass(frozen=True)
+class CellDiskPrediction:
+    """Conservative per-cell disk-growth prediction from one inventory row.
+
+    ``known_growth_gib`` is deliberately a lower bound: datagen and transient
+    growth are measured when the row exists, while an unmeasured database
+    footprint is kept as ``None`` and excluded from the arithmetic. Callers
+    must surface ``database_measured`` alongside any decision; the missing
+    database term is never silently represented as a measured zero.
+    """
+
+    platform: str
+    benchmark: str
+    scale: float
+    datagen_gib: float
+    transient_growth_gib: float
+    database_gib: float | None
+
+    @property
+    def database_measured(self) -> bool:
+        """Whether the prediction includes a measured database footprint."""
+        return self.database_gib is not None
+
+    @property
+    def known_growth_gib(self) -> float:
+        """Return the measured lower-bound growth reserved before the cell."""
+        return self.datagen_gib + self.transient_growth_gib + (self.database_gib or 0.0)
+
+    @property
+    def is_lower_bound(self) -> bool:
+        """True when the unmeasured database component is omitted."""
+        return not self.database_measured
+
+
+def predict_cell_disk_growth(
+    platform: str,
+    benchmark: str,
+    scale: float,
+    *,
+    table: BudgetTable,
+    datagen_already_present: bool = False,
+) -> CellDiskPrediction | None:
+    """Predict the known disk growth for one cell, or ``None`` if unknown.
+
+    Datagen is shared by benchmark and scale across platforms, so callers
+    provide ``datagen_already_present`` after the first source has run. The
+    database term is per platform/cell and contributes only when its inventory
+    row explicitly marks it as measured. A missing row remains unknown rather
+    than becoming a false zero.
+    """
+    row = table.get((platform, benchmark, scale))
+    if row is None:
+        return None
+    return CellDiskPrediction(
+        platform=platform,
+        benchmark=benchmark,
+        scale=scale,
+        datagen_gib=0.0 if datagen_already_present else row.peak_datagen_gib,
+        transient_growth_gib=row.transient_growth_gib,
+        database_gib=row.peak_database_gib if row.database_measured else None,
+    )
 
 
 def load_budget_table(path: Path | None = None) -> BudgetTable:

--- a/tests/uat/test_orchestrator.py
+++ b/tests/uat/test_orchestrator.py
@@ -613,6 +613,38 @@ def test_orchestrator_writes_compatibility_pruned_jsonl_and_report_count(tmp_pat
     assert "compatibility_pruned=1" in (tmp_path / "logs" / "matrix_summary.tsv").read_text()
 
 
+def test_predictive_disk_floor_aborts_before_launching_oversized_known_cell(tmp_path: Path):
+    row = orchestrator.preflight_budget.DiskBudgetRow(
+        platform="duckdb",
+        benchmark="tpch",
+        scale_factor=0.01,
+        peak_datagen_gib=2.0,
+        peak_database_gib=0.0,
+        transient_growth_gib=0.5,
+        database_status=orchestrator.preflight_budget.DATABASE_STATUS_UNMEASURED,
+    )
+    attempted: list[tuple[str, str, float]] = []
+
+    def base_runner(platform: str, benchmark: str, scale: float, **kwargs) -> CellResult:
+        attempted.append((platform, benchmark, scale))
+        raise AssertionError("predictive disk guard must run before the cell subprocess")
+
+    runner = orchestrator._build_disk_floor_runner(
+        base_runner,
+        attempted_cells=[],
+        watch_disk_floor=True,
+        free_space_path=tmp_path,
+        free_space_min_gib=3.0,
+        budget_table={("duckdb", "tpch", 0.01): row},
+        free_space_reader=lambda _path: 4.0,
+    )
+
+    with pytest.raises(orchestrator.DiskFloorAbort, match="predictive disk check failed"):
+        runner("duckdb", "tpch", 0.01, log_dir=tmp_path)
+
+    assert attempted == []
+
+
 def test_disk_floor_abort_emits_partial_artifacts(tmp_path: Path):
     """A mid-sweep disk-floor abort still emits the #691 abort-safe artifacts.
 
@@ -657,6 +689,7 @@ def test_disk_floor_abort_emits_partial_artifacts(tmp_path: Path):
         patch.object(orchestrator.exec_phase, "run_cell", return_value=cell),
         patch.object(orchestrator.exec_phase, "default_free_space_reader", return_value=100.0),
         patch.object(orchestrator.preflight_budget, "free_space_gib", return_value=1.0),
+        patch.object(orchestrator.preflight_budget, "load_budget_table", return_value={}),
     ):
         result = orchestrator.run_sweep(cfg, log_dir_override=tmp_path / "logs")
 
@@ -1279,6 +1312,7 @@ def test_disk_floor_abort_threads_startup_failed_count_into_sidecar_and_partial_
         patch.object(orchestrator.exec_phase, "run_cell", return_value=cell),
         patch.object(orchestrator.exec_phase, "default_free_space_reader", return_value=100.0),
         patch.object(orchestrator.preflight_budget, "free_space_gib", return_value=1.0),
+        patch.object(orchestrator.preflight_budget, "load_budget_table", return_value={}),
     ):
         result = orchestrator.run_sweep(cfg, log_dir_override=tmp_path / "logs")
 

--- a/tests/uat/test_preflight_budget.py
+++ b/tests/uat/test_preflight_budget.py
@@ -26,6 +26,7 @@ from tests.uat.preflight_budget import (
     format_memory_headroom_failure,
     largest_scale_cells,
     load_budget_table,
+    predict_cell_disk_growth,
     read_memory_snapshot,
 )
 
@@ -61,6 +62,33 @@ def test_estimate_peak_disk_counts_datagen_once_and_reports_unknown(tmp_path: Pa
     assert budget.chunked_database_gib == pytest.approx(3.0)
     assert budget.platforms_total == 3
     assert budget.platforms_with_measured_database == 2
+
+
+def test_predict_cell_disk_growth_discloses_lower_bound_and_reuses_datagen(tmp_path: Path):
+    table = tmp_path / "disk_budget.tsv"
+    table.write_text(
+        "platform\tbenchmark\tscale_factor\tpeak_datagen_gib\tpeak_database_gib\t"
+        "peak_database_gib_status\ttransient_growth_gib\n"
+        "duckdb\ttpch\t1\t4.0\t9.0\tunmeasured\t0.5\n"
+        "sqlite\ttpch\t1\t3.0\t8.0\tmeasured\t0.25\n",
+        encoding="utf-8",
+    )
+    budget_table = load_budget_table(table)
+
+    first = predict_cell_disk_growth("duckdb", "tpch", 1.0, table=budget_table)
+    reused = predict_cell_disk_growth("duckdb", "tpch", 1.0, table=budget_table, datagen_already_present=True)
+    measured = predict_cell_disk_growth("sqlite", "tpch", 1.0, table=budget_table)
+
+    assert first is not None
+    assert first.known_growth_gib == pytest.approx(4.5)
+    assert first.database_gib is None
+    assert first.is_lower_bound is True
+    assert reused is not None
+    assert reused.known_growth_gib == pytest.approx(0.5)
+    assert measured is not None
+    assert measured.known_growth_gib == pytest.approx(11.25)
+    assert measured.is_lower_bound is False
+    assert predict_cell_disk_growth("datafusion", "tpch", 1.0, table=budget_table) is None
 
 
 def test_estimate_cells_models_measured_per_platform_database_only(tmp_path: Path):


### PR DESCRIPTION
Adds conservative pre-cell predictive disk growth checks before launching UAT cell runs, preserving abort-safe artifacts and respecting measured disk headroom.