### PR TITLE
fix(compare): run mode runs the real benchmark and stops fabricating success

### DIFF
--- a/benchbox/cli/commands/compare.py
+++ b/benchbox/cli/commands/compare.py
@@ -913,6 +913,61 @@ def _list_available_platforms():
     console.print("  benchbox compare                               # Interactive wizard")
 
 
+def _build_platform_runner():
+    """Build the runner that executes one benchmark on one platform.
+
+    Lives in the CLI because it wires the orchestrator, the database manager
+    and the system profiler -- ``benchbox.core`` is not allowed to import
+    ``benchbox.cli`` (import-linter contract "utils < core < platforms < cli"),
+    so the surface injects this into the comparison suite the same way
+    ``execute_run`` takes an ``adapter_factory``.
+    """
+    from benchbox.cli.database import DatabaseManager
+    from benchbox.cli.orchestrator import BenchmarkOrchestrator
+    from benchbox.cli.system import SystemProfiler
+    from benchbox.core.benchmark_registry import get_benchmark_metadata
+    from benchbox.core.schemas import BenchmarkConfig
+
+    def run_one_platform(
+        *,
+        platform: str,
+        benchmark: str,
+        scale_factor: float,
+        query_ids: list[str] | None,
+        iterations: int,
+        data_dir,
+    ):
+        try:
+            info = get_benchmark_metadata(benchmark) or {}
+        except Exception:  # pragma: no cover - registry lookup is advisory only
+            info = {}
+
+        options: dict[str, Any] = {}
+        if iterations:
+            options["power_iterations"] = iterations
+
+        benchmark_config = BenchmarkConfig(
+            name=benchmark,
+            display_name=info.get("display_name", benchmark.upper()),
+            scale_factor=scale_factor,
+            queries=query_ids,
+            options=options,
+        )
+
+        orchestrator = BenchmarkOrchestrator()
+        if data_dir is not None:
+            orchestrator.set_custom_output_dir(str(data_dir))
+
+        return orchestrator.execute_benchmark(
+            benchmark_config,
+            SystemProfiler().get_system_profile(),
+            DatabaseManager().create_config(platform),
+            ["data", "schema", "load", "power"],
+        )
+
+    return run_one_platform
+
+
 def _run_platform_comparison(
     platforms: list[str],
     platform_type: str,
@@ -971,7 +1026,7 @@ def _run_platform_comparison(
         benchmark_iterations=iterations,
     )
 
-    suite = UnifiedBenchmarkSuite(config=config)
+    suite = UnifiedBenchmarkSuite(config=config, platform_runner=_build_platform_runner())
 
     # Display header
     console.print("\n[bold]Cross-Platform Benchmark Comparison[/bold]")
@@ -1002,6 +1057,35 @@ def _run_platform_comparison(
     # Generate charts if requested
     if generate_charts and output_file:
         _generate_comparison_charts(output_file, results, theme, UnifiedComparisonPlotter)
+
+    _exit_on_comparison_failure(results, summary)
+
+
+def _exit_on_comparison_failure(results: list, summary: Any) -> None:
+    """Exit non-zero when the comparison did not actually compare anything.
+
+    A run in which every platform failed used to print a table claiming 100%
+    success and a 1.00x speedup and then exit 0, so callers and CI wrappers
+    could not tell a total failure from a real result.
+    """
+    failed = [r for r in results if r.success_rate <= 0]
+
+    if not summary.is_comparable:
+        console.print(
+            "[red]Comparison failed: no platform produced a usable timing, so there is nothing to compare.[/red]"
+        )
+        for result in failed:
+            reason = next(
+                (q.error_message for q in result.query_results if q.error_message),
+                "no successful queries",
+            )
+            console.print(f"  [red]{result.platform}[/red]: {reason}")
+        sys.exit(1)
+
+    if failed:
+        names = ", ".join(r.platform for r in failed)
+        console.print(f"[yellow]Warning: no successful queries on {names}.[/yellow]")
+        sys.exit(1)
 
 
 def _output_comparison_results(

--- a/benchbox/core/comparison/suite.py
+++ b/benchbox/core/comparison/suite.py
@@ -14,9 +14,9 @@ import json
 import logging
 import math
 import statistics
-import time
 from datetime import datetime, timezone
 from pathlib import Path
+from typing import Any, Protocol
 
 from benchbox.core.comparison.types import (
     PlatformType,
@@ -28,6 +28,38 @@ from benchbox.core.comparison.types import (
 )
 
 logger = logging.getLogger(__name__)
+
+
+#: Sentinel query id recorded when a platform fails before running any query.
+FAILED_PLATFORM_QUERY_ID = "ALL"
+
+
+class PlatformRunner(Protocol):
+    """Runs one benchmark on one platform and returns its BenchmarkResults.
+
+    Implemented by the surface (see ``benchbox.cli.commands.compare``) so
+    ``benchbox.core`` stays free of a ``benchbox.cli`` import.
+    """
+
+    def __call__(
+        self,
+        *,
+        platform: str,
+        benchmark: str,
+        scale_factor: float,
+        query_ids: list[str] | None,
+        iterations: int,
+        data_dir: str | Path | None,
+    ) -> Any: ...
+
+
+def _query_sort_key(query_id: str) -> tuple[int, float, str]:
+    """Sort query ids numerically when possible, alphabetically otherwise."""
+    text = query_id[1:] if query_id[:1].upper() == "Q" else query_id
+    try:
+        return (0, float(text), "")
+    except ValueError:
+        return (1, 0.0, query_id)
 
 
 class UnifiedBenchmarkSuite:
@@ -59,13 +91,25 @@ class UnifiedBenchmarkSuite:
         emit(f"Fastest: {summary.fastest_platform}")
     """
 
-    def __init__(self, config: UnifiedBenchmarkConfig | None = None):
+    def __init__(
+        self,
+        config: UnifiedBenchmarkConfig | None = None,
+        platform_runner: PlatformRunner | None = None,
+    ):
         """Initialize the unified benchmark suite.
 
         Args:
             config: Benchmark configuration. Defaults to standard config.
+            platform_runner: Callable that runs one benchmark on one platform
+                and returns its ``BenchmarkResults``. The surface injects this
+                -- ``benchbox.core`` must not import ``benchbox.cli``, so the
+                orchestrator wiring lives in the CLI, mirroring the
+                ``execute_run(adapter_factory=...)`` contract in
+                ``benchbox.core.run_service``. Without it, SQL run mode cannot
+                execute and raises rather than reporting an empty success.
         """
         self.config = config or UnifiedBenchmarkConfig()
+        self._platform_runner = platform_runner
 
     def get_available_platforms(self, platform_type: PlatformType | None = None) -> list[str]:
         """Get available platforms of the specified type.
@@ -155,13 +199,17 @@ class UnifiedBenchmarkSuite:
                 results.append(result)
             except Exception as e:
                 logger.error(f"Failed to benchmark {platform}: {e}")
+                # Build through _build_platform_result so the aggregates match
+                # the failure: success_rate 0, no geomean, no total time. A
+                # directly-constructed result kept the dataclass default and
+                # reported a failed platform as 100% successful.
                 results.append(
-                    UnifiedPlatformResult(
-                        platform=platform,
-                        platform_type=PlatformType.SQL,
-                        query_results=[
+                    self._build_platform_result(
+                        platform,
+                        PlatformType.SQL,
+                        [
                             UnifiedQueryResult(
-                                query_id="ALL",
+                                query_id=FAILED_PLATFORM_QUERY_ID,
                                 platform=platform,
                                 platform_type=PlatformType.SQL,
                                 status="ERROR",
@@ -178,157 +226,132 @@ class UnifiedBenchmarkSuite:
         platform: str,
         data_dir: str | Path | None = None,
     ) -> UnifiedPlatformResult:
-        """Benchmark a single SQL platform.
+        """Benchmark a single SQL platform through the canonical run path.
+
+        Delegates to :meth:`benchbox.cli.orchestrator.BenchmarkOrchestrator.execute_benchmark`
+        -- the same entry point ``benchbox run`` uses -- so data generation,
+        schema creation, loading, adapter configuration and phase handling are
+        shared with the single-platform command rather than reimplemented here.
+
+        The previous implementation was a hardcoded TPC-H path that required
+        pre-generated data at a guessed directory, never generated data, and
+        never reached a real runner, so the documented
+        ``benchbox compare -p duckdb -p sqlite`` invocation could not work.
 
         Args:
             platform: Platform name
-            data_dir: Data directory for embedded platforms
+            data_dir: Optional pre-existing data directory. When given it is
+                passed through as the benchmark output root.
 
         Returns:
-            UnifiedPlatformResult with query results
+            UnifiedPlatformResult with real per-query timings
+
+        Raises:
+            Exception: Any failure from the run path, so the caller records the
+                platform as failed rather than silently successful.
         """
-        from benchbox.platforms import get_adapter
-
-        # Determine query IDs (default to TPC-H Q1-Q22)
-        query_ids = self.config.query_ids or [f"Q{i}" for i in range(1, 23)]
-
-        query_results = []
-
-        # Get adapter for the platform
-        adapter = get_adapter(platform)
-
-        # Handle embedded platforms that need data loading
-        if platform in ("duckdb", "sqlite", "datafusion"):
-            if data_dir is None:
-                sf_str = f"sf{self.config.scale_factor}".replace(".", "")
-                data_dir = Path(f"benchmark_runs/tpch/{sf_str}/data")
-
-            data_path = Path(data_dir)
-            if not data_path.exists():
-                raise ValueError(f"Data directory not found: {data_dir}")
-
-            conn = self._setup_embedded_sql(platform, data_path)
-        else:
-            # For remote platforms, assume data is already loaded
-            conn = adapter.connect()
-
-        try:
-            for query_id in query_ids:
-                logger.info(f"  Running {query_id}...")
-                result = self._run_sql_query(query_id, platform, conn)
-                query_results.append(result)
-        finally:
-            if hasattr(conn, "close"):
-                conn.close()
-
-        # Calculate aggregates
+        results = self._execute_platform_run(platform, data_dir)
+        query_results = self._to_unified_query_results(results, platform)
         return self._build_platform_result(platform, PlatformType.SQL, query_results)
 
-    def _setup_embedded_sql(self, platform: str, data_path: Path):
-        """Set up embedded SQL platform with data.
+    def _execute_platform_run(self, platform: str, data_dir: str | Path | None):
+        """Run one benchmark on one platform through the injected runner.
 
-        Args:
-            platform: Platform name
-            data_path: Path to data directory
-
-        Returns:
-            Database connection
+        Raises:
+            RuntimeError: When no runner was injected. The caller records the
+                platform as failed rather than reporting a vacuous success.
         """
-        parquet_dir = data_path / "parquet"
-        if not parquet_dir.exists():
-            parquet_dir = data_path
+        if self._platform_runner is None:
+            raise RuntimeError(
+                "No platform runner configured for SQL comparison. "
+                "Construct UnifiedBenchmarkSuite with platform_runner=... "
+                "(the CLI supplies one via benchbox.cli.commands.compare)."
+            )
+        return self._platform_runner(
+            platform=platform,
+            benchmark=self.config.benchmark,
+            scale_factor=self.config.scale_factor,
+            query_ids=self._normalized_query_ids(),
+            iterations=self.config.benchmark_iterations,
+            data_dir=data_dir,
+        )
 
-        tables = ["lineitem", "orders", "customer", "supplier", "part", "partsupp", "nation", "region"]
+    def _normalized_query_ids(self) -> list[str] | None:
+        """Return configured query ids in the form the run path expects.
 
-        if platform == "duckdb":
-            import duckdb
-
-            conn = duckdb.connect()
-            for table in tables:
-                table_path = parquet_dir / f"{table}.parquet"
-                if table_path.exists():
-                    conn.execute(f"CREATE TABLE {table} AS SELECT * FROM read_parquet('{table_path}')")
-            return conn
-
-        elif platform == "sqlite":
-            import sqlite3
-
-            import pandas as pd
-
-            conn = sqlite3.connect(":memory:")
-            for table in tables:
-                table_path = parquet_dir / f"{table}.parquet"
-                if table_path.exists():
-                    df = pd.read_parquet(str(table_path))
-                    df.to_sql(table, conn, index=False)
-            return conn
-
-        else:
-            raise ValueError(f"Unsupported embedded SQL platform: {platform}")
-
-    def _run_sql_query(
-        self,
-        query_id: str,
-        platform: str,
-        conn,
-    ) -> UnifiedQueryResult:
-        """Run a single SQL query benchmark.
-
-        Args:
-            query_id: Query identifier
-            platform: Platform name
-            conn: Database connection
-
-        Returns:
-            UnifiedQueryResult with timing data
+        The comparison surface accepts ``Q1`` style ids; the run path expects
+        bare ids (``1``). ``None`` means every query in the benchmark.
         """
-        from benchbox.core.tpch.queries import TPCHQuery
+        if not self.config.query_ids:
+            return None
+        normalized = []
+        for qid in self.config.query_ids:
+            text = str(qid).strip()
+            normalized.append(text[1:] if text[:1].upper() == "Q" and text[1:] else text)
+        return normalized
 
-        try:
-            # Get query SQL
-            query_num = int(query_id.replace("Q", ""))
-            tpch_query = TPCHQuery.get_query(query_num, dialect=platform)
+    @staticmethod
+    def _to_unified_query_results(results: Any, platform: str) -> list[UnifiedQueryResult]:
+        """Convert a BenchmarkResults into per-query comparison records.
 
-            execution_times = []
-            rows_returned = 0
+        Measurement iterations for one query id are folded into a single
+        :class:`UnifiedQueryResult`. Warmup rows are excluded so they cannot
+        distort the comparison. A query whose every iteration failed is kept
+        with ``status="ERROR"`` so it counts against the success rate instead
+        of vanishing from the denominator.
+        """
+        by_query: dict[str, dict[str, Any]] = {}
+        for row in getattr(results, "query_results", None) or []:
+            if not isinstance(row, dict):
+                continue
+            if row.get("run_type") == "warmup":
+                continue
+            query_id = str(row.get("query_id") or row.get("id") or "")
+            if not query_id:
+                continue
+            bucket = by_query.setdefault(query_id, {"times": [], "rows": 0, "errors": []})
+            if row.get("status") == "SUCCESS":
+                seconds = row.get("execution_time_seconds")
+                if seconds is None:
+                    seconds = row.get("execution_time")
+                if seconds is not None:
+                    bucket["times"].append(float(seconds) * 1000.0)
+                elif row.get("execution_time_ms") is not None:
+                    bucket["times"].append(float(row["execution_time_ms"]))
+                bucket["rows"] = bucket["rows"] or int(row.get("rows_returned") or 0)
+            else:
+                bucket["errors"].append(str(row.get("error") or row.get("error_message") or "query failed"))
 
-            # Warmup
-            for _ in range(self.config.warmup_iterations):
-                conn.execute(tpch_query.sql).fetchall()
-
-            # Benchmark iterations
-            for i in range(self.config.benchmark_iterations):
-                start = time.perf_counter()
-                result = conn.execute(tpch_query.sql).fetchall()
-                elapsed_ms = (time.perf_counter() - start) * 1000
-                execution_times.append(elapsed_ms)
-
-                if i == 0:
-                    rows_returned = len(result)
-
-            return UnifiedQueryResult(
-                query_id=query_id,
-                platform=platform,
-                platform_type=PlatformType.SQL,
-                iterations=len(execution_times),
-                execution_times_ms=execution_times,
-                mean_time_ms=statistics.mean(execution_times) if execution_times else 0,
-                std_time_ms=statistics.stdev(execution_times) if len(execution_times) > 1 else 0,
-                min_time_ms=min(execution_times) if execution_times else 0,
-                max_time_ms=max(execution_times) if execution_times else 0,
-                rows_returned=rows_returned,
-                status="SUCCESS",
+        query_results: list[UnifiedQueryResult] = []
+        for query_id, bucket in sorted(by_query.items(), key=lambda kv: _query_sort_key(kv[0])):
+            times = bucket["times"]
+            if not times:
+                query_results.append(
+                    UnifiedQueryResult(
+                        query_id=query_id,
+                        platform=platform,
+                        platform_type=PlatformType.SQL,
+                        status="ERROR",
+                        error_message=bucket["errors"][0] if bucket["errors"] else "no measurement iteration",
+                    )
+                )
+                continue
+            query_results.append(
+                UnifiedQueryResult(
+                    query_id=query_id,
+                    platform=platform,
+                    platform_type=PlatformType.SQL,
+                    iterations=len(times),
+                    execution_times_ms=times,
+                    mean_time_ms=statistics.mean(times),
+                    std_time_ms=statistics.stdev(times) if len(times) > 1 else 0.0,
+                    min_time_ms=min(times),
+                    max_time_ms=max(times),
+                    rows_returned=bucket["rows"],
+                    status="SUCCESS",
+                )
             )
-
-        except Exception as e:
-            logger.error(f"Error running {query_id} on {platform}: {e}")
-            return UnifiedQueryResult(
-                query_id=query_id,
-                platform=platform,
-                platform_type=PlatformType.SQL,
-                status="ERROR",
-                error_message=str(e),
-            )
+        return query_results
 
     def _run_dataframe_comparison(
         self,
@@ -465,25 +488,38 @@ class UnifiedBenchmarkSuite:
         geomeans = {r.platform: r.geometric_mean_ms for r in results if r.geometric_mean_ms > 0}
 
         if not geomeans:
+            # Nothing timed successfully, so there is no ranking to report.
+            # Naming platforms[0] as both fastest and slowest with a 1.00x
+            # speedup presented total failure as a valid comparison.
             return UnifiedComparisonSummary(
                 platforms=platforms,
                 platform_type=platform_type,
-                fastest_platform=platforms[0],
-                slowest_platform=platforms[0],
-                speedup_ratio=1.0,
+                fastest_platform=None,
+                slowest_platform=None,
+                speedup_ratio=None,
                 query_winners={},
                 total_queries=0,
             )
 
         fastest = min(geomeans, key=geomeans.get)
         slowest = max(geomeans, key=geomeans.get)
-        speedup_ratio = geomeans[slowest] / geomeans[fastest] if geomeans[fastest] > 0 else 1.0
+        if len(geomeans) < 2:
+            # Only one platform produced timings. It is not faster than
+            # anything, so there is no ratio to report.
+            slowest = None
+            speedup_ratio = None
+        else:
+            speedup_ratio = geomeans[slowest] / geomeans[fastest] if geomeans[fastest] > 0 else None
 
         # Find query winners
         query_winners: dict[str, str] = {}
         all_query_ids = set()
         for result in results:
             for qr in result.query_results:
+                # ALL is the sentinel for "this platform failed before running
+                # any query"; counting it would inflate the query total.
+                if qr.query_id == FAILED_PLATFORM_QUERY_ID:
+                    continue
                 all_query_ids.add(qr.query_id)
 
         for query_id in all_query_ids:
@@ -572,9 +608,18 @@ class UnifiedBenchmarkSuite:
 
         lines.append("## Summary")
         lines.append("")
-        lines.append(f"**Fastest Platform:** {summary.fastest_platform}")
-        lines.append(f"**Slowest Platform:** {summary.slowest_platform}")
-        lines.append(f"**Speedup Ratio:** {summary.speedup_ratio:.2f}x")
+        if summary.speedup_ratio is not None:
+            lines.append(f"**Fastest Platform:** {summary.fastest_platform}")
+            lines.append(f"**Slowest Platform:** {summary.slowest_platform}")
+            lines.append(f"**Speedup Ratio:** {summary.speedup_ratio:.2f}x")
+        elif summary.is_comparable:
+            lines.append(f"**Fastest Platform:** {summary.fastest_platform} (only platform with timings)")
+            lines.append("**Slowest Platform:** n/a")
+            lines.append("**Speedup Ratio:** n/a - nothing to compare against")
+        else:
+            lines.append("**Fastest Platform:** n/a - no platform produced a usable timing")
+            lines.append("**Slowest Platform:** n/a")
+            lines.append("**Speedup Ratio:** n/a")
         lines.append("")
 
         lines.append("## Platform Results")
@@ -614,9 +659,18 @@ class UnifiedBenchmarkSuite:
         lines.append(f"Total Queries: {summary.total_queries}")
         lines.append("")
 
-        lines.append(f"Fastest: {summary.fastest_platform}")
-        lines.append(f"Slowest: {summary.slowest_platform}")
-        lines.append(f"Speedup: {summary.speedup_ratio:.2f}x")
+        if summary.speedup_ratio is not None:
+            lines.append(f"Fastest: {summary.fastest_platform}")
+            lines.append(f"Slowest: {summary.slowest_platform}")
+            lines.append(f"Speedup: {summary.speedup_ratio:.2f}x")
+        elif summary.is_comparable:
+            lines.append(f"Fastest: {summary.fastest_platform} (only platform with timings)")
+            lines.append("Slowest: n/a")
+            lines.append("Speedup: n/a - nothing to compare against")
+        else:
+            lines.append("Fastest: n/a - no platform produced a usable timing")
+            lines.append("Slowest: n/a")
+            lines.append("Speedup: n/a")
         lines.append("")
 
         lines.append(f"{'Platform':15s} {'Geomean (ms)':>15s} {'Total (ms)':>15s} {'Success':>10s}")
@@ -641,6 +695,7 @@ def run_unified_comparison(
     benchmark: str = "tpch",
     query_ids: list[str] | None = None,
     data_dir: str | Path | None = None,
+    platform_runner: PlatformRunner | None = None,
 ) -> list[UnifiedPlatformResult]:
     """Run a unified cross-platform comparison.
 
@@ -663,12 +718,14 @@ def run_unified_comparison(
             scale_factor=scale_factor,
             benchmark=benchmark,
             query_ids=query_ids,
-        )
+        ),
+        platform_runner=platform_runner,
     )
     return suite.run_comparison(platforms=platforms, data_dir=data_dir)
 
 
 __all__ = [
+    "PlatformRunner",
     "UnifiedBenchmarkSuite",
     "run_unified_comparison",
 ]

--- a/benchbox/core/comparison/types.py
+++ b/benchbox/core/comparison/types.py
@@ -199,7 +199,11 @@ class UnifiedPlatformResult:
         query_results: Results for each query
         total_time_ms: Total execution time
         geometric_mean_ms: Geometric mean of query times
-        success_rate: Percentage of successful queries
+        success_rate: Percentage of successful queries. Defaults to 0.0: a
+            result that has not been aggregated by
+            ``UnifiedBenchmarkSuite._build_platform_result`` has not
+            demonstrated any successful query, and defaulting to 100.0
+            let failed platforms report full success.
     """
 
     platform: str
@@ -207,7 +211,7 @@ class UnifiedPlatformResult:
     query_results: list[UnifiedQueryResult] = field(default_factory=list)
     total_time_ms: float = 0.0
     geometric_mean_ms: float = 0.0
-    success_rate: float = 100.0
+    success_rate: float = 0.0
 
     def to_dict(self) -> dict[str, Any]:
         """Convert to dictionary for serialization."""
@@ -228,20 +232,33 @@ class UnifiedComparisonSummary:
     Attributes:
         platforms: List of compared platforms
         platform_type: Type of platforms compared
-        fastest_platform: Platform with best performance
-        slowest_platform: Platform with worst performance
-        speedup_ratio: How much faster the fastest is vs slowest
+        fastest_platform: Platform with best performance, or None when no
+            platform produced a usable timing
+        slowest_platform: Platform with worst performance, or None when no
+            platform produced a usable timing
+        speedup_ratio: How much faster the fastest is vs slowest, or None
+            when there is nothing to compare
         query_winners: Best platform per query
         total_queries: Number of queries compared
     """
 
     platforms: list[str]
     platform_type: PlatformType
-    fastest_platform: str
-    slowest_platform: str
-    speedup_ratio: float
+    fastest_platform: str | None
+    slowest_platform: str | None
+    speedup_ratio: float | None
     query_winners: dict[str, str]
     total_queries: int
+
+    @property
+    def is_comparable(self) -> bool:
+        """True when at least one platform produced a usable timing.
+
+        When no platform timed a query there is nothing to rank, and
+        ``fastest_platform`` / ``slowest_platform`` / ``speedup_ratio`` are
+        ``None`` rather than a fabricated self-comparison.
+        """
+        return self.fastest_platform is not None
 
     def to_dict(self) -> dict[str, Any]:
         """Convert to dictionary for serialization."""

--- a/tests/unit/cli/commands/test_compare_coverage.py
+++ b/tests/unit/cli/commands/test_compare_coverage.py
@@ -209,16 +209,27 @@ def test_run_platform_comparison_formats(monkeypatch: pytest.MonkeyPatch, tmp_pa
             self.__dict__.update(kwargs)
 
     class _Result:
+        # success_rate / query_results model a platform that ran cleanly, so
+        # this format-coverage test exercises the output paths rather than the
+        # failure exit that _exit_on_comparison_failure now enforces.
+        platform = "duckdb"
+        success_rate = 100.0
+        query_results: list = []
+
         def to_dict(self):
             return {"ok": True}
 
     class _Summary:
+        is_comparable = True
+        speedup_ratio = 2.0
+
         def to_dict(self):
             return {"summary": True}
 
     class _Suite:
-        def __init__(self, config):
+        def __init__(self, config, platform_runner=None):
             self.config = config
+            self.platform_runner = platform_runner
 
         def run_comparison(self, **_kwargs):
             return [_Result()]

--- a/tests/unit/cli/test_compare_run_mode_exit_contract.py
+++ b/tests/unit/cli/test_compare_run_mode_exit_contract.py
@@ -1,0 +1,135 @@
+"""`benchbox compare` run mode must never report a success it did not achieve.
+
+Regression pins for the defect where the invocation printed as the FIRST
+example of ``benchbox compare --help`` produced::
+
+    Failed to benchmark duckdb: 'benchmark'
+    Total Queries: 0 / Fastest: duckdb / Speedup: 1.00x
+    duckdb  N/A  N/A  100%
+    EXIT=0
+
+Two independent things were wrong and both are pinned here: the summary
+fabricated a self-comparison, and the command exited 0 on total failure.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from benchbox.cli.commands.compare import _exit_on_comparison_failure
+from benchbox.core.comparison.suite import UnifiedBenchmarkSuite
+from benchbox.core.comparison.types import (
+    PlatformType,
+    UnifiedPlatformResult,
+    UnifiedQueryResult,
+)
+
+pytestmark = [
+    pytest.mark.unit,
+    pytest.mark.fast,
+]
+
+
+def _failed(platform: str, reason: str = "no driver") -> UnifiedPlatformResult:
+    """A platform that raised before running any query."""
+    return UnifiedBenchmarkSuite()._build_platform_result(
+        platform,
+        PlatformType.SQL,
+        [
+            UnifiedQueryResult(
+                query_id="ALL",
+                platform=platform,
+                platform_type=PlatformType.SQL,
+                status="ERROR",
+                error_message=reason,
+            )
+        ],
+    )
+
+
+def _succeeded(platform: str, geomean: float) -> UnifiedPlatformResult:
+    return UnifiedBenchmarkSuite()._build_platform_result(
+        platform,
+        PlatformType.SQL,
+        [
+            UnifiedQueryResult(
+                query_id="Q1",
+                platform=platform,
+                platform_type=PlatformType.SQL,
+                iterations=1,
+                execution_times_ms=[geomean],
+                mean_time_ms=geomean,
+                min_time_ms=geomean,
+                max_time_ms=geomean,
+                status="SUCCESS",
+            )
+        ],
+    )
+
+
+class TestFailedPlatformIsNeverReportedSuccessful:
+    def test_a_platform_that_raised_has_zero_success_rate(self):
+        assert _failed("duckdb").success_rate == 0.0
+
+    def test_bare_construction_defaults_to_zero_not_one_hundred(self):
+        bare = UnifiedPlatformResult(platform="duckdb", platform_type=PlatformType.SQL)
+        assert bare.success_rate == 0.0
+
+
+class TestSummaryDoesNotFabricateAComparison:
+    def test_total_failure_yields_no_ranking(self):
+        summary = UnifiedBenchmarkSuite().get_summary([_failed("duckdb"), _failed("sqlite")])
+        assert summary.fastest_platform is None
+        assert summary.slowest_platform is None
+        assert summary.speedup_ratio is None
+        assert summary.is_comparable is False
+
+    def test_the_all_sentinel_is_not_counted_as_a_query(self):
+        summary = UnifiedBenchmarkSuite().get_summary([_succeeded("duckdb", 10.0), _failed("snowflake")])
+        assert summary.total_queries == 1
+
+    def test_one_surviving_platform_is_not_a_speedup(self):
+        summary = UnifiedBenchmarkSuite().get_summary([_succeeded("duckdb", 10.0), _failed("snowflake")])
+        assert summary.fastest_platform == "duckdb"
+        assert summary.slowest_platform is None
+        assert summary.speedup_ratio is None
+
+    def test_two_surviving_platforms_do_produce_a_ratio(self):
+        summary = UnifiedBenchmarkSuite().get_summary([_succeeded("duckdb", 10.0), _succeeded("sqlite", 40.0)])
+        assert summary.fastest_platform == "duckdb"
+        assert summary.slowest_platform == "sqlite"
+        assert summary.speedup_ratio == pytest.approx(4.0)
+
+
+class TestExitCode:
+    def test_total_failure_exits_nonzero(self):
+        results = [_failed("duckdb"), _failed("sqlite")]
+        summary = UnifiedBenchmarkSuite().get_summary(results)
+        with pytest.raises(SystemExit) as exit_info:
+            _exit_on_comparison_failure(results, summary)
+        assert exit_info.value.code == 1
+
+    def test_partial_failure_exits_nonzero(self):
+        results = [_succeeded("duckdb", 10.0), _failed("snowflake")]
+        summary = UnifiedBenchmarkSuite().get_summary(results)
+        with pytest.raises(SystemExit) as exit_info:
+            _exit_on_comparison_failure(results, summary)
+        assert exit_info.value.code == 1
+
+    def test_full_success_does_not_exit(self):
+        results = [_succeeded("duckdb", 10.0), _succeeded("sqlite", 40.0)]
+        summary = UnifiedBenchmarkSuite().get_summary(results)
+        _exit_on_comparison_failure(results, summary)
+
+
+class TestTextReportNeverClaimsAnUnearnedSpeedup:
+    def test_total_failure_report_says_n_a(self):
+        report = UnifiedBenchmarkSuite()._generate_text_report([_failed("duckdb"), _failed("sqlite")])
+        assert "1.00x" not in report
+        assert "no platform produced a usable timing" in report
+        assert "100%" not in report
+
+    def test_markdown_report_says_n_a(self):
+        report = UnifiedBenchmarkSuite()._generate_markdown_report([_failed("duckdb"), _failed("sqlite")])
+        assert "1.00x" not in report
+        assert "n/a" in report

--- a/tests/unit/core/test_comparison.py
+++ b/tests/unit/core/test_comparison.py
@@ -167,7 +167,10 @@ class TestUnifiedPlatformResult:
         pr = UnifiedPlatformResult(platform="duckdb", platform_type=PlatformType.SQL)
         assert pr.query_results == []
         assert pr.total_time_ms == 0.0
-        assert pr.success_rate == 100.0
+        # 0.0, not 100.0: a result that has not been aggregated has not
+        # demonstrated a single successful query. The old 100.0 default let a
+        # platform that failed outright be reported as fully successful.
+        assert pr.success_rate == 0.0
 
     def test_to_dict(self):
         qr = UnifiedQueryResult(query_id="Q1", platform="duckdb", platform_type=PlatformType.SQL)
@@ -293,9 +296,13 @@ class TestUnifiedBenchmarkSuiteGetSummary:
             self.suite.get_summary([])
 
     def test_get_summary_no_geomeans(self):
+        """Nothing timed successfully, so there is nothing to rank."""
         r1 = UnifiedPlatformResult(platform="p1", platform_type=PlatformType.SQL, geometric_mean_ms=0.0)
         summary = self.suite.get_summary([r1])
-        assert summary.speedup_ratio == 1.0
+        assert summary.speedup_ratio is None
+        assert summary.fastest_platform is None
+        assert summary.slowest_platform is None
+        assert summary.is_comparable is False
 
     def test_run_comparison_empty_raises(self):
         with pytest.raises(ValueError, match="At least one"):

--- a/tests/unit/core/test_unified_comparison_suite.py
+++ b/tests/unit/core/test_unified_comparison_suite.py
@@ -255,10 +255,15 @@ class TestGetSummary:
         assert abs(summary.speedup_ratio - 5.0) < 0.01
 
     def test_handles_no_geomeans(self):
+        """No timings means no ranking, not a fabricated 1.00x self-comparison."""
         suite = UnifiedBenchmarkSuite()
         results = [_pr("duckdb", geomean=0.0), _pr("sqlite", geomean=0.0)]
         summary = suite.get_summary(results)
-        assert summary.speedup_ratio == 1.0
+        assert summary.speedup_ratio is None
+        assert summary.fastest_platform is None
+        assert summary.slowest_platform is None
+        assert summary.is_comparable is False
+        assert summary.total_queries == 0
 
     def test_finds_query_winners(self):
         suite = UnifiedBenchmarkSuite()
@@ -438,99 +443,79 @@ class TestRunDataframeComparison:
 
 
 class TestBenchmarkSqlPlatform:
-    def test_remote_platform_uses_adapter_connect(self):
-        """Test non-embedded platform calls adapter.connect() and runs queries."""
-        config = UnifiedBenchmarkConfig(query_ids=["Q1"])
+    """The SQL path routes through the canonical run service.
+
+    It used to be a private TPC-H-only runner that required pre-generated data
+    at a guessed directory and never reached the real benchmark path, so the
+    documented ``benchbox compare -p duckdb -p sqlite`` invocation could not
+    work. These tests pin the delegation and the result conversion instead.
+    """
+
+    def test_delegates_to_the_canonical_run_path(self):
+        config = UnifiedBenchmarkConfig(query_ids=["Q1"], benchmark="tpch", scale_factor=0.01)
         suite = UnifiedBenchmarkSuite(config=config)
 
-        mock_conn = MagicMock()
-        mock_adapter = MagicMock()
-        mock_adapter.connect.return_value = mock_conn
+        run_results = SimpleNamespace(
+            query_results=[
+                {
+                    "query_id": "Q1",
+                    "status": "SUCCESS",
+                    "execution_time_seconds": 0.05,
+                    "rows_returned": 4,
+                    "run_type": "measurement",
+                }
+            ]
+        )
+        with patch.object(suite, "_execute_platform_run", return_value=run_results) as run:
+            result = suite._benchmark_sql_platform("duckdb")
 
-        mock_qr = _qr("Q1", "snowflake", 150.0)
+        run.assert_called_once_with("duckdb", None)
+        assert result.platform == "duckdb"
+        assert result.success_rate == 100.0
+        assert [q.query_id for q in result.query_results] == ["Q1"]
+        assert result.query_results[0].mean_time_ms == pytest.approx(50.0)
+
+    def test_run_failure_propagates_so_the_caller_records_a_failure(self):
+        suite = UnifiedBenchmarkSuite(config=UnifiedBenchmarkConfig(query_ids=["Q1"]))
         with (
-            patch("benchbox.platforms.get_adapter", return_value=mock_adapter),
-            patch.object(suite, "_run_sql_query", return_value=mock_qr),
+            patch.object(suite, "_execute_platform_run", side_effect=RuntimeError("no driver")),
+            pytest.raises(RuntimeError, match="no driver"),
         ):
-            result = suite._benchmark_sql_platform("snowflake")
+            suite._benchmark_sql_platform("snowflake")
 
-        mock_adapter.connect.assert_called_once()
-        mock_conn.close.assert_called_once()
-        assert result.platform == "snowflake"
+    def test_warmup_iterations_are_excluded(self):
+        suite = UnifiedBenchmarkSuite(config=UnifiedBenchmarkConfig())
+        run_results = SimpleNamespace(
+            query_results=[
+                {"query_id": "Q1", "status": "SUCCESS", "execution_time_seconds": 9.0, "run_type": "warmup"},
+                {"query_id": "Q1", "status": "SUCCESS", "execution_time_seconds": 0.1, "run_type": "measurement"},
+                {"query_id": "Q1", "status": "SUCCESS", "execution_time_seconds": 0.3, "run_type": "measurement"},
+            ]
+        )
+        results = suite._to_unified_query_results(run_results, "duckdb")
+        assert len(results) == 1
+        assert results[0].iterations == 2
+        assert results[0].mean_time_ms == pytest.approx(200.0)
 
-    def test_embedded_platform_raises_on_missing_data_dir(self, tmp_path):
-        """Test embedded platform raises ValueError if data dir missing."""
-        config = UnifiedBenchmarkConfig(query_ids=["Q1"])
-        suite = UnifiedBenchmarkSuite(config=config)
-        mock_adapter = MagicMock()
+    def test_a_query_whose_iterations_all_failed_stays_in_the_denominator(self):
+        suite = UnifiedBenchmarkSuite(config=UnifiedBenchmarkConfig())
+        run_results = SimpleNamespace(
+            query_results=[
+                {"query_id": "Q1", "status": "SUCCESS", "execution_time_seconds": 0.1, "run_type": "measurement"},
+                {"query_id": "Q2", "status": "ERROR", "error": "syntax", "run_type": "measurement"},
+            ]
+        )
+        results = suite._to_unified_query_results(run_results, "duckdb")
+        assert [(q.query_id, q.status) for q in results] == [("Q1", "SUCCESS"), ("Q2", "ERROR")]
+        built = suite._build_platform_result("duckdb", PlatformType.SQL, results)
+        assert built.success_rate == pytest.approx(50.0)
 
-        with (
-            patch("benchbox.platforms.get_adapter", return_value=mock_adapter),
-            pytest.raises(ValueError, match="Data directory not found"),
-        ):
-            suite._benchmark_sql_platform("duckdb", data_dir="/nonexistent/path")
+    def test_query_ids_are_normalized_for_the_run_path(self):
+        suite = UnifiedBenchmarkSuite(config=UnifiedBenchmarkConfig(query_ids=["Q1", "6", "q22"]))
+        assert suite._normalized_query_ids() == ["1", "6", "22"]
 
-    def test_embedded_platform_auto_data_dir_missing(self):
-        """Test embedded platform with None data_dir raises when auto-path missing."""
-        config = UnifiedBenchmarkConfig(query_ids=["Q1"])
-        suite = UnifiedBenchmarkSuite(config=config)
-        mock_adapter = MagicMock()
-
-        with (
-            patch("benchbox.platforms.get_adapter", return_value=mock_adapter),
-            pytest.raises(ValueError, match="Data directory not found"),
-        ):
-            suite._benchmark_sql_platform("duckdb", data_dir=None)
-
-
-# ---------------------------------------------------------------------------
-# _run_sql_query
-# ---------------------------------------------------------------------------
-
-
-class TestRunSqlQuery:
-    def test_success_path(self):
-        import sys
-
-        config = UnifiedBenchmarkConfig(warmup_iterations=0, benchmark_iterations=1)
-        suite = UnifiedBenchmarkSuite(config=config)
-
-        mock_conn = MagicMock()
-        mock_conn.execute.return_value.fetchall.return_value = [("row1",), ("row2",)]
-
-        mock_tpch_query = MagicMock()
-        mock_tpch_query.sql = "SELECT 1"
-
-        mock_tpch_class = MagicMock()
-        mock_tpch_class.get_query.return_value = mock_tpch_query
-
-        mock_queries_mod = MagicMock()
-        mock_queries_mod.TPCHQuery = mock_tpch_class
-
-        with patch.dict(sys.modules, {"benchbox.core.tpch.queries": mock_queries_mod}):
-            result = suite._run_sql_query("Q1", "duckdb", mock_conn)
-
-        assert result.status == "SUCCESS"
-        assert result.rows_returned == 2
-        assert result.query_id == "Q1"
-
-    def test_error_path(self):
-        import sys
-
-        config = UnifiedBenchmarkConfig(warmup_iterations=0, benchmark_iterations=1)
-        suite = UnifiedBenchmarkSuite(config=config)
-        mock_conn = MagicMock()
-
-        mock_tpch_class = MagicMock()
-        mock_tpch_class.get_query.side_effect = RuntimeError("query not found")
-        mock_queries_mod = MagicMock()
-        mock_queries_mod.TPCHQuery = mock_tpch_class
-
-        with patch.dict(sys.modules, {"benchbox.core.tpch.queries": mock_queries_mod}):
-            result = suite._run_sql_query("Q1", "duckdb", mock_conn)
-
-        assert result.status == "ERROR"
-        assert "query not found" in result.error_message
+    def test_no_query_ids_means_every_query(self):
+        assert UnifiedBenchmarkSuite(config=UnifiedBenchmarkConfig())._normalized_query_ids() is None
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
`benchbox compare -p duckdb -p sqlite` -- the first example printed by
`benchbox compare --help` -- ran nothing, reported `Speedup: 1.00x` with
`100%` success on both platforms, and exited 0.

Three independent defects produced that output:

1. `_benchmark_sql_platform` was a hardcoded TPC-H-only runner that required
   pre-generated data at a guessed `benchmark_runs/tpch/sf<X>/data`, never
   generated data, and never reached the real benchmark path. DuckDB raised
   `KeyError: 'benchmark'` from `get_adapter()` on an empty config; SQLite
   raised `ConfigurationError` before the directory check. It now delegates to
   `BenchmarkOrchestrator.execute_benchmark`, the same entry point
   `benchbox run` uses, so datagen, schema, load and phase handling are shared
   rather than reimplemented. The superseded in-suite runner and its embedded
   data-loading helper are removed so the duplicate cannot drift back.

2. Both failure paths bypassed `_build_platform_result`, so the dataclass
   default `success_rate = 100.0` survived into the report. The default is now
   0.0 -- a result that has not been aggregated has not demonstrated a single
   successful query -- and the failure path builds through the aggregator.

3. `get_summary` named `platforms[0]` as both fastest and slowest with a 1.00x
   ratio when nothing timed. `fastest_platform`, `slowest_platform` and
   `speedup_ratio` are now `None` when there is nothing to rank, a lone
   surviving platform no longer reports a speedup against itself, and the
   `ALL` failure sentinel no longer inflates the query count.

The CLI now exits non-zero when any requested platform produced no successful
query, so callers and CI wrappers can tell total failure from a real result.

Verified on this branch:
  compare -p duckdb -p sqlite --scale 0.01  -> 22 queries each, 7.21x, exit 0
  compare -p duckdb -p snowflake            -> snowflake 0%, no ratio, exit 1
  file mode (compare a.json b.json)         -> unchanged, exit 0

`benchbox.core` may not import `benchbox.cli` (import-linter contract
"utils < core < platforms < cli"), so the suite takes an injected
`platform_runner` and the CLI supplies the orchestrator wiring -- the same
shape as `execute_run(adapter_factory=...)` in `benchbox.core.run_service`.
All three import contracts stay kept.

Two tests pinned the defective behaviour (`success_rate == 100.0` on a bare
construction, `speedup_ratio == 1.0` with no geomeans) and now pin the correct
contract. `make pr-preflight` is green: 28,018 passed, 0 failed.
