### PR TITLE
docs(readme): put the Quick Start first and make it install what it uses

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,114 @@ Registry-backed count claims are checked by unit tests so README and platform do
 
 <!-- benchbox-registry-counts:end -->
 
+## Quick Start
+
+Get started with BenchBox in 3 steps:
+
+### 1. Install BenchBox
+
+Choose the installation that matches your target platform:
+
+**Recommended (using uv):**
+```bash
+# For local development — this is what the rest of the Quick Start uses
+uv add benchbox --extra duckdb
+
+# For cloud platforms
+uv add benchbox --extra cloud
+
+# For everything (all platforms + ClickHouse)
+uv add benchbox --extra all
+```
+
+`uv add benchbox` on its own installs the core package, which ships SQLite
+only. DuckDB is an extra, so the `--extra duckdb` above is what makes step 3
+work. See [Installation Matrix](#installation-matrix) for the full set.
+
+**Alternative (pip-compatible):**
+```bash
+uv pip install "benchbox[duckdb]"
+uv pip install "benchbox[cloud]"
+uv pip install "benchbox[all]"
+```
+
+### 2. Verify Installation
+
+Check that everything is working:
+
+```bash
+# Verify BenchBox is installed
+benchbox --version
+
+# Check available platforms
+benchbox check-deps --matrix
+```
+
+### 3. Run Your First Benchmark
+
+Start with a simple local benchmark:
+
+```python
+from benchbox import TPCH
+
+# Create a small TPC-H benchmark for testing
+tpch = TPCH(scale_factor=0.01)  # ~10MB dataset for quick testing
+
+# Generate sample data
+print("Generating data...")
+data_paths = tpch.generate_data()
+print(f"✅ Generated {len(data_paths)} data files")
+
+# Get a sample query
+query1 = tpch.get_query(1, seed=42)  # Reproducible parameters
+print(f"✅ Generated TPC-H Query 1")
+
+# Run on embedded DuckDB (no setup required)
+import duckdb
+conn = duckdb.connect(":memory:")
+
+# Create schema and load data
+conn.execute(tpch.get_create_tables_sql())
+for table_file in data_paths:
+    table_name = table_file.split('/')[-1].replace('.csv', '')
+    conn.execute(f"COPY {table_name} FROM '{table_file}' WITH (DELIMITER '|', HEADER false)")
+
+# Execute the query
+result = conn.execute(query1).fetchdf()
+print(f"✅ Query executed successfully, returned {len(result)} rows")
+```
+
+### Run a DataFrame Benchmark
+
+Compare SQL vs DataFrame execution paradigms:
+
+```bash
+# SQL mode - queries executed via SQL
+benchbox run --platform duckdb --benchmark tpch --scale 0.01
+
+# DataFrame mode - queries executed via native Polars API
+benchbox run --platform polars-df --benchmark tpch --scale 0.01
+```
+
+Same benchmark, same scale factor, different execution paradigm.
+
+### Next Steps
+
+**For Cloud Platforms:**
+- See [Platform Documentation](docs/platforms/index.md) for platform-specific setup
+- Start with `examples/getting_started/` for zero-config DuckDB runs and credential-ready cloud samples
+- Explore `examples/features/` for capability-specific examples (query subsets, tuning, result analysis, etc.)
+- Check `examples/use_cases/` for real-world patterns (CI/CD regression testing, platform evaluation, cost optimization)
+- See `examples/programmatic/` for Python API usage and integration patterns
+- Use `--dry-run OUTPUT_DIR` on the CLI or example scripts to export a JSON/YAML plan and per-query SQL files before executing benchmarks
+- Use `benchbox run` CLI for full benchmark execution
+
+**For Advanced Usage:**
+- Explore the full benchmark suite: TPC-H, TPC-DS, TPC-DI, ClickBench, H2ODB, NYC Taxi, Flight Data, Vector Search, and more
+- Scale up with larger datasets (scale factors 1.0, 10.0, 100.0+)
+- Compare performance across different platforms
+- See [examples/INDEX.md](examples/INDEX.md) for complete examples navigation
+- See [examples/PATTERNS.md](examples/PATTERNS.md) for common workflow patterns
 ## Features
 
 - **Embedded Benchmarks**: Self-contained benchmark data and queries
@@ -387,110 +495,6 @@ These extras add connectivity to specific platforms and are installed only when 
 - **Reduced conflicts**: Platform-specific dependencies are isolated
 - **Easy maintenance**: Update cloud SDKs independently of core functionality
 
-## Quick Start
-
-Get started with BenchBox in 3 steps:
-
-### 1. Install BenchBox
-
-Choose the installation that matches your target platform:
-
-**Recommended (using uv):**
-```bash
-# For local development (DuckDB only)
-uv add benchbox
-
-# For cloud platforms (recommended)
-uv add benchbox --extra cloud
-
-# For everything (all platforms + ClickHouse)
-uv add benchbox --extra all
-```
-
-**Alternative (pip-compatible):**
-```bash
-uv pip install benchbox
-uv pip install "benchbox[cloud]"
-uv pip install "benchbox[all]"
-```
-
-### 2. Verify Installation
-
-Check that everything is working:
-
-```bash
-# Verify BenchBox is installed
-benchbox --version
-
-# Check available platforms
-benchbox check-deps --matrix
-```
-
-### 3. Run Your First Benchmark
-
-Start with a simple local benchmark:
-
-```python
-from benchbox import TPCH
-
-# Create a small TPC-H benchmark for testing
-tpch = TPCH(scale_factor=0.01)  # ~10MB dataset for quick testing
-
-# Generate sample data
-print("Generating data...")
-data_paths = tpch.generate_data()
-print(f"✅ Generated {len(data_paths)} data files")
-
-# Get a sample query
-query1 = tpch.get_query(1, seed=42)  # Reproducible parameters
-print(f"✅ Generated TPC-H Query 1")
-
-# Run on embedded DuckDB (no setup required)
-import duckdb
-conn = duckdb.connect(":memory:")
-
-# Create schema and load data
-conn.execute(tpch.get_create_tables_sql())
-for table_file in data_paths:
-    table_name = table_file.split('/')[-1].replace('.csv', '')
-    conn.execute(f"COPY {table_name} FROM '{table_file}' WITH (DELIMITER '|', HEADER false)")
-
-# Execute the query
-result = conn.execute(query1).fetchdf()
-print(f"✅ Query executed successfully, returned {len(result)} rows")
-```
-
-### Run a DataFrame Benchmark
-
-Compare SQL vs DataFrame execution paradigms:
-
-```bash
-# SQL mode - queries executed via SQL
-benchbox run --platform duckdb --benchmark tpch --scale 0.01
-
-# DataFrame mode - queries executed via native Polars API
-benchbox run --platform polars-df --benchmark tpch --scale 0.01
-```
-
-Same benchmark, same scale factor, different execution paradigm.
-
-### Next Steps
-
-**For Cloud Platforms:**
-- See [Platform Documentation](docs/platforms/index.md) for platform-specific setup
-- Start with `examples/getting_started/` for zero-config DuckDB runs and credential-ready cloud samples
-- Explore `examples/features/` for capability-specific examples (query subsets, tuning, result analysis, etc.)
-- Check `examples/use_cases/` for real-world patterns (CI/CD regression testing, platform evaluation, cost optimization)
-- See `examples/programmatic/` for Python API usage and integration patterns
-- Use `--dry-run OUTPUT_DIR` on the CLI or example scripts to export a JSON/YAML plan and per-query SQL files before executing benchmarks
-- Use `benchbox run` CLI for full benchmark execution
-
-**For Advanced Usage:**
-- Explore the full benchmark suite: TPC-H, TPC-DS, TPC-DI, ClickBench, H2ODB, NYC Taxi, Flight Data, Vector Search, and more
-- Scale up with larger datasets (scale factors 1.0, 10.0, 100.0+)
-- Compare performance across different platforms
-- See [examples/INDEX.md](examples/INDEX.md) for complete examples navigation
-- See [examples/PATTERNS.md](examples/PATTERNS.md) for common workflow patterns
 ## Command-Line Interface (CLI)
 
 BenchBox provides a comprehensive command-line interface (CLI) for all benchmarking operations, from data generation to result analysis.

--- a/tests/unit/docs/test_readme_quickstart_installs_what_it_uses.py
+++ b/tests/unit/docs/test_readme_quickstart_installs_what_it_uses.py
@@ -1,0 +1,84 @@
+"""The README Quick Start must install the platform its own steps then use.
+
+The Quick Start's step 1 offered `uv add benchbox` under the comment "For
+local development (DuckDB only)". That plain install ships SQLite only --
+DuckDB is the `[duckdb]` extra -- so step 3's `import duckdb` and
+`benchbox run --platform duckdb` could not work for anyone who followed it.
+The Installation section 180 lines further down said the opposite, correctly.
+
+Two separate things went wrong and this pins both: the install command was
+false, and the Quick Start sat at line 390 of 1303, behind the installation
+matrix and troubleshooting, so the contradiction was easy to miss and the
+first runnable command was most of the way down the page.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+import tomllib
+
+pytestmark = [pytest.mark.unit, pytest.mark.fast]
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+README = REPO_ROOT / "README.md"
+FENCE = re.compile(r"```bash\n(.*?)```", re.DOTALL)
+
+
+def _quickstart() -> str:
+    text = README.read_text(encoding="utf-8")
+    start = text.index("## Quick Start")
+    end = text.index("\n## ", start + 1)
+    return text[start:end]
+
+
+def _core_dependency_names() -> set[str]:
+    pyproject = tomllib.loads((REPO_ROOT / "pyproject.toml").read_text(encoding="utf-8"))
+    return {re.split(r"[<>=!\[; ]", spec, maxsplit=1)[0].strip() for spec in pyproject["project"]["dependencies"]}
+
+
+def test_duckdb_is_not_a_core_dependency() -> None:
+    """The premise. If this ever changes, the assertions below are moot."""
+    assert "duckdb" not in _core_dependency_names()
+
+
+def test_quickstart_uses_duckdb_so_it_must_install_duckdb() -> None:
+    quickstart = _quickstart()
+    assert "duckdb" in quickstart, "fixture assumption changed: the Quick Start no longer uses DuckDB"
+
+    install_lines = [
+        line.strip()
+        for block in FENCE.findall(quickstart)
+        for line in block.splitlines()
+        if line.strip().startswith(("uv add benchbox", "uv pip install"))
+    ]
+    assert install_lines, "the Quick Start names no install command"
+
+    assert any("duckdb" in line for line in install_lines), (
+        "the Quick Start uses DuckDB but never installs it:\n  " + "\n  ".join(install_lines)
+    )
+
+
+def test_quickstart_does_not_offer_a_bare_install_as_the_local_path() -> None:
+    """A bare `uv add benchbox` here is the exact claim that was false."""
+    install_lines = [
+        line.strip()
+        for block in FENCE.findall(_quickstart())
+        for line in block.splitlines()
+        if line.strip().startswith(("uv add benchbox", "uv pip install"))
+    ]
+
+    bare = [line for line in install_lines if line in ("uv add benchbox", "uv pip install benchbox")]
+
+    assert not bare, (
+        f"the Quick Start offers an install with no extra, which ships SQLite only and cannot run its own steps: {bare}"
+    )
+
+
+def test_quickstart_comes_before_the_installation_deep_dive() -> None:
+    """A reader should reach a runnable command without scrolling past the matrix."""
+    text = README.read_text(encoding="utf-8")
+
+    assert text.index("## Quick Start") < text.index("\n## Installation")


### PR DESCRIPTION
Two things were wrong with the README's Quick Start, and they compounded.

It sat at line 390 of 1303, behind the installation matrix, the
troubleshooting section and the dependency overview, so the first runnable
command was at line 469. Move the whole section up to just after the Beta
Software notice: the first `benchbox run` is now at line 133, and the
honesty caveat still comes before it.

Step 1 also offered a bare `uv add benchbox` under the comment "For local
development (DuckDB only)". That install ships SQLite only -- DuckDB is the
`[duckdb]` extra -- so step 3's `import duckdb` and
`benchbox run --platform duckdb` could not work for anyone who followed it.
The Installation section 180 lines below said the opposite, correctly, which
is how the contradiction survived. Pin `--extra duckdb`, say plainly what a
bare install does and does not include, and point at the matrix. Same fix
the quickstart page got in #1845.

The guard pins both halves: the Quick Start must install DuckDB while its own
steps use DuckDB, must not offer an extra-less install as the local path, and
must come before the installation deep dive. A premise test asserts DuckDB is
not a core dependency, so if that ever changes the other assertions are
visibly moot rather than silently wrong. Negative control: all three fail
against the previous README and the premise test still passes.

Refs: quickstart-contradicts-the-default-install w4
