### PR TITLE
docs(blog): unify heading rules with published practice

### DIFF
--- a/_blog/STYLE_GUIDE.md
+++ b/_blog/STYLE_GUIDE.md
@@ -355,7 +355,7 @@ Use heading levels logically:
 - A title or heading whose news is a negation is allowed (for example: `# When two timings are not a comparison`).
 - Do not use first-person headings:
   - ❌ "How I optimized query performance"
-  - ✅ "Optimizing Query Performance" or "How we optimized query performance"
+  - ✅ "Optimizing Query Performance"
 - Avoid empty or clever headings that obscure the content.
 
 ---

--- a/_blog/STYLE_GUIDE.md
+++ b/_blog/STYLE_GUIDE.md
@@ -350,9 +350,13 @@ Use heading levels logically:
 #### Minor Point (H4 - use sparingly)
 ```
 
-**Heading Style**: Use sharp short phrases not sentences
-- ❌ "How I optimized query performance"
-- ✅ "Optimizing Query Performance"
+**Heading Style**:
+- Use sharp, descriptive phrases or sentence-style headings that name the section's point (for example: `## The problem: SF=1 meant nothing in particular`).
+- A title or heading whose news is a negation is allowed (for example: `# When two timings are not a comparison`).
+- Do not use first-person headings:
+  - ❌ "How I optimized query performance"
+  - ✅ "Optimizing Query Performance" or "How we optimized query performance"
+- Avoid empty or clever headings that obscure the content.
 
 ---
 
@@ -641,7 +645,7 @@ Include 5-8 relevant tags:
 
 ### Formatting
 
-- [ ] Heading hierarchy correct (H1 → H2 → H3)
+- [ ] Heading hierarchy correct (H1 → H2 → H3); headings name the section's point without first-person pronouns
 - [ ] Code formatted with language specified
 - [ ] Tables readable and not too wide
 - [ ] Numbers formatted consistently


### PR DESCRIPTION
Align `_blog/STYLE_GUIDE.md` with established Building BenchBox practice:
- Allow sentence-style H2/H3 headings when they name the section's point (e.g. `## The problem: SF=1 meant nothing in particular`).
- Allow a title whose news is a negation (e.g. `# When two timings are not a comparison`).
- Retain prohibition on first-person headings (`How I optimized...`) and empty headings.
- Update editorial checklist formatting item accordingly.