### PR TITLE
fix(tests): unbreak the canary assertion my setup delegation changed

### DIFF
--- a/tests/integration/test_platforms_cli_integration.py
+++ b/tests/integration/test_platforms_cli_integration.py
@@ -136,13 +136,23 @@ def test_platforms_install_help():
 
 @pytest.mark.integration
 def test_platforms_setup_help():
-    """Test that platforms setup shows help correctly."""
+    """Test that platforms setup shows help correctly.
+
+    The summary line moved from "Interactive platform setup wizard" to one
+    that says what the command actually does, when `--platform` was added to
+    delegate credential setup to `benchbox setup` (#1844). Assert on the
+    options and on the cross-reference the two same-named commands rely on,
+    rather than on prose that is expected to be edited.
+    """
     result = run_cli_command(["platforms", "setup", "--help"])
 
     assert result.returncode == 0
-    assert "Interactive platform setup wizard" in result.stdout
     assert "--interactive" in result.stdout
     assert "--non-interactive" in result.stdout
+    assert "--platform" in result.stdout
+    # `benchbox setup` is the other command spelled "setup"; each help text
+    # must name the other so a user who lands on one can find the right one.
+    assert "benchbox setup" in result.stdout
 
 
 @pytest.mark.integration


### PR DESCRIPTION
Release Canary shard 4/6 has failed since #1844 merged:

  FAILED tests/integration/test_platforms_cli_integration.py::test_platforms_setup_help
  assert 'Interactive platform setup wizard' in '...Enable and install local
  platform adapters, interac...'

That is my regression. #1844 gave `benchbox platforms setup` a `--platform`
option delegating to `benchbox setup`, and rewrote the summary line to say
what the command does rather than repeat the word "wizard". This test asserts
the old prose.

It did not show up in `make pr-preflight` because it is an integration test
outside the fast lane, so the change passed preflight green and broke the
canary instead -- the same class of gap as a corpus PR passing preflight while
violating an invariant no lane enforced.

Assert on the options and on the cross-reference to `benchbox setup` instead
of on a summary line that is expected to be edited. The cross-reference is the
load-bearing part: two commands are spelled "setup", and each help text must
name the other.

Shard 4 itself is healthy -- it now runs 15 minutes rather than hanging for 53,
so the fix in #1849 held. This is a separate, later failure.
