### PR TITLE
fix(worktree): harden worktree-audit collection integrity and contract compliance

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -216,6 +216,9 @@ _project/verification-logs/*/
 _project/verification-logs/*.log
 _project/verification-logs/*.out
 
+# Ephemeral worktree lifecycle audit snapshots (Spec §9)
+_project/reports/worktree-lifecycle/
+
 # The _project/scripts environment now contains the released todo-db runtime.
 # Its lockfile is tracked so cutover, clean-clone, and CI commands resolve the
 # same immutable package instead of relying on a developer checkout or PATH.

--- a/_project/scripts/worktree_audit.py
+++ b/_project/scripts/worktree_audit.py
@@ -26,11 +26,13 @@ import subprocess
 import urllib.error
 import urllib.parse
 import urllib.request
+import uuid
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Set, Tuple
 
 SCHEMA_VERSION = 1
 STRUCTURAL_BASES = {"develop", "release", "published-results"}
+_EVIDENCE_SOURCE_KEY = "_benchbox_evidence_source"
 
 REPORT_AUTHORITY = {
     "is_deletion_authority": False,
@@ -93,6 +95,10 @@ class Classification:
         }
 
 
+class GitCollectionError(RuntimeError):
+    """A Git command could not provide a trustworthy collection result."""
+
+
 # ---------------------------------------------------------------------------
 # Git interaction helpers (read-only)
 # ---------------------------------------------------------------------------
@@ -100,10 +106,10 @@ def _run_git(args: List[str], cwd: Path, timeout: float = 30.0) -> Tuple[int, st
     try:
         proc = subprocess.run(["git", *args], capture_output=True, text=True, cwd=cwd, timeout=timeout)
         return proc.returncode, proc.stdout.strip(), proc.stderr.strip()
-    except subprocess.TimeoutExpired:
-        return 124, "", f"git command timed out after {timeout}s: git {' '.join(args)}"
+    except subprocess.TimeoutExpired as exc:
+        raise GitCollectionError(f"git command timed out after {timeout}s: git {' '.join(args)}") from exc
     except Exception as exc:
-        return 1, "", f"git command error: {exc}"
+        raise GitCollectionError(f"git command failed before producing a result: git {' '.join(args)}: {exc}") from exc
 
 
 def get_primary_clone_path(repo_root: Path) -> Optional[Path]:
@@ -322,9 +328,8 @@ def _github_api_request(
 
 def resolve_github_token() -> Optional[str]:
     """Resolve GitHub token from environment variables or `gh auth token` CLI."""
-    token = os.environ.get("GH_TOKEN") or os.environ.get("GITHUB_TOKEN")
-    if token:
-        token = token.strip()
+    for variable in ("GH_TOKEN", "GITHUB_TOKEN"):
+        token = os.environ.get(variable, "").strip()
         if token:
             return token
 
@@ -385,17 +390,28 @@ def resolve_repository_identity(
         return None, None, "Repository payload missing 'id'"
     full_name = data.get("full_name", f"{owner}/{repo}")
 
-    # Plausibility cross-check against git remote URL if available (Spec §3)
+    # Compare stable repository identities so redirects work without accepting
+    # an unrelated same-named fork (Spec §3).
     if remote_slug:
-        remote_repo_name = remote_slug.split("/", 1)[1] if "/" in remote_slug else remote_slug
-        observed_repo_name = full_name.split("/", 1)[1] if "/" in full_name else full_name
-        if remote_repo_name.lower() != observed_repo_name.lower():
+        if "/" not in remote_slug:
+            return None, None, f"Invalid GitHub remote repository slug: '{remote_slug}'"
+        remote_owner, remote_repo = remote_slug.split("/", 1)
+        encoded_remote_owner = urllib.parse.quote(remote_owner, safe="")
+        encoded_remote_repo = urllib.parse.quote(remote_repo, safe="")
+        remote_url = f"https://api.github.com/repos/{encoded_remote_owner}/{encoded_remote_repo}"
+        remote_data, _, remote_err = _github_api_request(remote_url, token)
+        if remote_err or not isinstance(remote_data, dict):
+            return None, None, f"Failed to resolve remote repository '{remote_slug}': {remote_err or 'invalid payload'}"
+        remote_repo_id = remote_data.get("id")
+        if remote_repo_id is None:
+            return None, None, f"Remote repository payload for '{remote_slug}' missing 'id'"
+        if remote_repo_id != repo_id:
             return (
                 None,
                 None,
                 (
-                    f"Repository plausibility mismatch: remote URL points to '{remote_slug}', "
-                    f"but API resolved to '{full_name}'"
+                    f"Repository identity mismatch: remote '{remote_slug}' resolved to id {remote_repo_id}, "
+                    f"but requested repository '{full_name}' resolved to id {repo_id}"
                 ),
             )
 
@@ -424,7 +440,7 @@ def fetch_prs_for_branch(
     """
     encoded_owner = urllib.parse.quote(owner, safe="")
     encoded_repo = urllib.parse.quote(repo, safe="")
-    all_prs: List[Dict[str, Any]] = []
+    all_prs: List[Tuple[Any, str]] = []
     page = 1
 
     while True:
@@ -443,11 +459,11 @@ def fetch_prs_for_branch(
         if not isinstance(data, list):
             return [], "Expected list of PRs from API"
 
-        all_prs.extend(data)
+        all_prs.extend((pr, url) for pr in data)
 
         link_header = headers.get("link", "") if headers else ""
         has_next = 'rel="next"' in link_header
-        if not has_next or len(data) < 100:
+        if not has_next:
             break
 
         page += 1
@@ -458,7 +474,7 @@ def fetch_prs_for_branch(
         return [], None
 
     validated_prs: List[Dict[str, Any]] = []
-    for pr in all_prs:
+    for pr, source_url in all_prs:
         if not isinstance(pr, dict):
             continue
         base_repo = pr.get("base", {}).get("repo")
@@ -466,7 +482,9 @@ def fetch_prs_for_branch(
             base_repo_id = base_repo.get("id") if isinstance(base_repo, dict) else None
             if base_repo_id != expected_repo_id:
                 continue
-        validated_prs.append(pr)
+        validated_pr = dict(pr)
+        validated_pr[_EVIDENCE_SOURCE_KEY] = f"GET {source_url}"
+        validated_prs.append(validated_pr)
 
     if all_prs and not validated_prs:
         return [], (
@@ -561,7 +579,7 @@ def _build_integration_evidence_list(
                 merge_commit_sha=merge_commit_sha,
                 merge_commit_reachable_from_target_tip=merge_reachable,
                 checked_at=checked_at,
-                source=f"https://api.github.com/repos/{repo_owner}/{repo_name}/pulls/{pr_number}",
+                source=str(pr.get(_EVIDENCE_SOURCE_KEY, "canned PR evidence")),
             )
         )
     return evidence_list
@@ -770,22 +788,38 @@ def audit_worktrees(
     repo_root: Path,
     repo_slug: str = "BenchBox-dev/BenchBox",
     token: Optional[str] = None,
+    initial_collection_errors: Optional[List[str]] = None,
 ) -> Dict[str, Any]:
     """Perform read-only inventory and audit across worktrees and local branches."""
     if token is None:
         token = resolve_github_token()
 
-    remote_slug = get_remote_repository_slug(repo_root)
-    owner, repo = repo_slug.split("/", 1) if "/" in repo_slug else ("BenchBox-dev", repo_slug)
-    repo_id, full_name, repo_err = resolve_repository_identity(owner, repo, token, remote_slug=remote_slug)
-    effective_repo_err = repo_err if (repo_err or repo_id is None) else None
-    if repo_id is None and not effective_repo_err:
-        effective_repo_err = "Repository ID unavailable"
-
-    worktrees_info, wt_err = get_git_worktrees(repo_root)
-    local_branches = get_local_branches(repo_root)
-
     generated_at = datetime.datetime.now(datetime.timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+    owner, repo = repo_slug.split("/", 1) if "/" in repo_slug else ("BenchBox-dev", repo_slug)
+    collection_errors = list(initial_collection_errors or [])
+    repo_id: Optional[int] = None
+    full_name: Optional[str] = repo_slug
+    effective_repo_err: Optional[str] = None
+    worktrees_info: List[WorktreeInfo] = []
+    local_branches: List[Dict[str, Any]] = []
+    wt_err: Optional[str] = None
+
+    try:
+        remote_slug = get_remote_repository_slug(repo_root)
+        repo_id, full_name, repo_err = resolve_repository_identity(owner, repo, token, remote_slug=remote_slug)
+        effective_repo_err = repo_err if (repo_err or repo_id is None) else None
+        if repo_id is None and not effective_repo_err:
+            effective_repo_err = "Repository ID unavailable"
+        if effective_repo_err:
+            collection_errors.append(f"Repository identity collection failed: {effective_repo_err}")
+
+        worktrees_info, wt_err = get_git_worktrees(repo_root)
+        if wt_err:
+            collection_errors.append(f"Git worktree enumeration failed: {wt_err}")
+        local_branches = get_local_branches(repo_root)
+    except GitCollectionError as err:
+        wt_err = str(err)
+        collection_errors.append(f"Git collection failed: {err}")
 
     worktree_records: List[Dict[str, Any]] = []
     finish_candidates = 0
@@ -831,15 +865,26 @@ def audit_worktrees(
         unavailable_count = 1
     else:
         for wt in worktrees_info:
-            classification, evidence = evaluate_and_classify_worktree(
-                wt=wt,
-                repo_owner=owner,
-                repo_name=repo,
-                expected_repo_id=repo_id,
-                token=token,
-                repo_root=repo_root,
-                repo_identity_error=effective_repo_err,
-            )
+            try:
+                classification, evidence = evaluate_and_classify_worktree(
+                    wt=wt,
+                    repo_owner=owner,
+                    repo_name=repo,
+                    expected_repo_id=repo_id,
+                    token=token,
+                    repo_root=repo_root,
+                    repo_identity_error=effective_repo_err,
+                )
+            except GitCollectionError as err:
+                error = f"Git collection failed for worktree '{wt.path}': {err}"
+                collection_errors.append(error)
+                classification = Classification(
+                    state="unavailable",
+                    item_classification="Git error",
+                    reason=error,
+                    signals=[],
+                )
+                evidence = []
 
             if classification.state == "verified-integrated":
                 finish_candidates += 1
@@ -887,6 +932,7 @@ def audit_worktrees(
             "resolved_via": f"https://api.github.com/repos/{owner}/{repo}",
         },
         "report_authority": REPORT_AUTHORITY,
+        "collection_errors": collection_errors,
         "worktrees": worktree_records,
         "local_branches": local_branches,
         "summary": {
@@ -895,21 +941,35 @@ def audit_worktrees(
             "finish_candidates": finish_candidates,
             "uncertain": uncertain_count,
             "unavailable": unavailable_count,
+            "collection_errors": len(collection_errors),
         },
     }
 
-    # Write timestamped snapshot to gitignored location (Spec §9)
+    snapshot_error = _write_report_snapshot(report, repo_root)
+    if snapshot_error:
+        report["snapshot_path"] = None
+        collection_errors.append(snapshot_error)
+        report["collection_errors"] = collection_errors
+        report["summary"]["collection_errors"] = len(collection_errors)
+
+    return report
+
+
+def _write_report_snapshot(report: Dict[str, Any], repo_root: Path) -> Optional[str]:
+    """Persist a collision-resistant report snapshot without overwriting an existing run."""
     report_dir = repo_root / "_project" / "reports" / "worktree-lifecycle"
     try:
         report_dir.mkdir(parents=True, exist_ok=True)
-        ts_slug = generated_at.replace(":", "-")
-        snapshot_file = report_dir / f"{ts_slug}.json"
-        snapshot_file.write_text(json.dumps(report, indent=2), encoding="utf-8")
+        ts_slug = str(report["generated_at"]).replace(":", "-")
+        snapshot_file = report_dir / f"{ts_slug}-{uuid.uuid4().hex}.json"
         report["snapshot_path"] = str(snapshot_file)
-    except Exception:
+        with snapshot_file.open("x", encoding="utf-8") as handle:
+            json.dump(report, handle, indent=2)
+            handle.write("\n")
+    except Exception as err:
         report["snapshot_path"] = None
-
-    return report
+        return f"Snapshot persistence failed: {err}"
+    return None
 
 
 def render_text_report(report: Dict[str, Any]) -> str:
@@ -947,7 +1007,10 @@ def render_text_report(report: Dict[str, Any]) -> str:
     lines.append(f"  Finish candidates:    {summary.get('finish_candidates', 0)}")
     lines.append(f"  Uncertain:            {summary.get('uncertain', 0)}")
     lines.append(f"  Unavailable:          {summary.get('unavailable', 0)}")
+    lines.append(f"  Collection errors:    {summary.get('collection_errors', 0)}")
     lines.append(f"  Local branches:       {summary.get('total_local_branches', 0)}")
+    for error in report.get("collection_errors", []):
+        lines.append(f"  - {error}")
     lines.append("")
     lines.append(f"Authority Note: {report.get('report_authority', {}).get('note')}")
     return "\n".join(lines)
@@ -979,18 +1042,29 @@ def main(argv: Optional[List[str]] = None) -> int:
     token = resolve_github_token()
     repo_root = Path.cwd()
 
-    code, root_out, _ = _run_git(["rev-parse", "--show-toplevel"], repo_root)
-    if code == 0 and root_out:
-        repo_root = Path(root_out)
+    initial_collection_errors: List[str] = []
+    try:
+        code, root_out, _ = _run_git(["rev-parse", "--show-toplevel"], repo_root)
+        if code == 0 and root_out:
+            repo_root = Path(root_out)
+    except GitCollectionError as err:
+        initial_collection_errors.append(f"Git repository root collection failed: {err}")
 
-    report = audit_worktrees(repo_root=repo_root, repo_slug=args.repo, token=token)
+    report = audit_worktrees(
+        repo_root=repo_root,
+        repo_slug=args.repo,
+        token=token,
+        initial_collection_errors=initial_collection_errors,
+    )
 
     if args.format == "json":
         print(json.dumps(report, indent=2))
     else:
         print(render_text_report(report))
 
-    if args.strict and report.get("summary", {}).get("unavailable", 0) > 0:
+    if args.strict and (
+        report.get("summary", {}).get("unavailable", 0) > 0 or report.get("summary", {}).get("collection_errors", 0) > 0
+    ):
         return 1
 
     return 0

--- a/_project/scripts/worktree_audit.py
+++ b/_project/scripts/worktree_audit.py
@@ -96,9 +96,14 @@ class Classification:
 # ---------------------------------------------------------------------------
 # Git interaction helpers (read-only)
 # ---------------------------------------------------------------------------
-def _run_git(args: List[str], cwd: Path) -> Tuple[int, str, str]:
-    proc = subprocess.run(["git", *args], capture_output=True, text=True, cwd=cwd)
-    return proc.returncode, proc.stdout.strip(), proc.stderr.strip()
+def _run_git(args: List[str], cwd: Path, timeout: float = 30.0) -> Tuple[int, str, str]:
+    try:
+        proc = subprocess.run(["git", *args], capture_output=True, text=True, cwd=cwd, timeout=timeout)
+        return proc.returncode, proc.stdout.strip(), proc.stderr.strip()
+    except subprocess.TimeoutExpired:
+        return 124, "", f"git command timed out after {timeout}s: git {' '.join(args)}"
+    except Exception as exc:
+        return 1, "", f"git command error: {exc}"
 
 
 def get_primary_clone_path(repo_root: Path) -> Optional[Path]:
@@ -157,19 +162,23 @@ def _parse_worktree_porcelain_entries(stdout: str) -> List[Dict[str, Any]]:
     return entries
 
 
-def get_git_worktrees(repo_root: Path, include_primary: bool = False) -> List[WorktreeInfo]:
+def get_git_worktrees(repo_root: Path, include_primary: bool = False) -> Tuple[List[WorktreeInfo], Optional[str]]:
     """Parse `git worktree list --porcelain` into structured WorktreeInfo list.
 
     By default, filters out the primary clone to report only linked worktrees
     per the evidence contract specification (§4, §10).
+
+    Returns (worktrees, error_message).
     """
-    code, stdout, _ = _run_git(["worktree", "list", "--porcelain"], repo_root)
-    if code != 0 or not stdout:
-        return []
+    code, stdout, stderr = _run_git(["worktree", "list", "--porcelain"], repo_root)
+    if code != 0:
+        return [], f"Failed to list git worktrees (exit {code}): {stderr or 'unknown error'}"
+    if not stdout:
+        return [], None
 
     entries = _parse_worktree_porcelain_entries(stdout)
     if not entries:
-        return []
+        return [], None
 
     primary_clone = get_primary_clone_path(repo_root) if not include_primary else None
     worktrees: List[WorktreeInfo] = []
@@ -183,11 +192,11 @@ def get_git_worktrees(repo_root: Path, include_primary: bool = False) -> List[Wo
                         continue
                 except Exception:
                     pass
-            if idx == 0:
+            elif idx == 0:
                 continue
         worktrees.append(info)
 
-    return worktrees
+    return worktrees, None
 
 
 def _build_worktree_info(entry: Dict[str, Any]) -> WorktreeInfo:
@@ -285,8 +294,10 @@ def is_branch_gone_upstream(branch: str, repo_root: Path) -> bool:
 # ---------------------------------------------------------------------------
 # GitHub API interaction helpers
 # ---------------------------------------------------------------------------
-def _github_api_request(url: str, token: Optional[str]) -> Tuple[Optional[Any], Optional[str]]:
-    """Execute authenticated GitHub REST request. Returns (parsed_json, error_message)."""
+def _github_api_request(
+    url: str, token: Optional[str]
+) -> Tuple[Optional[Any], Optional[Dict[str, str]], Optional[str]]:
+    """Execute authenticated GitHub REST request. Returns (parsed_json, response_headers, error_message)."""
     headers = {
         "Accept": "application/vnd.github+json",
         "User-Agent": "benchbox-worktree-audit",
@@ -297,20 +308,21 @@ def _github_api_request(url: str, token: Optional[str]) -> Tuple[Optional[Any], 
     req = urllib.request.Request(url, headers=headers)
     try:
         with urllib.request.urlopen(req, timeout=30) as resp:
-            return json.load(resp), None
+            resp_headers = {k.lower(): v for k, v in resp.headers.items()}
+            return json.load(resp), resp_headers, None
     except urllib.error.HTTPError as err:
         if err.code == 404:
-            return None, "HTTP 404 Not Found"
-        return None, f"HTTP Error {err.code}: {err.reason}"
+            return None, None, "HTTP 404 Not Found"
+        return None, None, f"HTTP Error {err.code}: {err.reason}"
     except urllib.error.URLError as err:
-        return None, f"URL Error: {err.reason}"
+        return None, None, f"URL Error: {err.reason}"
     except Exception as err:
-        return None, f"Unexpected error: {err}"
+        return None, None, f"Unexpected error: {err}"
 
 
 def resolve_github_token() -> Optional[str]:
     """Resolve GitHub token from environment variables or `gh auth token` CLI."""
-    token = os.environ.get("GITHUB_TOKEN") or os.environ.get("GH_TOKEN")
+    token = os.environ.get("GH_TOKEN") or os.environ.get("GITHUB_TOKEN")
     if token:
         token = token.strip()
         if token:
@@ -331,20 +343,71 @@ def resolve_github_token() -> Optional[str]:
     return None
 
 
+def get_remote_repository_slug(repo_root: Path, preferred_remote: str = "origin") -> Optional[str]:
+    """Extract owner/repo slug from git remote URL as a plausibility check (Spec §3)."""
+    code, stdout, _ = _run_git(["remote", "get-url", preferred_remote], repo_root)
+    if code != 0 or not stdout:
+        code, remotes_out, _ = _run_git(["remote"], repo_root)
+        if code == 0 and remotes_out:
+            first_remote = remotes_out.splitlines()[0].strip()
+            code, stdout, _ = _run_git(["remote", "get-url", first_remote], repo_root)
+            if code != 0 or not stdout:
+                return None
+        else:
+            return None
+
+    url = stdout.strip().removesuffix(".git")
+    if "github.com/" in url:
+        return url.split("github.com/", 1)[1].strip("/")
+    if "github.com:" in url:
+        return url.split("github.com:", 1)[1].strip("/")
+    return None
+
+
 def resolve_repository_identity(
-    owner: str, repo: str, token: Optional[str]
+    owner: str,
+    repo: str,
+    token: Optional[str],
+    remote_slug: Optional[str] = None,
 ) -> Tuple[Optional[int], Optional[str], Optional[str]]:
-    """Resolve repository numeric ID and full name. Returns (id, full_name, error)."""
+    """Resolve repository numeric ID and full name with remote plausibility cross-check.
+
+    Returns (id, full_name, error).
+    """
     encoded_owner = urllib.parse.quote(owner, safe="")
     encoded_repo = urllib.parse.quote(repo, safe="")
     url = f"https://api.github.com/repos/{encoded_owner}/{encoded_repo}"
-    data, err = _github_api_request(url, token)
+    data, _, err = _github_api_request(url, token)
     if err or not isinstance(data, dict):
         return None, None, err or "Invalid repository payload"
     repo_id = data.get("id")
     if repo_id is None:
         return None, None, "Repository payload missing 'id'"
-    return repo_id, data.get("full_name", f"{owner}/{repo}"), None
+    full_name = data.get("full_name", f"{owner}/{repo}")
+
+    # Plausibility cross-check against git remote URL if available (Spec §3)
+    if remote_slug:
+        remote_repo_name = remote_slug.split("/", 1)[1] if "/" in remote_slug else remote_slug
+        observed_repo_name = full_name.split("/", 1)[1] if "/" in full_name else full_name
+        if remote_repo_name.lower() != observed_repo_name.lower():
+            return (
+                None,
+                None,
+                (
+                    f"Repository plausibility mismatch: remote URL points to '{remote_slug}', "
+                    f"but API resolved to '{full_name}'"
+                ),
+            )
+
+    return repo_id, full_name, None
+
+
+def is_pr_merged(pr: Dict[str, Any]) -> bool:
+    """Return True if PR payload indicates merged state (supports both GET and LIST schemas)."""
+    if pr.get("merged") is True:
+        return True
+    # GitHub LIST PR endpoint omits 'merged: bool' and provides 'merged_at: timestamp'
+    return bool(pr.get("merged_at"))
 
 
 def fetch_prs_for_branch(
@@ -353,23 +416,49 @@ def fetch_prs_for_branch(
     branch: str,
     expected_repo_id: Optional[int],
     token: Optional[str],
+    max_pages: int = 10,
 ) -> Tuple[List[Dict[str, Any]], Optional[str]]:
-    """Fetch PRs for branch, validating repository identity on each.
+    """Fetch PRs for branch, validating repository identity on each and handling pagination.
 
     Returns (prs_list, error_message).
     """
     encoded_owner = urllib.parse.quote(owner, safe="")
     encoded_repo = urllib.parse.quote(repo, safe="")
-    params = urllib.parse.urlencode({"head": f"{owner}:{branch}", "state": "all", "per_page": 100})
-    url = f"https://api.github.com/repos/{encoded_owner}/{encoded_repo}/pulls?{params}"
-    data, err = _github_api_request(url, token)
-    if err:
-        return [], err
-    if not isinstance(data, list):
-        return [], "Expected list of PRs from API"
+    all_prs: List[Dict[str, Any]] = []
+    page = 1
+
+    while True:
+        params = urllib.parse.urlencode(
+            {
+                "head": f"{owner}:{branch}",
+                "state": "all",
+                "per_page": 100,
+                "page": page,
+            }
+        )
+        url = f"https://api.github.com/repos/{encoded_owner}/{encoded_repo}/pulls?{params}"
+        data, headers, err = _github_api_request(url, token)
+        if err:
+            return [], err
+        if not isinstance(data, list):
+            return [], "Expected list of PRs from API"
+
+        all_prs.extend(data)
+
+        link_header = headers.get("link", "") if headers else ""
+        has_next = 'rel="next"' in link_header
+        if not has_next or len(data) < 100:
+            break
+
+        page += 1
+        if page > max_pages:
+            return [], f"PR listing pagination truncated: exceeded {max_pages} pages for branch '{branch}'"
+
+    if not all_prs:
+        return [], None
 
     validated_prs: List[Dict[str, Any]] = []
-    for pr in data:
+    for pr in all_prs:
         if not isinstance(pr, dict):
             continue
         base_repo = pr.get("base", {}).get("repo")
@@ -379,6 +468,12 @@ def fetch_prs_for_branch(
                 continue
         validated_prs.append(pr)
 
+    if all_prs and not validated_prs:
+        return [], (
+            f"All {len(all_prs)} PRs returned for branch '{branch}' failed repository identity validation "
+            f"(expected repo id {expected_repo_id})"
+        )
+
     return validated_prs, None
 
 
@@ -386,12 +481,21 @@ def fetch_prs_for_branch(
 # Core evaluation and classification logic (§5, §6, §7)
 # ---------------------------------------------------------------------------
 def _check_worktree_boundary_states(wt: WorktreeInfo, signals: List[str]) -> Optional[Classification]:
-    """Evaluate filesystem, registration, dirty, locked, and detached boundary states."""
+    """Evaluate filesystem, registration, dirty, locked, detached, and prunable boundary states."""
     if not wt.path_exists or not wt.registered:
         return Classification(
             state="unavailable",
             item_classification="missing",
             reason=f"Worktree path '{wt.path}' does not exist on disk or is not registered",
+            signals=signals,
+        )
+
+    if wt.prunable:
+        reason = f"Worktree is prunable ({wt.prunable_reason})" if wt.prunable_reason else "Worktree is prunable"
+        return Classification(
+            state="unavailable",
+            item_classification="prunable",
+            reason=reason,
             signals=signals,
         )
 
@@ -437,7 +541,7 @@ def _build_integration_evidence_list(
         pr_number = pr.get("number", 0)
         pr_head_sha = pr.get("head", {}).get("sha", "")
         pr_base_ref = pr.get("base", {}).get("ref", "")
-        is_merged = pr.get("merged", False) or bool(pr.get("merged_at"))
+        is_merged = is_pr_merged(pr)
         merge_commit_sha = pr.get("merge_commit_sha")
 
         target_tip = get_ref_commit_sha(f"origin/{pr_base_ref}", repo_root) or get_ref_commit_sha(
@@ -457,7 +561,7 @@ def _build_integration_evidence_list(
                 merge_commit_sha=merge_commit_sha,
                 merge_commit_reachable_from_target_tip=merge_reachable,
                 checked_at=checked_at,
-                source=f"gh api /repos/{repo_owner}/{repo_name}/pulls/{pr_number}",
+                source=f"https://api.github.com/repos/{repo_owner}/{repo_name}/pulls/{pr_number}",
             )
         )
     return evidence_list
@@ -540,6 +644,19 @@ def _evaluate_merged_pr_integration(
     )
 
 
+def get_branch_age_days(branch: str, repo_root: Path) -> Optional[float]:
+    """Return age of latest commit on branch in days, or None if unresolvable."""
+    code, stdout, _ = _run_git(["log", "-1", "--format=%ct", f"refs/heads/{branch}"], repo_root)
+    if code != 0 or not stdout:
+        return None
+    try:
+        commit_ts = int(stdout.strip())
+        now_ts = int(datetime.datetime.now(datetime.timezone.utc).timestamp())
+        return max(0.0, (now_ts - commit_ts) / 86400.0)
+    except Exception:
+        return None
+
+
 def evaluate_and_classify_worktree(
     wt: WorktreeInfo,
     repo_owner: str,
@@ -553,10 +670,14 @@ def evaluate_and_classify_worktree(
 ) -> Tuple[Classification, List[IntegrationEvidence]]:
     """Evaluate integration evidence and classify worktree according to evidence contract."""
     signals: List[str] = []
-    if not wt.is_dirty:
+    if wt.path_exists and not wt.is_dirty:
         signals.append("clean")
     if wt.branch and is_branch_gone_upstream(wt.branch, repo_root):
         signals.append("gone-upstream")
+    if wt.branch:
+        age_days = get_branch_age_days(wt.branch, repo_root)
+        if age_days is not None and age_days >= 30.0:
+            signals.append("old")
 
     if repo_identity_error:
         return (
@@ -618,7 +739,7 @@ def evaluate_and_classify_worktree(
     sorted_prs = sorted(prs, key=lambda p: p.get("number", 0), reverse=True)
     evidence_list = _build_integration_evidence_list(sorted_prs, repo_owner, repo_name, repo_root)
 
-    merged_prs = [p for p in sorted_prs if p.get("merged", False) or bool(p.get("merged_at"))]
+    merged_prs = [p for p in sorted_prs if is_pr_merged(p)]
     if merged_prs:
         latest_merged_cls: Optional[Classification] = None
         for p in merged_prs:
@@ -654,13 +775,14 @@ def audit_worktrees(
     if token is None:
         token = resolve_github_token()
 
+    remote_slug = get_remote_repository_slug(repo_root)
     owner, repo = repo_slug.split("/", 1) if "/" in repo_slug else ("BenchBox-dev", repo_slug)
-    repo_id, full_name, repo_err = resolve_repository_identity(owner, repo, token)
+    repo_id, full_name, repo_err = resolve_repository_identity(owner, repo, token, remote_slug=remote_slug)
     effective_repo_err = repo_err if (repo_err or repo_id is None) else None
     if repo_id is None and not effective_repo_err:
         effective_repo_err = "Repository ID unavailable"
 
-    worktrees_info = get_git_worktrees(repo_root)
+    worktrees_info, wt_err = get_git_worktrees(repo_root)
     local_branches = get_local_branches(repo_root)
 
     generated_at = datetime.datetime.now(datetime.timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
@@ -670,51 +792,91 @@ def audit_worktrees(
     uncertain_count = 0
     unavailable_count = 0
 
-    for wt in worktrees_info:
-        classification, evidence = evaluate_and_classify_worktree(
-            wt=wt,
-            repo_owner=owner,
-            repo_name=repo,
-            expected_repo_id=repo_id,
-            token=token,
-            repo_root=repo_root,
-            repo_identity_error=effective_repo_err,
-        )
-
-        if classification.state == "verified-integrated":
-            finish_candidates += 1
-        elif classification.state == "unavailable":
-            unavailable_count += 1
-        else:
-            uncertain_count += 1
-
+    if wt_err:
+        # Collection failure in Git worktree enumeration fails closed to unavailable (Spec §5)
         record = {
             "schema_version": SCHEMA_VERSION,
             "generated_at": generated_at,
             "repository": {
                 "id": repo_id,
                 "full_name_observed": full_name or repo_slug,
-                "resolved_via": "gh api /repos/{owner}/{repo} --jq .id",
+                "resolved_via": f"https://api.github.com/repos/{owner}/{repo}",
             },
             "worktree": {
-                "path": wt.path,
-                "registered": wt.registered,
-                "path_exists": wt.path_exists,
-                "is_detached": wt.is_detached,
-                "is_locked": wt.is_locked,
-                "lock_reason": wt.lock_reason,
-                "is_dirty": wt.is_dirty,
-                "branch": wt.branch,
-                "head_sha": wt.head_sha,
+                "path": str(repo_root),
+                "registered": False,
+                "path_exists": repo_root.exists(),
+                "is_detached": False,
+                "is_locked": False,
+                "lock_reason": None,
+                "is_dirty": False,
+                "branch": None,
+                "head_sha": None,
+                "is_prunable": False,
+                "prunable_reason": None,
             },
-            "integration_evidence": [ev.to_dict() for ev in evidence],
+            "integration_evidence": [],
             "task_run_evidence": {
                 "available": False,
                 "reason": "no published Bossmode public JSON contract yet (see §8)",
             },
-            "classification": classification.to_dict(),
+            "classification": {
+                "state": "unavailable",
+                "item_classification": "Git error",
+                "reason": f"Git worktree enumeration failed: {wt_err}",
+                "signals": [],
+            },
         }
         worktree_records.append(record)
+        unavailable_count = 1
+    else:
+        for wt in worktrees_info:
+            classification, evidence = evaluate_and_classify_worktree(
+                wt=wt,
+                repo_owner=owner,
+                repo_name=repo,
+                expected_repo_id=repo_id,
+                token=token,
+                repo_root=repo_root,
+                repo_identity_error=effective_repo_err,
+            )
+
+            if classification.state == "verified-integrated":
+                finish_candidates += 1
+            elif classification.state == "unavailable":
+                unavailable_count += 1
+            else:
+                uncertain_count += 1
+
+            record = {
+                "schema_version": SCHEMA_VERSION,
+                "generated_at": generated_at,
+                "repository": {
+                    "id": repo_id,
+                    "full_name_observed": full_name or repo_slug,
+                    "resolved_via": f"https://api.github.com/repos/{owner}/{repo}",
+                },
+                "worktree": {
+                    "path": wt.path,
+                    "registered": wt.registered,
+                    "path_exists": wt.path_exists,
+                    "is_detached": wt.is_detached,
+                    "is_locked": wt.is_locked,
+                    "lock_reason": wt.lock_reason,
+                    "is_dirty": wt.is_dirty,
+                    "branch": wt.branch,
+                    "head_sha": wt.head_sha,
+                    "is_prunable": wt.prunable,
+                    "prunable_reason": wt.prunable_reason,
+                },
+                "integration_evidence": [ev.to_dict() for ev in evidence],
+                "task_run_evidence": {
+                    "available": False,
+                    "reason": "no published Bossmode public JSON contract yet (see §8)",
+                },
+                "classification": classification.to_dict(),
+            }
+            worktree_records.append(record)
 
     report = {
         "schema_version": SCHEMA_VERSION,
@@ -722,7 +884,7 @@ def audit_worktrees(
         "repository": {
             "id": repo_id,
             "full_name_observed": full_name or repo_slug,
-            "resolved_via": "gh api /repos/{owner}/{repo} --jq .id",
+            "resolved_via": f"https://api.github.com/repos/{owner}/{repo}",
         },
         "report_authority": REPORT_AUTHORITY,
         "worktrees": worktree_records,
@@ -735,6 +897,18 @@ def audit_worktrees(
             "unavailable": unavailable_count,
         },
     }
+
+    # Write timestamped snapshot to gitignored location (Spec §9)
+    report_dir = repo_root / "_project" / "reports" / "worktree-lifecycle"
+    try:
+        report_dir.mkdir(parents=True, exist_ok=True)
+        ts_slug = generated_at.replace(":", "-")
+        snapshot_file = report_dir / f"{ts_slug}.json"
+        snapshot_file.write_text(json.dumps(report, indent=2), encoding="utf-8")
+        report["snapshot_path"] = str(snapshot_file)
+    except Exception:
+        report["snapshot_path"] = None
+
     return report
 
 
@@ -744,6 +918,8 @@ def render_text_report(report: Dict[str, Any]) -> str:
     lines.append("=== BenchBox Worktree Lifecycle Audit ===")
     lines.append(f"Generated at: {report.get('generated_at')}")
     lines.append(f"Repository:   {report.get('repository', {}).get('full_name_observed')}")
+    if report.get("snapshot_path"):
+        lines.append(f"Snapshot:     {report.get('snapshot_path')}")
     lines.append("")
 
     worktrees = report.get("worktrees", [])
@@ -793,6 +969,11 @@ def main(argv: Optional[List[str]] = None) -> int:
         default=os.environ.get("GITHUB_REPOSITORY", "BenchBox-dev/BenchBox"),
         help="GitHub repository slug owner/name (default: $GITHUB_REPOSITORY or BenchBox-dev/BenchBox)",
     )
+    parser.add_argument(
+        "--strict",
+        action="store_true",
+        help="Exit with code 1 if any worktree is unavailable or collection fails",
+    )
     args = parser.parse_args(argv)
 
     token = resolve_github_token()
@@ -808,6 +989,9 @@ def main(argv: Optional[List[str]] = None) -> int:
         print(json.dumps(report, indent=2))
     else:
         print(render_text_report(report))
+
+    if args.strict and report.get("summary", {}).get("unavailable", 0) > 0:
+        return 1
 
     return 0
 

--- a/_project/specs/worktree-lifecycle-evidence-contract.md
+++ b/_project/specs/worktree-lifecycle-evidence-contract.md
@@ -53,12 +53,11 @@ second transfer. Every evidence record MUST resolve identity by API `id`
 as the source of truth) and MUST NOT assume the current `owner/name` is
 permanent.
 
-When querying GitHub APIs via `gh api` (which expands placeholders only for
-`{owner}`, `{repo}`, and `{branch}`), the collector resolves the stable
-numeric/node `id` to the currently observed `owner/name` to formulate the
-request path (e.g. `gh api /repos/{owner}/{repo}/pulls/{number}`), and then
-MUST validate that the returned payload's repository identity matches the
-expected repository `id` before using the response.
+When querying GitHub APIs, the collector resolves the stable numeric/node `id`
+to the currently observed `owner/name` to formulate the request URL. It records
+the exact list endpoint that supplied each PR (including query parameters and
+page), then validates that the returned payload's repository identity matches
+the expected repository `id` before using the response.
 
 ## 4. Evidence model (schema-versioned)
 
@@ -99,7 +98,7 @@ understands (`_project/specs/todo-db-tracker.md`).
       "merge_commit_sha": "def456...",
       "merge_commit_reachable_from_target_tip": true,
       "checked_at": "2026-08-26T00:00:00Z",
-      "source": "gh api /repos/{owner}/{repo}/pulls/1914"
+      "source": "GET https://api.github.com/repos/{owner}/{repo}/pulls?head={owner}%3Afix%2Fexample&state=all&per_page=100&page=1"
     }
   ],
   "task_run_evidence": {

--- a/docs/operations/dev-loop-worktrees.md
+++ b/docs/operations/dev-loop-worktrees.md
@@ -63,7 +63,9 @@ git -C /absolute/path/to/worktree status --short
 
 `make worktree-audit` performs a bounded, fail-closed inventory combining live
 Git structure, exact GitHub PR evidence, and structural-branch policies. It
-never mutates Git state, never prunes, and never unlocks.
+records point-in-time snapshot files under `_project/reports/worktree-lifecycle/`
+(gitignored), never mutates Git state, never prunes, and never unlocks.
+Per Spec §9, audit reports carry zero deletion authority; removal requires manual verification.
 
 Existing registrations created by the retired workflow are not automatically
 reset or removed by this workflow. Review and remove them separately,

--- a/tests/integration/worktree/test_worktree_audit.py
+++ b/tests/integration/worktree/test_worktree_audit.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import importlib.util
 import json
+import os
 import subprocess
 import sys
 from pathlib import Path
@@ -35,8 +36,11 @@ def _load_audit_module():
 audit_mod = _load_audit_module()
 
 
-def _git(cmd: list[str], cwd: Path) -> str:
-    res = subprocess.run(["git", *cmd], cwd=cwd, check=True, text=True, capture_output=True)
+def _git(cmd: list[str], cwd: Path, env: dict[str, str] | None = None) -> str:
+    full_env = os.environ.copy()
+    if env:
+        full_env.update(env)
+    res = subprocess.run(["git", *cmd], cwd=cwd, check=True, text=True, capture_output=True, env=full_env)
     return res.stdout.strip()
 
 
@@ -63,12 +67,12 @@ def mock_github_api_offline(monkeypatch: pytest.MonkeyPatch):
     monkeypatch.setattr(
         audit_mod,
         "resolve_repository_identity",
-        lambda owner, repo, token: (123456789, f"{owner}/{repo}", None),
+        lambda owner, repo, token, *args, **kwargs: (123456789, f"{owner}/{repo}", None),
     )
     monkeypatch.setattr(
         audit_mod,
         "fetch_prs_for_branch",
-        lambda owner, repo, branch, repo_id, token: ([], None),
+        lambda owner, repo, branch, repo_id, token, *args, **kwargs: ([], None),
     )
 
 
@@ -159,7 +163,7 @@ def test_fixture_gone_upstream_squash_merged(tmp_path: Path):
         }
     ]
 
-    wt_info = audit_mod.get_git_worktrees(repo)
+    wt_info, _ = audit_mod.get_git_worktrees(repo)
     matched = [w for w in wt_info if w.branch == "fix/feature-squash"][0]
 
     cls, evidence = audit_mod.evaluate_and_classify_worktree(
@@ -212,7 +216,7 @@ def test_fixture_post_merge_commits_unintegrated(tmp_path: Path):
         }
     ]
 
-    wt_info = audit_mod.get_git_worktrees(repo)
+    wt_info, _ = audit_mod.get_git_worktrees(repo)
     matched = [w for w in wt_info if w.branch == "fix/feature-post-merge"][0]
 
     cls, _ = audit_mod.evaluate_and_classify_worktree(
@@ -261,7 +265,7 @@ def test_fixture_squash_source_tip_not_ancestor(tmp_path: Path):
         }
     ]
 
-    wt_info = audit_mod.get_git_worktrees(repo)
+    wt_info, _ = audit_mod.get_git_worktrees(repo)
     matched = [w for w in wt_info if w.branch == "fix/feature-ancestry-test"][0]
 
     cls, _ = audit_mod.evaluate_and_classify_worktree(
@@ -279,54 +283,57 @@ def test_fixture_squash_source_tip_not_ancestor(tmp_path: Path):
     assert cls.item_classification == "finish candidate"
 
 
-def test_make_worktree_audit_json_output():
-    res = subprocess.run(
-        ["make", "-s", "worktree-audit", "FORMAT=json"],
-        cwd=_ROOT,
-        capture_output=True,
-        text=True,
-        check=False,
-    )
-    assert res.returncode == 0, res.stderr
-    data = json.loads(res.stdout)
+def test_make_worktree_audit_json_output(capsys: pytest.CaptureFixture):
+    # Test JSON output formatting and schema via main() offline entrypoint (Spec §10)
+    code = audit_mod.main(["--format", "json"])
+    assert code == 0
+    captured = capsys.readouterr()
+    data = json.loads(captured.out)
     assert isinstance(data, dict)
     assert data["schema_version"] == 1
     assert "worktrees" in data
     assert "report_authority" in data
     assert data["report_authority"]["is_deletion_authority"] is False
+    assert "snapshot_path" in data
 
 
 def test_fixture_primary_clone(tmp_path: Path):
     repo = init_repo(tmp_path / "repo")
-    add_worktree(repo, "fix/feature-primary-test", tmp_path / "wt_primary")
+    wt = add_worktree(repo, "fix/feature-primary-test", tmp_path / "wt_primary")
 
-    report_from_repo = audit_mod.audit_worktrees(repo_root=repo)
-    repo_paths = [Path(r["worktree"]["path"]).resolve() for r in report_from_repo["worktrees"]]
-    assert repo.resolve() not in repo_paths
-    assert len(report_from_repo["worktrees"]) == 1
-    assert report_from_repo["worktrees"][0]["worktree"]["branch"] == "fix/feature-primary-test"
+    (wt / "file.txt").write_text("hello\n", encoding="utf-8")
+    _git(["add", "file.txt"], wt)
+    _git(["commit", "-m", "commit in linked wt"], wt)
 
-    report_from_wt = audit_mod.audit_worktrees(repo_root=tmp_path / "wt_primary")
-    wt_paths = [Path(r["worktree"]["path"]).resolve() for r in report_from_wt["worktrees"]]
-    assert repo.resolve() not in wt_paths
-    assert len(report_from_wt["worktrees"]) == 1
-    assert report_from_wt["worktrees"][0]["worktree"]["branch"] == "fix/feature-primary-test"
+    # 1. Audit run from repo root (primary clone)
+    report_from_primary = audit_mod.audit_worktrees(repo_root=repo)
+    paths_from_primary = [w["worktree"]["path"] for w in report_from_primary["worktrees"]]
+    assert str(repo.resolve()) not in paths_from_primary
+    assert any(wt.resolve() == Path(p).resolve() for p in paths_from_primary)
+
+    # 2. Audit run from linked worktree path
+    report_from_linked = audit_mod.audit_worktrees(repo_root=wt)
+    paths_from_linked = [w["worktree"]["path"] for w in report_from_linked["worktrees"]]
+    assert str(repo.resolve()) not in paths_from_linked
+    assert any(wt.resolve() == Path(p).resolve() for p in paths_from_linked)
 
 
 def test_fixture_merge_commit_not_yet_reachable(tmp_path: Path):
     repo = init_repo(tmp_path / "repo")
     wt = add_worktree(repo, "fix/feature-unreachable", tmp_path / "wt_unreachable")
 
-    (wt / "feature.txt").write_text("feature\n", encoding="utf-8")
-    _git(["add", "feature.txt"], wt)
-    _git(["commit", "-m", "feature commit"], wt)
+    (wt / "work.txt").write_text("work in progress\n", encoding="utf-8")
+    _git(["add", "work.txt"], wt)
+    _git(["commit", "-m", "work commit"], wt)
     branch_head_sha = _git(["rev-parse", "HEAD"], wt)
 
-    _git(["checkout", "-b", "other-unmerged-branch"], wt)
-    (wt / "unmerged.txt").write_text("unmerged\n", encoding="utf-8")
-    _git(["add", "unmerged.txt"], wt)
-    _git(["commit", "-m", "unmerged commit"], wt)
-    unreachable_merge_sha = _git(["rev-parse", "HEAD"], wt)
+    # Create a separate commit that is not reachable from develop
+    _git(["checkout", "-b", "other-branch"], repo)
+    (repo / "other.txt").write_text("other\n", encoding="utf-8")
+    _git(["add", "other.txt"], repo)
+    _git(["commit", "-m", "other commit"], repo)
+    unreachable_merge_sha = _git(["rev-parse", "HEAD"], repo)
+    _git(["checkout", "develop"], repo)
     _git(["checkout", "fix/feature-unreachable"], wt)
 
     canned_prs = [
@@ -341,7 +348,7 @@ def test_fixture_merge_commit_not_yet_reachable(tmp_path: Path):
         }
     ]
 
-    wt_info = audit_mod.get_git_worktrees(repo)
+    wt_info, _ = audit_mod.get_git_worktrees(repo)
     matched = [w for w in wt_info if w.branch == "fix/feature-unreachable"][0]
 
     cls, evidence = audit_mod.evaluate_and_classify_worktree(
@@ -387,7 +394,7 @@ def test_fixture_gone_upstream_no_pr_evidence(tmp_path: Path):
 
     assert audit_mod.is_branch_gone_upstream("fix/feature-gone", repo) is True
 
-    wt_info = audit_mod.get_git_worktrees(repo)
+    wt_info, _ = audit_mod.get_git_worktrees(repo)
     matched = [w for w in wt_info if w.branch == "fix/feature-gone"][0]
 
     cls, evidence = audit_mod.evaluate_and_classify_worktree(
@@ -404,3 +411,207 @@ def test_fixture_gone_upstream_no_pr_evidence(tmp_path: Path):
     assert cls.item_classification == "active"
     assert "gone-upstream" in cls.signals
     assert len(evidence) == 0
+
+
+def test_fixture_missing_directory(tmp_path: Path):
+    """Spec §10 fixture: registered in git worktree list but path missing on disk."""
+    repo = init_repo(tmp_path / "repo")
+    wt = add_worktree(repo, "fix/feature-missing", tmp_path / "wt_missing")
+    # Delete the directory from disk while keeping git registration
+    import shutil
+
+    shutil.rmtree(wt)
+
+    wt_info, _ = audit_mod.get_git_worktrees(repo)
+    matched = [w for w in wt_info if w.path == str(wt)][0]
+    assert matched.path_exists is False
+
+    cls, _ = audit_mod.evaluate_and_classify_worktree(
+        wt=matched,
+        repo_owner="BenchBox-dev",
+        repo_name="BenchBox",
+        expected_repo_id=None,
+        token=None,
+        repo_root=repo,
+    )
+    assert cls.state == "unavailable"
+    assert cls.item_classification == "missing"
+
+
+def test_fixture_unregistered_path(tmp_path: Path):
+    """Spec §10 fixture: path on disk not registered in git worktree list."""
+    repo = init_repo(tmp_path / "repo")
+    unregistered_dir = tmp_path / "unregistered_dir"
+    unregistered_dir.mkdir()
+
+    wt = audit_mod.WorktreeInfo(
+        path=str(unregistered_dir),
+        registered=False,
+        path_exists=True,
+        is_detached=False,
+        is_locked=False,
+        lock_reason=None,
+        is_dirty=False,
+        branch="fix/unregistered",
+        head_sha="head123",
+    )
+    cls, _ = audit_mod.evaluate_and_classify_worktree(
+        wt=wt,
+        repo_owner="BenchBox-dev",
+        repo_name="BenchBox",
+        expected_repo_id=None,
+        token=None,
+        repo_root=repo,
+    )
+    assert cls.state == "unavailable"
+    assert cls.item_classification == "missing"
+
+
+def test_fixture_prunable_worktree(tmp_path: Path):
+    """Spec §10 fixture: worktree entry marked prunable by git."""
+    repo = init_repo(tmp_path / "repo")
+    wt = audit_mod.WorktreeInfo(
+        path=str(tmp_path / "prunable_wt"),
+        registered=True,
+        path_exists=True,
+        is_detached=False,
+        is_locked=False,
+        lock_reason=None,
+        is_dirty=False,
+        branch="fix/prunable",
+        head_sha="head123",
+        prunable=True,
+        prunable_reason="gitdir missing",
+    )
+    cls, _ = audit_mod.evaluate_and_classify_worktree(
+        wt=wt,
+        repo_owner="BenchBox-dev",
+        repo_name="BenchBox",
+        expected_repo_id=None,
+        token=None,
+        repo_root=repo,
+    )
+    assert cls.state == "unavailable"
+    assert cls.item_classification == "prunable"
+    assert "gitdir missing" in cls.reason
+
+
+def test_fixture_gone_upstream_unmerged_pr(tmp_path: Path):
+    """Spec §10 fixture: branch gone-upstream but PR closed without merge."""
+    repo = init_repo(tmp_path / "repo")
+    add_worktree(repo, "fix/feature-closed-unmerged", tmp_path / "wt_closed")
+
+    canned_prs = [
+        {
+            "number": 1940,
+            "state": "closed",
+            "merged": False,
+            "merged_at": None,
+            "head": {"sha": "head123"},
+            "base": {"ref": "develop"},
+        }
+    ]
+
+    wt_info, _ = audit_mod.get_git_worktrees(repo)
+    matched = [w for w in wt_info if w.branch == "fix/feature-closed-unmerged"][0]
+
+    cls, evidence = audit_mod.evaluate_and_classify_worktree(
+        wt=matched,
+        repo_owner="BenchBox-dev",
+        repo_name="BenchBox",
+        expected_repo_id=None,
+        token=None,
+        repo_root=repo,
+        canned_prs=canned_prs,
+    )
+    assert cls.state == "uncertain"
+    assert cls.item_classification == "closed-unmerged"
+
+
+def test_fixture_wrong_base_pr(tmp_path: Path):
+    """Spec §10 fixture: PR merged into a non-structural feature branch."""
+    repo = init_repo(tmp_path / "repo")
+    wt = add_worktree(repo, "fix/feature-wrong-base", tmp_path / "wt_wrong_base")
+    (wt / "change.txt").write_text("change\n", encoding="utf-8")
+    _git(["add", "change.txt"], wt)
+    _git(["commit", "-m", "change"], wt)
+    head_sha = _git(["rev-parse", "HEAD"], wt)
+
+    canned_prs = [
+        {
+            "number": 1945,
+            "state": "closed",
+            "merged": True,
+            "merged_at": "2026-08-26T12:00:00Z",
+            "merge_commit_sha": "merge1945",
+            "head": {"sha": head_sha},
+            "base": {"ref": "feature/arbitrary-base"},
+        }
+    ]
+
+    wt_info, _ = audit_mod.get_git_worktrees(repo)
+    matched = [w for w in wt_info if w.branch == "fix/feature-wrong-base"][0]
+
+    cls, evidence = audit_mod.evaluate_and_classify_worktree(
+        wt=matched,
+        repo_owner="BenchBox-dev",
+        repo_name="BenchBox",
+        expected_repo_id=None,
+        token=None,
+        repo_root=repo,
+        canned_prs=canned_prs,
+    )
+    assert cls.state == "uncertain"
+    assert cls.item_classification == "wrong base"
+
+
+def test_fixture_old_but_active_worktree(tmp_path: Path):
+    """Spec §10 fixture: active clean worktree with commit older than 30 days."""
+    repo = init_repo(tmp_path / "repo")
+    wt = add_worktree(repo, "fix/feature-old", tmp_path / "wt_old")
+    (wt / "old.txt").write_text("old work\n", encoding="utf-8")
+    _git(["add", "old.txt"], wt)
+    _git(
+        ["commit", "-m", "old commit", "--date=2026-06-01T00:00:00Z"],
+        wt,
+        env={"GIT_COMMITTER_DATE": "2026-06-01T00:00:00Z"},
+    )
+
+    wt_info, _ = audit_mod.get_git_worktrees(repo)
+    matched = [w for w in wt_info if w.branch == "fix/feature-old"][0]
+
+    cls, _ = audit_mod.evaluate_and_classify_worktree(
+        wt=matched,
+        repo_owner="BenchBox-dev",
+        repo_name="BenchBox",
+        expected_repo_id=None,
+        token=None,
+        repo_root=repo,
+        canned_prs=[],
+    )
+    assert cls.state == "uncertain"
+    assert cls.item_classification == "active"
+    assert "old" in cls.signals
+    assert "clean" in cls.signals
+
+
+def test_fixture_incomplete_collection_error(tmp_path: Path):
+    """Spec §10 fixture: API error or timeout resolves fail-closed to unavailable."""
+    repo = init_repo(tmp_path / "repo")
+    add_worktree(repo, "fix/feature-api-err", tmp_path / "wt_api_err")
+
+    wt_info, _ = audit_mod.get_git_worktrees(repo)
+    matched = [w for w in wt_info if w.branch == "fix/feature-api-err"][0]
+
+    cls, evidence = audit_mod.evaluate_and_classify_worktree(
+        wt=matched,
+        repo_owner="BenchBox-dev",
+        repo_name="BenchBox",
+        expected_repo_id=None,
+        token=None,
+        repo_root=repo,
+        api_error_override="HTTP Error 503: Service Unavailable",
+    )
+    assert cls.state == "unavailable"
+    assert cls.item_classification == "API error"
+    assert "503" in cls.reason

--- a/tests/unit/scripts/test_worktree_audit.py
+++ b/tests/unit/scripts/test_worktree_audit.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import importlib.util
+import subprocess
 import sys
 from pathlib import Path
 from typing import Any, Dict, List
@@ -704,8 +705,12 @@ def test_snapshot_file_persistence(tmp_path: Path, monkeypatch: pytest.MonkeyPat
     assert "_project/reports/worktree-lifecycle" in str(snapshot_path)
 
 
-def test_git_run_timeout():
+def test_git_run_timeout(monkeypatch: pytest.MonkeyPatch):
     # Verify timeout handling in _run_git
-    code, stdout, stderr = mod._run_git(["sleep", "2"], cwd=Path.cwd(), timeout=0.01)
+    def mock_run(*args, **kwargs):
+        raise subprocess.TimeoutExpired(cmd=["git", "status"], timeout=0.01)
+
+    monkeypatch.setattr(mod.subprocess, "run", mock_run)
+    code, stdout, stderr = mod._run_git(["status"], cwd=Path.cwd(), timeout=0.01)
     assert code == 124
-    assert "timed out" in stderr
+    assert "timed out after 0.01s" in stderr

--- a/tests/unit/scripts/test_worktree_audit.py
+++ b/tests/unit/scripts/test_worktree_audit.py
@@ -555,6 +555,9 @@ def test_resolve_github_token_precedence(monkeypatch: pytest.MonkeyPatch):
     monkeypatch.setenv("GITHUB_TOKEN", "token-from-github-token")
     assert mod.resolve_github_token() == "token-from-gh-token"
 
+    monkeypatch.setenv("GH_TOKEN", "  ")
+    assert mod.resolve_github_token() == "token-from-github-token"
+
 
 def test_resolve_github_token_fallback_gh_cli(monkeypatch: pytest.MonkeyPatch):
     monkeypatch.delenv("GITHUB_TOKEN", raising=False)
@@ -613,6 +616,50 @@ def test_pagination_and_truncation_resolves_unavailable(monkeypatch: pytest.Monk
     assert "PR listing pagination truncated" in err
 
 
+def test_pagination_follows_next_link_after_short_page(monkeypatch: pytest.MonkeyPatch):
+    page_calls: List[str] = []
+
+    def mock_paginated_request(url: str, token: Any):
+        page_calls.append(url)
+        if len(page_calls) == 1:
+            return ([{"number": 1, "base": {"repo": {"id": 123}}}], {"link": '<next>; rel="next"'}, None)
+        return ([], {}, None)
+
+    monkeypatch.setattr(mod, "_github_api_request", mock_paginated_request)
+    prs, err = mod.fetch_prs_for_branch("owner", "repo", "branch", expected_repo_id=123, token=None)
+
+    assert err is None
+    assert [pr["number"] for pr in prs] == [1]
+    assert len(page_calls) == 2
+    assert "page=1" in page_calls[0]
+    assert "page=2" in page_calls[1]
+
+
+def test_integration_evidence_records_the_list_request_that_supplied_the_pr(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    pr = {
+        "number": 42,
+        "base": {"ref": "develop", "repo": {"id": 123}},
+        "head": {"sha": "head123"},
+        "merged_at": "2026-08-28T18:17:34Z",
+        "merge_commit_sha": "merge123",
+    }
+    monkeypatch.setattr(mod, "_github_api_request", lambda url, token: ([pr], {}, None))
+    monkeypatch.setattr(mod, "get_ref_commit_sha", lambda ref, root: None)
+
+    prs, err = mod.fetch_prs_for_branch(
+        "my-owner", "repo/special", "feature/awesome#1", expected_repo_id=123, token=None
+    )
+    evidence = mod._build_integration_evidence_list(prs, "my-owner", "repo/special", tmp_path)
+
+    assert err is None
+    assert evidence[0].source == (
+        "GET https://api.github.com/repos/my-owner/repo%2Fspecial/pulls?"
+        "head=my-owner%3Afeature%2Fawesome%231&state=all&per_page=100&page=1"
+    )
+
+
 def test_repo_id_validation_all_mismatched_fails_fetch(monkeypatch: pytest.MonkeyPatch):
     foreign_prs = [
         {"number": 1, "base": {"repo": {"id": 99999}}},
@@ -626,24 +673,26 @@ def test_repo_id_validation_all_mismatched_fails_fetch(monkeypatch: pytest.Monke
 
 
 def test_remote_plausibility_cross_check(monkeypatch: pytest.MonkeyPatch):
-    monkeypatch.setattr(
-        mod,
-        "_github_api_request",
-        lambda url, token: ({"id": 123, "full_name": "BenchBox-dev/BenchBox"}, {}, None),
-    )
-    # Matching repo name (e.g. transfer from joeharris76/BenchBox to BenchBox-dev/BenchBox) passes
+    def mock_repo_request(url: str, token: Any):
+        if url.endswith("/alice/BenchBox"):
+            return {"id": 999, "full_name": "alice/BenchBox"}, {}, None
+        return {"id": 123, "full_name": "BenchBox-dev/BenchBox"}, {}, None
+
+    monkeypatch.setattr(mod, "_github_api_request", mock_repo_request)
+
+    # A transferred repository resolves to the same stable ID and passes.
     repo_id, full_name, err = mod.resolve_repository_identity(
         "BenchBox-dev", "BenchBox", token=None, remote_slug="joeharris76/BenchBox"
     )
     assert err is None
     assert repo_id == 123
 
-    # Completely different repo fails plausibility
+    # A same-named fork resolves to a different ID and fails closed.
     repo_id, full_name, err = mod.resolve_repository_identity(
-        "BenchBox-dev", "BenchBox", token=None, remote_slug="unrelated/other-project"
+        "BenchBox-dev", "BenchBox", token=None, remote_slug="alice/BenchBox"
     )
     assert repo_id is None
-    assert "Repository plausibility mismatch" in (err or "")
+    assert "Repository identity mismatch" in (err or "")
 
 
 def test_list_api_schema_without_merged_boolean_evaluates_verified_integrated(
@@ -697,12 +746,74 @@ def test_snapshot_file_persistence(tmp_path: Path, monkeypatch: pytest.MonkeyPat
     monkeypatch.setattr(mod, "get_git_worktrees", lambda root: ([], None))
     monkeypatch.setattr(mod, "get_local_branches", lambda root: [])
 
+    first_report = mod.audit_worktrees(repo_root=tmp_path)
+    second_report = mod.audit_worktrees(repo_root=tmp_path)
+    first_snapshot = Path(first_report["snapshot_path"])
+    second_snapshot = Path(second_report["snapshot_path"])
+
+    assert first_snapshot != second_snapshot
+    assert first_snapshot.is_file()
+    assert second_snapshot.is_file()
+    assert "_project/reports/worktree-lifecycle" in str(first_snapshot)
+
+
+def test_git_timeout_in_worktree_evaluation_resolves_unavailable(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    wt_info = mod.WorktreeInfo(
+        path=str(tmp_path / "wt"),
+        registered=True,
+        path_exists=True,
+        is_detached=False,
+        is_locked=False,
+        lock_reason=None,
+        is_dirty=False,
+        branch="fix/timeout",
+        head_sha="abc",
+    )
+    monkeypatch.setattr(mod, "get_remote_repository_slug", lambda root: None)
+    monkeypatch.setattr(mod, "resolve_repository_identity", lambda *a, **kw: (123, "BenchBox-dev/BenchBox", None))
+    monkeypatch.setattr(mod, "get_git_worktrees", lambda root: ([wt_info], None))
+    monkeypatch.setattr(mod, "get_local_branches", lambda root: [])
+    monkeypatch.setattr(
+        mod,
+        "evaluate_and_classify_worktree",
+        lambda **kwargs: (_ for _ in ()).throw(mod.GitCollectionError("git status timed out")),
+    )
+
     report = mod.audit_worktrees(repo_root=tmp_path)
-    assert report.get("snapshot_path") is not None
-    snapshot_path = Path(report["snapshot_path"])
-    assert snapshot_path.exists()
-    assert snapshot_path.is_file()
-    assert "_project/reports/worktree-lifecycle" in str(snapshot_path)
+
+    assert report["summary"]["unavailable"] == 1
+    assert report["summary"]["collection_errors"] == 1
+    assert report["worktrees"][0]["classification"]["state"] == "unavailable"
+    assert "git status timed out" in report["collection_errors"][0]
+
+
+def test_strict_mode_detects_top_level_collection_failure(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setattr(mod, "get_remote_repository_slug", lambda root: None)
+    monkeypatch.setattr(mod, "resolve_repository_identity", lambda *a, **kw: (None, None, "HTTP 503"))
+    monkeypatch.setattr(mod, "get_git_worktrees", lambda root: ([], None))
+    monkeypatch.setattr(mod, "get_local_branches", lambda root: [])
+    report = mod.audit_worktrees(repo_root=tmp_path)
+    assert report["summary"]["unavailable"] == 0
+    assert report["summary"]["collection_errors"] == 1
+
+    monkeypatch.setattr(mod, "resolve_github_token", lambda: None)
+    monkeypatch.setattr(mod, "_run_git", lambda args, cwd, **kwargs: (1, "", "not a repository"))
+    monkeypatch.setattr(mod, "audit_worktrees", lambda **kwargs: report)
+    assert mod.main(["--strict", "--repo", "BenchBox-dev/BenchBox"]) == 1
+
+
+def test_snapshot_failure_is_a_top_level_collection_error(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setattr(mod, "get_remote_repository_slug", lambda root: None)
+    monkeypatch.setattr(mod, "resolve_repository_identity", lambda *a, **kw: (123, "BenchBox-dev/BenchBox", None))
+    monkeypatch.setattr(mod, "get_git_worktrees", lambda root: ([], None))
+    monkeypatch.setattr(mod, "get_local_branches", lambda root: [])
+    monkeypatch.setattr(mod, "_write_report_snapshot", lambda report, root: "Snapshot persistence failed: disk full")
+
+    report = mod.audit_worktrees(repo_root=tmp_path)
+
+    assert report["snapshot_path"] is None
+    assert report["summary"]["collection_errors"] == 1
+    assert report["collection_errors"] == ["Snapshot persistence failed: disk full"]
 
 
 def test_git_run_timeout(monkeypatch: pytest.MonkeyPatch):
@@ -711,6 +822,5 @@ def test_git_run_timeout(monkeypatch: pytest.MonkeyPatch):
         raise subprocess.TimeoutExpired(cmd=["git", "status"], timeout=0.01)
 
     monkeypatch.setattr(mod.subprocess, "run", mock_run)
-    code, stdout, stderr = mod._run_git(["status"], cwd=Path.cwd(), timeout=0.01)
-    assert code == 124
-    assert "timed out after 0.01s" in stderr
+    with pytest.raises(mod.GitCollectionError, match="timed out after 0.01s"):
+        mod._run_git(["status"], cwd=Path.cwd(), timeout=0.01)

--- a/tests/unit/scripts/test_worktree_audit.py
+++ b/tests/unit/scripts/test_worktree_audit.py
@@ -312,7 +312,7 @@ def test_repo_identity_error_resolution(monkeypatch: pytest.MonkeyPatch):
     monkeypatch.setattr(
         mod,
         "_github_api_request",
-        lambda url, token: ({"message": "Not Found"}, None),
+        lambda url, token: ({"message": "Not Found"}, {}, None),
     )
     repo_id, full_name, err = mod.resolve_repository_identity("BenchBox-dev", "BenchBox", token=None)
     assert repo_id is None
@@ -350,7 +350,7 @@ def test_audit_worktrees_repo_identity_error(tmp_path: Path, monkeypatch: pytest
     monkeypatch.setattr(
         mod,
         "resolve_repository_identity",
-        lambda owner, repo, token: (None, None, "Could not resolve repository"),
+        lambda owner, repo, token, remote_slug=None: (None, None, "Could not resolve repository"),
     )
     wt_info = mod.WorktreeInfo(
         path=str(tmp_path / "wt1"),
@@ -363,7 +363,7 @@ def test_audit_worktrees_repo_identity_error(tmp_path: Path, monkeypatch: pytest
         branch="fix/test-branch",
         head_sha="abc",
     )
-    monkeypatch.setattr(mod, "get_git_worktrees", lambda root: [wt_info])
+    monkeypatch.setattr(mod, "get_git_worktrees", lambda root: ([wt_info], None))
     monkeypatch.setattr(mod, "get_local_branches", lambda root: [])
 
     report = mod.audit_worktrees(repo_root=tmp_path)
@@ -379,7 +379,7 @@ def test_url_encoding_resolve_repository_identity(monkeypatch: pytest.MonkeyPatc
 
     def mock_request(url: str, token: Any):
         captured_urls.append(url)
-        return {"id": 123, "full_name": "owner/repo"}, None
+        return {"id": 123, "full_name": "owner/repo"}, {}, None
 
     monkeypatch.setattr(mod, "_github_api_request", mock_request)
     mod.resolve_repository_identity("owner/with-slash", "repo with spaces", token=None)
@@ -393,7 +393,7 @@ def test_url_encoding_fetch_prs_for_branch(monkeypatch: pytest.MonkeyPatch):
 
     def mock_request(url: str, token: Any):
         captured_urls.append(url)
-        return [], None
+        return [], {}, None
 
     monkeypatch.setattr(mod, "_github_api_request", mock_request)
     mod.fetch_prs_for_branch("my-owner", "repo/special", "feature/awesome#1", expected_repo_id=None, token=None)
@@ -401,7 +401,7 @@ def test_url_encoding_fetch_prs_for_branch(monkeypatch: pytest.MonkeyPatch):
     assert len(captured_urls) == 1
     expected_url = (
         "https://api.github.com/repos/my-owner/repo%2Fspecial/pulls?"
-        + "head=my-owner%3Afeature%2Fawesome%231&state=all&per_page=100"
+        + "head=my-owner%3Afeature%2Fawesome%231&state=all&per_page=100&page=1"
     )
     assert captured_urls[0] == expected_url
 
@@ -429,7 +429,7 @@ def test_fetch_prs_for_branch_base_repo_id_validation(monkeypatch: pytest.Monkey
             "head": {"repo": {"id": 88888}},
         },
     ]
-    monkeypatch.setattr(mod, "_github_api_request", lambda url, token: (fake_prs, None))
+    monkeypatch.setattr(mod, "_github_api_request", lambda url, token: (fake_prs, {}, None))
 
     validated, err = mod.fetch_prs_for_branch("owner", "repo", "branch", expected_repo_id=12345, token=None)
     assert err is None
@@ -549,6 +549,12 @@ def test_resolve_github_token_from_env(monkeypatch: pytest.MonkeyPatch):
     assert mod.resolve_github_token() == "token-from-gh-token"
 
 
+def test_resolve_github_token_precedence(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv("GH_TOKEN", "token-from-gh-token")
+    monkeypatch.setenv("GITHUB_TOKEN", "token-from-github-token")
+    assert mod.resolve_github_token() == "token-from-gh-token"
+
+
 def test_resolve_github_token_fallback_gh_cli(monkeypatch: pytest.MonkeyPatch):
     monkeypatch.delenv("GITHUB_TOKEN", raising=False)
     monkeypatch.delenv("GH_TOKEN", raising=False)
@@ -571,3 +577,135 @@ def test_resolve_github_token_failure(monkeypatch: pytest.MonkeyPatch):
 
     monkeypatch.setattr(mod.subprocess, "run", mock_run_fail)
     assert mod.resolve_github_token() is None
+
+
+def test_git_worktrees_enumeration_failure_resolves_unavailable(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setattr(mod, "resolve_repository_identity", lambda *a, **kw: (123, "BenchBox-dev/BenchBox", None))
+    monkeypatch.setattr(mod, "_run_git", lambda args, cwd, **kwargs: (128, "", "fatal: not a git repository"))
+
+    report = mod.audit_worktrees(repo_root=tmp_path)
+    assert report["summary"]["unavailable"] == 1
+    assert len(report["worktrees"]) == 1
+    rec = report["worktrees"][0]
+    assert rec["classification"]["state"] == "unavailable"
+    assert rec["classification"]["item_classification"] == "Git error"
+    assert "Git worktree enumeration failed" in rec["classification"]["reason"]
+
+
+def test_pagination_and_truncation_resolves_unavailable(monkeypatch: pytest.MonkeyPatch):
+    # Simulate pagination returning 100 items per page with link header
+    page_calls = []
+
+    def mock_paginated_request(url: str, token: Any):
+        page_calls.append(url)
+        # return 100 items and a Link next header
+        return (
+            [{"number": len(page_calls) * 100 + i, "base": {"repo": {"id": 123}}} for i in range(100)],
+            {"link": '<https://api.github.com/next>; rel="next"'},
+            None,
+        )
+
+    monkeypatch.setattr(mod, "_github_api_request", mock_paginated_request)
+    prs, err = mod.fetch_prs_for_branch("owner", "repo", "branch", expected_repo_id=123, token=None, max_pages=3)
+    assert prs == []
+    assert err is not None
+    assert "PR listing pagination truncated" in err
+
+
+def test_repo_id_validation_all_mismatched_fails_fetch(monkeypatch: pytest.MonkeyPatch):
+    foreign_prs = [
+        {"number": 1, "base": {"repo": {"id": 99999}}},
+        {"number": 2, "base": {"repo": {"id": 88888}}},
+    ]
+    monkeypatch.setattr(mod, "_github_api_request", lambda url, token: (foreign_prs, {}, None))
+    prs, err = mod.fetch_prs_for_branch("owner", "repo", "branch", expected_repo_id=12345, token=None)
+    assert prs == []
+    assert err is not None
+    assert "failed repository identity validation" in err
+
+
+def test_remote_plausibility_cross_check(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setattr(
+        mod,
+        "_github_api_request",
+        lambda url, token: ({"id": 123, "full_name": "BenchBox-dev/BenchBox"}, {}, None),
+    )
+    # Matching repo name (e.g. transfer from joeharris76/BenchBox to BenchBox-dev/BenchBox) passes
+    repo_id, full_name, err = mod.resolve_repository_identity(
+        "BenchBox-dev", "BenchBox", token=None, remote_slug="joeharris76/BenchBox"
+    )
+    assert err is None
+    assert repo_id == 123
+
+    # Completely different repo fails plausibility
+    repo_id, full_name, err = mod.resolve_repository_identity(
+        "BenchBox-dev", "BenchBox", token=None, remote_slug="unrelated/other-project"
+    )
+    assert repo_id is None
+    assert "Repository plausibility mismatch" in (err or "")
+
+
+def test_list_api_schema_without_merged_boolean_evaluates_verified_integrated(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    wt = mod.WorktreeInfo(
+        path=str(tmp_path),
+        registered=True,
+        path_exists=True,
+        is_detached=False,
+        is_locked=False,
+        lock_reason=None,
+        is_dirty=False,
+        branch="fix/list-api-schema",
+        head_sha="head_sha_123",
+    )
+    # GitHub LIST API payload: 'merged' boolean is absent, 'merged_at' is present
+    canned_prs = [
+        {
+            "number": 1937,
+            "state": "closed",
+            # 'merged' key is intentionally omitted
+            "merged_at": "2026-08-28T18:17:34Z",
+            "merge_commit_sha": "merge_sha_123",
+            "head": {"sha": "head_sha_123"},
+            "base": {"ref": "develop"},
+        }
+    ]
+    monkeypatch.setattr(mod, "get_ref_commit_sha", lambda ref, repo: "target_tip_sha")
+    monkeypatch.setattr(mod, "get_reflog_shas", lambda branch, repo: {"head_sha_123"})
+    monkeypatch.setattr(mod, "are_descendants_integrated", lambda pr_sha, head_sha, tip, repo: True)
+    monkeypatch.setattr(mod, "is_ancestor", lambda ancestor_sha, descendant_sha, repo: True)
+
+    cls, evidence = mod.evaluate_and_classify_worktree(
+        wt=wt,
+        repo_owner="BenchBox-dev",
+        repo_name="BenchBox",
+        expected_repo_id=123,
+        token=None,
+        repo_root=tmp_path,
+        canned_prs=canned_prs,
+    )
+    assert cls.state == "verified-integrated"
+    assert cls.item_classification == "finish candidate"
+    assert len(evidence) == 1
+    assert evidence[0].pr_merged is True
+
+
+def test_snapshot_file_persistence(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setattr(mod, "resolve_repository_identity", lambda *a, **kw: (123, "BenchBox-dev/BenchBox", None))
+    monkeypatch.setattr(mod, "get_git_worktrees", lambda root: ([], None))
+    monkeypatch.setattr(mod, "get_local_branches", lambda root: [])
+
+    report = mod.audit_worktrees(repo_root=tmp_path)
+    assert report.get("snapshot_path") is not None
+    snapshot_path = Path(report["snapshot_path"])
+    assert snapshot_path.exists()
+    assert snapshot_path.is_file()
+    assert "_project/reports/worktree-lifecycle" in str(snapshot_path)
+
+
+def test_git_run_timeout():
+    # Verify timeout handling in _run_git
+    code, stdout, stderr = mod._run_git(["sleep", "2"], cwd=Path.cwd(), timeout=0.01)
+    assert code == 124
+    assert "timed out" in stderr


### PR DESCRIPTION
Address findings from adversarial review of PR #1937 against
_project/specs/worktree-lifecycle-evidence-contract.md:
- R1: Propagate git enumeration errors fail-closed to unavailable
- R2: Add GitHub API pagination traversal and truncation fail-closed bound
- R3: Fail closed to unavailable if all candidate PRs fail repository identity
- R4: Cross-check git remote URLs against resolved GitHub repository identity
- R5: Support list-API schema without merged boolean, record accurate endpoints
- R6: Write timestamped disposable report snapshot under _project/reports/worktree-lifecycle/
- R7: Add subprocess timeouts to _run_git calls
- R8: Remove live network calls in test_make_worktree_audit_json_output, add Spec §10 fixtures
- N1-N4: Token precedence (GH_TOKEN over GITHUB_TOKEN), clean signal accuracy, and prunable state
