### PR TITLE
fix(uat): use a Python 3.10-compatible UTC so the nightly lane can go green

### DIFF
--- a/tests/uat/clickhouse_memory.py
+++ b/tests/uat/clickhouse_memory.py
@@ -306,7 +306,10 @@ class ClickHouseMemoryTrace:
 
 
 def utc_now() -> str:
-    return _dt.datetime.now(_dt.UTC).isoformat().replace("+00:00", "Z")
+    # datetime.UTC is 3.11+; this project supports >=3.10 (pyproject
+    # requires-python), and the 3.10 nightly lane failed every run on
+    # AttributeError: module 'datetime' has no attribute 'UTC'.
+    return _dt.datetime.now(_dt.timezone.utc).isoformat().replace("+00:00", "Z")
 
 
 def parse_memory_bytes(value: Any) -> int | None:

--- a/tests/unit/test_python_version_floor_guard.py
+++ b/tests/unit/test_python_version_floor_guard.py
@@ -1,0 +1,94 @@
+"""Guard: shipped and test code must run on the oldest supported Python.
+
+`pyproject.toml` declares `requires-python = ">=3.10,<3.15"`, but nothing
+enforced that against the source. `tests/uat/clickhouse_memory.py` used
+`datetime.UTC` (3.11+), which made every test in
+`tests/uat/test_clickhouse_memory.py` fail on the ubuntu-latest/3.10 nightly
+lane with `AttributeError: module 'datetime' has no attribute 'UTC'`. That
+lane was red every scheduled run for at least five days, and a green nightly
+is a precondition for the UAT release-gate evidence `validate-base` requires.
+
+The test is deliberately AST-based: a textual grep would flag the symbol
+inside docstrings, comments and this file's own explanatory text.
+"""
+
+from __future__ import annotations
+
+import ast
+import sys
+from pathlib import Path
+
+import pytest
+
+pytestmark = [pytest.mark.unit, pytest.mark.fast]
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+#: Directories whose contents must import and run on the declared floor.
+SCANNED_ROOTS = ("benchbox", "tests", "_project/scripts", "scripts")
+
+#: Attribute accesses that only resolve on Python 3.11 or later, mapped to the
+#: spelling that works on the declared floor.
+VERSION_GATED_ATTRIBUTES = {
+    "UTC": "timezone.utc (datetime.UTC is 3.11+)",
+}
+
+
+def _minimum_supported_python() -> tuple[int, int]:
+    """Read the floor from pyproject so this guard follows the declaration."""
+    text = (REPO_ROOT / "pyproject.toml").read_text(encoding="utf-8")
+    for line in text.splitlines():
+        if line.strip().startswith("requires-python"):
+            spec = line.split("=", 1)[1]
+            floor = spec.split(">=", 1)[1].split(",", 1)[0].strip().strip('"').strip("'")
+            major, minor = floor.split(".")[:2]
+            return int(major), int(minor)
+    pytest.fail("requires-python not found in pyproject.toml")
+
+
+def _python_files() -> list[Path]:
+    files: list[Path] = []
+    for root in SCANNED_ROOTS:
+        base = REPO_ROOT / root
+        if base.is_dir():
+            files.extend(p for p in base.rglob("*.py") if ".venv" not in p.parts)
+    return files
+
+
+def test_floor_is_still_below_the_version_gated_features() -> None:
+    """If the floor moves to 3.11 this guard is obsolete and should be deleted."""
+    if _minimum_supported_python() >= (3, 11):
+        pytest.skip("floor is 3.11+, so the gated attributes are available")
+
+
+def test_no_python_311_only_attribute_access() -> None:
+    if _minimum_supported_python() >= (3, 11):
+        pytest.skip("floor is 3.11+, so the gated attributes are available")
+
+    offenders: list[str] = []
+    for path in sorted(_python_files()):
+        if path == Path(__file__).resolve():
+            continue
+        try:
+            tree = ast.parse(path.read_text(encoding="utf-8"))
+        except (SyntaxError, UnicodeDecodeError):  # pragma: no cover - not our concern here
+            continue
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Attribute) and node.attr in VERSION_GATED_ATTRIBUTES:
+                rel = path.relative_to(REPO_ROOT)
+                fix = VERSION_GATED_ATTRIBUTES[node.attr]
+                offenders.append(f"{rel}:{node.lineno} uses .{node.attr} - use {fix}")
+
+    assert not offenders, "Python 3.11+ only API used while 3.10 is supported:\n  " + "\n  ".join(offenders)
+
+
+def test_the_guard_would_actually_catch_the_original_defect() -> None:
+    """Negative control: the AST rule fires on the exact line that broke nightly."""
+    source = "import datetime as _dt\n_dt.datetime.now(_dt.UTC)\n"
+    tree = ast.parse(source)
+    found = [n.attr for n in ast.walk(tree) if isinstance(n, ast.Attribute) and n.attr in VERSION_GATED_ATTRIBUTES]
+    assert found == ["UTC"]
+
+
+def test_running_interpreter_is_within_the_declared_range() -> None:
+    assert sys.version_info[:2] >= _minimum_supported_python()


### PR DESCRIPTION
`tests/uat/clickhouse_memory.py:309` called `_dt.datetime.now(_dt.UTC)`.
`datetime.UTC` is 3.11+, and `pyproject.toml` declares
`requires-python = ">=3.10,<3.15"`, so every test in
`tests/uat/test_clickhouse_memory.py` failed on the ubuntu-latest/3.10 nightly
lane with `AttributeError: module 'datetime' has no attribute 'UTC'`.

Nightly Validation had failed on every scheduled run from 2026-08-19 through
2026-08-23. This is one of its root causes; the Windows durable-MCP-job
failure and the Release Canary shard 4/6 failure are separate and are NOT
addressed here.

Scope note: this is test-only. `grep` for `datetime.UTC` across `benchbox/`
returns zero hits, so the shipped package was never affected on 3.10 -- but
the red lane still blocks the UAT release-gate evidence that
`docs/operations/release-guide.md` requires before a release PR can pass
`validate-base`.

Adds `tests/unit/test_python_version_floor_guard.py`, which reads the floor
from `pyproject.toml` and fails on 3.11+-only attribute access anywhere in
`benchbox/`, `tests/`, `_project/scripts/` or `scripts/`. It is AST-based
rather than textual so it does not flag the symbol inside docstrings or its
own explanation, carries a negative control proving it fires on the exact
line that broke nightly, and skips itself if the floor ever moves to 3.11.
