### PR TITLE
fix(corpus): gate the cohort-depth requirement instead of only documenting it

### DIFF
--- a/results-data/validate_corpus.py
+++ b/results-data/validate_corpus.py
@@ -1,44 +1,105 @@
 #!/usr/bin/env python3
-"""Validate the seed corpus meets depth and schema requirements."""
+"""Validate the seed corpus meets depth and schema requirements.
+
+`SEED_CORPUS_SPEC.md` states the hard requirement this enforces: every
+committed cohort must have at least 3 platforms. A one-platform cohort is not
+a comparison, so publishing it would put a row on the public leaderboard that
+nothing can be read against.
+
+Structured into functions so `tests/unit/scripts/test_corpus_cohort_depth.py`
+can import and assert the same rule instead of restating it. Before that, the
+script ran in no CI lane at all -- every workflow reference to it is a path
+list for mirroring -- so a corpus PR could violate the requirement, pass
+pr-preflight green, and merge. That is exactly what PR #1854 did.
+
+Kept deliberately stdlib-only and free of `benchbox` imports: this file is
+vendored onto the slim `published-results` branch, where the package is not
+installed.
+"""
+
+from __future__ import annotations
 
 import collections
 import json
 import pathlib
 import sys
 
-bundles_dir = pathlib.Path(__file__).parent / "bundles"
-bundles = [
-    path
-    for path in bundles_dir.rglob("*.json")
-    if path.name != "submission-manifest.json"
-    and not path.name.endswith(".manifest.json")
-    and not path.name.endswith(".plans.json")
-    and not path.name.endswith(".tuning.json")
-    and not path.name.endswith(".applied.json")
-]
-print(f"Found {len(bundles)} bundles")
+#: Companion suffixes that are not primary result bundles.
+COMPANION_SUFFIXES = (".manifest.json", ".plans.json", ".tuning.json", ".applied.json")
+LEGACY_MANIFEST_NAME = "submission-manifest.json"
 
-cohorts: collections.defaultdict[tuple[str, str], set[str]] = collections.defaultdict(set)
-for b in bundles:
-    try:
-        with open(b, encoding="utf-8") as fh:
-            d = json.load(fh)
-        benchmark_id = d["benchmark"]["id"]
-        scale_factor = str(d["benchmark"].get("scale_factor", ""))
-        platform = d["platform"]["name"]
+#: A cohort below this many distinct platforms is not a comparison.
+MINIMUM_PLATFORMS_PER_COHORT = 3
+
+CohortKey = tuple[str, str]
+
+
+class CorpusReadError(Exception):
+    """A bundle could not be read or lacks the fields a cohort key needs."""
+
+
+def discover_bundles(bundles_dir: pathlib.Path) -> list[pathlib.Path]:
+    """Primary result bundles under *bundles_dir*, companions excluded."""
+    return sorted(
+        path
+        for path in bundles_dir.rglob("*.json")
+        if path.name != LEGACY_MANIFEST_NAME and not path.name.endswith(COMPANION_SUFFIXES)
+    )
+
+
+def cohort_platforms(bundles: list[pathlib.Path]) -> dict[CohortKey, set[str]]:
+    """Map (benchmark id, scale factor) to the distinct platforms present.
+
+    Raises:
+        CorpusReadError: if any bundle is unreadable or missing a key field.
+            Fail closed -- an unparseable bundle is exactly the state a
+            truncated or unreviewed one would be in, and skipping it would let
+            the corpus regress while this gate stayed green.
+    """
+    cohorts: collections.defaultdict[CohortKey, set[str]] = collections.defaultdict(set)
+    for bundle in bundles:
+        try:
+            with open(bundle, encoding="utf-8") as handle:
+                payload = json.load(handle)
+            benchmark_id = payload["benchmark"]["id"]
+            scale_factor = str(payload["benchmark"].get("scale_factor", ""))
+            platform = payload["platform"]["name"]
+        except Exception as exc:  # noqa: BLE001 - any read failure is fatal here
+            raise CorpusReadError(f"ERROR reading {bundle}: {exc}") from exc
         cohorts[(benchmark_id, scale_factor)].add(platform)
-    except Exception as e:
-        print(f"ERROR reading {b}: {e}")
-        sys.exit(1)
+    return dict(cohorts)
 
-print("\nCohorts:")
-for k, platforms in sorted(cohorts.items()):
-    status = "OK" if len(platforms) >= 3 else "WARN (<3 platforms)"
-    print(f"  {k[0]} SF={k[1]}: {len(platforms)} platforms ({sorted(platforms)}) [{status}]")
 
-low = {k: v for k, v in cohorts.items() if len(v) < 3}
-if low:
-    print(f"\nWARN: {len(low)} cohort(s) have <3 platforms: { {k: len(v) for k, v in low.items()} }")
-    sys.exit(1)
-else:
-    print(f"\nAll {len(cohorts)} cohort(s) meet the >=3-platform depth criterion.")
+def shallow_cohorts(cohorts: dict[CohortKey, set[str]]) -> dict[CohortKey, set[str]]:
+    """Cohorts with fewer than the required number of platforms."""
+    return {key: platforms for key, platforms in cohorts.items() if len(platforms) < MINIMUM_PLATFORMS_PER_COHORT}
+
+
+def main(bundles_dir: pathlib.Path | None = None) -> int:
+    """Print the cohort report and return the process exit code."""
+    bundles_dir = bundles_dir or pathlib.Path(__file__).parent / "bundles"
+    bundles = discover_bundles(bundles_dir)
+    print(f"Found {len(bundles)} bundles")
+
+    try:
+        cohorts = cohort_platforms(bundles)
+    except CorpusReadError as exc:
+        print(exc)
+        return 1
+
+    print("\nCohorts:")
+    for key, platforms in sorted(cohorts.items()):
+        status = "OK" if len(platforms) >= MINIMUM_PLATFORMS_PER_COHORT else "WARN (<3 platforms)"
+        print(f"  {key[0]} SF={key[1]}: {len(platforms)} platforms ({sorted(platforms)}) [{status}]")
+
+    low = shallow_cohorts(cohorts)
+    if low:
+        print(f"\nWARN: {len(low)} cohort(s) have <3 platforms: { {k: len(v) for k, v in low.items()} }")
+        return 1
+
+    print(f"\nAll {len(cohorts)} cohort(s) meet the >={MINIMUM_PLATFORMS_PER_COHORT}-platform depth criterion.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/unit/scripts/test_corpus_cohort_depth.py
+++ b/tests/unit/scripts/test_corpus_cohort_depth.py
@@ -1,0 +1,143 @@
+"""The corpus cohort-depth requirement must fail a PR, not just a manual run.
+
+`results-data/SEED_CORPUS_SPEC.md` states it as a hard requirement: every
+committed cohort must have at least 3 platforms. `results-data/validate_corpus.py`
+enforces it and exits 1 on violation.
+
+Nothing ran it. Every reference to that script in `.github/workflows` is a path
+list for mirroring, not an execution, and it was absent from pr-preflight, from
+ci-lint and from every pre-commit hook. So PR #1854 added a TPC-DS SF10 cohort
+with DuckDB alone, passed pr-preflight green with 28,043 tests, and merged --
+leaving develop carrying a violated invariant until someone happened to run the
+validator by hand.
+
+This module closes that gap by importing the script rather than restating its
+rule, so the gate and the contributor-facing tool cannot drift apart. It lives
+in the whole-corpus unit lane beside `test_corpus_privacy_invariant.py`, which
+already closed the same class of hole for path leaks and sidecar hashes, and
+therefore runs in pr-preflight and in the required CI lane without a new
+workflow job.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+
+pytestmark = [pytest.mark.unit, pytest.mark.fast]
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+VALIDATOR = REPO_ROOT / "results-data" / "validate_corpus.py"
+BUNDLES = REPO_ROOT / "results-data" / "bundles"
+
+
+def _load_validator() -> ModuleType:
+    """Import the vendored script by path; it is not an installed module."""
+    spec = importlib.util.spec_from_file_location("validate_corpus", VALIDATOR)
+    assert spec and spec.loader, f"cannot load {VALIDATOR}"
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _write_bundle(directory: Path, name: str, *, benchmark: str, scale: float, platform: str) -> None:
+    directory.mkdir(parents=True, exist_ok=True)
+    (directory / name).write_text(
+        json.dumps(
+            {
+                "benchmark": {"id": benchmark, "scale_factor": scale},
+                "platform": {"name": platform},
+            }
+        ),
+        encoding="utf-8",
+    )
+
+
+def test_every_committed_cohort_meets_the_platform_floor() -> None:
+    """The invariant itself, against the real corpus."""
+    validator = _load_validator()
+    cohorts = validator.cohort_platforms(validator.discover_bundles(BUNDLES))
+
+    assert cohorts, "no cohorts found - this gate would be vacuous"
+    shallow = validator.shallow_cohorts(cohorts)
+    assert not shallow, (
+        f"{len(shallow)} cohort(s) below {validator.MINIMUM_PLATFORMS_PER_COHORT} platforms; a one-platform "
+        "cohort is not a comparison. See results-data/SEED_CORPUS_SPEC.md:\n  "
+        + "\n  ".join(
+            f"{benchmark} SF={scale}: {sorted(platforms)}" for (benchmark, scale), platforms in shallow.items()
+        )
+    )
+
+
+def test_the_gate_detects_a_one_platform_cohort(tmp_path: Path) -> None:
+    """Negative control, on synthetic bundles.
+
+    Asserting against a real violation would stop being a control the moment
+    the corpus is correct, which is the state this gate exists to keep it in.
+    """
+    validator = _load_validator()
+    _write_bundle(tmp_path, "a.json", benchmark="tpcds", scale=10.0, platform="DuckDB")
+
+    shallow = validator.shallow_cohorts(validator.cohort_platforms(validator.discover_bundles(tmp_path)))
+
+    assert shallow == {("tpcds", "10.0"): {"DuckDB"}}
+
+
+def test_the_gate_accepts_a_full_cohort(tmp_path: Path) -> None:
+    """Positive control: three platforms in one cohort must not be flagged."""
+    validator = _load_validator()
+    for platform in ("DuckDB", "DataFusion", "Spark"):
+        _write_bundle(tmp_path, f"{platform}.json", benchmark="tpcds", scale=10.0, platform=platform)
+
+    assert validator.shallow_cohorts(validator.cohort_platforms(validator.discover_bundles(tmp_path))) == {}
+
+
+def test_companion_files_are_not_counted_as_bundles(tmp_path: Path) -> None:
+    """A sidecar must not pad a cohort's platform count.
+
+    Counting `x.manifest.json` beside `x.json` would let a one-platform cohort
+    look deeper than it is, which is the failure mode this gate exists to stop.
+    """
+    validator = _load_validator()
+    _write_bundle(tmp_path, "a.json", benchmark="tpch", scale=1.0, platform="DuckDB")
+    for companion in ("a.manifest.json", "a.plans.json", "a.tuning.json", "a.applied.json"):
+        (tmp_path / companion).write_text("{}", encoding="utf-8")
+    (tmp_path / "submission-manifest.json").write_text("{}", encoding="utf-8")
+
+    assert [path.name for path in validator.discover_bundles(tmp_path)] == ["a.json"]
+
+
+def test_an_unreadable_bundle_fails_closed(tmp_path: Path) -> None:
+    """The validator's other invariant: a bundle that cannot be read is fatal.
+
+    Skipping it would let a truncated or unreviewed bundle pass while the gate
+    stayed green.
+    """
+    validator = _load_validator()
+    (tmp_path / "broken.json").write_text("{not json", encoding="utf-8")
+
+    with pytest.raises(validator.CorpusReadError):
+        validator.cohort_platforms(validator.discover_bundles(tmp_path))
+
+
+@pytest.mark.parametrize(
+    ("platforms", "expected_exit"),
+    [(("DuckDB",), 1), (("DuckDB", "DataFusion", "Spark"), 0)],
+)
+def test_the_entry_point_returns_the_right_exit_code(
+    tmp_path: Path, platforms: tuple[str, ...], expected_exit: int
+) -> None:
+    """End-to-end through `main`, so a change that swallows the failure is caught.
+
+    The assertions above use the helpers directly; this one pins the exit code
+    the contributor and any future CI caller actually observe.
+    """
+    validator = _load_validator()
+    for platform in platforms:
+        _write_bundle(tmp_path, f"{platform}.json", benchmark="tpcds", scale=10.0, platform=platform)
+
+    assert validator.main(tmp_path) == expected_exit


### PR DESCRIPTION
`results-data/SEED_CORPUS_SPEC.md` states it as a hard requirement -- every
committed cohort must have at least 3 platforms -- and
`results-data/validate_corpus.py` enforces it and exits 1 on violation.

Nothing ran it. All four references to that script in `.github/workflows` are
path lists for mirroring, not executions, and it was absent from
pr-preflight, from ci-lint, and from every pre-commit hook. So PR #1854 added
a TPC-DS SF10 cohort with DuckDB alone, passed pr-preflight green with 28,043
tests, and merged. develop then carried a violated invariant until someone
happened to run the validator by hand. A documented hard requirement that no
lane enforces is indistinguishable from a suggestion.

Restructure the script into `discover_bundles` / `cohort_platforms` /
`shallow_cohorts` / `main`, and import it from a test in the whole-corpus
unit lane. Importing rather than restating the rule means the gate and the
contributor-facing tool cannot drift apart, and placing it beside
`test_corpus_privacy_invariant.py` -- which already closed this same class of
hole for path leaks and sidecar hashes -- means it runs in pr-preflight and
in the required CI lane without a new workflow job.

The script stays stdlib-only with no `benchbox` imports: it is vendored onto
the slim `published-results` branch, where the package is not installed.

Behaviour is unchanged. Byte-identical stdout and the same exit code against
the real corpus, checked before and after.

Verified by planting a one-platform cohort and running the real command:

    PREFLIGHT EXIT=2
    AssertionError: 1 cohort(s) below 3 platforms; a one-platform cohort is
    not a comparison. See results-data/SEED_CORPUS_SPEC.md:
      probe_benchmark SF=99.0: ['DuckDB']

Seven tests: the invariant against the real corpus, a synthetic negative
control, a positive control, a check that companions cannot pad a cohort's
platform count, the fail-closed unreadable-bundle path, and both exit codes
end to end through `main` so a future change that swallows the failure is
caught.

Refs: corpus-invariant-validator-runs-in-no-ci-lane w0-w3
