### PR TITLE
fix(results): harden published submission policy

### DIFF
--- a/.github/workflows/validate-submission.yml
+++ b/.github/workflows/validate-submission.yml
@@ -34,6 +34,7 @@ jobs:
           CHANGED_GUARD=$(git diff --name-only "$BASE_SHA"...HEAD -- \
             scripts/validate_submission.py \
             benchbox/validation/bundle.py \
+            benchbox/core/results/query_status.py \
             scripts/generate_corpus_inventory.py \
             .github/workflows/validate-submission.yml \
             || true)
@@ -49,7 +50,7 @@ jobs:
         env:
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
           AUTHOR_ASSOCIATION: ${{ github.event.pull_request.author_association }}
-          # Same two-signal trust check as the "Validate bundles" step below
+          # Same three-signal trust check as the "Validate bundles" step below
           # (see its comment for the full reasoning): a maintainer adding a
           # vendor bundle on develop is published through a same-repo
           # auto/results-mirror-* PR opened by sync-results-data-to-published.yml
@@ -58,9 +59,11 @@ jobs:
           # PR falls through to the else branch and blocks legitimate
           # maintainer vendor bundles. head.repo.fork is the load-bearing
           # signal (unforgeable from a fork); the branch-name pattern alone
-          # would be spoofable.
+          # would be spoofable, and a same-repository integration must not be
+          # able to impersonate the sync bot.
           IS_FORK: ${{ github.event.pull_request.head.repo.fork }}
           HEAD_REF: ${{ github.head_ref }}
+          PR_AUTHOR: ${{ github.event.pull_request.user.login }}
         run: |
           # The vendor-supplied trust label is RANKING-ELIGIBLE and is granted
           # purely by a bundle living under results-data/bundles/vendor/ (see
@@ -78,7 +81,7 @@ jobs:
             'results-data/bundles/vendor/**' || true)
           if [ -n "$VENDOR_CHANGES" ]; then
             TRUSTED_MIRROR="false"
-            if [ "$IS_FORK" = "false" ]; then
+            if [ "$IS_FORK" = "false" ] && [ "$PR_AUTHOR" = "github-actions[bot]" ]; then
               case "$HEAD_REF" in
                 auto/results-mirror-*) TRUSTED_MIRROR="true" ;;
               esac
@@ -89,7 +92,7 @@ jobs:
                 ;;
               *)
                 if [ "$TRUSTED_MIRROR" = "true" ]; then
-                  echo "Trusted same-repo mirror PR ($HEAD_REF) vendor/ addition - allowed."
+                  echo "Trusted bot-created same-repo mirror PR ($HEAD_REF) vendor/ addition - allowed."
                 else
                   echo "::error::This PR adds or modifies files under results-data/bundles/vendor/, which grants the ranking-eligible vendor-supplied label. Only maintainers may do this:"
                   printf '%s\n' "$VENDOR_CHANGES"
@@ -241,18 +244,19 @@ jobs:
           # the community-submission trust signal). Require the sidecar unless
           # this is a maintainer mirror PR.
           #
-          # The waiver gates on TWO signals, and `head.repo.fork` is the load-bearing
-          # one: `github.head_ref` is attacker-controlled on fork PRs, so a branch
+          # The waiver gates on three signals. `github.head_ref` is attacker-controlled
+          # on fork PRs, so a branch
           # name alone (`auto/results-mirror-*`) is spoofable — anyone could open a
           # fork PR from a branch so named and drop `--require-manifest`, laundering
           # a community bundle into a maintainer-run (ranking-eligible) stamp. The
           # branch pattern only narrows *which* same-repo PRs qualify; the
-          # `head.repo.fork == false` check (unforgeable — a fork PR cannot present
-          # itself as same-repo) is what actually confines the waiver to the trusted
-          # sync bot, whose mirror branches live on this repo. If both aren't
+          # `head.repo.fork == false` check is unforgeable by a fork, and the PR
+          # author must be GitHub Actions itself. Together they confine the waiver
+          # to the trusted sync bot, whose mirror branches live on this repo. If all aren't
           # satisfied we fail closed and require the sidecar.
           IS_FORK: ${{ github.event.pull_request.head.repo.fork }}
           HEAD_REF: ${{ github.head_ref }}
+          PR_AUTHOR: ${{ github.event.pull_request.user.login }}
         run: |
           # `pipefail` is load-bearing, not hygiene. The validator's exit code is
           # this gate: it is piped into `tee` below, and a bash pipeline returns
@@ -267,16 +271,23 @@ jobs:
           # remove this line while the pipe exists.
           set -euo pipefail
           REQUIRE_MANIFEST="--require-manifest"
-          if [ "$IS_FORK" = "false" ]; then
+          ALLOW_PARTIAL_VALIDATION=""
+          if [ "$IS_FORK" = "false" ] && [ "$PR_AUTHOR" = "github-actions[bot]" ]; then
             case "$HEAD_REF" in
-              auto/results-mirror-*) REQUIRE_MANIFEST="" ;;
+              auto/results-mirror-*)
+                REQUIRE_MANIFEST=""
+                ALLOW_PARTIAL_VALIDATION="--allow-partial-validation"
+                ;;
             esac
           fi
+          # Trusted bot-created same-repo mirrors preserve truthful partial maintainer seed
+          # results as non-ranking capability evidence. Community submissions
+          # remain strict: manifest required, non-empty, and validation=passed.
           # Validate and generate PR comment in a single invocation.
           # --pr-comment writes the Markdown file; exit code reflects validation
           # result -- which reaches this step's outcome only because of the
           # `set -o pipefail` above.
-          xargs -d '\n' uv run --no-project --python 3.11 -- python scripts/validate_submission.py $REQUIRE_MANIFEST --pr-comment /tmp/pr_comment.md < /tmp/changed_bundles.txt \
+          xargs -d '\n' uv run --no-project --python 3.11 -- python scripts/validate_submission.py $REQUIRE_MANIFEST $ALLOW_PARTIAL_VALIDATION --pr-comment /tmp/pr_comment.md < /tmp/changed_bundles.txt \
             | tee /tmp/validation_output.txt
 
       - name: Check corpus inventory

--- a/README.md
+++ b/README.md
@@ -5,6 +5,12 @@ This is the **slim, corpus-only branch** of
 only the files needed to receive, validate, and host the public results
 corpus consumed by the BenchBox results explorer.
 
+This branch is authoritative for the complete accepted Phase 2 archive,
+including operator and community submissions that do not belong in the
+curated maintainer seed on `develop`. Inventory files are generated from this
+branch's union corpus. Code, validators, generators, and the curated seed stay
+authoritative on `develop` and are ported here through reviewed mirror PRs.
+
 For the BenchBox project itself — the benchmark engine, platform adapters,
 documentation, blog, results explorer source — see the
 [`develop`](https://github.com/joeharris76/BenchBox/tree/develop) and
@@ -21,6 +27,7 @@ documentation, blog, results explorer source — see the
 | `results-data/SEED_CORPUS_SPEC.md` | Maintainer-run seed lane spec. |
 | `results-data/validate_corpus.py` | The cohort-depth gate (≥3 platforms per cohort). |
 | `scripts/validate_submission.py` | Per-bundle schema, hash, and contract validator (vendored from develop). |
+| `benchbox/validation/bundle.py` and `benchbox/core/results/query_status.py` | Vendored validator implementation and failed-query policy. |
 | `scripts/generate_corpus_inventory.py` | Inventory generator (vendored from develop). |
 | `.github/workflows/validate-submission.yml` | The submission CI gate. |
 | `LICENSE`, `COPYRIGHT.md`, `DISCLAIMER.md` | Standard public-repo legal docs. |

--- a/benchbox/core/results/query_status.py
+++ b/benchbox/core/results/query_status.py
@@ -1,0 +1,53 @@
+"""Stdlib-only failed-query policy shared with the public corpus validator."""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+def bundle_failed_query_count(data: dict[str, Any]) -> int:
+    """Return failed measurement count from a schema-v2 bundle dict."""
+    summary = data.get("summary")
+    if isinstance(summary, dict):
+        queries = summary.get("queries")
+        if isinstance(queries, dict):
+            failed = int_or_none(queries.get("failed"))
+            if failed is not None and failed > 0:
+                return failed
+
+            total = int_or_none(queries.get("total"))
+            passed = int_or_none(queries.get("passed"))
+            skipped = int_or_none(queries.get("skipped")) or 0
+            if total is not None and passed is not None and total > passed + skipped:
+                return max(total - passed - skipped, 0)
+
+    query_rows = data.get("queries")
+    if isinstance(query_rows, list):
+        return sum(1 for query in query_rows if _query_row_failed(query))
+    return 0
+
+
+def int_or_none(value: Any) -> int | None:
+    """Return an integer only when the input represents one exactly."""
+    if isinstance(value, bool):
+        return int(value)
+    if isinstance(value, int):
+        return value
+    if isinstance(value, float) and value.is_integer():
+        return int(value)
+    if isinstance(value, str):
+        try:
+            return int(value)
+        except ValueError:
+            return None
+    return None
+
+
+def _query_row_failed(query: Any) -> bool:
+    if not isinstance(query, dict):
+        return False
+    run_type = str(query.get("run_type") or "measurement").lower()
+    if run_type != "measurement":
+        return False
+    status = query.get("status")
+    return status is not None and str(status).upper() not in {"SUCCESS", "SKIPPED"}

--- a/benchbox/validation/bundle.py
+++ b/benchbox/validation/bundle.py
@@ -32,6 +32,8 @@ except ImportError:  # pragma: no cover - slim published-results branch mirror.
     FUNDING_SOURCES = ("employer", "personal", "free-trial", "vendor-sponsored", "grant", "unspecified")
     RESULT_SOURCES = ("internal", "community", "vendor")
 
+from benchbox.core.results.query_status import bundle_failed_query_count
+
 # Max length for the optional free-text submission_notes manifest field.
 SUBMISSION_NOTES_MAX_LEN = 500
 
@@ -304,7 +306,7 @@ def _validate_summary_section(
     if isinstance(queries_summary, dict):
         total_q = queries_summary.get("total", 0)
         if isinstance(total_q, (int, float)) and total_q == 0:
-            vr.warn("summary.queries.total is 0 - empty result?")
+            vr.error("summary.queries.total must be greater than 0 for a public result")
 
     validation_status = _normalize_status(summary.get("validation"))
     allowed = (
@@ -549,16 +551,35 @@ def _validate_queries_section(queries: Any, vr: ValidationResult) -> None:
         vr.error("'queries' must be a list")
         return
     if len(queries) == 0:
-        vr.warn("queries array is empty")
+        vr.error("queries array must not be empty for a public result")
         return
 
     any_nonzero = False
+    any_nonzero_measurement = False
     for i, q in enumerate(queries):
-        if _validate_single_query(i, q, vr):
+        is_nonzero = _validate_single_query(i, q, vr)
+        if is_nonzero:
             any_nonzero = True
+            run_type = str(q.get("run_type") or "measurement").lower() if isinstance(q, dict) else ""
+            if run_type == "measurement":
+                any_nonzero_measurement = True
 
     if not any_nonzero:
         vr.error("All query timings are 0ms - likely invalid data")
+    elif not any_nonzero_measurement:
+        vr.error("queries must contain at least one positive measurement timing")
+
+
+def _validate_execution_consistency(data: dict[str, Any], vr: ValidationResult) -> None:
+    """Reject a clean validation claim that contradicts measurement evidence."""
+    summary = data.get("summary")
+    if not isinstance(summary, dict) or _normalize_status(summary.get("validation")) != PUBLIC_CLEAN_VALIDATION_STATUS:
+        return
+
+    failed = bundle_failed_query_count(data)
+    if failed > 0:
+        noun = "query" if failed == 1 else "queries"
+        vr.error(f"summary.validation='passed' contradicts {failed} failed measurement {noun}")
 
 
 def _validate_bundle(
@@ -587,6 +608,7 @@ def _validate_bundle(
     _validate_translation_section(data, vr)
     _validate_public_cost_section(data, vr)
     _validate_queries_section(data.get("queries", []), vr)
+    _validate_execution_consistency(data, vr)
 
 
 def _hash_file(file_path: Path) -> str:


### PR DESCRIPTION
Manual slim-branch port of the submission-policy portion of #1880. It adds the shared failed-query policy, rejects zero-query and false-clean submissions, and requires all three trusted-mirror signals. The slim `uv` invocation remains branch-compatible. The root README now records split authority.

Expected protected gate: the existing base workflow self-green control rejects PRs that modify validator or workflow files. Maintainer review and an override are therefore required. Do not merge this port before the source changes in #1880 are approved.
