### PR TITLE
docs: do not org-verify benchbox.dev before the repo transfer

### DIFF
--- a/_project/decisions/github-org-transfer-benchbox-dev-2026-08-21.md
+++ b/_project/decisions/github-org-transfer-benchbox-dev-2026-08-21.md
@@ -56,13 +56,21 @@ retargeting lands **after** hosted rebuild.
 
 Accepted: transfer-fragile `GITHUB_REPOSITORY` tests; JoinOrder URL is
 identity; Pages `curl` is serving-only; shadow workflow must resolve
-`develop-squash-only` by name not id `15611785`; org-level
-`benchbox.dev` verification before transfer; `admin:org` and PAT policy;
-Actions `allowed_actions=all`; environment JSON rebuild including
+`develop-squash-only` by name not id `15611785`; `admin:org` and PAT
+policy; Actions `allowed_actions=all`; environment JSON rebuild including
 `github-pages` release-only branch policy; pin-update avoids soundness
 paths; never change answers default URL; issue template is wrong user
 **and** `main`; `ruleset-drift` keys by name not ID; PyPI dual-register
 on the existing `benchbox` project is the primary G2 path.
+
+**Superseded 2026-08-21 (00b):** Claude C5 / Agy “org domain verification
+before transfer” is **rejected**. GitHub Pages domain verification is
+exclusive to one account. Verifying `benchbox.dev` on `BenchBox-dev`
+while the site is still published from `joeharris76/BenchBox` would
+either fail (already verified by the user) or immediately unbind the
+live site. Do not click Verify on the org before G4. Optional: add the
+org challenge TXT only. Keep `_github-pages-challenge-joeharris76`.
+Org-verify **after G4** once apex and www still return 200.
 
 Rebutted: adding `User:57046` or `OrganizationAdmin` bypass on
 `develop-squash-only`. Live policy is `bypass_actors: none`. This program
@@ -71,14 +79,15 @@ preserves that gate.
 ## Gates
 
 ```text
-G0  Org hardening + admin:org + benchbox.dev org verification + PAT policy
-G1  Decision/runbook + owner-agnostic CI merged
+G0  Org hardening + admin:org + PAT policy (no org Pages Verify)
+G1  Decision/runbook + owner-agnostic CI merged (includes 00b)
 G2  PyPI + TestPyPI trusted publishers for BenchBox-dev/BenchBox
-G3  Merge freeze + ruleset/env JSON snapshot + written operator GO
+G3  Merge freeze + ruleset/env/Pages snapshot + written operator GO
 G4  Transfer
-G5  Hosted rebuild (capability, not names-only); Pages serving-only
+G5  Hosted rebuild; Pages serving-only (apex and www 200)
+G5b Org-verify benchbox.dev; then drop user verification; www CNAME
 G6  Pin-update PR (no soundness paths)
-G7  Redirects, downloads, scheduled workflows, Codecov, ruleset-drift
+G7  Redirects, downloads, workflows, Codecov, drift, org domain lock
 G7b First post-transfer push to release proves Pages publish path
 ```
 
@@ -90,8 +99,11 @@ operator. Completing an operator-gated TODO without its gate is a defect.
 Abort G0 if `BenchBox-dev` is not empty of a `BenchBox` repo or the
 operator is not org admin. Abort G3 if a release is in flight or
 `incident:develop-red` is open. Abort G4 if dest `full_name` is wrong.
-Abort G5 if `benchbox.dev` stops serving. Do not leave the custom domain
-unverified overnight.
+Abort G5 if `benchbox.dev` or `www.benchbox.dev` stops serving. Do not
+click org Pages Verify before G4. After G4, if GitHub refuses org
+verification because the user still holds the exclusive lock, remove
+user-account verification only after the repo is already in the org and
+apex is 200, then Verify on `BenchBox-dev`.
 
 ## Rollback
 

--- a/docs/operations/github-org-transfer.md
+++ b/docs/operations/github-org-transfer.md
@@ -6,6 +6,10 @@ This file is the transfer restore checklist. Live develop/release/tag
 semantics stay in `repo-admin-settings.md`.
 
 Do not enable merge queue. Do not add `develop-squash-only` bypass actors.
+GitHub Pages domain verification is exclusive. do not click Verify on
+org `BenchBox-dev` for `benchbox.dev` before G4; keep
+`_github-pages-challenge-joeharris76` until after G4 and a live 200.
+`www.benchbox.dev` is `CNAME joeharris76.github.io` until after G4.
 
 ## Never recreate the old owner/name
 
@@ -29,10 +33,17 @@ edited as part of transfer.
 7. Do **not** restrict org `allowed_actions` and do **not** enable org
    SHA pinning. Live source repo is `enabled=true`,
    `allowed_actions=all`, `sha_pinning_required=false`.
-8. Org-verify `benchbox.dev` (TXT
-   `_github-pages-challenge-BenchBox-dev`). `protected_domain_state` on
-   the **user** account does not transfer. G3 must not GO until the org
-   shows the domain verified.
+8. **Do not click Verify** for `benchbox.dev` on org `BenchBox-dev`
+   while the repo is still user-owned. GitHub Pages domain verification
+   is **exclusive**: a domain verified on a user account can only be
+   published by that user’s repos; verifying it on another account
+   immediately releases other Pages bindings, and an already-verified
+   domain refuses a second verification. Keep
+   `_github-pages-challenge-joeharris76`. Optional and safe: add TXT
+   `_github-pages-challenge-BenchBox-dev.benchbox.dev` without Verify
+   (different hostname from the user challenge). Do not change apex
+   A/AAAA (they already point at GitHub Pages IPs). Do not retarget
+   `www.benchbox.dev` (today `CNAME joeharris76.github.io`) before G4.
 9. Org PAT / fine-grained token policy must allow
    `RULESET_DRIFT_TOKEN` and `TODO_EXPORT_PR_TOKEN` against
    `BenchBox-dev/BenchBox`, or replace those secrets with
@@ -54,7 +65,12 @@ project.
 3. Save **full JSON** for every ruleset and environment, including
    `github-pages` `deployment-branch-policies` (live: branch `release`
    only) and develop `require_extra_approval_for_unattributed_changes`.
-4. Written GO in this decision record or a dated operator note.
+4. Snapshot Pages: `gh api repos/joeharris76/BenchBox/pages` (`cname`,
+   `protected_domain_state=verified`, HTTPS approved) and
+   `curl -fsSI https://benchbox.dev/` plus `https://www.benchbox.dev/`
+   (HTTP 200). Record `dig` of apex A/AAAA and `www` CNAME.
+5. Written GO in this decision record or a dated operator note. G3 GO
+   does **not** require org Pages verification.
 
 ## G4 — Transfer (operator)
 
@@ -86,10 +102,20 @@ Order:
 5. Confirm secret **names** exist, then prove
    `RULESET_DRIFT_TOKEN` and `TODO_EXPORT_PR_TOKEN` **authenticate**
    against `BenchBox-dev/BenchBox` (name presence is not enough).
-6. Pages serving-only: `curl -fsSI https://benchbox.dev/` HTTP 200.
-   This is **not** publish-path proof. `.github/workflows/docs.yml`
-   `deploy` runs only on `push` to `refs/heads/release`. G7b is the
-   next release-branch deploy.
+6. Pages serving-only: `curl -fsSI https://benchbox.dev/` and
+   `https://www.benchbox.dev/` HTTP 200.
+   `gh api repos/BenchBox-dev/BenchBox/pages` still has
+   `cname=benchbox.dev`. This is **not** publish-path proof.
+   `.github/workflows/docs.yml` `deploy` runs only on `push` to
+   `refs/heads/release`. G7b is the next release-branch deploy.
+7. **After G4 and those 200s**, org-verify `benchbox.dev` (now click
+   Verify). If GitHub says the domain is already verified by the user,
+   remove user-account Pages verification **only after** the repo is in
+   the org, then Verify on `BenchBox-dev`. Then retarget
+   `www.benchbox.dev` CNAME from `joeharris76.github.io` to
+   `BenchBox-dev.github.io` if www is not 200 or as the planned DNS
+   step. Keep the user challenge TXT until org `protected_domain_state`
+   is `verified`.
 
 ## G6 — Pin-update (after G5)
 
@@ -105,7 +131,9 @@ new ruleset IDs only). See the tracker item
 G7: old git URL redirects; answers-v1 and JoinOrder archives still
 fetch via the old owner URL; scheduled workflows registered (none
 `disabled_inactivity`); Codecov badge regenerated; `ruleset-drift`
-green.
+green; org Pages `protected_domain_state=verified` for `benchbox.dev`;
+apex and www HTTP 200; `www` CNAME `BenchBox-dev.github.io` (or still
+GitHub Pages with 200).
 
 G7b: first post-transfer `push` to `release` proves Pages publish.
 Serving-only success at G5 does not close G7b.

--- a/docs/operations/repo-admin-settings.md
+++ b/docs/operations/repo-admin-settings.md
@@ -655,7 +655,8 @@ gh label list --search incident
 
 The 2026-08-21 cutover to org `BenchBox-dev` is documented in
 `docs/operations/github-org-transfer.md` (gates G0–G7b, Pages
-serving-only vs publish, org `protected_domain` verification,
+serving-only vs publish, exclusive Pages domain lock: do not click
+org Verify before G4, org `protected_domain` verification after G4,
 environment `deployment-branch` policies, `RULESET_DRIFT_TOKEN`
 authentication, and **never recreate** `joeharris76/BenchBox`). Follow
 that runbook for an ownership transfer. The numbered restore below is


### PR DESCRIPTION
GitHub Pages domain verification is exclusive to one account. Verifying
the domain on BenchBox-dev while the site is still published from
joeharris76 would unbind or refuse the live custom domain. Keep user
verification and apex DNS until after G4; org Verify and www CNAME
retarget follow a live 200.
