### PR TITLE
docs: record BenchBox-dev transfer gates and restore runbook

### DIFF
--- a/_project/decisions/github-org-transfer-benchbox-dev-2026-08-21.md
+++ b/_project/decisions/github-org-transfer-benchbox-dev-2026-08-21.md
@@ -1,0 +1,99 @@
+# Decision: Transfer BenchBox to GitHub organization `BenchBox-dev`
+
+Date: 2026-08-21
+Status: Accepted for planning and pre-transfer in-repo work. Transfer itself
+is operator-only and remains behind gates G0+G1+G2+G3.
+Destination: `https://github.com/BenchBox-dev/BenchBox`
+Source: `https://github.com/joeharris76/BenchBox`
+
+Related: `_project/decisions/strict-base-refresh-policy-2026-08-14.md`;
+`_project/decisions/strict-base-refresh-merge-queue-2026-08-14.md`;
+`_project/decisions/strict-base-refresh-activation-2026-08-14.md`
+(`SHADOW_ONLY`); `docs/operations/repo-admin-settings.md`;
+`docs/operations/github-org-transfer.md`.
+
+This record authorizes transferring repository **ownership** to org
+`BenchBox-dev`. It does **not** authorize native merge queue, `merge_group`
+workflows, reduced-refresh skips, or un-dropping
+`strict-base-refresh-07b-native-merge-queue-migration`.
+
+## Decision
+
+Transfer `joeharris76/BenchBox` to `BenchBox-dev/BenchBox`. Keep the
+repository name. Keep squash-only develop, strict current-base checks, and
+`bypass_actors: none` on `develop-squash-only`. Keep CODEOWNERS
+`@joeharris76` and the `pypi` environment reviewer `User:57046`.
+
+Do not change `benchbox/core/joinorder/data_manifest.toml` `url` (it is
+inside `manifest_hash`) or `_DEFAULT_ANSWERS_BASE_URL` (published wheels
+hardcode it). GitHub Releases redirects from the old owner/name are a
+shipped-artifact availability dependency. Never recreate
+`joeharris76/BenchBox`.
+
+Owner-agnostic CI hardening lands **before** transfer. Public URL
+retargeting lands **after** hosted rebuild.
+
+## Non-goals
+
+- Native merge queue, `merge_group`, reduced-refresh skip paths.
+- Moving `textcharts`, `skill-sync`, or `skill-sync-skills`.
+- Adding develop ruleset bypass actors to relieve CODEOWNERS self-approval.
+- Renaming Turso (`benchbox-todo-joeharris76...`), PyPI project `benchbox`,
+  or domain `benchbox.dev`.
+- Rewriting published blog permalinks.
+
+## Prior-decision reconciliation
+
+| Record | Relation |
+|---|---|
+| strict-base-refresh-policy | Transfer remains operator-only. This record does not mutate ruleset 15611785 before transfer. |
+| strict-base-refresh-merge-queue assessment | Reuse inventory. Do not execute its queue path. Destination is now `BenchBox-dev`. |
+| SHADOW_ONLY activation | Still governs. `07b` stays dropped. Availability of merge queue after transfer is not authorization. |
+| repo-admin-settings | Extend via `docs/operations/github-org-transfer.md`. |
+| future-state index / support-tier freeze | Out of scope. |
+
+## Review disposition (Claude + Agy, 2026-08-21)
+
+Accepted: transfer-fragile `GITHUB_REPOSITORY` tests; JoinOrder URL is
+identity; Pages `curl` is serving-only; shadow workflow must resolve
+`develop-squash-only` by name not id `15611785`; org-level
+`benchbox.dev` verification before transfer; `admin:org` and PAT policy;
+Actions `allowed_actions=all`; environment JSON rebuild including
+`github-pages` release-only branch policy; pin-update avoids soundness
+paths; never change answers default URL; issue template is wrong user
+**and** `main`; `ruleset-drift` keys by name not ID; PyPI dual-register
+on the existing `benchbox` project is the primary G2 path.
+
+Rebutted: adding `User:57046` or `OrganizationAdmin` bypass on
+`develop-squash-only`. Live policy is `bypass_actors: none`. This program
+preserves that gate.
+
+## Gates
+
+```text
+G0  Org hardening + admin:org + benchbox.dev org verification + PAT policy
+G1  Decision/runbook + owner-agnostic CI merged
+G2  PyPI + TestPyPI trusted publishers for BenchBox-dev/BenchBox
+G3  Merge freeze + ruleset/env JSON snapshot + written operator GO
+G4  Transfer
+G5  Hosted rebuild (capability, not names-only); Pages serving-only
+G6  Pin-update PR (no soundness paths)
+G7  Redirects, downloads, scheduled workflows, Codecov, ruleset-drift
+G7b First post-transfer push to release proves Pages publish path
+```
+
+Agents may complete G1 (and G6 after G5). G0, G2–G5, and G7b are
+operator. Completing an operator-gated TODO without its gate is a defect.
+
+## Abort
+
+Abort G0 if `BenchBox-dev` is not empty of a `BenchBox` repo or the
+operator is not org admin. Abort G3 if a release is in flight or
+`incident:develop-red` is open. Abort G4 if dest `full_name` is wrong.
+Abort G5 if `benchbox.dev` stops serving. Do not leave the custom domain
+unverified overnight.
+
+## Rollback
+
+Phase 1/6 PRs revert on `develop`. Transfer org→user is last resort
+(Pages flaps twice). Queue disable is N/A (must not be enabled).

--- a/docs/operations/github-org-transfer.md
+++ b/docs/operations/github-org-transfer.md
@@ -1,0 +1,111 @@
+# Transfer `joeharris76/BenchBox` to `BenchBox-dev`
+
+Operator runbook for the ownership cutover authorized by
+`_project/decisions/github-org-transfer-benchbox-dev-2026-08-21.md`.
+This file is the transfer restore checklist. Live develop/release/tag
+semantics stay in `repo-admin-settings.md`.
+
+Do not enable merge queue. Do not add `develop-squash-only` bypass actors.
+
+## Never recreate the old owner/name
+
+After transfer, GitHub redirects `https://github.com/joeharris76/BenchBox`
+and its git/release URLs. Creating a new repository at that owner/name
+permanently deletes those redirects. Published wheels hardcode
+`_DEFAULT_ANSWERS_BASE_URL` under the old owner. JoinOrder
+`data_manifest.toml` `url` is inside `manifest_hash` and must not be
+edited as part of transfer.
+
+## G0 — Org hardening (operator)
+
+1. `gh auth refresh -s admin:org` (current `repo`/`read:org` is not enough
+   for org Actions/PAT policy).
+2. Confirm `gh api orgs/BenchBox-dev` and membership role `admin`.
+3. Confirm the org has **no** repository named `BenchBox`.
+4. Set org profile (description, website `https://benchbox.dev`).
+5. Enable required 2FA for the organization.
+6. Leave `default_repository_permission=read`. Prefer
+   `members_can_create_repositories=false` for a one-repo org.
+7. Do **not** restrict org `allowed_actions` and do **not** enable org
+   SHA pinning. Live source repo is `enabled=true`,
+   `allowed_actions=all`, `sha_pinning_required=false`.
+8. Org-verify `benchbox.dev` (TXT
+   `_github-pages-challenge-BenchBox-dev`). `protected_domain_state` on
+   the **user** account does not transfer. G3 must not GO until the org
+   shows the domain verified.
+9. Org PAT / fine-grained token policy must allow
+   `RULESET_DRIFT_TOKEN` and `TODO_EXPORT_PR_TOKEN` against
+   `BenchBox-dev/BenchBox`, or replace those secrets with
+   org-approved tokens **before** G4.
+
+## G2 — PyPI trusted publishers (operator)
+
+On the existing PyPI project `benchbox`, add a GitHub publisher for
+`BenchBox-dev/BenchBox`, workflow `release.yml`, environment `pypi`.
+Repeat on TestPyPI for environment `test-pypi`. Keep the
+`joeharris76/BenchBox` publishers during overlap. OIDC is checked at
+publish time; the repo does not have to exist yet for an existing
+project.
+
+## G3 — Freeze and snapshot (operator)
+
+1. No `release-cut` / `v*` tag in flight; no `incident:develop-red`.
+2. Accept that open develop PRs move with the repo.
+3. Save **full JSON** for every ruleset and environment, including
+   `github-pages` `deployment-branch-policies` (live: branch `release`
+   only) and develop `require_extra_approval_for_unattributed_changes`.
+4. Written GO in this decision record or a dated operator note.
+
+## G4 — Transfer (operator)
+
+Transfer to owner `BenchBox-dev`, keep name `BenchBox`. Confirm:
+
+```bash
+gh api repos/BenchBox-dev/BenchBox --jq '{full_name,owner:.owner.login,type:.owner.type,default_branch}'
+```
+
+Expected: `BenchBox-dev/BenchBox`, `Organization`, `develop`.
+
+## G5 — Rebuild (operator)
+
+Order:
+
+1. Workflow permissions: `default_workflow_permissions=read`,
+   `can_approve_pull_request_reviews=true`.
+2. `actions/permissions`: `enabled=true`, `allowed_actions=all`,
+   `sha_pinning_required=false`.
+3. Recreate four named rulesets from the G3 JSON:
+   `develop-squash-only`, `release-only`,
+   `v-release-branches-minimal`, `v-tag-restricted`.
+   Develop: no bypass_actors. Tag: bypass `User:57046` always.
+   Capture **new IDs** for the pin-update PR.
+4. Rebuild environments `github-pages` (deployment-branch `release`
+   only), `pypi` (required reviewer `joeharris76` / 57046,
+   `can_admins_bypass: true`, `prevent_self_review: false`),
+   `test-pypi` (empty protection).
+5. Confirm secret **names** exist, then prove
+   `RULESET_DRIFT_TOKEN` and `TODO_EXPORT_PR_TOKEN` **authenticate**
+   against `BenchBox-dev/BenchBox` (name presence is not enough).
+6. Pages serving-only: `curl -fsSI https://benchbox.dev/` HTTP 200.
+   This is **not** publish-path proof. `.github/workflows/docs.yml`
+   `deploy` runs only on `push` to `refs/heads/release`. G7b is the
+   next release-branch deploy.
+
+## G6 — Pin-update (after G5)
+
+Retarget public and load-bearing owner strings. Do not touch
+`SOUNDNESS_PREFIXES` / CODEOWNERS soundness paths, JoinOrder
+`data_manifest.toml`, or `_DEFAULT_ANSWERS_BASE_URL`. Edit
+`repo-admin-settings.md` parse blocks **in place** (owner strings and
+new ruleset IDs only). See the tracker item
+`github-org-transfer-03-pin-update`.
+
+## G7 / G7b
+
+G7: old git URL redirects; answers-v1 and JoinOrder archives still
+fetch via the old owner URL; scheduled workflows registered (none
+`disabled_inactivity`); Codecov badge regenerated; `ruleset-drift`
+green.
+
+G7b: first post-transfer `push` to `release` proves Pages publish.
+Serving-only success at G5 does not close G7b.

--- a/docs/operations/repo-admin-settings.md
+++ b/docs/operations/repo-admin-settings.md
@@ -653,13 +653,24 @@ gh label list --search incident
 
 ## Re-applying after a transfer or restore
 
-If the repo is transferred, restored from backup, or the rules drift,
-re-apply in this order:
+The 2026-08-21 cutover to org `BenchBox-dev` is documented in
+`docs/operations/github-org-transfer.md` (gates G0–G7b, Pages
+serving-only vs publish, org `protected_domain` verification,
+environment `deployment-branch` policies, `RULESET_DRIFT_TOKEN`
+authentication, and **never recreate** `joeharris76/BenchBox`). Follow
+that runbook for an ownership transfer. The numbered restore below is
+the subset that still applies after a backup restore or ruleset wipe
+**without** changing owners.
+
+If the repo is restored from backup or the rules drift without a
+transfer, re-apply in this order:
 
 1. Workflow permissions (`gh api -X PUT … actions/permissions/workflow`).
 2. Develop ruleset — recreate `develop-squash-only` with the required
    contexts list above. The ruleset id will change; update this file
-   and the `Makefile`/`scripts/` references that hard-code it.
+   and the `Makefile`/`scripts/` references that hard-code it. Prefer
+   resolving the live ruleset **by name** (`develop-squash-only`) in
+   workflows; do not treat a stale numeric id as authority.
 3. Verify with the `gh api … rulesets/<id> --jq …` command above.
 4. Push a no-op commit to develop and confirm `develop-post-merge.yml`
    produces a `metrics` artifact and the lint + fast-test jobs are green.


### PR DESCRIPTION
Authorize transferring joeharris76/BenchBox to org BenchBox-dev without
enabling merge queue. Capture the post-review restore checklist so Pages,
OIDC, and rulesets can be rebuilt without treating serving-only as publish
proof.
