### PR TITLE
fix(uat): consume run-official quiet result path

### DIFF
--- a/benchbox/cli/commands/run_official.py
+++ b/benchbox/cli/commands/run_official.py
@@ -61,6 +61,7 @@ def _forward_requested_streams(streams: int | None) -> Iterator[None]:
 @click.option("--seed", type=int, help="Random seed for reproducible official runs")
 @click.option("--output", "output_dir", type=click.Path(), help="Output directory")
 @click.option("--verbose", "-v", is_flag=True, help="Enable verbose logging")
+@click.option("-q", "--quiet", is_flag=True, help="Emit the exported result path on the final non-empty stdout line")
 @click.option("--validate-results", is_flag=True, help="Enable result validation")
 @click.pass_context
 def run_official(
@@ -74,6 +75,7 @@ def run_official(
     seed,
     output_dir,
     verbose,
+    quiet,
     validate_results,
 ):
     """Run TPC-compliant official benchmark tests. Deprecated; use `benchbox run --official`."""
@@ -84,7 +86,7 @@ def run_official(
         console.print(f"Allowed scale factors: {sorted(TPC_ALLOWED_SCALE_FACTORS)}")
         sys.exit(1)
 
-    if seed is None:
+    if seed is None and not quiet:
         console.print("[yellow]Warning: No seed specified. Official TPC runs require a random seed.[/yellow]")
         console.print("Use --seed <N> for reproducible results")
 
@@ -94,20 +96,21 @@ def run_official(
         console.print(f"[red]Error: {exc}[/red]")
         sys.exit(1)
 
-    console.print("[bold blue]TPC-Compliant Official Benchmark Run[/bold blue]")
-    for label, value in [
-        ("Benchmark", f"TPC-{benchmark.upper()}"),
-        ("Platform", platform),
-        ("Scale Factor", scale),
-        ("Phases", phases),
-        ("Streams", streams),
-        ("Seed", seed),
-    ]:
-        if value is not None:
-            console.print(f"{label}: {value}")
-    console.print("")
-    if streams:
-        console.print(f"[green]Concurrency: {streams} concurrent stream(s) will run the throughput phase[/green]")
+    if not quiet:
+        console.print("[bold blue]TPC-Compliant Official Benchmark Run[/bold blue]")
+        for label, value in [
+            ("Benchmark", f"TPC-{benchmark.upper()}"),
+            ("Platform", platform),
+            ("Scale Factor", scale),
+            ("Phases", phases),
+            ("Streams", streams),
+            ("Seed", seed),
+        ]:
+            if value is not None:
+                console.print(f"{label}: {value}")
+        console.print("")
+        if streams:
+            console.print(f"[green]Concurrency: {streams} concurrent stream(s) will run the throughput phase[/green]")
 
     try:
         # Streams is now a first-class run parameter — forwarded as ``concurrency``
@@ -122,6 +125,7 @@ def run_official(
             seed=seed,
             output=output_dir,
             verbose=verbose,
+            quiet=quiet,
             validation=ValidationConfig.parse("full") if validate_results else None,
             platform_option_pairs=platform_option_pairs,
             concurrency=streams,

--- a/docs/reference/public-contracts.md
+++ b/docs/reference/public-contracts.md
@@ -57,6 +57,22 @@ The `textcharts-mcp` external visualization server is intentionally a separate-c
 | `_project` scripts, audits, and analysis artifacts | `repo-only` | maintainers | Contributor workflow and project governance aids; not user-facing API. | Repo workflow docs or TODO updates. | Script-specific tests where present. | `_project/` |
 | TODO, DONE, and ADR/future-state docs | `repo-only` | maintainers | Planning and decision records guide implementation but do not themselves create runtime API. | Move accepted decisions into user/developer docs when they become product contracts. | TODO validation and review. | `_project/TODO/`, `_project/DONE/`, `docs/design/future-state/` |
 
+### CLI compatibility note: deprecated `run-official` quiet-path contract
+
+The hidden deprecated `benchbox run-official` command remains inside the
+beta-public CLI surface as a compatibility shim. Its multi-stream throughput
+support still routes through `--streams`, but result-path discovery is no longer
+allowed to infer from filenames, globs, or mtimes.
+
+When `run-official` is invoked with `--quiet`, it reuses the same contract as
+`benchbox run --quiet`: after a successful export, the **final non-empty stdout
+line is the JSON result path**. UAT's official/throughput branch consumes that
+emitted path directly and must fail loudly if it is missing or invalid; callers
+must not reintroduce directory search as a fallback.
+
+Source of truth: `benchbox/cli/commands/run_official.py`, `tests/uat/runner.py`,
+and `tests/uat/throughput.py`.
+
 ## Support Status Taxonomy
 
 `support_status` is a product-support classification for platforms and

--- a/tests/uat/matrix.py
+++ b/tests/uat/matrix.py
@@ -501,6 +501,7 @@ def benchbox_run_official_argv(
     seed: int | None = None,
     extra_args: Iterable[str] = (),
     local_managed_platform: bool = False,
+    quiet: bool = True,
 ) -> list[str]:
     """Build the `uv run -- benchbox run-official ...` argv for a throughput cell.
 
@@ -510,10 +511,10 @@ def benchbox_run_official_argv(
     can request N>1 concurrent throughput streams today; see
     `tests.uat.throughput` and the `throughput-stream-count-wiring-defect`
     TODO's `deferred` note. `run-official` requires a TPC-compliant scale
-    factor (`tests.uat.throughput.TPC_ALLOWED_SCALE_FACTORS`) and has no
-    `--quiet`/`--non-interactive` flags of its own, so this does not include
-    them -- see `tests.uat.throughput.resolve_official_result_path` for how
-    the runner locates the result JSON without a parseable stdout line.
+    factor (`tests.uat.throughput.TPC_ALLOWED_SCALE_FACTORS`). UAT uses
+    `--quiet` by default so the deprecated command reuses the same final
+    bare-path stdout contract as `benchbox run`; callers can disable it for
+    a verbose diagnostic rerun.
     """
     argv = uv_run_argv(platform)
     argv += [
@@ -531,6 +532,8 @@ def benchbox_run_official_argv(
     ]
     if seed is not None:
         argv += ["--seed", str(seed)]
+    if quiet:
+        argv += ["--quiet"]
     argv += PLATFORM_CLI_FLAGS.get(platform, [])
     argv += docker_assets.platform_extra_opts(platform)
     if local_managed_platform:

--- a/tests/uat/runner.py
+++ b/tests/uat/runner.py
@@ -237,6 +237,77 @@ def _materialize_load_failure_sidecar(
     return result_path, sidecar
 
 
+def _diagnostic_rerun_argv(
+    *,
+    official: bool,
+    platform: str,
+    benchmark: str,
+    scale: float,
+    phases: str,
+    compression: str | None,
+    runs_dir: Path,
+    extra_args,
+    local_managed_platform: bool,
+    streams: int | None,
+    seed: int | None,
+) -> list[str]:
+    """Return the verbose rerun argv for a quiet cell that failed silently."""
+    output_args = ("--output", str(runs_dir / "datagen"), *extra_args)
+    if official:
+        return benchbox_run_official_argv(
+            platform,
+            benchmark,
+            scale,
+            phases=phases,
+            streams=streams,
+            seed=seed,
+            extra_args=output_args,
+            local_managed_platform=local_managed_platform,
+            quiet=False,
+        )
+    return benchbox_run_argv(
+        platform,
+        benchmark,
+        scale,
+        phases=phases,
+        compression=compression,
+        extra_args=output_args,
+        local_managed_platform=local_managed_platform,
+        quiet=False,
+    )
+
+
+def _resolve_cell_result_path(
+    *,
+    official: bool,
+    stdout_text: str,
+    runs_dir: Path,
+    platform: str,
+    benchmark: str,
+    scale: float,
+    started_at: _dt.datetime,
+) -> Path | None:
+    """Resolve the exported result JSON for one cell from its stdout contract."""
+    if official:
+        result_path = resolve_official_result_path(
+            runs_dir / "results",
+            platform=platform,
+            benchmark=benchmark,
+            started_after=started_at,
+            scale=scale,
+            emitted_path=last_nonempty_output_line(stdout_text),
+        )
+        if result_path is not None and (result_path.suffix.lower() != ".json" or not result_path.exists()):
+            return None
+        return result_path
+
+    result_path_str = last_nonempty_output_line(stdout_text)
+    result_path = _resolve_result_path(result_path_str, runs_dir) if result_path_str else None
+    if result_path is not None and (result_path.suffix.lower() != ".json" or not result_path.exists()):
+        return None
+    return result_path
+
+
 def run_cell(
     platform: str,
     benchmark: str,
@@ -321,24 +392,28 @@ def run_cell(
             log_fh.write(stdout_text)
         if timeout_result.timed_out:
             log_fh.write(f"# UAT_TIMEOUT timeout_s={timeout_s} exit_code={timeout_result.exit_code}\n")
-        elif not official and timeout_result.exit_code != 0 and not stdout_text.strip() and not stderr_has_content:
-            # Only `--quiet` `benchbox run` cells can suppress their own error
-            # reporting this way; `run-official` never runs quiet, so an
-            # empty-output failure there is a real crash, not a suppressed
-            # one, and re-running with `quiet=False` would also silently
-            # drop the --streams/--seed flags this cell was built with.
+        elif timeout_result.exit_code != 0 and not stdout_text.strip() and not stderr_has_content:
+            # Both `benchbox run` and `run-official` now run quiet under UAT,
+            # so a nonzero empty-output failure may just mean the CLI
+            # suppressed its own diagnostic text before exiting. Re-run the
+            # SAME cell verbosely (preserving official/streams/seed wiring) and
+            # append that output to the log.
+            rerun_argv = _diagnostic_rerun_argv(
+                official=official,
+                platform=platform,
+                benchmark=benchmark,
+                scale=scale,
+                phases=phases,
+                compression=compression,
+                runs_dir=runs_dir,
+                extra_args=extra_args,
+                local_managed_platform=local_managed_platform,
+                streams=streams,
+                seed=seed,
+            )
             _append_diagnostic_rerun(
                 log_fh,
-                benchbox_run_argv(
-                    platform,
-                    benchmark,
-                    scale,
-                    phases=phases,
-                    compression=compression,
-                    extra_args=("--output", str(runs_dir / "datagen"), *extra_args),
-                    local_managed_platform=local_managed_platform,
-                    quiet=False,
-                ),
+                rerun_argv,
                 timeout_s=min(timeout_s, DIAGNOSTIC_RERUN_TIMEOUT_S),
                 env=env,
             )
@@ -347,26 +422,20 @@ def run_cell(
         # Fail loudly if datagen (or anything else) leaked into the local tree.
         assert_no_local_growth(local_snapshot, external_root)
 
-    if official:
-        # `run-official` has no --quiet flag, so it never prints a bare,
-        # parseable result-path stdout line -- resolve the exported JSON by
-        # filename + mtime instead. It also still exports a result JSON for
-        # a non-clean (exit code != 0) run, so this isn't gated on exit_code.
-        result_path = resolve_official_result_path(
-            runs_dir / "results",
-            platform=platform,
-            benchmark=benchmark,
-            started_after=now,
-            scale=scale,
-        )
-    else:
-        # A failed query can still export a result bundle before the CLI exits
-        # nonzero. Preserve that path so reporting/classification can explain
-        # the query failure instead of misclassifying it as missing JSON.
-        result_path_str = last_nonempty_output_line(stdout_text)
-        result_path = _resolve_result_path(result_path_str, runs_dir) if result_path_str else None
-        if result_path is not None and (result_path.suffix.lower() != ".json" or not result_path.exists()):
-            result_path = None
+    # A failed query can still export a result bundle before the CLI exits
+    # nonzero. Preserve that path so reporting/classification can explain the
+    # query failure instead of misclassifying it as missing JSON. Official
+    # cells use the same helper, but read the backward-compatible emitted-path
+    # wrapper instead of globbing the results directory.
+    result_path = _resolve_cell_result_path(
+        official=official,
+        stdout_text=stdout_text,
+        runs_dir=runs_dir,
+        platform=platform,
+        benchmark=benchmark,
+        scale=scale,
+        started_at=now,
+    )
 
     result_path, load_failure_path = _materialize_load_failure_sidecar(
         log_path=log_path,

--- a/tests/uat/test_matrix.py
+++ b/tests/uat/test_matrix.py
@@ -451,6 +451,25 @@ def test_benchbox_run_argv_velox_iterations_one():
     assert iter_idx < opt_idx
 
 
+def test_benchbox_run_official_argv_includes_quiet_by_default():
+    argv = matrix.benchbox_run_official_argv("duckdb", "tpch", 1, phases="throughput", streams=3, seed=42)
+    assert "--quiet" in argv
+    assert "--streams" in argv and argv[argv.index("--streams") + 1] == "3"
+
+
+def test_benchbox_run_official_argv_can_omit_quiet_for_diagnostics():
+    argv = matrix.benchbox_run_official_argv(
+        "duckdb",
+        "tpch",
+        1,
+        phases="throughput",
+        streams=3,
+        seed=42,
+        quiet=False,
+    )
+    assert "--quiet" not in argv
+
+
 # ---------------------------------------------------------------------------
 # w1 (uat-operator-provisioning): every release-gate platform must resolve
 # from the persistent dev venv (`uv sync` dev group) OR have a

--- a/tests/uat/test_runner.py
+++ b/tests/uat/test_runner.py
@@ -794,17 +794,24 @@ def test_run_cell_official_downgrades_passed_cell_on_stream_count_mismatch(tmp_p
     assert "throughput stream count mismatch" in (result.throughput_check or "")
 
 
-def test_run_cell_official_threads_scale_into_result_resolution(tmp_path: Path):
-    """w3 wiring guard (C2): run_cell must forward its `scale` to resolve_official_result_path
-    so the resolver can filter candidates by the sf<N> token. Every other official test mocks
-    the resolver without asserting kwargs, so deleting `scale=scale` (runner.py) would otherwise
-    pass silently -- this pins the runner->resolver contract.
+def test_run_cell_official_threads_emitted_path_and_scale_into_result_resolution(tmp_path: Path):
+    """run_cell must forward BOTH the emitted quiet-path line and `scale` into the
+    backward-compatible official resolver wrapper. Otherwise the runner silently falls back to
+    a None result even though the CLI emitted the authoritative path.
     """
     result_path = tmp_path / "benchmark_runs" / "results" / "official.json"
     _write_result_json(result_path)
     fake_argv = [sys.executable, "-c", "pass"]
+    timeout_result = TimeoutResult(
+        exit_code=0,
+        timed_out=False,
+        elapsed_s=0.1,
+        stdout=f"{result_path}\n".encode(),
+        stderr=b"",
+    )
     with (
         patch.object(runner, "benchbox_run_official_argv", return_value=fake_argv),
+        patch.object(runner, "run_with_timeout", return_value=timeout_result),
         patch.object(runner, "resolve_official_result_path", return_value=result_path) as mock_resolve,
     ):
         runner.run_cell(
@@ -818,6 +825,7 @@ def test_run_cell_official_threads_scale_into_result_resolution(tmp_path: Path):
         )
 
     mock_resolve.assert_called_once()
+    assert mock_resolve.call_args.kwargs["emitted_path"] == str(result_path)
     assert mock_resolve.call_args.kwargs["scale"] == 1
     assert mock_resolve.call_args.kwargs["platform"] == "duckdb"
     assert mock_resolve.call_args.kwargs["benchmark"] == "tpch"

--- a/tests/uat/test_throughput.py
+++ b/tests/uat/test_throughput.py
@@ -1,9 +1,8 @@
 """Fast-test coverage for tests/uat/throughput.py.
 
-Covers the two pieces a `run-official --streams N`-backed UAT cell needs
-that a `--quiet` `benchbox run` cell gets for free (see the module
-docstring in tests/uat/throughput.py): locating the result JSON on disk,
-and validating a throughput result against the requested stream count.
+Covers the two pieces a `run-official --streams N`-backed UAT cell needs:
+resolving the emitted quiet result path, and validating a throughput result
+against the requested stream count.
 """
 
 from __future__ import annotations
@@ -25,206 +24,59 @@ from tests.uat.throughput import (
 pytestmark = pytest.mark.fast
 
 
-# ``resolve_official_result_path`` filters candidates by ``st_mtime >=
-# started_after``. Capturing ``started_after = datetime.now()`` immediately
-# before writing the fixture file is racy: filesystem mtime granularity (or a
-# small backward NTP step between the two calls) can floor the written file's
-# mtime just *below* ``started_after``, dropping the file and returning None
-# (observed as a one-off CI flake). Backdating ``started_after`` by a slack
-# margin makes the boundary robust without weakening any test's intent -- the
-# "ignores older files" case backdates its stale file by a full hour, well
-# outside this margin.
-_MTIME_SLACK = _dt.timedelta(seconds=2)
-
-
 # ---------------------------------------------------------------------------
 # resolve_official_result_path
 # ---------------------------------------------------------------------------
 
 
-def test_resolve_official_result_path_returns_none_for_missing_dir(tmp_path: Path):
-    missing = tmp_path / "results"
+def test_resolve_official_result_path_returns_none_without_emitted_path(tmp_path: Path):
+    results_dir = tmp_path / "shared-runs" / "results"
     assert (
-        resolve_official_result_path(missing, platform="duckdb", benchmark="tpch", started_after=_dt.datetime.now())
+        resolve_official_result_path(results_dir, platform="duckdb", benchmark="tpch", started_after=_dt.datetime.now())
         is None
     )
 
 
-def test_resolve_official_result_path_returns_none_when_no_candidates(tmp_path: Path):
-    results_dir = tmp_path / "results"
-    results_dir.mkdir()
-    (results_dir / "tpcds_sf1_duckdb_sql_unrelated.json").write_text("{}", encoding="utf-8")
+def test_resolve_official_result_path_accepts_absolute_emitted_path(tmp_path: Path):
+    results_dir = tmp_path / "shared-runs" / "results"
+    result_path = results_dir / "tpch_sf1_duckdb_sql_20260822_130141_a3f0c570.json"
+    result_path.parent.mkdir(parents=True)
+    result_path.write_text("{}", encoding="utf-8")
+
     out = resolve_official_result_path(
-        results_dir, platform="duckdb", benchmark="tpch", started_after=_dt.datetime.now()
+        results_dir,
+        platform="duckdb",
+        benchmark="tpch",
+        started_after=_dt.datetime.now(),
+        emitted_path=str(result_path),
     )
-    assert out is None
+    assert out == result_path
 
 
-def test_resolve_official_result_path_matches_platform_and_benchmark(tmp_path: Path):
-    results_dir = tmp_path / "results"
-    results_dir.mkdir()
-    started = _dt.datetime.now() - _MTIME_SLACK
-    match = results_dir / "tpch_sf1_duckdb_sql_20260709_223304_0865bb91.json"
-    match.write_text("{}", encoding="utf-8")
-    # A same-timestamp but different-platform file must not match.
-    (results_dir / "tpch_sf1_postgresql_sql_20260709_223304_deadbeef.json").write_text("{}", encoding="utf-8")
-    out = resolve_official_result_path(results_dir, platform="duckdb", benchmark="tpch", started_after=started)
-    assert out == match
-
-
-def test_resolve_official_result_path_ignores_files_older_than_started_after(tmp_path: Path):
-    results_dir = tmp_path / "results"
-    results_dir.mkdir()
-    stale = results_dir / "tpch_sf1_duckdb_sql_stale.json"
-    stale.write_text("{}", encoding="utf-8")
-    # Backdate the stale file's mtime well before "started_after".
-    import os
-
-    old_time = (_dt.datetime.now() - _dt.timedelta(hours=1)).timestamp()
-    os.utime(stale, (old_time, old_time))
+def test_resolve_official_result_path_resolves_runs_relative_path(tmp_path: Path):
+    results_dir = tmp_path / "shared-runs" / "results"
+    results_dir.mkdir(parents=True)
     out = resolve_official_result_path(
-        results_dir, platform="duckdb", benchmark="tpch", started_after=_dt.datetime.now()
+        results_dir,
+        platform="duckdb",
+        benchmark="tpch",
+        started_after=_dt.datetime.now(),
+        emitted_path="results/tpch_sf1_duckdb_sql_20260822_130141_a3f0c570.json",
     )
-    assert out is None
+    assert out == results_dir / "tpch_sf1_duckdb_sql_20260822_130141_a3f0c570.json"
 
 
-def test_resolve_official_result_path_picks_newest_of_multiple_candidates(tmp_path: Path):
-    results_dir = tmp_path / "results"
-    results_dir.mkdir()
-    started = _dt.datetime.now() - _MTIME_SLACK
-    older = results_dir / "tpch_sf1_duckdb_sql_older.json"
-    newer = results_dir / "tpch_sf1_duckdb_sql_newer.json"
-    older.write_text("{}", encoding="utf-8")
-    newer.write_text("{}", encoding="utf-8")
-    import os
-    import time
-
-    time.sleep(0.01)
-    now = _dt.datetime.now().timestamp()
-    os.utime(newer, (now, now))
-    out = resolve_official_result_path(results_dir, platform="duckdb", benchmark="tpch", started_after=started)
-    assert out == newer
-
-
-def test_resolve_official_result_path_is_case_and_dash_insensitive(tmp_path: Path):
-    """Platform tokens with dashes (e.g. `pg-duckdb`) normalize like the CLI's own output filenames."""
-    results_dir = tmp_path / "results"
-    results_dir.mkdir()
-    started = _dt.datetime.now() - _MTIME_SLACK
-    match = results_dir / "tpch_sf1_pg_duckdb_sql_20260709.json"
-    match.write_text("{}", encoding="utf-8")
-    out = resolve_official_result_path(results_dir, platform="pg-duckdb", benchmark="tpch", started_after=started)
-    assert out == match
-
-
-def test_resolve_official_result_path_duckdb_does_not_match_pg_duckdb_file(tmp_path: Path):
-    """Regression: the old substring glob (`*{platform_token}*`) let platform="duckdb" match a
-    `pg_duckdb` result file because "duckdb" is a substring of "pg_duckdb". Token-exact matching
-    must reject it -- this is the collision direction the pre-existing test above didn't cover
-    (it only asserted the *positive* pg-duckdb match, not that plain duckdb excludes it).
-    """
-    results_dir = tmp_path / "results"
-    results_dir.mkdir()
-    started = _dt.datetime.now() - _MTIME_SLACK
-    (results_dir / "tpch_sf1_pg_duckdb_sql_20260709_223304_deadbeef.json").write_text("{}", encoding="utf-8")
-    out = resolve_official_result_path(results_dir, platform="duckdb", benchmark="tpch", started_after=started)
-    assert out is None
-
-
-def test_resolve_official_result_path_pg_duckdb_does_not_match_plain_duckdb_file(tmp_path: Path):
-    """Reverse collision direction: platform="pg-duckdb" must not resolve a plain `duckdb` file."""
-    results_dir = tmp_path / "results"
-    results_dir.mkdir()
-    started = _dt.datetime.now() - _MTIME_SLACK
-    (results_dir / "tpch_sf1_duckdb_sql_20260709_223304_0865bb91.json").write_text("{}", encoding="utf-8")
-    out = resolve_official_result_path(results_dir, platform="pg-duckdb", benchmark="tpch", started_after=started)
-    assert out is None
-
-
-def test_resolve_official_result_path_matches_multi_token_benchmark(tmp_path: Path):
-    """Regression (C1): registry ids like `tpcds_obt`/`tsbs_devops` split into MULTIPLE
-    `_`-tokens, so a matcher that hardcoded benchmark=token[0]/scale=token[1] shifted every
-    index and returned None for a real `tpcds_obt_sf1_duckdb_sql_*.json` file -- a NEW
-    false-negative worse than the substring false-positive it replaced (a None result
-    downgrades a passing official cell to FAILED). The benchmark must match as a token
-    *prefix sequence*, with scale/platform offsets derived from its length.
-    """
-    results_dir = tmp_path / "results"
-    results_dir.mkdir()
-    started = _dt.datetime.now() - _MTIME_SLACK
-    match = results_dir / "tpcds_obt_sf1_duckdb_sql_20260709_223304_abcdabcd.json"
-    match.write_text("{}", encoding="utf-8")
-    # A pg_duckdb file for the same multi-token benchmark must NOT collide with plain duckdb.
-    (results_dir / "tpcds_obt_sf1_pg_duckdb_sql_20260709_223304_deadbeef.json").write_text("{}", encoding="utf-8")
+def test_resolve_official_result_path_resolves_benchmark_runs_prefixed_path(tmp_path: Path):
+    results_dir = tmp_path / "shared-runs" / "results"
+    results_dir.mkdir(parents=True)
     out = resolve_official_result_path(
-        results_dir, platform="duckdb", benchmark="tpcds_obt", started_after=started, scale=1
+        results_dir,
+        platform="duckdb",
+        benchmark="tpch",
+        started_after=_dt.datetime.now(),
+        emitted_path="benchmark_runs/results/tpch_sf1_duckdb_sql_20260822_130141_a3f0c570.json",
     )
-    assert out == match
-
-
-def test_resolve_official_result_path_multi_token_benchmark_without_scale(tmp_path: Path):
-    """The multi-token benchmark prefix + platform-token match holds even when `scale` is omitted."""
-    results_dir = tmp_path / "results"
-    results_dir.mkdir()
-    started = _dt.datetime.now() - _MTIME_SLACK
-    match = results_dir / "tsbs_devops_sf1_duckdb_sql_20260709_223304_abcdabcd.json"
-    match.write_text("{}", encoding="utf-8")
-    out = resolve_official_result_path(results_dir, platform="duckdb", benchmark="tsbs_devops", started_after=started)
-    assert out == match
-
-
-def test_resolve_official_result_path_filters_by_scale_when_given(tmp_path: Path):
-    """`scale` (optional, keyword) narrows candidates to the matching sf<N> token."""
-    results_dir = tmp_path / "results"
-    results_dir.mkdir()
-    started = _dt.datetime.now() - _MTIME_SLACK
-    sf1 = results_dir / "tpch_sf1_duckdb_sql_20260709_223304_aaaaaaaa.json"
-    sf10 = results_dir / "tpch_sf10_duckdb_sql_20260709_223304_bbbbbbbb.json"
-    sf1.write_text("{}", encoding="utf-8")
-    sf10.write_text("{}", encoding="utf-8")
-    out = resolve_official_result_path(results_dir, platform="duckdb", benchmark="tpch", started_after=started, scale=1)
-    assert out == sf1
-    out10 = resolve_official_result_path(
-        results_dir, platform="duckdb", benchmark="tpch", started_after=started, scale=10
-    )
-    assert out10 == sf10
-
-
-def test_resolve_official_result_path_ignores_scale_when_omitted(tmp_path: Path):
-    """Backward compatibility: existing callers that don't pass `scale` are unaffected by SF."""
-    results_dir = tmp_path / "results"
-    results_dir.mkdir()
-    started = _dt.datetime.now() - _MTIME_SLACK
-    sf1 = results_dir / "tpch_sf1_duckdb_sql_20260709_223304_aaaaaaaa.json"
-    sf1.write_text("{}", encoding="utf-8")
-    out = resolve_official_result_path(results_dir, platform="duckdb", benchmark="tpch", started_after=started)
-    assert out == sf1
-
-
-def test_resolve_official_result_path_breaks_equal_mtime_ties_deterministically(tmp_path: Path):
-    """Equal-mtime candidates (within filesystem mtime granularity) must resolve to the same file
-    on every call, not whatever order the filesystem/glob happens to yield -- the arbitrary
-    max-mtime tie-break this test guards used to depend on iteration order when mtimes tied.
-    """
-    import os
-
-    results_dir = tmp_path / "results"
-    results_dir.mkdir()
-    started = _dt.datetime.now() - _MTIME_SLACK
-    file_a = results_dir / "tpch_sf1_duckdb_sql_20260709_223304_aaaaaaaa.json"
-    file_z = results_dir / "tpch_sf1_duckdb_sql_20260709_223304_zzzzzzzz.json"
-    file_a.write_text("{}", encoding="utf-8")
-    file_z.write_text("{}", encoding="utf-8")
-    same_time = _dt.datetime.now().timestamp()
-    os.utime(file_a, (same_time, same_time))
-    os.utime(file_z, (same_time, same_time))
-
-    results = {
-        resolve_official_result_path(results_dir, platform="duckdb", benchmark="tpch", started_after=started)
-        for _ in range(5)
-    }
-    assert len(results) == 1, "tie-break must be deterministic across repeated calls"
-    assert results == {file_z}, "tie-break must prefer the lexicographically-greater filename"
+    assert out == tmp_path / "benchmark_runs" / "results" / "tpch_sf1_duckdb_sql_20260822_130141_a3f0c570.json"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/uat/throughput.py
+++ b/tests/uat/throughput.py
@@ -6,14 +6,14 @@ option of its own -- see the `throughput-stream-count-wiring-defect` TODO's
 `deferred` section. `benchbox run-official --streams N` is, today, the only
 CLI surface that can make a requested stream count reach the throughput
 driver, via a transient `BenchmarkOrchestrator.execute_benchmark` patch
-(`benchbox/cli/commands/run_official.py::_forward_requested_streams`). This
-module supplies the two things a `run-official`-backed UAT cell needs that a
-`--quiet` `benchbox run` cell gets for free:
+(`benchbox/cli/commands/run_official.py::_forward_requested_streams`). UAT
+now runs that deprecated command with `--quiet`, so it reuses the same final
+bare-path stdout contract as every other `benchbox run` cell. This module
+supplies the two things a `run-official`-backed UAT cell needs:
 
-1. `resolve_official_result_path` -- `run-official` has no `--quiet` flag, so
-   it never prints a bare, parseable result-path line the way `run_cell`'s
-   default stdout parsing (`last_nonempty_output_line`) expects. The result
-   JSON is instead located on disk by filename + mtime.
+1. `resolve_official_result_path` -- reads the emitted quiet-path line through
+   a backward-compatible resolver wrapper, so the official branch keeps its
+   existing call shape while retiring glob/mtime inference entirely.
 2. `validate_throughput_result` -- checks the exported result JSON for the
    three things a silent concurrency regression would break: every requested
    stream actually executed at least one query (`validate_stream_count`),
@@ -34,7 +34,6 @@ from pathlib import Path
 from typing import Any
 
 from benchbox.core.results.metrics import TPCMetricsCalculator
-from benchbox.utils.scale_factor import format_scale_factor
 
 # Mirrors benchbox/cli/commands/run_official.py::TPC_ALLOWED_SCALE_FACTORS.
 # `run-official` rejects any other scale factor outright, so a throughput UAT
@@ -50,87 +49,35 @@ def resolve_official_result_path(
     benchmark: str,
     started_after: _dt.datetime,
     scale: float | None = None,
+    emitted_path: str | None = None,
 ) -> Path | None:
-    """Find the newest result JSON exported for (platform, benchmark[, scale]).
+    """Resolve the result JSON path emitted by `run-official --quiet`.
 
-    `run-official` prints its result path through Rich's non-quiet console
-    output (e.g. ``JSON: [dim]/path/to/result.json[/dim]``), which is not a
-    bare, parseable stdout line -- unlike `--quiet` `benchbox run`, which
-    `run_cell`'s default `last_nonempty_output_line` parsing expects.
-    Locating the file by name + mtime instead works regardless of console
-    formatting and also survives a non-clean (exit code != 0) run, which
-    `run-official` still exports a full result JSON for.
+    The authoritative contract is now the same one `benchbox run --quiet`
+    already exposes: the final non-empty stdout line is the exported result
+    JSON path. `run_cell` passes that line here via `emitted_path`.
 
-    Filename grammar (pinned from the exporter every result JSON funnels
-    through, ``benchbox.core.results.filenames.build_result_filename_base``,
-    as exercised by the fixtures in ``tests/uat/test_throughput.py``)::
+    `results_dir`/`platform`/`benchmark`/`started_after`/`scale` remain in the
+    signature for backward compatibility with the historical glob-based
+    resolver and existing call sites/tests, but resolution itself is now a
+    read, not a filename search. There is intentionally NO fallback to glob or
+    mtime inference: a missing/invalid emitted path returns `None`, and the
+    caller must fail loudly.
 
-        {benchmark...}_{sf<N>}_{platform...}_{mode}_{timestamp}[_{execution_id}].json
-
-    The exporter writes the registry ``benchmark_id`` and the normalized
-    platform name verbatim, and BOTH can themselves contain underscores, so
-    each spans a *variable-length* run of ``"_"``-split tokens rather than a
-    single fixed slot:
-
-    - single-token benchmark, single-token platform --
-      ``tpch_sf1_duckdb_sql_20260709_223304_0865bb91.json`` ->
-      ``["tpch", "sf1", "duckdb", "sql", ...]``
-    - single-token benchmark, two-token platform (``pg-duckdb`` ->
-      ``pg_duckdb``) -- ``tpch_sf1_pg_duckdb_sql_20260709.json`` ->
-      ``["tpch", "sf1", "pg", "duckdb", "sql", ...]``
-    - two-token benchmark (``tpcds_obt``, ``tsbs_devops``, ``tpch_skew``,
-      ``vector_search``, ``*_primitives`` ...) --
-      ``tpcds_obt_sf1_duckdb_sql_20260709.json`` ->
-      ``["tpcds", "obt", "sf1", "duckdb", "sql", ...]``
-
-    Matching is token-exact, not substring. A candidate's ``"_"``-split stem
-    must (1) begin with the benchmark's own token sequence as a prefix, then
-    (2) carry the scale-factor token at index ``len(benchmark_tokens)`` (only
-    *checked* when `scale` is given, but always skipped over so the platform
-    slice lines up), then (3) carry the platform's own token sequence in the
-    slots immediately after. This is what stops ``platform="duckdb"`` from
-    matching a ``pg_duckdb`` result file (or the reverse), and
-    ``benchmark="tpcds_obt"`` from being shifted/rejected -- both of which
-    the old glob-based ``f"{benchmark}_*{platform}*.json"`` pattern got
-    wrong (a false-positive on the platform, a false-negative on the
-    multi-token benchmark).
-
-    `scale` is optional and keyword-only for backward compatibility with
-    existing callers that don't (yet) pass it; when omitted, the
-    scale-factor token is present in the filename but not checked.
-
-    Ties (equal ``st_mtime``, e.g. within filesystem mtime granularity) are
-    broken deterministically by filename, not left to whatever order the
-    filesystem happens to yield candidates in.
+    Relative paths resolve the same way the runner resolves quiet output from
+    normal `benchbox run` cells: relative to the shared runs root, with a
+    leading `benchmark_runs/...` anchored one directory above it.
     """
-    if not results_dir.is_dir():
+    _ = (platform, benchmark, started_after, scale)
+    if not emitted_path:
         return None
-    benchmark_tokens = benchmark.lower().split("_")
-    platform_tokens = platform.lower().replace("-", "_").split("_")
-    scale_token = format_scale_factor(scale) if scale is not None else None
-    scale_idx = len(benchmark_tokens)
-    platform_start = scale_idx + 1
-    platform_end = platform_start + len(platform_tokens)
-    started_ts = started_after.timestamp()
-
-    candidates: list[Path] = []
-    for path in results_dir.glob(f"{benchmark.lower()}_*.json"):
-        if not path.is_file() or path.stat().st_mtime < started_ts:
-            continue
-        tokens = path.stem.split("_")
-        if tokens[:scale_idx] != benchmark_tokens:
-            continue
-        # The scale-factor token always occupies ``scale_idx`` in the pinned
-        # grammar; only *check* it when the caller supplied `scale`, but the
-        # platform slice below is offset past it regardless.
-        if scale_token is not None and (len(tokens) <= scale_idx or tokens[scale_idx] != scale_token):
-            continue
-        if tokens[platform_start:platform_end] != platform_tokens:
-            continue
-        candidates.append(path)
-    if not candidates:
-        return None
-    return max(candidates, key=lambda path: (path.stat().st_mtime, path.name))
+    path = Path(emitted_path).expanduser()
+    if path.is_absolute() or path.exists():
+        return path
+    runs_dir = results_dir.parent
+    if len(path.parts) >= 2 and path.parts[0] == "benchmark_runs":
+        return runs_dir.parent / path
+    return runs_dir / path
 
 
 def validate_stream_count(

--- a/tests/unit/cli/commands/test_run_official.py
+++ b/tests/unit/cli/commands/test_run_official.py
@@ -44,3 +44,39 @@ def test_run_official_accepts_and_forwards_platform_options(monkeypatch):
     assert result.exit_code == 0, result.output
     assert captured["platform"] == "postgresql"
     assert captured["platform_option_pairs"] == (("username", "benchbox"), ("password", "benchbox"))
+
+
+def test_run_official_quiet_forwards_to_run_and_suppresses_banner(monkeypatch):
+    """`run-official --quiet` must reuse the standard bare result-path contract."""
+    captured: dict[str, object] = {}
+
+    def fake_run(**kwargs):
+        captured.update(kwargs)
+        click.echo("/tmp/official-result.json")
+
+    monkeypatch.setattr(run_official_module, "run", click.Command("run", callback=fake_run))
+
+    result = CliRunner().invoke(
+        run_official_module.run_official,
+        [
+            "tpch",
+            "--platform",
+            "duckdb",
+            "--scale",
+            "1",
+            "--phases",
+            "throughput",
+            "--streams",
+            "3",
+            "--seed",
+            "42",
+            "--quiet",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert captured["quiet"] is True
+    lines = [line.strip() for line in result.output.splitlines() if line.strip()]
+    assert lines[-1] == "/tmp/official-result.json"
+    assert "TPC-Compliant Official Benchmark Run" not in result.output
+    assert "Concurrency:" not in result.output

--- a/tests/unit/cli/test_new_commands.py
+++ b/tests/unit/cli/test_new_commands.py
@@ -566,6 +566,12 @@ class TestRunOfficialCommand:
         # May show deprecation warning but should still work
         assert "TPC-compliant" in result.output or "DEPRECATED" in result.output
 
+    def test_run_official_help_mentions_quiet(self):
+        runner = CliRunner()
+        result = runner.invoke(cli, ["run-official", "--help"])
+        assert result.exit_code == 0
+        assert "--quiet" in result.output
+
     def test_run_official_shows_deprecation_warning(self):
         """Test run-official shows deprecation warning when executed."""
         runner = CliRunner()


### PR DESCRIPTION
## Summary
- add `--quiet` to deprecated `benchbox run-official` and forward it to `benchbox run`
- switch official throughput UAT cells to consume the emitted final-line result path instead of glob/mtime inference
- document the quiet-path contract in `docs/reference/public-contracts.md` and add regression coverage

## Contract decision
Reused the existing quiet-path convention instead of inventing a new manifest format:
- `run-official --quiet` now carries the authoritative result-path contract
- the final non-empty stdout line is the exported JSON result path
- UAT fails loudly when that emitted path is missing or invalid
- no glob or mtime fallback remains in the official resolver path

## Revalidated
- current real CLI output: `uv run -- benchbox run-official tpch --platform duckdb --scale 1 --phases throughput --streams 3 --seed 42 --quiet`
  - emits the result path on the final non-empty stdout line
- existing hardening lineage reviewed against this change:
  - #1094 throughput UAT coverage
  - #1119 resolver test hardening
  - #1228 hardened glob resolver
  - #1202 follow-up that expanded this TODO's scope to include `tests/uat/runner.py`

## Tests
- `uv run -- python -m pytest tests/uat/test_throughput.py tests/uat/test_runner.py tests/uat/test_matrix.py tests/unit/cli/commands/test_run_official.py tests/unit/cli/test_new_commands.py -q`
- `uv run -- ruff check benchbox/cli/commands/run_official.py tests/uat/matrix.py tests/uat/runner.py tests/uat/test_matrix.py tests/uat/test_runner.py tests/uat/test_throughput.py tests/uat/throughput.py tests/unit/cli/commands/test_run_official.py tests/unit/cli/test_new_commands.py`
- `make pr-preflight` (all non-fast-test gates completed clean; fast-test leg was externally lock-blocked twice by another active worktree run, then completed clean via `make pr-preflight-fast-tests` once the lock cleared)

## Public contract check
- updated `docs/reference/public-contracts.md`
- no CODEOWNERS soundness paths touched
