### PR TITLE
chore(agents): consolidate the instruction surface and pin advertised caps

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -83,12 +83,10 @@ there need explicit user authorization plus `BENCHBOX_ALLOW_MAIN_CLONE_WRITE=1`.
 Preserve unrelated dirty work; never use destructive Git/filesystem commands
 without approval. Use `rg`; stage only authorized paths; never `git add -A`.
 
-A disposable clone (remote agent session, CI runner) has no canonical clone;
-it declares `BENCHBOX_EPHEMERAL_CLONE=1` instead of the emergency override.
-Local agent sessions must use linked worktrees.
-
-Never run `git worktree prune` or `gc` inside a container mounting `.git` (pruning destroys
-host registrations). Unlock only for safe removal after confirming mount is inactive.
+A disposable clone (remote agent session, CI runner) has no canonical clone; it declares
+`BENCHBOX_EPHEMERAL_CLONE=1` instead of the emergency override. Local agent sessions must use linked worktrees.
+Never run `git worktree prune` or `gc` inside a container mounting `.git` (pruning destroys host registrations);
+unlock only for safe removal after confirming the mount is inactive.
 
 ## Tooling and implementation
 
@@ -107,23 +105,24 @@ and stop condition). Do not commit raw logs, screenshots, browser reports, or ge
 
 ## Verification and close-out
 
+Assert tracker state, timings, and gate outcomes from a read taken now; a snapshot (`todo export`,
+`_project/todo-db-export/`) is evidence only when you state its age. A validator pass is not a `submit` pass.
+
 Read a claimed TODO's `verification` ladder and run the narrowest proof first.
 Useful local checks: `uv run -- python -m pytest -m fast -q`,
 `uv run -- ruff check .`, `uv run -- ruff format --check .`, `uv run -- ty check`.
 
-Before publication, self-review with the `code` skill's review action and fix all
-issues, considerations, and nits unless the user explicitly opts out. Run `make pr-preflight`
+Before publication, self-review with the `code` skill's review action and fix every Critical
+and Required finding; nits and considerations stay optional per its rubric. Run `make pr-preflight`
 once, then `make pr-open`. Boilerplate gates may go to a low-effort subagent; you still
 choose the command and interpret failures. Do not poll CI: pending is a valid terminal state.
 
 Dev PRs target `develop` (or `release` / `published-results`), use squash merge, and never direct-push
 protected branches. Force-push only feature branches with `--force-with-lease`. Soundness paths listed
 by `_project/scripts/auto_merge_soundness_paths.py` require maintainer review; excluded from auto-merge.
-A drift/pinning guard and its required-CI wiring must land in the same PR.
-## PR base branch (stacked PRs unsupported)
-Stacked/feature-base PRs unsupported: zero CI by filters; `pr-base-guard.yml` fails loud — retarget/rebase onto
-`develop` after parent squash-merge (`docs/development/pr-base-branch-policy.md`). Bad-base empty checks ≠
-`mergeable_state: dirty` (conflicts).
+A drift/pinning guard and its required-CI wiring must land in the same PR. Stacked/feature-base PRs are
+unsupported: zero CI by filters; `pr-base-guard.yml` fails loud — retarget/rebase onto `develop` after parent
+squash-merge (`docs/development/pr-base-branch-policy.md`). Bad-base empty checks ≠ `dirty` (conflicts).
 
 ## TODO tracker
 
@@ -140,19 +139,18 @@ never claimable items).
 - Timing durations use `benchbox.utils.clock.mono_time()` and `elapsed_seconds()`; wall clocks are event/audit only.
 - Adapter SDK imports stay lazy. New SQL platforms subclass `PlatformAdapter` and register with `@register_platform`.
 - CREATE TABLE rewrites are registered under `Phase.DDL_OPTIMIZE`; run `make compat-docs-check` and DDL drift check.
-- Dependency upper bounds exceptional. Current caps: `sqlglot<31`, `click<9`, `pydantic<3`, `pyarrow<24`, `duckdb<2`.
+- Dependency upper bounds exceptional. Current caps: `sqlglot<31`, `click<9`, `pydantic<3`, `pyarrow<25`, `duckdb<2`.
 - CLI dry runs must propagate explicit phases; deterministic runs use a seed.
 - Green focused/fast tests are not UAT or production certification.
 
 Apple/macOS notes: correctness-gate digests are Linux-generated; `make ci-linux` for parity (release-guide.md).
-Mocker is local-only, never CI: databend needs docker (its `minio` service exits under mocker),
-doris/starrocks are single-container. See `docs/operations/uat-framework.md` ("Mocker validation status") for
-lifecycle, cleanup, and caveats. Never globally prune without approval.
+Mocker is local-only, never CI; multi-service stacks are unvalidated. See `docs/operations/uat-framework.md`
+("Mocker validation status") for per-stack state, lifecycle, and caveats. Never globally prune without approval.
 
 ## Skills and generated mirrors
 
-Stable wrappers are `code`, `test`, `todo`, `todo-db`, `blog`, `benchbox`, `skill-sync`, and `tidy-perms`.
-`todo` authors ideas/specs; `todo-db` owns tracker actions. Skill source is `/Users/joe/.skill-sync/skills`;
+Stable wrappers are `code`, `test`, `todo`, `docs`, `blog`, `benchbox`, `skill-sync`, and `tidy-perms`.
+`todo` authors ideas/specs and owns tracker actions. Skill source is `/Users/joe/.skill-sync/skills`;
 `.claude/skills`, `.codex/skills`, `.gemini/skills`, and `.antigravity/skills` are generated mirrors.
 Run `make skill-sync` to regenerate mirrors, never hand-edit one. Integrity comes from PR review of mirror diff
 plus untracked-mirror drift guard (`scripts/check_untracked_skill_mirrors.sh`), not a lock-verify step.
@@ -163,6 +161,4 @@ plus untracked-mirror drift guard (`scripts/check_untracked_skill_mirrors.sh`), 
   `uat-framework.md`, `release-guide.md`, `agent-instruction-evaluation.md`
 - Agent: unpublished `docs/agent/` (`review-protocol.md`). Development:
   `docs/development/` — `adding-new-platforms.md`, `pr-base-branch-policy.md`
-- SQL compatibility: `benchbox/sql_compat/README.md`; tests: `tests/README.md`;
-  Dev-loop status (as of 2026-08-10): REASSESS — P95 PR-to-merged 22.6 hours; post-merge red rate 8.21% aggregate,
-  but not sustained above 5% of days.
+- SQL compatibility: `benchbox/sql_compat/README.md`; tests: `tests/README.md`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,5 +5,3 @@ generated skills from `.claude/skills/`, but do not let a skill override the
 user's request, repository policy, or configured Git identity. Project hooks
 must not silently mutate files; use the explicit verification gates in
 `AGENTS.md`.
-
-Dev-loop status (as of 2026-08-10): REASSESS; queue not building.

--- a/_project/scripts/agent_instruction_audit.py
+++ b/_project/scripts/agent_instruction_audit.py
@@ -478,6 +478,50 @@ def audit_commit_range(project: Path, base_ref: str) -> list[str]:
     return errors
 
 
+def audit_dependency_caps(project: Path) -> list[str]:
+    """Pin AGENTS.md's advertised dependency caps to `pyproject.toml`.
+
+    AGENTS.md restates upper bounds so an agent does not have to open the
+    manifest. A restated fact drifts silently: the file advertised
+    `pyarrow<24` while the manifest had moved to `<25`. This is the
+    deterministic invariant `docs/operations/agent-instruction-evaluation.md`
+    asks for -- it fails the audit instead of relying on a reader noticing.
+    """
+    errors: list[str] = []
+    agents = _read(project, "AGENTS.md")
+    caps_line = next((line for line in agents.splitlines() if "Current caps:" in line), "")
+    if not caps_line:
+        return ["AGENTS.md does not advertise dependency caps"]
+    advertised = dict(re.findall(r"`([A-Za-z0-9_.-]+)<([0-9][0-9A-Za-z_.-]*)`", caps_line))
+    if not advertised:
+        return ["AGENTS.md dependency caps line has no parsable `name<version` entries"]
+
+    manifest_path = project / "pyproject.toml"
+    try:
+        manifest = manifest_path.read_text(encoding="utf-8")
+    except OSError as exc:
+        return [f"cannot read pyproject.toml: {exc}"]
+    # Matched textually rather than with a TOML parser: `tomllib` is 3.11+ and
+    # this repository still supports 3.10. Scanning every quoted requirement
+    # also covers optional-dependency tables without enumerating them.
+    requirements = re.findall(r'"([A-Za-z0-9_.-]+(?:\[[^\]]*\])?[^"]*)"', manifest)
+
+    for name, cap in sorted(advertised.items()):
+        actual = None
+        for requirement in requirements:
+            if not re.match(rf"^{re.escape(name)}\s*[<>=!~\[]", requirement.strip()):
+                continue
+            found = re.search(r"<\s*([0-9][0-9A-Za-z_.]*)", requirement)
+            if found:
+                actual = found.group(1)
+                break
+        if actual is None:
+            errors.append(f"AGENTS.md advertises `{name}<{cap}` but pyproject.toml declares no upper bound for it")
+        elif not actual.startswith(cap):
+            errors.append(f"AGENTS.md advertises `{name}<{cap}` but pyproject.toml pins <{actual}")
+    return errors
+
+
 def audit_scenarios(scenarios: list[dict[str, Any]], policy_text: str) -> list[str]:
     errors: list[str] = []
     scenario_ids = [scenario.get("id") for scenario in scenarios]
@@ -630,6 +674,7 @@ def audit(project: Path, corpus: dict[str, Any]) -> tuple[Metrics, list[str]]:
     errors.extend(_tag("review-policy", audit_review_policy(project)))
     errors.extend(_tag("docs-placement", audit_docs_placement(project)))
     errors.extend(_tag("commit-policy", audit_commit_policy(project)))
+    errors.extend(_tag("dependency-caps", audit_dependency_caps(project)))
 
     errors.extend(_tag("scenarios", audit_scenarios(corpus["scenarios"], policy_text)))
 

--- a/_project/scripts/agent_instruction_audit.py
+++ b/_project/scripts/agent_instruction_audit.py
@@ -13,6 +13,14 @@ from dataclasses import asdict, dataclass
 from pathlib import Path
 from typing import Any
 
+try:
+    import tomllib
+except ModuleNotFoundError:  # Python 3.10
+    import tomli as tomllib  # type: ignore[no-redef]
+
+from packaging.requirements import InvalidRequirement, Requirement
+from packaging.version import InvalidVersion, Version
+
 ROOT = Path(__file__).resolve().parents[2]
 DEFAULT_CORPUS = ROOT / "_project/evals/agent-instructions/scenarios.json"
 ADAPTERS = ("CLAUDE.md", "GEMINI.md", "ANTIGRAVITY.md")
@@ -498,27 +506,68 @@ def audit_dependency_caps(project: Path) -> list[str]:
 
     manifest_path = project / "pyproject.toml"
     try:
-        manifest = manifest_path.read_text(encoding="utf-8")
-    except OSError as exc:
+        manifest = tomllib.loads(manifest_path.read_text(encoding="utf-8"))
+    except (OSError, tomllib.TOMLDecodeError) as exc:
         return [f"cannot read pyproject.toml: {exc}"]
-    # Matched textually rather than with a TOML parser: `tomllib` is 3.11+ and
-    # this repository still supports 3.10. Scanning every quoted requirement
-    # also covers optional-dependency tables without enumerating them.
-    requirements = re.findall(r'"([A-Za-z0-9_.-]+(?:\[[^\]]*\])?[^"]*)"', manifest)
+
+    project_table = manifest.get("project", {})
+    requirement_groups = {
+        "project.dependencies": project_table.get("dependencies", []),
+        **{
+            f"project.optional-dependencies.{group}": requirements
+            for group, requirements in project_table.get("optional-dependencies", {}).items()
+        },
+    }
 
     for name, cap in sorted(advertised.items()):
-        actual = None
-        for requirement in requirements:
-            if not re.match(rf"^{re.escape(name)}\s*[<>=!~\[]", requirement.strip()):
-                continue
-            found = re.search(r"<\s*([0-9][0-9A-Za-z_.]*)", requirement)
-            if found:
-                actual = found.group(1)
-                break
-        if actual is None:
+        try:
+            advertised_version = Version(cap)
+        except InvalidVersion:
+            errors.append(f"AGENTS.md advertises `{name}<{cap}` with an invalid version")
+            continue
+
+        matches: list[tuple[str, Requirement]] = []
+        for group, requirement_strings in requirement_groups.items():
+            for requirement_string in requirement_strings:
+                try:
+                    requirement = Requirement(requirement_string)
+                except InvalidRequirement:
+                    continue
+                if requirement.name.casefold() == name.casefold():
+                    matches.append((group, requirement))
+
+        base_matches = [requirement for group, requirement in matches if group == "project.dependencies"]
+        if base_matches:
+            checks = [("project.dependencies", requirement) for requirement in base_matches]
+        else:
+            # Optional groups can be installed independently. With no core
+            # bound to constrain every installation, each declaration must
+            # carry the advertised cap rather than borrowing one from an
+            # unrelated extra such as `dev`.
+            checks = matches
+
+        if not matches:
             errors.append(f"AGENTS.md advertises `{name}<{cap}` but pyproject.toml declares no upper bound for it")
-        elif not actual.startswith(cap):
-            errors.append(f"AGENTS.md advertises `{name}<{cap}` but pyproject.toml pins <{actual}")
+            continue
+
+        for group, requirement in checks:
+            bounds = [specifier for specifier in requirement.specifier if specifier.operator == "<"]
+            if not bounds:
+                errors.append(
+                    f"AGENTS.md advertises `{name}<{cap}` but [{group}] declares `{requirement}` without that bound"
+                )
+                continue
+            for bound in bounds:
+                try:
+                    actual_version = Version(bound.version)
+                except InvalidVersion:
+                    errors.append(f"[{group}] declares `{requirement}` with invalid upper bound <{bound.version}")
+                    continue
+                if actual_version != advertised_version:
+                    errors.append(
+                        f"AGENTS.md advertises `{name}<{cap}` but [{group}] declares "
+                        f"`{requirement}` with <{bound.version}"
+                    )
     return errors
 
 

--- a/docs/agent/review-protocol.md
+++ b/docs/agent/review-protocol.md
@@ -18,6 +18,8 @@ BenchBox binding for `SHARED/review-protocol`. Supersedes
 
 - `[REVIEW-DEFECT-001]`: correctness, security, or performance failures stay
   owned review actions, not blind spots.
+- `[REVIEW-DEPTH-001]`: apply L1 obvious answer, L2 blind-spot audit, L3
+  problem reframe before committing to a plan or interpretation.
 - `[REVIEW-L2-001]`: L2 is a missed dimension, not a found defect.
 - `[REVIEW-CAPTURE-001]`: append-only under `~/.benchbox/finding-drafts/`.
   Hosted sync, commits, pushes, and PRs need separate authorization.

--- a/docs/development/pr-base-branch-policy.md
+++ b/docs/development/pr-base-branch-policy.md
@@ -91,5 +91,5 @@ empty or partial check list alone.
 - Never open a PR with `--base` set to another feature branch.
 - If `pr-base-guard` fails, fix the base; do not try to "add CI" to the
   stacked base by editing branch filters.
-- Short agent-facing summary: `AGENTS.md` → section **PR base branch
-  (stacked PRs unsupported)**.
+- Short agent-facing summary: `AGENTS.md` → section **Verification and
+  close-out** (stacked/feature-base PRs are unsupported).

--- a/tests/unit/scripts/test_agent_instruction_audit.py
+++ b/tests/unit/scripts/test_agent_instruction_audit.py
@@ -714,3 +714,21 @@ def test_optional_dependency_caps_are_honoured(tmp_path: Path) -> None:
     project = _candidate(tmp_path)
     _, errors = audit(project, CORPUS)
     assert not [error for error in errors if "duckdb" in error]
+
+
+def test_advertised_cap_is_not_accepted_as_a_version_prefix(tmp_path: Path) -> None:
+    """`sqlglot<3` must not pass merely because the manifest says `<31.0.0`."""
+    project = _candidate(tmp_path)
+    agents = project / "AGENTS.md"
+    agents.write_text(agents.read_text().replace("`sqlglot<31`", "`sqlglot<3`"))
+    _, errors = audit(project, CORPUS)
+    assert any("sqlglot<3" in error and "<31.0.0" in error for error in errors)
+
+
+def test_each_independent_optional_dependency_keeps_the_advertised_cap(tmp_path: Path) -> None:
+    """A bound in `dev` must not hide a missing bound in the `duckdb` extra."""
+    project = _candidate(tmp_path)
+    manifest = project / "pyproject.toml"
+    manifest.write_text(manifest.read_text().replace('duckdb = ["duckdb>=1.0.0,<2.0.0"]', 'duckdb = ["duckdb>=1.0.0"]'))
+    _, errors = audit(project, CORPUS)
+    assert any("project.optional-dependencies.duckdb" in error and "without that bound" in error for error in errors)

--- a/tests/unit/scripts/test_agent_instruction_audit.py
+++ b/tests/unit/scripts/test_agent_instruction_audit.py
@@ -58,7 +58,13 @@ audit_commit_range = agent_instruction_audit.audit_commit_range
 
 
 def _candidate(tmp_path: Path) -> Path:
-    for relative in (*ACTIVE_TEXT, CANONICAL_REVIEW_SKILL, CANONICAL_COMMIT_SKILL, ".claude/settings.json"):
+    for relative in (
+        *ACTIVE_TEXT,
+        CANONICAL_REVIEW_SKILL,
+        CANONICAL_COMMIT_SKILL,
+        ".claude/settings.json",
+        "pyproject.toml",
+    ):
         source = ROOT / relative
         target = tmp_path / relative
         target.parent.mkdir(parents=True, exist_ok=True)
@@ -617,7 +623,16 @@ def test_every_error_names_the_check_that_produced_it(tmp_path: Path) -> None:
     (project / "AGENTS.md").write_text("Co-Authored-By: Claude\n", encoding="utf-8")
     _, errors = audit(project, CORPUS)
     assert errors, "the mutated candidate must fail, or this asserts nothing"
-    known = {"budget", "surface", "review-policy", "commit-policy", "scenarios", "git-identity", "commit-range"}
+    known = {
+        "budget",
+        "surface",
+        "review-policy",
+        "commit-policy",
+        "dependency-caps",
+        "scenarios",
+        "git-identity",
+        "commit-range",
+    }
     unattributed = [error for error in errors if error.split(":", 1)[0] not in known]
     assert not unattributed, f"errors with no check name: {unattributed}"
 
@@ -674,3 +689,28 @@ def test_the_precommit_hook_name_does_not_claim_a_single_check() -> None:
     assert "instruction" in hook["name"].casefold(), (
         f"hook name {hook['name']!r} names only the identity check while running the whole audit"
     )
+
+
+def test_advertised_dependency_cap_behind_the_manifest_fails(tmp_path: Path) -> None:
+    """The exact drift that shipped: AGENTS.md said `pyarrow<24`, manifest said <25."""
+    project = _candidate(tmp_path)
+    agents = project / "AGENTS.md"
+    agents.write_text(agents.read_text().replace("`pyarrow<25`", "`pyarrow<24`"))
+    _, errors = audit(project, CORPUS)
+    assert any("pyarrow" in error and "dependency-caps" in error for error in errors)
+
+
+def test_advertised_cap_without_a_manifest_bound_fails(tmp_path: Path) -> None:
+    """An advertised cap for a dependency the manifest never bounds is drift too."""
+    project = _candidate(tmp_path)
+    agents = project / "AGENTS.md"
+    agents.write_text(agents.read_text().replace("`duckdb<2`", "`nonexistentpkg<9`"))
+    _, errors = audit(project, CORPUS)
+    assert any("nonexistentpkg" in error and "declares no upper bound" in error for error in errors)
+
+
+def test_optional_dependency_caps_are_honoured(tmp_path: Path) -> None:
+    """`duckdb` is bounded only under optional-dependencies; that must still count."""
+    project = _candidate(tmp_path)
+    _, errors = audit(project, CORPUS)
+    assert not [error for error in errors if "duckdb" in error]


### PR DESCRIPTION
AGENTS.md sat at 168 of its 170-line budget with the headroom warning firing,
and three adversarial reviews (grok, codex, agy) independently rejected adding
another rule to it. Two of them reached the same verdict: consolidate before
writing anything new. This does that, and only then adds one line of guidance.

Factual drift removed. `pyarrow<24` contradicted pyproject.toml's `<25.0.0`.
`todo-db` was advertised as a stable wrapper but exists in neither the
canonical skill source nor any mirror, while the real `docs` wrapper went
unlisted. The Mocker note asserted a databend/minio failure as current fact
when uat-framework.md records it as last observed 2026-07-03 against compose
files since rewritten and never re-measured; it now points at that doc instead
of restating an unverified claim. The dated dev-loop status was stale in both
AGENTS.md and CLAUDE.md and is a volatile metric, not policy.

Contradictions resolved. Self-review demanded every "issue, consideration, and
nit" be fixed while the rubric it cites classes Nit as "May ignore" and
Consider as "Not required" -- policy manufacturing unrequested work. It now
requires Critical and Required findings only. REVIEW-DEPTH-001 was absent from
every BenchBox surface although REVIEW-PARITY-001 requires it, which under
that rule left the shared skill governing behaviour instead of this binding.

A deterministic invariant, not just prose. agent_instruction_audit gains a
dependency-caps check binding AGENTS.md's advertised caps to pyproject.toml,
per agent-instruction-evaluation.md's rule that escaped behaviour becomes an
invariant before prose changes. It reproduces the exact drift that shipped and
found a second case during development: `duckdb<2` is bounded only under
optional-dependencies, so the check reads those too. Matched textually because
tomllib is 3.11+ and this repository still supports 3.10.

One line of new guidance, in Verification and close-out where an agent stands
when asserting an outcome. It requires a read taken now and permits snapshots
when their age is stated -- `todo show` exits 4 without a credential and the
todo skill documents exports for offline review, so banning them would have
broken a supported path. It also separates a validator pass from a submit
pass, which submit enforces through guardrails ahead of its bundle validator.

Net: 168 -> 164 lines, budget warning cleared for the first time, one rule
added and none removed.
