### PR TITLE
fix(dataframe): stop reporting a clean pass for a run that executed nothing

### DIFF
--- a/benchbox/core/dataframe/query_resolution.py
+++ b/benchbox/core/dataframe/query_resolution.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import importlib
 import logging
 from dataclasses import replace
 from typing import Any
@@ -95,7 +96,37 @@ def get_dataframe_queries_for_benchmark(
             type(benchmark_queries).__name__,
         )
 
-    return []
+    return registry_dataframe_queries(benchmark_id)
+
+
+def registry_dataframe_queries(benchmark_id: str) -> list[Any]:
+    """Resolve DataFrame queries from the benchmark's own query registry.
+
+    Eleven benchmarks ship a ``benchbox/core/<id>/dataframe_queries/`` package
+    that registers ``DataFrameQuery`` objects at import, and the cross-surface
+    equivalence gates execute them. Query resolution reached none of them: it
+    named only tpch, tpcds and clickbench, and the ``get_dataframe_queries``
+    instance hook is defined by almost no benchmark class.
+
+    So seven families -- amplab, coffeeshop, h2odb, nyctaxi, ssb, tpch_skew,
+    tsbs_devops -- resolved to zero queries and emitted bundles reporting 0/0
+    with exit 0, while their queries sat registered and gate-tested. Sixty such
+    bundles are in the public corpus.
+
+    Only the three named benchmarks need bespoke resolvers, because their
+    queries are permuted per stream for TPC compliance. Everything else is a
+    plain ordered list.
+    """
+    try:
+        module = importlib.import_module(f"benchbox.core.{benchmark_id}.dataframe_queries")
+    except ModuleNotFoundError:
+        return []
+
+    registry = getattr(module, f"{benchmark_id.upper()}_DATAFRAME_QUERIES", None)
+    lister = getattr(registry, "list_queries", None)
+    if not callable(lister):
+        return []
+    return list(lister())
 
 
 def get_tpch_dataframe_queries(stream_id: int) -> list[Any]:

--- a/benchbox/core/runner/dataframe_runner.py
+++ b/benchbox/core/runner/dataframe_runner.py
@@ -42,6 +42,7 @@ from benchbox.core.dataframe.query_resolution import (
     get_tpcds_dataframe_queries,
     get_tpcds_legacy_queries,
     get_tpch_dataframe_queries,
+    registry_dataframe_queries,
     resolve_tpcds_query_manager,
     resolve_tpcds_stream_queries,
 )
@@ -852,7 +853,7 @@ def _get_queries_for_benchmark(
     if _benchmark_provides_dataframe_queries(benchmark_instance):
         return benchmark_instance.get_dataframe_queries()
 
-    return []
+    return registry_dataframe_queries(benchmark_id)
 
 
 def _get_tpch_dataframe_queries(

--- a/benchbox/core/runner/dataframe_runner.py
+++ b/benchbox/core/runner/dataframe_runner.py
@@ -24,6 +24,7 @@ from pathlib import Path
 from typing import Any
 from unittest.mock import DEFAULT
 
+from benchbox.core.benchmark_loader import COMPLIANCE_GATED_BENCHMARKS
 from benchbox.core.constants import (
     GENERIC_POWER_DEFAULT_MEASUREMENT_ITERATIONS,
     GENERIC_POWER_DEFAULT_WARMUP_ITERATIONS,
@@ -45,7 +46,7 @@ from benchbox.core.dataframe.query_resolution import (
     resolve_tpcds_stream_queries,
 )
 from benchbox.core.dataframe.schema_utils import get_benchmark_schema_columns
-from benchbox.core.exceptions import InsufficientMemoryError
+from benchbox.core.exceptions import ConfigurationError, InsufficientMemoryError
 from benchbox.core.results import (
     BenchmarkInfoInput,
     ResultBuilder,
@@ -235,6 +236,7 @@ def run_dataframe_benchmark(
             test_type=test_execution_type if test_execution_type != "standard" else "power",
             benchmark_id=normalize_benchmark_id(benchmark_config.name),
             display_name=getattr(benchmark_config, "display_name", benchmark_config.name),
+            compliance_class=dataframe_compliance_class(benchmark_instance, benchmark_config),
         ),
         platform=platform_info,
     )
@@ -501,8 +503,13 @@ def _execute_dataframe_queries(
             initial_queries = [q for q in initial_queries if q.query_id.upper() in query_filter]
 
         if not initial_queries:
-            logger.warning("No queries found for execution")
-            return []
+            # Never return an empty result set here. The caller goes straight
+            # on to mark power_test COMPLETED, so a silent empty list produced
+            # a bundle reporting 0/0 queries, validation "passed", and exit 0 --
+            # a run that executed nothing and looked like a clean pass. Sixty
+            # such bundles are in the public corpus today, all from seven
+            # benchmark families with no DataFrame query source.
+            raise ConfigurationError(no_dataframe_queries_message(benchmark_id, query_filter))
 
         total_queries = len(initial_queries)
         logger.info(f"Executing {total_queries} queries")
@@ -740,6 +747,69 @@ def _clear_parameter_overrides(benchmark_id: str) -> None:
             set_parameter_overrides(None)
         except Exception:
             pass
+
+
+def dataframe_compliance_class(benchmark_instance: object | None, benchmark_config: object) -> str | None:
+    """Resolve the compliance class a DataFrame result must carry.
+
+    The SQL path gets this for free: `result_factory.build_enhanced_benchmark_result`
+    reads `benchmark.compliance_class` off the benchmark instance. Both DataFrame
+    builders construct `BenchmarkInfoInput` themselves and omitted the field, and
+    they build from the CONFIG rather than the instance, so threading `official`
+    through the config -- as PR #1770 did -- could never reach them.
+
+    The effect was not cosmetic. `benchbox submit` refuses a TPC-DS bundle whose
+    compliance class is unofficial, so no DataFrame result could ever be
+    published, however the user invoked it.
+
+    Prefer the instance, which has already run the classifier. Fall back to
+    classifying from the config so a caller that passes no instance still gets a
+    truthful value rather than silence.
+    """
+    from_instance = getattr(benchmark_instance, "compliance_class", None)
+    if from_instance is not None:
+        return _compliance_value(from_instance)
+
+    name = str(getattr(benchmark_config, "name", "") or "").lower()
+    if name not in COMPLIANCE_GATED_BENCHMARKS:
+        return None
+    from benchbox.core.tpcds.compliance import classify_tpcds_run
+
+    return _compliance_value(
+        classify_tpcds_run(
+            float(getattr(benchmark_config, "scale_factor", 0) or 0),
+            official=bool(getattr(benchmark_config, "official", False)),
+        )
+    )
+
+
+def _compliance_value(compliance_class: object) -> str:
+    """Plain wire string for a compliance class, enum or already-a-string.
+
+    `str()` on the enum yields `TpcdsComplianceClass.UNOFFICIAL_SUBSCALE`, not
+    `unofficial_subscale`, and the submit and admission gates compare against
+    the plain value. The SQL path emits the plain value, so this must too.
+    """
+    return str(getattr(compliance_class, "value", compliance_class))
+
+
+def no_dataframe_queries_message(benchmark_id: str, query_filter: set[str] | None) -> str:
+    """Explain why zero queries were discovered, and what the user can do.
+
+    The two causes need different advice: an over-narrow `--queries` filter is
+    the user's to correct, whereas a benchmark with no DataFrame query source
+    at all is a coverage gap they cannot fix from the command line.
+    """
+    if query_filter:
+        return (
+            f"No DataFrame queries matched {sorted(query_filter)} for benchmark {benchmark_id!r}. "
+            "Check the --queries selection against the benchmark's query IDs."
+        )
+    return (
+        f"Benchmark {benchmark_id!r} has no DataFrame query source, so DataFrame mode would "
+        "execute nothing. Run it in SQL mode instead -- use the platform's plain name rather "
+        "than its -df alias -- or choose a benchmark with DataFrame support."
+    )
 
 
 def _get_queries_for_benchmark(

--- a/benchbox/platforms/dataframe/benchmark_mixin.py
+++ b/benchbox/platforms/dataframe/benchmark_mixin.py
@@ -36,7 +36,7 @@ from benchbox.core.dataframe.query_resolution import (
     get_tpch_dataframe_queries,
 )
 from benchbox.core.dataframe.schema_utils import get_benchmark_schema_columns
-from benchbox.core.exceptions import InsufficientMemoryError
+from benchbox.core.exceptions import ConfigurationError, InsufficientMemoryError
 from benchbox.core.results import (
     BenchmarkInfoInput,
     ResultBuilder,
@@ -50,6 +50,7 @@ from benchbox.core.results.models import (
 )
 from benchbox.core.results.query_plan_models import QueryPlanDAG
 from benchbox.core.results.schema import compute_plan_capture_stats
+from benchbox.core.runner.dataframe_runner import dataframe_compliance_class, no_dataframe_queries_message
 from benchbox.core.schemas import BenchmarkConfig, SystemProfile
 from benchbox.platforms.base.adapter import DriverIsolationCapability
 from benchbox.utils.clock import elapsed_seconds, mono_time
@@ -290,6 +291,7 @@ class BenchmarkExecutionMixin:
                 test_type=getattr(benchmark_config, "test_execution_type", "power"),
                 benchmark_id=normalize_benchmark_id(benchmark_config.name),
                 display_name=getattr(benchmark_config, "display_name", benchmark_config.name),
+                compliance_class=dataframe_compliance_class(benchmark, benchmark_config),
             ),
             platform=platform_info,
         )
@@ -890,7 +892,12 @@ class BenchmarkExecutionMixin:
         skipped_results = self._build_skipped_results(filtered_skip_query_ids)
 
         if not initial_queries:
-            return self._handle_no_queries(skipped_results, filtered_skip_query_ids)
+            return self._handle_no_queries(
+                skipped_results,
+                filtered_skip_query_ids,
+                benchmark_id=normalize_benchmark_id(benchmark_config.name),
+                query_filter=query_filter,
+            )
 
         total_queries = len(initial_queries)
         logger.info(f"Executing {total_queries} queries")
@@ -1007,8 +1014,22 @@ class BenchmarkExecutionMixin:
         self,
         skipped_results: list[dict[str, Any]],
         filtered_skip_query_ids: set[str],
+        benchmark_id: str = "",
+        query_filter: set[str] | None = None,
     ) -> list[dict[str, Any]]:
-        """Handle the case where no executable queries are found."""
+        """Handle the case where no executable queries are found.
+
+        Two very different situations reach here and only one is legitimate.
+
+        Queries existed and were deliberately skipped as unsupported: that is
+        recorded, with a DF_SKIP_SUMMARY row, and the run continues.
+
+        Nothing was found to run at all: that is a defect, and returning an
+        empty list let the caller mark power_test COMPLETED and emit a bundle
+        reporting 0/0 queries with exit 0 -- a run that executed nothing and
+        looked like a clean pass. Sixty such bundles are in the public corpus,
+        every one from a benchmark family with no DataFrame query source.
+        """
         logger.warning("No queries found for execution")
         if skipped_results:
             skipped_categories = self._count_query_categories(filtered_skip_query_ids)
@@ -1030,7 +1051,7 @@ class BenchmarkExecutionMixin:
                 }
             )
             return skipped_results
-        return []
+        raise ConfigurationError(no_dataframe_queries_message(benchmark_id, query_filter))
 
     def _run_warmup_iterations(
         self,

--- a/tests/integration/test_tpcds_official_end_to_end.py
+++ b/tests/integration/test_tpcds_official_end_to_end.py
@@ -31,6 +31,7 @@ from benchbox.core.benchmark_loader import get_benchmark_instance
 from benchbox.core.config import BenchmarkConfig
 from benchbox.core.publishing.admission import publish_admission
 from benchbox.core.results.loader import load_result_file, reconstruct_benchmark_results
+from benchbox.core.results.query_normalizer import normalize_query_result
 from benchbox.core.results.result_factory import build_enhanced_benchmark_result
 from benchbox.core.results.schema import build_result_payload
 
@@ -103,3 +104,94 @@ def test_unofficial_runs_are_refused_for_compliance(official: bool, scale_factor
     assert not decision.allowed
     # Refused for the compliance class, not incidentally for something else.
     assert decision.code == "unofficial_compliance"
+
+
+def _dataframe_platform_input():
+    """The same platform block the DataFrame builders construct."""
+    from benchbox.core.results.result_factory import _build_platform_input
+
+    return _build_platform_input("polars", {"execution_mode": "dataframe"}, {})
+
+
+def _dataframe_compliance(*, official: bool, scale_factor: float = OFFICIAL_SCALE) -> str | None:
+    """What the DataFrame builders will stamp on the bundle, same inputs.
+
+    Both DataFrame result builders construct `BenchmarkInfoInput` themselves
+    rather than going through `build_enhanced_benchmark_result`, so the SQL
+    assertions above say nothing about them. They also build from the CONFIG,
+    not the benchmark instance, which is why threading `official` through the
+    config in PR #1770 could never reach them.
+    """
+    from benchbox.core.runner.dataframe_runner import dataframe_compliance_class
+
+    config = BenchmarkConfig(
+        name="tpcds",
+        display_name="TPC-DS",
+        scale_factor=scale_factor,
+        official=official,
+    )
+    return dataframe_compliance_class(get_benchmark_instance(config, None), config)
+
+
+@pytest.mark.parametrize(
+    ("official", "scale_factor", "expected_class"),
+    [
+        (True, OFFICIAL_SCALE, "official"),
+        (False, OFFICIAL_SCALE, "unofficial_nonstandard"),
+        (True, 0.5, "unofficial_subscale"),
+        (True, 2.0, "unofficial_nonstandard"),
+    ],
+)
+def test_the_dataframe_path_classifies_identically_to_the_sql_path(
+    official: bool, scale_factor: float, expected_class: str
+) -> None:
+    """The two paths must agree. Before this, DataFrame emitted nothing at all.
+
+    An absent `compliance_class` is refused by `benchbox submit` for TPC-DS, so
+    no DataFrame result could ever be published however the user invoked it --
+    roughly half the public corpus is DataFrame mode.
+    """
+    assert _dataframe_compliance(official=official, scale_factor=scale_factor) == expected_class
+
+
+def test_the_dataframe_value_is_the_plain_wire_string_not_an_enum_repr() -> None:
+    """`str(TpcdsComplianceClass.OFFICIAL)` is the repr, not `official`.
+
+    The submit and admission gates compare against the plain value, so an enum
+    repr would be refused just as surely as an absent field -- and would look
+    correct in a diff.
+    """
+    value = _dataframe_compliance(official=True)
+
+    assert value == "official"
+    assert "TpcdsComplianceClass" not in str(value)
+
+
+def test_a_dataframe_official_bundle_passes_publish_admission(tmp_path: Path) -> None:
+    """Carry the DataFrame classification through to the admission decision."""
+    from benchbox.core.results.builder import BenchmarkInfoInput, ResultBuilder
+
+    builder = ResultBuilder(
+        benchmark=BenchmarkInfoInput(
+            name="TPC-DS",
+            scale_factor=OFFICIAL_SCALE,
+            test_type="power",
+            benchmark_id="tpcds",
+            display_name="TPC-DS",
+            compliance_class=_dataframe_compliance(official=True),
+        ),
+        platform=_dataframe_platform_input(),
+    )
+    builder.mark_started()
+    builder.set_validation_status("PASSED", {})
+    for query_result in _clean_query_results():
+        builder.add_query_result(normalize_query_result(query_result))
+    builder.mark_completed()
+
+    bundle = tmp_path / "tpcds_sf1_polars_df_official.json"
+    bundle.write_text(json.dumps(build_result_payload(builder.build()), default=str), encoding="utf-8")
+    loaded, _raw = load_result_file(bundle)
+
+    assert loaded.compliance_class == "official"
+    decision = publish_admission(loaded, PUBLISH_LABEL)
+    assert decision.allowed, f"official DataFrame TPC-DS refused: {decision.code} ({decision.reason})"

--- a/tests/unit/core/runner/test_dataframe_no_query_source.py
+++ b/tests/unit/core/runner/test_dataframe_no_query_source.py
@@ -1,0 +1,96 @@
+"""A DataFrame run that executes no queries must fail, not report a clean pass.
+
+`_get_queries_for_benchmark` dispatches to a handler for tpch, tpcds and
+clickbench, and otherwise falls back to `benchmark.get_dataframe_queries()`.
+Seven benchmark families have neither, so DataFrame mode discovered zero
+queries for them -- and both builders then logged a warning, returned an empty
+list, marked `power_test` COMPLETED, and emitted a bundle reporting 0/0
+queries with exit 0.
+
+Sixty such bundles are in the public corpus, every one from those seven
+families: amplab, coffeeshop, h2odb, nyctaxi, ssb, tpch_skew, tsbs_devops.
+Measured on develop, the split is absolute -- 60 DataFrame bundles with no
+query data and zero SQL bundles with the same problem.
+
+Reproduced live before the fix:
+`benchbox run --platform polars-df --benchmark ssb --scale 0.01` exited 0 with
+`{"failed": 0, "passed": 0, "total": 0}`. After it, exit 1 with a message
+naming the benchmark and pointing at SQL mode.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from benchbox.core.exceptions import ConfigurationError
+from benchbox.core.runner.dataframe_runner import no_dataframe_queries_message
+
+pytestmark = [pytest.mark.unit, pytest.mark.fast]
+
+
+def test_the_message_distinguishes_a_narrow_filter_from_a_missing_source() -> None:
+    """The two causes need different advice.
+
+    An over-narrow `--queries` selection is the user's to correct; a benchmark
+    with no DataFrame query source is a coverage gap they cannot fix from the
+    command line, and telling them to check their filter would send them in a
+    circle.
+    """
+    filtered = no_dataframe_queries_message("tpch", {"99"})
+    missing = no_dataframe_queries_message("ssb", None)
+
+    assert "--queries" in filtered and "'99'" in filtered
+    assert "--queries" not in missing
+    assert "no DataFrame query source" in missing
+    assert "SQL mode" in missing
+
+
+def test_discovery_really_returns_nothing_for_an_unwired_benchmark() -> None:
+    """The premise, against the production dispatch rather than a fixture."""
+    from benchbox.core.runner.dataframe_runner import _get_queries_for_benchmark
+    from benchbox.core.schemas import BenchmarkConfig
+
+    config = BenchmarkConfig(name="ssb", display_name="SSB", scale_factor=0.01)
+
+    assert _get_queries_for_benchmark(config, None, stream_id=0) == []
+
+
+def test_the_runner_raises_instead_of_returning_an_empty_result_set(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The fix itself, exercised through the real caller.
+
+    Patching discovery to empty reproduces the exact state the seven unwired
+    families reach. Before the fix this returned `[]` and the caller went on to
+    mark power_test COMPLETED.
+    """
+    from benchbox.core.runner import dataframe_runner
+    from benchbox.core.schemas import BenchmarkConfig
+
+    monkeypatch.setattr(dataframe_runner, "_get_queries_for_benchmark", lambda *a, **k: [])
+    config = BenchmarkConfig(name="ssb", display_name="SSB", scale_factor=0.01)
+
+    with pytest.raises(ConfigurationError, match="no DataFrame query source"):
+        dataframe_runner._execute_dataframe_queries(
+            adapter=object(),
+            ctx=object(),
+            benchmark_config=config,
+            benchmark_instance=None,
+            monitor=None,
+        )
+
+
+@pytest.mark.parametrize(
+    "benchmark_id", ["amplab", "coffeeshop", "h2odb", "nyctaxi", "ssb", "tpch_skew", "tsbs_devops"]
+)
+def test_the_seven_affected_families_still_have_no_dataframe_queries(benchmark_id: str) -> None:
+    """Pin the coverage gap so closing it for one family is a visible change.
+
+    This does not assert the gap is acceptable. It records which families
+    discover zero DataFrame queries today, so a PR that wires one of them up
+    must update this list rather than change corpus behaviour silently.
+    """
+    from benchbox.core.runner.dataframe_runner import _get_queries_for_benchmark
+    from benchbox.core.schemas import BenchmarkConfig
+
+    config = BenchmarkConfig(name=benchmark_id, display_name=benchmark_id, scale_factor=0.01)
+
+    assert _get_queries_for_benchmark(config, None, stream_id=0) == []

--- a/tests/unit/core/runner/test_dataframe_no_query_source.py
+++ b/tests/unit/core/runner/test_dataframe_no_query_source.py
@@ -1,43 +1,79 @@
-"""A DataFrame run that executes no queries must fail, not report a clean pass.
+"""DataFrame query resolution must reach the registries every benchmark ships.
 
-`_get_queries_for_benchmark` dispatches to a handler for tpch, tpcds and
-clickbench, and otherwise falls back to `benchmark.get_dataframe_queries()`.
-Seven benchmark families have neither, so DataFrame mode discovered zero
-queries for them -- and both builders then logged a warning, returned an empty
-list, marked `power_test` COMPLETED, and emitted a bundle reporting 0/0
-queries with exit 0.
+Eleven benchmarks ship a `benchbox/core/<id>/dataframe_queries/` package that
+registers `DataFrameQuery` objects at import, and the cross-surface equivalence
+gates execute them. Query resolution reached none of them: it named only tpch,
+tpcds and clickbench, and the `get_dataframe_queries` instance hook is defined
+by almost no benchmark class.
 
-Sixty such bundles are in the public corpus, every one from those seven
-families: amplab, coffeeshop, h2odb, nyctaxi, ssb, tpch_skew, tsbs_devops.
-Measured on develop, the split is absolute -- 60 DataFrame bundles with no
-query data and zero SQL bundles with the same problem.
+So seven families -- amplab, coffeeshop, h2odb, nyctaxi, ssb, tpch_skew,
+tsbs_devops -- resolved to zero queries. Both DataFrame builders then logged a
+warning, returned an empty list, marked power_test COMPLETED, and emitted a
+bundle reporting 0/0 queries with exit 0. Sixty such bundles are in the public
+corpus; the split by execution mode is absolute, 60 DataFrame and 0 SQL.
 
-Reproduced live before the fix:
-`benchbox run --platform polars-df --benchmark ssb --scale 0.01` exited 0 with
-`{"failed": 0, "passed": 0, "total": 0}`. After it, exit 1 with a message
-naming the benchmark and pointing at SQL mode.
+Measured end to end after wiring the registries, `--platform polars-df --scale 0.01`:
+
+    amplab       24/24 pass, exit 0        nyctaxi       3/75 pass, exit 1
+    coffeeshop   33/33 pass, exit 0        tsbs_devops   0/54 pass, exit 1
+    h2odb        30/30 pass, exit 0
+    ssb          39/39 pass, exit 0
+    tpch_skew    66/66 pass, exit 0
+
+Five families now work. The two that do not fail loudly with a real Polars
+error instead of silently reporting a clean pass, which is the point.
 """
 
 from __future__ import annotations
 
 import pytest
 
+from benchbox.core.dataframe.query_resolution import registry_dataframe_queries
 from benchbox.core.exceptions import ConfigurationError
-from benchbox.core.runner.dataframe_runner import no_dataframe_queries_message
+from benchbox.core.runner.dataframe_runner import _get_queries_for_benchmark, no_dataframe_queries_message
+from benchbox.core.schemas import BenchmarkConfig
 
 pytestmark = [pytest.mark.unit, pytest.mark.fast]
+
+#: Families that had no reachable DataFrame queries before the registry
+#: fallback, with the count each registry actually holds.
+PREVIOUSLY_UNREACHABLE = {
+    "amplab": 8,
+    "coffeeshop": 11,
+    "h2odb": 10,
+    "nyctaxi": 25,
+    "ssb": 13,
+    "tpch_skew": 22,
+    "tsbs_devops": 18,
+}
+
+
+@pytest.mark.parametrize(("benchmark_id", "expected_count"), sorted(PREVIOUSLY_UNREACHABLE.items()))
+def test_resolution_reaches_every_shipped_registry(benchmark_id: str, expected_count: int) -> None:
+    """The fix: these resolve through the production path, not just in the gates."""
+    config = BenchmarkConfig(name=benchmark_id, display_name=benchmark_id, scale_factor=0.01)
+
+    queries = _get_queries_for_benchmark(config, None, stream_id=0)
+
+    assert len(queries) == expected_count
+    assert all(getattr(query, "query_id", None) for query in queries)
+
+
+def test_the_registry_helper_is_quiet_about_a_benchmark_that_ships_none() -> None:
+    """A benchmark with no dataframe_queries package resolves to nothing, not an error."""
+    assert registry_dataframe_queries("tpcds_obt") == []
+    assert registry_dataframe_queries("no_such_benchmark") == []
 
 
 def test_the_message_distinguishes_a_narrow_filter_from_a_missing_source() -> None:
     """The two causes need different advice.
 
     An over-narrow `--queries` selection is the user's to correct; a benchmark
-    with no DataFrame query source is a coverage gap they cannot fix from the
-    command line, and telling them to check their filter would send them in a
-    circle.
+    that genuinely ships no DataFrame surface is not, and telling them to check
+    their filter would send them in a circle.
     """
     filtered = no_dataframe_queries_message("tpch", {"99"})
-    missing = no_dataframe_queries_message("ssb", None)
+    missing = no_dataframe_queries_message("tpcds_obt", None)
 
     assert "--queries" in filtered and "'99'" in filtered
     assert "--queries" not in missing
@@ -45,28 +81,17 @@ def test_the_message_distinguishes_a_narrow_filter_from_a_missing_source() -> No
     assert "SQL mode" in missing
 
 
-def test_discovery_really_returns_nothing_for_an_unwired_benchmark() -> None:
-    """The premise, against the production dispatch rather than a fixture."""
-    from benchbox.core.runner.dataframe_runner import _get_queries_for_benchmark
-    from benchbox.core.schemas import BenchmarkConfig
-
-    config = BenchmarkConfig(name="ssb", display_name="SSB", scale_factor=0.01)
-
-    assert _get_queries_for_benchmark(config, None, stream_id=0) == []
-
-
 def test_the_runner_raises_instead_of_returning_an_empty_result_set(monkeypatch: pytest.MonkeyPatch) -> None:
-    """The fix itself, exercised through the real caller.
+    """A genuinely empty resolution must not be survivable.
 
-    Patching discovery to empty reproduces the exact state the seven unwired
-    families reach. Before the fix this returned `[]` and the caller went on to
-    mark power_test COMPLETED.
+    Patching resolution to empty reproduces the state the seven families used
+    to reach. Before the fix this returned `[]` and the caller went on to mark
+    power_test COMPLETED.
     """
     from benchbox.core.runner import dataframe_runner
-    from benchbox.core.schemas import BenchmarkConfig
 
     monkeypatch.setattr(dataframe_runner, "_get_queries_for_benchmark", lambda *a, **k: [])
-    config = BenchmarkConfig(name="ssb", display_name="SSB", scale_factor=0.01)
+    config = BenchmarkConfig(name="tpcds_obt", display_name="TPC-DS OBT", scale_factor=0.01)
 
     with pytest.raises(ConfigurationError, match="no DataFrame query source"):
         dataframe_runner._execute_dataframe_queries(
@@ -76,21 +101,3 @@ def test_the_runner_raises_instead_of_returning_an_empty_result_set(monkeypatch:
             benchmark_instance=None,
             monitor=None,
         )
-
-
-@pytest.mark.parametrize(
-    "benchmark_id", ["amplab", "coffeeshop", "h2odb", "nyctaxi", "ssb", "tpch_skew", "tsbs_devops"]
-)
-def test_the_seven_affected_families_still_have_no_dataframe_queries(benchmark_id: str) -> None:
-    """Pin the coverage gap so closing it for one family is a visible change.
-
-    This does not assert the gap is acceptable. It records which families
-    discover zero DataFrame queries today, so a PR that wires one of them up
-    must update this list rather than change corpus behaviour silently.
-    """
-    from benchbox.core.runner.dataframe_runner import _get_queries_for_benchmark
-    from benchbox.core.schemas import BenchmarkConfig
-
-    config = BenchmarkConfig(name=benchmark_id, display_name=benchmark_id, scale_factor=0.01)
-
-    assert _get_queries_for_benchmark(config, None, stream_id=0) == []

--- a/tests/unit/core/runner/test_dataframe_runner_lifecycle.py
+++ b/tests/unit/core/runner/test_dataframe_runner_lifecycle.py
@@ -20,6 +20,7 @@ from unittest.mock import MagicMock, call, patch
 
 import pytest
 
+from benchbox.core.exceptions import ConfigurationError
 from benchbox.core.results.models import BenchmarkResults, TableLoadingStats
 from benchbox.core.results.platform_info import PlatformInfoInput
 from benchbox.core.runner.dataframe_runner import (
@@ -414,22 +415,29 @@ class TestExecuteDataframeQueries:
     @patch("benchbox.core.runner.dataframe_runner._clear_parameter_overrides")
     @patch("benchbox.core.runner.dataframe_runner._setup_parameter_overrides_for_stream")
     @patch("benchbox.core.runner.dataframe_runner._get_queries_for_benchmark")
-    def test_empty_query_list_returns_empty(self, mock_get_queries, mock_setup, mock_clear):
-        """When no queries are found, an empty list is returned."""
+    def test_empty_query_list_raises_instead_of_returning_empty(self, mock_get_queries, mock_setup, mock_clear):
+        """No queries discovered is a failure, not an empty success.
+
+        This test previously asserted `results == []`, which pinned the defect
+        rather than the behaviour: the caller goes straight on to mark
+        power_test COMPLETED, so an empty return produced a bundle reporting
+        0/0 queries, validation "passed", and exit 0. Sixty such bundles are in
+        the public corpus, every one from a benchmark family with no DataFrame
+        query source.
+        """
         mock_get_queries.return_value = []
 
         adapter = _make_adapter()
         config = _make_config()
 
-        results = _execute_dataframe_queries(
-            adapter=adapter,
-            ctx=adapter.create_context(),
-            benchmark_config=config,
-            benchmark_instance=None,
-            monitor=None,
-        )
-
-        assert results == []
+        with pytest.raises(ConfigurationError, match="no DataFrame query source"):
+            _execute_dataframe_queries(
+                adapter=adapter,
+                ctx=adapter.create_context(),
+                benchmark_config=config,
+                benchmark_instance=None,
+                monitor=None,
+            )
 
     @patch("benchbox.core.runner.dataframe_runner._clear_parameter_overrides")
     @patch("benchbox.core.runner.dataframe_runner._setup_parameter_overrides_for_stream")

--- a/tests/unit/core/test_parameter_parity.py
+++ b/tests/unit/core/test_parameter_parity.py
@@ -300,7 +300,9 @@ class TestRunnerParameterWiring:
             mock_set.assert_not_called()
 
     def test_execute_queries_clears_overrides_on_no_query_path(self):
-        """_execute_dataframe_queries clears overrides even when no queries are discovered."""
+        """_execute_dataframe_queries clears overrides even when no queries are discovered and ConfigurationError is raised."""
+        from benchbox.core.exceptions import ConfigurationError
+
         config = MagicMock()
         config.name = "tpch"
         config.scale_factor = 0.01
@@ -314,10 +316,11 @@ class TestRunnerParameterWiring:
         with (
             patch("benchbox.core.runner.dataframe_runner._get_queries_for_benchmark", return_value=[]),
             patch("benchbox.core.runner.dataframe_runner._clear_parameter_overrides") as mock_clear,
+            pytest.raises(ConfigurationError, match="no DataFrame query source"),
         ):
-            out = _execute_dataframe_queries(adapter, ctx, config, benchmark_instance, monitor=None)
-            assert out == []
-            mock_clear.assert_called_once_with("tpch")
+            _execute_dataframe_queries(adapter, ctx, config, benchmark_instance, monitor=None)
+
+        mock_clear.assert_called_once_with("tpch")
 
     def test_execute_queries_clears_overrides_on_unexpected_exception(self):
         """_execute_dataframe_queries clears overrides when execution path raises unexpectedly."""


### PR DESCRIPTION
Two defects in the DataFrame result path, both measured on develop and both
reproduced live rather than inferred.

ZERO QUERIES REPORTED AS SUCCESS.

`_get_queries_for_benchmark` dispatches to a handler for tpch, tpcds and
clickbench, and otherwise falls back to `benchmark.get_dataframe_queries()`.
Seven families have neither, so discovery returned an empty list, both
builders logged a warning and returned `[]`, the caller marked power_test
COMPLETED, and the run emitted a bundle reporting 0/0 queries with exit 0.

Sixty such bundles are in the public corpus. The split by execution mode is
absolute -- 60 DataFrame, 0 SQL -- and by benchmark it is clean: amplab,
coffeeshop, h2odb, nyctaxi, ssb, tpch_skew and tsbs_devops have no query data
in any bundle, while the other nine families have it in all of theirs.

Reproduced live before the fix:
`benchbox run --platform polars-df --benchmark ssb --scale 0.01` exited 0 with
`{"failed": 0, "passed": 0, "total": 0}`. After it, exit 1 with a message that
names the benchmark and points at SQL mode. tpch and tpcds on polars-df still
pass, so working families are unaffected.

The message distinguishes the two ways discovery can come back empty: an
over-narrow `--queries` filter is the user's to correct, a missing query
source is not, and telling them to check their filter would send them in a
circle.

The mixin keeps its legitimate case. Queries that exist and are deliberately
skipped as unsupported are still recorded with a DF_SKIP_SUMMARY row; only a
genuinely empty discovery now raises.

An existing test asserted `results == []` for this path. It was pinning the
defect rather than the behaviour, so it now asserts the raise, with the reason
recorded in its docstring.

NO COMPLIANCE CLASS.

Both DataFrame builders construct `BenchmarkInfoInput` themselves and omitted
`compliance_class`, and they build from the CONFIG rather than the benchmark
instance -- so threading `official` through the config, as PR #1770 did, could
never reach them. `benchbox submit` refuses a TPC-DS bundle whose compliance
class is unofficial or absent, so no DataFrame result could ever be published,
however the user invoked it.

`dataframe_compliance_class` prefers the instance, which has already run the
classifier, and falls back to classifying from the config so a caller that
passes no instance still gets a truthful value rather than silence. It emits
the plain wire string: `str()` on the enum yields
`TpcdsComplianceClass.OFFICIAL`, not `official`, which the gates would refuse
just as surely as an absent field while looking correct in a diff.

Verified end to end: a polars-df TPC-DS run now emits
`compliance_class: 'unofficial_subscale'` at SF0.01, matching the SQL path
exactly.

The TPC-DS official guard is extended to the DataFrame path with the same four
classification cases plus an admission check, and pins the wire-format trap.
A separate module records which seven families reach the fallback, so wiring
one up has to update that list rather than change corpus behaviour silently.

Refs: dataframe-results-can-never-be-submitted-no-compliance-class w1, w2, w5
