### PR TITLE
fix(ci): rebalance release-canary shards and raise shard timeout

### DIFF
--- a/.github/workflows/release-canary.yml
+++ b/.github/workflows/release-canary.yml
@@ -16,7 +16,7 @@ permissions:
 
 env:
   RELEASE_CANARY_REF: develop
-  RELEASE_CANARY_SHARD_COUNT: 4
+  RELEASE_CANARY_SHARD_COUNT: 6
 
 jobs:
   collect-credential-free-non-fast:
@@ -94,10 +94,10 @@ jobs:
           retention-days: 30
 
   credential-free-non-fast:
-    name: credential-free non-fast canary (shard ${{ matrix.shard_number }}/4)
+    name: credential-free non-fast canary (shard ${{ matrix.shard_number }}/6)
     runs-on: ubuntu-latest
     needs: [collect-credential-free-non-fast]
-    timeout-minutes: 45
+    timeout-minutes: 75
     strategy:
       fail-fast: false
       matrix:
@@ -110,6 +110,10 @@ jobs:
             shard_number: 3
           - shard_index: 3
             shard_number: 4
+          - shard_index: 4
+            shard_number: 5
+          - shard_index: 5
+            shard_number: 6
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/scripts/release_canary_sharding.py
+++ b/scripts/release_canary_sharding.py
@@ -11,7 +11,7 @@ from pathlib import Path
 from typing import Any
 
 MARKER_EXPRESSION = "(slow or resource_heavy) and not (stress or live_integration)"
-DEFAULT_SHARD_COUNT = 4
+DEFAULT_SHARD_COUNT = 6
 
 
 def _canonical_node_ids(node_ids: Iterable[str]) -> list[str]:

--- a/tests/unit/test_release_canary_sharding.py
+++ b/tests/unit/test_release_canary_sharding.py
@@ -115,7 +115,7 @@ def test_collection_and_shard_manifests_conserve_node_ids(tmp_path: Path):
     assert sorted(assigned) == sorted(nodeids.read_text(encoding="utf-8").splitlines())
 
 
-def test_release_canary_workflow_uses_collection_artifact_and_four_single_threaded_shards():
+def test_release_canary_workflow_uses_collection_artifact_and_six_single_threaded_shards():
     workflow = _workflow()
     jobs = workflow["jobs"]
 
@@ -139,8 +139,10 @@ def test_release_canary_workflow_uses_collection_artifact_and_four_single_thread
     shards = jobs["credential-free-non-fast"]
     assert shards["needs"] == ["collect-credential-free-non-fast"]
     assert shards["strategy"]["fail-fast"] is False
-    assert [entry["shard_index"] for entry in shards["strategy"]["matrix"]["include"]] == [0, 1, 2, 3]
-    assert shards["timeout-minutes"] == 45
+    assert [entry["shard_index"] for entry in shards["strategy"]["matrix"]["include"]] == [0, 1, 2, 3, 4, 5]
+    assert shards["timeout-minutes"] == 75
+    assert shards["strategy"]["matrix"]["include"][-1]["shard_number"] == DEFAULT_SHARD_COUNT
+    assert workflow["env"]["RELEASE_CANARY_SHARD_COUNT"] == DEFAULT_SHARD_COUNT
     shard_text = _run_text("credential-free-non-fast")
     assert shard_text.count(f'-m "{MARKER_EXPRESSION}"') == 1
     assert "actions/download-artifact@v4" in "\n".join(str(step) for step in shards["steps"])

--- a/tests/unit/test_release_infrastructure.py
+++ b/tests/unit/test_release_infrastructure.py
@@ -382,9 +382,9 @@ class TestReleaseInfrastructure:
         # Each shard is deliberately single-threaded; process-level sharding
         # keeps the timeout bounded without enabling unsafe xdist concurrency.
         non_fast_job = jobs["credential-free-non-fast"]
-        assert non_fast_job["timeout-minutes"] == 45
+        assert non_fast_job["timeout-minutes"] == 75
         assert non_fast_job["strategy"]["fail-fast"] is False
-        assert len(non_fast_job["strategy"]["matrix"]["include"]) == 4
+        assert len(non_fast_job["strategy"]["matrix"]["include"]) == 6
 
         # pypi-latest-installability must not gate on (or be gated by) the
         # other canary jobs, and must not check out the repo (it installs


### PR DESCRIPTION
Shard 2 of the daily credential-free non-fast canary has been hitting the
45-minute job timeout, cancelling the whole run since 12 Aug and blocking
the 0.4.0 cut. Spread 611 tests across six shards and allow 75 minutes so
a slow partition cannot fail-close the aggregator.
