### PR TITLE
feat(explorer): ingest warmup executions and surface basis availability

### DIFF
--- a/_project/scripts/explorer_pipeline/duckdb_builder.py
+++ b/_project/scripts/explorer_pipeline/duckdb_builder.py
@@ -6,6 +6,7 @@ This file is loaded by DuckDB-WASM in the browser for filtering and analysis.
 
 from __future__ import annotations
 
+import json
 import logging
 import math
 import os
@@ -336,6 +337,7 @@ class DuckDBSnapshotBuilder:
                 self._create_metadata(con)
                 self._populate_supporting_tables(con, entries, details_map)
                 self._populate_results(con, entries, details_map, prefix)
+                self._populate_result_basis_availability(con, entries, details_map)
                 self._populate_query_display_timings(con, entries, details_map)
                 self._populate_query_executions(con, entries, details_map)
                 self._populate_benchmark_matrix_cells(con, summaries)
@@ -386,6 +388,16 @@ class DuckDBSnapshotBuilder:
                 phase      VARCHAR NOT NULL,
                 duration_s DOUBLE  NOT NULL,
                 PRIMARY KEY (result_id, phase)
+            )
+        """)
+        con.execute("""
+            CREATE TABLE result_basis_availability (
+                result_id               VARCHAR PRIMARY KEY,
+                has_warmup              BOOLEAN NOT NULL,
+                measurement_pass_count  INTEGER NOT NULL,
+                warmup_status           VARCHAR NOT NULL,
+                available_bases         VARCHAR NOT NULL,
+                varying_pass_queries    VARCHAR
             )
         """)
         con.execute("""
@@ -854,6 +866,41 @@ class DuckDBSnapshotBuilder:
         if rows:
             placeholders = ", ".join(["?"] * len(rows[0]))
             con.executemany(f"INSERT INTO results VALUES ({placeholders})", rows)
+
+    def _populate_result_basis_availability(
+        self,
+        con: Any,
+        entries: list[ManifestEntry],
+        details_map: dict[str, DetailResult],
+    ) -> None:
+        rows: list[tuple] = []
+        for entry in entries:
+            detail = details_map.get(entry.result_id)
+            basis_avail = detail.basis_availability if detail is not None else None
+            if basis_avail is None:
+                basis_avail = entry.basis_availability
+            if basis_avail is None:
+                from _project.scripts.explorer_pipeline.transformer import _compute_basis_availability
+
+                queries = detail.queries if detail is not None else []
+                basis_avail = _compute_basis_availability(queries)
+            varying_json = (
+                json.dumps(basis_avail.varying_pass_queries, sort_keys=True)
+                if basis_avail.varying_pass_queries
+                else None
+            )
+            rows.append(
+                (
+                    entry.result_id,
+                    basis_avail.has_warmup,
+                    basis_avail.measurement_pass_count,
+                    basis_avail.warmup_status,
+                    ",".join(basis_avail.available_bases),
+                    varying_json,
+                )
+            )
+        if rows:
+            con.executemany("INSERT INTO result_basis_availability VALUES (?, ?, ?, ?, ?, ?)", rows)
 
     def _populate_query_display_timings(
         self,

--- a/_project/scripts/explorer_pipeline/models.py
+++ b/_project/scripts/explorer_pipeline/models.py
@@ -215,12 +215,25 @@ class ManifestEntry(BaseModel):
     instance_or_warehouse: str | None = None
     storage_format: str | None = None
     compliance_class: str | None = None
+    basis_availability: BasisAvailability | None = None
 
     @model_validator(mode="after")
     def _default_logical_query_count(self) -> ManifestEntry:
         if self.logical_query_count == 0 and self.query_count > 0:
             self.logical_query_count = self.query_count
         return self
+
+
+class BasisAvailability(BaseModel):
+    """Measurement basis availability for a result bundle."""
+
+    has_warmup: bool = False
+    measurement_pass_count: int = 0
+    warmup_status: str = "no_warmup_recorded"
+    available_bases: list[str] = Field(default_factory=list)
+    unavailable_bases: dict[str, str] = Field(default_factory=dict)
+    query_pass_counts: dict[str, int] = Field(default_factory=dict)
+    varying_pass_queries: dict[str, int] = Field(default_factory=dict)
 
 
 class QueryTiming(BaseModel):
@@ -459,6 +472,7 @@ class DetailResult(BaseModel):
     # mechanisms" mismatch instead of "nothing to compare".
     physical_mechanisms: list[str] | None = None
     physical_rendering_id: str | None = None
+    basis_availability: BasisAvailability | None = None
 
 
 # ---------------------------------------------------------------------------

--- a/_project/scripts/explorer_pipeline/transformer.py
+++ b/_project/scripts/explorer_pipeline/transformer.py
@@ -11,11 +11,13 @@ import hashlib
 import json
 import logging
 import math
+from collections import Counter
 from decimal import Decimal, InvalidOperation
 from pathlib import Path
 from typing import Any, cast
 
 from _project.scripts.explorer_pipeline.models import (
+    BasisAvailability,
     DetailResult,
     ManifestEntry,
     PercentileStats,
@@ -209,6 +211,10 @@ def _public_companion_bytes(
 
 # Status values that are considered passing for the query timing status field.
 _PASS_STATUSES = {"SUCCESS", "PASS", "pass", "success"}
+# Allowed run_type values for query execution rows ingested into query_executions.
+# Narrows the ingest filter to execution timings only (measurement + warmup),
+# explicitly excluding metadata and summary pseudo-rows.
+_ALLOWED_EXECUTION_RUN_TYPES: frozenset[str] = frozenset({"measurement", "warmup"})
 _COST_MODEL_SOURCE = "benchbox.core.cost.pricing"
 _COST_SCOPES: frozenset[str] = frozenset({"compute_only", "compute_plus_storage"})
 _COST_STATUSES: frozenset[str] = frozenset({"normalized", "not_applicable_local", "unavailable"})
@@ -991,7 +997,8 @@ def _platform_percentile_stats(display_timings: list[QueryDisplayTiming]) -> Per
 def _query_timings(data: dict[str, Any]) -> list[QueryTiming]:
     """Extract per-query timings from the queries list in a schema-v2 bundle.
 
-    Includes measurement-run-type queries (or those without a run_type).
+    Includes measurement and warmup execution queries (or those without a run_type).
+    Explicitly filters out non-execution pseudo-rows (metadata, summary).
     Preserves run_type, iter, and stream fields for provenance.
     """
     raw_queries: list[dict[str, Any]] = data.get("queries", [])
@@ -1000,7 +1007,11 @@ def _query_timings(data: dict[str, Any]) -> list[QueryTiming]:
         if not isinstance(q, dict):
             continue
         run_type = q.get("run_type")
-        if run_type is not None and run_type != "measurement":
+        # Ingest both measurement and warmup executions. Narrow the filter to an
+        # explicit allow-list; do not remove the check entirely, because the corpus
+        # carries "metadata" and "summary" pseudo-rows (ms=0, status=SKIPPED) that
+        # are not execution timings.
+        if run_type is not None and run_type not in _ALLOWED_EXECUTION_RUN_TYPES:
             continue
         query_id = q.get("id") or q.get("query_id", "")
         ms_raw = q.get("ms")
@@ -1036,8 +1047,9 @@ def _query_display_ms(query_timings: list[QueryTiming]) -> tuple[float | None, i
 
     Algorithm:
       1. Filter to passing (status == "pass") rows.
-      2. Prefer run_type == "measurement" rows; fall back to all passing rows
-         when no passing row has run_type == "measurement".
+      2. Prefer run_type == "measurement" rows; fall back to unlabelled legacy rows
+         (run_type is None) when no explicit measurement rows exist. Warmup rows
+         (run_type == "warmup") are NEVER used for display_ms or sample_count.
       3. Return (median duration_ms, sample_count).
       4. Return (None, 0) when no passing rows exist.
 
@@ -1048,7 +1060,15 @@ def _query_display_ms(query_timings: list[QueryTiming]) -> tuple[float | None, i
     if not passing:
         return None, 0
     measurement = [t for t in passing if t.run_type == "measurement"]
-    candidates = measurement if measurement else passing
+    # DECISION: Fall back to unlabelled legacy rows (run_type is None) only when
+    # no explicit measurement rows exist. Warmup rows (run_type == "warmup")
+    # must NEVER be picked up by the fallback branch; doing so would let warmup
+    # rows feed display_ms for bundles that recorded warmup without measurement
+    # or whose measurement executions failed.
+    legacy_unlabelled = [t for t in passing if t.run_type is None]
+    candidates = measurement if measurement else legacy_unlabelled
+    if not candidates:
+        return None, 0
     durations = sorted(t.duration_ms for t in candidates)
     mid = len(durations) // 2
     if len(durations) % 2 == 1:
@@ -1066,6 +1086,59 @@ def _build_display_timings(timings: list[QueryTiming]) -> list[QueryDisplayTimin
         display_ms, sample_count = _query_display_ms(qid_timings)
         result.append(QueryDisplayTiming(query_id=qid, display_ms=display_ms, sample_count=sample_count))
     return result
+
+
+def _compute_basis_availability(queries: list[QueryTiming]) -> BasisAvailability:
+    """Derive basis availability from query timings for a result bundle.
+
+    Surfaces whether warmup exists, measurement pass count, available bases,
+    and per-query pass count where it varies.
+    """
+    warmup_passing = [q for q in queries if q.run_type == "warmup" and q.status == "pass"]
+    has_warmup = len(warmup_passing) > 0
+    warmup_status = "available" if has_warmup else "no_warmup_recorded"
+
+    # Pre-initialize every attempted measurement query with 0 so completely failed queries
+    # are not silently dropped from varying_pass_queries
+    measurement_queries = [q for q in queries if q.run_type == "measurement" or q.run_type is None]
+    query_pass_counts: dict[str, int] = {q.query_id: 0 for q in measurement_queries}
+    for q in measurement_queries:
+        if q.status == "pass":
+            query_pass_counts[q.query_id] += 1
+
+    if query_pass_counts:
+        counts = list(query_pass_counts.values())
+        count_freq = Counter(counts)
+        nominal_count = sorted(count_freq.items(), key=lambda x: (x[1], x[0]), reverse=True)[0][0]
+        varying_pass_queries = {qid: cnt for qid, cnt in sorted(query_pass_counts.items()) if cnt != nominal_count}
+    else:
+        nominal_count = 0
+        varying_pass_queries = {}
+
+    available_bases: list[str] = ["default"]
+    unavailable_bases: dict[str, str] = {}
+
+    if has_warmup:
+        available_bases.append("warmup")
+    else:
+        unavailable_bases["warmup"] = "no_warmup_recorded"
+
+    if nominal_count > 0:
+        available_bases.append("all_warm")
+        for p in range(1, nominal_count + 1):
+            available_bases.append(f"warm_pass_{p}")
+    else:
+        unavailable_bases["all_warm"] = "no_measurement_executions"
+
+    return BasisAvailability(
+        has_warmup=has_warmup,
+        measurement_pass_count=nominal_count,
+        warmup_status=warmup_status,
+        available_bases=available_bases,
+        unavailable_bases=unavailable_bases,
+        query_pass_counts=query_pass_counts,
+        varying_pass_queries=varying_pass_queries,
+    )
 
 
 def _display_geomean_ms(display_timings: list[QueryDisplayTiming]) -> float | None:
@@ -1286,6 +1359,7 @@ class BundleTransformer:
             instance_or_warehouse=environment_facets["instance_or_warehouse"],
             storage_format=environment_facets["storage_format"],
             compliance_class=_compliance_class(bundle_data),
+            basis_availability=_compute_basis_availability(timings),
         )
         return entry.model_copy(update={"ranking_exclusion_reason": ranking_exclusion_reason(entry)})
 
@@ -1371,6 +1445,7 @@ class BundleTransformer:
             phase_durations=_phase_durations(bundle_data),
             physical_mechanisms=_physical_mechanisms(bundle_data),
             physical_rendering_id=_physical_rendering_id(bundle_data),
+            basis_availability=_compute_basis_availability(timings),
         )
         manifest_peer = ManifestEntry(
             result_id=result_id,

--- a/_project/scripts/results_explorer_snapshot_invariants.py
+++ b/_project/scripts/results_explorer_snapshot_invariants.py
@@ -53,6 +53,13 @@ REQUIRED_COLUMNS: dict[str, set[str]] = {
         "comparison_exclusion_reason",
         "ranking_exclusion_reason",
     },
+    "result_basis_availability": {
+        "result_id",
+        "has_warmup",
+        "measurement_pass_count",
+        "warmup_status",
+        "available_bases",
+    },
 }
 
 # These are the same required non-empty scans used by the browser during
@@ -64,6 +71,7 @@ REQUIRED_NONEMPTY_SCANS: tuple[tuple[str, str], ...] = (
     ("benchmark_rankings", "SELECT COUNT(*) FROM benchmark_rankings"),
     ("benchmark_matrix_cells", "SELECT COUNT(*) FROM benchmark_matrix_cells"),
     ("result_detail_metrics", "SELECT COUNT(*) FROM result_detail_metrics"),
+    ("result_basis_availability", "SELECT COUNT(*) FROM result_basis_availability"),
 )
 
 
@@ -245,6 +253,61 @@ def check_snapshot(db_path: Path) -> list[str]:
                   AND rank IS NULL
                   AND metric_value IS NOT NULL
                   AND COALESCE(ranking_exclusion_reason, cohort_ranking_exclusion_reason) IS NULL
+                """,
+            ),
+            (
+                "snapshots claiming warmup basis availability must have passing warmup executions in query_executions",
+                """
+                SELECT COUNT(*)
+                FROM result_basis_availability rba
+                WHERE rba.has_warmup = TRUE
+                  AND NOT EXISTS (
+                    SELECT 1 FROM query_executions qe
+                    WHERE qe.result_id = rba.result_id
+                      AND qe.run_type = 'warmup'
+                      AND qe.status = 'pass'
+                  )
+                """,
+            ),
+            (
+                "results with passing warmup executions must report warmup as available",
+                """
+                SELECT COUNT(*)
+                FROM result_basis_availability rba
+                WHERE rba.has_warmup = FALSE
+                  AND EXISTS (
+                    SELECT 1 FROM query_executions qe
+                    WHERE qe.result_id = rba.result_id
+                      AND qe.run_type = 'warmup'
+                      AND qe.status = 'pass'
+                  )
+                """,
+            ),
+            (
+                "results without warmup executions must report warmup as unavailable",
+                """
+                SELECT COUNT(*)
+                FROM result_basis_availability rba
+                WHERE rba.has_warmup = FALSE
+                  AND rba.warmup_status = 'available'
+                """,
+            ),
+            (
+                "basis availability must cover every result in the snapshot",
+                """
+                SELECT COUNT(*)
+                FROM results r
+                LEFT JOIN result_basis_availability rba USING (result_id)
+                WHERE rba.result_id IS NULL
+                """,
+            ),
+            (
+                "query_executions must only contain allowed execution run types",
+                """
+                SELECT COUNT(*)
+                FROM query_executions
+                WHERE run_type IS NOT NULL
+                  AND run_type NOT IN ('measurement', 'warmup')
                 """,
             ),
         ]

--- a/docs/development/browser-duckdb-schema.sql
+++ b/docs/development/browser-duckdb-schema.sql
@@ -44,6 +44,15 @@ CREATE TABLE IF NOT EXISTS result_phase_durations (
     PRIMARY KEY (result_id, phase)
 );
 
+CREATE TABLE IF NOT EXISTS result_basis_availability (
+    result_id               VARCHAR PRIMARY KEY,
+    has_warmup              BOOLEAN NOT NULL,
+    measurement_pass_count  INTEGER NOT NULL,
+    warmup_status           VARCHAR NOT NULL,
+    available_bases         VARCHAR NOT NULL,
+    varying_pass_queries    VARCHAR
+);
+
 -- ---------------------------------------------------------------------------
 -- Table 1: results
 -- One row per result bundle. Extends the current 19-column stub to cover all

--- a/tests/unit/scripts/explorer_pipeline/test_duckdb_browser_contract.py
+++ b/tests/unit/scripts/explorer_pipeline/test_duckdb_browser_contract.py
@@ -113,6 +113,14 @@ class TestG1SchemaContract:
         },
         "result_environment": {"result_id", "os", "arch", "cpu_count", "memory_gb", "python"},
         "result_phase_durations": {"result_id", "phase", "duration_s"},
+        "result_basis_availability": {
+            "result_id",
+            "has_warmup",
+            "measurement_pass_count",
+            "warmup_status",
+            "available_bases",
+            "varying_pass_queries",
+        },
         "query_display_timings": {
             "result_id",
             "query_id",

--- a/tests/unit/scripts/explorer_pipeline/test_measurement_basis.py
+++ b/tests/unit/scripts/explorer_pipeline/test_measurement_basis.py
@@ -1,0 +1,270 @@
+"""Tests for measurement basis ingest, basis availability, and display invariance.
+
+Pins:
+  (1) A bundle with 1 warmup + 3 measurement passes yields 4 query_executions rows
+      for that query, and a display_ms equal to the median of the 3 measurement values.
+  (2) A bundle with no warmup rows ingests cleanly and reports warmup as an unavailable basis.
+  (3) A query with fewer measurement passes than its siblings reports its own pass count.
+  (4) display_ms does not move when warmup rows are present.
+  (5) result_basis_availability DuckDB snapshot table correctly reflects basis state.
+"""
+
+from __future__ import annotations
+
+import copy
+import json
+from pathlib import Path
+
+import duckdb
+import pytest
+
+from _project.scripts.explorer_pipeline.pipeline import ExplorerPipeline
+from _project.scripts.explorer_pipeline.transformer import (
+    BundleTransformer,
+    _compute_basis_availability,
+    _query_display_ms,
+    _query_timings,
+)
+from tests.unit.scripts.explorer_pipeline.conftest import MINIMAL_BUNDLE
+
+pytestmark = [pytest.mark.unit, pytest.mark.fast]
+
+
+def test_warmup_plus_three_measurement_passes_yields_four_executions_and_measurement_median(
+    tmp_path: Path,
+) -> None:
+    """1 warmup + 3 measurement passes -> 4 query_executions rows and display_ms = median(3 measurements)."""
+    data = copy.deepcopy(MINIMAL_BUNDLE)
+    data["queries"] = [
+        {"id": "Q1", "ms": 999.0, "iter": 0, "stream": 0, "run_type": "warmup", "status": "SUCCESS"},
+        {"id": "Q1", "ms": 100.0, "iter": 1, "stream": 0, "run_type": "measurement", "status": "SUCCESS"},
+        {"id": "Q1", "ms": 200.0, "iter": 2, "stream": 0, "run_type": "measurement", "status": "SUCCESS"},
+        {"id": "Q1", "ms": 300.0, "iter": 3, "stream": 0, "run_type": "measurement", "status": "SUCCESS"},
+        {"id": "Q6", "ms": 400.0, "iter": 1, "stream": 0, "run_type": "measurement", "status": "SUCCESS"},
+        {"id": "Q6", "ms": 410.0, "iter": 2, "stream": 0, "run_type": "measurement", "status": "SUCCESS"},
+        {"id": "Q6", "ms": 420.0, "iter": 3, "stream": 0, "run_type": "measurement", "status": "SUCCESS"},
+    ]
+
+    timings = _query_timings(data)
+    q1_timings = [t for t in timings if t.query_id == "Q1"]
+    assert len(q1_timings) == 4
+
+    # display_ms must be the median of the 3 measurement rows (200.0), NOT affected by 999.0 warmup
+    display_ms, sample_count = _query_display_ms(q1_timings)
+    assert display_ms == pytest.approx(200.0)
+    assert sample_count == 3
+
+    # Basis availability reflects warmup and 3 passes
+    avail = _compute_basis_availability(timings)
+    assert avail.has_warmup is True
+    assert avail.warmup_status == "available"
+    assert avail.measurement_pass_count == 3
+    assert "warmup" in avail.available_bases
+    assert "all_warm" in avail.available_bases
+    assert "warm_pass_1" in avail.available_bases
+    assert "warm_pass_2" in avail.available_bases
+    assert "warm_pass_3" in avail.available_bases
+    assert "warmup" not in avail.unavailable_bases
+
+    # End-to-end pipeline run: check query_executions and result_basis_availability in DuckDB
+    data_dir = tmp_path / "data"
+    bundles_dir = data_dir / "bundles"
+    bundles_dir.mkdir(parents=True)
+    (bundles_dir / "bundle.json").write_text(json.dumps(data), encoding="utf-8")
+
+    out_dir = tmp_path / "out"
+    ExplorerPipeline().run(data_dir, out_dir, bundle_url_prefix="/results/data/bundles")
+    db_path = out_dir / "results.duckdb"
+
+    with duckdb.connect(str(db_path), read_only=True) as con:
+        # Exactly 4 executions for Q1
+        exec_rows = con.execute(
+            "SELECT duration_ms, run_type, iter FROM query_executions WHERE query_id = 'Q1' ORDER BY iter"
+        ).fetchall()
+        assert len(exec_rows) == 4
+        assert exec_rows[0] == (999.0, "warmup", 0)
+        assert exec_rows[1] == (100.0, "measurement", 1)
+        assert exec_rows[2] == (200.0, "measurement", 2)
+        assert exec_rows[3] == (300.0, "measurement", 3)
+
+        # display_timings has sample_count=3, display_ms=200.0
+        dt_row = con.execute(
+            "SELECT display_ms, sample_count FROM query_display_timings WHERE query_id = 'Q1'"
+        ).fetchone()
+        assert dt_row == (pytest.approx(200.0), 3)
+
+        # result_basis_availability reflects available warmup and 3 passes
+        rba = con.execute(
+            "SELECT has_warmup, measurement_pass_count, warmup_status, available_bases, varying_pass_queries "
+            "FROM result_basis_availability"
+        ).fetchone()
+        assert rba[0] is True
+        assert rba[1] == 3
+        assert rba[2] == "available"
+        assert "warmup" in rba[3].split(",")
+        assert rba[4] is None
+
+
+def test_bundle_with_no_warmup_ingests_cleanly_and_reports_warmup_unavailable(
+    tmp_path: Path,
+) -> None:
+    """A bundle with no warmup rows ingests cleanly and reports warmup as an unavailable basis."""
+    data = copy.deepcopy(MINIMAL_BUNDLE)
+    data["queries"] = [
+        {"id": "Q1", "ms": 100.0, "iter": 1, "stream": 0, "run_type": "measurement", "status": "SUCCESS"},
+        {"id": "Q1", "ms": 200.0, "iter": 2, "stream": 0, "run_type": "measurement", "status": "SUCCESS"},
+        {"id": "Q1", "ms": 300.0, "iter": 3, "stream": 0, "run_type": "measurement", "status": "SUCCESS"},
+        {"id": "Q6", "ms": 400.0, "iter": 1, "stream": 0, "run_type": "measurement", "status": "SUCCESS"},
+        {"id": "Q6", "ms": 410.0, "iter": 2, "stream": 0, "run_type": "measurement", "status": "SUCCESS"},
+        {"id": "Q6", "ms": 420.0, "iter": 3, "stream": 0, "run_type": "measurement", "status": "SUCCESS"},
+    ]
+
+    timings = _query_timings(data)
+    avail = _compute_basis_availability(timings)
+    assert avail.has_warmup is False
+    assert avail.warmup_status == "no_warmup_recorded"
+    assert "warmup" in avail.unavailable_bases
+    assert avail.unavailable_bases["warmup"] == "no_warmup_recorded"
+    assert "warmup" not in avail.available_bases
+    assert avail.measurement_pass_count == 3
+
+    # Pipeline output check
+    data_dir = tmp_path / "data"
+    bundles_dir = data_dir / "bundles"
+    bundles_dir.mkdir(parents=True)
+    (bundles_dir / "bundle.json").write_text(json.dumps(data), encoding="utf-8")
+
+    out_dir = tmp_path / "out"
+    ExplorerPipeline().run(data_dir, out_dir, bundle_url_prefix="/results/data/bundles")
+    db_path = out_dir / "results.duckdb"
+
+    with duckdb.connect(str(db_path), read_only=True) as con:
+        rba = con.execute(
+            "SELECT has_warmup, measurement_pass_count, warmup_status, available_bases FROM result_basis_availability"
+        ).fetchone()
+        assert rba[0] is False
+        assert rba[1] == 3
+        assert rba[2] == "no_warmup_recorded"
+        assert "warmup" not in rba[3].split(",")
+
+
+def test_query_with_fewer_measurement_passes_reports_own_pass_count(tmp_path: Path) -> None:
+    """A query with fewer measurement passes than its siblings reports its own pass count."""
+    data = copy.deepcopy(MINIMAL_BUNDLE)
+    data["queries"] = [
+        {"id": "Q1", "ms": 10.0, "iter": 1, "stream": 0, "run_type": "measurement", "status": "SUCCESS"},
+        {"id": "Q1", "ms": 11.0, "iter": 2, "stream": 0, "run_type": "measurement", "status": "SUCCESS"},
+        {"id": "Q1", "ms": 12.0, "iter": 3, "stream": 0, "run_type": "measurement", "status": "SUCCESS"},
+        {"id": "Q2", "ms": 20.0, "iter": 1, "stream": 0, "run_type": "measurement", "status": "SUCCESS"},
+        {"id": "Q2", "ms": 21.0, "iter": 2, "stream": 0, "run_type": "measurement", "status": "SUCCESS"},
+        {"id": "Q2", "ms": 22.0, "iter": 3, "stream": 0, "run_type": "measurement", "status": "SUCCESS"},
+        # Q3 has only 1 pass instead of 3
+        {"id": "Q3", "ms": 30.0, "iter": 1, "stream": 0, "run_type": "measurement", "status": "SUCCESS"},
+    ]
+
+    timings = _query_timings(data)
+    avail = _compute_basis_availability(timings)
+    assert avail.measurement_pass_count == 3
+    assert avail.query_pass_counts["Q1"] == 3
+    assert avail.query_pass_counts["Q2"] == 3
+    assert avail.query_pass_counts["Q3"] == 1
+    assert avail.varying_pass_queries == {"Q3": 1}
+
+    # Pipeline output check
+    data_dir = tmp_path / "data"
+    bundles_dir = data_dir / "bundles"
+    bundles_dir.mkdir(parents=True)
+    (bundles_dir / "bundle.json").write_text(json.dumps(data), encoding="utf-8")
+
+    out_dir = tmp_path / "out"
+    ExplorerPipeline().run(data_dir, out_dir, bundle_url_prefix="/results/data/bundles")
+    db_path = out_dir / "results.duckdb"
+
+    with duckdb.connect(str(db_path), read_only=True) as con:
+        rba = con.execute(
+            "SELECT measurement_pass_count, varying_pass_queries FROM result_basis_availability"
+        ).fetchone()
+        assert rba[0] == 3
+        assert json.loads(rba[1]) == {"Q3": 1}
+
+        # query_display_timings sample_count matches per-query pass count
+        q_counts = dict(
+            con.execute("SELECT query_id, sample_count FROM query_display_timings ORDER BY query_id").fetchall()
+        )
+        assert q_counts == {"Q1": 3, "Q2": 3, "Q3": 1}
+
+
+def test_display_ms_does_not_move_when_warmup_rows_present() -> None:
+    """display_ms and sample_count are identical whether or not warmup executions are present."""
+    base_measurements = [
+        {"id": "Q1", "ms": 10.0, "iter": 1, "stream": 0, "run_type": "measurement", "status": "SUCCESS"},
+        {"id": "Q1", "ms": 25.0, "iter": 2, "stream": 0, "run_type": "measurement", "status": "SUCCESS"},
+        {"id": "Q1", "ms": 40.0, "iter": 3, "stream": 0, "run_type": "measurement", "status": "SUCCESS"},
+    ]
+
+    bundle_without_warmup = copy.deepcopy(MINIMAL_BUNDLE)
+    bundle_without_warmup["queries"] = list(base_measurements)
+
+    bundle_with_warmup = copy.deepcopy(MINIMAL_BUNDLE)
+    bundle_with_warmup["queries"] = [
+        {"id": "Q1", "ms": 9999.0, "iter": 0, "stream": 0, "run_type": "warmup", "status": "SUCCESS"},
+        *base_measurements,
+    ]
+
+    timings_no_warm = _query_timings(bundle_without_warmup)
+    timings_with_warm = _query_timings(bundle_with_warmup)
+
+    d_no_warm, s_no_warm = _query_display_ms(timings_no_warm)
+    d_with_warm, s_with_warm = _query_display_ms(timings_with_warm)
+
+    assert d_no_warm == pytest.approx(25.0)
+    assert d_with_warm == pytest.approx(25.0)
+    assert s_no_warm == 3
+    assert s_with_warm == 3
+
+
+def test_metadata_and_summary_rows_are_filtered_out() -> None:
+    """Non-execution rows (run_type='metadata' or 'summary') are excluded from timings."""
+    data = copy.deepcopy(MINIMAL_BUNDLE)
+    data["queries"] = [
+        {"id": "meta_1", "ms": 0.0, "run_type": "metadata", "status": "SKIPPED"},
+        {"id": "summary_1", "ms": 0.0, "run_type": "summary", "status": "SKIPPED"},
+        {"id": "Q1", "ms": 50.0, "run_type": "measurement", "status": "SUCCESS"},
+    ]
+    timings = _query_timings(data)
+    assert len(timings) == 1
+    assert timings[0].query_id == "Q1"
+
+
+def test_failed_warmup_query_does_not_claim_warmup_available() -> None:
+    """A failed warmup execution must not cause warmup to be advertised as available."""
+    data = copy.deepcopy(MINIMAL_BUNDLE)
+    data["queries"] = [
+        {"id": "Q1", "ms": 0.0, "iter": 0, "stream": 0, "run_type": "warmup", "status": "FAILED"},
+        {"id": "Q1", "ms": 100.0, "iter": 1, "stream": 0, "run_type": "measurement", "status": "SUCCESS"},
+    ]
+    timings = _query_timings(data)
+    avail = _compute_basis_availability(timings)
+    assert avail.has_warmup is False
+    assert avail.warmup_status == "no_warmup_recorded"
+    assert "warmup" not in avail.available_bases
+    assert "warmup" in avail.unavailable_bases
+
+
+def test_completely_failed_measurement_query_reported_in_varying_pass_queries() -> None:
+    """A query that fails all passes is reported with 0 passes in varying_pass_queries."""
+    data = copy.deepcopy(MINIMAL_BUNDLE)
+    data["queries"] = [
+        {"id": "Q1", "ms": 10.0, "iter": 1, "stream": 0, "run_type": "measurement", "status": "SUCCESS"},
+        {"id": "Q1", "ms": 11.0, "iter": 2, "stream": 0, "run_type": "measurement", "status": "SUCCESS"},
+        {"id": "Q2", "ms": 20.0, "iter": 1, "stream": 0, "run_type": "measurement", "status": "SUCCESS"},
+        {"id": "Q2", "ms": 21.0, "iter": 2, "stream": 0, "run_type": "measurement", "status": "SUCCESS"},
+        # Q3 fails both iterations
+        {"id": "Q3", "ms": 0.0, "iter": 1, "stream": 0, "run_type": "measurement", "status": "FAILED"},
+        {"id": "Q3", "ms": 0.0, "iter": 2, "stream": 0, "run_type": "measurement", "status": "FAILED"},
+    ]
+    timings = _query_timings(data)
+    avail = _compute_basis_availability(timings)
+    assert avail.measurement_pass_count == 2
+    assert avail.query_pass_counts["Q3"] == 0
+    assert avail.varying_pass_queries == {"Q3": 0}

--- a/tests/unit/scripts/explorer_pipeline/test_transformer.py
+++ b/tests/unit/scripts/explorer_pipeline/test_transformer.py
@@ -281,8 +281,8 @@ class TestZeroDurationQuery:
         assert len(detail.queries) == 1
         assert detail.queries[0].duration_ms == pytest.approx(0.0)
 
-    def test_warmup_queries_excluded(self, tmp_path: Path) -> None:
-        """Warmup-typed queries must not appear in query timings."""
+    def test_warmup_queries_admitted_to_queries_but_excluded_from_display_timings(self, tmp_path: Path) -> None:
+        """Warmup queries appear in detail.queries for query_executions, but do not feed display_timings."""
         data = {**MINIMAL_BUNDLE}
         data["queries"] = [
             {"id": "Q1", "ms": 100.0, "iter": 0, "stream": 0, "run_type": "warmup", "status": "SUCCESS"},
@@ -295,8 +295,15 @@ class TestZeroDurationQuery:
         rid = transformer.result_id_from_bundle(bundle)
         detail = transformer.to_detail_result(bundle, rid)
 
-        assert len(detail.queries) == 1
-        assert detail.queries[0].duration_ms == pytest.approx(200.0)
+        # Both warmup and measurement appear in queries (for query_executions ingest)
+        assert len(detail.queries) == 2
+        run_types = {q.run_type for q in detail.queries}
+        assert run_types == {"warmup", "measurement"}
+
+        # But display_timings for Q1 must only use measurement (200.0)
+        dt_q1 = next(dt for dt in detail.display_timings if dt.query_id == "Q1")
+        assert dt_q1.display_ms == pytest.approx(200.0)
+        assert dt_q1.sample_count == 1
 
 
 class TestExtendedManifestFields:


### PR DESCRIPTION
## Summary

Ingest warmup executions alongside warm measurements in the explorer pipeline, and surface basis availability through the read models and DuckDB snapshot (`explorer-basis-ingest-warmup-pass-provenance`).

### Changes
1. **Pipeline Ingest (`_project/scripts/explorer_pipeline/transformer.py`)**:
   - Admitted `warmup` run_type in `_query_timings` while keeping non-execution pseudo-rows (`metadata`, `summary`) strictly filtered out.
   - Preserved canonical `display_ms`, `display_geomean_ms`, and `sample_count` isolation so warmup runs never contaminate warm measurement aggregations. Fallback only targets legacy unlabelled runs (`run_type is None`), never warmup rows.
   - Added `BasisAvailability` derivation reporting whether a bundle has passing warmup executions, nominal measurement pass count, available/unavailable bases, and per-query pass count where it varies. Pre-initialized attempted queries to ensure 0-pass failed queries are surfaced.
2. **Read Models (`_project/scripts/explorer_pipeline/models.py`)**:
   - Added `BasisAvailability` model.
   - Added `basis_availability: BasisAvailability | None = None` to `ManifestEntry` and `DetailResult`.
3. **Database Schema & Snapshot (`duckdb_builder.py`, `docs/development/browser-duckdb-schema.sql`)**:
   - Added `result_basis_availability` supporting table (primary key `result_id`, `has_warmup`, `measurement_pass_count`, `warmup_status`, `available_bases`, `varying_pass_queries`).
4. **Snapshot Invariants (`_project/scripts/results_explorer_snapshot_invariants.py`)**:
   - Enforced that basis availability covers all snapshot results.
   - Enforced that warmup availability claims are backed by actual passing warmup executions.
   - Enforced that non-warmup results report warmup as unavailable (`no_warmup_recorded`).
   - Enforced that `query_executions` only contains execution run types (`measurement`, `warmup`).
5. **Tests**:
   - Added `test_measurement_basis.py` pinning 1-warmup + 3-measurement executions, clean ingest for no-warmup bundles, varying pass queries, display invariance, and edge cases.
   - Updated `test_transformer.py` and `test_duckdb_browser_contract.py`.

### Adversarial Review Summary
Adversarial review identified:
1. `varying_pass_queries` previously omitted completely failed measurement queries (0 passes): Resolved by pre-initializing all attempted measurement queries with 0 passes.
2. Failed warmup executions previously advertised warmup as available: Resolved by requiring passing warmup executions (`status == 'pass'`).
3. Import in hot path: Resolved by moving `Counter` import to module level.

### Verification
- `uv run -- pytest tests/unit/scripts/explorer_pipeline -q`: 373 passed.
- `make explorer-snapshot-check`: Passed.
- Bit-identical table diff on committed corpus: 0 differences across all 11 existing non-`query_executions` tables.
- `query_executions`: Exactly 25,532 measurement rows (unchanged) + 8,338 admitted warmup executions.
- `results-explorer`: 77 test files passed, 928 passed, 8 skipped.
- Range-read byte budget Playwright test: Passed.
