### PR TITLE
feat/spark driver memory platform option

### DIFF
--- a/benchbox/platforms/__init__.py
+++ b/benchbox/platforms/__init__.py
@@ -826,6 +826,7 @@ sqlite|timeout|SQLite connection timeout in seconds|{'parser': 'float', 'default
 sqlite|check_same_thread|Enforce that connections are used on the creating thread only|{'parser': 'parse_bool', 'default': 'false'}
 spark|adaptive_enabled|Enable or disable Spark Adaptive Query Execution (AQE)|{'parser': 'parse_bool', 'default': 'true'}
 spark|java_home|Path to the JDK Spark should run under|{}
+spark|driver_memory|Spark driver JVM heap, e.g. 4g or 8g (default 4g)|{}
 athena|aws_profile|Named AWS CLI profile to authenticate with|{}
 athena|s3_bucket|S3 bucket for query results and data staging|{}
 athena|s3_staging_dir|S3 URI Athena writes query results to (e.g., s3://bucket/path)|{}

--- a/tests/unit/cli/test_configuration_guidance.py
+++ b/tests/unit/cli/test_configuration_guidance.py
@@ -68,6 +68,7 @@ def test_connection_guidance_does_not_advertise_unregistered_platform_options(
         ("redshift", "staging_root", "s3://benchbox-redshift-staging/data"),
         ("snowflake", "iceberg_external_volume", "benchbox_vol"),
         ("snowflake", "staging_root", "s3://benchbox-snowflake-staging/data"),
+        ("spark", "driver_memory", "8g"),
         ("spark", "java_home", "/usr/lib/jvm/java-17"),
         ("synapse", "staging_root", "abfss://c@a.dfs.core.windows.net/data"),
         # An alias the CLI has always accepted; the guard used to miss it.


### PR DESCRIPTION
- **test(platforms): fail when an adapter advertises a --platform-option the CLI rejects**
- **fix(platforms): make BigQuery and Databricks config guidance true**
- **fix(platforms): resolve the last 15 advertised-but-rejected options**
- **fix(cli): make platforms setup --platform work instead of exiting 2**
- **test(cli): isolate interactive credential path from platform options**
- **feat(spark): expose driver_memory as a real --platform-option**
