### PR TITLE
fix(agent): stop restating mechanically-owned facts in AGENTS.md

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -118,7 +118,7 @@ repos:
         language: system
         pass_filenames: false
         stages: [pre-commit]
-        files: ^(AGENTS\.md|CLAUDE\.md|GEMINI\.md|ANTIGRAVITY\.md|\.claude/(commands/|settings\.json)|\.claude/skills/|docs/(agent/|operations/agent-instruction)|_project/(evals/agent-instructions/|scripts/agent_instruction_audit\.py)|skill-sync\.(yaml|lock)|pyproject\.toml)
+        files: ^(AGENTS\.md|CLAUDE\.md|GEMINI\.md|ANTIGRAVITY\.md|\.claude/(commands/|settings\.json)|\.claude/skills/|docs/(agent/|operations/agent-instruction)|_project/(evals/agent-instructions/|scripts/agent_instruction_audit\.py)|skill-sync\.(yaml|lock))
 
       # Enforce the linked-worktree boundary at the last safe point before Git
       # creates a commit object. The same declarations accepted by the session

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -118,7 +118,7 @@ repos:
         language: system
         pass_filenames: false
         stages: [pre-commit]
-        files: ^(AGENTS\.md|CLAUDE\.md|GEMINI\.md|ANTIGRAVITY\.md|\.claude/(commands/|settings\.json)|\.claude/skills/|docs/(agent/|operations/agent-instruction)|_project/(evals/agent-instructions/|scripts/agent_instruction_audit\.py)|skill-sync\.(yaml|lock))
+        files: ^(AGENTS\.md|CLAUDE\.md|GEMINI\.md|ANTIGRAVITY\.md|\.claude/(commands/|settings\.json)|\.claude/skills/|docs/(agent/|operations/agent-instruction)|_project/(evals/agent-instructions/|scripts/agent_instruction_audit\.py)|skill-sync\.(yaml|lock)|pyproject\.toml)
 
       # Enforce the linked-worktree boundary at the last safe point before Git
       # creates a commit object. The same declarations accepted by the session

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -105,8 +105,8 @@ and stop condition). Do not commit raw logs, screenshots, browser reports, or ge
 
 ## Verification and close-out
 
-Assert tracker state, timings, and gate outcomes from a read taken now; a snapshot (`todo export`,
-`_project/todo-db-export/`) is evidence only when you state its age. A validator pass is not a `submit` pass.
+Assert tracker state, timings, and gate outcomes from a live read; a snapshot (`todo export`,
+`_project/todo-db-export/`) dates a past state and never a current one. A validator pass is not a `submit` pass.
 
 Read a claimed TODO's `verification` ladder and run the narrowest proof first.
 Useful local checks: `uv run -- python -m pytest -m fast -q`,
@@ -122,7 +122,7 @@ protected branches. Force-push only feature branches with `--force-with-lease`. 
 by `_project/scripts/auto_merge_soundness_paths.py` require maintainer review; excluded from auto-merge.
 A drift/pinning guard and its required-CI wiring must land in the same PR. Stacked/feature-base PRs are
 unsupported: zero CI by filters; `pr-base-guard.yml` fails loud — retarget/rebase onto `develop` after parent
-squash-merge (`docs/development/pr-base-branch-policy.md`). Bad-base empty checks ≠ `dirty` (conflicts).
+squash-merge (`docs/development/pr-base-branch-policy.md`). Bad-base empty checks ≠ `mergeable_state: dirty`.
 
 ## TODO tracker
 
@@ -139,13 +139,13 @@ never claimable items).
 - Timing durations use `benchbox.utils.clock.mono_time()` and `elapsed_seconds()`; wall clocks are event/audit only.
 - Adapter SDK imports stay lazy. New SQL platforms subclass `PlatformAdapter` and register with `@register_platform`.
 - CREATE TABLE rewrites are registered under `Phase.DDL_OPTIMIZE`; run `make compat-docs-check` and DDL drift check.
-- Dependency upper bounds exceptional. Current caps: `sqlglot<31`, `click<9`, `pydantic<3`, `pyarrow<25`, `duckdb<2`.
+- Upper bounds exceptional. Current caps (core): `sqlglot<31`, `click<9`, `pydantic<3`, `pyarrow<25`, `duckdb<2`.
 - CLI dry runs must propagate explicit phases; deterministic runs use a seed.
 - Green focused/fast tests are not UAT or production certification.
 
-Apple/macOS notes: correctness-gate digests are Linux-generated; `make ci-linux` for parity (release-guide.md).
-Mocker is local-only, never CI; multi-service stacks are unvalidated. See `docs/operations/uat-framework.md`
-("Mocker validation status") for per-stack state, lifecycle, and caveats. Never globally prune without approval.
+Apple/macOS: correctness-gate digests are Linux-generated; use `make ci-linux` (release-guide.md). Mocker is local-only,
+never CI: databend's `minio` was observed to exit under it; doris/starrocks are single-service. `docs/operations/uat-
+framework.md` ("Mocker validation status") holds per-stack state. Never globally prune without approval.
 
 ## Skills and generated mirrors
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -139,7 +139,7 @@ never claimable items).
 - Timing durations use `benchbox.utils.clock.mono_time()` and `elapsed_seconds()`; wall clocks are event/audit only.
 - Adapter SDK imports stay lazy. New SQL platforms subclass `PlatformAdapter` and register with `@register_platform`.
 - CREATE TABLE rewrites are registered under `Phase.DDL_OPTIMIZE`; run `make compat-docs-check` and DDL drift check.
-- Upper bounds exceptional. Current caps (core): `sqlglot<31`, `click<9`, `pydantic<3`, `pyarrow<25`, `duckdb<2`.
+- Upper bounds exceptional; `pyproject.toml` owns them, `docs/development/dependency-compatibility.md` explains them.
 - CLI dry runs must propagate explicit phases; deterministic runs use a seed.
 - Green focused/fast tests are not UAT or production certification.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -137,7 +137,8 @@ never claimable items).
 ## BenchBox invariants
 
 - Timing durations use `benchbox.utils.clock.mono_time()` and `elapsed_seconds()`; wall clocks are event/audit only.
-- Adapter SDK imports stay lazy. New SQL platforms subclass `PlatformAdapter` and register with `@register_platform`.
+- Adapter SDK imports stay lazy. New platforms follow `docs/development/adding-new-platforms.md` (manifest-driven;
+  decorator discovery was rejected) and must pass `make platform-manifest-check`.
 - CREATE TABLE rewrites are registered under `Phase.DDL_OPTIMIZE`; run `make compat-docs-check` and DDL drift check.
 - CLI dry runs must propagate explicit phases; deterministic runs use a seed.
 - Green focused/fast tests are not UAT or production certification.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -139,7 +139,6 @@ never claimable items).
 - Timing durations use `benchbox.utils.clock.mono_time()` and `elapsed_seconds()`; wall clocks are event/audit only.
 - Adapter SDK imports stay lazy. New SQL platforms subclass `PlatformAdapter` and register with `@register_platform`.
 - CREATE TABLE rewrites are registered under `Phase.DDL_OPTIMIZE`; run `make compat-docs-check` and DDL drift check.
-- Upper bounds exceptional; `pyproject.toml` owns them, `docs/development/dependency-compatibility.md` explains them.
 - CLI dry runs must propagate explicit phases; deterministic runs use a seed.
 - Green focused/fast tests are not UAT or production certification.
 

--- a/_project/scripts/agent_instruction_audit.py
+++ b/_project/scripts/agent_instruction_audit.py
@@ -13,14 +13,6 @@ from dataclasses import asdict, dataclass
 from pathlib import Path
 from typing import Any
 
-try:
-    import tomllib
-except ModuleNotFoundError:  # Python 3.10
-    import tomli as tomllib  # type: ignore[no-redef]
-
-from packaging.requirements import InvalidRequirement, Requirement
-from packaging.version import InvalidVersion, Version
-
 ROOT = Path(__file__).resolve().parents[2]
 DEFAULT_CORPUS = ROOT / "_project/evals/agent-instructions/scenarios.json"
 ADAPTERS = ("CLAUDE.md", "GEMINI.md", "ANTIGRAVITY.md")
@@ -33,6 +25,7 @@ REQUIRED_POLICY_IDS = {
     "COMMIT-IDENTITY-001",
     "REVIEW-AUTH-001",
     "REVIEW-DEFECT-001",
+    "REVIEW-DEPTH-001",
     "REVIEW-L2-001",
     "REVIEW-CAPTURE-001",
     "REVIEW-PARITY-001",
@@ -50,6 +43,7 @@ CANONICAL_REVIEW_ANCHORS = {
         "without changing tracked worktree content",
         "combines review and remediation remains review-only",
     ),
+    "REVIEW-DEPTH-001": ("L1", "L2", "L3"),
     "REVIEW-DEFECT-001": ("classify it as a defect", "never in blind-spots"),
     "REVIEW-L2-001": ("gaps in the review framework", "not defects already found"),
     "REVIEW-CAPTURE-001": ("protocol governs behavior", "governs storage formats"),
@@ -486,6 +480,64 @@ def audit_commit_range(project: Path, base_ref: str) -> list[str]:
     return errors
 
 
+def _requirement_name(requirement: str) -> str:
+    """Leading distribution name of a PEP 508 requirement string."""
+    match = re.match(r"\s*([A-Za-z0-9][A-Za-z0-9._-]*)", requirement)
+    return match.group(1) if match else ""
+
+
+def _normalize(name: str) -> str:
+    """PEP 503 normalized name, so `foo_bar` and `Foo-Bar` compare equal."""
+    return re.sub(r"[-_.]+", "-", name).casefold()
+
+
+def _version_tuple(version: str) -> tuple[int, ...] | None:
+    """Numeric release components, or None when the version is not comparable."""
+    release = re.match(r"(\d+(?:\.\d+)*)", version.strip())
+    if not release:
+        return None
+    return tuple(int(part) for part in release.group(1).split("."))
+
+
+def _upper_bounds(requirement: str) -> list[str]:
+    """Every `<` bound in a requirement, excluding `<=`."""
+    specifier = requirement.split(";", 1)[0]
+    return re.findall(r"<(?!=)\s*([0-9][0-9A-Za-z_.*+!-]*)", specifier)
+
+
+def _manifest_requirements(manifest: str) -> dict[str, list[str]]:
+    """Quoted requirement strings per dependency table, stdlib-only.
+
+    Deliberately not `tomllib`/`tomli`/`packaging`: `.github/workflows/pr.yml`
+    runs this file with bare `python3` before `uv sync`, so a non-stdlib import
+    here hard-fails the required skill-integrity lane. 3.10 is also supported
+    and has no `tomllib`.
+    """
+    groups: dict[str, list[str]] = {}
+    table = ""
+    key = ""
+    for line in manifest.splitlines():
+        stripped = line.strip()
+        if stripped.startswith("["):
+            table = stripped.strip("[]")
+            key = ""
+            continue
+        assignment = re.match(r"([A-Za-z0-9._-]+)\s*=", stripped)
+        if assignment:
+            key = assignment.group(1)
+        if table not in {"project", "project.optional-dependencies", "dependency-groups"}:
+            continue
+        if table == "project" and key != "dependencies":
+            continue
+        label = table if table != "project" else "project.dependencies"
+        if table != "project" and key:
+            label = f"{table}.{key}"
+        for quoted in re.findall(r'"([^"]+)"', stripped):
+            if _requirement_name(quoted):
+                groups.setdefault(label, []).append(quoted)
+    return groups
+
+
 def audit_dependency_caps(project: Path) -> list[str]:
     """Pin AGENTS.md's advertised dependency caps to `pyproject.toml`.
 
@@ -494,80 +546,70 @@ def audit_dependency_caps(project: Path) -> list[str]:
     `pyarrow<24` while the manifest had moved to `<25`. This is the
     deterministic invariant `docs/operations/agent-instruction-evaluation.md`
     asks for -- it fails the audit instead of relying on a reader noticing.
+
+    Every dependency table is scanned, `[dependency-groups]` included: CI
+    installs with `uv sync --group dev`, so a cap dropped there is a cap the
+    real install path loses.
     """
     errors: list[str] = []
     agents = _read(project, "AGENTS.md")
-    caps_line = next((line for line in agents.splitlines() if "Current caps:" in line), "")
+    caps_line = next((line for line in agents.splitlines() if "Current caps" in line), "")
     if not caps_line:
         return ["AGENTS.md does not advertise dependency caps"]
-    advertised = dict(re.findall(r"`([A-Za-z0-9_.-]+)<([0-9][0-9A-Za-z_.-]*)`", caps_line))
+
+    _, _, tail = caps_line.partition("Current caps")
+    entries = re.findall(r"`([^`]+)`", tail.partition(":")[2])
+    advertised: dict[str, str] = {}
+    for entry in entries:
+        parsed = re.fullmatch(r"([A-Za-z0-9][A-Za-z0-9._-]*)<([0-9][0-9A-Za-z_.]*)", entry.strip())
+        if not parsed:
+            errors.append(f"AGENTS.md caps entry `{entry}` is not a plain `name<version`")
+            continue
+        advertised[parsed.group(1)] = parsed.group(2)
     if not advertised:
-        return ["AGENTS.md dependency caps line has no parsable `name<version` entries"]
+        return errors or ["AGENTS.md dependency caps line has no parsable `name<version` entries"]
 
-    manifest_path = project / "pyproject.toml"
     try:
-        manifest = tomllib.loads(manifest_path.read_text(encoding="utf-8"))
-    except (OSError, tomllib.TOMLDecodeError) as exc:
-        return [f"cannot read pyproject.toml: {exc}"]
-
-    project_table = manifest.get("project", {})
-    requirement_groups = {
-        "project.dependencies": project_table.get("dependencies", []),
-        **{
-            f"project.optional-dependencies.{group}": requirements
-            for group, requirements in project_table.get("optional-dependencies", {}).items()
-        },
-    }
+        manifest = (project / "pyproject.toml").read_text(encoding="utf-8")
+    except OSError as exc:
+        return [*errors, f"cannot read pyproject.toml: {exc}"]
+    requirement_groups = _manifest_requirements(manifest)
 
     for name, cap in sorted(advertised.items()):
-        try:
-            advertised_version = Version(cap)
-        except InvalidVersion:
-            errors.append(f"AGENTS.md advertises `{name}<{cap}` with an invalid version")
+        wanted = _version_tuple(cap)
+        if wanted is None:
+            errors.append(f"AGENTS.md advertises `{name}<{cap}` with an uncomparable version")
             continue
-
-        matches: list[tuple[str, Requirement]] = []
-        for group, requirement_strings in requirement_groups.items():
-            for requirement_string in requirement_strings:
-                try:
-                    requirement = Requirement(requirement_string)
-                except InvalidRequirement:
-                    continue
-                if requirement.name.casefold() == name.casefold():
-                    matches.append((group, requirement))
-
-        base_matches = [requirement for group, requirement in matches if group == "project.dependencies"]
-        if base_matches:
-            checks = [("project.dependencies", requirement) for requirement in base_matches]
-        else:
-            # Optional groups can be installed independently. With no core
-            # bound to constrain every installation, each declaration must
-            # carry the advertised cap rather than borrowing one from an
-            # unrelated extra such as `dev`.
-            checks = matches
-
+        matches = [
+            (label, requirement)
+            for label, requirements in requirement_groups.items()
+            for requirement in requirements
+            if _normalize(_requirement_name(requirement)) == _normalize(name)
+        ]
         if not matches:
             errors.append(f"AGENTS.md advertises `{name}<{cap}` but pyproject.toml declares no upper bound for it")
             continue
-
-        for group, requirement in checks:
-            bounds = [specifier for specifier in requirement.specifier if specifier.operator == "<"]
+        # An unconditional core requirement constrains every install, so extras
+        # may restate the package without repeating the bound. A core entry
+        # carrying an environment marker does not constrain every install, so
+        # in that case each declaration must carry the cap itself.
+        core = [
+            (label, requirement)
+            for label, requirement in matches
+            if label == "project.dependencies" and ";" not in requirement
+        ]
+        checks = core if any(_upper_bounds(requirement) for _, requirement in core) else matches
+        for label, requirement in checks:
+            bounds = _upper_bounds(requirement)
             if not bounds:
                 errors.append(
-                    f"AGENTS.md advertises `{name}<{cap}` but [{group}] declares `{requirement}` without that bound"
+                    f"AGENTS.md advertises `{name}<{cap}` but [{label}] declares `{requirement}` without that bound"
                 )
                 continue
             for bound in bounds:
-                try:
-                    actual_version = Version(bound.version)
-                except InvalidVersion:
-                    errors.append(f"[{group}] declares `{requirement}` with invalid upper bound <{bound.version}")
-                    continue
-                if actual_version != advertised_version:
-                    errors.append(
-                        f"AGENTS.md advertises `{name}<{cap}` but [{group}] declares "
-                        f"`{requirement}` with <{bound.version}"
-                    )
+                found = _version_tuple(bound)
+                if found is None or found[: len(wanted)] != wanted:
+                    errors.append(f"AGENTS.md advertises `{name}<{cap}` but [{label}] pins <{bound}")
     return errors
 
 

--- a/_project/scripts/agent_instruction_audit.py
+++ b/_project/scripts/agent_instruction_audit.py
@@ -480,137 +480,30 @@ def audit_commit_range(project: Path, base_ref: str) -> list[str]:
     return errors
 
 
-def _requirement_name(requirement: str) -> str:
-    """Leading distribution name of a PEP 508 requirement string."""
-    match = re.match(r"\s*([A-Za-z0-9][A-Za-z0-9._-]*)", requirement)
-    return match.group(1) if match else ""
-
-
-def _normalize(name: str) -> str:
-    """PEP 503 normalized name, so `foo_bar` and `Foo-Bar` compare equal."""
-    return re.sub(r"[-_.]+", "-", name).casefold()
-
-
-def _version_tuple(version: str) -> tuple[int, ...] | None:
-    """Numeric release components, or None when the version is not comparable."""
-    release = re.match(r"(\d+(?:\.\d+)*)", version.strip())
-    if not release:
-        return None
-    return tuple(int(part) for part in release.group(1).split("."))
-
-
-def _upper_bounds(requirement: str) -> list[str]:
-    """Every `<` bound in a requirement, excluding `<=`."""
-    specifier = requirement.split(";", 1)[0]
-    return re.findall(r"<(?!=)\s*([0-9][0-9A-Za-z_.*+!-]*)", specifier)
-
-
-def _manifest_requirements(manifest: str) -> dict[str, list[str]]:
-    """Quoted requirement strings per dependency table, stdlib-only.
-
-    Deliberately not `tomllib`/`tomli`/`packaging`: `.github/workflows/pr.yml`
-    runs this file with bare `python3` before `uv sync`, so a non-stdlib import
-    here hard-fails the required skill-integrity lane. 3.10 is also supported
-    and has no `tomllib`.
-    """
-    groups: dict[str, list[str]] = {}
-    table = ""
-    key = ""
-    for line in manifest.splitlines():
-        stripped = line.strip()
-        if stripped.startswith("["):
-            table = stripped.strip("[]")
-            key = ""
-            continue
-        assignment = re.match(r"([A-Za-z0-9._-]+)\s*=", stripped)
-        if assignment:
-            key = assignment.group(1)
-        if table not in {"project", "project.optional-dependencies", "dependency-groups"}:
-            continue
-        if table == "project" and key != "dependencies":
-            continue
-        label = table if table != "project" else "project.dependencies"
-        if table != "project" and key:
-            label = f"{table}.{key}"
-        for quoted in re.findall(r'"([^"]+)"', stripped):
-            if _requirement_name(quoted):
-                groups.setdefault(label, []).append(quoted)
-    return groups
-
-
 def audit_dependency_caps(project: Path) -> list[str]:
-    """Pin AGENTS.md's advertised dependency caps to `pyproject.toml`.
+    """Forbid AGENTS.md restating dependency version caps.
 
-    AGENTS.md restates upper bounds so an agent does not have to open the
-    manifest. A restated fact drifts silently: the file advertised
-    `pyarrow<24` while the manifest had moved to `<25`. This is the
-    deterministic invariant `docs/operations/agent-instruction-evaluation.md`
-    asks for -- it fails the audit instead of relying on a reader noticing.
+    `pyproject.toml` owns the bounds and carries the rationale inline;
+    `docs/development/dependency-compatibility.md` explains them. AGENTS.md
+    used to restate the list as a convenience, and it drifted silently --
+    advertising `pyarrow<24` long after the manifest moved to `<25`.
 
-    Every dependency table is scanned, `[dependency-groups]` included: CI
-    installs with `uv sync --group dev`, so a cap dropped there is a cap the
-    real install path loses.
+    A synchronization check would have to run forever to keep a duplicate
+    honest. Deleting the duplicate ends the drift class instead, so this
+    invariant guards the deletion: reintroducing a restated cap fails the
+    audit. It is deliberately the inverse of the check it replaces.
     """
-    errors: list[str] = []
     agents = _read(project, "AGENTS.md")
-    caps_line = next((line for line in agents.splitlines() if "Current caps" in line), "")
-    if not caps_line:
-        return ["AGENTS.md does not advertise dependency caps"]
-
-    _, _, tail = caps_line.partition("Current caps")
-    entries = re.findall(r"`([^`]+)`", tail.partition(":")[2])
-    advertised: dict[str, str] = {}
-    for entry in entries:
-        parsed = re.fullmatch(r"([A-Za-z0-9][A-Za-z0-9._-]*)<([0-9][0-9A-Za-z_.]*)", entry.strip())
-        if not parsed:
-            errors.append(f"AGENTS.md caps entry `{entry}` is not a plain `name<version`")
-            continue
-        advertised[parsed.group(1)] = parsed.group(2)
-    if not advertised:
-        return errors or ["AGENTS.md dependency caps line has no parsable `name<version` entries"]
-
-    try:
-        manifest = (project / "pyproject.toml").read_text(encoding="utf-8")
-    except OSError as exc:
-        return [*errors, f"cannot read pyproject.toml: {exc}"]
-    requirement_groups = _manifest_requirements(manifest)
-
-    for name, cap in sorted(advertised.items()):
-        wanted = _version_tuple(cap)
-        if wanted is None:
-            errors.append(f"AGENTS.md advertises `{name}<{cap}` with an uncomparable version")
-            continue
-        matches = [
-            (label, requirement)
-            for label, requirements in requirement_groups.items()
-            for requirement in requirements
-            if _normalize(_requirement_name(requirement)) == _normalize(name)
+    # No per-line exemption: an exemption keyed on the pointer text would be
+    # defeated by putting the caps on the same line as the pointer.
+    offenders = re.findall(r"`([A-Za-z0-9][A-Za-z0-9._-]*\s*<=?\s*[0-9][0-9A-Za-z_.]*)`", agents)
+    if offenders:
+        return [
+            "AGENTS.md restates dependency caps ("
+            + ", ".join(sorted(set(offenders)))
+            + "); pyproject.toml owns them and docs/development/dependency-compatibility.md explains them"
         ]
-        if not matches:
-            errors.append(f"AGENTS.md advertises `{name}<{cap}` but pyproject.toml declares no upper bound for it")
-            continue
-        # An unconditional core requirement constrains every install, so extras
-        # may restate the package without repeating the bound. A core entry
-        # carrying an environment marker does not constrain every install, so
-        # in that case each declaration must carry the cap itself.
-        core = [
-            (label, requirement)
-            for label, requirement in matches
-            if label == "project.dependencies" and ";" not in requirement
-        ]
-        checks = core if any(_upper_bounds(requirement) for _, requirement in core) else matches
-        for label, requirement in checks:
-            bounds = _upper_bounds(requirement)
-            if not bounds:
-                errors.append(
-                    f"AGENTS.md advertises `{name}<{cap}` but [{label}] declares `{requirement}` without that bound"
-                )
-                continue
-            for bound in bounds:
-                found = _version_tuple(bound)
-                if found is None or found[: len(wanted)] != wanted:
-                    errors.append(f"AGENTS.md advertises `{name}<{cap}` but [{label}] pins <{bound}")
-    return errors
+    return []
 
 
 def audit_scenarios(scenarios: list[dict[str, Any]], policy_text: str) -> list[str]:

--- a/_project/scripts/agent_instruction_audit.py
+++ b/_project/scripts/agent_instruction_audit.py
@@ -483,15 +483,17 @@ def audit_commit_range(project: Path, base_ref: str) -> list[str]:
 def audit_dependency_caps(project: Path) -> list[str]:
     """Forbid AGENTS.md restating dependency version caps.
 
-    `pyproject.toml` owns the bounds and carries the rationale inline;
-    `docs/development/dependency-compatibility.md` explains them. AGENTS.md
-    used to restate the list as a convenience, and it drifted silently --
-    advertising `pyarrow<24` long after the manifest moved to `<25`.
+    Bounds are already owned mechanically three times over: `pyproject.toml`
+    declares them with rationale inline, `uv lock` enforces them at install,
+    and `scripts/check_dependency_bounds.py --fail-on=cap-reached` blocks in
+    `test.yml` and `release.yml`. `docs/development/dependency-compatibility.md`
+    explains them. None of that needs an agent to be told anything.
 
-    A synchronization check would have to run forever to keep a duplicate
-    honest. Deleting the duplicate ends the drift class instead, so this
-    invariant guards the deletion: reintroducing a restated cap fails the
-    audit. It is deliberately the inverse of the check it replaces.
+    AGENTS.md restated the list anyway, and it drifted -- advertising
+    `pyarrow<24` long after the manifest moved to `<25`. A synchronization
+    check would have to run forever to keep that duplicate honest. The
+    duplicate is gone; this invariant guards its absence, so the drift class
+    cannot return through a well-meaning convenience edit.
     """
     agents = _read(project, "AGENTS.md")
     # No per-line exemption: an exemption keyed on the pointer text would be

--- a/tests/unit/scripts/test_agent_instruction_audit.py
+++ b/tests/unit/scripts/test_agent_instruction_audit.py
@@ -717,7 +717,7 @@ def test_restating_a_dependency_cap_in_agents_md_fails(tmp_path: Path) -> None:
     """`pyproject.toml` owns the bounds; a restated copy drifted once already."""
     project = _candidate(tmp_path)
     agents = project / "AGENTS.md"
-    agents.write_text(agents.read_text().replace("- Upper bounds exceptional;", "- Caps: `pyarrow<25`;"))
+    agents.write_text(agents.read_text() + "\n- Caps: `pyarrow<25`.\n")
     _, errors = audit(project, CORPUS)
     assert any("restates dependency caps" in error and "pyarrow<25" in error for error in errors)
 
@@ -727,10 +727,7 @@ def test_the_cap_guard_is_not_defeated_by_same_line_placement(tmp_path: Path) ->
     project = _candidate(tmp_path)
     agents = project / "AGENTS.md"
     agents.write_text(
-        agents.read_text().replace(
-            "- Upper bounds exceptional;",
-            "- Upper bounds exceptional. Caps: `duckdb<2`;",
-        )
+        agents.read_text() + "\n- See `docs/development/dependency-compatibility.md`; caps: `duckdb<2`.\n"
     )
     _, errors = audit(project, CORPUS)
     assert any("restates dependency caps" in error and "duckdb<2" in error for error in errors)

--- a/tests/unit/scripts/test_agent_instruction_audit.py
+++ b/tests/unit/scripts/test_agent_instruction_audit.py
@@ -732,3 +732,54 @@ def test_each_independent_optional_dependency_keeps_the_advertised_cap(tmp_path:
     manifest.write_text(manifest.read_text().replace('duckdb = ["duckdb>=1.0.0,<2.0.0"]', 'duckdb = ["duckdb>=1.0.0"]'))
     _, errors = audit(project, CORPUS)
     assert any("project.optional-dependencies.duckdb" in error and "without that bound" in error for error in errors)
+
+
+def test_audit_entry_point_imports_without_third_party_packages() -> None:
+    """`.github/workflows/pr.yml` runs this file with bare `python3` before `uv sync`.
+
+    A non-stdlib import at module scope hard-fails the required skill-integrity
+    lane. That lane is path-filtered, so the PR that introduced `packaging` and
+    `tomli` never exercised it.
+    """
+    source = (ROOT / "_project/scripts/agent_instruction_audit.py").read_text(encoding="utf-8")
+    forbidden = ("import packaging", "from packaging", "import tomli", "import tomllib")
+    offenders = [needle for needle in forbidden if needle in source]
+    assert not offenders, f"audit entry point imports non-stdlib modules: {offenders}"
+
+
+def test_dependency_group_cap_drift_is_caught(tmp_path: Path) -> None:
+    """CI installs with `uv sync --group dev`, so a cap dropped there is real drift."""
+    project = _candidate(tmp_path)
+    manifest = project / "pyproject.toml"
+    text = manifest.read_text(encoding="utf-8")
+    head, marker, tail = text.partition("[dependency-groups]")
+    manifest.write_text(head + marker + tail.replace('"duckdb>=1.0.0,<2.0.0"', '"duckdb>=1.0.0"', 1))
+    _, errors = audit(project, CORPUS)
+    assert any("duckdb" in error and "without that bound" in error for error in errors)
+
+
+def test_a_shorter_advertised_cap_does_not_prefix_match(tmp_path: Path) -> None:
+    """`sqlglot<3` must not pass against a manifest bound of `<31.0.0`."""
+    project = _candidate(tmp_path)
+    agents = project / "AGENTS.md"
+    agents.write_text(agents.read_text().replace("`sqlglot<31`", "`sqlglot<3`"))
+    _, errors = audit(project, CORPUS)
+    assert any("sqlglot" in error and "pins <31" in error for error in errors)
+
+
+def test_a_non_plain_advertised_cap_is_rejected_not_ignored(tmp_path: Path) -> None:
+    """An advertised `<=` used to be dropped by the parser and silently pass."""
+    project = _candidate(tmp_path)
+    agents = project / "AGENTS.md"
+    agents.write_text(agents.read_text().replace("`pyarrow<25`", "`pyarrow<=25`"))
+    _, errors = audit(project, CORPUS)
+    assert any("pyarrow<=25" in error and "not a plain" in error for error in errors)
+
+
+def test_missing_review_depth_binding_fails_the_parity_audit(tmp_path: Path) -> None:
+    """REVIEW-PARITY-001 requires REVIEW-DEPTH-001; the audit must enforce it."""
+    project = _candidate(tmp_path)
+    protocol = project / "docs/agent/review-protocol.md"
+    protocol.write_text(re.sub(r"- `\[REVIEW-DEPTH-001\]`.*?\n(?=- )", "", protocol.read_text(), flags=re.S))
+    _, errors = audit(project, CORPUS)
+    assert any("REVIEW-DEPTH-001" in error for error in errors)

--- a/tests/unit/scripts/test_agent_instruction_audit.py
+++ b/tests/unit/scripts/test_agent_instruction_audit.py
@@ -691,49 +691,6 @@ def test_the_precommit_hook_name_does_not_claim_a_single_check() -> None:
     )
 
 
-def test_advertised_dependency_cap_behind_the_manifest_fails(tmp_path: Path) -> None:
-    """The exact drift that shipped: AGENTS.md said `pyarrow<24`, manifest said <25."""
-    project = _candidate(tmp_path)
-    agents = project / "AGENTS.md"
-    agents.write_text(agents.read_text().replace("`pyarrow<25`", "`pyarrow<24`"))
-    _, errors = audit(project, CORPUS)
-    assert any("pyarrow" in error and "dependency-caps" in error for error in errors)
-
-
-def test_advertised_cap_without_a_manifest_bound_fails(tmp_path: Path) -> None:
-    """An advertised cap for a dependency the manifest never bounds is drift too."""
-    project = _candidate(tmp_path)
-    agents = project / "AGENTS.md"
-    agents.write_text(agents.read_text().replace("`duckdb<2`", "`nonexistentpkg<9`"))
-    _, errors = audit(project, CORPUS)
-    assert any("nonexistentpkg" in error and "declares no upper bound" in error for error in errors)
-
-
-def test_optional_dependency_caps_are_honoured(tmp_path: Path) -> None:
-    """`duckdb` is bounded only under optional-dependencies; that must still count."""
-    project = _candidate(tmp_path)
-    _, errors = audit(project, CORPUS)
-    assert not [error for error in errors if "duckdb" in error]
-
-
-def test_advertised_cap_is_not_accepted_as_a_version_prefix(tmp_path: Path) -> None:
-    """`sqlglot<3` must not pass merely because the manifest says `<31.0.0`."""
-    project = _candidate(tmp_path)
-    agents = project / "AGENTS.md"
-    agents.write_text(agents.read_text().replace("`sqlglot<31`", "`sqlglot<3`"))
-    _, errors = audit(project, CORPUS)
-    assert any("sqlglot<3" in error and "<31.0.0" in error for error in errors)
-
-
-def test_each_independent_optional_dependency_keeps_the_advertised_cap(tmp_path: Path) -> None:
-    """A bound in `dev` must not hide a missing bound in the `duckdb` extra."""
-    project = _candidate(tmp_path)
-    manifest = project / "pyproject.toml"
-    manifest.write_text(manifest.read_text().replace('duckdb = ["duckdb>=1.0.0,<2.0.0"]', 'duckdb = ["duckdb>=1.0.0"]'))
-    _, errors = audit(project, CORPUS)
-    assert any("project.optional-dependencies.duckdb" in error and "without that bound" in error for error in errors)
-
-
 def test_audit_entry_point_imports_without_third_party_packages() -> None:
     """`.github/workflows/pr.yml` runs this file with bare `python3` before `uv sync`.
 
@@ -747,35 +704,6 @@ def test_audit_entry_point_imports_without_third_party_packages() -> None:
     assert not offenders, f"audit entry point imports non-stdlib modules: {offenders}"
 
 
-def test_dependency_group_cap_drift_is_caught(tmp_path: Path) -> None:
-    """CI installs with `uv sync --group dev`, so a cap dropped there is real drift."""
-    project = _candidate(tmp_path)
-    manifest = project / "pyproject.toml"
-    text = manifest.read_text(encoding="utf-8")
-    head, marker, tail = text.partition("[dependency-groups]")
-    manifest.write_text(head + marker + tail.replace('"duckdb>=1.0.0,<2.0.0"', '"duckdb>=1.0.0"', 1))
-    _, errors = audit(project, CORPUS)
-    assert any("duckdb" in error and "without that bound" in error for error in errors)
-
-
-def test_a_shorter_advertised_cap_does_not_prefix_match(tmp_path: Path) -> None:
-    """`sqlglot<3` must not pass against a manifest bound of `<31.0.0`."""
-    project = _candidate(tmp_path)
-    agents = project / "AGENTS.md"
-    agents.write_text(agents.read_text().replace("`sqlglot<31`", "`sqlglot<3`"))
-    _, errors = audit(project, CORPUS)
-    assert any("sqlglot" in error and "pins <31" in error for error in errors)
-
-
-def test_a_non_plain_advertised_cap_is_rejected_not_ignored(tmp_path: Path) -> None:
-    """An advertised `<=` used to be dropped by the parser and silently pass."""
-    project = _candidate(tmp_path)
-    agents = project / "AGENTS.md"
-    agents.write_text(agents.read_text().replace("`pyarrow<25`", "`pyarrow<=25`"))
-    _, errors = audit(project, CORPUS)
-    assert any("pyarrow<=25" in error and "not a plain" in error for error in errors)
-
-
 def test_missing_review_depth_binding_fails_the_parity_audit(tmp_path: Path) -> None:
     """REVIEW-PARITY-001 requires REVIEW-DEPTH-001; the audit must enforce it."""
     project = _candidate(tmp_path)
@@ -783,3 +711,26 @@ def test_missing_review_depth_binding_fails_the_parity_audit(tmp_path: Path) -> 
     protocol.write_text(re.sub(r"- `\[REVIEW-DEPTH-001\]`.*?\n(?=- )", "", protocol.read_text(), flags=re.S))
     _, errors = audit(project, CORPUS)
     assert any("REVIEW-DEPTH-001" in error for error in errors)
+
+
+def test_restating_a_dependency_cap_in_agents_md_fails(tmp_path: Path) -> None:
+    """`pyproject.toml` owns the bounds; a restated copy drifted once already."""
+    project = _candidate(tmp_path)
+    agents = project / "AGENTS.md"
+    agents.write_text(agents.read_text().replace("- Upper bounds exceptional;", "- Caps: `pyarrow<25`;"))
+    _, errors = audit(project, CORPUS)
+    assert any("restates dependency caps" in error and "pyarrow<25" in error for error in errors)
+
+
+def test_the_cap_guard_is_not_defeated_by_same_line_placement(tmp_path: Path) -> None:
+    """An exemption keyed on the pointer text would be bypassed by one line."""
+    project = _candidate(tmp_path)
+    agents = project / "AGENTS.md"
+    agents.write_text(
+        agents.read_text().replace(
+            "- Upper bounds exceptional;",
+            "- Upper bounds exceptional. Caps: `duckdb<2`;",
+        )
+    )
+    _, errors = audit(project, CORPUS)
+    assert any("restates dependency caps" in error and "duckdb<2" in error for error in errors)


### PR DESCRIPTION
Four commits, driven by three adversarial review cycles and two owner questions that each invalidated a premise of the previous commit.

## 1. The audit entry point stopped being stdlib-only (blocking)

`.github/workflows/pr.yml:335` runs `python3 _project/scripts/agent_instruction_audit.py` **before** installing uv. A commit on #1801 added `packaging` and `tomli` imports to that entry point. On bare `python3` it raised `ModuleNotFoundError: No module named 'tomli'` at line 19. The `skill-integrity` lane is path-filtered on `.claude/skills/**`, so it was SKIPPED on #1801 and CI never exercised the broken path.

Manifest parsing is stdlib again. Versions compare on release components, so `sqlglot<3` still fails against `<31.0.0`. `[dependency-groups]` is scanned, since CI installs `uv sync --group dev`.

## 2. Then: why is this in AGENTS.md at all?

The caps list was a **third copy**. `pyproject.toml` declares the bounds with rationale inline; `docs/development/dependency-compatibility.md` explains them. AGENTS.md restated them and drifted, advertising `pyarrow<24` after the manifest moved to `<25`.

The synchronization check was the wrong shape: it accepted the duplicate as permanent and committed to policing it forever, which is why it kept accreting — environment markers, optional-dependency precedence, dependency-groups, version-prefix comparison, `<=` rejection. All of it existed only because the copy existed. The invariant is **inverted**: restating a cap in AGENTS.md now fails the audit. One regex, no manifest parsing.

## 3. Then: why tell an agent about a mechanical check?

Bounds are owned mechanically three times over — `pyproject.toml` declares, `uv lock` enforces at install, and `scripts/check_dependency_bounds.py --fail-on=cap-reached` blocks in `test.yml:365` and `release.yml:94`. The whole bullet is deleted.

Principle: an agent guide carries what an agent must **choose** to do and no machine will catch. A blocking CI gate is the opposite of that.

## 4. `@register_platform` does not exist

AGENTS.md told agents to register new platforms with a decorator that `rg 'def register_platform'` cannot find, and which `adding-new-platforms.md:51-54` records as deliberately **not** introduced — it would weaken the lazy optional-dependency boundary. Now points at the platform guide and `make platform-manifest-check`.

## Also fixed from review

- `REVIEW-DEPTH-001` is **enforced**, not just written. #1801 added the binding but left the ID out of `REQUIRED_POLICY_IDS`, so deleting it kept the audit green. Canonical anchors now pin its L1/L2/L3 content.
- Mocker named facts restored. `uat-framework.md` records that commit `fd29aa77c0` already compressed this to a vague line and calls that a drift incident; #1801 repeated it.
- `mergeable_state: dirty` restored over bare `dirty`, which reads as worktree dirtiness.
- The snapshot clause said a snapshot is evidence "when you state its age", which let an agent date a stale export and still assert current state. It now says a snapshot dates a past state and never a current one.

## Verification

- Audit **PASS on bare `/usr/bin/python3`** — no uv, no third-party imports
- `make pr-preflight`: **27,928 passed**, 19 skipped
- 69 audit tests; eight obsolete synchronization tests deleted with the code they covered
- AGENTS.md **163 → 164 lines**, budget warning clear (threshold 164.9)
- Negative controls: reintroducing a restated cap fails; the guard is not defeatable by same-line placement; deleting the REVIEW-DEPTH binding fails

Reviewed by grok, codex and agy across three cycles. Final verdict MERGE WITH CHANGES, holding only for this body rewrite and the `@register_platform` fix — both now done.

Follow-ups deliberately **not** in this PR: ~24 further lines of restatement identified in AGENTS.md, `docs/agent/review-protocol.md` duplicating behavioural rules the shared skill forbids it to duplicate, eight dead AGENTS.md heading pointers in Makefile and ops docs, and `dependency-compatibility.md` itself having drifted from the manifest.
