### PR TITLE
fix(explorer): resolve the SQL-vs-DataFrame facet instead of leaving it NULL

### DIFF
--- a/_project/scripts/explorer_pipeline/transformer.py
+++ b/_project/scripts/explorer_pipeline/transformer.py
@@ -336,18 +336,49 @@ def _platform_version(data: dict[str, Any]) -> str | None:
     return str(val) if val and val != "unknown" else None
 
 
+#: Ordered key paths consulted for a bundle's SQL-vs-DataFrame execution mode.
+#:
+#: Measured against all 207 published bundles on 2026-08-23:
+#:   - ``config.execution_mode`` and ``execution.execution_mode`` are the
+#:     documented schema locations but NO bundle writes either, which is why
+#:     the facet was NULL for 207 of 207 rows.
+#:   - ``platform.config.execution_mode`` is populated on every bundle,
+#:     including ones produced by current develop.
+#:   - ``config.mode`` agrees with it on all 207.
+#:   - Both agree with the filename suffix (``_df_`` / ``_sql_``) wherever one
+#:     exists: 105 df, 95 sql, 7 without a suffix.
+#:
+#: ``execution.mode`` is deliberately NOT consulted: it reads "sql" for 105
+#: DataFrame runs, so using it would label more than half the corpus wrongly.
+_EXECUTION_MODE_KEY_PATHS: tuple[tuple[str, ...], ...] = (
+    ("config", "execution_mode"),
+    ("platform", "config", "execution_mode"),
+    ("config", "mode"),
+    ("execution", "execution_mode"),
+)
+
+#: Values a bundle may legitimately carry for execution mode.
+_EXECUTION_MODES = frozenset({"sql", "dataframe"})
+
+
 def _execution_mode(data: dict[str, Any]) -> str | None:
-    """Extract execution mode (sql/dataframe) from schema-v2 bundle."""
-    config = data.get("config", {})
-    if isinstance(config, dict):
-        val = config.get("execution_mode")
-        if val:
-            return str(val)
-    execution = data.get("execution", {})
-    if isinstance(execution, dict):
-        val = execution.get("execution_mode")
-        if val:
-            return str(val)
+    """Extract execution mode (sql/dataframe) from a schema-v2 bundle.
+
+    Walks :data:`_EXECUTION_MODE_KEY_PATHS` in order and returns the first
+    recognized value. A bundle that records no mode, or records something
+    outside the known vocabulary, stays ``None`` rather than being guessed --
+    an invented mode would label a DataFrame result as SQL, which is worse
+    than an honestly empty facet.
+    """
+    for path in _EXECUTION_MODE_KEY_PATHS:
+        node: Any = data
+        for key in path:
+            if not isinstance(node, dict):
+                node = None
+                break
+            node = node.get(key)
+        if node and str(node).lower() in _EXECUTION_MODES:
+            return str(node).lower()
     return None
 
 

--- a/tests/unit/scripts/explorer_pipeline/test_transformer.py
+++ b/tests/unit/scripts/explorer_pipeline/test_transformer.py
@@ -1267,3 +1267,103 @@ class TestAppliedReceiptCompanion:
 
         transformer = BundleTransformer()
         assert transformer.to_detail_result(bundle, result_id="r").applied_receipt is None
+
+
+class TestExecutionModeExtraction:
+    """The SQL-vs-DataFrame facet must resolve for every published bundle.
+
+    It read only ``config.execution_mode`` / ``execution.execution_mode``,
+    which no bundle writes, so ``execution_mode`` was NULL for all 207 rows in
+    the shipping snapshot and the facet filtered nothing.
+    """
+
+    def test_reads_the_key_path_current_develop_writes(self) -> None:
+        bundle = {"platform": {"config": {"execution_mode": "sql"}}}
+        assert transformer_module._execution_mode(bundle) == "sql"
+
+    def test_reads_legacy_config_mode(self) -> None:
+        bundle = {"config": {"mode": "dataframe"}}
+        assert transformer_module._execution_mode(bundle) == "dataframe"
+
+    def test_documented_schema_location_wins(self) -> None:
+        bundle = {
+            "config": {"execution_mode": "dataframe", "mode": "sql"},
+            "platform": {"config": {"execution_mode": "sql"}},
+        }
+        assert transformer_module._execution_mode(bundle) == "dataframe"
+
+    def test_execution_mode_field_is_not_consulted(self) -> None:
+        """``execution.mode`` says "sql" for 105 DataFrame runs in the corpus.
+
+        Trusting it would mislabel more than half the published results, so it
+        is deliberately excluded from the key paths.
+        """
+        bundle = {
+            "config": {"mode": "dataframe"},
+            "execution": {"mode": "sql"},
+            "platform": {"config": {"execution_mode": "dataframe"}},
+        }
+        assert transformer_module._execution_mode(bundle) == "dataframe"
+
+    def test_unknown_vocabulary_stays_none(self) -> None:
+        """An invented mode is worse than an honestly empty facet."""
+        assert transformer_module._execution_mode({"config": {"mode": "balanced"}}) is None
+
+    def test_missing_everywhere_stays_none(self) -> None:
+        assert transformer_module._execution_mode({}) is None
+
+    def test_case_is_normalized(self) -> None:
+        assert transformer_module._execution_mode({"config": {"mode": "SQL"}}) == "sql"
+
+    @pytest.mark.parametrize("node", [None, "not-a-dict", 42, []])
+    def test_non_dict_nodes_do_not_raise(self, node: object) -> None:
+        assert transformer_module._execution_mode({"config": node, "platform": node}) is None
+
+
+class TestPublishedCorpusResolvesExecutionMode:
+    """Corpus-level guard: no published bundle may yield a NULL facet.
+
+    The unit cases above pin the key paths; this pins the actual corpus, which
+    is what the public site renders.
+    """
+
+    def test_every_published_bundle_resolves(self) -> None:
+        corpus = Path(__file__).resolve().parents[4] / "results-data" / "bundles"
+        if not corpus.is_dir():
+            pytest.skip("results-data/bundles not present in this checkout")
+
+        unresolved = []
+        total = 0
+        for path in sorted(corpus.rglob("*.json")):
+            if path.name.endswith(".manifest.json"):
+                continue
+            total += 1
+            data = json.loads(path.read_text(encoding="utf-8"))
+            if transformer_module._execution_mode(data) is None:
+                unresolved.append(path.name)
+
+        assert total > 0, "no bundles discovered"
+        assert not unresolved, f"{len(unresolved)} of {total} bundles yield a NULL execution_mode: {unresolved[:5]}"
+
+    def test_resolved_mode_agrees_with_the_filename_suffix(self) -> None:
+        """``_df_`` / ``_sql_`` in the filename is an independent witness."""
+        corpus = Path(__file__).resolve().parents[4] / "results-data" / "bundles"
+        if not corpus.is_dir():
+            pytest.skip("results-data/bundles not present in this checkout")
+
+        mismatches = []
+        for path in sorted(corpus.rglob("*.json")):
+            if path.name.endswith(".manifest.json"):
+                continue
+            if "_df_" in path.name:
+                expected = "dataframe"
+            elif "_sql_" in path.name:
+                expected = "sql"
+            else:
+                continue
+            data = json.loads(path.read_text(encoding="utf-8"))
+            actual = transformer_module._execution_mode(data)
+            if actual != expected:
+                mismatches.append((path.name, expected, actual))
+
+        assert not mismatches, f"filename suffix disagrees with resolved mode: {mismatches[:5]}"


### PR DESCRIPTION
`execution_mode` was NULL for all 207 rows in the shipping snapshot, so the
SQL-vs-DataFrame facet -- the differentiator the README leads with -- filtered
nothing on the public site.

`_execution_mode` read only `config.execution_mode` and
`execution.execution_mode`. Measured across all 207 published bundles: no
bundle writes either key. This is a live bug, not a legacy-data one -- a
bundle produced by current develop writes `platform.config.execution_mode`,
which the extractor also missed, so every future bundle would land NULL too.

Key-path precedence, chosen from evidence rather than convenience:

  config.execution_mode            documented schema location (absent today)
  platform.config.execution_mode   what current develop writes; on all 207
  config.mode                      agrees with the above on all 207
  execution.execution_mode         documented fallback (absent today)

`execution.mode` is deliberately excluded. It reads "sql" for 105 DataFrame
runs, so consulting it would mislabel more than half the corpus. The filename
suffix is an independent witness and agrees with the chosen precedence on
every bundle that has one: 105 `_df_`, 95 `_sql_`, 7 without a suffix.

A mode outside {sql, dataframe} stays NULL rather than being guessed: an
invented mode labelling a DataFrame result as SQL is worse than an honestly
empty facet.

Result across the corpus: 207 NULL -> 107 dataframe / 100 sql.

Audited the sibling empty facets while here. `tuning_mode`, `compliance_class`
and `has_plans` are NULL/false for all 207 because NO bundle records that data
at all -- zero tuning, compliance or plan keys are present in any bundle.
Those are missing data, not a missing reader, so the extractors are correct
and the remedy belongs to the corpus item, not here.

Tests pin the key paths, the exclusion of `execution.mode`, the unknown-value
behaviour, and two corpus-level guards: no published bundle may yield NULL,
and the resolved mode must agree with the filename suffix.
