### PR TITLE
fix(tests): unbreak three Windows failure groups, scope one to POSIX

### DIFF
--- a/tests/integration/worktree/test_worktree_release_dirty_guard.py
+++ b/tests/integration/worktree/test_worktree_release_dirty_guard.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import os
 import shutil
 import subprocess
+import sys
 import time
 from pathlib import Path
 
@@ -13,6 +14,21 @@ import pytest
 pytestmark = [
     pytest.mark.integration,
     pytest.mark.fast,
+    # These drive `make worktree-create` / `make worktree-remove`, which are
+    # maintainer and agent tooling: they run on the maintainer's machine and in
+    # Linux CI, and no Windows support is claimed for them. On Windows CI they
+    # fail in the tooling rather than in the behaviour under test -- `awk:
+    # escape sequence \U treated as plain U`, `fatal: could not create leading
+    # directories` -- so 11 of the 18 have failed every nightly run, taking
+    # Nightly Validation red with them.
+    #
+    # This does drop the 7 that currently pass on Windows. That is the trade,
+    # stated rather than hidden: a module whose subject is a POSIX make target
+    # was not meaningfully covering Windows with the other 11 broken.
+    pytest.mark.skipif(
+        sys.platform == "win32",
+        reason="make worktree-* targets are POSIX shell tooling; not supported on Windows",
+    ),
 ]
 
 REPO_ROOT = Path(__file__).resolve().parents[3]

--- a/tests/uat/test_timeouts.py
+++ b/tests/uat/test_timeouts.py
@@ -287,6 +287,13 @@ def test_timeout_path_drains_using_the_reap_timeout_constant(monkeypatch):
 
     monkeypatch.setattr(timeouts.subprocess, "Popen", lambda *a, **k: FakeProc())
     monkeypatch.setattr(timeouts.os, "killpg", lambda pid, sig: None, raising=False)
+    # Inject the signals too, same technique and same reason as the two tests
+    # above: on win32 `signal.SIGKILL` does not exist, and the ladder evaluates
+    # it as an ARGUMENT to os.killpg, so patching killpg alone still raised
+    # AttributeError before the call. Patching both keeps the POSIX branch --
+    # the thing under test -- reachable on Windows rather than skipping it.
+    monkeypatch.setattr(timeouts.signal, "SIGTERM", object(), raising=False)
+    monkeypatch.setattr(timeouts.signal, "SIGKILL", object(), raising=False)
     # The ladder's real 200 ms grace sleep is left in place: `timeouts` imports
     # `time` inside the function rather than at module scope, so there is no
     # module attribute to patch, and 200 ms is not worth reshaping the module for.

--- a/tests/unit/core/test_run_service.py
+++ b/tests/unit/core/test_run_service.py
@@ -67,9 +67,14 @@ class TestLayering:
 
 class TestResolveRunConfig:
     def test_a_path_object_is_stringified(self):
-        run_config = resolve_run_config(_config(), database_path=Path("/tmp/db.duckdb"), verbosity=SilentVerbosity())
+        # The property under test is "a Path becomes a str", not the separator
+        # the host OS uses. Hardcoding the POSIX spelling failed on Windows,
+        # where str(Path("/tmp/db.duckdb")) is "\\tmp\\db.duckdb" and the
+        # behaviour is correct.
+        database_path = Path("/tmp/db.duckdb")
+        run_config = resolve_run_config(_config(), database_path=database_path, verbosity=SilentVerbosity())
 
-        assert run_config.connection["database_path"] == "/tmp/db.duckdb"
+        assert run_config.connection["database_path"] == str(database_path)
         assert isinstance(run_config.connection["database_path"], str)
 
     def test_defaults_match_the_core_constants(self):

--- a/tests/unit/scripts/test_check_makefile_inventory.py
+++ b/tests/unit/scripts/test_check_makefile_inventory.py
@@ -151,6 +151,10 @@ def test_reserved_include_root_rejects_cli_and_environment_override(
     assert "/definitely/missing" not in result.stderr
 
 
+@pytest.mark.skipif(
+    sys.platform == "win32",
+    reason="creating a symlink on Windows requires elevation or developer mode",
+)
 def test_absolute_symlink_makefile_preserves_module_resolution(tmp_path: Path) -> None:
     repository = tmp_path / "repository"
     repository.mkdir()


### PR DESCRIPTION
Nightly Validation has failed every scheduled run since 2026-08-19. Roughly
24 Windows failures across at least five causes, not one. This handles four
of them; two turned out to be real test defects rather than platform limits,
so they are fixed rather than skipped.

FIXED, coverage kept.

`test_a_path_object_is_stringified` asserted `"/tmp/db.duckdb"` literally.
The property under test is "a Path becomes a str", not which separator the
host OS uses -- `str(Path("/tmp/db.duckdb"))` is `\tmp\db.duckdb` on Windows
and the behaviour is correct. Compare against `str(database_path)`.

`test_timeout_path_drains_using_the_reap_timeout_constant` patched
`os.killpg` with `raising=False` but not the signals. The ladder evaluates
`signal.SIGKILL` as an ARGUMENT to `os.killpg`, so on Windows it raised
AttributeError before the call. Inject both signals, the same technique the
two sibling tests in that module already use, and for the reason their
comments give: a skipif would drop the POSIX branch that is the thing under
test.

SCOPED TO POSIX, with the trade stated.

`test_worktree_release_dirty_guard.py` drives `make worktree-create` and
`make worktree-remove`. Those are maintainer and agent tooling that runs on
the maintainer's machine and in Linux CI; no Windows support is claimed for
them. On Windows the failures are in the tooling, not the behaviour --
`awk: escape sequence \U`, `fatal: could not create leading directories` --
and 11 of 18 fail. Skipping the module also drops the 7 that currently pass;
that is worth saying out loud, but a module whose subject is a POSIX make
target was not meaningfully covering Windows with the other 11 broken.

`test_absolute_symlink_makefile_preserves_module_resolution` creates a
symlink, which needs elevation or developer mode on Windows.

NOT TOUCHED, and not diagnosable from a log.

The MCP durable-jobs group (7 tests, jobs never reaching `completed`) is the
one genuinely product-facing Windows question and needs a decision, not a
skip. Two others -- a `NoneType.splitlines()` in the makefile inventory guard
and a pytest-benchmark/xdist warning surfacing as a failure in the release
curation guard -- need a Windows machine to diagnose honestly. Guessing at
them from a log line is how a skip gets applied to a test that would have
passed.

Refs: nightly-red-blocks-release-evidence w3
