### PR TITLE
ci: schedule monthly seed-corpus publication

### DIFF
--- a/.github/workflows/seed-corpus.yml
+++ b/.github/workflows/seed-corpus.yml
@@ -6,6 +6,11 @@ name: Seed Corpus
 # ClickHouse Cloud jobs require CLICKHOUSE_CLOUD_HOST and CLICKHOUSE_CLOUD_PASSWORD secrets.
 
 on:
+  schedule:
+    # Monthly publication sweep. Generation already existed as an on-demand
+    # workflow; the missing piece was putting it on a calendar so
+    # published-results does not stall until someone remembers to click.
+    - cron: "0 7 1 * *"
   workflow_dispatch:
     inputs:
       benchmark:
@@ -116,7 +121,7 @@ jobs:
     # failed run with zero jobs on every push. `env` at job level *can* read
     # matrix, so the condition is computed once here and each step guards on it.
     env:
-      SELECTED: ${{ github.event.inputs.benchmark == '' || github.event.inputs.benchmark == matrix.benchmark }}
+      SELECTED: ${{ github.event_name == 'schedule' || github.event.inputs.benchmark == '' || github.event.inputs.benchmark == matrix.benchmark }}
       # BenchBox normally keeps generated data beside the checkout so worktrees
       # can share it. CI must keep the run inside the workspace because the
       # later staging steps intentionally collect and commit result bundles.
@@ -147,12 +152,17 @@ jobs:
           CLICKHOUSE_CLOUD_HOST: ${{ secrets.CLICKHOUSE_CLOUD_HOST }}
           CLICKHOUSE_CLOUD_PASSWORD: ${{ secrets.CLICKHOUSE_CLOUD_PASSWORD }}
         run: |
+          EXTRA=()
+          if [ "${{ matrix.benchmark }}" = "tpcds" ]; then
+            EXTRA+=(--official --seed 42)
+          fi
           uv run benchbox run \
             --platform "${{ matrix.platform }}" \
             --benchmark "${{ matrix.benchmark }}" \
             --scale "${{ matrix.scale_factor }}" \
             --phases generate,load,power \
-            --compression zstd:9
+            --compression zstd:9 \
+            "${EXTRA[@]}"
 
       - name: Locate result bundle
         if: env.SELECTED == 'true'

--- a/.github/workflows/seed-corpus.yml
+++ b/.github/workflows/seed-corpus.yml
@@ -255,11 +255,17 @@ jobs:
             rmdir "$artifact_dir" 2>/dev/null || true
           done
 
-      - name: Check for new bundles
+      - name: Install uv
+        uses: astral-sh/setup-uv@v4
+
+      - name: Regenerate corpus inventory
+        run: uv run -- python scripts/generate_corpus_inventory.py --write
+
+      - name: Check for new corpus changes
         id: check
         shell: bash
         run: |
-          git add results-data/bundles/
+          git add results-data/bundles/ results-data/corpus-inventory.json
           if git diff --cached --quiet; then
             echo "no_changes=true" >> "$GITHUB_OUTPUT"
           else

--- a/docs/contributing-results.md
+++ b/docs/contributing-results.md
@@ -105,7 +105,13 @@ uv run -- python scripts/generate_corpus_inventory.py --write
 
 ### 5. Review and merge
 
-A maintainer reviews the submission for quality and environment consistency. Once approved and merged into `published-results`, the bundle enters the public corpus. The Results Explorer is not built directly from `published-results`; the documented `docs.yml` workflow builds on the curated release path and deploys only after a protected push to `release`. The Explorer is a curated preview, not a broad leaderboard claim. See [`docs/operations/results-phase-2-runbook.md`](operations/results-phase-2-runbook.md#13-explorer-publish-path) for the publication path and launch evidence.
+A maintainer reviews the submission for quality and environment consistency. Once approved and merged into `published-results`, the bundle enters the public corpus.
+
+Maintainer-run refreshes are monthly via `.github/workflows/seed-corpus.yml`
+(see [`docs/operations/corpus-refresh.md`](operations/corpus-refresh.md)). That
+path is not a substitute for community `benchbox submit` PRs.
+
+The Results Explorer is not built directly from `published-results`; the documented `docs.yml` workflow builds on the curated release path and deploys only after a protected push to `release`. The Explorer is a curated preview, not a broad leaderboard claim. See [`docs/operations/results-phase-2-runbook.md`](operations/results-phase-2-runbook.md#13-explorer-publish-path) for the publication path and launch evidence.
 
 ## What Makes a Good Submission
 

--- a/docs/operations/corpus-refresh.md
+++ b/docs/operations/corpus-refresh.md
@@ -1,0 +1,44 @@
+# Public corpus refresh
+
+The public corpus on `published-results` goes stale when nobody *submits*,
+not when CI stops running. Nightly tests do not publish bundles. This page
+is the publication calendar.
+
+## Cadence
+
+Monthly, on the 1st at 07:00 UTC, via `.github/workflows/seed-corpus.yml`
+(`schedule` plus the existing `workflow_dispatch`). Each run opens a PR
+against `develop`. Merging that PR triggers
+`sync-results-data-to-published.yml`, which opens a draft mirror onto
+`published-results` for a maintainer to accept.
+
+Do not add a second nightly UAT gate for this. Generation already lives in
+`seed-corpus.yml`; the schedule is what was missing.
+
+## Recurring matrix
+
+This is the `seed-corpus.yml` matrix. It is DuckDB / DataFusion / Polars
+(and optional ClickHouse Cloud when secrets exist). Cloud warehouses
+(Snowflake, Databricks, BigQuery) are not on this calendar until live
+credentials are confirmed.
+
+| Benchmark | Scales | Platforms | Notes |
+| --- | --- | --- | --- |
+| TPC-H | 0.01, 0.1, 1.0 | DuckDB, DataFusion, Polars-DF (SF 0.01/0.1); DuckDB, DataFusion, ClickHouse Cloud optional (SF 1.0) | Power phase only |
+| TPC-DS | 1 | DuckDB, DataFusion | Integer SF only. Runs with `--official --seed 42` so submit/admission will not classify them unofficial |
+| SSB | 0.01, 0.1 | DuckDB, DataFusion, Polars-DF | Power phase only |
+
+TPC-H SF10 / SF100 and extra TPC-DS platforms stay operator-run (too large
+for a GitHub-hosted monthly job). They still publish through
+`benchbox submit` onto `published-results`, as in PR #1786.
+
+## Operator trigger
+
+```bash
+gh workflow run seed-corpus.yml
+# optional: -f benchmark=tpch
+```
+
+After the develop PR merges, confirm the mirror draft against
+`published-results` and merge it. `corpus-drift-check.yml` remains the
+loud canary if a push-triggered mirror is dropped.

--- a/docs/operations/results-phase-2-runbook.md
+++ b/docs/operations/results-phase-2-runbook.md
@@ -21,8 +21,9 @@ no hosted API is involved.
 
 ### 1.2 Maintainer-run additions (sync from develop)
 
-Maintainer-side corpus changes — the `seed-corpus.yml` workflow's on-demand
-(`workflow_dispatch`) refresh, ad-hoc UAT integrations like PR #164, validator updates — land on
+Maintainer-side corpus changes — the `seed-corpus.yml` workflow's monthly
+schedule and on-demand (`workflow_dispatch`) refresh (see
+[`corpus-refresh.md`](corpus-refresh.md)), ad-hoc UAT integrations like PR #164, validator updates — land on
 `develop` first because that is where the project's tooling and tests live.
 The
 [`sync-results-data-to-published.yml`](../../.github/workflows/sync-results-data-to-published.yml)

--- a/tests/unit/workflows/test_seed_corpus_pr_base.py
+++ b/tests/unit/workflows/test_seed_corpus_pr_base.py
@@ -94,6 +94,20 @@ def test_seed_corpus_pr_targets_develop() -> None:
     assert "--base release" not in run
 
 
+def test_seed_corpus_pr_regenerates_and_stages_inventory() -> None:
+    """A generated-bundle PR must keep develop's derived inventory current."""
+    steps = _workflow()["jobs"]["create-pr"]["steps"]
+    names = [step.get("name") for step in steps]
+    regenerate_index = names.index("Regenerate corpus inventory")
+    stage_index = names.index("Check for new corpus changes")
+
+    assert regenerate_index < stage_index
+    assert "scripts/generate_corpus_inventory.py --write" in steps[regenerate_index]["run"]
+    stage_script = steps[stage_index]["run"]
+    assert "results-data/bundles/" in stage_script
+    assert "results-data/corpus-inventory.json" in stage_script
+
+
 def test_seed_corpus_head_branch_can_never_target_the_release_branch() -> None:
     """The pushed head is a `chore/` branch, so the release branch would reject it."""
     steps = _create_pr_steps()

--- a/tests/unit/workflows/test_seed_corpus_pr_base.py
+++ b/tests/unit/workflows/test_seed_corpus_pr_base.py
@@ -1,15 +1,17 @@
 """Guardrails for the seed-corpus workflow's PR base branch.
 
-`seed-corpus.yml` is `workflow_dispatch`-only and `release-cut` curates it out
-of the release tree, so no CI job ever exercises its `gh pr create` call. These
-tests stand in for that missing coverage: they pin the base branch to `develop`
-and encode why the release-only branch can never be a valid target.
+`seed-corpus.yml` is scheduled monthly and remains `workflow_dispatch`-callable.
+`release-cut` curates it out of the release tree, so no CI job ever exercises
+its `gh pr create` call. These tests stand in for that missing coverage: they
+pin the base branch to `develop` and encode why the release-only branch can
+never be a valid target.
 """
 
 from __future__ import annotations
 
 import re
 from pathlib import Path
+from typing import Any
 
 import pytest
 import yaml
@@ -43,6 +45,40 @@ def _rendered_head_branch(commit_script: str) -> str:
     branch = match.group(1)
     branch = branch.replace("${{ github.run_number }}", "123")
     return branch.replace("${DATE}", "20260710")
+
+
+def _workflow() -> dict[str, Any]:
+    return yaml.safe_load(WORKFLOW_PATH.read_text(encoding="utf-8"))
+
+
+def _triggers(workflow: dict[str, Any]) -> dict[str, Any]:
+    on = workflow.get("on", workflow.get(True))
+    assert on is not None, "seed-corpus.yml has no `on:` block"
+    return on
+
+
+def test_seed_corpus_is_scheduled_monthly_and_still_dispatchable() -> None:
+    """Publication was stalling because generation existed only as a manual click."""
+    on = _triggers(_workflow())
+    crons = [entry["cron"] for entry in on["schedule"]]
+    assert "0 7 1 * *" in crons
+    assert "workflow_dispatch" in on
+
+
+def test_schedule_runs_the_full_matrix() -> None:
+    selected = _workflow()["jobs"]["generate-seed-corpus"]["env"]["SELECTED"]
+    assert "github.event_name == 'schedule'" in selected
+
+
+def test_tpcds_runs_are_official() -> None:
+    """Unofficial TPC-DS must not be published as official."""
+    run = next(
+        step["run"]
+        for step in _workflow()["jobs"]["generate-seed-corpus"]["steps"]
+        if step.get("name") == "Run benchmark"
+    )
+    assert "--official" in run
+    assert "tpcds" in run
 
 
 def test_seed_corpus_pr_targets_develop() -> None:


### PR DESCRIPTION
## Summary

Put the existing `seed-corpus.yml` generator on a monthly calendar so `published-results` does not stall until someone remembers `workflow_dispatch`. Merging the resulting develop PR still uses `sync-results-data-to-published.yml` for the public corpus.

TPC-DS matrix entries now run `--official --seed 42`. Matrix and cadence: `docs/operations/corpus-refresh.md`.

This is not a new UAT gate. SF10/SF100 stay operator-run (`benchbox submit`, as in #1786).

## Verify

```bash
uv run -- python -m pytest tests/unit/workflows/test_seed_corpus_pr_base.py -q
python -c 'import json; d=json.load(open("results-data/corpus-inventory.json")); print(max(b["timestamp"] for b in d["bundles"]))'
# on published-results: timestamps 2026-08-17 / 2026-08-18 after #1786
```
