### PR TITLE
docs(blog): lead voice guides with what to write

### DIFF
--- a/.claude/skills/bossmode/SKILL.md
+++ b/.claude/skills/bossmode/SKILL.md
@@ -1,178 +1,133 @@
 ---
 name: bossmode
-description: Organize and execute complex multi-step work through an executive, accountable managers, focused workers, and independent review. Use when work divides across multiple parallel workstreams or requires an independent review gate.
-version: 0.2.0
+description: Organize and execute complex multi-step work through an executive, one persistent manager, focused workers, and independent review. Use when work divides across parallel workstreams or requires an independent review gate.
+version: 0.3.2
 tools: Bash, Read, Write, Edit, Task
 ---
 
 # Bossmode
 
-Operate using this organizational structure:
+Use Bossmode for a complex goal that benefits from delegated work, isolated
+workspaces, or an independent review gate. For routine work that does not need
+this structure, act directly unless the user explicitly invokes Bossmode.
+
+## Required Topology
 
 ```text
-Executive (Loading Session Coordinator)
-  -> Manager(s) (Goal Owner & Worktree Coordinator)
-      -> Worker(s) (Focused Implementers in Dedicated Worktrees)
-      -> Independent Reviewer (Read-Only Evaluator)
+User <-> Executive <-> exactly one persistent, resumable Manager
+                         <-> Workers / Independent Reviewer
 ```
 
-The loading agent session acts as coordinator (Executive and Manager). Two separations are mandatory:
-1. **Worker Isolation**: A worker must not review its own work.
-2. **Reviewer Independence**: The reviewer must be a separate dispatch running an enforced read-only configuration.
+The Executive must never act as the Manager or dispatch or direct Workers or
+Reviewers. Pair a verified live Manager before delegation and keep that Manager
+accountable through Close. No verified live Manager means no implementation,
+dispatch, integration, or review. Replace a Manager only through
+[references/recovery.md](references/recovery.md).
 
-Use Bossmode when a goal requires parallel workstreams in separate worktrees or an explicit independent review gate. For single-file, single-symbol, or routine edits, act directly without spawning a hierarchy. Project tracking (e.g. `todo-db`, BenchBox `todo`) remains authoritative.
+Before pairing the Manager or dispatching any Worker or Reviewer, read
+[references/agent-execution.md](references/agent-execution.md). It owns model,
+reasoning-effort, harness, and Manager-capability selection. Do not reproduce
+those details here.
 
-## Roles and Authority
+After pairing, the Manager reads
+[references/manager.md](references/manager.md). The Executive reads the
+recovery reference only when the Manager is lost, unresponsive, or must be
+replaced. Do not load both references routinely.
 
-### Executive
-- Define outcomes, priorities, constraints, and authority boundaries.
-- **Authorization Boundary**: A user request to implement authorizes repository writes within scope. A review, audit, or full-pass plan produces findings only; remediation requires a subsequent user turn (`shared-review-protocol/SKILL.md` [REVIEW-AUTH-001]). The human user holds sole authority over remote pushes, draft PRs, and destructive operations.
-- Direct Managers; do not invoke worker CLIs directly.
-- Accept concise summaries; do not micromanage workers.
+## Authority
 
-### Manager
-- Decompose goals into non-overlapping assignments with explicit boundaries and acceptance criteria.
-- **Workspace Isolation**: Allocate dedicated worktrees for parallel workers (`git worktree add <path> -b bm/<goal>/<worker-n>`). Never permit concurrent writers on the same branch or workspace.
-- **Tracker & Claim Safety**: Parallel workers share the single active task claim and must operate on disjoint path bounds. If the project tracker forbids concurrent workers, run them sequentially.
-- Maintain proactive checkins with the Executive. Report progress when batches return or milestones pass.
-- Delegate fixes back to workers. Do not act as primary implementer or independent reviewer of the same work.
-- Arrange independent review before recommending acceptance to the Executive.
+- The Executive defines the outcome, priorities, constraints, acceptance
+  criteria, and authority boundary, then directs only the Manager. It may
+  inspect live state and evidence read-only at material gates.
+- **[REVIEW-AUTH-001]** Only the user may authorize writes. A review, audit, or
+  plan produces findings only, even when the same user turn also asks for fixes.
+  A later user turn may authorize narrow remediation of reported findings. That
+  authority does not include unrelated cleanup, auto-merge, destructive work,
+  hosted-service writes, or remote repository writes unless the user explicitly
+  authorizes them. Internal verification of already-authorized implementation
+  is not a review and may run within that implementation scope.
+- An implementation request authorizes only in-scope repository writes. Only
+  the user may authorize remote pushes, PR creation, destructive cleanup, or
+  protected trust and permission approvals.
+- The Manager and delegated agents must stop and report a protected approval;
+  they must never approve one themselves.
 
-### Workers
-- Own a single bounded assignment within an assigned worktree.
-- Follow every rule in §Delegation Envelope; it is the contract under which workers are dispatched.
+## Separation of Duties
 
-### Independent Review
-- Structurally independent from implementation; must not have authored the reviewed work.
-- **Read-Only Enforcement**: Inspect artifacts, code, and test outputs using enforced read-only modes (hard sandbox, tool allowlist, or plan mode). Never edit repository files, commit, push, or auto-merge.
-- Judge work from the worker log, the worktree diff, and recorded verification output. Do not re-run mutating checks. If required evidence logs are missing, report that as a defect.
-- Return concrete defect descriptions and acceptance recommendations.
+The Manager owns decomposition, task claims, worker and integration worktrees,
+dispatch, integration, evidence, corrections, the independent-review cycle,
+and cleanup that the user has explicitly authorized. The Manager must not
+author implementation changes or serve as the Independent Reviewer. It
+integrates without editing source in a dedicated integration worktree and
+delegates content fixes and conflicts to Workers.
 
-## Operating Cycle
+Workers receive one bounded assignment with path ownership, permission scope,
+success criteria, and an output contract. Concurrent writers must have
+disjoint paths and worktrees.
 
-1. **Direct**: Executive defines the goal, constraints, and scope.
-2. **Isolate**: Manager breaks down assignments and provisions dedicated Git worktrees for workers.
-3. **Execute**: Workers run within their worktrees, execute verification ladders, and write outputs to `/tmp/bossmode/<goal>/<worker-n>.log`. Manager reports progress upon worker return.
-4. **Integrate**: Manager merges worker branches into an integration branch (`bm/<goal>/integration`) without source edits. Content conflicts are delegated back to workers.
-5. **Review**: A separate reviewer evaluates the integrated outcome against acceptance criteria using an enforced read-only configuration.
-6. **Gate**:
-   - *Review Passed*: Manager recommends acceptance to the Executive.
-   - *Gaps Found*: The reviewer returns findings and stops. Manager delegates each finding to a worker as a bounded fix assignment, then re-runs step 5. After two failed correction rounds, stop and escalate outstanding findings to the Executive.
-7. **Close**: Executive presents verified results to the user for final approval. After acceptance, remove worker worktrees (`git worktree remove`) and delete merged worker branches. Follow `shared-change-framework` for commit/PR close-out unless local-only.
+The Independent Reviewer must not have authored the work. Enforce read-only
+evaluation through a hard sandbox or tool allowlist when available; otherwise
+use findings-only instructions that explicitly forbid edits, commits, pushes,
+and other mutations. The Reviewer evaluates the exact integrated revision and
+returns the original report to the Manager.
 
-## Checkin Loop
+Operate from live session state, Git, and durable artifacts. Do not invent a
+registry, scheduler, generation protocol, background polling loop, or clock-
+based health system. Transient logs are diagnostics, not durable Close evidence.
 
-The Manager reports progress upward to the Executive proactively; the Executive remains event-driven and does not poll.
+## Executive Reporting
 
-- **Trigger**: Report when a worker batch returns, at major milestone completions, or if a worker is blocked or exceeds its time budget.
-- **Payload**:
-  - *Current Focus*: Active worker IDs, assigned tasks, and worktree locations.
-  - *Completed Milestones*: Steps finished and verification checks passed since last checkin.
-  - *Blockers & Deviations*: Immediate obstacles, stuck workers, or unexpected failures.
-  - *Next Action*: Immediate next milestone and planned next checkin event.
+Begin every user-facing Executive message, including Close, with this exact
+line:
 
-## Model Tiers
+```text
+-B-O-S-S-M-O-D-E-
+```
 
-Tiers describe operating roles, not absolute quality rankings. Match models to task complexity and risk.
+Do not add the marker to internal Manager, Worker, or Reviewer messages.
 
-*Selection Rule*: Pick the tier here; take the exact identifier from the target harness row below. Default reasoning effort to `medium`. Use maximum effort only for Tier 1 adversarial review; use `low` for mechanical bulk work.
+Keep progress status separate from terminal outcome:
 
-- **Tier 1: Strategic**
-  - Models: `gpt-5.6-sol`, `claude-fable-5`, `grok-4.6`, `gemini-3.7-flash-high`
-  - Usage: Strategic planning, architecture, high-risk tradeoffs, and final adversarial review.
-- **Tier 2: Generalist**
-  - Models: `gpt-5.6-terra`, `claude-opus-5`, `grok-4.5`, `gemini-3.7-flash-medium`, `muse-spark-1.2`
-  - Usage: Management, decomposition, integration, investigation, and routine review.
-- **Tier 3: Contributor**
-  - Models: `gpt-5.6-luna`, `claude-sonnet-5`, `gemini-3.7-flash-low`, `gemini-3.7-flash-tiered`, `muse-spark-1.2-contributor`
-  - Usage: Focused implementation, bounded research, bulk work, and parallel coverage.
+- Progress: `in_progress`, `waiting_user`, `blocked`,
+  `verified_awaiting_acceptance`.
+- Terminal outcome: `complete`, `partial`, `cancelled`, `superseded`.
 
-## Reasoning Effort Reference
+Use progress status while the goal remains open. Report a terminal outcome only
+when the goal is closed. A material update states:
 
-| Harness | CLI Flag / Option | Supported Values (Lowest to Highest) |
-| :--- | :--- | :--- |
-| **pi** | `--thinking <level>` | `off`, `minimal`, `low`, `medium`, `high`, `xhigh`, `max` |
-| **claude** | `--effort <level>` | `low`, `medium`, `high`, `xhigh`, `max` |
-| **muse** | `--reasoning-effort <EFFORT>` | `none`, `minimal`, `low`, `medium`, `high`, `xhigh`, `ultra` |
-| **agy** | `--effort <level>` | `low`, `medium`, `high` |
-| **grok** | `--reasoning-effort <EFFORT>` | `low`, `medium`, `high`, `xhigh` |
-| **codex** | `-c model_reasoning_effort="<level>"` | `low`, `medium`, `high`, `xhigh`, `max`, `ultra` |
-| **prime-agent** | `--thinking <level>` | `off`, `minimal`, `low`, `medium`, `high`, `xhigh`, `max` |
+- Instruction coverage: delivered, open, and user-approved deferred work.
+- Final decisions and any superseded interpretations.
+- Durable verification evidence and independent-review state.
+- Material risks, blockers, and protected approvals.
+- The next action.
 
-For `jcode`, `opencode`, `hermes`, `goose`, and `aider`, effort is selected via model variants (e.g. `gemini-3.7-flash-tiered`, `:thinking` suffix) or provider settings.
+Report Manager pairing at start, replacement, and Close. Suppress Worker IDs,
+models, worktrees, and command chronology unless the user requests them or they
+are needed to explain an exception.
 
-## Agent Dispatch
+## Execution and Close
 
-### Delegation Envelope
+1. The Executive gives the Manager a compact charter containing the requested
+   outcome, instruction coverage, constraints, authority, and acceptance
+   criteria.
+   The close is encouragement only and does not change the charter's scope,
+   authority, constraints, success criteria, verification, or return contract.
+   After all operational content, end the charter with exactly:
+   `I have strong confidence in your ability to complete this goal. Good luck!`
+   This does not apply to Independent Reviewer prompts, steering messages, or
+   Executive reports.
+2. The Manager follows the Manager reference to isolate and dispatch work,
+   integrate without authoring changes, collect durable evidence, and obtain
+   independent review.
+3. The Manager supplies a Close packet with instruction-by-instruction
+   coverage, the exact integrated revision, durable verification evidence, the
+   original Independent Reviewer report, and all remaining, preserved,
+   blocked, or user-approved deferred work.
+4. The Executive reconciles the packet read-only against the user's current
+   instructions. Its summary must expose every unresolved reviewer finding.
 
-Every delegated prompt — native or headless — must include:
-1. Exact path boundaries (do not modify files outside scope).
-2. Git safety: Never run `git add -A`. Stage only modified files explicitly by path.
-3. Identity safety: Adhere to `[COMMIT-IDENTITY-001]`; do not commit under synthetic or vendor agent identities (`shared-change-framework/SKILL.md`).
-4. Verification: Run the repository's narrowest proving check before returning.
-5. Evidence: Save command output to `/tmp/bossmode/<goal>/<worker-n>.log` and return concise status.
-6. Reviewer prompts additionally state acceptance criteria, require findings-only output, and forbid edits, commits, and pushes.
-
-Headless dispatch may suppress interactive approval prompts only when write scope is bounded by a sandbox, workspace flag, or dedicated worktree. Never pass flags that remove path or permission limits (e.g. `--permission-mode acceptEdits`, `--dangerously-skip-permissions`, `--always-approve`, or `--yolo`).
-
-### Native Host Subagents
-
-When running inside an environment with native subagent tooling (e.g. Antigravity `invoke_subagent`, Codex threads, Claude subagents), prefer native dispatch:
-- Assign explicit roles, bounded prompts, and path constraints matching the Delegation Envelope.
-- Reviewer subagents must run with read-only instructions and tools.
-
-### Known-Good Harness Configurations
-
-Confirm binary presence with `command -v <harness>` before dispatch.
-
-#### Frontier Lab Harnesses
-
-- **codex**
-  - Worker (Write): `codex exec -C "$WORKSPACE" --model "$MODEL" --sandbox workspace-write "$PROMPT"`
-  - Reviewer (Hard Read-Only): `codex exec -C "$WORKSPACE" --model "$MODEL" --sandbox read-only "$PROMPT"`
-  - Known-good models: `gpt-5.6-sol`, `gpt-5.6-terra`, `gpt-5.6-luna`
-  - Effort: Optional `-c model_reasoning_effort="<level>"`
-- **claude**
-  - Worker (Write): `(cd "$WORKSPACE" && claude --print --model "$MODEL" --effort "$EFFORT" "$PROMPT")`
-  - Reviewer (Hard Read-Only): `(cd "$WORKSPACE" && claude --print --tools Read,Grep,Glob --model "$MODEL" --effort "$EFFORT" "$PROMPT")`
-  - Known-good models: `claude-fable-5`, `claude-opus-5`, `claude-sonnet-5`
-- **agy**
-  - Worker (Write): `(cd "$WORKSPACE" && agy --model "$MODEL" --effort "$EFFORT" --print="$PROMPT")`
-  - Reviewer (Soft Read-Only): `(cd "$WORKSPACE" && agy --model "$MODEL" --effort "$EFFORT" --mode plan --print="$PROMPT")`
-  - Known-good models: `gemini-3.7-flash-high`, `gemini-3.7-flash-medium`, `gemini-3.7-flash-low`
-- **grok**
-  - Worker (Write): `grok --cwd "$WORKSPACE" --single "$PROMPT" --model "$MODEL" --reasoning-effort "$EFFORT"`
-  - Reviewer (Soft Read-Only): `grok --cwd "$WORKSPACE" --single "$PROMPT" --model "$MODEL" --reasoning-effort "$EFFORT" --permission-mode plan`
-  - Known-good models: `grok-4.6`, `grok-4.5`
-- **muse**
-  - Worker (Write): `muse exec --workspace "$WORKSPACE" --disable-approval --model "$MODEL" --reasoning-effort "$EFFORT" "$PROMPT"`
-  - Reviewer (Hard Read-Only): `muse exec --workspace "$WORKSPACE" --disable-approval --disable-write --disable-shell --model "$MODEL" --reasoning-effort "$EFFORT" "$PROMPT"`
-  - Known-good models: `muse-spark-1.2-contributor`, `muse-spark-1.2`
-  - Note: Unset invalid credentials with `env -u META_API_KEY` before execution.
-
-#### Extensible and Community Harnesses
-
-- **pi**
-  - Worker (Write): `(cd "$WORKSPACE" && pi --print --model "$MODEL" --thinking "$EFFORT" "$PROMPT")`
-  - Reviewer (Hard Read-Only): `(cd "$WORKSPACE" && pi --print --tools read,grep,find,ls --model "$MODEL" --thinking "$EFFORT" "$PROMPT")`
-  - Known-good models: `openai-codex/gpt-5.6-sol`, `openai-codex/gpt-5.6-terra`, `openai-codex/gpt-5.6-luna`, `anthropic/claude-fable-5`, `anthropic/claude-opus-5`, `anthropic/claude-sonnet-5`, `xai/grok-4.6`, `xai/grok-4.5`, `muse-spark/muse-spark-1.2-contributor`
-- **jcode**
-  - Worker (Write): `jcode run -C "$WORKSPACE" --model "$MODEL" "$PROMPT"`
-  - Reviewer (Hard Read-Only): `jcode run -C "$WORKSPACE" --disable-base-tools --tools read --model "$MODEL" "$PROMPT"`
-  - Known-good models: `gpt-5.6-sol`, `gpt-5.6-terra`, `gpt-5.6-luna`, `claude-fable-5`, `claude-opus-5`, `claude-sonnet-5`, `gemini-3.7-flash-tiered`, `muse-spark-1.2-contributor`
-- **goose**
-  - Worker (Write): `(cd "$WORKSPACE" && goose run --text "$PROMPT" --no-session --provider "$PROVIDER" --model "$MODEL")`
-  - Reviewer (Hard Read-Only): `(cd "$WORKSPACE" && goose review --prompt "$CRITERIA_FILE" --model "$MODEL")`
-- **prime-agent**
-  - Worker (Write): `prime-agent -p --cwd "$WORKSPACE" --provider "$PROVIDER" --model "$MODEL" --thinking "$EFFORT" "$PROMPT"`
-  - Reviewer (Hard Read-Only): `prime-agent -p --tools read,grep,find,ls --cwd "$WORKSPACE" --provider "$PROVIDER" --model "$MODEL" --thinking "$EFFORT" "$PROMPT"`
-- **opencode**
-  - Worker (Write): `(cd "$WORKSPACE" && opencode run -m "$MODEL" "$PROMPT")`
-  - Reviewer (Soft Read-Only): `(cd "$WORKSPACE" && opencode run --agent plan -m "$MODEL" "$PROMPT")`
-  - Note: Model format is `<provider>/<model>`.
-- **hermes**
-  - Worker (Write): `(cd "$WORKSPACE" && hermes chat -q "$PROMPT")`
-  - Reviewer (Hard Read-Only): `(cd "$WORKSPACE" && hermes chat -q --tools read,search "$PROMPT")`
-- **aider**
-  - Worker (Write): `(cd "$WORKSPACE" && aider --model "$MODEL" --message "$PROMPT" --yes-always --no-auto-commits)`
-  - Reviewer (Hard Read-Only): `(cd "$WORKSPACE" && aider --model "$MODEL" --message "$PROMPT" --chat-mode ask --yes-always)`
+Requested work cannot be declared out of scope without the user's agreement.
+Required integration, synchronization, review, or approval prevents
+`complete`. Use `verified_awaiting_acceptance` after verification and before
+user acceptance. Cleanup is a separate post-acceptance action and requires
+explicit user authority.

--- a/.claude/skills/bossmode/references/agent-execution.md
+++ b/.claude/skills/bossmode/references/agent-execution.md
@@ -1,0 +1,77 @@
+# Agent Execution
+
+Read this reference when pairing the Manager or selecting a Worker or
+Independent Reviewer. Bossmode retains ownership of decomposition,
+authorization, workspace isolation, and acceptance criteria.
+
+## Model Tiers
+
+Tiers describe operating roles, not absolute quality rankings. Match models to
+task complexity and risk.
+
+*Selection Rule*: Pick the tier here. For native dispatch, choose the listed
+tier model directly. When an external harness is selected, take its exact
+harness-specific identifier from
+[external-harnesses.md](external-harnesses.md). Default reasoning effort to
+`medium`. Use maximum effort only for Tier 1 adversarial review; use `low` for
+mechanical bulk work.
+
+- **Tier 1: Strategic**
+  - Models: `gpt-5.6-sol`, `claude-fable-5`, `grok-4.6`, `gemini-3.7-flash-high`
+  - Usage: Strategic planning, architecture, high-risk tradeoffs, and final adversarial review.
+- **Tier 2: Generalist**
+  - Models: `gpt-5.6-terra`, `claude-opus-5`, `grok-4.5`, `gemini-3.7-flash-medium`, `muse-spark-1.2`
+  - Usage: Management, decomposition, integration, investigation, and routine review.
+- **Tier 3: Contributor**
+  - Models: `gpt-5.6-luna`, `claude-sonnet-5`, `gemini-3.7-flash-low`, `gemini-3.7-flash-tiered`, `muse-spark-1.2-contributor`
+  - Usage: Focused implementation, bounded research, bulk work, and parallel coverage.
+
+## Reasoning Effort Reference
+
+| Harness | CLI Flag / Option | Supported Values (Lowest to Highest) |
+| :--- | :--- | :--- |
+| **pi** | `--thinking <level>` | `off`, `minimal`, `low`, `medium`, `high`, `xhigh`, `max` |
+| **claude** | `--effort <level>` | `low`, `medium`, `high`, `xhigh`, `max` |
+| **muse** | `--reasoning-effort <EFFORT>` | `none`, `minimal`, `low`, `medium`, `high`, `xhigh`, `ultra` |
+| **agy** | `--effort <level>` | `low`, `medium`, `high` |
+| **grok** | `--reasoning-effort <EFFORT>` | `low`, `medium`, `high`, `xhigh` |
+| **codex** | `-c model_reasoning_effort="<level>"` | `low`, `medium`, `high`, `xhigh`, `max`, `ultra` |
+| **prime-agent** | `--thinking <level>` | `off`, `minimal`, `low`, `medium`, `high`, `xhigh`, `max` |
+
+For `jcode`, `opencode`, `hermes`, `goose`, and `aider`, effort is selected via
+model variants such as `gemini-3.7-flash-tiered`, a `:thinking` suffix, or
+provider settings.
+
+## Dispatch Rules
+
+Treat native subagents and external harnesses as peer dispatch choices. Select
+between them using the factors relevant to the assignment: task and model fit,
+provider usage or capacity, cost, isolation or read-only strength, and useful
+parallelism. Assign an explicit role, bounded goal, path constraints,
+permission scope, success criteria, and output contract.
+
+Choose the dispatch mode from the delegated role:
+
+- **Manager:** select a channel only when current runtime capabilities or
+  behavioral evidence verify a stable live session identity, resume or
+  follow-up, live status and interrupt, and a working path to dispatch or
+  coordinate Workers and Reviewers. Do not infer Manager capability from a
+  one-shot Worker or Reviewer command. Invocations such as `--print`, `exec`,
+  `--single`, or equivalents are not Manager-capable unless a separate verified
+  continuation channel supplies every required capability; they remain valid
+  Worker or Reviewer choices.
+- **Worker:** use a write-capable mode only within the authorized workspace or
+  sandbox. Require the repository's narrowest proving check and explicit-path
+  staging; never permit `git add -A`.
+- **Reviewer:** use a separate dispatch that did not author the work. Prefer a
+  hard read-only sandbox or tool allowlist. A plan mode is soft read-only and
+  requires explicit findings-only instructions that forbid edits, commits,
+  pushes, and other mutations.
+
+Only when selecting an external or headless harness, read
+[external-harnesses.md](external-harnesses.md), choose the documented command
+for the role, and use it directly.
+
+Headless Worker dispatch may automate confirmations only when write scope is
+already bounded by a sandbox, workspace flag, or dedicated worktree. Never add
+flags that remove workspace, sandbox, or tool boundaries.

--- a/.claude/skills/bossmode/references/external-harnesses.md
+++ b/.claude/skills/bossmode/references/external-harnesses.md
@@ -1,0 +1,67 @@
+# External Harnesses
+
+Use these known-good direct configurations whenever an external harness is
+selected. Choose the documented command for the delegated role and use it
+directly. Only after an actual command failure may reactive diagnosis use
+`command -v` and the installed `--help` output to distinguish a missing binary
+from flag drift. Do not run those checks proactively.
+
+- Worker commands require already-authorized write scope bounded by a sandbox,
+  workspace, or dedicated worktree. Confirmation automation in a documented
+  Worker command is allowed only within that bounded scope.
+- Reviewer commands use the declared **Hard Read-Only** or **Soft Read-Only**
+  classification. Reinforce Soft Read-Only with findings-only instructions that
+  forbid edits, commits, pushes, and other mutations.
+- Do not add flags that remove workspace, sandbox, or tool boundaries.
+
+## Frontier Lab Harnesses
+
+- **codex**
+  - Worker (Write): `codex exec -C "$WORKSPACE" --model "$MODEL" --sandbox workspace-write "$PROMPT"`
+  - Reviewer (Hard Read-Only): `codex exec -C "$WORKSPACE" --model "$MODEL" --sandbox read-only "$PROMPT"`
+  - Known-good models: `gpt-5.6-sol`, `gpt-5.6-terra`, `gpt-5.6-luna`
+  - Effort: Optional `-c model_reasoning_effort="<level>"`
+- **claude**
+  - Worker (Write): `(cd "$WORKSPACE" && claude --print --model "$MODEL" --effort "$EFFORT" "$PROMPT")`
+  - Reviewer (Hard Read-Only): `(cd "$WORKSPACE" && claude --print --tools Read,Grep,Glob --model "$MODEL" --effort "$EFFORT" "$PROMPT")`
+  - Known-good models: `claude-fable-5`, `claude-opus-5`, `claude-sonnet-5`
+- **agy**
+  - Worker (Write): `(cd "$WORKSPACE" && agy --model "$MODEL" --effort "$EFFORT" --print="$PROMPT")`
+  - Reviewer (Soft Read-Only): `(cd "$WORKSPACE" && agy --model "$MODEL" --effort "$EFFORT" --mode plan --print="$PROMPT")`
+  - Known-good models: `gemini-3.7-flash-high`, `gemini-3.7-flash-medium`, `gemini-3.7-flash-low`
+- **grok**
+  - Worker (Write): `grok --cwd "$WORKSPACE" --single "$PROMPT" --model "$MODEL" --reasoning-effort "$EFFORT"`
+  - Reviewer (Soft Read-Only): `grok --cwd "$WORKSPACE" --single "$PROMPT" --model "$MODEL" --reasoning-effort "$EFFORT" --permission-mode plan`
+  - Known-good models: `grok-4.6`, `grok-4.5`
+- **muse**
+  - Worker (Write): `muse exec --workspace "$WORKSPACE" --disable-approval --model "$MODEL" --reasoning-effort "$EFFORT" "$PROMPT"`
+  - Reviewer (Hard Read-Only): `muse exec --workspace "$WORKSPACE" --disable-approval --disable-write --disable-shell --model "$MODEL" --reasoning-effort "$EFFORT" "$PROMPT"`
+  - Known-good models: `muse-spark-1.2-contributor`, `muse-spark-1.2`
+  - Note: Unset invalid credentials with `env -u META_API_KEY` before execution.
+
+## Extensible and Community Harnesses
+
+- **pi**
+  - Worker (Write): `(cd "$WORKSPACE" && pi --print --model "$MODEL" --thinking "$EFFORT" "$PROMPT")`
+  - Reviewer (Hard Read-Only): `(cd "$WORKSPACE" && pi --print --tools read,grep,find,ls --model "$MODEL" --thinking "$EFFORT" "$PROMPT")`
+  - Known-good models: `openai-codex/gpt-5.6-sol`, `openai-codex/gpt-5.6-terra`, `openai-codex/gpt-5.6-luna`, `anthropic/claude-fable-5`, `anthropic/claude-opus-5`, `anthropic/claude-sonnet-5`, `xai/grok-4.6`, `xai/grok-4.5`, `muse-spark/muse-spark-1.2-contributor`
+- **jcode**
+  - Worker (Write): `jcode run -C "$WORKSPACE" --model "$MODEL" "$PROMPT"`
+  - Reviewer (Hard Read-Only): `jcode run -C "$WORKSPACE" --disable-base-tools --tools read --model "$MODEL" "$PROMPT"`
+  - Known-good models: `gpt-5.6-sol`, `gpt-5.6-terra`, `gpt-5.6-luna`, `claude-fable-5`, `claude-opus-5`, `claude-sonnet-5`, `gemini-3.7-flash-tiered`, `muse-spark-1.2-contributor`
+- **goose**
+  - Worker (Write): `(cd "$WORKSPACE" && goose run --text "$PROMPT" --no-session --provider "$PROVIDER" --model "$MODEL")`
+  - Reviewer (Hard Read-Only): `(cd "$WORKSPACE" && goose review --prompt "$CRITERIA_FILE" --model "$MODEL")`
+- **prime-agent**
+  - Worker (Write): `prime-agent -p --cwd "$WORKSPACE" --provider "$PROVIDER" --model "$MODEL" --thinking "$EFFORT" "$PROMPT"`
+  - Reviewer (Hard Read-Only): `prime-agent -p --tools read,grep,find,ls --cwd "$WORKSPACE" --provider "$PROVIDER" --model "$MODEL" --thinking "$EFFORT" "$PROMPT"`
+- **opencode**
+  - Worker (Write): `(cd "$WORKSPACE" && opencode run -m "$MODEL" "$PROMPT")`
+  - Reviewer (Soft Read-Only): `(cd "$WORKSPACE" && opencode run --agent plan -m "$MODEL" "$PROMPT")`
+  - Note: Model format is `<provider>/<model>`.
+- **hermes**
+  - Worker (Write): `(cd "$WORKSPACE" && hermes chat -q "$PROMPT")`
+  - Reviewer (Hard Read-Only): `(cd "$WORKSPACE" && hermes chat -q --tools read,search "$PROMPT")`
+- **aider**
+  - Worker (Write): `(cd "$WORKSPACE" && aider --model "$MODEL" --message "$PROMPT" --yes-always --no-auto-commits)`
+  - Reviewer (Hard Read-Only): `(cd "$WORKSPACE" && aider --model "$MODEL" --message "$PROMPT" --chat-mode ask)`

--- a/.claude/skills/bossmode/references/manager.md
+++ b/.claude/skills/bossmode/references/manager.md
@@ -1,0 +1,81 @@
+# Manager Operations
+
+Read this reference only after the Executive pairs you as the one live Manager
+for a Bossmode goal. Remain the accountable, resumable Manager through Close.
+
+## Compact Charter
+
+Keep one concise charter containing:
+
+- The requested outcome and instruction coverage.
+- Scope, constraints, acceptance criteria, and authority boundaries.
+- Work assignments, disjoint path claims, and integration destination.
+- Applicable time, cost, worker, and review-round limits.
+
+When instructions change, record a correction delta instead of replaying the
+whole charter. Identify affected assignments and ensure each proceeds under the
+current instruction. Do not remove or defer requested work without user
+agreement.
+
+## Workspaces and Ownership
+
+Give every writing Worker a dedicated worktree and explicit path ownership.
+Never allow concurrent writers in one workspace or on overlapping paths. Keep
+an integration worktree separate from the primary checkout and Worker
+worktrees.
+
+Do not author source changes. Integrate verified Worker commits without editing
+their content. Send merge conflicts, review fixes, and other content changes to
+a bounded Worker assignment.
+
+## Dispatch and Evidence
+
+Follow [agent-execution.md](agent-execution.md) for Manager capability and every
+Worker or Reviewer selection. Each assignment states its goal, path boundary,
+permissions, success criteria, verification, and return contract.
+The close is encouragement only and does not change those terms. Every Worker
+assignment, including initial and correction assignments, must end after all
+operational content with exactly:
+`I have strong confidence in your ability to complete this assignment. Good luck!`
+Do not add this close to Independent Reviewer prompts, steering messages, or
+Executive reports.
+
+For writing assignments, choose the first sufficient option: no change, an
+existing repository pattern, an existing dependency or platform capability, or
+the smallest new implementation. Keep changes scoped and concurrent ownership
+disjoint. Before work begins, inspect the named worktree and branch state. Run
+the narrowest proving checks before project-wide verification.
+
+Before any commit, inspect the effective Git `user.name` and `user.email` and
+their configuration origins; use only the intended human identity. Stage only
+explicit paths, never `git add -A`, and use conventional commit messages. Push
+or open a PR only when the user has authorized that remote action.
+
+Require Workers to return bounded summaries containing changed paths, the
+exact revision, verification results, residual risk, and decisions needed.
+Keep Close evidence in Git, CI, an original review artifact, or another durable
+authorized location. Temporary logs may aid diagnosis but do not prove Close.
+
+## Corrections, Integration, and Review
+
+Steer an active assignment only when its channel supports reliable steering.
+Otherwise interrupt it, or let it finish and reject stale output, then
+re-delegate under the correction delta. Never assume pause or follow-up support.
+
+Integrate only assignments that satisfy their contracts. Dispatch an
+Independent Reviewer against the exact integrated revision and preserve the
+original findings. Delegate corrections to Workers and repeat independent
+review. After two failed review rounds by default, stop and return the
+outstanding findings to the Executive; a stricter charter limit wins.
+
+Provide the Executive only the facts required by the reporting and Close
+contracts in [../SKILL.md](../SKILL.md). Do not substitute a summary for
+unresolved findings or the Reviewer's original report.
+
+## Acceptance and Cleanup
+
+Verification does not imply acceptance. After the user accepts the outcome,
+perform cleanup only when the user has separately authorized it. Reconcile each
+exact worktree and branch against live ownership, dirtiness, merge state, and
+expected revision before removal. Preserve unrelated, ambiguous, or unaccepted
+work and report it instead of resetting or deleting it.

--- a/.claude/skills/bossmode/references/recovery.md
+++ b/.claude/skills/bossmode/references/recovery.md
@@ -1,0 +1,35 @@
+# Manager Recovery
+
+Read this reference only when the paired Manager is lost, unresponsive, or must
+be replaced. Do not use it during ordinary execution.
+
+## Authority and Containment
+
+Live runtime state is authoritative. Stored handles are hints only; reconcile a
+session against its live identity and state before acting on it.
+
+The Executive may interrupt verified live descendants only to contain work
+after Manager failure. The Executive must not redirect those agents or adopt,
+integrate, evaluate, or accept their work. Never act on a stale name, pane, or
+stored session handle alone.
+
+## Resume or Replace
+
+Resume the same Manager when its live identity, continuation channel, and
+ownership can be verified. Otherwise, before pairing a replacement:
+
+1. Reconcile live descendants and contain active writers.
+2. Inspect worktrees, branches, path claims, current instructions, correction
+   deltas, integrated revisions, and durable evidence.
+3. Preserve ambiguous or unverified work. Do not reset, clean, merge, or delete
+   it automatically.
+4. Give the replacement Manager a bounded handoff of verified state and route
+   it to [manager.md](manager.md).
+5. Report the replacement through the Executive reporting contract.
+
+No replacement may begin dispatch, implementation, integration, or review
+until it is verified live and owns the reconciled charter and work boundaries.
+
+Recovery is event-driven. Do not invent generations, clocks, background health
+polling, a scheduler, or a registry to simulate runtime authority. Use live
+sessions, Git, and durable authorized artifacts as evidence.

--- a/_blog/PUBLISHING.md
+++ b/_blog/PUBLISHING.md
@@ -44,64 +44,18 @@ Create the post in `_blog/{series}/drafts/`. Follow the style guide:
 
 - **Voice**: Community-inclusive ("we" not "I"), enthusiastic but grounded
 - **Claims**: Back with data, not opinions ("2.3x faster" not "much faster")
-- **Platforms**: Neutral, no advocacy ("outperformed by 15%" not "crushes")
+- **Platforms**: Neutral, no advocacy ("In this run, [platform A] finished [query] in [time] on [hardware]; [platform B] finished the same query in [time]. Include benchmark, scale, and phase so readers can interpret the measurement.")
 - **Methodology**: Show your work, acknowledge limitations
 
-See `_blog/STYLE_GUIDE.md` for the full guide and `_blog/VOICE_REFERENCE.md` for a quick tone reference.
+See `_blog/STYLE_GUIDE.md` for the full guide and `_blog/VOICE_REFERENCE.md` for a quick tone reference. Sentence craft is defined in VOICE_REFERENCE. Do not copy it here.
 
-### 2. Run content validation
+### 2. Editorial check
 
-From the private repo root, validate the post against style rules:
-
-```python
-from benchbox.release.content_validation import validate_file
-from pathlib import Path
-
-violations = validate_file(
-    Path("_blog/{series}/drafts/{post}.md"),
-    repo_root=Path("."),
-)
-for v in violations:
-    print(v)
-```
-
-Or validate all blog content at once:
-
-```python
-from benchbox.release.content_validation import validate_content
-from pathlib import Path
-
-result = validate_content(Path("."), patterns=["_blog/**/*.md"], verbose=True)
-print(result.summary())
-for v in result.violations:
-    print(v)
-```
-
-**Severity levels:**
-
-| Level | Rule categories | Action |
-|-------|----------------|--------|
-| Error | `punctuation`, `platform_advocacy` | Must fix before publishing |
-| Warning | `vague_claims`, `marketing`, `voice`, `restricted_vendor` | Should fix |
-| Suggestion | `hedging`, `cliche` | Consider fixing |
-
-**Inline overrides** for intentional exceptions:
-
-```markdown
-<!-- content-ok: restricted_vendor -->
-Oracle's DeWitt clause restricts benchmark publication...
-```
-
-Use the same override when naming a vendor as the origin of a SQL dialect feature, not to imply platform support, but to provide accurate technical context:
-
-```markdown
-<!-- content-ok: restricted_vendor -->
-**Oracle DUAL table (1 failure)**: Q17_v4 references the `DUAL` table (an Oracle-ism).
-```
+`benchbox.release.content_validation` is not in this repository. Before publication, run the STYLE_GUIDE editorial checklist by hand (Voice, punctuation, limitations, citations). Do not record a validator pass.
 
 ### 3. Finalize the post
 
-Once validation passes and the post is reviewed:
+Once the editorial checklist is complete and the post is reviewed:
 
 1. Move (or copy) the draft to `_blog/{series}/published/` for archival
 2. Prepare the filename for publication: `YYYY-MM-DD-{slug}.md`
@@ -203,7 +157,7 @@ Note: `benchbox-sync` only syncs files under `ALLOWED_ROOT_FILES` (which include
 
 - [ ] Draft written in `_blog/{series}/drafts/`
 - [ ] Style guide followed (`STYLE_GUIDE.md`)
-- [ ] Content validation passes (no errors)
+- [ ] STYLE_GUIDE editorial checklist completed by hand
 - [ ] ABlog frontmatter added (`blogpost`, `date`, `author`, `tags`)
 - [ ] Filename follows convention: `YYYY-MM-DD-{slug}.md`
 - [ ] Post copied to `docs/blog/` in public repo

--- a/_blog/STYLE_GUIDE.md
+++ b/_blog/STYLE_GUIDE.md
@@ -2,8 +2,8 @@
 
 > A guide for writing technical blog posts that educate, inform, and engage the data engineering community with a friendly, OSS-community voice.
 
-**Version**: 2.0
-**Last Updated**: 2026-01-22
+**Version**: 2.1
+**Last Updated**: 2026-08-29
 
 ---
 
@@ -24,15 +24,17 @@
 
 ## Voice & Tone
 
-The BenchBox voice is that of a **friendly community member sharing useful findings**. We're enthusiastic about what we've learned, rigorous about methodology, and neutral when comparing tools. We write to help readers make informed decisions, not to tell them what to think.
+The BenchBox voice is that of a **friendly community member sharing useful findings**. We're enthusiastic about what we've learned, rigorous about methodology, and neutral when comparing tools. We write so readers can make informed decisions.
 
 ### Core Voice: "Factual yet friendly, technical yet understandable"
+
+Drafting card: [_blog/VOICE_REFERENCE.md](VOICE_REFERENCE.md), including Sentence craft. Do not copy that section into this file.
 
 ### Voice Characteristics
 
 **1. Community-Inclusive**
 
-Use "we" to represent the project and community. Position yourself as a fellow practitioner sharing discoveries, not an authority pronouncing judgments.
+Write as a fellow practitioner sharing discoveries with the community.
 
 ✅ **Do**:
 - "We designed BenchBox's validation to check row counts, column types, and sort order..."
@@ -64,9 +66,11 @@ Celebrate findings with genuine enthusiasm, backed by data. Avoid empty superlat
 Show your work. Acknowledge limitations. Let methodology build credibility.
 
 ✅ **Do**:
-- "BenchBox's power phase uses cold cache between queries, we validated this adds ~2s overhead on c6i.4xlarge instances."
+- "BenchBox's power phase uses cold cache between queries."
 - "BenchBox currently supports analytical benchmarks (TPC-H, TPC-DS, SSB, ClickBench). Transactional benchmarks are not yet supported."
 - "Our DataFrame path has limitations: correlated subqueries and CASE expressions require manual translation."
+
+Name hardware and overhead in Methodology; do not invent a number here.
 
 ❌ **Don't**:
 - Make claims without specifying test conditions
@@ -75,31 +79,33 @@ Show your work. Acknowledge limitations. Let methodology build credibility.
 
 **4. Neutral on Platforms**
 
-When demonstrating BenchBox, present results without platform advocacy. Focus on what we learned about benchmarking, not which platform "wins."
+Report what the run shows about benchmarking. Ground every platform result in its conditions.
 
 ✅ **Do**:
 - "We ran BenchBox against three platforms to demonstrate multi-platform support."
-- "Results varied by query type, aggregations and joins showed different patterns."
+- "Results varied by query type. Aggregations and joins showed different patterns."
 - "Each platform required different dialect translation in BenchBox's SQL layer."
 
 ❌ **Don't**:
 - "Platform B is clearly inferior and should be avoided."
 - "Vendor X backed the wrong horse and needs to pivot."
 - "Anyone still using Y is making a mistake."
+- "Each platform has different strengths for different workloads."
 
 **5. Helpful and Educational**
 
-Frame content as sharing learnings, not lecturing. Invite readers to explore further.
+Share concrete lessons as one practitioner to another. Invite readers to explore further.
 
 ✅ **Do**:
 - "Here's what we learned about benchmark methodology from this exercise..."
-- "If you're building similar benchmarking pipelines, these patterns may help..."
-- "We'd love to hear about your experiences, open an issue to discuss."
+- "Here's how we approached TPC-H compliance in BenchBox."
+- "Open an issue to discuss."
 
 ❌ **Don't**:
-- "You must follow these steps exactly."
-- "The only correct approach is..."
-- "If you're not doing X, you're doing it wrong."
+- "You must follow TPC compliance exactly."
+- "The only correct way to benchmark is..."
+- "If you're not validating, you're wrong."
+- "you may want to consider; your mileage may vary"
 
 **6. Accessible Without Dumbing Down**
 
@@ -118,9 +124,9 @@ Layer explanations. Define terms naturally. Use examples to ground abstract conc
 
 | Content Type            | Tone                     | Example Opening                                                                             |
 | ----------------------- | ------------------------ | ------------------------------------------------------------------------------------------- |
-| **Architecture/Design** | Exploratory, educational | "Let's look at how BenchBox handles multi-platform dialect translation..."                  |
-| **Methodology Guide**   | Rigorous, helpful        | "Consistent benchmark results require careful methodology. Here's our approach..."          |
-| **Tutorial/How-To**     | Helpful, encouraging     | "Getting started with BenchBox is straightforward. Here's a quick guide..."                 |
+| **Architecture/Design** | Exploratory, educational | "BenchBox handles multi-platform dialect translation in the layers described below."        |
+| **Methodology Guide**   | Rigorous, helpful        | "Here is the protocol we use for cold cache between runs."                                  |
+| **Tutorial/How-To**     | Helpful, encouraging     | "Install BenchBox with `uv add benchbox`, then run TPC-H at SF 0.01 with the command below." |
 | **BenchBox in Action**  | Curious, evidence-based  | "We ran TPC-H at SF10 across three platforms. Here's what we learned about benchmarking..." |
 | **Release Notes**       | Celebratory, grateful    | "We're excited to release v0.2.0. Thanks to our 23 contributors..."                         |
 
@@ -137,6 +143,13 @@ Layer explanations. Define terms naturally. Use examples to ground abstract conc
 
 **Hedging Everything**
 > ❌ "It might possibly be the case that perhaps in some scenarios..." (Be clear about what you found)
+> ❌ "This is not a certification. It is not a complete ranking. It does not claim..."
+> ❌ "Each platform has different strengths for different workloads."
+> ❌ "Your mileage may vary."
+> ❌ "Platform results illustrate BenchBox. They are not a buying recommendation."
+> ❌ "We are community members, not analysts."
+
+State the finding once. Keep a negative bound only when it changes the claim or carries the news.
 
 **Forced Humor**
 > ❌ "OMG you won't BELIEVE these benchmark results! 🚀🔥 Database X got absolutely DESTROYED lol"
@@ -146,6 +159,8 @@ Layer explanations. Define terms naturally. Use examples to ground abstract conc
 ## Content Principles
 
 ### 1. Lead with Data, Not Opinions
+
+Lead with the point of the section. A measurement belongs in a results or methodology section; an architecture section may lead with the mechanism.
 
 ❌ **Don't**: "BenchBox is clearly the best benchmarking framework available."
 ✅ **Do**: "BenchBox completed TPC-H data generation and all 22 queries in under 10 minutes at SF1, with validation against reference answers."
@@ -200,12 +215,12 @@ Full configuration and raw results: [link to GitHub]
 ### 4. Explain the Trade-offs
 
 ❌ **Don't**: "SQL mode is better than DataFrame mode."
-✅ **Do**: "SQL mode supports all N queries. DataFrame mode currently covers N of M but offers better something."
+✅ **Do**: "SQL mode covers all queries in the spec set. DataFrame mode covers [N] of [M] queries and [named gain, with a number or condition]."
 
 **Always discuss**:
-- What scenarios favor each approach
-- Trade-offs (compliance vs. flexibility, setup complexity vs. reproducibility)
-- When results might differ (different scale factors, platforms, configurations)
+- When a reader should choose each approach, with a number or named condition
+- Trade-offs (compliance vs flexibility, setup cost vs reproducibility)
+- When results might differ (scale factor, platform, configuration)
 
 ### 5. Celebrate the Community
 
@@ -213,7 +228,7 @@ Acknowledge contributors, highlight community work, invite participation.
 
 - "Thanks to contributor @username for this improvement..."
 - "This finding came from a community discussion in issue #123..."
-- "We'd love your feedback, join the discussion at..."
+- "We'd love your feedback. Join the discussion at..."
 
 ---
 
@@ -227,6 +242,8 @@ Acknowledge contributors, highlight community work, invite participation.
 > [One-sentence summary of what readers will learn]
 
 **TL;DR**: [2-3 sentence summary]
+
+The pull quote and TL;DR state the finding. A bound belongs there when the summary would be misleading without it. Negative scope is allowed when it is the finding ("When two timings are not a comparison").
 
 ---
 
@@ -309,7 +326,7 @@ Acknowledge contributors, highlight community work, invite participation.
 
 ### 2. Define Technical Terms
 
-On first use, define or link to definitions:
+Define a term the first time it appears. Restate later if a skimming reader would miss the first definition.
 
 ```markdown
 BenchBox measures how vectorized execution (processing data in batches of
@@ -390,22 +407,22 @@ Don't use for:
 
 ### Em-dashes and En-dashes
 
-**Never use em-dashes (,) or en-dashes (-) in BenchBox content.** These characters create inconsistency across text editors, copy-paste operations, and rendering contexts.
+Do not use em-dashes (Unicode U+2014) or en-dashes (Unicode U+2013) in BenchBox content. These characters create inconsistency across text editors, copy-paste operations, and rendering contexts. Use ASCII hyphen `-` for ranges (10-20), commas or parentheses for asides, and a colon or a new sentence for an explanation. Do not replace a dash with a bare comma.
 
 | Character | Unicode | Status       |
 | --------- | ------- | ------------ |
-| Em-dash,  | U+2014  | ❌ Prohibited |
-| En-dash - | U+2013  | ❌ Prohibited |
-| Hyphen -  | U+002D  | ✅ Allowed    |
+| Em-dash   | U+2014  | ❌ Prohibited |
+| En-dash   | U+2013  | ❌ Prohibited |
+| Hyphen    | U+002D  | ✅ Allowed    |
 
 ### Alternatives
 
-| Instead of                | Use                   | Example                                |
-| ------------------------- | --------------------- | -------------------------------------- |
-| Parenthetical, like this, | Commas or parentheses | "Parenthetical, like this, works well" |
-| A statement,              | Colon                 | "A statement:"                         |
-| Number range 10-20        | Hyphen                | "10-20"                                |
-| Attribution, Author       | Colon or comma        | "Attribution: Author"                  |
+| Instead of                         | Use                   | Example                                |
+| ---------------------------------- | --------------------- | -------------------------------------- |
+| Em-dash or en-dash aside           | Commas or parentheses | "Parenthetical, like this, works well" |
+| Em-dash introducing an explanation | Colon or a new sentence | "A statement:"                       |
+| Number range written with en-dash  | ASCII hyphen          | "10-20"                                |
+| Attribution with em-dash           | Colon or comma        | "Attribution: Author"                  |
 
 **Why this rule?** Plain ASCII punctuation is more portable, accessible, and consistent across all editing environments and platforms.
 
@@ -562,13 +579,13 @@ Include 5-8 relevant tags:
 **Tone**: Curious, evidence-based, neutral on platform performance
 
 **Essential elements**:
-- Clear question about benchmarking methodology (not "which platform wins")
+- Clear question about benchmarking methodology
 - BenchBox commands used, fully reproducible
 - Results presented neutrally (no platform advocacy)
 - Focus on what we learned about the benchmarking process
 - Methodology details and limitations
 
-**Important**: This is NOT a platform comparison post. The focus is on demonstrating BenchBox's capabilities and sharing methodology insights. Platform results are presented as illustration, not as recommendations.
+**Important**: Use platform results to illustrate BenchBox methodology and reporting, with enough conditions for readers to interpret each measurement.
 
 **Example topics**:
 - Running TPC-H at scale: what happens from SF1 to SF100
@@ -609,6 +626,9 @@ Include 5-8 relevant tags:
 - [ ] Neutral on platforms (no platform advocacy or vendor criticism)
 - [ ] Helpful framing (sharing learnings, not lecturing)
 - [ ] Accessible explanations (terms defined, examples given)
+- [ ] How-to and Try-it-yourself steps use direct imperatives ("Run", "Open")
+- [ ] Em-dashes and en-dashes are absent (ASCII hyphen only)
+- [ ] Every negative bound adds a fact, legal boundary, or scope condition
 
 ### Technical Accuracy
 
@@ -664,6 +684,7 @@ This style guide is informed by analysis of OSS blog best practices from:
 
 | Version | Date       | Changes                                                                                                        |
 | ------- | ---------- | -------------------------------------------------------------------------------------------------------------- |
+| 2.1     | 2026-08-29 | Voice examples lead with what to write. Sentence craft lives in VOICE_REFERENCE. Hedge rewrites removed. Punctuation glyphs described by codepoint. Publishing steps no longer call a missing validator. |
 | 2.0     | 2026-01-22 | Complete rewrite for OSS community voice. Removed analyst/commentator tone. Added neutral comparison guidance. |
 | 1.2     | 2025-12-15 | Voice characteristics (removed from this guide)                                                                |
 | 1.1     | 2025-12-02 | Citations section                                                                                              |
@@ -671,4 +692,4 @@ This style guide is informed by analysis of OSS blog best practices from:
 
 ---
 
-*Last updated: 2026-01-22*
+*Last updated: 2026-08-29*

--- a/_blog/VOICE_REFERENCE.md
+++ b/_blog/VOICE_REFERENCE.md
@@ -8,67 +8,87 @@
 
 **"Factual yet friendly, technical yet understandable"**
 
-We are a **community member sharing useful findings about benchmarking**, not an analyst pronouncing judgments on databases.
+Write as a community member sharing useful findings about the tool, methodology, and craft of benchmarking. Report measurements with their conditions, and describe ranking only as a BenchBox feature.
 
-**BenchBox content is about the tool, the methodology, and the craft of benchmarking**,not about which platform "wins."
+---
+
+## Sentence craft
+
+Write clear sentences, then apply voice and identity.
+
+1. Lead with what happened, what we built, or what to run. Add a distinction only when it changes how the reader should interpret the claim.
+2. Give each sentence a main point. A bound that makes the claim accurate belongs in that sentence. Cut empty openers ("Let's look at", "It is important to note").
+3. Place a bound where it keeps a claim accurate: beside a number, in the TL;DR, in Methodology, or in Limitations. Repeat it when a skimming reader has a new job. Keep negative scope when it carries the news, a legal boundary, or a necessary condition. Drop any denial that only echoes an adjacent affirmation (even a single "X is Y. X is not Z" pair).
+4. Use direct imperatives for concrete steps such as "Run `benchbox …`" and "Open Query", in any post type. Describe methodology through what we did.
+
+This matches the global writing standard: plain language; simplicity, brevity, clarity, humanity.
 
 ---
 
 ## The 6 Voice Rules
 
+Each rule leads with what to write. Avoid is a counterexample.
+
 ### 1. Community-Inclusive
 Use "we" for the project/community.
 
-| Don't                                       | Do                                                     |
-| ------------------------------------------- | ------------------------------------------------------ |
-| "I think this approach is better"           | "Our testing showed this approach produced more stable results" |
-| "In my expert opinion"                      | "Based on our benchmark design experience"             |
-| "You should definitely use BenchBox"        | "BenchBox users can reproduce these results with..."   |
+| Write                                                     | Avoid                                     |
+| --------------------------------------------------------- | ----------------------------------------- |
+| "Our testing showed this approach produced more stable results" | "I think this approach is better"         |
+| "Based on our benchmark design experience"                | "In my expert opinion"                    |
+| "BenchBox users can reproduce these results with..."      | "You should definitely use BenchBox"      |
 
 ### 2. Enthusiastic but Grounded
 Celebrate with data, not superlatives.
 
-| Don't                                        | Do                                                              |
-| -------------------------------------------- | --------------------------------------------------------------- |
-| "Revolutionary benchmarking framework!"      | "BenchBox reduced our setup time from 3 hours to 10 minutes"   |
-| "Incredible DataFrame performance gains"     | "The DataFrame path completed 18 of 22 TPC-H queries correctly" |
-| "Everyone should switch to DataFrame mode"   | "DataFrame mode works well for exploratory benchmarking"        |
+| Write                                                              | Avoid                                       |
+| ------------------------------------------------------------------ | ------------------------------------------- |
+| "BenchBox reduced our setup time from [old time] to [new time]"    | "Revolutionary benchmarking framework!"     |
+| "The DataFrame path completed [N] of [M] TPC-H queries correctly"  | "Incredible DataFrame performance gains"    |
+| "DataFrame mode works well for exploratory benchmarking"           | "Everyone should switch to DataFrame mode"  |
 
 ### 3. Technically Rigorous
 Show methodology. Acknowledge limitations.
 
-| Don't                                              | Do                                                                   |
-| -------------------------------------------------- | -------------------------------------------------------------------- |
-| "BenchBox is the most accurate tool" (no context)  | "BenchBox validates results against TPC-H reference answers"         |
-| Hide validation limitations                        | "Our validation checks row counts and column types but not ordering" |
-| Single run as truth                                | "These results reflect median of 5 runs with cold cache between each" |
+| Write                                                                  | Avoid                                             |
+| ---------------------------------------------------------------------- | ------------------------------------------------- |
+| "BenchBox validates results against TPC-H reference answers"           | "BenchBox is the most accurate tool" (no context) |
+| "Our validation checks row counts and column types but not ordering"   | Hide validation limitations                       |
+| "These results reflect median of 5 runs with cold cache between each"  | Single run as truth                               |
 
 ### 4. Neutral on Platforms
 When demonstrating BenchBox, let data speak. No vendor advocacy.
 
-| Don't                                            | Do                                                               |
-| ------------------------------------------------ | ---------------------------------------------------------------- |
-| "Platform B is clearly inferior"                 | "We used DuckDB and SQLite to demonstrate BenchBox's multi-platform support" |
-| "This proves Platform X is the best choice"      | "Results varied by query type, see the full breakdown below"      |
-| "Anyone using Y is making a mistake"             | "Each platform has different strengths for different workloads"   |
+| Write | Avoid |
+| --- | --- |
+| We used DuckDB and SQLite to demonstrate BenchBox's multi-platform support | Platform B is clearly inferior |
+| Results varied by query type. See the full breakdown below. | This proves Platform X is the best choice |
+| In this run, [platform] finished [query] in [time] on [hardware in Methodology] | Anyone using Y is making a mistake. Each platform has different strengths for different workloads. |
+
+A neutral sentence reports the measurement and its conditions, then stops.
 
 ### 5. Helpful and Educational
 Share learnings. Don't lecture.
 
-| Don't                                            | Do                                                              |
-| ------------------------------------------------ | --------------------------------------------------------------- |
-| "You must follow TPC compliance exactly"         | "Here's how we approached TPC-H compliance in BenchBox"         |
-| "The only correct way to benchmark is"           | "One approach that produced consistent results for us was"      |
-| "If you're not validating, you're wrong"         | "We found validation caught subtle bugs, your mileage may vary"  |
+| Write | Avoid |
+| --- | --- |
+| Here's how we approached TPC-H compliance in BenchBox | You must follow TPC compliance exactly |
+| We got consistent results with cold cache between queries | The only correct way to benchmark is |
+| Validation caught [N] ordering bugs in this run | If you're not validating, you're wrong |
+| Run `benchbox run --platform duckdb --benchmark tpch --scale 1` | you may want to consider; your mileage may vary |
+
+Share what we did, and use direct imperatives for concrete steps.
 
 ### 6. Accessible Without Dumbing Down
 Define terms. Layer complexity.
 
-| Don't                                    | Do                                                                      |
-| ---------------------------------------- | ----------------------------------------------------------------------- |
-| Assume readers know TPC phases           | "The power run (executing each query once, sequentially)"               |
-| Over-explain to condescension            | Brief parenthetical definitions                                         |
-| Jargon without context                   | "Scale factor (SF),the multiplier that determines data size in GB"      |
+| Write                                                                                      | Avoid                          |
+| ------------------------------------------------------------------------------------------ | ------------------------------ |
+| "The power run (executing each query once, sequentially)"                                  | Assume readers know TPC phases |
+| Brief parenthetical definitions                                                            | Over-explain to condescension  |
+| "Scale factor (SF): how a given benchmark sizes its data. For TPC-H, SF 1 is about 1 GB; other BenchBox benchmarks may use a different meaning." | Jargon without context         |
+
+Define a term the first time it appears. Later restatement is fine if a skimming reader would miss the first definition.
 
 ---
 
@@ -76,46 +96,45 @@ Define terms. Layer complexity.
 
 Before each section, ask:
 
-1. **Am I using "we" or "I"?** → Use "we"
-2. **Is this claim backed by specific data?** → Add numbers
-3. **Am I advocating for a specific platform?** → Reframe as neutral demonstration
-4. **Would a tool maintainer say this?** → Adjust tone if not
-5. **Did I define technical terms?** → Add brief explanations
+1. Am I using "we" for the project? Use "we".
+2. Is this claim backed by a number, a named condition, or a mechanism? If none of those, add one. Keep a true explanation that names a mechanism even when it has no number.
+3. Am I writing a platform winner verdict? Report the measurement instead.
+4. Would a tool maintainer say this out loud? If not, rewrite.
+5. Did I define new terms on first use?
+6. Does each negative sentence add a fact, legal boundary, or scope condition? Remove any denial that only echoes the preceding point.
 
 ---
 
-## Sentence Starters
+## Optional stems
 
-**For methodology and design:**
+Use only when stuck. Prefer an ordinary sentence. Do not start consecutive sections with the same stem. This list is complete: delete every current stem not named here.
+
+**Methodology and design**
 - "We designed the benchmark to..."
 - "BenchBox handles this by..."
 - "The validation step checks..."
 - "Our data generation approach..."
 
-**For tool capabilities:**
+**Tool capabilities**
 - "BenchBox supports..."
 - "Users can configure..."
 - "The MCP server exposes..."
 - "With the `--queries` flag, you can..."
 
-**For DataFrame and SQL topics:**
+**DataFrame and SQL**
 - "The DataFrame path differs from SQL in..."
 - "We found that translating TPC-H to DataFrames required..."
 - "SQL and DataFrame modes produce equivalent results when..."
 
-**For findings about benchmarking methodology:**
+**Findings**
 - "Our testing showed that cold-cache runs..."
-- "We found that scale factor affects..."
 - "The compliance challenge was..."
 - "Consistent results required..."
 
-**For limitations:**
+**Limitations**
 - "Our approach has trade-offs: we chose..."
-- "This doesn't cover [specific scenario]..."
-- "At larger scale factors, you may encounter..."
 
-**For engagement:**
-- "We'd love to hear about your benchmarking experiences..."
+**Engagement**
 - "Open an issue to discuss..."
 - "You can reproduce these results with..."
 - "Contributions welcome, especially for new platforms."
@@ -124,13 +143,7 @@ Before each section, ask:
 
 ## Punctuation Rules
 
-**Never use em-dashes (,) or en-dashes (-).** Use alternatives:
-
-| Instead of | Use |
-|------------|-----|
-| Clause, like this, | Commas: "Clause, like this, works" |
-| Statement, | Colon: "Statement:" |
-| 10-20 range | Hyphen: "10-20" |
+Do not use em-dashes (Unicode U+2014) or en-dashes (Unicode U+2013). Use ASCII hyphen `-` for ranges (10-20), commas or parentheses for asides, and a colon or a new sentence for an explanation. Do not replace a dash with a bare comma.
 
 ---
 
@@ -140,11 +153,12 @@ Before each section, ask:
 | ------------------------------------------- | ---------------------------------------------------- |
 | "revolutionary", "game-changing"            | Specific metric or capability                        |
 | "clearly superior/inferior"                 | Neutral data presentation                            |
-| "everyone should", "you must"               | "Worth considering", "may help"                      |
+| "everyone should", "you must"               | For a concrete step, use the imperative ("Run `benchbox …`"). For a finding, state what we did ("We used cold cache between queries"). |
 | "in my opinion", "I think"                  | "Our testing showed", "we found"                     |
 | "Platform X is best for"                    | "In our TPC-H runs, Platform X completed in..."      |
 | "obviously", "simply"                       | Remove (often condescending)                         |
 | "Vendor X needs to fix"                     | Focus on BenchBox's findings, not vendor advice      |
+| If a denial only restates an adjacent affirmation, even once ("X is Y. X is not Z.") | State the point once. Keep negative scope when it adds a fact, legal meaning, or the news. |
 
 ---
 
@@ -170,8 +184,10 @@ Before each section, ask:
 > DataFrames are way better than SQL for benchmarking. The API is cleaner and the results are more predictable.
 
 **After (tool builder sharing learnings):**
-> We added DataFrame support (Polars, Pandas) alongside SQL to give users flexibility. Translating TPC-H's 22 queries to DataFrame operations surfaced interesting challenges, correlated subqueries and CASE expressions required creative workarounds. Both paths validate against the same reference answers.
+> We added DataFrame support (Polars, Pandas) alongside SQL to give users flexibility. Translating TPC-H's 22 queries to DataFrame operations surfaced correlated subqueries and CASE expressions that needed workarounds. Both paths validate against the same reference answers.
 
 ---
 
-*Apply this reference actively while drafting each section.*
+*Apply this reference, including Sentence craft, while drafting each section.*
+
+Revised 2026-08-29: Do-first tables; sentence craft; hedge rewrites removed; scale-factor definition corrected; optional stems enumerated.

--- a/skill-sync.lock
+++ b/skill-sync.lock
@@ -1,16 +1,16 @@
 {
   "version": 1,
-  "lockedAt": "2026-08-27T17:32:29.861Z",
+  "lockedAt": "2026-08-29T12:18:27.047Z",
   "skills": {
     "blog": {
       "source": {
         "type": "git",
         "name": "canonical",
         "url": "https://github.com/joeharris76/skill-sync-skills.git",
-        "ref": "104150cffcb2fbfc610c1993803912f42a9b25ed",
+        "ref": "6580679cca642e704725ce43a20316aa2ff634f2",
         "subdir": "skills",
-        "revision": "104150cffcb2fbfc610c1993803912f42a9b25ed",
-        "fetchedAt": "2026-08-27T17:31:43.733Z"
+        "revision": "6580679cca642e704725ce43a20316aa2ff634f2",
+        "fetchedAt": "2026-08-29T12:18:15.334Z"
       },
       "installMode": "mirror",
       "files": {
@@ -23,8 +23,8 @@
           "size": 144
         },
         "references/critique.md": {
-          "sha256": "05845f7d6c7e4daff03661861213fdc53d916fafe610694936b623706209ac8f",
-          "size": 1876
+          "sha256": "c08ef957d4c9abf3c20466b1472dfa2fd590b8d89d224c67426294bc9933da87",
+          "size": 2252
         },
         "references/deformulize.md": {
           "sha256": "17cf904d4fd63b1e1615e6865c77c477f895f5d54a4949039e186c5637a32024",
@@ -47,8 +47,8 @@
           "size": 333
         },
         "SKILL.md": {
-          "sha256": "727ef2c529298c2d704a55da80f4ed9aeb1bcdb1cd7969da89eb59c195c30327",
-          "size": 1862
+          "sha256": "db0a04fa995167bb6b843fd3cfe914cacc26f4a1cc10f5c3be0f440311651fa9",
+          "size": 1941
         },
         "skill.yaml": {
           "sha256": "1cce293dc1f340df37065a440d0d790073155863a13b27c82291a936b83f19f2",
@@ -61,10 +61,10 @@
         "type": "git",
         "name": "canonical",
         "url": "https://github.com/joeharris76/skill-sync-skills.git",
-        "ref": "104150cffcb2fbfc610c1993803912f42a9b25ed",
+        "ref": "6580679cca642e704725ce43a20316aa2ff634f2",
         "subdir": "skills",
-        "revision": "104150cffcb2fbfc610c1993803912f42a9b25ed",
-        "fetchedAt": "2026-08-27T17:31:44.614Z"
+        "revision": "6580679cca642e704725ce43a20316aa2ff634f2",
+        "fetchedAt": "2026-08-29T12:18:16.086Z"
       },
       "installMode": "mirror",
       "files": {
@@ -119,10 +119,10 @@
         "type": "git",
         "name": "canonical",
         "url": "https://github.com/joeharris76/skill-sync-skills.git",
-        "ref": "104150cffcb2fbfc610c1993803912f42a9b25ed",
+        "ref": "6580679cca642e704725ce43a20316aa2ff634f2",
         "subdir": "skills",
-        "revision": "104150cffcb2fbfc610c1993803912f42a9b25ed",
-        "fetchedAt": "2026-08-27T17:31:45.461Z"
+        "revision": "6580679cca642e704725ce43a20316aa2ff634f2",
+        "fetchedAt": "2026-08-29T12:18:16.807Z"
       },
       "installMode": "mirror",
       "files": {
@@ -168,7 +168,7 @@
         "ref": "77ab905fe66cc86a8d8a11fdc4b3500e28d8e0d0",
         "subdir": "skills",
         "revision": "77ab905fe66cc86a8d8a11fdc4b3500e28d8e0d0",
-        "fetchedAt": "2026-08-27T17:31:47.152Z"
+        "fetchedAt": "2026-08-29T12:18:18.475Z"
       },
       "installMode": "mirror",
       "files": {
@@ -227,10 +227,10 @@
         "type": "git",
         "name": "canonical",
         "url": "https://github.com/joeharris76/skill-sync-skills.git",
-        "ref": "104150cffcb2fbfc610c1993803912f42a9b25ed",
+        "ref": "6580679cca642e704725ce43a20316aa2ff634f2",
         "subdir": "skills",
-        "revision": "104150cffcb2fbfc610c1993803912f42a9b25ed",
-        "fetchedAt": "2026-08-27T17:31:47.997Z"
+        "revision": "6580679cca642e704725ce43a20316aa2ff634f2",
+        "fetchedAt": "2026-08-29T12:18:19.173Z"
       },
       "installMode": "mirror",
       "files": {
@@ -289,10 +289,10 @@
         "type": "git",
         "name": "canonical",
         "url": "https://github.com/joeharris76/skill-sync-skills.git",
-        "ref": "104150cffcb2fbfc610c1993803912f42a9b25ed",
+        "ref": "6580679cca642e704725ce43a20316aa2ff634f2",
         "subdir": "skills",
-        "revision": "104150cffcb2fbfc610c1993803912f42a9b25ed",
-        "fetchedAt": "2026-08-27T17:31:53.452Z"
+        "revision": "6580679cca642e704725ce43a20316aa2ff634f2",
+        "fetchedAt": "2026-08-29T12:18:22.627Z"
       },
       "installMode": "mirror",
       "files": {
@@ -326,7 +326,7 @@
         "ref": "6139085a35455fe90c8d6c94d7567e131a24db96",
         "subdir": "skills",
         "revision": "6139085a35455fe90c8d6c94d7567e131a24db96",
-        "fetchedAt": "2026-08-27T17:31:52.344Z"
+        "fetchedAt": "2026-08-29T12:18:21.923Z"
       },
       "installMode": "mirror",
       "files": {
@@ -349,10 +349,10 @@
         "type": "git",
         "name": "canonical",
         "url": "https://github.com/joeharris76/skill-sync-skills.git",
-        "ref": "104150cffcb2fbfc610c1993803912f42a9b25ed",
+        "ref": "6580679cca642e704725ce43a20316aa2ff634f2",
         "subdir": "skills",
-        "revision": "104150cffcb2fbfc610c1993803912f42a9b25ed",
-        "fetchedAt": "2026-08-27T17:31:46.303Z"
+        "revision": "6580679cca642e704725ce43a20316aa2ff634f2",
+        "fetchedAt": "2026-08-29T12:18:17.552Z"
       },
       "installMode": "mirror",
       "files": {
@@ -391,16 +391,32 @@
         "type": "git",
         "name": "canonical",
         "url": "https://github.com/joeharris76/skill-sync-skills.git",
-        "ref": "104150cffcb2fbfc610c1993803912f42a9b25ed",
+        "ref": "6580679cca642e704725ce43a20316aa2ff634f2",
         "subdir": "skills",
-        "revision": "104150cffcb2fbfc610c1993803912f42a9b25ed",
-        "fetchedAt": "2026-08-27T17:31:42.907Z"
+        "revision": "6580679cca642e704725ce43a20316aa2ff634f2",
+        "fetchedAt": "2026-08-29T12:18:14.589Z"
       },
       "installMode": "mirror",
       "files": {
+        "references/agent-execution.md": {
+          "sha256": "b8979b1167902bbdaaa5ccdf11efbaa90558f189a82503156b4dfa11954cca98",
+          "size": 4123
+        },
+        "references/external-harnesses.md": {
+          "sha256": "0b77d6a86381ade8648a0b59a57d47b62cac3fe589d1d7724e9db94fd349841d",
+          "size": 4864
+        },
+        "references/manager.md": {
+          "sha256": "5dedb2710b61592690ee64b59954955a24d981aeef978176182463536211e0be",
+          "size": 4019
+        },
+        "references/recovery.md": {
+          "sha256": "3f4374e30b9b0fa7e6cc7aaa71fc37cb1ceaa06189be1faf5b62ad36be73cbf6",
+          "size": 1602
+        },
         "SKILL.md": {
-          "sha256": "cd5bcbf1274cf385a277fc6ab1d89046e3833d7f27bb57b0a4841431742a1ec3",
-          "size": 12615
+          "sha256": "38f81c047f4efc3ad0e234682f54f23f85951e6d9a12dda9c429f29bf62c704c",
+          "size": 6364
         },
         "skill.yaml": {
           "sha256": "6ceb8ac77a646a81d17370124ddbce8b931b5784c97a81f0027ba26354307763",
@@ -413,10 +429,10 @@
         "type": "git",
         "name": "canonical",
         "url": "https://github.com/joeharris76/skill-sync-skills.git",
-        "ref": "104150cffcb2fbfc610c1993803912f42a9b25ed",
+        "ref": "6580679cca642e704725ce43a20316aa2ff634f2",
         "subdir": "skills",
-        "revision": "104150cffcb2fbfc610c1993803912f42a9b25ed",
-        "fetchedAt": "2026-08-27T17:31:48.795Z"
+        "revision": "6580679cca642e704725ce43a20316aa2ff634f2",
+        "fetchedAt": "2026-08-29T12:18:19.878Z"
       },
       "installMode": "mirror",
       "files": {
@@ -439,10 +455,10 @@
         "type": "git",
         "name": "canonical",
         "url": "https://github.com/joeharris76/skill-sync-skills.git",
-        "ref": "104150cffcb2fbfc610c1993803912f42a9b25ed",
+        "ref": "6580679cca642e704725ce43a20316aa2ff634f2",
         "subdir": "skills",
-        "revision": "104150cffcb2fbfc610c1993803912f42a9b25ed",
-        "fetchedAt": "2026-08-27T17:31:49.641Z"
+        "revision": "6580679cca642e704725ce43a20316aa2ff634f2",
+        "fetchedAt": "2026-08-29T12:18:20.572Z"
       },
       "installMode": "mirror",
       "files": {
@@ -461,10 +477,10 @@
         "type": "git",
         "name": "canonical",
         "url": "https://github.com/joeharris76/skill-sync-skills.git",
-        "ref": "104150cffcb2fbfc610c1993803912f42a9b25ed",
+        "ref": "6580679cca642e704725ce43a20316aa2ff634f2",
         "subdir": "skills",
-        "revision": "104150cffcb2fbfc610c1993803912f42a9b25ed",
-        "fetchedAt": "2026-08-27T17:31:50.587Z"
+        "revision": "6580679cca642e704725ce43a20316aa2ff634f2",
+        "fetchedAt": "2026-08-29T12:18:21.266Z"
       },
       "installMode": "mirror",
       "files": {
@@ -486,7 +502,7 @@
         "ref": "77ab905fe66cc86a8d8a11fdc4b3500e28d8e0d0",
         "subdir": "skills",
         "revision": "77ab905fe66cc86a8d8a11fdc4b3500e28d8e0d0",
-        "fetchedAt": "2026-08-27T17:32:24.771Z"
+        "fetchedAt": "2026-08-29T12:18:24.017Z"
       },
       "installMode": "mirror",
       "files": {
@@ -508,7 +524,7 @@
         "ref": "77ab905fe66cc86a8d8a11fdc4b3500e28d8e0d0",
         "subdir": "skills",
         "revision": "77ab905fe66cc86a8d8a11fdc4b3500e28d8e0d0",
-        "fetchedAt": "2026-08-27T17:32:27.292Z"
+        "fetchedAt": "2026-08-29T12:18:25.398Z"
       },
       "installMode": "mirror",
       "files": {
@@ -530,7 +546,7 @@
         "ref": "77ab905fe66cc86a8d8a11fdc4b3500e28d8e0d0",
         "subdir": "skills",
         "revision": "77ab905fe66cc86a8d8a11fdc4b3500e28d8e0d0",
-        "fetchedAt": "2026-08-27T17:32:29.822Z"
+        "fetchedAt": "2026-08-29T12:18:26.974Z"
       },
       "installMode": "mirror",
       "files": {

--- a/skill-sync.yaml
+++ b/skill-sync.yaml
@@ -3,7 +3,7 @@ sources:
   - name: canonical
     type: git
     url: https://github.com/joeharris76/skill-sync-skills.git
-    ref: 104150cffcb2fbfc610c1993803912f42a9b25ed
+    ref: 6580679cca642e704725ce43a20316aa2ff634f2
     subdir: skills
   - name: todo-context-efficiency
     type: git


### PR DESCRIPTION
## Summary

Voice guide 2.1. Drafting examples now lead with what to write. Sentence craft lives only in `_blog/VOICE_REFERENCE.md`. Publishing runs the editorial checklist by hand; it no longer calls `benchbox.release.content_validation`.

The canonical skill-sync pin advances to `6580679` so the blog skill reads project `_blog/` guides and skips `~/.claude/blog/*` when those files exist. Critique Voice treats a single redundant denial pair as a fail, and keeps negation that is the news, a legal bound, or a necessary condition.

That pin also refreshes the tracked bossmode skill mirror already present on that revision (streamlined SKILL.md plus the agent-execution, external-harnesses, manager, and recovery references).

Skill source: [skill-sync-skills#61](https://github.com/joeharris76/skill-sync-skills/pull/61) (merged).

## Test plan

- [x] v3 acceptance greps on `_blog/VOICE_REFERENCE.md`, `_blog/STYLE_GUIDE.md`, `_blog/PUBLISHING.md`
- [x] `make skill-sync` then `make skill-sync-check`
- [x] `uv run -- python scripts/skill_sync_ci_policy.py validate --manifest skill-sync.yaml`
- [x] `make pr-preflight` (skill-integrity + content)
