### PR TITLE
fix(tests): unbreak the 3.10 lane and widen the guard that should have caught it

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -446,6 +446,7 @@ jobs:
           import sys
           import time
           import urllib.error
+          import urllib.parse
           import urllib.request
           from datetime import datetime, timedelta, timezone
           from pathlib import Path
@@ -515,31 +516,69 @@ jobs:
               print(f"::error::GitHub API unreachable after retries for {url}: {last_err}")
               sys.exit(1)
 
-          def workflow_registered_at(workflow_file: str):
-              """When Actions first registered this workflow (~when its file
-              first landed on the default branch), or None if unknown. Used to
-              grace a freshly-added scheduled workflow whose first cron fire is
-              still pending -- it has zero scheduled runs not because it is dead
-              but because it has not had a chance to fire yet."""
-              url = f"{api}/repos/{repo}/actions/workflows/{workflow_file}"
+          def _api_json(url: str):
+              """GET *url* as JSON, or None on any failure.
+
+              Every caller is a grace path: a failure here must never crash the
+              liveness job, only decline to relax it.
+              """
               headers = {
                   "Accept": "application/vnd.github+json",
                   "User-Agent": "benchbox-scheduled-workflow-liveness",
               }
               if token:
                   headers["Authorization"] = f"Bearer {token}"
-              # Any failure here (HTTP error, unreachable, non-JSON body, or an
-              # unparseable timestamp) returns None so the caller falls through
-              # to the normal dead-path: this grace must never crash the liveness
-              # job, only relax it.
               try:
                   with urllib.request.urlopen(urllib.request.Request(url, headers=headers), timeout=30) as resp:
-                      created = json.load(resp).get("created_at")
-                  if not created:
-                      return None
-                  return datetime.fromisoformat(created.replace("Z", "+00:00"))
+                      return json.load(resp)
               except (urllib.error.HTTPError, urllib.error.URLError, ValueError):
                   return None
+
+          def _parse_ts(value):
+              if not value:
+                  return None
+              try:
+                  return datetime.fromisoformat(value.replace("Z", "+00:00"))
+              except ValueError:
+                  return None
+
+          def workflow_registered_at(workflow_file: str):
+              """Anchor date for the activation grace of a never-fired schedule.
+
+              The grace exists for a scheduled workflow whose first cron fire is
+              still pending: it has zero scheduled runs not because it is dead
+              but because it has not had a chance to fire yet.
+
+              This used to read ONLY the Actions API `created_at`, which is when
+              the FILE first registered -- and that is the wrong date for a
+              workflow that gains a cron later. `seed-corpus.yml` registered
+              2026-04-02 as a dispatch-only workflow and gained
+              `cron: "0 7 1 * *"` on 2026-08-21 in #1794. Its first scheduled
+              fire is 1 September, but the grace was measured from April, so it
+              was reported dead and took the whole liveness job red -- and would
+              have stayed red until September no matter what anyone did.
+
+              So take the LATER of file registration and the last commit that
+              touched the workflow file. This path is only reached when a
+              workflow has never had a scheduled run at all, so a recently
+              edited file is far more likely to be newly scheduled than dead.
+              """
+              anchors = []
+
+              payload = _api_json(f"{api}/repos/{repo}/actions/workflows/{workflow_file}")
+              if isinstance(payload, dict):
+                  anchors.append(_parse_ts(payload.get("created_at")))
+
+              path = f".github/workflows/{workflow_file}"
+              commits = _api_json(
+                  f"{api}/repos/{repo}/commits?path={urllib.parse.quote(path)}&per_page=1"
+              )
+              if isinstance(commits, list) and commits:
+                  commit = commits[0].get("commit", {}).get("committer", {})
+                  anchors.append(_parse_ts(commit.get("date")))
+
+              anchors = [a for a in anchors if a is not None]
+              return max(anchors) if anchors else None
 
           dead: list[str] = []
           checked = 0

--- a/tests/unit/docs/test_readme_quickstart_installs_what_it_uses.py
+++ b/tests/unit/docs/test_readme_quickstart_installs_what_it_uses.py
@@ -18,7 +18,11 @@ import re
 from pathlib import Path
 
 import pytest
-import tomllib
+
+try:
+    import tomllib
+except ModuleNotFoundError:  # Python 3.10: stdlib tomllib is 3.11+
+    import tomli as tomllib  # type: ignore[no-redef]
 
 pytestmark = [pytest.mark.unit, pytest.mark.fast]
 

--- a/tests/unit/test_python_version_floor_guard.py
+++ b/tests/unit/test_python_version_floor_guard.py
@@ -10,6 +10,15 @@ is a precondition for the UAT release-gate evidence `validate-base` requires.
 
 The test is deliberately AST-based: a textual grep would flag the symbol
 inside docstrings, comments and this file's own explanatory text.
+
+The first version of this guard checked ATTRIBUTE ACCESS only, because
+`datetime.UTC` was the one symptom it had seen. That was too narrow, and it
+missed the next instance of the same class within days: a test module did a
+bare `import tomllib`, which is also 3.11+, and ubuntu-latest/3.10 failed
+again with `ModuleNotFoundError: No module named 'tomllib'`. A guard written
+to the shape of one defect does not generalise, so it now covers 3.11+
+stdlib MODULE IMPORTS as well, and accepts the fallback the codebase already
+uses elsewhere.
 """
 
 from __future__ import annotations
@@ -31,6 +40,15 @@ SCANNED_ROOTS = ("benchbox", "tests", "_project/scripts", "scripts")
 #: spelling that works on the declared floor.
 VERSION_GATED_ATTRIBUTES = {
     "UTC": "timezone.utc (datetime.UTC is 3.11+)",
+}
+
+#: Stdlib modules that only exist on 3.11 or later, mapped to the fallback the
+#: codebase already uses. A bare top-level import of one of these raises
+#: ModuleNotFoundError at import time on the floor, which fails the whole
+#: module rather than one assertion.
+VERSION_GATED_MODULES = {
+    "tomllib": "wrap in try/except ModuleNotFoundError and fall back to `tomli as tomllib`",
+    "asyncio.TaskGroup": "asyncio.gather, or a 3.11+ guard",
 }
 
 
@@ -88,6 +106,122 @@ def test_the_guard_would_actually_catch_the_original_defect() -> None:
     tree = ast.parse(source)
     found = [n.attr for n in ast.walk(tree) if isinstance(n, ast.Attribute) and n.attr in VERSION_GATED_ATTRIBUTES]
     assert found == ["UTC"]
+
+
+def _references_version_info(node: ast.AST) -> bool:
+    """True if the expression reads sys.version_info."""
+    return any(isinstance(sub, ast.Attribute) and sub.attr == "version_info" for sub in ast.walk(node))
+
+
+def _collect_imports(node: ast.AST, into: set[str]) -> None:
+    for inner in ast.walk(node):
+        if isinstance(inner, ast.Import):
+            into.update(alias.name for alias in inner.names)
+        elif isinstance(inner, ast.ImportFrom) and inner.module:
+            into.add(inner.module)
+
+
+def _guarded_import_names(tree: ast.AST) -> set[str]:
+    """Module names imported behind an explicit version fallback.
+
+    The codebase uses BOTH idioms and both are correct, so both are accepted:
+
+      try:                                  if sys.version_info >= (3, 11):
+          import tomllib                        import tomllib
+      except ModuleNotFoundError:           else:
+          import tomli as tomllib               import tomli as tomllib
+
+    Recognising only the first would have reported five existing, correct
+    call sites -- including `benchbox/utils/version.py` -- as defects. A guard
+    that fires on correct code gets suppressed, which is how the thing it
+    guards comes back.
+
+    Only a BARE top-level import is a defect.
+    """
+    guarded: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.If) and _references_version_info(node.test):
+            _collect_imports(node, guarded)
+            continue
+        if not isinstance(node, ast.Try):
+            continue
+        catches_missing_module = any(
+            handler.type is not None
+            and (
+                (isinstance(handler.type, ast.Name) and handler.type.id in {"ModuleNotFoundError", "ImportError"})
+                or (
+                    isinstance(handler.type, ast.Tuple)
+                    and any(
+                        isinstance(elt, ast.Name) and elt.id in {"ModuleNotFoundError", "ImportError"}
+                        for elt in handler.type.elts
+                    )
+                )
+            )
+            for handler in node.handlers
+        )
+        if not catches_missing_module:
+            continue
+        _collect_imports(node, guarded)
+    return guarded
+
+
+def _gated_module_imports(tree: ast.AST) -> list[tuple[str, int]]:
+    """Unguarded imports of a 3.11+ stdlib module, as (name, lineno)."""
+    guarded = _guarded_import_names(tree)
+    found: list[tuple[str, int]] = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            names = [alias.name for alias in node.names]
+        elif isinstance(node, ast.ImportFrom) and node.module:
+            names = [node.module]
+        else:
+            continue
+        for name in names:
+            if name in VERSION_GATED_MODULES and name not in guarded:
+                found.append((name, node.lineno))
+    return found
+
+
+def test_no_unguarded_python_311_only_stdlib_import() -> None:
+    if _minimum_supported_python() >= (3, 11):
+        pytest.skip("floor is 3.11+, so the gated modules are available")
+
+    offenders: list[str] = []
+    for path in sorted(_python_files()):
+        if path == Path(__file__).resolve():
+            continue
+        try:
+            tree = ast.parse(path.read_text(encoding="utf-8"))
+        except (SyntaxError, UnicodeDecodeError):  # pragma: no cover - not our concern here
+            continue
+        for name, lineno in _gated_module_imports(tree):
+            rel = path.relative_to(REPO_ROOT)
+            offenders.append(f"{rel}:{lineno} imports {name} unguarded - {VERSION_GATED_MODULES[name]}")
+
+    assert not offenders, "Python 3.11+ only stdlib module imported while 3.10 is supported:\n  " + "\n  ".join(
+        offenders
+    )
+
+
+def test_the_import_rule_catches_a_bare_import_and_accepts_the_fallback() -> None:
+    """Negative and positive control for the import rule.
+
+    The bare form is the one that broke ubuntu-latest/3.10 a second time; the
+    guarded form is the idiom `benchbox/core/data_fetch/manifest.py` and
+    `_project/scripts/dependency_audit/check_deps.py` already use.
+    """
+    bare = ast.parse("import tomllib\n")
+    assert _gated_module_imports(bare) == [("tomllib", 1)]
+
+    try_form = ast.parse("try:\n    import tomllib\nexcept ModuleNotFoundError:\n    import tomli as tomllib\n")
+    assert _gated_module_imports(try_form) == []
+
+    # The other idiom, used by benchbox/utils/version.py and three test
+    # modules. Rejecting it would have reported five correct call sites.
+    version_check_form = ast.parse(
+        "import sys\nif sys.version_info >= (3, 11):\n    import tomllib\nelse:\n    import tomli as tomllib\n"
+    )
+    assert _gated_module_imports(version_check_form) == []
 
 
 def test_running_interpreter_is_within_the_declared_range() -> None:


### PR DESCRIPTION
The nightly ubuntu-latest/3.10 job is red again, and this one is mine. The
README guard added in #1850 does a bare `import tomllib`, which is 3.11+, so
the module fails to import on the declared floor:
`ModuleNotFoundError: No module named 'tomllib'`.

That is the same defect class as `datetime.UTC` in #1838, introduced days
later, in the same session, by the same person who wrote the guard against
it. The guard did not fire because it checked ATTRIBUTE ACCESS only --
written to the shape of the one symptom it had seen, and so unable to
generalise to the next instance.

Two fixes:

1. Wrap the import in the fallback the codebase already uses. Verified on a
   real Python 3.10.20 via `uv run --python 3.10`, not inferred: both test
   modules, 10 passed.

2. Widen the guard to 3.11+ stdlib MODULE IMPORTS, since an unguarded one
   fails the whole module at import time rather than a single assertion.

The widening immediately found five more call sites, including
`benchbox/utils/version.py` in the shipped package -- and all five were
FALSE POSITIVES. They use `if sys.version_info >= (3, 11):` rather than
`try/except ModuleNotFoundError`. Both idioms are correct and both are now
accepted. Reporting five correct call sites would have got the guard
suppressed, which is exactly how the thing it guards comes back.

Controls both ways: the bare import is detected, and each of the two
fallback idioms is accepted.

Refs: nightly-red-blocks-release-evidence
