### PR TITLE
fix(windows): repair Nightly portability for MCP durable jobs and test suite

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -13,6 +13,8 @@
 # green on Linux. The tree is entirely text (400 .json, 4 .md, 1 .py), so
 # pinning it wholesale is safe.
 /results-data/** text eol=lf
+/_binaries/**/tpcds.dst -text
+/_binaries/**/dists.dss -text
 
 # >>> skill-sync managed (do not edit) >>>
 /.claude/skills/** -text

--- a/benchbox/mcp/jobs.py
+++ b/benchbox/mcp/jobs.py
@@ -7,6 +7,7 @@ import logging
 import os
 import shutil
 import sqlite3
+import sys
 import uuid
 from collections.abc import Callable, Mapping
 from contextlib import asynccontextmanager
@@ -828,7 +829,14 @@ class DurableJobWorker:
 
     @staticmethod
     def _sync_path(path: Path) -> None:
-        """Flush a file or directory before a durable state transition."""
+        """Flush a file or directory before a durable state transition.
+
+        Directory metadata is flushed where supported (POSIX); on Windows
+        directory ``fsync`` is skipped because opening directories with
+        ``os.open`` is not supported.
+        """
+        if path.is_dir() and sys.platform == "win32":
+            return
         descriptor = os.open(path, os.O_RDONLY)
         try:
             os.fsync(descriptor)

--- a/tests/integration/mcp/test_durable_jobs.py
+++ b/tests/integration/mcp/test_durable_jobs.py
@@ -251,7 +251,12 @@ def test_tenant_job_tools_are_remote_only_and_cross_tenant_fail_closed(tmp_path:
             for _ in range(100):
                 current = await client_a.call_tool("get_benchmark_status", {"execution_id": execution_id})
                 assert isinstance(current.content[0], TextContent)
-                if json.loads(current.content[0].text)["status"] == "completed":
+                payload = json.loads(current.content[0].text)
+                if payload["status"] in ("failed", "cancelled"):
+                    pytest.fail(
+                        f"durable benchmark terminally {payload['status']} (error_code={payload.get('error_code')!r})"
+                    )
+                if payload["status"] == "completed":
                     break
                 await anyio.sleep(0.01)
             else:

--- a/tests/integration/mcp/test_multiworker_acceptance.py
+++ b/tests/integration/mcp/test_multiworker_acceptance.py
@@ -105,6 +105,11 @@ def test_remote_contract_survives_alternating_workers(tmp_path: Path, monkeypatc
     async def wait_for(client: Client, execution_id: str, state: str) -> dict[str, Any]:
         for _ in range(200):
             status = _content(await client.call_tool("get_benchmark_status", {"execution_id": execution_id}))
+            if status["status"] in ("failed", "cancelled") and state == "completed":
+                pytest.fail(
+                    f"job {execution_id} terminally {status['status']} "
+                    f"(error_code={status.get('error_code')!r}) instead of completed"
+                )
             if status["status"] == state:
                 return status
             await anyio.sleep(0.01)

--- a/tests/unit/cli/test_configuration_guidance.py
+++ b/tests/unit/cli/test_configuration_guidance.py
@@ -48,7 +48,7 @@ def test_connection_guidance_does_not_advertise_unregistered_platform_options(
     relative_path: str, forbidden_advice: tuple[str, ...]
 ) -> None:
     """Connection keys must not be presented as ``--platform-option`` unless registered."""
-    source = (REPO_ROOT / relative_path).read_text()
+    source = (REPO_ROOT / relative_path).read_text(encoding="utf-8")
     for advice in forbidden_advice:
         assert advice not in source
 

--- a/tests/unit/core/runner/test_clickhouse_load_failure.py
+++ b/tests/unit/core/runner/test_clickhouse_load_failure.py
@@ -15,10 +15,13 @@ from benchbox.platforms.base.data_loading import ClickHouseServerLoadError
 pytestmark = [pytest.mark.unit, pytest.mark.fast]
 
 
-def _failure() -> ClickHouseServerLoadError:
+def _failure(
+    database_path: Path | None = None,
+) -> ClickHouseServerLoadError:
+    base = database_path or Path("/tmp/lineitem.tbl.1")
     return ClickHouseServerLoadError(
         "lineitem",
-        [Path("/tmp/lineitem.tbl.1"), Path("/tmp/lineitem.tbl.2")],
+        [base.parent / "lineitem.tbl.1", base.parent / "lineitem.tbl.2"],
         65_536,
         RuntimeError("server closed the connection after memory limit"),
     )
@@ -33,15 +36,17 @@ def test_clickhouse_load_failure_details_preserve_streaming_and_memory_settings(
         insert_block_size=65_536,
         send_receive_timeout=900,
     )
+    database_path = Path("/tmp/lineitem.tbl.1")
+    failure = _failure(database_path)
     details = _clickhouse_load_failure_details(
-        _failure(),
+        failure,
         adapter=adapter,
         platform_config={"max_memory_usage": "24GB", "send_receive_timeout": 1200},
     )
 
     assert details == {
         "table": "lineitem",
-        "source_files": ["/tmp/lineitem.tbl.1", "/tmp/lineitem.tbl.2"],
+        "source_files": [str(database_path), str(database_path.parent / "lineitem.tbl.2")],
         "rows_attempted": 65_536,
         "memory_settings": {
             "max_memory_usage": "24GB",

--- a/tests/unit/mcp/test_durable_jobs.py
+++ b/tests/unit/mcp/test_durable_jobs.py
@@ -357,3 +357,74 @@ def test_retention_removes_artifact_before_terminal_metadata(tmp_path: Path) -> 
     assert [job.execution_id for job in repository.expired_terminal()] == [submitted.execution_id]
     worker.purge_expired()
     assert repository.get(submitted.execution_id) is None
+
+
+class TestDurableJobWindowsDirectoryFsync:
+    """Windows cannot open directories with ``os.open``; file durability must remain."""
+
+    def test_windows_directories_are_not_opened(self, tmp_path: Path, monkeypatch) -> None:
+        directory = tmp_path / "stage"
+        directory.mkdir()
+        (directory / "file.txt").write_text("payload", encoding="utf-8")
+        monkeypatch.setattr("benchbox.mcp.jobs.sys.platform", "win32")
+        calls: list[Path] = []
+
+        original_open = __import__("os").open
+
+        def tracking_open(path, *args, **kwargs):
+            calls.append(Path(path))
+            return original_open(path, *args, **kwargs)
+
+        monkeypatch.setattr("benchbox.mcp.jobs.os.open", tracking_open)
+        DurableJobWorker._sync_tree(directory)
+
+        assert directory not in calls
+        assert (directory / "file.txt") in calls
+
+    def test_windows_regular_files_still_fsync_and_close(self, tmp_path: Path, monkeypatch) -> None:
+        regular = tmp_path / "response.json"
+        regular.write_text("{}", encoding="utf-8")
+        directory = tmp_path / "stage"
+        directory.mkdir()
+        (directory / "nested.txt").write_text("x", encoding="utf-8")
+        monkeypatch.setattr("benchbox.mcp.jobs.sys.platform", "win32")
+        monkeypatch.setattr("benchbox.mcp.jobs.os.fsync", lambda fd: None)
+        closes: list[int] = []
+        original_close = __import__("os").close
+        monkeypatch.setattr("benchbox.mcp.jobs.os.close", lambda fd: closes.append(fd) or original_close(fd))
+
+        DurableJobWorker._sync_path(regular)
+        DurableJobWorker._sync_tree(directory)
+
+        assert closes, "regular files must still be opened and closed on Windows"
+
+    def test_posix_directories_are_still_flushed(self, tmp_path: Path, monkeypatch) -> None:
+        directory = tmp_path / "stage-posix"
+        directory.mkdir()
+        monkeypatch.setattr("benchbox.mcp.jobs.sys.platform", "linux")
+        opened: list[Path] = []
+        original_open = __import__("os").open
+
+        def tracking_open(path, *args, **kwargs):
+            opened.append(Path(path))
+            return original_open(path, *args, **kwargs)
+
+        monkeypatch.setattr("benchbox.mcp.jobs.os.open", tracking_open)
+        DurableJobWorker._sync_tree(directory)
+
+        assert directory in opened
+
+    def test_regular_file_oserror_propagates(self, tmp_path: Path, monkeypatch) -> None:
+        regular = tmp_path / "failure.json"
+        regular.write_text("{}", encoding="utf-8")
+        monkeypatch.setattr("benchbox.mcp.jobs.sys.platform", "win32")
+
+        def failing_fsync(_fd: int) -> None:
+            raise OSError("simulated fsync failure")
+
+        monkeypatch.setattr("benchbox.mcp.jobs.os.fsync", failing_fsync)
+        try:
+            DurableJobWorker._sync_path(regular)
+            raise AssertionError("OSError must propagate")
+        except OSError as exc:
+            assert "simulated" in str(exc)

--- a/tests/unit/scripts/test_check_makefile_inventory.py
+++ b/tests/unit/scripts/test_check_makefile_inventory.py
@@ -38,6 +38,7 @@ def _run_make(root: Path, *arguments: str, env: dict[str, str] | None = None) ->
         check=False,
         capture_output=True,
         text=True,
+        encoding="utf-8",
         env=env,
     )
 
@@ -170,6 +171,7 @@ def test_absolute_symlink_makefile_preserves_module_resolution(tmp_path: Path) -
         check=False,
         capture_output=True,
         text=True,
+        encoding="utf-8",
     )
 
     assert result.returncode == 0, result.stderr

--- a/tests/unit/scripts/test_check_release_curation.py
+++ b/tests/unit/scripts/test_check_release_curation.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import importlib.util
+import os
 import shutil
 import subprocess
 import sys
@@ -244,12 +245,18 @@ def test_curated_release_removes_dangling_project_test_and_runs_retained_tests(
         shutil.copy2(REPO_ROOT / relative, retained_test)
         retained_tests.append(str(retained_test))
 
+    env = {
+        key: value
+        for key, value in os.environ.items()
+        if not key.startswith(("PYTEST_XDIST", "COV_CORE")) and key != "PYTEST_CURRENT_TEST"
+    }
     result = subprocess.run(
-        [sys.executable, "-m", "pytest", "-q", *retained_tests],
+        [sys.executable, "-m", "pytest", "-q", "-n", "0", "-p", "no:cacheprovider", *retained_tests],
         cwd=tmp_path,
         check=False,
         capture_output=True,
         text=True,
+        env=env,
     )
 
     assert result.returncode == 0, result.stderr

--- a/tests/unit/test_worktree_identity.py
+++ b/tests/unit/test_worktree_identity.py
@@ -126,8 +126,10 @@ def test_reads_identity_from_global_includes(fixture_repo, conditional: bool) ->
         f"[user]\n\tname = {HUMAN_NAME}\n\temail = {HUMAN_EMAIL}\n",
         encoding="utf-8",
     )
+    # Use a relative (or POSIX) path so Windows backslashes do not become escapes.
+    include_path = included.relative_to(home).as_posix()
     section = '[includeIf "onbranch:work"]' if conditional else "[include]"
-    (home / ".gitconfig").write_text(f"{section}\n\tpath = {included}\n", encoding="utf-8")
+    (home / ".gitconfig").write_text(f"{section}\n\tpath = {include_path}\n", encoding="utf-8")
 
     result = _run_helper(linked, home)
 
@@ -142,7 +144,8 @@ def test_refuses_agent_identity_from_global_include(fixture_repo) -> None:
         f"[user]\n\tname = {AGENT_NAME}\n\temail = {AGENT_EMAIL}\n",
         encoding="utf-8",
     )
-    (home / ".gitconfig").write_text(f"[include]\n\tpath = {included}\n", encoding="utf-8")
+    include_path = included.relative_to(home).as_posix()
+    (home / ".gitconfig").write_text(f"[include]\n\tpath = {include_path}\n", encoding="utf-8")
 
     result = _run_helper(linked, home)
 

--- a/tests/unit/workflows/test_validate_submission_changed_bundles.py
+++ b/tests/unit/workflows/test_validate_submission_changed_bundles.py
@@ -268,7 +268,7 @@ def test_live_orphan_companion_is_rejected(tmp_path: Path, companion_suffix: str
     )
 
     assert result.returncode != 0
-    assert str(companion.relative_to(tmp_path)) in result.stdout
+    assert companion.relative_to(tmp_path).as_posix() in result.stdout
     assert "has no primary bundle" in result.stdout
 
 


### PR DESCRIPTION
MCP durable flush used os.open on directories, which Windows rejects;
skip directory fsync only on win32 while continuing to flush regular
files and POSIX directories. Harden integration polling to fail
immediately on terminal failed/cancelled jobs including error_code.

Test portability: derive clickhouse expected paths from fixture
instead of hard-coded /tmp, read_text with utf-8, set utf-8 on make
subprocess, isolate nested pytest from xdist/coverage env, use
relative Git-config-safe include paths, pin _binaries tpcds/dists
as binary, and assert POSIX paths for GitHub annotations. Negative
controls cover Windows directory skip, file flush, POSIX flush, and
file OSError propagation.
