### PR TITLE
fix/architecture integrity batch

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -146,7 +146,7 @@ jobs:
           retention-days: 30
 
   publish:
-    needs: build
+    needs: [build, test-installation]
     runs-on: ubuntu-latest
     environment:
       name: ${{ github.event.inputs.test_pypi == 'true' && 'test-pypi' || 'pypi' }}
@@ -213,9 +213,11 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-  # Verify installation works across platforms after publishing
+  # Verify installation works across platforms before publishing. Installing
+  # the uploaded wheel avoids PyPI propagation races and makes this a real
+  # publication gate rather than a post-publication smoke test.
   test-installation:
-    needs: [build, publish]
+    needs: build
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -229,38 +231,27 @@ jobs:
           - os: macos-latest
             python-version: '3.13'
     steps:
+      - name: Download build artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: release-dist
+          path: dist/
+
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
 
-      - name: Wait for package availability
+      - name: Test installation from built wheel
         shell: bash
-        run: sleep 60
-
-      - name: Test installation from PyPI
-        if: github.event.inputs.test_pypi != 'true'
-        shell: bash
-        env:
-          BENCHBOX_VERSION: ${{ needs.build.outputs.version }}
         run: |
-          pip install "benchbox==${BENCHBOX_VERSION}"
-          python -c "import importlib.util; import benchbox; assert importlib.util.find_spec('pandas') is None, 'published core wheel must not pull pandas'; print(f'BenchBox {benchbox.__version__} installed successfully (minimal import surface)')"
-          benchbox --help
-
-      - name: Test installation from Test PyPI
-        if: github.event.inputs.test_pypi == 'true'
-        shell: bash
-        env:
-          BENCHBOX_VERSION: ${{ needs.build.outputs.version }}
-        run: |
-          pip install -i https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple/ "benchbox==${BENCHBOX_VERSION}"
+          python -m pip install dist/*.whl
           python -c "import importlib.util; import benchbox; assert importlib.util.find_spec('pandas') is None, 'published core wheel must not pull pandas'; print(f'BenchBox {benchbox.__version__} installed successfully (minimal import surface)')"
           benchbox --help
 
   # Delete old workflow artifacts to prevent confusion
   cleanup-artifacts:
-    needs: test-installation
+    needs: [publish, test-installation]
     runs-on: ubuntu-latest
     permissions:
       actions: write

--- a/benchbox/cli/commands/compare.py
+++ b/benchbox/cli/commands/compare.py
@@ -1135,7 +1135,7 @@ def _output_comparison_results(
 
     elif output_format == "html":
         content = suite._generate_text_report(results)
-        html_content = f"<pre>{content}</pre>" if output_file else content
+        html_content = f"<pre>{_escape_html(content)}</pre>" if output_file else content
         _write_or_print(html_content if output_file else content, output_file, "comparison.html")
         if not output_file:
             console.print(content)

--- a/benchbox/cli/commands/compare.py
+++ b/benchbox/cli/commands/compare.py
@@ -20,6 +20,7 @@ import json
 import statistics
 import sys
 import warnings
+from html import escape as html_escape
 from pathlib import Path
 from typing import Any
 
@@ -37,6 +38,11 @@ from benchbox.core.results.loader import (
 )
 from benchbox.core.results.regression_policy import is_regression
 from benchbox.validation.bundle import COMPANION_SUFFIXES
+
+
+def _escape_html(value: Any) -> str:
+    """Escape arbitrary comparison data before placing it in HTML text."""
+    return html_escape(str(value), quote=True)
 
 
 class ResultFileMetadata:
@@ -1751,10 +1757,12 @@ def _append_html_header(html: list[str]) -> None:
 def _append_html_metadata(html: list[str], comparison: dict[str, Any], baseline: Any) -> None:
     """Append HTML metadata section (title, file paths, benchmark info)."""
     html.append("<h1>Benchmark Comparison Report</h1>")
-    html.append(f"<p><strong>Baseline:</strong> {comparison['baseline_file']}</p>")
-    html.append(f"<p><strong>Current:</strong> {comparison['current_file']}</p>")
+    html.append(f"<p><strong>Baseline:</strong> {_escape_html(comparison['baseline_file'])}</p>")
+    html.append(f"<p><strong>Current:</strong> {_escape_html(comparison['current_file'])}</p>")
     html.append(
-        f"<p><strong>Benchmark:</strong> {baseline.benchmark_name} | <strong>Platform:</strong> {baseline.platform} | <strong>Scale:</strong> {baseline.scale_factor}</p>"
+        f"<p><strong>Benchmark:</strong> {_escape_html(baseline.benchmark_name)} | "
+        f"<strong>Platform:</strong> {_escape_html(baseline.platform)} | "
+        f"<strong>Scale:</strong> {_escape_html(baseline.scale_factor)}</p>"
     )
 
 
@@ -1766,10 +1774,14 @@ def _append_html_summary_table(html: list[str], comparison: dict[str, Any]) -> N
     html.append("<h2>Summary</h2>")
     html.append("<table>")
     html.append("<tr><th>Metric</th><th>Value</th></tr>")
-    html.append(f"<tr><td>Total Queries</td><td>{summary.get('total_queries_compared', 0)}</td></tr>")
-    html.append(f"<tr><td>Improved</td><td class='improved'>{summary.get('improved_queries', 0)}</td></tr>")
-    html.append(f"<tr><td>Regressed</td><td class='regressed'>{summary.get('regressed_queries', 0)}</td></tr>")
-    html.append(f"<tr><td>Unchanged</td><td>{summary.get('unchanged_queries', 0)}</td></tr>")
+    html.append(f"<tr><td>Total Queries</td><td>{_escape_html(summary.get('total_queries_compared', 0))}</td></tr>")
+    html.append(
+        f"<tr><td>Improved</td><td class='improved'>{_escape_html(summary.get('improved_queries', 0))}</td></tr>"
+    )
+    html.append(
+        f"<tr><td>Regressed</td><td class='regressed'>{_escape_html(summary.get('regressed_queries', 0))}</td></tr>"
+    )
+    html.append(f"<tr><td>Unchanged</td><td>{_escape_html(summary.get('unchanged_queries', 0))}</td></tr>")
     html.append("</table>")
 
 
@@ -1802,7 +1814,7 @@ def _append_html_query_comparison(html: list[str], comparison: dict[str, Any]) -
         row_class, severity = _html_query_row_class_and_severity(query["improved"], query["change_percent"])
         change_str = f"{query['change_percent']:+.2f}%"
         html.append(f"<tr{row_class}>")
-        html.append(f"<td>{query['query_id']}</td>")
+        html.append(f"<td>{_escape_html(query['query_id'])}</td>")
         html.append(f"<td>{query['baseline_time_ms']:.2f}</td>")
         html.append(f"<td>{query['current_time_ms']:.2f}</td>")
         html.append(f"<td>{change_str}</td>")
@@ -1842,17 +1854,17 @@ def _append_html_plan_section(html: list[str], comparison: dict[str, Any]) -> No
     # Summary cards
     html.append("<div style='display: grid; grid-template-columns: repeat(4, 1fr); gap: 10px; margin: 20px 0;'>")
     html.append(
-        f"<div style='background: #f8f9fa; padding: 15px; border-radius: 8px; text-align: center;'><strong>{plans_compared}</strong><br>Plans Compared</div>"
+        f"<div style='background: #f8f9fa; padding: 15px; border-radius: 8px; text-align: center;'><strong>{_escape_html(plans_compared)}</strong><br>Plans Compared</div>"
     )
     html.append(
-        f"<div style='background: #d4edda; padding: 15px; border-radius: 8px; text-align: center;'><strong>{plans_unchanged}</strong><br>Unchanged</div>"
+        f"<div style='background: #d4edda; padding: 15px; border-radius: 8px; text-align: center;'><strong>{_escape_html(plans_unchanged)}</strong><br>Unchanged</div>"
     )
     html.append(
-        f"<div style='background: #fff3cd; padding: 15px; border-radius: 8px; text-align: center;'><strong>{plans_changed}</strong><br>Changed</div>"
+        f"<div style='background: #fff3cd; padding: 15px; border-radius: 8px; text-align: center;'><strong>{_escape_html(plans_changed)}</strong><br>Changed</div>"
     )
     regression_style = "background: #f8d7da;" if regressions_detected > 0 else "background: #d4edda;"
     html.append(
-        f"<div style='{regression_style} padding: 15px; border-radius: 8px; text-align: center;'><strong>{regressions_detected}</strong><br>Regressions</div>"
+        f"<div style='{regression_style} padding: 15px; border-radius: 8px; text-align: center;'><strong>{_escape_html(regressions_detected)}</strong><br>Regressions</div>"
     )
     html.append("</div>")
 
@@ -1872,7 +1884,7 @@ def _append_html_plan_section(html: list[str], comparison: dict[str, Any]) -> No
             prop_diff = plan.get("property_mismatches", 0)
             perf_change = plan.get("perf_change_pct", 0.0)
             html.append(f"<tr{row_class}>")
-            html.append(f"<td>{plan.get('query_id', '?')}</td>")
+            html.append(f"<td>{_escape_html(plan.get('query_id', '?'))}</td>")
             html.append(f"<td>{plan.get('similarity', 1.0):.1%}</td>")
             html.append(f"<td>{type_diff if type_diff > 0 else '-'}</td>")
             html.append(f"<td>{prop_diff if prop_diff > 0 else '-'}</td>")
@@ -1893,7 +1905,7 @@ def _append_html_plan_section(html: list[str], comparison: dict[str, Any]) -> No
         html.append("<ul>")
         for reg in regressions:
             html.append(
-                f"<li><strong>{reg.get('query_id', '?')}</strong>: plan similarity {reg.get('similarity', 0.0):.0%}, performance {reg.get('perf_change_pct', 0.0):+.1f}%</li>"
+                f"<li><strong>{_escape_html(reg.get('query_id', '?'))}</strong>: plan similarity {reg.get('similarity', 0.0):.0%}, performance {reg.get('perf_change_pct', 0.0):+.1f}%</li>"
             )
         html.append("</ul>")
         html.append("</div>")

--- a/benchbox/cli/commands/compare.py
+++ b/benchbox/cli/commands/compare.py
@@ -1288,7 +1288,7 @@ def _output_file_comparison(
         "text": lambda: _format_text_comparison(comparison, baseline, current, show_all_queries),
         "json": lambda: json.dumps(comparison, indent=2),
         "html": lambda: _format_html_comparison(comparison, baseline, current),
-        "markdown": lambda: _format_html_comparison(comparison, baseline, current),
+        "markdown": lambda: _format_markdown_comparison(comparison, baseline, current, show_all_queries),
     }
 
     formatter = format_dispatch.get(output_format)
@@ -1470,6 +1470,124 @@ def _check_regression(comparison: dict[str, Any], threshold: float) -> bool:
             return True
 
     return False
+
+
+def _markdown_cell(value: Any) -> str:
+    """Make arbitrary comparison data safe for a Markdown table cell."""
+    return str(value).replace("\\", "\\\\").replace("|", "\\|").replace("\n", " ")
+
+
+def _format_markdown_comparison(comparison: dict[str, Any], baseline: Any, current: Any, show_all: bool) -> str:
+    """Format a file comparison as a Markdown report."""
+    lines = [
+        "# Benchmark Comparison Report",
+        "",
+        f"- **Baseline:** {_markdown_cell(comparison['baseline_file'])}",
+        f"- **Current:** {_markdown_cell(comparison['current_file'])}",
+        f"- **Benchmark:** {_markdown_cell(baseline.benchmark_name)}",
+        f"- **Platform:** {_markdown_cell(baseline.platform)}",
+        f"- **Scale:** {_markdown_cell(baseline.scale_factor)}",
+        "",
+    ]
+
+    summary = comparison.get("summary", {})
+    if summary:
+        lines.extend(
+            [
+                "## Summary",
+                "",
+                "| Metric | Value |",
+                "| --- | ---: |",
+                f"| Total Queries | {_markdown_cell(summary.get('total_queries_compared', 0))} |",
+                f"| Improved | {_markdown_cell(summary.get('improved_queries', 0))} |",
+                f"| Regressed | {_markdown_cell(summary.get('regressed_queries', 0))} |",
+                f"| Unchanged | {_markdown_cell(summary.get('unchanged_queries', 0))} |",
+                f"| Assessment | {_markdown_cell(summary.get('overall_assessment', 'unknown'))} |",
+                "",
+            ]
+        )
+
+    performance_changes = comparison.get("performance_changes", {})
+    if performance_changes:
+        lines.extend(
+            ["## Performance Metrics", "", "| Metric | Baseline | Current | Change |", "| --- | ---: | ---: | ---: |"]
+        )
+        for metric, values in performance_changes.items():
+            if not isinstance(values, dict):
+                continue
+            lines.append(
+                f"| {_markdown_cell(str(metric).replace('_', ' ').title())} | "
+                f"{values.get('baseline', 0):.3f} | {values.get('current', 0):.3f} | "
+                f"{values.get('change_percent', 0):+.2f}% |"
+            )
+        lines.append("")
+
+    query_comparisons = comparison.get("query_comparisons", [])
+    if query_comparisons:
+        lines.extend(
+            [
+                "## Query Comparison",
+                "",
+                "| Query | Baseline (ms) | Current (ms) | Change | Severity |",
+                "| --- | ---: | ---: | ---: | --- |",
+            ]
+        )
+        for query in sorted(query_comparisons, key=lambda item: item.get("change_percent", 0), reverse=True):
+            change_pct = query["change_percent"]
+            if not show_all and abs(change_pct) < 1.0:
+                continue
+            severity, change_str = _query_severity_and_change(query["improved"], change_pct)
+            lines.append(
+                f"| {_markdown_cell(query['query_id'])} | {query['baseline_time_ms']:.2f} | "
+                f"{query['current_time_ms']:.2f} | {change_str} | {_markdown_cell(severity)} |"
+            )
+        lines.append("")
+
+    plan_comparison = comparison.get("plan_comparison")
+    if plan_comparison:
+        lines.extend(
+            [
+                "## Query Plan Analysis",
+                "",
+                f"- Plans compared: {_markdown_cell(plan_comparison.get('plans_compared', 0))}",
+                f"- Unchanged: {_markdown_cell(plan_comparison.get('plans_unchanged', 0))}",
+                f"- Changed: {_markdown_cell(plan_comparison.get('plans_changed', 0))}",
+                "",
+            ]
+        )
+        query_plans = plan_comparison.get("query_plans", [])
+        if query_plans:
+            lines.extend(
+                [
+                    "| Query | Similarity | Type Δ | Prop Δ | Perf Δ | Status |",
+                    "| --- | ---: | ---: | ---: | ---: | --- |",
+                ]
+            )
+            for plan in sorted(query_plans, key=lambda item: item.get("similarity", 1.0)):
+                status = _plan_status_label(
+                    plan.get("plans_identical", False),
+                    plan.get("similarity", 1.0),
+                    plan.get("is_regression", False),
+                )
+                lines.append(
+                    f"| {_markdown_cell(plan.get('query_id', '?'))} | {plan.get('similarity', 1.0):.1%} | "
+                    f"{plan.get('type_mismatches', 0)} | {plan.get('property_mismatches', 0)} | "
+                    f"{plan.get('perf_change_pct', 0.0):+.1f}% | {_markdown_cell(status)} |"
+                )
+            lines.append("")
+
+        regressions = plan_comparison.get("regressions", [])
+        if regressions:
+            lines.extend(["### Plan-Correlated Regressions", ""])
+            for regression in regressions:
+                lines.append(
+                    f"- **{_markdown_cell(regression.get('query_id', '?'))}**: "
+                    f"plan similarity {regression.get('similarity', 0.0):.0%}, "
+                    f"performance {regression.get('perf_change_pct', 0.0):+.1f}%"
+                )
+            lines.append("")
+
+    return "\n".join(lines)
 
 
 def _format_text_comparison(comparison: dict[str, Any], baseline: Any, current: Any, show_all: bool) -> str:

--- a/benchbox/cli/commands/config.py
+++ b/benchbox/cli/commands/config.py
@@ -1,7 +1,10 @@
 """Configuration validation command implementation."""
 
+from pathlib import Path
+
 import click
 
+from benchbox.cli.config import ConfigManager
 from benchbox.cli.shared import console
 
 
@@ -19,11 +22,16 @@ def validate(ctx, config):
         benchbox validate                    # Validate default configuration
         benchbox validate --config custom.yaml  # Validate specific config file
     """
-    config_manager = ctx.obj["config"]
-    if config_manager.validate_config():
-        console.print("[green]✅ Configuration is valid[/green]")
-    else:
-        console.print("[red]❌ Configuration validation failed[/red]")
+    try:
+        config_manager = (
+            ConfigManager(config_path=Path(config).expanduser(), strict=True) if config else ctx.obj["config"]
+        )
+        if not config_manager.validate_config():
+            raise click.ClickException("Configuration validation failed")
+    except (OSError, ValueError) as exc:
+        raise click.ClickException(str(exc)) from exc
+
+    console.print("[green]✅ Configuration is valid[/green]")
 
 
 __all__ = ["validate"]

--- a/benchbox/cli/commands/export.py
+++ b/benchbox/cli/commands/export.py
@@ -144,20 +144,20 @@ def _load_export_result(source_path):
     """Load a result JSON, printing user-facing errors and returning None on failure."""
     try:
         result, _raw_data = load_result_file(source_path)
-    except FileNotFoundError:
+    except FileNotFoundError as e:
         console.print(f"[red]Error: Result file not found: {source_path}[/red]")
-        return None
+        raise click.ClickException(f"Result file not found: {source_path}") from e
     except UnsupportedSchemaError as e:
         console.print(f"[red]Error: {e}[/red]")
         console.print("[dim]Only schema version 1.0 is currently supported[/dim]")
-        return None
+        raise click.ClickException(str(e)) from e
     except ResultLoadError as e:
         console.print(f"[red]Error loading result file: {e}[/red]")
         console.print("[dim]The file may be corrupted or in an invalid format[/dim]")
-        return None
+        raise click.ClickException(f"Error loading result file: {e}") from e
     except Exception as e:
         console.print(f"[red]Unexpected error: {e}[/red]")
-        return None
+        raise click.ClickException(f"Unexpected error: {e}") from e
 
     console.print(f"[green]✓[/green] Loaded: {result.benchmark_name} ({result.platform})")
     console.print(

--- a/benchbox/cli/commands/export.py
+++ b/benchbox/cli/commands/export.py
@@ -106,6 +106,7 @@ def export(ctx, result_file, formats, output_dir, last, benchmark, platform, for
         _print_export_summary(exported, output_directory)
     except Exception as e:
         console.print(f"\n[red]Export failed: {e}[/red]")
+        raise click.ClickException(f"Export failed: {e}") from e
 
 
 def _resolve_export_source(result_file, last, benchmark, platform):

--- a/benchbox/cli/config.py
+++ b/benchbox/cli/config.py
@@ -181,8 +181,9 @@ class BenchBoxConfig(BaseModel):
 class ConfigManager:
     """Configuration file and settings management."""
 
-    def __init__(self, config_path: Optional[Path] = None):
+    def __init__(self, config_path: Optional[Path] = None, *, strict: bool = False):
         self.console = quiet_console
+        self.strict = strict
         self.config_path = config_path or self._get_default_config_path()
         self.config = self._load_config()
         # Apply environment variable overrides for tuning settings
@@ -202,6 +203,9 @@ class ConfigManager:
     def _load_config(self) -> BenchBoxConfig:
         """Load configuration from file or create default."""
         try:
+            if self.strict and not self.config_path.exists():
+                raise FileNotFoundError(f"Configuration file not found: {self.config_path}")
+
             if self.config_path.exists():
                 try:
                     with open(self.config_path, encoding="utf-8") as f:
@@ -209,16 +213,24 @@ class ConfigManager:
 
                     # If config file is empty or doesn't have any of our main sections,
                     # return default config
-                    if not config_data or not any(
-                        key in config_data
-                        for key in [
-                            "system",
-                            "database",
-                            "benchmarks",
-                            "output",
-                            "execution",
-                        ]
+                    if (
+                        not config_data
+                        or not isinstance(config_data, dict)
+                        or not any(
+                            key in config_data
+                            for key in [
+                                "system",
+                                "database",
+                                "benchmarks",
+                                "output",
+                                "execution",
+                            ]
+                        )
                     ):
+                        if self.strict:
+                            raise ValueError(
+                                f"Configuration file {self.config_path} is empty or has no recognized sections"
+                            )
                         return self._get_default_config()
 
                     # Merge with defaults to ensure all required fields exist
@@ -226,11 +238,15 @@ class ConfigManager:
                     merged_config = deep_merge_dicts(default_config.model_dump(), config_data)
                     return BenchBoxConfig(**merged_config)
                 except Exception as e:
+                    if self.strict:
+                        raise ValueError(f"Failed to load config from {self.config_path}: {e}") from e
                     console.print(f"[yellow]Warning: Failed to load config from {self.config_path}: {e}[/yellow]")
                     return self._get_default_config()
             else:
                 return self._get_default_config()
         except (PermissionError, OSError) as e:
+            if self.strict:
+                raise ValueError(f"Failed to access config from {self.config_path}: {e}") from e
             console.print(f"[yellow]Warning: Permission denied accessing {self.config_path}: {e}[/yellow]")
             return self._get_default_config()
 

--- a/benchbox/core/results/builder.py
+++ b/benchbox/core/results/builder.py
@@ -595,12 +595,10 @@ class ResultBuilder:
         measurement_results = [r for r in self._query_results if r.run_type == "measurement" and r.iteration > 0]
         results_for_stats = measurement_results if measurement_results else self._query_results
         successful_queries = [r for r in results_for_stats if r.status == "SUCCESS"]
-        # VALIDATION_FAILED (a write/op that ran but failed a post-condition
-        # check, e.g. write_primitives/transaction_primitives) counts as a
-        # failure here too, not just an execution FAILED -- mirroring
-        # execution.py's _log_execution_summary, which already treats the two
-        # the same for the console summary (#1150 review).
-        failed_queries = [r for r in results_for_stats if r.status in ("FAILED", "VALIDATION_FAILED")]
+        # Only SUCCESS is eligible for aggregate metrics. Treat every other
+        # status as failed accounting so newly introduced statuses cannot
+        # silently disappear from the result summary or publication gates.
+        failed_queries = [r for r in results_for_stats if r.status != "SUCCESS"]
 
         # Use measurement execution times for aggregate timing metrics when possible
         exec_times_all = [

--- a/benchbox/core/results/builder.py
+++ b/benchbox/core/results/builder.py
@@ -595,10 +595,10 @@ class ResultBuilder:
         measurement_results = [r for r in self._query_results if r.run_type == "measurement" and r.iteration > 0]
         results_for_stats = measurement_results if measurement_results else self._query_results
         successful_queries = [r for r in results_for_stats if r.status == "SUCCESS"]
-        # Only SUCCESS is eligible for aggregate metrics. Treat every other
-        # status as failed accounting so newly introduced statuses cannot
-        # silently disappear from the result summary or publication gates.
-        failed_queries = [r for r in results_for_stats if r.status != "SUCCESS"]
+        # Only successful or intentionally skipped queries are non-failures.
+        # Keep SKIPPED out of failure accounting so optional unsupported
+        # operations remain separately represented in the exported query rows.
+        failed_queries = [r for r in results_for_stats if r.status not in ("SUCCESS", "SKIPPED")]
 
         # Use measurement execution times for aggregate timing metrics when possible
         exec_times_all = [

--- a/benchbox/core/results/database.py
+++ b/benchbox/core/results/database.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 import hashlib
 import json
 import logging
+import re
 import sqlite3
 from collections.abc import Iterator
 from contextlib import contextmanager
@@ -41,6 +42,14 @@ _RANKING_METRIC_CONFIG = {
     "power_at_size": ("power_at_size", "DESC"),
     "cost_efficiency": ("total_cost / NULLIF(successful_queries, 0)", "ASC"),
 }
+_BACKUP_TABLE_NAME_PATTERN = re.compile(r"^queries_orphan_backup_\d{20}$")
+
+
+def _validate_backup_table_name(table_name: str) -> str:
+    """Validate a generated orphan-backup table name before SQL interpolation."""
+    if _BACKUP_TABLE_NAME_PATTERN.fullmatch(table_name) is None:
+        raise ValueError(f"Unsafe SQLite backup table name: {table_name!r}")
+    return table_name
 
 
 @dataclass
@@ -720,7 +729,9 @@ class ResultDatabase:
             if dry_run or orphan_count == 0:
                 return orphan_count
 
-            backup_table = f"queries_orphan_backup_{datetime.now(timezone.utc):%Y%m%d%H%M%S%f}"
+            backup_table = _validate_backup_table_name(
+                f"queries_orphan_backup_{datetime.now(timezone.utc):%Y%m%d%H%M%S%f}"
+            )
             conn.execute(
                 f"""
                 CREATE TABLE {backup_table} AS

--- a/benchbox/core/results/database.py
+++ b/benchbox/core/results/database.py
@@ -196,6 +196,7 @@ class ResultDatabase:
         """Get a database connection with row factory."""
         conn = sqlite3.connect(self.db_path)
         conn.row_factory = sqlite3.Row
+        conn.execute("PRAGMA foreign_keys = ON")
         try:
             yield conn
         finally:
@@ -680,6 +681,67 @@ class ResultDatabase:
             if deleted:
                 logger.info(f"Deleted result {execution_id}")
             return deleted
+
+    def count_orphaned_queries(self) -> int:
+        """Count query rows whose parent result no longer exists."""
+        with self._connection() as conn:
+            row = conn.execute(
+                """
+                SELECT COUNT(*)
+                FROM queries AS q
+                WHERE NOT EXISTS (
+                    SELECT 1 FROM results AS r WHERE r.id = q.result_id
+                )
+                """
+            ).fetchone()
+            return int(row[0])
+
+    def repair_orphaned_queries(self, *, dry_run: bool = True) -> int:
+        """Back up and remove orphaned query rows when explicitly requested.
+
+        Args:
+            dry_run: Return the orphan count without changing the database.
+
+        Returns:
+            Number of orphaned query rows found (and removed when ``dry_run`` is
+            false). A timestamped backup table is created before deletion.
+        """
+        with self._connection() as conn:
+            row = conn.execute(
+                """
+                SELECT COUNT(*)
+                FROM queries AS q
+                WHERE NOT EXISTS (
+                    SELECT 1 FROM results AS r WHERE r.id = q.result_id
+                )
+                """
+            ).fetchone()
+            orphan_count = int(row[0])
+            if dry_run or orphan_count == 0:
+                return orphan_count
+
+            backup_table = f"queries_orphan_backup_{datetime.now(timezone.utc):%Y%m%d%H%M%S%f}"
+            conn.execute(
+                f"""
+                CREATE TABLE {backup_table} AS
+                SELECT q.*
+                FROM queries AS q
+                WHERE NOT EXISTS (
+                    SELECT 1 FROM results AS r WHERE r.id = q.result_id
+                )
+                """
+            )
+            conn.execute(
+                """
+                DELETE FROM queries
+                WHERE NOT EXISTS (
+                    SELECT 1 FROM results AS r WHERE r.id = queries.result_id
+                )
+                """
+            )
+            conn.commit()
+            logger.warning("Removed %d orphaned query rows; backup table: %s", orphan_count, backup_table)
+            return orphan_count
 
     def calculate_rankings(
         self,

--- a/benchbox/core/results/exporter.py
+++ b/benchbox/core/results/exporter.py
@@ -1130,7 +1130,7 @@ class ResultExporter:
         <ul>
             {
             "".join(
-                f"<li>{metric.replace('_', ' ').title()}: {vals['change_percent']:+.1f}% "
+                f"<li>{html_escape(str(metric).replace('_', ' ').title(), quote=True)}: {vals['change_percent']:+.1f}% "
                 f"({'Improved' if vals['improved'] else 'Regressed'})</li>"
                 for metric, vals in performance_changes.items()
             )
@@ -1141,7 +1141,7 @@ class ResultExporter:
             <tr><th>Query</th><th>Baseline (ms)</th><th>Current (ms)</th><th>Change</th><th>Status</th></tr>
             {
             "".join(
-                f"<tr><td>{q['query_id']}</td><td>{q['baseline_time_ms']:.1f}</td>"
+                f"<tr><td>{html_escape(str(q['query_id']), quote=True)}</td><td>{q['baseline_time_ms']:.1f}</td>"
                 f"<td>{q['current_time_ms']:.1f}</td><td>{q['change_percent']:+.1f}%</td>"
                 f"<td>{'Improved' if q['improved'] else 'Regressed'}</td></tr>"
                 for q in query_comparisons

--- a/benchbox/core/results/exporter.py
+++ b/benchbox/core/results/exporter.py
@@ -1081,6 +1081,10 @@ class ResultExporter:
         summary = comparison.get("summary", {})
         performance_changes = comparison.get("performance_changes", {})
         query_comparisons = comparison.get("query_comparisons", [])
+        total_queries_compared = html_escape(str(summary.get("total_queries_compared", 0)), quote=True)
+        improved_queries = html_escape(str(summary.get("improved_queries", 0)), quote=True)
+        regressed_queries = html_escape(str(summary.get("regressed_queries", 0)), quote=True)
+        unchanged_queries = html_escape(str(summary.get("unchanged_queries", 0)), quote=True)
 
         html_content = f"""<!DOCTYPE html>
 <html>
@@ -1111,19 +1115,19 @@ class ResultExporter:
         <div class="summary">
             <div class="metric neutral">
                 <h3>Queries Compared</h3>
-                <p>{summary.get("total_queries_compared", 0)}</p>
+                <p>{total_queries_compared}</p>
             </div>
             <div class="metric improved">
                 <h3>Improved</h3>
-                <p>{summary.get("improved_queries", 0)}</p>
+                <p>{improved_queries}</p>
             </div>
             <div class="metric regressed">
                 <h3>Regressed</h3>
-                <p>{summary.get("regressed_queries", 0)}</p>
+                <p>{regressed_queries}</p>
             </div>
             <div class="metric neutral">
                 <h3>Unchanged</h3>
-                <p>{summary.get("unchanged_queries", 0)}</p>
+                <p>{unchanged_queries}</p>
             </div>
         </div>
         <h2>Performance Changes</h2>

--- a/benchbox/core/results/exporter.py
+++ b/benchbox/core/results/exporter.py
@@ -19,6 +19,7 @@ import io
 import json
 import logging
 import os
+import tempfile
 from collections.abc import Iterable
 from datetime import datetime
 from pathlib import Path
@@ -58,6 +59,10 @@ logger = logging.getLogger(__name__)
 
 ResultLike = BenchmarkResults
 QueryResultLike = "QueryResult | dict[str, Any]"
+
+
+class ResultExportError(RuntimeError):
+    """Raised when one or more requested result artifacts cannot be exported."""
 
 
 def _redact_usernames(value: Any) -> Any:
@@ -151,8 +156,22 @@ class ResultExporter:
             # does not yet expose pathlib's newline keyword.
             file_path.write_text(content, encoding="utf-8")
         else:
-            with open(file_path, mode, encoding="utf-8", newline="") as handle:
-                handle.write(content)
+            destination = Path(file_path)
+            temporary_path: Path | None = None
+            file_descriptor, temporary_name = tempfile.mkstemp(
+                prefix=f".{destination.name}.",
+                suffix=".tmp",
+                dir=destination.parent,
+            )
+            temporary_path = Path(temporary_name)
+            try:
+                with os.fdopen(file_descriptor, mode, encoding="utf-8", newline="") as handle:
+                    handle.write(content)
+                os.replace(temporary_path, destination)
+                temporary_path = None
+            finally:
+                if temporary_path is not None:
+                    temporary_path.unlink(missing_ok=True)
 
     def _create_file_path(self, filename: str):
         """Create file path, ensuring parent directory exists."""
@@ -189,6 +208,7 @@ class ResultExporter:
             formats = ["json"]
 
         exported_files: dict[str, Path] = {}
+        failures: list[str] = []
 
         timestamp = (
             result.timestamp.strftime("%Y%m%d_%H%M%S")
@@ -208,8 +228,7 @@ class ResultExporter:
                 elif format_name == "html":
                     filepath = self._export_html_detailed(result, filename_base)
                 else:
-                    self.console.print(f"[yellow]Unknown export format: {format_name}[/yellow]")
-                    continue
+                    raise ResultExportError(f"Unknown export format: {format_name}")
 
                 exported_files[format_name] = filepath
                 self.console.print(f"[green]Exported {format_name.upper()}:[/green] {filepath}")
@@ -223,6 +242,10 @@ class ResultExporter:
                 # so failure diagnostics are still observable via caplog.
                 logging.critical(message)
                 self.console.print(f"[red]Failed to export {format_name}: {exc}[/red]")
+                failures.append(message)
+
+        if failures:
+            raise ResultExportError("; ".join(failures))
 
         return exported_files
 
@@ -280,7 +303,7 @@ class ResultExporter:
         try:
             self._validator.validate(payload)
         except SchemaV2ValidationError as e:
-            logger.warning(f"Schema validation warning: {e}")
+            raise ResultExportError(f"Schema validation failed: {e}") from e
 
         # Write primary result file
         filepath = self._create_file_path(f"{filename_base}.json")

--- a/benchbox/core/results/exporter.py
+++ b/benchbox/core/results/exporter.py
@@ -22,6 +22,7 @@ import os
 import tempfile
 from collections.abc import Iterable
 from datetime import datetime
+from html import escape as html_escape
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Union
 
@@ -648,12 +649,13 @@ class ResultExporter:
         """Export result to HTML format."""
         filepath = self._create_file_path(f"{filename_base}.html")
 
-        benchmark_name = getattr(result, "benchmark_name", "Unknown Benchmark")
-        execution_id = getattr(result, "execution_id", "")
+        benchmark_name = html_escape(str(getattr(result, "benchmark_name", "Unknown Benchmark")), quote=True)
+        execution_id = html_escape(str(getattr(result, "execution_id", "")), quote=True)
         timestamp = getattr(result, "timestamp", datetime.now())
+        timestamp_text = html_escape(timestamp.isoformat() if timestamp else "N/A", quote=True)
         duration = getattr(result, "duration_seconds", 0.0)
-        scale_factor = getattr(result, "scale_factor", 1.0)
-        platform = getattr(result, "platform", "Unknown")
+        scale_factor = html_escape(str(getattr(result, "scale_factor", 1.0)), quote=True)
+        platform = html_escape(str(getattr(result, "platform", "Unknown")), quote=True)
 
         total_queries, successful_queries = self._count_queries(result)
         failed_queries = max(total_queries - successful_queries, 0)
@@ -706,7 +708,7 @@ class ResultExporter:
             <strong>Platform:</strong> {platform} |
             <strong>Scale:</strong> {scale_factor} |
             <strong>Run:</strong> {execution_id} |
-            <strong>Time:</strong> {timestamp.isoformat() if timestamp else "N/A"}
+            <strong>Time:</strong> {timestamp_text}
         </div>
         <div class="stats">
             <div class="stat">
@@ -769,14 +771,18 @@ class ResultExporter:
             exec_time_ms = float(exec_time_seconds) * 1000.0
 
         time_display = f"{exec_time_ms:.1f}" if exec_time_ms is not None else ""
+        query_id = html_escape(str(query.get("query_id", "")), quote=True)
+        rows_returned = html_escape(str(query.get("rows_returned", "")), quote=True)
+        status_text = html_escape(str(status), quote=True)
+        error_text = html_escape(str(query.get("error") or query.get("error_message", "") or ""), quote=True)
 
         return (
             "<tr>"
-            f"<td>{query.get('query_id', '')}</td>"
-            f"<td>{time_display}</td>"
-            f"<td>{query.get('rows_returned', '')}</td>"
-            f"<td class='{status_class}'>{status}</td>"
-            f"<td>{query.get('error') or query.get('error_message', '')}</td>"
+            f"<td>{query_id}</td>"
+            f"<td>{html_escape(time_display, quote=True)}</td>"
+            f"<td>{rows_returned}</td>"
+            f"<td class='{status_class}'>{status_text}</td>"
+            f"<td>{error_text}</td>"
             "</tr>"
         )
 

--- a/benchbox/core/results/exporter.py
+++ b/benchbox/core/results/exporter.py
@@ -19,7 +19,8 @@ import io
 import json
 import logging
 import os
-import tempfile
+import stat
+import uuid
 from collections.abc import Iterable
 from datetime import datetime
 from html import escape as html_escape
@@ -159,18 +160,36 @@ class ResultExporter:
         else:
             destination = Path(file_path)
             temporary_path: Path | None = None
-            file_descriptor, temporary_name = tempfile.mkstemp(
-                prefix=f".{destination.name}.",
-                suffix=".tmp",
-                dir=destination.parent,
-            )
-            temporary_path = Path(temporary_name)
+            file_descriptor: int | None = None
+            for _ in range(10):
+                candidate = destination.parent / f".{destination.name}.{uuid.uuid4().hex}.tmp"
+                try:
+                    # 0o666 preserves the normal open(..., "w") behavior because
+                    # the process umask is applied by os.open at creation time.
+                    file_descriptor = os.open(
+                        candidate,
+                        os.O_WRONLY | os.O_CREAT | os.O_EXCL,
+                        0o666,
+                    )
+                    temporary_path = candidate
+                    break
+                except FileExistsError:
+                    continue
+            if file_descriptor is None or temporary_path is None:
+                raise FileExistsError(f"Unable to allocate a unique temporary export path for {destination}")
+
             try:
+                existing_mode = stat.S_IMODE(destination.stat().st_mode) if destination.exists() else None
+                if existing_mode is not None:
+                    os.fchmod(file_descriptor, existing_mode)
                 with os.fdopen(file_descriptor, mode, encoding="utf-8", newline="") as handle:
+                    file_descriptor = None
                     handle.write(content)
                 os.replace(temporary_path, destination)
                 temporary_path = None
             finally:
+                if file_descriptor is not None:
+                    os.close(file_descriptor)
                 if temporary_path is not None:
                     temporary_path.unlink(missing_ok=True)
 

--- a/benchbox/core/results/timing.py
+++ b/benchbox/core/results/timing.py
@@ -270,21 +270,24 @@ class TimingCollector:
 
     def get_timing_summary(self) -> dict[str, Any]:
         """Get a summary of all collected timings."""
-        if not self._completed_timings:
+        with self._lock:
+            completed_timings = self._completed_timings.copy()
+
+        if not completed_timings:
             return {}
 
-        execution_times = [t.execution_time for t in self._completed_timings if t.status == "SUCCESS"]
+        execution_times = [t.execution_time for t in completed_timings if t.status == "SUCCESS"]
 
         if not execution_times:
             return {
-                "total_queries": len(self._completed_timings),
+                "total_queries": len(completed_timings),
                 "successful_queries": 0,
             }
 
         return {
-            "total_queries": len(self._completed_timings),
+            "total_queries": len(completed_timings),
             "successful_queries": len(execution_times),
-            "failed_queries": len(self._completed_timings) - len(execution_times),
+            "failed_queries": len(completed_timings) - len(execution_times),
             "total_execution_time": sum(execution_times),
             "average_execution_time": statistics.mean(execution_times),
             "median_execution_time": statistics.median(execution_times),

--- a/benchbox/core/results/timing.py
+++ b/benchbox/core/results/timing.py
@@ -10,8 +10,10 @@ Licensed under the MIT License. See LICENSE file in the project root for details
 
 import logging
 import statistics
+import threading
 import time
 from contextlib import contextmanager
+from contextvars import ContextVar
 from dataclasses import dataclass, field
 from datetime import datetime
 from typing import Any, Optional
@@ -112,7 +114,25 @@ class TimingCollector:
         """
         self.enable_detailed_timing = enable_detailed_timing
         self._active_timings: dict[str, dict[str, Any]] = {}
+        self._active_query_tokens: dict[str, list[str]] = {}
         self._completed_timings: list[QueryTiming] = []
+        self._lock = threading.RLock()
+        self._current_timing_token: ContextVar[str | None] = ContextVar(
+            "benchbox_current_timing_token",
+            default=None,
+        )
+
+    def _resolve_timing_token(self, query_id: str) -> str | None:
+        """Resolve a query ID to the current execution, preferring context scope."""
+        current_token = self._current_timing_token.get()
+        with self._lock:
+            if current_token is not None:
+                timing_data = self._active_timings.get(current_token)
+                if timing_data is not None and timing_data["query_id"] == query_id:
+                    return current_token
+
+            query_tokens = self._active_query_tokens.get(query_id)
+            return query_tokens[-1] if query_tokens else None
 
     @contextmanager
     def time_query(self, query_id: str, query_name: Optional[str] = None):
@@ -136,7 +156,11 @@ class TimingCollector:
             "metrics": {},
         }
 
-        self._active_timings[query_id] = timing_data
+        execution_token = f"{query_id}:{id(timing_data)}"
+        with self._lock:
+            self._active_timings[execution_token] = timing_data
+            self._active_query_tokens.setdefault(query_id, []).append(execution_token)
+        context_token = self._current_timing_token.set(execution_token)
 
         try:
             yield timing_data
@@ -151,10 +175,18 @@ class TimingCollector:
 
             # Create QueryTiming object
             query_timing = self._create_query_timing(timing_data)
-            self._completed_timings.append(query_timing)
+            with self._lock:
+                self._completed_timings.append(query_timing)
 
             # Clean up active timing
-            self._active_timings.pop(query_id, None)
+            with self._lock:
+                self._active_timings.pop(execution_token, None)
+                query_tokens = self._active_query_tokens.get(query_id)
+                if query_tokens is not None:
+                    query_tokens.remove(execution_token)
+                    if not query_tokens:
+                        self._active_query_tokens.pop(query_id, None)
+            self._current_timing_token.reset(context_token)
 
     @contextmanager
     def time_phase(self, query_id: str, phase_name: str):
@@ -164,7 +196,12 @@ class TimingCollector:
             query_id: Query identifier this phase belongs to
             phase_name: Name of the execution phase (e.g., 'parse', 'optimize', 'execute')
         """
-        if not self.enable_detailed_timing or query_id not in self._active_timings:
+        if not self.enable_detailed_timing:
+            yield
+            return
+
+        execution_token = self._resolve_timing_token(query_id)
+        if execution_token is None:
             yield
             return
 
@@ -176,8 +213,10 @@ class TimingCollector:
             end_time = time.perf_counter()
             phase_duration = end_time - start_time
 
-            timing_data = self._active_timings[query_id]
-            timing_data["timing_breakdown"][phase_name] = phase_duration
+            with self._lock:
+                timing_data = self._active_timings.get(execution_token)
+                if timing_data is not None:
+                    timing_data["timing_breakdown"][phase_name] = phase_duration
 
     def record_metric(self, query_id: str, metric_name: str, value: Any):
         """Record a metric for a query execution.
@@ -187,8 +226,12 @@ class TimingCollector:
             metric_name: Name of the metric
             value: Metric value
         """
-        if query_id in self._active_timings:
-            self._active_timings[query_id]["metrics"][metric_name] = value
+        execution_token = self._resolve_timing_token(query_id)
+        if execution_token is not None:
+            with self._lock:
+                timing_data = self._active_timings.get(execution_token)
+                if timing_data is not None:
+                    timing_data["metrics"][metric_name] = value
 
     def _create_query_timing(self, timing_data: dict[str, Any]) -> QueryTiming:
         """Create a QueryTiming object from collected timing data."""
@@ -217,11 +260,13 @@ class TimingCollector:
 
     def get_completed_timings(self) -> list[QueryTiming]:
         """Get all completed query timings."""
-        return self._completed_timings.copy()
+        with self._lock:
+            return self._completed_timings.copy()
 
     def clear_completed_timings(self):
         """Clear the completed timings cache."""
-        self._completed_timings.clear()
+        with self._lock:
+            self._completed_timings.clear()
 
     def get_timing_summary(self) -> dict[str, Any]:
         """Get a summary of all collected timings."""

--- a/benchbox/core/runner/runner.py
+++ b/benchbox/core/runner/runner.py
@@ -13,8 +13,10 @@ import logging
 import time
 import uuid
 from collections.abc import Mapping
+from copy import copy
 from dataclasses import dataclass
 from datetime import datetime
+from pathlib import Path
 from typing import Any
 
 from benchbox.core.benchmark_loader import (
@@ -1522,17 +1524,24 @@ def _ensure_data_generated(benchmark: Any, config: BenchmarkConfig) -> bool:
     options = getattr(config, "options", {}) or {}
     force_regenerate_flag = bool(options.get("force_regenerate"))
     no_regenerate_flag = bool(options.get("no_regenerate"))
+    populated_tables_invalid = False
 
-    # If tables already present, assume generation done (unless force requested)
+    # Validate populated tables too. Callers may provide stale or incomplete
+    # mappings, so truthiness alone must not bypass manifest and file checks.
     if getattr(benchmark, "tables", None) and not force_regenerate_flag:
-        return False
+        if _populated_tables_are_valid(benchmark, config):
+            return False
+        populated_tables_invalid = True
+        if no_regenerate_flag:
+            raise RuntimeError("no_regenerate is set but populated benchmark tables are missing or stale")
+        emit("⚠️ Populated benchmark tables are missing or stale; regenerating benchmark data")
 
     output_dir = getattr(benchmark, "output_dir", None)
     manifest_valid = False
     manifest_found = False
     manifest_data: dict | None = None
 
-    if output_dir and not force_regenerate_flag:
+    if output_dir and not force_regenerate_flag and not populated_tables_invalid:
         manifest_valid, manifest_data, manifest_found = _validate_manifest_if_present(benchmark, config)
         if manifest_valid:
             summary = _populate_tables_from_manifest(benchmark, manifest_data)
@@ -1582,6 +1591,49 @@ def _ensure_data_generated(benchmark: Any, config: BenchmarkConfig) -> bool:
     benchmark.generate_data()
     emit(f"✅ Data generation completed in {time.monotonic() - _gen_start:.2f}s")
     return True
+
+
+def _populated_tables_are_valid(benchmark: Any, config: BenchmarkConfig) -> bool:
+    """Return whether caller-provided table mappings are safe to reuse."""
+    tables = getattr(benchmark, "tables", None)
+    if not tables or not _table_mapping_paths_exist(tables):
+        return False
+
+    output_dir = getattr(benchmark, "output_dir", None)
+    if not output_dir:
+        # External table mappings have no local manifest to compare against;
+        # existence is the strongest validation available at this boundary.
+        return True
+
+    manifest_valid, manifest_data, _manifest_found = _validate_manifest_if_present(benchmark, config)
+    if not manifest_valid or manifest_data is None:
+        return False
+
+    manifest_benchmark = copy(benchmark)
+    manifest_benchmark.tables = None
+    _populate_tables_from_manifest(manifest_benchmark, manifest_data)
+    return _normalize_table_mapping(tables) == _normalize_table_mapping(getattr(manifest_benchmark, "tables", None))
+
+
+def _table_mapping_paths_exist(value: Any) -> bool:
+    """Recursively verify that every path in a table mapping exists."""
+    if isinstance(value, Mapping):
+        return bool(value) and all(_table_mapping_paths_exist(child) for child in value.values())
+    if isinstance(value, (list, tuple, set)):
+        return bool(value) and all(_table_mapping_paths_exist(child) for child in value)
+    if isinstance(value, (str, Path)):
+        return Path(value).exists()
+    exists = getattr(value, "exists", None)
+    return bool(exists and exists()) if callable(exists) else False
+
+
+def _normalize_table_mapping(value: Any) -> Any:
+    """Normalize table mapping containers for stable path comparisons."""
+    if isinstance(value, Mapping):
+        return {str(key): _normalize_table_mapping(child) for key, child in sorted(value.items())}
+    if isinstance(value, (list, tuple, set)):
+        return [_normalize_table_mapping(child) for child in value]
+    return str(value)
 
 
 def _populate_tables_from_manifest(benchmark: Any, manifest: dict | None = None) -> dict[str, Any] | None:

--- a/benchbox/core/runner/runner.py
+++ b/benchbox/core/runner/runner.py
@@ -71,7 +71,7 @@ from benchbox.platforms.base.runtime_metadata import (
     collect_normalized_result_metadata,
 )
 from benchbox.platforms.dataframe.benchmark_mixin import DataFramePhases, DataFrameRunOptions
-from benchbox.utils.cloud_storage import CloudStagingPath, create_path_handler
+from benchbox.utils.cloud_storage import CloudStagingPath, create_path_handler, is_cloud_path
 from benchbox.utils.dialect_utils import (
     SqlTranslationOutcome,
     sql_translation_context,
@@ -1596,8 +1596,16 @@ def _ensure_data_generated(benchmark: Any, config: BenchmarkConfig) -> bool:
 def _populated_tables_are_valid(benchmark: Any, config: BenchmarkConfig) -> bool:
     """Return whether caller-provided table mappings are safe to reuse."""
     tables = getattr(benchmark, "tables", None)
-    if not tables or not _table_mapping_paths_exist(tables):
+    table_mode = str((getattr(config, "options", {}) or {}).get("table_mode", "native") or "native").lower()
+    if not tables or not _table_mapping_paths_exist(tables, allow_cloud_uris=table_mode == "external"):
         return False
+
+    if table_mode == "external":
+        # External table mappings are supplied by the caller and may not have a
+        # local datagen manifest. Their paths are validated at the adapter
+        # boundary, so local manifest comparison would incorrectly regenerate
+        # otherwise usable external data.
+        return True
 
     output_dir = getattr(benchmark, "output_dir", None)
     if not output_dir:
@@ -1615,13 +1623,19 @@ def _populated_tables_are_valid(benchmark: Any, config: BenchmarkConfig) -> bool
     return _normalize_table_mapping(tables) == _normalize_table_mapping(getattr(manifest_benchmark, "tables", None))
 
 
-def _table_mapping_paths_exist(value: Any) -> bool:
+def _table_mapping_paths_exist(value: Any, *, allow_cloud_uris: bool = False) -> bool:
     """Recursively verify that every path in a table mapping exists."""
     if isinstance(value, Mapping):
-        return bool(value) and all(_table_mapping_paths_exist(child) for child in value.values())
+        return bool(value) and all(
+            _table_mapping_paths_exist(child, allow_cloud_uris=allow_cloud_uris) for child in value.values()
+        )
     if isinstance(value, (list, tuple, set)):
-        return bool(value) and all(_table_mapping_paths_exist(child) for child in value)
+        return bool(value) and all(
+            _table_mapping_paths_exist(child, allow_cloud_uris=allow_cloud_uris) for child in value
+        )
     if isinstance(value, (str, Path)):
+        if allow_cloud_uris and is_cloud_path(value):
+            return True
         return Path(value).exists()
     exists = getattr(value, "exists", None)
     return bool(exists and exists()) if callable(exists) else False

--- a/benchbox/core/tpch/reporting.py
+++ b/benchbox/core/tpch/reporting.py
@@ -24,6 +24,7 @@ import csv
 import statistics
 from dataclasses import dataclass, field
 from datetime import datetime
+from html import escape as html_escape
 from pathlib import Path
 from typing import Optional, Union
 
@@ -505,11 +506,12 @@ class TPCHReportGenerator:
         include_certification_info: bool,
     ) -> str:
         """Generate HTML report content."""
+        safe_title = html_escape(str(title), quote=True)
         html = f"""
 <!DOCTYPE html>
 <html>
 <head>
-    <title>{title}</title>
+    <title>{safe_title}</title>
     <style>
         body {{ font-family: Arial, sans-serif; margin: 20px; }}
         .header {{ background-color: #f0f0f0; padding: 20px; border-radius: 5px; }}
@@ -526,7 +528,7 @@ class TPCHReportGenerator:
 </head>
 <body>
     <div class="header">
-        <h1>{title}</h1>
+        <h1>{safe_title}</h1>
         <p>Generated on {datetime.now().strftime("%Y-%m-%d %H:%M:%S")}</p>
     </div>
 
@@ -582,7 +584,10 @@ class TPCHReportGenerator:
 
             for query_id, query_time in sorted(result.power_test.query_times.items()):
                 relative_perf = query_time / metrics.average_query_time if metrics.average_query_time > 0 else 0
-                html += f"<tr><td>{query_id}</td><td>{query_time:.3f}</td><td>{relative_perf:.2f}</td></tr>"
+                html += (
+                    f"<tr><td>{html_escape(str(query_id), quote=True)}</td>"
+                    f"<td>{query_time:.3f}</td><td>{relative_perf:.2f}</td></tr>"
+                )
 
             html += "</table></div>"
 
@@ -599,13 +604,13 @@ class TPCHReportGenerator:
             if validation.issues:
                 html += "<h3>Issues</h3><ul>"
                 for issue in validation.issues:
-                    html += f"<li class='error'>{issue}</li>"
+                    html += f"<li class='error'>{html_escape(str(issue), quote=True)}</li>"
                 html += "</ul>"
 
             if validation.warnings:
                 html += "<h3>Warnings</h3><ul>"
                 for warning in validation.warnings:
-                    html += f"<li class='warning'>{warning}</li>"
+                    html += f"<li class='warning'>{html_escape(str(warning), quote=True)}</li>"
                 html += "</ul>"
 
             html += "</div>"
@@ -624,13 +629,14 @@ class TPCHReportGenerator:
         title: str,
     ) -> str:
         """Generate HTML comparison report."""
+        safe_title = html_escape(str(title), quote=True)
         change_class = "success" if comparison.relative_change > 0 else "error"
 
         html = f"""
 <!DOCTYPE html>
 <html>
 <head>
-    <title>{title}</title>
+    <title>{safe_title}</title>
     <style>
         body {{ font-family: Arial, sans-serif; margin: 20px; }}
         .header {{ background-color: #f0f0f0; padding: 20px; border-radius: 5px; }}
@@ -647,7 +653,7 @@ class TPCHReportGenerator:
 </head>
 <body>
     <div class="header">
-        <h1>{title}</h1>
+        <h1>{safe_title}</h1>
         <p>Generated on {datetime.now().strftime("%Y-%m-%d %H:%M:%S")}</p>
     </div>
 

--- a/benchbox/platforms/azure/fabric_spark_adapter.py
+++ b/benchbox/platforms/azure/fabric_spark_adapter.py
@@ -539,7 +539,7 @@ class FabricSparkAdapter(LivyStatementMixin, SparkTuningMixin, PlatformAdapter):
                 per_table_timings[table] = {"total_ms": elapsed_seconds(tbl_start) * 1000}
                 logger.debug("Created %s table: %s", self.table_format, table)
             except Exception as e:
-                logger.warning("Failed to create table %s: %s", table, e)
+                raise RuntimeError(f"Failed to create Fabric Spark table {table}: {e}") from e
 
         return {}, elapsed_seconds(start_time), per_table_timings or None
 

--- a/benchbox/platforms/azure/synapse_spark_adapter.py
+++ b/benchbox/platforms/azure/synapse_spark_adapter.py
@@ -525,7 +525,7 @@ class SynapseSparkAdapter(LivyStatementMixin, SparkTuningMixin, PlatformAdapter)
                 self._execute_statement(create_sql, kind="sql")
                 logger.debug(f"Created table: {table}")
             except Exception as e:
-                logger.warning(f"Failed to create table {table}: {e}")
+                raise RuntimeError(f"Failed to create Synapse Spark table {table}: {e}") from e
 
         return dict.fromkeys(tables, 0), elapsed_seconds(start_time), {"table_uris": table_uris}
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -3,6 +3,8 @@
 minversion = 8.0
 testpaths =
     tests
+pythonpath =
+    .
 python_files = test_*.py *_test.py
 python_classes = Test* *Tests
 python_functions = test_* benchmark_*

--- a/tests/integration/test_cli_subprocess_architecture.py
+++ b/tests/integration/test_cli_subprocess_architecture.py
@@ -1,0 +1,57 @@
+"""Subprocess acceptance tests for the documented BenchBox CLI contract."""
+
+from __future__ import annotations
+
+import pytest
+
+from tests.integration._cli_e2e_utils import run_cli_command
+
+pytestmark = [
+    pytest.mark.integration,
+    pytest.mark.fast,
+]
+
+
+def test_validate_rejects_malformed_explicit_config(tmp_path):
+    config_path = tmp_path / "invalid.yaml"
+    config_path.write_text("database: [unclosed\n", encoding="utf-8")
+
+    result = run_cli_command(["validate", "--config", str(config_path)], cwd=tmp_path)
+
+    assert result.returncode != 0
+    assert "Configuration is valid" not in result.stdout + result.stderr
+
+
+def test_invalid_platform_returns_nonzero():
+    result = run_cli_command(
+        ["run", "--platform", "definitely-not-a-real-platform", "--benchmark", "tpch"],
+    )
+
+    assert result.returncode != 0
+    assert "not available" in result.stdout + result.stderr
+
+
+def test_dry_run_preserves_explicit_phase_selection(tmp_path):
+    output_dir = tmp_path / "dry-run"
+
+    result = run_cli_command(
+        [
+            "run",
+            "--dry-run",
+            str(output_dir),
+            "--platform",
+            "duckdb",
+            "--benchmark",
+            "tpch",
+            "--scale",
+            "0.01",
+            "--phases",
+            "generate,load",
+            "--non-interactive",
+        ],
+        cwd=tmp_path,
+    )
+
+    assert result.returncode == 0
+    assert "Load Only (Data Generation)" in result.stdout
+    assert list(output_dir.glob("*.json"))

--- a/tests/integration/test_export_cli.py
+++ b/tests/integration/test_export_cli.py
@@ -205,8 +205,12 @@ def test_export_invalid_schema_version(tmp_path):
 
     result = run_cli_command(["export", str(result_file), "--format", "csv"])
 
-    assert result.returncode == 0  # Command completes but shows error
-    assert "Unsupported schema version" in result.stdout or "Error" in result.stdout
+    assert result.returncode == 1  # Invalid input must fail closed
+    assert (
+        "Unsupported schema version" in result.stdout
+        or "Error" in result.stdout
+        or "unsupported" in result.stderr.lower()
+    )
 
 
 @pytest.mark.integration
@@ -219,8 +223,8 @@ def test_export_corrupted_json(tmp_path):
 
     result = run_cli_command(["export", str(result_file), "--format", "csv"])
 
-    assert result.returncode == 0  # Command completes but shows error
-    assert "Error" in result.stdout or "Invalid" in result.stdout
+    assert result.returncode == 1  # Invalid input must fail closed
+    assert "Error" in result.stdout or "Invalid" in result.stdout or "invalid" in result.stderr.lower()
 
 
 @pytest.mark.integration

--- a/tests/unit/cli/commands/test_compare_coverage.py
+++ b/tests/unit/cli/commands/test_compare_coverage.py
@@ -355,6 +355,28 @@ def test_run_platform_comparison_formats(monkeypatch: pytest.MonkeyPatch, tmp_pa
     assert html.exists()
 
 
+def test_run_platform_comparison_html_escapes_platform_labels(tmp_path: Path) -> None:
+    malicious = '"><img src=x onerror=alert(1)>'
+    output = tmp_path / "comparison.html"
+
+    class _Suite:
+        def _generate_text_report(self, _results):
+            return f"Platforms: {malicious}"
+
+    mod._output_comparison_results(
+        output_format="html",
+        output_file=str(output),
+        suite=_Suite(),
+        config=SimpleNamespace(),
+        results=[],
+        summary=SimpleNamespace(),
+    )
+
+    content = output.read_text(encoding="utf-8")
+    assert malicious not in content
+    assert "&quot;&gt;&lt;img src=x onerror=alert(1)&gt;" in content
+
+
 def test_run_file_comparison_paths(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     b = tmp_path / "b.json"
     c = tmp_path / "c.json"

--- a/tests/unit/cli/commands/test_compare_coverage.py
+++ b/tests/unit/cli/commands/test_compare_coverage.py
@@ -118,6 +118,28 @@ def test_format_text_and_html_comparison() -> None:
     assert "Query Plan Analysis" in html
 
 
+def test_format_html_comparison_escapes_all_result_derived_labels() -> None:
+    malicious = '"><img src=x onerror=alert(1)>'
+    comparison = _comparison_payload()
+    comparison["baseline_file"] = malicious
+    comparison["current_file"] = malicious
+    for key in ("total_queries_compared", "improved_queries", "regressed_queries", "unchanged_queries"):
+        comparison["summary"][key] = malicious
+    for query in comparison["query_comparisons"]:
+        query["query_id"] = malicious
+    plan_comparison = comparison["plan_comparison"]
+    for plan in plan_comparison["query_plans"]:
+        plan["query_id"] = malicious
+    for regression in plan_comparison["regressions"]:
+        regression["query_id"] = malicious
+
+    baseline = SimpleNamespace(benchmark_name=malicious, platform=malicious, scale_factor=malicious)
+    html = mod._format_html_comparison(comparison, baseline, SimpleNamespace())
+
+    assert malicious not in html
+    assert "&quot;&gt;&lt;img src=x onerror=alert(1)&gt;" in html
+
+
 def test_discover_metadata_and_table_render(tmp_path: Path) -> None:
     good = tmp_path / "good.json"
     bad = tmp_path / "bad.json"

--- a/tests/unit/cli/commands/test_compare_coverage.py
+++ b/tests/unit/cli/commands/test_compare_coverage.py
@@ -140,6 +140,20 @@ def test_format_html_comparison_escapes_all_result_derived_labels() -> None:
     assert "&quot;&gt;&lt;img src=x onerror=alert(1)&gt;" in html
 
 
+def test_format_markdown_comparison_returns_markdown(tmp_path: Path) -> None:
+    comparison = _comparison_payload()
+    baseline = SimpleNamespace(benchmark_name="tpch", platform="duckdb", scale_factor=1)
+    current = SimpleNamespace(benchmark_name="tpch", platform="duckdb", scale_factor=1)
+    output = tmp_path / "comparison.md"
+
+    mod._output_file_comparison(comparison, baseline, current, "markdown", str(output), show_all_queries=True)
+
+    content = output.read_text(encoding="utf-8")
+    assert content.startswith("# Benchmark Comparison Report")
+    assert "| Metric | Value |" in content
+    assert "<!DOCTYPE html>" not in content
+
+
 def test_discover_metadata_and_table_render(tmp_path: Path) -> None:
     good = tmp_path / "good.json"
     bad = tmp_path / "bad.json"

--- a/tests/unit/cli/commands/test_export_coverage.py
+++ b/tests/unit/cli/commands/test_export_coverage.py
@@ -59,7 +59,7 @@ def test_export_load_errors(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> 
     src.write_text("{}", encoding="utf-8")
     monkeypatch.setattr(ex, "load_result_file", lambda *_a, **_k: (_ for _ in ()).throw(ex.ResultLoadError("bad")))
     result = CliRunner().invoke(ex.export, [str(src)])
-    assert result.exit_code == 0
+    assert result.exit_code != 0
     assert "Error loading result file" in result.output
 
 

--- a/tests/unit/cli/commands/test_lightweight_entrypoints.py
+++ b/tests/unit/cli/commands/test_lightweight_entrypoints.py
@@ -58,8 +58,35 @@ def test_validate_command_reports_success_and_failure() -> None:
     with patch("benchbox.cli.commands.config.console.print") as console_print:
         result = runner.invoke(validate, obj={"config": config_manager})
 
-    assert result.exit_code == 0
-    console_print.assert_called_once_with("[red]❌ Configuration validation failed[/red]")
+    assert result.exit_code != 0
+    assert "Configuration validation failed" in result.output
+    console_print.assert_not_called()
+
+
+def test_validate_command_uses_explicit_config_path_and_fails_closed(tmp_path) -> None:
+    runner = CliRunner()
+    malformed = tmp_path / "malformed.yaml"
+    malformed.write_text("database: [unclosed\n", encoding="utf-8")
+
+    with patch("benchbox.cli.commands.config.ConfigManager") as manager_cls:
+        manager_cls.side_effect = ValueError("invalid YAML")
+        result = runner.invoke(validate, ["--config", str(malformed)], obj={"config": MagicMock()})
+
+    assert result.exit_code != 0
+    assert "Configuration is valid" not in result.output
+    manager_cls.assert_called_once()
+    assert manager_cls.call_args.kwargs["config_path"] == malformed
+    assert manager_cls.call_args.kwargs["strict"] is True
+
+
+def test_validate_command_rejects_missing_explicit_config(tmp_path) -> None:
+    runner = CliRunner()
+    missing = tmp_path / "missing.yaml"
+
+    result = runner.invoke(validate, ["--config", str(missing)], obj={"config": MagicMock()})
+
+    assert result.exit_code != 0
+    assert "Configuration is valid" not in result.output
 
 
 def test_profile_command_renders_panel_and_uses_system_profiler() -> None:

--- a/tests/unit/cli/test_cli_output.py
+++ b/tests/unit/cli/test_cli_output.py
@@ -989,15 +989,15 @@ class TestResultExporterErrorHandling:
             validation_status="PASSED",
         )
 
-        exported = self.exporter.export_result(result, formats=["invalid_format"])
+        with pytest.raises(RuntimeError, match="Unknown export format"):
+            self.exporter.export_result(result, formats=["invalid_format"])
 
-        # Should not include the invalid format
-        assert "invalid_format" not in exported
-
-        # Should print warning message
+        # Should print an actionable error message
         assert mock_console.print.called
         calls = [str(call) for call in mock_console.print.call_args_list]
-        assert any("Unknown export format" in call for call in calls)
+        assert any("Unknown export format" in call for call in calls) or any(
+            "Failed to export" in call for call in calls
+        )
 
     @pytest.mark.skipif(sys.platform == "win32", reason="Path handling differs on Windows")
     def test_export_with_invalid_output_dir(self):

--- a/tests/unit/cli/test_cli_output.py
+++ b/tests/unit/cli/test_cli_output.py
@@ -939,6 +939,12 @@ class TestResultExporter:
         """Comparison reports must not render result-controlled labels as markup."""
         untrusted = '"><script>alert(1)</script>'
         comparison = {
+            "summary": {
+                "total_queries_compared": untrusted,
+                "improved_queries": untrusted,
+                "regressed_queries": untrusted,
+                "unchanged_queries": untrusted,
+            },
             "performance_changes": {
                 untrusted: {"change_percent": 1.0, "improved": False},
             },

--- a/tests/unit/cli/test_cli_output.py
+++ b/tests/unit/cli/test_cli_output.py
@@ -935,6 +935,30 @@ class TestResultExporter:
         assert "Q1" in html_content
         assert "Improved" in html_content
 
+    def test_export_comparison_report_escapes_untrusted_labels(self):
+        """Comparison reports must not render result-controlled labels as markup."""
+        untrusted = '"><script>alert(1)</script>'
+        comparison = {
+            "performance_changes": {
+                untrusted: {"change_percent": 1.0, "improved": False},
+            },
+            "query_comparisons": [
+                {
+                    "query_id": untrusted,
+                    "baseline_time_ms": 1.0,
+                    "current_time_ms": 2.0,
+                    "change_percent": 100.0,
+                    "improved": False,
+                }
+            ],
+        }
+
+        report_path = self.exporter.export_comparison_report(comparison)
+        html_content = report_path.read_text(encoding="utf-8")
+
+        assert untrusted not in html_content
+        assert "&quot;&gt;&lt;script&gt;alert(1)&lt;/script&gt;" in html_content
+
     def test_assess_performance_change(self):
         """Test performance change assessment."""
         # Significant improvement

--- a/tests/unit/cli/test_cli_parameter_consistency.py
+++ b/tests/unit/cli/test_cli_parameter_consistency.py
@@ -77,7 +77,7 @@ class TestCLIParameterConsistency:
             patch.object(_run_module, "BenchmarkManager") as mock_bench,
             patch.object(_run_module, "SystemProfiler") as mock_system,
             patch.object(_run_module, "get_platform_manager") as mock_platform,
-            patch("benchbox.cli.main.ResultExporter") as mock_exporter,
+            patch.object(_run_module, "ResultExporter") as mock_exporter,
         ):
             # Setup database manager
             mock_db_instance = MagicMock()
@@ -434,11 +434,12 @@ class TestGlobalCacheCLIFlag:
             patch.object(_run_module, "BenchmarkManager") as mock_bench,
             patch.object(_run_module, "SystemProfiler"),
             patch.object(_run_module, "get_platform_manager"),
-            patch("benchbox.cli.main.ResultExporter"),
+            patch.object(_run_module, "ResultExporter") as mock_exporter,
         ):
             mock_bench_instance = MagicMock()
             mock_bench_instance.benchmarks = {"tpch": {"display_name": "TPC-H", "estimated_time_range": "1-5min"}}
             mock_bench.return_value = mock_bench_instance
+            mock_exporter.return_value.export_result.return_value = {"json": "test.json"}
 
             mock_orch_instance = MagicMock()
             mock_orch_instance.execute_benchmark.return_value = mock_result

--- a/tests/unit/cli/test_compression_cli.py
+++ b/tests/unit/cli/test_compression_cli.py
@@ -81,23 +81,27 @@ class TestCompressionCLI:
         mock_orchestrator.return_value = mock_orchestrator_instance
         mock_result = MagicMock()
         mock_result.validation_status = "PASSED"
+        mock_result.query_results = []
+        mock_result.execution_id = "test-123"
         mock_orchestrator_instance.execute_benchmark.return_value = mock_result
 
         # Test CLI with compression options
-        result = self.runner.invoke(
-            cli,
-            [
-                "run",
-                "--platform",
-                "duckdb",
-                "--benchmark",
-                "ssb",
-                "--scale",
-                "0.01",
-                "--compression",
-                "zstd:5",
-            ],
-        )
+        with patch.object(_run_module, "ResultExporter") as mock_exporter:
+            mock_exporter.return_value.export_result.return_value = {"json": "test.json"}
+            result = self.runner.invoke(
+                cli,
+                [
+                    "run",
+                    "--platform",
+                    "duckdb",
+                    "--benchmark",
+                    "ssb",
+                    "--scale",
+                    "0.01",
+                    "--compression",
+                    "zstd:5",
+                ],
+            )
 
         # Check that command executed without errors
         assert result.exit_code == 0
@@ -159,13 +163,17 @@ class TestCompressionCLI:
         mock_orchestrator.return_value = mock_orchestrator_instance
         mock_result = MagicMock()
         mock_result.validation_status = "PASSED"
+        mock_result.query_results = []
+        mock_result.execution_id = "test-123"
         mock_orchestrator_instance.execute_benchmark.return_value = mock_result
 
         # Test CLI without compression options
-        result = self.runner.invoke(
-            cli,
-            ["run", "--platform", "duckdb", "--benchmark", "ssb", "--scale", "0.01"],
-        )
+        with patch.object(_run_module, "ResultExporter") as mock_exporter:
+            mock_exporter.return_value.export_result.return_value = {"json": "test.json"}
+            result = self.runner.invoke(
+                cli,
+                ["run", "--platform", "duckdb", "--benchmark", "ssb", "--scale", "0.01"],
+            )
 
         # Check that command executed without errors
         assert result.exit_code == 0

--- a/tests/unit/core/results/test_builder.py
+++ b/tests/unit/core/results/test_builder.py
@@ -195,6 +195,20 @@ class TestResultBuilder:
         assert result.failed_queries == 1
         assert result.validation_status == "PARTIAL"
 
+    @pytest.mark.parametrize("status", ["ERROR", "TIMEOUT", "SKIPPED", "UNKNOWN"])
+    def test_build_counts_every_non_success_status_as_failed(self, status: str) -> None:
+        """Non-success statuses must not disappear from aggregate accounting."""
+        builder = self.create_builder()
+        builder.add_query_result(self.create_query_result("1", 1.0, 100, "SUCCESS"))
+        builder.add_query_result(self.create_query_result("2", 0.0, 0, status))
+
+        result = builder.build()
+
+        assert result.successful_queries == 1
+        assert result.failed_queries == 1
+        assert result.validation_status == "PARTIAL"
+        assert result.power_at_size is None
+
     def test_build_calculates_tpc_metrics(self) -> None:
         """Test that TPC metrics are calculated."""
         builder = self.create_builder(scale_factor=1.0)

--- a/tests/unit/core/results/test_builder.py
+++ b/tests/unit/core/results/test_builder.py
@@ -195,9 +195,19 @@ class TestResultBuilder:
         assert result.failed_queries == 1
         assert result.validation_status == "PARTIAL"
 
-    @pytest.mark.parametrize("status", ["ERROR", "TIMEOUT", "SKIPPED", "UNKNOWN"])
-    def test_build_counts_every_non_success_status_as_failed(self, status: str) -> None:
-        """Non-success statuses must not disappear from aggregate accounting."""
+    @pytest.mark.parametrize(
+        ("status", "expected_failed", "expected_validation"),
+        [
+            ("ERROR", 1, "PARTIAL"),
+            ("TIMEOUT", 1, "PARTIAL"),
+            ("UNKNOWN", 1, "PARTIAL"),
+            ("SKIPPED", 0, "PASSED"),
+        ],
+    )
+    def test_build_counts_failure_statuses_without_counting_skipped(
+        self, status: str, expected_failed: int, expected_validation: str
+    ) -> None:
+        """Failure statuses affect gates, while intentional skips remain non-failures."""
         builder = self.create_builder()
         builder.add_query_result(self.create_query_result("1", 1.0, 100, "SUCCESS"))
         builder.add_query_result(self.create_query_result("2", 0.0, 0, status))
@@ -205,9 +215,10 @@ class TestResultBuilder:
         result = builder.build()
 
         assert result.successful_queries == 1
-        assert result.failed_queries == 1
-        assert result.validation_status == "PARTIAL"
-        assert result.power_at_size is None
+        assert result.failed_queries == expected_failed
+        assert result.validation_status == expected_validation
+        if expected_failed:
+            assert result.power_at_size is None
 
     def test_build_calculates_tpc_metrics(self) -> None:
         """Test that TPC metrics are calculated."""

--- a/tests/unit/core/results/test_database.py
+++ b/tests/unit/core/results/test_database.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import sqlite3
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
@@ -142,6 +143,44 @@ class TestResultDatabase:
             cursor.execute("SELECT version FROM schema_version")
             version = cursor.fetchone()[0]
             assert version == SCHEMA_VERSION
+
+    def test_foreign_keys_enabled_on_every_connection(self, tmp_path):
+        """SQLite cascade enforcement must be enabled per connection."""
+        db = ResultDatabase(tmp_path / "test.db")
+
+        with db._connection() as conn:
+            assert conn.execute("PRAGMA foreign_keys").fetchone()[0] == 1
+
+    def test_delete_result_cascades_queries(self, tmp_path):
+        """Deleting a result removes its child query rows."""
+        db = ResultDatabase(tmp_path / "test.db")
+        result_id = db.store_result(create_test_result(execution_id="cascade", include_queries=True))
+
+        assert len(db.get_queries(result_id)) == 2
+        assert db.delete_result("cascade") is True
+        assert db.get_queries(result_id) == []
+
+    def test_orphan_repair_is_dry_run_by_default_and_backed_up_when_applied(self, tmp_path):
+        """Legacy orphan rows require explicit repair and retain a backup."""
+        db_path = tmp_path / "test.db"
+        db = ResultDatabase(db_path)
+        with sqlite3.connect(db_path) as conn:
+            conn.execute(
+                """INSERT INTO queries
+                    (result_id, query_id, execution_order, execution_time_ms, status)
+                    VALUES (999999, 'orphan', 1, 1.0, 'ERROR')"""
+            )
+            conn.commit()
+
+        assert db.repair_orphaned_queries() == 1
+        assert db.count_orphaned_queries() == 1
+        assert db.repair_orphaned_queries(dry_run=False) == 1
+        assert db.count_orphaned_queries() == 0
+        with db._connection() as conn:
+            backup_tables = conn.execute(
+                "SELECT name FROM sqlite_master WHERE name LIKE 'queries_orphan_backup_%'"
+            ).fetchall()
+            assert len(backup_tables) == 1
 
 
 class TestStoreAndRetrieve:

--- a/tests/unit/core/results/test_database.py
+++ b/tests/unit/core/results/test_database.py
@@ -18,6 +18,7 @@ from benchbox.core.results.database import (
     ResultDatabase,
     StoredQuery,
     StoredResult,
+    _validate_backup_table_name,
 )
 from benchbox.core.results.models import (
     BenchmarkResults,
@@ -159,6 +160,13 @@ class TestResultDatabase:
         assert len(db.get_queries(result_id)) == 2
         assert db.delete_result("cascade") is True
         assert db.get_queries(result_id) == []
+
+    def test_backup_table_identifier_validation_rejects_sql(self):
+        valid_name = "queries_orphan_backup_20260826215959123456"
+        assert _validate_backup_table_name(valid_name) == valid_name
+
+        with pytest.raises(ValueError, match="Unsafe SQLite backup table name"):
+            _validate_backup_table_name("queries_orphan_backup_20260826215959123456; DROP TABLE results")
 
     def test_orphan_repair_is_dry_run_by_default_and_backed_up_when_applied(self, tmp_path):
         """Legacy orphan rows require explicit repair and retain a backup."""

--- a/tests/unit/core/results/test_display_timing.py
+++ b/tests/unit/core/results/test_display_timing.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from datetime import datetime
+from threading import Barrier, Thread
 
 import pytest
 
@@ -160,6 +161,30 @@ def test_query_timing_and_collector(monkeypatch):
     collector.clear_completed_timings()
     assert collector.get_completed_timings() == []
     assert collector.get_timing_summary() == {}
+
+
+def test_timing_collector_isolates_concurrent_repeated_query_ids():
+    collector = TimingCollector()
+    barrier = Barrier(2)
+    errors = []
+
+    def worker(label: str) -> None:
+        try:
+            with collector.time_query("Q1"):
+                barrier.wait(timeout=5)
+                collector.record_metric("Q1", "thread_id", label)
+        except Exception as exc:  # pragma: no cover - assertion below reports failures
+            errors.append((label, exc))
+
+    threads = [Thread(target=worker, args=(label,)) for label in ("first", "second")]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join()
+
+    assert errors == []
+    completed = collector.get_completed_timings()
+    assert sorted(t.thread_id for t in completed) == ["first", "second"]
 
 
 def test_timing_analyzer_statistics_outliers_and_comparison():

--- a/tests/unit/core/results/test_display_timing.py
+++ b/tests/unit/core/results/test_display_timing.py
@@ -187,6 +187,18 @@ def test_timing_collector_isolates_concurrent_repeated_query_ids():
     assert sorted(t.thread_id for t in completed) == ["first", "second"]
 
 
+def test_timing_summary_uses_a_consistent_completed_snapshot():
+    collector = TimingCollector()
+    with collector.time_query("Q1"):
+        pass
+
+    summary = collector.get_timing_summary()
+
+    assert summary["total_queries"] == 1
+    assert summary["successful_queries"] == 1
+    assert summary["failed_queries"] == 0
+
+
 def test_timing_analyzer_statistics_outliers_and_comparison():
     timings = [
         QueryTiming(query_id="Q1", execution_time=1.0, rows_returned=100),

--- a/tests/unit/core/results/test_export_anonymization_surfaces.py
+++ b/tests/unit/core/results/test_export_anonymization_surfaces.py
@@ -54,6 +54,29 @@ class TestCsvHtmlAnonymization:
         path = exporter._export_csv_detailed(_result_with_error(), "run1")
         assert SENTINEL_ERROR in path.read_text(encoding="utf-8")
 
+    def test_html_escapes_untrusted_metadata_and_query_values(self, tmp_path):
+        untrusted = '"><script>alert(1)</script>'
+        result = SimpleNamespace(
+            benchmark_name=untrusted,
+            execution_id=untrusted,
+            platform=untrusted,
+            query_results=[
+                {
+                    "query_id": untrusted,
+                    "status": untrusted,
+                    "execution_time_ms": 1.0,
+                    "rows_returned": untrusted,
+                    "error_message": untrusted,
+                }
+            ],
+        )
+
+        path = ResultExporter(output_dir=tmp_path)._export_html_detailed(result, "run1")
+        content = path.read_text(encoding="utf-8")
+
+        assert untrusted not in content
+        assert "&quot;&gt;&lt;script&gt;alert(1)&lt;/script&gt;" in content
+
     def test_html_row_shape_preserved(self, tmp_path):
         exporter = ResultExporter(output_dir=tmp_path, anonymize=True)
         row = exporter._render_query_row(

--- a/tests/unit/core/test_runner_manifest_reuse.py
+++ b/tests/unit/core/test_runner_manifest_reuse.py
@@ -248,6 +248,43 @@ def test_force_regenerate_overrides_populated_tables(tmp_path: Path, benchmark_c
     dummy.generate_data.assert_called_once()
 
 
+def test_populated_missing_tables_trigger_regeneration(tmp_path: Path, benchmark_config: BenchmarkConfig):
+    """A populated mapping with missing files must not bypass generation."""
+
+    class DummyBenchmark:
+        def __init__(self) -> None:
+            self.output_dir = tmp_path
+            self.tables = {"orders": tmp_path / "missing.dat"}
+            self.generate_data = Mock()
+
+    dummy = DummyBenchmark()
+
+    result = _ensure_data_generated(dummy, benchmark_config)
+
+    assert result is True
+    dummy.generate_data.assert_called_once()
+
+
+def test_populated_tables_must_match_manifest_before_reuse(tmp_path: Path, benchmark_config: BenchmarkConfig):
+    """Existing but stale table mappings must not be reused."""
+    _write_manifest(tmp_path, table_names=["customer"])
+    stale_path = tmp_path / "orders.dat"
+    stale_path.write_text("stale\n")
+
+    class DummyBenchmark:
+        def __init__(self) -> None:
+            self.output_dir = tmp_path
+            self.tables = {"orders": stale_path}
+            self.generate_data = Mock()
+
+    dummy = DummyBenchmark()
+
+    result = _ensure_data_generated(dummy, benchmark_config)
+
+    assert result is True
+    dummy.generate_data.assert_called_once()
+
+
 def test_invalid_manifest_regenerates(tmp_path: Path, benchmark_config: BenchmarkConfig):
     manifest = _write_manifest(tmp_path, table_names=["orders"])
     # Corrupt manifest by altering file size expectation

--- a/tests/unit/core/test_runner_manifest_reuse.py
+++ b/tests/unit/core/test_runner_manifest_reuse.py
@@ -285,6 +285,24 @@ def test_populated_tables_must_match_manifest_before_reuse(tmp_path: Path, bench
     dummy.generate_data.assert_called_once()
 
 
+def test_external_populated_tables_without_manifest_are_reused(tmp_path: Path, benchmark_config: BenchmarkConfig):
+    """External caller-provided tables must not require a local datagen manifest."""
+    benchmark_config.options["table_mode"] = "external"
+
+    class DummyBenchmark:
+        def __init__(self) -> None:
+            self.output_dir = tmp_path
+            self.tables = {"orders": "s3://bucket/benchbox/orders"}
+            self.generate_data = Mock()
+
+    dummy = DummyBenchmark()
+
+    result = _ensure_data_generated(dummy, benchmark_config)
+
+    assert result is False
+    dummy.generate_data.assert_not_called()
+
+
 def test_invalid_manifest_regenerates(tmp_path: Path, benchmark_config: BenchmarkConfig):
     manifest = _write_manifest(tmp_path, table_names=["orders"])
     # Corrupt manifest by altering file size expectation

--- a/tests/unit/core/tpch/test_reporting_html_security.py
+++ b/tests/unit/core/tpch/test_reporting_html_security.py
@@ -1,0 +1,98 @@
+"""Security regression tests for TPC-H HTML report rendering."""
+
+from html import escape as html_escape
+from types import SimpleNamespace
+
+import pytest
+
+from benchbox.core.tpch.reporting import ComparisonResult, PerformanceMetrics, TPCHReportGenerator, ValidationResult
+
+pytestmark = [
+    pytest.mark.unit,
+    pytest.mark.fast,
+]
+
+
+UNTRUSTED_TITLE = '"><script>alert("title")</script>'
+UNTRUSTED_QUERY_ID = '"><script>alert("query")</script>'
+UNTRUSTED_ISSUE = '"><script>alert("issue")</script>'
+UNTRUSTED_WARNING = '"><script>alert("warning")</script>'
+
+
+def _benchmark_result(query_id: str = UNTRUSTED_QUERY_ID):
+    return SimpleNamespace(
+        qphh_at_size=10.0,
+        scale_factor=1.0,
+        power_test=SimpleNamespace(
+            power_at_size=10.0,
+            total_time=1.0,
+            success=True,
+            query_times={query_id: 1.0},
+        ),
+        throughput_test=SimpleNamespace(
+            throughput_at_size=10.0,
+            total_time=1.0,
+            num_streams=2,
+            success=True,
+        ),
+    )
+
+
+def _metrics() -> PerformanceMetrics:
+    return PerformanceMetrics(
+        qphh_at_size=10.0,
+        power_at_size=10.0,
+        throughput_at_size=10.0,
+        total_execution_time=1.0,
+        average_query_time=1.0,
+        median_query_time=1.0,
+        query_time_std_dev=0.0,
+        throughput_efficiency=1.0,
+        power_efficiency=1.0,
+        scale_factor=1.0,
+    )
+
+
+def test_detailed_report_escapes_title_query_id_issues_and_warnings(tmp_path):
+    generator = TPCHReportGenerator(tmp_path)
+    validation = ValidationResult(
+        compliant=False,
+        certification_ready=False,
+        issues=[UNTRUSTED_ISSUE],
+        warnings=[UNTRUSTED_WARNING],
+    )
+
+    html = generator._generate_html_report(
+        _benchmark_result(),
+        _metrics(),
+        validation,
+        UNTRUSTED_TITLE,
+        include_detailed_analysis=True,
+        include_certification_info=True,
+    )
+
+    for raw_value in (UNTRUSTED_TITLE, UNTRUSTED_QUERY_ID, UNTRUSTED_ISSUE, UNTRUSTED_WARNING):
+        assert raw_value not in html
+        assert html_escape(raw_value, quote=True) in html
+
+
+def test_comparison_report_escapes_title(tmp_path):
+    generator = TPCHReportGenerator(tmp_path)
+    comparison = ComparisonResult(
+        baseline_qphh=10.0,
+        current_qphh=11.0,
+        performance_change=1.0,
+        relative_change=0.1,
+        significant_change=False,
+        query_level_changes={1: -0.1},
+    )
+
+    html = generator._generate_comparison_html(
+        _benchmark_result(query_id="1"),
+        _benchmark_result(query_id="1"),
+        comparison,
+        UNTRUSTED_TITLE,
+    )
+
+    assert UNTRUSTED_TITLE not in html
+    assert html_escape(UNTRUSTED_TITLE, quote=True) in html

--- a/tests/unit/platforms/azure/test_fabric_spark_adapter.py
+++ b/tests/unit/platforms/azure/test_fabric_spark_adapter.py
@@ -318,6 +318,27 @@ class TestFabricSparkAdapterConnection:
 class TestFabricSparkAdapterDataLoading:
     """Test data loading functionality."""
 
+    def test_load_data_propagates_table_creation_failure(self, tmp_path):
+        """A failed table creation must not produce a successful load result."""
+        with (
+            patch("benchbox.platforms.azure.fabric_spark_adapter.AZURE_IDENTITY_AVAILABLE", True),
+            patch("benchbox.platforms.azure.fabric_spark_adapter.DefaultAzureCredential", MagicMock()),
+            patch("benchbox.platforms.azure.fabric_spark_adapter.REQUESTS_AVAILABLE", True),
+            patch("benchbox.platforms.azure.fabric_spark_adapter.CloudSparkStaging") as mock_staging,
+        ):
+            staging = MagicMock()
+            staging.tables_exist.return_value = True
+            mock_staging.from_uri.return_value = staging
+
+            from benchbox.platforms.azure import FabricSparkAdapter
+
+            adapter = FabricSparkAdapter(workspace_id="workspace", lakehouse_id="lakehouse")
+            adapter._execute_statement = MagicMock(side_effect=RuntimeError("table create failed"))
+            benchmark = MagicMock(tables={"orders": None})
+
+            with pytest.raises(RuntimeError, match="Failed to create Fabric Spark table orders"):
+                adapter.load_data(benchmark, None, tmp_path)
+
     def test_load_data_skips_when_exists(self):
         """Test that load_data skips upload when tables already exist."""
         with (
@@ -367,7 +388,8 @@ class TestFabricSparkAdapterDataLoading:
                 with tempfile.TemporaryDirectory() as tmpdir:
                     from pathlib import Path
 
-                    adapter.load_data(mock_benchmark, None, Path(tmpdir))
+                    with patch.object(adapter, "_execute_statement", return_value={}):
+                        adapter.load_data(mock_benchmark, None, Path(tmpdir))
 
                     # Should not call upload_tables since tables exist
                     mock_staging_instance.upload_tables.assert_not_called()
@@ -418,7 +440,8 @@ class TestFabricSparkAdapterDataLoading:
                 with tempfile.TemporaryDirectory() as tmpdir:
                     from pathlib import Path
 
-                    adapter.load_data(mock_benchmark, None, Path(tmpdir))
+                    with patch.object(adapter, "_execute_statement", return_value={}):
+                        adapter.load_data(mock_benchmark, None, Path(tmpdir))
 
                     mock_staging_instance.upload_tables.assert_called_once_with(
                         tables=["lineitem", "orders"],

--- a/tests/unit/platforms/azure/test_synapse_spark_adapter.py
+++ b/tests/unit/platforms/azure/test_synapse_spark_adapter.py
@@ -17,6 +17,33 @@ pytestmark = [
 ]
 
 
+def test_synapse_spark_load_data_propagates_table_creation_failure(tmp_path):
+    """A failed table creation must not be reported as a successful load."""
+    with (
+        patch("benchbox.platforms.azure.synapse_spark_adapter.AZURE_IDENTITY_AVAILABLE", True),
+        patch("benchbox.platforms.azure.synapse_spark_adapter.DefaultAzureCredential", MagicMock()),
+        patch("benchbox.platforms.azure.synapse_spark_adapter.REQUESTS_AVAILABLE", True),
+        patch("benchbox.platforms.azure.synapse_spark_adapter.CloudSparkStaging") as mock_staging,
+    ):
+        staging = MagicMock()
+        staging.tables_exist.return_value = True
+        mock_staging.from_uri.return_value = staging
+
+        from benchbox.platforms.azure import SynapseSparkAdapter
+
+        adapter = SynapseSparkAdapter(
+            workspace_name="workspace",
+            spark_pool_name="pool",
+            storage_account="account",
+            storage_container="container",
+        )
+        adapter._execute_statement = MagicMock(side_effect=RuntimeError("table create failed"))
+        benchmark = MagicMock(tables={"orders": None})
+
+        with pytest.raises(RuntimeError, match="Failed to create Synapse Spark table orders"):
+            adapter.load_data(benchmark, None, tmp_path)
+
+
 class TestSynapseSparkAdapterInitialization:
     """Test SynapseSparkAdapter initialization."""
 

--- a/tests/unit/platforms/azure/test_synapse_spark_coverage.py
+++ b/tests/unit/platforms/azure/test_synapse_spark_coverage.py
@@ -91,7 +91,7 @@ def test_load_data_validates_source_dir_and_builds_table_uris(tmp_path: Path) ->
     adapter = _adapter()
     adapter._staging = MagicMock()
     adapter._staging.tables_exist.return_value = False
-    adapter._execute_statement = MagicMock(side_effect=[None, RuntimeError("table create failed")])
+    adapter._execute_statement = MagicMock(side_effect=[None, None])
 
     with pytest.raises(ConfigurationError, match="Source directory not found"):
         adapter.load_data(_benchmark("lineitem"), None, tmp_path / "missing")

--- a/tests/unit/test_base_advanced.py
+++ b/tests/unit/test_base_advanced.py
@@ -1037,6 +1037,7 @@ class TestMockBaseBenchmarkResultHelpers:
                     "execution_time_seconds": 1.25,
                     "row_count": 3,
                     "query_text": "select 1",
+                    "status": "SUCCESS",
                 }
             ],
             execution_metadata={

--- a/tests/unit/test_release_infrastructure.py
+++ b/tests/unit/test_release_infrastructure.py
@@ -248,32 +248,30 @@ class TestReleaseInfrastructure:
         assert "id-token" in publish_job["permissions"]
         assert publish_job["permissions"]["id-token"] == "write"
 
-    def test_release_smoke_test_pins_installed_version(self):
-        """#1072 review: the post-publish smoke test must install the exact
-        version this workflow run just built, not an unqualified `benchbox`
-        - PyPI/Test PyPI propagation lag or a pre-existing Test PyPI version
-        could otherwise mask a broken current wheel."""
+    def test_release_smoke_test_runs_before_publication_from_built_wheel(self):
+        """Installation validation must gate publication using the built wheel."""
         jobs = _workflow("release.yml")["jobs"]
         test_installation_job = jobs["test-installation"]
 
         needs = test_installation_job["needs"]
         needs = [needs] if isinstance(needs, str) else needs
         assert "build" in needs, "test-installation must depend on build to reach needs.build.outputs.version"
+        assert "publish" not in needs, "pre-publication installation validation must not depend on publish"
+        publish_needs = jobs["publish"]["needs"]
+        publish_needs = [publish_needs] if isinstance(publish_needs, str) else publish_needs
+        assert "test-installation" in publish_needs
 
         release_workflow_text = (REPO_ROOT / ".github" / "workflows" / "release.yml").read_text(encoding="utf-8")
         assert "pip install benchbox" not in release_workflow_text, "smoke test must not install an unpinned benchbox"
-        assert release_workflow_text.count("needs.build.outputs.version") >= 3, (
-            "the build/publish version pin, plus both PyPI and Test PyPI install steps, must reference it"
-        )
+        assert "python -m pip install dist/*.whl" in release_workflow_text
+        assert "Download build artifacts" in release_workflow_text
 
         steps = test_installation_job["steps"]
         install_steps = [s for s in steps if s.get("name", "").startswith("Test installation from")]
-        assert len(install_steps) == 2, "expected exactly the PyPI and Test PyPI install steps"
+        assert len(install_steps) == 1, "expected exactly one pre-publication built-wheel install step"
         for step in install_steps:
             assert step.get("shell") == "bash", (
-                f"{step['name']!r} must pin shell: bash - the matrix includes windows-latest, whose "
-                "default runner shell is PowerShell and does not understand ${BENCHBOX_VERSION} bash "
-                "syntax, so the Windows leg would silently install an unversioned/empty package name"
+                f"{step['name']!r} must pin shell: bash - the matrix includes windows-latest"
             )
 
     def test_release_required_result_contract(self):

--- a/tests/unit/test_results_exporter.py
+++ b/tests/unit/test_results_exporter.py
@@ -77,8 +77,23 @@ def test_write_file_disables_local_newline_translation(monkeypatch, tmp_path):
     monkeypatch.setattr("builtins.open", open_without_translation)
 
     ResultExporter(output_dir=tmp_path, anonymize=False)._write_file(destination, "{\n}\n")
-
     assert destination.read_bytes() == b"{\n}\n"
+
+
+def test_write_file_is_atomic_when_replace_fails(monkeypatch, tmp_path):
+    destination = tmp_path / "result.json"
+    destination.write_text("old\n", encoding="utf-8")
+
+    def fail_replace(_temporary, _destination):
+        raise OSError("replace failed")
+
+    monkeypatch.setattr(exporter_module.os, "replace", fail_replace)
+
+    with pytest.raises(OSError, match="replace failed"):
+        ResultExporter(output_dir=tmp_path, anonymize=False)._write_file(destination, "new\n")
+
+    assert destination.read_text(encoding="utf-8") == "old\n"
+    assert not list(tmp_path.glob(".result.json.*.tmp"))
 
 
 def test_write_file_prefers_canonical_cloud_bytes(tmp_path):
@@ -567,18 +582,15 @@ def test_exporter_preserves_local_zero_total_with_normalized_provenance(tmp_path
 
 
 def test_exporter_rejects_unsupported_type(tmp_path, caplog) -> None:
-    """Exporter should handle unsupported types gracefully by logging error."""
+    """Exporter should reject unsupported result types with an actionable error."""
 
     exporter = ResultExporter(output_dir=tmp_path, anonymize=False)
 
     class LegacyResult:
         timestamp = datetime.now()
 
-    # Exporter catches exceptions and logs them instead of raising
-    result = exporter.export_result(LegacyResult(), formats=["json"])  # type: ignore[arg-type]
-
-    # Should return empty dict (no files exported)
-    assert result == {}
+    with pytest.raises(RuntimeError, match="Failed to export json"):
+        exporter.export_result(LegacyResult(), formats=["json"])  # type: ignore[arg-type]
 
     # Error should be logged - check for any error message indicating failure
     assert any("Failed to export" in record.message or "Error" in record.levelname for record in caplog.records)

--- a/tests/unit/test_results_exporter.py
+++ b/tests/unit/test_results_exporter.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import stat
 from datetime import datetime
 from pathlib import Path
 
@@ -94,6 +95,17 @@ def test_write_file_is_atomic_when_replace_fails(monkeypatch, tmp_path):
 
     assert destination.read_text(encoding="utf-8") == "old\n"
     assert not list(tmp_path.glob(".result.json.*.tmp"))
+
+
+def test_write_file_preserves_existing_permissions(tmp_path):
+    destination = tmp_path / "result.json"
+    destination.write_text("old\n", encoding="utf-8")
+    destination.chmod(0o640)
+
+    ResultExporter(output_dir=tmp_path, anonymize=False)._write_file(destination, "new\n")
+
+    assert destination.read_text(encoding="utf-8") == "new\n"
+    assert stat.S_IMODE(destination.stat().st_mode) == 0o640
 
 
 def test_write_file_prefers_canonical_cloud_bytes(tmp_path):


### PR DESCRIPTION
## Summary

- Make explicit configuration validation fail closed and honor `--config`.
- Treat every non-success query status as ineligible for aggregate benchmark metrics.
- Enforce SQLite foreign keys and provide guarded orphan-query repair.
- Make result exports fail closed with atomic local artifact writes.
- Isolate concurrent repeated-query timing state.
- Validate populated table mappings before reuse and propagate Spark load failures.
- Add subprocess CLI acceptance coverage and gate release publication on built-wheel installation tests.

## Verification

- `make pr-preflight`
- Result: `28381 passed, 19 skipped, 52 warnings, 4 subtests passed`
- Focused remediation suite: `297 passed, 12 deselected`

Auto-merge is intentionally withheld pending maintainer review.
