### PR TITLE
fix(ci): stop develop CI from pinning a GitHub owner or ruleset id

### DIFF
--- a/.github/workflows/develop-refresh-shadow.yml
+++ b/.github/workflows/develop-refresh-shadow.yml
@@ -153,7 +153,18 @@ jobs:
               return None
 
           repo = os.environ["GITHUB_REPOSITORY"]
-          ruleset = api("/repos/{0}/rulesets/15611785".format(repo))
+          listing = api("/repos/{0}/rulesets".format(repo))
+          ruleset_id = None
+          if isinstance(listing, list):
+              for entry in listing:
+                  if isinstance(entry, dict) and entry.get("name") == "develop-squash-only":
+                      ruleset_id = entry.get("id")
+                      break
+          ruleset = (
+              api("/repos/{0}/rulesets/{1}".format(repo, ruleset_id))
+              if ruleset_id
+              else {"_error": "develop-squash-only-missing"}
+          )
           contexts = []
           if isinstance(ruleset, dict) and "_error" not in ruleset:
               for rule in ruleset.get("rules") or []:

--- a/docs/operations/browser-ci.md
+++ b/docs/operations/browser-ci.md
@@ -25,7 +25,7 @@ It is wired through the develop branch ruleset instead:
 
 | Piece | Value |
 |-------|--------|
-| Ruleset | `develop-squash-only` (id `15611785`) |
+| Ruleset | `develop-squash-only` (resolve by name; current id `15611785` until a transfer) |
 | Required context | `Results Explorer browser gate` |
 | Gate job | `browser-required-result` in `results-explorer-browser.yml` |
 | Gate inputs | `needs: [explorer-changes, chromium]`, `if: always()` |
@@ -47,7 +47,8 @@ Firefox and WebKit remain advisory (`non-blocking` in the job name,
 Live ruleset confirmation:
 
 ```bash
-gh api repos/joeharris76/BenchBox/rulesets/15611785 \
+gh api repos/joeharris76/BenchBox/rulesets --jq '.[] | select(.name=="develop-squash-only") | .id' \
+  | xargs -I{} gh api repos/joeharris76/BenchBox/rulesets/{} \
   --jq '.rules[]|select(.type=="required_status_checks")'
 ```
 

--- a/tests/unit/test_release_readiness.py
+++ b/tests/unit/test_release_readiness.py
@@ -194,12 +194,13 @@ def test_main_queries_trusted_default_branch(monkeypatch: pytest.MonkeyPatch) ->
 
     monkeypatch.setattr(release_readiness_check, "_api_json", _fake_api_json)
     monkeypatch.setenv("GITHUB_TOKEN", "token")
+    monkeypatch.setenv("GITHUB_REPOSITORY", "BenchBox-dev/BenchBox")
     monkeypatch.delenv("GITHUB_STEP_SUMMARY", raising=False)
     monkeypatch.delenv("RELEASE_CANARY_BRANCH", raising=False)
     monkeypatch.delenv("RELEASE_READINESS_OVERRIDE_SHA", raising=False)
     monkeypatch.delenv("RELEASE_READINESS_OVERRIDE_REASON", raising=False)
 
-    rc = release_readiness_check.main(["--head-sha", "release-head"])
+    rc = release_readiness_check.main(["--head-sha", "release-head", "--repo", "joeharris76/BenchBox"])
 
     assert rc == 1
     assert captured_urls == [

--- a/tests/unit/workflows/test_results_explorer_browser_gate.py
+++ b/tests/unit/workflows/test_results_explorer_browser_gate.py
@@ -9,9 +9,10 @@ following hold:
 3. The gate job's `name:` (`Results Explorer browser gate`) is the context
    recorded in the admin runbook and in `docs/operations/browser-ci.md`.
 
-The live ruleset membership (develop ruleset `develop-squash-only` /
-15611785 requires that context) is not reachable from unit tests; pin the
+The live ruleset membership (develop ruleset `develop-squash-only`
+requires that context) is not reachable from unit tests; pin the
 documented agreement here and confirm the ruleset with `gh api` when triaging.
+The numeric ruleset id changes on repository transfer; the name does not.
 """
 
 from __future__ import annotations
@@ -79,7 +80,7 @@ def test_gate_context_matches_the_documented_required_check(workflow: dict[str, 
     assert GATE_CONTEXT in admin_runbook, "required gate context is not recorded in the repo admin runbook"
     browser_runbook = BROWSER_CI_RUNBOOK.read_text(encoding="utf-8")
     assert GATE_CONTEXT in browser_runbook, "required gate context is not recorded in docs/operations/browser-ci.md"
-    assert "15611785" in browser_runbook, "browser-ci runbook must cite develop ruleset id 15611785"
+    assert "develop-squash-only" in browser_runbook, "browser-ci runbook must cite develop ruleset name"
 
 
 def test_lane_still_runs_on_pull_requests_into_develop(workflow: dict[str, Any]) -> None:


### PR DESCRIPTION
Release-readiness tests now pass --repo explicitly so Actions
GITHUB_REPOSITORY cannot fail them after an org transfer. The refresh-shadow
collector resolves develop-squash-only by name, and the browser-ci contract
pins that name instead of ruleset id 15611785.
