### PR TITLE
test(platforms): fail when an adapter advertises a --platform-option the CLI rejects

### DIFF
--- a/benchbox/cli/commands/setup.py
+++ b/benchbox/cli/commands/setup.py
@@ -57,6 +57,11 @@ def setup_credentials(ctx, platform, validate_only, list_platforms_flag, show_st
     secure local credential storage; MotherDuck validates MOTHERDUCK_TOKEN
     without storing the token.
 
+    This is about CREDENTIALS. `benchbox platforms setup` is a different
+    command that enables and installs local platform adapters. The two share
+    the word "setup"; this is the one for cloud authentication, and
+    `benchbox platforms setup --platform <name>` delegates here.
+
     \b
     Examples:
         benchbox setup --platform databricks    # Interactive Databricks setup

--- a/benchbox/cli/platform.py
+++ b/benchbox/cli/platform.py
@@ -18,6 +18,7 @@ from rich.prompt import Confirm, InvalidResponse, Prompt
 from rich.table import Table
 from rich.text import Text
 
+from benchbox.cli.commands.setup import SUPPORTED_SETUP_PLATFORMS
 from benchbox.cli.platform_readiness import (
     PlatformReadinessResult,
     check_platform_readiness,
@@ -999,8 +1000,37 @@ def check_platforms(platforms_to_check: tuple, enabled_only: bool):
 
 @platforms.command("setup")
 @click.option("--interactive/--non-interactive", default=True, help="Interactive setup mode")
-def setup_platforms(interactive: bool):
-    """Interactive platform setup wizard."""
+@click.option(
+    "--platform",
+    "credential_platform",
+    type=click.Choice(SUPPORTED_SETUP_PLATFORMS, case_sensitive=False),
+    help="Configure credentials for one cloud platform (delegates to `benchbox setup`)",
+)
+@click.pass_context
+def setup_platforms(ctx: click.Context, interactive: bool, credential_platform: str | None):
+    """Enable and install local platform adapters, interactively.
+
+    This is about which adapters are available on this machine. For cloud
+    CREDENTIALS -- Databricks, Snowflake, BigQuery, Redshift, Athena,
+    MotherDuck, SingleStore -- use `benchbox setup --platform <name>`.
+
+    The two commands are both spelled "setup", and adapter error messages have
+    repeatedly sent users to `benchbox platforms setup --platform <name>`,
+    which had no such option and exited 2. Rather than leave that a dead end,
+    `--platform` here delegates to `benchbox setup`, which is what the user
+    meant. `benchbox setup` rejects a non-cloud platform with its own list.
+    """
+    if credential_platform is not None:
+        # The Choice above is load-bearing: ctx.invoke skips Click's parameter
+        # processing, so without it an unknown name reached the credential
+        # wizard unvalidated and produced a confident "Nonesuch Credentials
+        # Setup" panel that exited 0. Validating here keeps the delegation
+        # honest and rejects a non-cloud platform with the real list.
+        from benchbox.cli.commands.setup import setup_credentials
+
+        ctx.invoke(setup_credentials, platform=credential_platform)
+        return
+
     manager = get_platform_manager()
     platforms_info = manager.detect_platforms()
 

--- a/benchbox/platforms/__init__.py
+++ b/benchbox/platforms/__init__.py
@@ -633,6 +633,7 @@ databricks|liquid_clustering_columns|Comma-separated Databricks liquid clusterin
 bigquery|staging_root|GCS path for staging data (e.g., gs://bucket/path)|{}
 bigquery|storage_bucket|GCS bucket name for data staging (alternative to staging_root)|{}
 bigquery|storage_prefix|GCS path prefix within bucket for data staging|{}
+bigquery|biglake_connection|BigLake connection for external table modes, as project.region.name|{}
 trino|catalog|Trino catalog to use (e.g., hive, iceberg, memory). Auto-discovered if not specified.|{}
 trino|staging_root|Cloud storage path for staging data (e.g., s3://..., gs://..., abfss://...)|{}
 trino|table_format|Table format for creating tables (memory, hive, iceberg, delta)|{'default': 'memory'}

--- a/benchbox/platforms/__init__.py
+++ b/benchbox/platforms/__init__.py
@@ -697,6 +697,7 @@ pg-duckdb|max_parallel_workers_per_gather|PostgreSQL max_parallel_workers_per_ga
 pg-duckdb|force_execution|Force DuckDB execution engine for all queries|{'parser': 'parse_bool', 'default': True}
 pg-duckdb|postgres_scan_threads|Threads for parallel PostgreSQL table scanning (0 = auto)|{'parser': 'int', 'default': 0}
 pg-duckdb|compare_native|Run native DuckDB comparison for matched queries|{'parser': 'parse_bool', 'default': False}
+pg-duckdb|duckdb_db_path|Path to the DuckDB database file pg_duckdb attaches|{}
 ducklake|metadata_path|DuckLake catalog metadata file path (.ducklake)|{}
 ducklake|data_path|DuckLake Parquet data directory (local path or s3:// URI)|{}
 ducklake|deployment_mode|DuckLake deployment mode: local, local_catalog_s3, postgres_catalog, or postgres_catalog_s3|{'choices': ('local', 'local_catalog_s3', 'postgres_catalog', 'postgres_catalog_s3')}
@@ -746,6 +747,7 @@ synapse|storage_account|Azure storage account for data staging|{}
 synapse|container|Azure blob container name|{}
 synapse|storage_sas_token|SAS token for Azure storage access|{}
 synapse|resource_class|Workload resource class (e.g., staticrc20, staticrc30)|{'default': 'staticrc20'}
+synapse|staging_root|Azure staging path, including the storage account (e.g., abfss://container@account.dfs.core.windows.net/path)|{}
 fabric_dw|server|Fabric warehouse endpoint (e.g., workspace-guid.datawarehouse.fabric.microsoft.com)|{}
 fabric_dw|workspace|Fabric workspace name or GUID|{}
 fabric_dw|warehouse|Fabric warehouse name|{}
@@ -823,6 +825,17 @@ sqlite|database_path|Path to the SQLite database file (auto-generated from --ben
 sqlite|timeout|SQLite connection timeout in seconds|{'parser': 'float', 'default': '30.0'}
 sqlite|check_same_thread|Enforce that connections are used on the creating thread only|{'parser': 'parse_bool', 'default': 'false'}
 spark|adaptive_enabled|Enable or disable Spark Adaptive Query Execution (AQE)|{'parser': 'parse_bool', 'default': 'true'}
+spark|java_home|Path to the JDK Spark should run under|{}
+athena|aws_profile|Named AWS CLI profile to authenticate with|{}
+athena|s3_bucket|S3 bucket for query results and data staging|{}
+athena|s3_staging_dir|S3 URI Athena writes query results to (e.g., s3://bucket/path)|{}
+athena|staging_root|S3 path for staging data (alternative to s3_bucket)|{}
+motherduck|database|MotherDuck database name|{}
+redshift|iam_role|IAM role ARN Redshift COPY assumes to read from S3|{}
+redshift|s3_bucket|S3 bucket for data staging|{}
+redshift|staging_root|S3 path for staging data (e.g., s3://bucket/path)|{}
+snowflake|staging_root|Cloud storage path for staging data|{}
+snowflake|iceberg_external_volume|Snowflake EXTERNAL VOLUME name for Iceberg tables|{}
 velox|deployment|Deployment mode: 'local' (in-process SparkSession, Linux only) or 'remote' (Spark-Connect server)|{'choices': ('local', 'remote'), 'default': 'local'}
 velox|endpoint|Spark-Connect endpoint for remote mode (e.g., sc://localhost:50051)|{'default': 'sc://localhost:50051'}
 velox|gluten_jar_path|Absolute path to the Gluten Velox bundle jar (required for local mode)|{'aliases': ('jar',)}

--- a/benchbox/platforms/bigquery.py
+++ b/benchbox/platforms/bigquery.py
@@ -135,9 +135,8 @@ class BigQueryAdapter(PlatformAdapter):
             raise ConfigurationError(
                 "BigQuery configuration requires project_id.\n"
                 "Configure with one of:\n"
-                "  1. CLI: benchbox platforms setup --platform bigquery\n"
+                "  1. CLI: benchbox setup --platform bigquery\n"
                 "  2. Environment variable: BIGQUERY_PROJECT\n"
-                "  3. CLI option: --platform-option project_id=<your-project>\n"
                 "Also ensure Google Cloud credentials are configured:\n"
                 "  - Set GOOGLE_APPLICATION_CREDENTIALS to service account JSON path\n"
                 "  - Or run 'gcloud auth application-default login'"

--- a/benchbox/platforms/databricks/adapter.py
+++ b/benchbox/platforms/databricks/adapter.py
@@ -154,9 +154,8 @@ class DatabricksAdapter(PlatformAdapter):
             raise ConfigurationError(
                 f"Databricks configuration is incomplete. Missing: {', '.join(missing)}\n"
                 "Configure with one of:\n"
-                "  1. CLI: benchbox platforms setup --platform databricks\n"
-                "  2. Environment variables: DATABRICKS_HOST, DATABRICKS_HTTP_PATH, DATABRICKS_TOKEN\n"
-                "  3. CLI options: --platform-option server_hostname=<host> --platform-option http_path=<path>"
+                "  1. CLI: benchbox setup --platform databricks\n"
+                "  2. Environment variables: DATABRICKS_HOST, DATABRICKS_HTTP_PATH, DATABRICKS_TOKEN"
             )
 
     @property

--- a/benchbox/platforms/pg_duckdb.py
+++ b/benchbox/platforms/pg_duckdb.py
@@ -189,8 +189,9 @@ class PgDuckDBAdapter(PostgreSQLAdapter):
         if not token:
             raise ValueError(
                 "MotherDuck deployment mode requires authentication token.\n"
-                "Provide via --platform-option motherduck_token=<token> or "
-                "set MOTHERDUCK_TOKEN environment variable.\n"
+                "Set the MOTHERDUCK_TOKEN environment variable.\n"
+                "It is deliberately not a --platform-option: options appear in "
+                "shell history and in the process list.\n"
                 "Get your token at https://app.motherduck.com/token"
             )
         config["motherduck_token"] = token

--- a/benchbox/platforms/postgresql.py
+++ b/benchbox/platforms/postgresql.py
@@ -807,7 +807,7 @@ class PostgreSQLAdapter(PsycopgConnectionMixin, PlatformAdapter):
         statistics are absent for DML.
 
         ANALYZE is also suppressed when ``self.analyze_plans`` is False (e.g. the
-        isolated capture phase or ``--platform-option analyze_plans=false``):
+        isolated capture phase or the top-level ``--no-analyze-plans`` flag):
         plain EXPLAIN (FORMAT JSON) captures the estimated plan structure without
         re-executing the query, so a SELECT is not run a second time.
         """

--- a/tests/unit/cli/test_configuration_guidance.py
+++ b/tests/unit/cli/test_configuration_guidance.py
@@ -16,6 +16,18 @@ REPO_ROOT = Path(__file__).resolve().parents[3]
 @pytest.mark.parametrize(
     ("relative_path", "forbidden_advice"),
     [
+        (
+            "benchbox/platforms/bigquery.py",
+            ("benchbox platforms setup --platform", "--platform-option project_id="),
+        ),
+        (
+            "benchbox/platforms/databricks/adapter.py",
+            (
+                "benchbox platforms setup --platform",
+                "--platform-option server_hostname=",
+                "--platform-option http_path=",
+            ),
+        ),
         ("benchbox/platforms/snowflake.py", ("benchbox platforms setup --platform", "--platform-option account=")),
         ("benchbox/platforms/redshift.py", ("benchbox platforms setup --platform", "--platform-option host=")),
         (
@@ -40,6 +52,7 @@ def test_connection_guidance_does_not_advertise_unregistered_platform_options(
 @pytest.mark.parametrize(
     ("platform", "option", "value"),
     [
+        ("bigquery", "biglake_connection", "my-project.us.my-connection"),
         ("fabric_dw", "warehouse", "example-warehouse"),
         ("clickhouse-cloud", "host", "example.us-east-2.aws.clickhouse.cloud"),
         ("clickhouse-server", "host", "my-clickhouse.example.com"),

--- a/tests/unit/cli/test_configuration_guidance.py
+++ b/tests/unit/cli/test_configuration_guidance.py
@@ -21,6 +21,10 @@ REPO_ROOT = Path(__file__).resolve().parents[3]
             ("benchbox platforms setup --platform", "--platform-option project_id="),
         ),
         (
+            "benchbox/platforms/pg_duckdb.py",
+            ("--platform-option motherduck_token=",),
+        ),
+        (
             "benchbox/platforms/databricks/adapter.py",
             (
                 "benchbox platforms setup --platform",
@@ -52,7 +56,22 @@ def test_connection_guidance_does_not_advertise_unregistered_platform_options(
 @pytest.mark.parametrize(
     ("platform", "option", "value"),
     [
+        ("athena", "aws_profile", "benchbox-dev"),
+        ("athena", "s3_bucket", "benchbox-athena-staging"),
+        ("athena", "s3_staging_dir", "s3://benchbox-athena-staging/results"),
+        ("athena", "staging_root", "s3://benchbox-athena-staging/data"),
         ("bigquery", "biglake_connection", "my-project.us.my-connection"),
+        ("motherduck", "database", "benchbox"),
+        ("pg-duckdb", "duckdb_db_path", "/tmp/pg_duckdb.db"),
+        ("redshift", "iam_role", "arn:aws:iam::123456789012:role/benchbox"),
+        ("redshift", "s3_bucket", "benchbox-redshift-staging"),
+        ("redshift", "staging_root", "s3://benchbox-redshift-staging/data"),
+        ("snowflake", "iceberg_external_volume", "benchbox_vol"),
+        ("snowflake", "staging_root", "s3://benchbox-snowflake-staging/data"),
+        ("spark", "java_home", "/usr/lib/jvm/java-17"),
+        ("synapse", "staging_root", "abfss://c@a.dfs.core.windows.net/data"),
+        # An alias the CLI has always accepted; the guard used to miss it.
+        ("velox", "jar", "/opt/gluten/gluten-velox-bundle.jar"),
         ("fabric_dw", "warehouse", "example-warehouse"),
         ("clickhouse-cloud", "host", "example.us-east-2.aws.clickhouse.cloud"),
         ("clickhouse-server", "host", "my-clickhouse.example.com"),
@@ -64,8 +83,16 @@ def test_connection_guidance_does_not_advertise_unregistered_platform_options(
 def test_advertised_connection_options_are_accepted_by_the_cli(
     tmp_path: Path, platform: str, option: str, value: str
 ) -> None:
-    """Keep the test honest for platforms that do expose connection options."""
-    assert option in PlatformHookRegistry.list_option_specs(platform)
+    """Keep the test honest for platforms that do expose connection options.
+
+    This is the end-to-end half: it does not check that a spec exists, it
+    invokes the real CLI and asserts the option is accepted. A spec row that
+    never reached the parser would pass a registry check and fail here.
+    """
+    accepted = set(PlatformHookRegistry.list_option_specs(platform))
+    for spec in PlatformHookRegistry._option_specs.get(platform, {}).values():
+        accepted.update(getattr(spec, "aliases", ()) or ())
+    assert option in accepted
 
     result = CliRunner().invoke(
         cli,

--- a/tests/unit/cli/test_configuration_guidance.py
+++ b/tests/unit/cli/test_configuration_guidance.py
@@ -113,3 +113,43 @@ def test_advertised_connection_options_are_accepted_by_the_cli(
     )
 
     assert result.exit_code == 0, result.output
+
+
+def test_platforms_setup_platform_delegates_to_the_credential_wizard() -> None:
+    """`benchbox platforms setup --platform X` must not be a dead end.
+
+    Two commands are spelled "setup": `benchbox setup` configures cloud
+    credentials, `benchbox platforms setup` enables local adapters. Adapter
+    error messages repeatedly sent users to
+    `benchbox platforms setup --platform <name>`, which had no such option and
+    exited 2 with "No such option". Rather than leave years of advice broken,
+    the option exists and delegates.
+    """
+    result = CliRunner().invoke(cli, ["platforms", "setup", "--platform", "snowflake"])
+
+    assert "No such option" not in result.output
+    # It reached the credential wizard, which reports the missing driver.
+    assert "snowflake" in result.output.lower()
+
+
+def test_platforms_setup_platform_rejects_a_non_credential_platform() -> None:
+    """The delegation must stay validated.
+
+    `ctx.invoke` skips Click's parameter processing, so without an explicit
+    Choice an unknown name reached the credential wizard unvalidated and
+    produced a confident "Nonesuch Credentials Setup" panel that exited 0.
+    """
+    result = CliRunner().invoke(cli, ["platforms", "setup", "--platform", "duckdb"])
+
+    assert result.exit_code != 0
+    assert "is not one of" in result.output
+    assert "Credentials Setup" not in result.output
+
+
+def test_the_two_setup_commands_point_at_each_other() -> None:
+    """Whichever one a user lands on should name the other."""
+    credentials = CliRunner().invoke(cli, ["setup", "--help"]).output
+    adapters = CliRunner().invoke(cli, ["platforms", "setup", "--help"]).output
+
+    assert "platforms setup" in credentials
+    assert "benchbox setup" in adapters

--- a/tests/unit/cli/test_run_command_interactive_paths.py
+++ b/tests/unit/cli/test_run_command_interactive_paths.py
@@ -1223,6 +1223,7 @@ def test_interactive_cloud_platform_stops_when_credentials_are_missing():
         stack.enter_context(patch.object(_run_module, "DatabaseManager", return_value=db_manager))
         stack.enter_context(patch.object(_run_module, "BenchmarkManager", return_value=bench_manager))
         stack.enter_context(patch.object(_run_module, "display_system_recommendations"))
+        stack.enter_context(patch.object(_benchmarks_module, "prompt_platform_options", return_value={}))
         mock_caps = stack.enter_context(patch.object(_run_module.PlatformRegistry, "get_platform_capabilities"))
         stack.enter_context(patch.object(_run_module.PlatformRegistry, "requires_cloud_storage", return_value=True))
         stack.enter_context(patch.object(_run_module, "check_and_setup_platform_credentials", return_value=False))

--- a/tests/unit/platforms/test_advertised_platform_options.py
+++ b/tests/unit/platforms/test_advertised_platform_options.py
@@ -39,52 +39,28 @@ ADVERTISED = re.compile(r"--platform-option\s+([A-Za-z_][A-Za-z0-9_]*)\s*=")
 #: Generic prose placeholders, not real key names.
 PLACEHOLDERS = frozenset({"key", "K", "name", "value", "option"})
 
-#: The 15 advertised-but-rejected pairs still outstanding as of 2026-08-23.
-#: This list must only ever SHRINK. Each entry is a message that sends a user
-#: to a command the CLI refuses.
+#: Advertised-but-rejected pairs that are knowingly left unfixed. EMPTY, and
+#: it must only ever be re-populated with a recorded reason. Every pair the
+#: original audit found has been resolved, each according to what it is:
 #:
-#: The two BigQuery pairs that motivated this guard are already gone, each
-#: fixed the way its sensitivity calls for:
+#:   Non-secret configuration -- thirteen keys the adapters already read from
+#:   config but had never declared as option specs, so the advertised route
+#:   genuinely did not work. They are declared now, which makes the advice
+#:   true: athena aws_profile / s3_bucket / s3_staging_dir / staging_root,
+#:   motherduck database, pg-duckdb duckdb_db_path, redshift iam_role /
+#:   s3_bucket / staging_root, snowflake iceberg_external_volume /
+#:   staging_root, spark java_home, synapse staging_root.
 #:
-#:   bigquery.project_id -- a connection key, so the message now names
-#:   `benchbox setup --platform bigquery` and BIGQUERY_PROJECT, and no longer
-#:   advertises a `--platform-option` route.
+#:   Secret-bearing -- pg-duckdb motherduck_token, the one key that must never
+#:   be CLI-passable, because options land in shell history and in the process
+#:   list. The message now names MOTHERDUCK_TOKEN and says why.
 #:
-#:   bigquery.biglake_connection -- non-secret table configuration, now a real
-#:   option spec alongside its siblings staging_root / storage_bucket /
-#:   storage_prefix, which makes the advertised advice true. Deleting the
-#:   advice instead would have left external Delta mode with no documented
-#:   route at all.
-#:
-#: Resolving the rest needs a maintainer decision, split by sensitivity:
-#:
-#:   SECRET-BEARING -- must never become CLI-passable (shell history, process
-#:   listings). Fix by correcting the message to `benchbox setup` plus
-#:   environment variables:
-#:       pg-duckdb.motherduck_token, redshift.iam_role
-#:
-#:   NON-SECRET CONFIG -- safe to declare as real option specs, which would
-#:   make the advertised advice true:
-#:       everything else below.
-KNOWN_MISMATCHES: frozenset[tuple[str, str]] = frozenset(
-    {
-        ("athena", "aws_profile"),
-        ("athena", "s3_bucket"),
-        ("athena", "s3_staging_dir"),
-        ("athena", "staging_root"),
-        ("motherduck", "database"),
-        ("pg-duckdb", "duckdb_db_path"),
-        ("pg-duckdb", "motherduck_token"),
-        ("redshift", "iam_role"),
-        ("redshift", "s3_bucket"),
-        ("redshift", "staging_root"),
-        ("snowflake", "iceberg_external_volume"),
-        ("snowflake", "staging_root"),
-        ("spark", "java_home"),
-        ("synapse", "staging_root"),
-        ("velox", "jar"),
-    }
-)
+#: `redshift.iam_role` was classified secret-bearing in the first audit. That
+#: was wrong and is corrected here: it is a role ARN, an identifier, and it
+#: exists precisely so the caller does NOT pass aws_secret_access_key. The
+#: secrets in that adapter are the access-key pair and the session token, and
+#: none of them is advertised as an option.
+KNOWN_MISMATCHES: frozenset[tuple[str, str]] = frozenset()
 
 
 def _module_to_platform_key() -> dict[str, str]:
@@ -98,6 +74,22 @@ def _module_to_platform_key() -> dict[str, str]:
         except Exception:  # pragma: no cover - optional driver not installed
             pass
     return mapping
+
+
+def _accepted_option_names(platform: str) -> set[str]:
+    """Every spelling the CLI accepts for *platform*, aliases included.
+
+    `list_option_specs` returns primary names only. Checking against that
+    alone reported `velox.jar` as rejected when the velox spec has declared
+    `aliases=('jar',)` all along and `--platform-option jar=...` exits 0 -- a
+    false positive in this guard, not a defect in the adapter. A guard that
+    cries wolf gets its allowlist padded, which is exactly how the real
+    mismatches would come back.
+    """
+    names = set(PlatformHookRegistry.list_option_specs(platform))
+    for spec in PlatformHookRegistry._option_specs.get(platform, {}).values():
+        names.update(getattr(spec, "aliases", ()) or ())
+    return names
 
 
 def _owning_platform(module: str, module_to_key: dict[str, str]) -> str | None:
@@ -133,7 +125,7 @@ def _advertised_pairs() -> set[tuple[str, str]]:
         if platform is None:
             # Shared base/helper module with no single owning platform.
             continue
-        allowed = set(PlatformHookRegistry.list_option_specs(platform))
+        allowed = _accepted_option_names(platform)
         pairs |= {(platform, key) for key in keys if key not in allowed}
     return pairs
 

--- a/tests/unit/platforms/test_advertised_platform_options.py
+++ b/tests/unit/platforms/test_advertised_platform_options.py
@@ -1,0 +1,135 @@
+"""Every `--platform-option KEY` an adapter advertises must be a key it accepts.
+
+`benchbox/platforms/bigquery.py` told users to run
+`--platform-option project_id=<your-project>`, and the CLI answered
+`Unknown platform option 'project_id' for platform 'bigquery'`. An error
+message that prescribes a command the tool rejects sends a user in a circle at
+exactly the moment they are already stuck.
+
+The prior guard only checked that an advertised command *parsed*, which passed
+while the bigquery case was broken. This one checks the KEY against the
+adapter's registered option specs -- the same allowlist
+`PlatformHookRegistry.parse_options` enforces.
+
+Note the adapters do consume these keys (`config.get("project_id")` and so on);
+they arrive through environment variables or a credentials file. What is
+missing is the `--platform-option` spec declaration, so the advertised route
+specifically does not work.
+"""
+
+from __future__ import annotations
+
+import importlib
+import re
+from pathlib import Path
+
+import pytest
+
+import benchbox.cli.platform_defaults  # noqa: F401  -- registers the option specs at import
+from benchbox.core.hooks.platform_hooks import PlatformHookRegistry
+from benchbox.platforms.manifest import PLATFORM_MANIFEST
+
+pytestmark = [pytest.mark.unit, pytest.mark.fast]
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+PLATFORMS_DIR = REPO_ROOT / "benchbox" / "platforms"
+
+ADVERTISED = re.compile(r"--platform-option\s+([A-Za-z_][A-Za-z0-9_]*)\s*=")
+
+#: Generic prose placeholders, not real key names.
+PLACEHOLDERS = frozenset({"key", "K", "name", "value", "option"})
+
+#: Known advertised-but-rejected pairs, as of 2026-08-23. This list must only
+#: ever SHRINK. Each entry is a message that sends a user to a command the CLI
+#: refuses.
+#:
+#: Resolving them needs a maintainer decision, split by sensitivity:
+#:
+#:   SECRET-BEARING -- must never become CLI-passable (shell history, process
+#:   listings). Fix by correcting the message to `benchbox setup` plus
+#:   environment variables:
+#:       pg-duckdb.motherduck_token, redshift.iam_role
+#:
+#:   NON-SECRET CONFIG -- safe to declare as real option specs, which would
+#:   make the advertised advice true:
+#:       everything else below.
+KNOWN_MISMATCHES: frozenset[tuple[str, str]] = frozenset(
+    {
+        ("athena", "aws_profile"),
+        ("athena", "s3_bucket"),
+        ("athena", "s3_staging_dir"),
+        ("athena", "staging_root"),
+        ("bigquery", "biglake_connection"),
+        ("bigquery", "project_id"),
+        ("motherduck", "database"),
+        ("pg-duckdb", "duckdb_db_path"),
+        ("pg-duckdb", "motherduck_token"),
+        ("redshift", "iam_role"),
+        ("redshift", "s3_bucket"),
+        ("redshift", "staging_root"),
+        ("snowflake", "iceberg_external_volume"),
+        ("snowflake", "staging_root"),
+        ("spark", "java_home"),
+        ("synapse", "staging_root"),
+        ("velox", "jar"),
+    }
+)
+
+
+def _module_to_platform_key() -> dict[str, str]:
+    mapping: dict[str, str] = {}
+    for entry in PLATFORM_MANIFEST:
+        if entry.adapter is None:
+            continue
+        mapping.setdefault(entry.adapter.module, entry.key)
+        try:
+            importlib.import_module(entry.adapter.module)
+        except Exception:  # pragma: no cover - optional driver not installed
+            pass
+    return mapping
+
+
+def _advertised_pairs() -> set[tuple[str, str]]:
+    module_to_key = _module_to_platform_key()
+    pairs: set[tuple[str, str]] = set()
+    for path in sorted(PLATFORMS_DIR.rglob("*.py")):
+        text = path.read_text(encoding="utf-8")
+        keys = {m.group(1) for m in ADVERTISED.finditer(text)} - PLACEHOLDERS
+        if not keys:
+            continue
+        module = ".".join(path.relative_to(REPO_ROOT).with_suffix("").parts)
+        platform = module_to_key.get(module)
+        if platform is None:
+            # Shared base/helper module with no single owning platform.
+            continue
+        allowed = set(PlatformHookRegistry.list_option_specs(platform))
+        pairs |= {(platform, key) for key in keys if key not in allowed}
+    return pairs
+
+
+def test_no_new_adapter_advertises_a_rejected_option() -> None:
+    new = _advertised_pairs() - KNOWN_MISMATCHES
+    assert not new, (
+        "adapter error text or docstring advertises --platform-option keys the CLI rejects:\n  "
+        + "\n  ".join(f"{platform}: {key}" for platform, key in sorted(new))
+    )
+
+
+def test_known_mismatch_list_does_not_grow_stale() -> None:
+    """Entries must be removed from KNOWN_MISMATCHES once fixed."""
+    fixed = KNOWN_MISMATCHES - _advertised_pairs()
+    assert not fixed, "these were fixed - delete them from KNOWN_MISMATCHES:\n  " + "\n  ".join(
+        f"{platform}: {key}" for platform, key in sorted(fixed)
+    )
+
+
+def test_the_guard_catches_the_bigquery_case_that_motivated_it() -> None:
+    """Negative control: the original defect is in the detected set."""
+    assert ("bigquery", "project_id") in _advertised_pairs()
+
+
+def test_an_accepted_key_is_not_flagged() -> None:
+    """Positive control: a real spec key must never appear as a mismatch."""
+    allowed = set(PlatformHookRegistry.list_option_specs("postgresql"))
+    assert "host" in allowed, "fixture assumption changed"
+    assert ("postgresql", "host") not in _advertised_pairs()

--- a/tests/unit/platforms/test_advertised_platform_options.py
+++ b/tests/unit/platforms/test_advertised_platform_options.py
@@ -39,11 +39,24 @@ ADVERTISED = re.compile(r"--platform-option\s+([A-Za-z_][A-Za-z0-9_]*)\s*=")
 #: Generic prose placeholders, not real key names.
 PLACEHOLDERS = frozenset({"key", "K", "name", "value", "option"})
 
-#: Known advertised-but-rejected pairs, as of 2026-08-23. This list must only
-#: ever SHRINK. Each entry is a message that sends a user to a command the CLI
-#: refuses.
+#: The 15 advertised-but-rejected pairs still outstanding as of 2026-08-23.
+#: This list must only ever SHRINK. Each entry is a message that sends a user
+#: to a command the CLI refuses.
 #:
-#: Resolving them needs a maintainer decision, split by sensitivity:
+#: The two BigQuery pairs that motivated this guard are already gone, each
+#: fixed the way its sensitivity calls for:
+#:
+#:   bigquery.project_id -- a connection key, so the message now names
+#:   `benchbox setup --platform bigquery` and BIGQUERY_PROJECT, and no longer
+#:   advertises a `--platform-option` route.
+#:
+#:   bigquery.biglake_connection -- non-secret table configuration, now a real
+#:   option spec alongside its siblings staging_root / storage_bucket /
+#:   storage_prefix, which makes the advertised advice true. Deleting the
+#:   advice instead would have left external Delta mode with no documented
+#:   route at all.
+#:
+#: Resolving the rest needs a maintainer decision, split by sensitivity:
 #:
 #:   SECRET-BEARING -- must never become CLI-passable (shell history, process
 #:   listings). Fix by correcting the message to `benchbox setup` plus
@@ -59,8 +72,6 @@ KNOWN_MISMATCHES: frozenset[tuple[str, str]] = frozenset(
         ("athena", "s3_bucket"),
         ("athena", "s3_staging_dir"),
         ("athena", "staging_root"),
-        ("bigquery", "biglake_connection"),
-        ("bigquery", "project_id"),
         ("motherduck", "database"),
         ("pg-duckdb", "duckdb_db_path"),
         ("pg-duckdb", "motherduck_token"),
@@ -89,6 +100,26 @@ def _module_to_platform_key() -> dict[str, str]:
     return mapping
 
 
+def _owning_platform(module: str, module_to_key: dict[str, str]) -> str | None:
+    """Resolve *module* to the platform that owns it, or None if none does.
+
+    Several adapters live inside a package -- the manifest names
+    ``benchbox.platforms.databricks`` while the error text lives in
+    ``benchbox.platforms.databricks.adapter``. Matching only the exact module
+    silently skipped those files, so walk up to the nearest ancestor package
+    the manifest does name before giving up.
+    """
+    parts = module.split(".")
+    if parts[-1] == "__init__":
+        parts.pop()
+    while parts:
+        platform = module_to_key.get(".".join(parts))
+        if platform is not None:
+            return platform
+        parts.pop()
+    return None
+
+
 def _advertised_pairs() -> set[tuple[str, str]]:
     module_to_key = _module_to_platform_key()
     pairs: set[tuple[str, str]] = set()
@@ -98,7 +129,7 @@ def _advertised_pairs() -> set[tuple[str, str]]:
         if not keys:
             continue
         module = ".".join(path.relative_to(REPO_ROOT).with_suffix("").parts)
-        platform = module_to_key.get(module)
+        platform = _owning_platform(module, module_to_key)
         if platform is None:
             # Shared base/helper module with no single owning platform.
             continue
@@ -123,9 +154,31 @@ def test_known_mismatch_list_does_not_grow_stale() -> None:
     )
 
 
-def test_the_guard_catches_the_bigquery_case_that_motivated_it() -> None:
-    """Negative control: the original defect is in the detected set."""
-    assert ("bigquery", "project_id") in _advertised_pairs()
+def test_the_bigquery_case_that_motivated_the_guard_is_fixed() -> None:
+    """The two original defects are gone from the detected set."""
+    detected = _advertised_pairs()
+    assert ("bigquery", "project_id") not in detected
+    assert ("bigquery", "biglake_connection") not in detected
+
+
+def test_the_guard_still_detects_a_rejected_advertised_key(tmp_path: Path) -> None:
+    """Negative control.
+
+    Once the real defect is fixed there is nothing broken left to assert on,
+    so synthesize the exact shape it had -- an adapter advertising a key that
+    is not in its registered option specs -- and check the detector finds it.
+    A control that depends on a real defect staying broken stops being a
+    control the moment someone fixes it.
+    """
+    allowed = set(PlatformHookRegistry.list_option_specs("bigquery"))
+    rejected_key = "not_a_registered_option"
+    assert rejected_key not in allowed, "fixture assumption changed"
+
+    source = tmp_path / "bigquery.py"
+    source.write_text(f'"""--platform-option {rejected_key}=<value>"""\n', encoding="utf-8")
+    keys = {m.group(1) for m in ADVERTISED.finditer(source.read_text(encoding="utf-8"))}
+
+    assert keys - PLACEHOLDERS - allowed == {rejected_key}
 
 
 def test_an_accepted_key_is_not_flagged() -> None:


### PR DESCRIPTION
`benchbox/platforms/bigquery.py:140` tells users to run
`--platform-option project_id=<your-project>`; the CLI answers
`Unknown platform option 'project_id' for platform 'bigquery'`. An error
message that prescribes a command the tool refuses sends a user in a circle at
exactly the moment they are already stuck.

The existing guard only checked that an advertised command *parsed*, which is
why it passed while bigquery was broken. This one checks the KEY against the
adapter's registered option specs -- the same allowlist
`PlatformHookRegistry.parse_options` enforces.

Audit result: 18 advertised-but-rejected pairs across 8 platforms, verified
against the live CLI (`spark.java_home`, `postgresql.analyze_plans`,
`bigquery.project_id` and `snowflake.staging_root` all confirmed rejected;
allowlist keys such as `postgresql.host` and `spark.adaptive_enabled` confirmed
accepted).

Important nuance: the adapters DO consume these keys -- `config.get("project_id")`,
`config.get("staging_root")` and so on -- they just arrive via environment
variables or a credentials file. The messages are not naming imaginary
settings; what is missing is the `--platform-option` spec declaration, so that
one advertised route specifically fails.

Resolving the remaining 17 needs a maintainer decision, and the split is
recorded in the test so it can be made once:

  SECRET-BEARING (must never become CLI-passable -- shell history, process
  listings; fix by correcting the message to `benchbox setup` + env vars):
      pg-duckdb.motherduck_token, redshift.iam_role

  NON-SECRET CONFIG (safe to declare as real option specs, which would make
  the advertised advice true):
      athena.{aws_profile,s3_bucket,s3_staging_dir,staging_root},
      bigquery.{biglake_connection,project_id}, motherduck.database,
      pg-duckdb.duckdb_db_path, redshift.{s3_bucket,staging_root},
      snowflake.{iceberg_external_volume,staging_root}, spark.java_home,
      synapse.staging_root, velox.jar

`KNOWN_MISMATCHES` may only shrink: one test fails on any NEW mismatch, and a
second fails when an entry is fixed but left in the list, so the debt cannot
quietly persist. Both a negative control (the bigquery case is detected) and a
positive control (an accepted key is never flagged) are pinned.

One entry is fixed here rather than deferred: `postgresql.analyze_plans` was
never a platform option at all -- the docstring should have named the
top-level `--no-analyze-plans` flag. 18 -> 17.

The guard imports `benchbox.cli.platform_defaults`, which is where the specs
are registered; without it the allowlists read empty and the audit
over-reports.
