### PR TITLE
fix(results): capture the real CPU model instead of the bare architecture

### DIFF
--- a/benchbox/core/results/environment.py
+++ b/benchbox/core/results/environment.py
@@ -93,6 +93,21 @@ class ClientHostEnvironment:
         cpu_model = profile.get("cpu_model")
         cpu_vendor = profile.get("cpu_vendor")
         if system_profile is None and (not cpu_model or not cpu_vendor):
+            # DELIBERATELY gated on a wholly absent profile.
+            #
+            # It is tempting to widen this to "fill whenever the value is
+            # missing", because every production caller passes a dict and this
+            # branch therefore almost never runs. That would be wrong: this
+            # constructor also runs on the LOAD path, where
+            # `_extract_system_profile` rebuilds a profile from a stored
+            # bundle. Detecting there would stamp the CPU of whatever machine
+            # happens to re-derive an old result onto that result's history --
+            # inventing hardware provenance for a run that executed elsewhere.
+            #
+            # The capture-time gap this was meant to close is fixed at its
+            # source instead: `benchbox.utils.system_info.get_system_info`
+            # now detects the real CPU and emits cpu_model/cpu_vendor, so the
+            # profile handed in already carries them.
             from benchbox.utils.environment import detect_cpu_info
 
             detected_model, detected_vendor = detect_cpu_info()

--- a/benchbox/utils/system_info.py
+++ b/benchbox/utils/system_info.py
@@ -25,6 +25,10 @@ class SystemInfo:
     available_memory_gb: float
     python_version: str
     hostname: str
+    # Appended with a default rather than inserted next to cpu_model: every
+    # existing positional construction of SystemInfo keeps working, and a
+    # producer that cannot determine the vendor simply omits it.
+    cpu_vendor: str | None = None
 
     def to_dict(self) -> dict[str, Any]:
         """Convert to dictionary for compatibility."""
@@ -33,7 +37,17 @@ class SystemInfo:
             "os_version": self.os_version,
             "architecture": self.architecture,
             "cpu_model": self.cpu_model,
+            "cpu_vendor": self.cpu_vendor,
             "cpu_cores": self.cpu_cores,
+            # `cpu_count` and `memory_gb` are the spellings
+            # ClientHostEnvironment.from_system_profile reads. They are emitted
+            # alongside the originals rather than replacing them: the original
+            # names are part of this dict's existing contract, and dropping
+            # them to fix the consumer would trade one silent mismatch for
+            # another.
+            "cpu_count": self.cpu_cores,
+            "memory_gb": self.total_memory_gb,
+            "os_release": self.os_version,
             "total_memory_gb": self.total_memory_gb,
             "available_memory_gb": self.available_memory_gb,
             "python_version": self.python_version,
@@ -48,27 +62,49 @@ def get_system_info() -> SystemInfo:
     total_memory_gb = memory_info.total / (1024**3)
     available_memory_gb = memory_info.available / (1024**3)
 
-    # Get CPU info
+    # Get CPU info.
+    #
+    # detect_cpu_info() first, NOT platform.processor(). On Darwin
+    # platform.processor() returns the bare architecture ("arm"), which is not
+    # a CPU model at all -- it normalizes to the cpu_family "unknown" and makes
+    # the published hardware axis useless. detect_cpu_info() reads the real
+    # brand string (sysctl on Darwin, /proc/cpuinfo on Linux, wmic on Windows)
+    # and degrades to None rather than to a placeholder.
+    cpu_vendor: str | None = None
     try:
-        cpu_model = platform.processor() or "Unknown"
-        if not cpu_model or cpu_model == "":
-            # Fallback for some systems
-            try:
-                with open("/proc/cpuinfo", encoding="utf-8") as f:
-                    for line in f:
-                        if "model name" in line:
-                            cpu_model = line.split(":")[1].strip()
-                            break
-            except (FileNotFoundError, OSError):
-                cpu_model = f"{platform.machine()} CPU"
+        from benchbox.utils.environment import detect_cpu_info
+
+        cpu_model, cpu_vendor = detect_cpu_info()
     except Exception:
-        cpu_model = f"{platform.machine()} CPU"
+        cpu_model = None
+
+    if not cpu_model:
+        # Legacy fallback chain, kept for platforms detect_cpu_info() cannot
+        # answer. platform.processor() is still consulted last rather than not
+        # at all: on several Linux distributions it does return a real model.
+        try:
+            cpu_model = platform.processor() or ""
+            if not cpu_model:
+                try:
+                    with open("/proc/cpuinfo", encoding="utf-8") as f:
+                        for line in f:
+                            if "model name" in line:
+                                cpu_model = line.split(":")[1].strip()
+                                break
+                except (FileNotFoundError, OSError):
+                    cpu_model = ""
+        except Exception:
+            cpu_model = ""
+        if not cpu_model or cpu_model == platform.machine():
+            # Never publish the architecture as if it were a CPU model.
+            cpu_model = f"{platform.machine()} CPU"
 
     return SystemInfo(
         os_name=platform.system(),
         os_version=platform.release(),
         architecture=platform.machine(),
         cpu_model=cpu_model,
+        cpu_vendor=cpu_vendor,
         cpu_cores=psutil.cpu_count(),
         total_memory_gb=total_memory_gb,
         available_memory_gb=available_memory_gb,

--- a/benchbox/utils/system_info.py
+++ b/benchbox/utils/system_info.py
@@ -55,6 +55,53 @@ class SystemInfo:
         }
 
 
+# Values platform.processor() returns that name an ARCHITECTURE, not a CPU
+# model. Comparing against platform.machine() alone is not enough: on Apple
+# Silicon processor() returns "arm" while machine() returns "arm64", so an
+# equality check lets "arm" through -- which is precisely the value that
+# normalizes to the cpu_family "unknown" and the defect this module exists to
+# prevent.
+_ARCHITECTURE_TOKENS = frozenset(
+    {
+        "aarch64",
+        "amd64",
+        "arm",
+        "arm64",
+        "armv6l",
+        "armv7l",
+        "armv8",
+        "i386",
+        "i486",
+        "i586",
+        "i686",
+        "mips",
+        "mips64",
+        "ppc",
+        "ppc64",
+        "ppc64le",
+        "riscv64",
+        "s390x",
+        "x86",
+        "x86_64",
+    }
+)
+
+
+def _is_architecture_token(value: str, machine: str) -> bool:
+    """True when *value* names an architecture rather than a CPU model.
+
+    Publishing an architecture as if it were a model is the failure this guard
+    exists to stop: it normalizes to the cpu_family "unknown", which looks
+    populated and says nothing.
+    """
+    cleaned = value.strip().lower()
+    if not cleaned:
+        return True
+    if cleaned == machine.strip().lower():
+        return True
+    return cleaned in _ARCHITECTURE_TOKENS
+
+
 def _proc_cpuinfo_model() -> str | None:
     """Return the CPU model from /proc/cpuinfo, or None when unavailable.
 
@@ -106,7 +153,7 @@ def get_system_info() -> SystemInfo:
                 cpu_model = _proc_cpuinfo_model() or ""
         except Exception:
             cpu_model = ""
-        if not cpu_model or cpu_model == platform.machine():
+        if not cpu_model or _is_architecture_token(cpu_model, platform.machine()):
             # Never publish the architecture as if it were a CPU model.
             cpu_model = f"{platform.machine()} CPU"
 

--- a/benchbox/utils/system_info.py
+++ b/benchbox/utils/system_info.py
@@ -55,6 +55,24 @@ class SystemInfo:
         }
 
 
+def _proc_cpuinfo_model() -> str | None:
+    """Return the CPU model from /proc/cpuinfo, or None when unavailable.
+
+    Extracted so tests can neutralise exactly this read. Patching
+    ``builtins.open`` instead is too broad: psutil reads /proc on Linux (and
+    does not on macOS), so a blanket patch passes locally and then fails in CI
+    with FileNotFoundError escaping from an unrelated call.
+    """
+    try:
+        with open("/proc/cpuinfo", encoding="utf-8") as handle:
+            for line in handle:
+                if "model name" in line:
+                    return line.split(":")[1].strip()
+    except (FileNotFoundError, OSError):
+        return None
+    return None
+
+
 def get_system_info() -> SystemInfo:
     """Get current system information."""
     # Get memory info
@@ -85,14 +103,7 @@ def get_system_info() -> SystemInfo:
         try:
             cpu_model = platform.processor() or ""
             if not cpu_model:
-                try:
-                    with open("/proc/cpuinfo", encoding="utf-8") as f:
-                        for line in f:
-                            if "model name" in line:
-                                cpu_model = line.split(":")[1].strip()
-                                break
-                except (FileNotFoundError, OSError):
-                    cpu_model = ""
+                cpu_model = _proc_cpuinfo_model() or ""
         except Exception:
             cpu_model = ""
         if not cpu_model or cpu_model == platform.machine():

--- a/tests/unit/utils/test_system_info.py
+++ b/tests/unit/utils/test_system_info.py
@@ -272,7 +272,7 @@ class TestGetSystemInfo:
 
         # Mock file not found for /proc/cpuinfo
         with patch("benchbox.utils.environment.detect_cpu_info", return_value=(None, None)):
-            with patch("builtins.open", side_effect=FileNotFoundError()):
+            with patch("benchbox.utils.system_info._proc_cpuinfo_model", return_value=None):
                 result = get_system_info()
 
         # With no detector, no processor string and no cpuinfo, the placeholder
@@ -320,7 +320,7 @@ class TestGetSystemInfo:
         # Silence the detector AND /proc/cpuinfo: both are real on a Linux
         # runner and would answer before the placeholder branch is reached.
         with patch("benchbox.utils.environment.detect_cpu_info", return_value=(None, None)):
-            with patch("builtins.open", side_effect=FileNotFoundError()):
+            with patch("benchbox.utils.system_info._proc_cpuinfo_model", return_value=None):
                 result = get_system_info()
 
         # Should fallback to machine + " CPU" on exception
@@ -697,7 +697,7 @@ class TestCpuIdentityCapture:
         # of this test pass on macOS and fail in CI.
         with patch("benchbox.utils.environment.detect_cpu_info", return_value=(None, None)):
             with patch("benchbox.utils.system_info.platform.processor", return_value=""):
-                with patch("builtins.open", side_effect=FileNotFoundError()):
+                with patch("benchbox.utils.system_info._proc_cpuinfo_model", return_value=None):
                     info = get_system_info()
         # A placeholder must be recognisable as one, not a bare arch string.
         assert info.cpu_model.endswith("CPU")
@@ -707,7 +707,7 @@ class TestCpuIdentityCapture:
 
         with patch("benchbox.utils.environment.detect_cpu_info", return_value=(None, None)):
             with patch("benchbox.utils.system_info.platform.processor", return_value=platform.machine()):
-                with patch("builtins.open", side_effect=FileNotFoundError()):
+                with patch("benchbox.utils.system_info._proc_cpuinfo_model", return_value=None):
                     info = get_system_info()
         assert info.cpu_model != platform.machine()
 

--- a/tests/unit/utils/test_system_info.py
+++ b/tests/unit/utils/test_system_info.py
@@ -169,7 +169,12 @@ class TestGetSystemInfo:
         mock_python_version.return_value = "3.11.0"
         mock_node.return_value = "test-machine"
 
-        result = get_system_info()
+        # detect_cpu_info() is tried first now, and it reads real hardware --
+        # on a Linux CI runner it returns the runner's actual CPU and shadows
+        # the mocked processor string. Silence it so this test still exercises
+        # the legacy platform.processor() path it was written for.
+        with patch("benchbox.utils.environment.detect_cpu_info", return_value=(None, None)):
+            result = get_system_info()
 
         assert isinstance(result, SystemInfo)
         assert result.os_name == "Linux"
@@ -312,7 +317,11 @@ class TestGetSystemInfo:
         mock_python_version.return_value = "3.9.0"
         mock_node.return_value = "old-system"
 
-        result = get_system_info()
+        # Silence the detector AND /proc/cpuinfo: both are real on a Linux
+        # runner and would answer before the placeholder branch is reached.
+        with patch("benchbox.utils.environment.detect_cpu_info", return_value=(None, None)):
+            with patch("builtins.open", side_effect=FileNotFoundError()):
+                result = get_system_info()
 
         # Should fallback to machine + " CPU" on exception
         assert result.cpu_model == "i686 CPU"
@@ -683,9 +692,13 @@ class TestCpuIdentityCapture:
         assert info.cpu_model != platform.processor() or info.cpu_model != platform.machine()
 
     def test_falls_back_to_a_labelled_placeholder_when_detection_fails(self) -> None:
+        # /proc/cpuinfo must be mocked away too: it exists on Linux runners and
+        # answers before the placeholder branch, which made the first version
+        # of this test pass on macOS and fail in CI.
         with patch("benchbox.utils.environment.detect_cpu_info", return_value=(None, None)):
-            with patch("platform.processor", return_value=""):
-                info = get_system_info()
+            with patch("benchbox.utils.system_info.platform.processor", return_value=""):
+                with patch("builtins.open", side_effect=FileNotFoundError()):
+                    info = get_system_info()
         # A placeholder must be recognisable as one, not a bare arch string.
         assert info.cpu_model.endswith("CPU")
 
@@ -693,8 +706,9 @@ class TestCpuIdentityCapture:
         import platform
 
         with patch("benchbox.utils.environment.detect_cpu_info", return_value=(None, None)):
-            with patch("platform.processor", return_value=platform.machine()):
-                info = get_system_info()
+            with patch("benchbox.utils.system_info.platform.processor", return_value=platform.machine()):
+                with patch("builtins.open", side_effect=FileNotFoundError()):
+                    info = get_system_info()
         assert info.cpu_model != platform.machine()
 
     def test_to_dict_emits_the_keys_the_environment_consumer_reads(self) -> None:

--- a/tests/unit/utils/test_system_info.py
+++ b/tests/unit/utils/test_system_info.py
@@ -70,11 +70,19 @@ class TestSystemInfo:
             "os_version": "21.6.0",
             "architecture": "arm64",
             "cpu_model": "Apple M1",
+            "cpu_vendor": None,
             "cpu_cores": 8,
             "total_memory_gb": 16.0,
             "available_memory_gb": 14.2,
             "python_version": "3.11.2",
             "hostname": "macbook-pro",
+            # Aliases for the spellings ClientHostEnvironment.from_system_profile
+            # actually reads. Emitted alongside the originals, not instead of
+            # them -- without these three the consumer silently dropped the
+            # CPU count, the memory size and the OS release from every bundle.
+            "cpu_count": 8,
+            "memory_gb": 16.0,
+            "os_release": "21.6.0",
         }
 
         assert result == expected
@@ -208,14 +216,18 @@ class TestGetSystemInfo:
         mock_python_version.return_value = "3.11.2"
         mock_node.return_value = "macbook"
 
-        with patch(
-            "builtins.open",
-            mock_open(read_data="model name\t: Apple M1\nother: value\n"),
-        ):
-            result = get_system_info()
+        with patch("benchbox.utils.environment.detect_cpu_info", return_value=(None, None)):
+            with patch(
+                "builtins.open",
+                mock_open(read_data="model name\t: Apple M1\nother: value\n"),
+            ):
+                result = get_system_info()
 
-        # Empty processor string gets converted to "Unknown" before fallback logic runs
-        assert result.cpu_model == "Unknown"
+        # An empty processor string must fall through to /proc/cpuinfo and use
+        # the model it finds. This previously asserted "Unknown": the old
+        # `platform.processor() or "Unknown"` short-circuited the fallback, so
+        # the cpuinfo data supplied right above was read and then discarded.
+        assert result.cpu_model == "Apple M1"
         assert result.os_name == "Darwin"
         assert result.architecture == "arm64"
 
@@ -254,11 +266,15 @@ class TestGetSystemInfo:
         mock_node.return_value = "windows-pc"
 
         # Mock file not found for /proc/cpuinfo
-        with patch("builtins.open", side_effect=FileNotFoundError()):
-            result = get_system_info()
+        with patch("benchbox.utils.environment.detect_cpu_info", return_value=(None, None)):
+            with patch("builtins.open", side_effect=FileNotFoundError()):
+                result = get_system_info()
 
-        # None processor gets converted to "Unknown" before fallback logic runs
-        assert result.cpu_model == "Unknown"
+        # With no detector, no processor string and no cpuinfo, the placeholder
+        # must still be recognisable as one. "Unknown" said nothing about the
+        # machine; "AMD64 CPU" at least carries the architecture and cannot be
+        # mistaken for a real model by the cpu_family normalizer.
+        assert result.cpu_model == "AMD64 CPU"
         assert result.os_name == "Windows"
         assert result.architecture == "AMD64"
 
@@ -575,11 +591,16 @@ class TestSystemInfoIntegration:
             "os_version",
             "architecture",
             "cpu_model",
+            "cpu_vendor",
             "cpu_cores",
             "total_memory_gb",
             "available_memory_gb",
             "python_version",
             "hostname",
+            # Consumer-facing aliases; see test_system_info_to_dict.
+            "cpu_count",
+            "memory_gb",
+            "os_release",
         }
         assert set(system_dict.keys()) == expected_keys
 
@@ -638,3 +659,56 @@ class TestSystemInfoIntegration:
         # Memory info should work even if CPU info fails
         memory_info = get_memory_info()
         assert memory_info["total_gb"] == 8.0
+
+
+class TestCpuIdentityCapture:
+    """The CPU identity that reaches a published result bundle.
+
+    Regression cover for a capture defect: `get_system_info` sourced
+    `cpu_model` from `platform.processor()`, which on Darwin returns the bare
+    architecture ("arm"). That is not a CPU model -- the explorer's
+    `normalize_cpu_family` maps it to the family "unknown" -- so every run
+    published a hardware axis that said nothing, and `cpu_vendor`,
+    `cpu_count` and `memory_gb` never reached the bundle at all.
+    """
+
+    def test_cpu_model_is_never_the_bare_architecture(self) -> None:
+        import platform
+
+        info = get_system_info()
+        assert info.cpu_model
+        # "arm" / "x86_64" alone is an architecture, not a model. Publishing it
+        # normalizes to the cpu_family "unknown" and makes the axis useless.
+        assert info.cpu_model != platform.machine()
+        assert info.cpu_model != platform.processor() or info.cpu_model != platform.machine()
+
+    def test_falls_back_to_a_labelled_placeholder_when_detection_fails(self) -> None:
+        with patch("benchbox.utils.environment.detect_cpu_info", return_value=(None, None)):
+            with patch("platform.processor", return_value=""):
+                info = get_system_info()
+        # A placeholder must be recognisable as one, not a bare arch string.
+        assert info.cpu_model.endswith("CPU")
+
+    def test_never_publishes_the_arch_even_when_processor_returns_it(self) -> None:
+        import platform
+
+        with patch("benchbox.utils.environment.detect_cpu_info", return_value=(None, None)):
+            with patch("platform.processor", return_value=platform.machine()):
+                info = get_system_info()
+        assert info.cpu_model != platform.machine()
+
+    def test_to_dict_emits_the_keys_the_environment_consumer_reads(self) -> None:
+        # ClientHostEnvironment.from_system_profile reads cpu_count, memory_gb
+        # and os_release. This dict previously emitted cpu_cores,
+        # total_memory_gb and os_version, so those three fields were silently
+        # dropped on the way into every bundle.
+        keys = get_system_info().to_dict().keys()
+        for consumed in ("cpu_model", "cpu_vendor", "cpu_count", "memory_gb", "os_release"):
+            assert consumed in keys, f"from_system_profile reads {consumed!r}"
+
+    def test_to_dict_keeps_its_original_key_names(self) -> None:
+        # Additive, not a rename: the original names are part of this dict's
+        # existing contract.
+        keys = get_system_info().to_dict().keys()
+        for original in ("cpu_cores", "total_memory_gb", "os_version", "os_type"):
+            assert original in keys

--- a/tests/unit/utils/test_system_info.py
+++ b/tests/unit/utils/test_system_info.py
@@ -711,6 +711,49 @@ class TestCpuIdentityCapture:
                     info = get_system_info()
         assert info.cpu_model != platform.machine()
 
+    def test_rejects_an_architecture_alias_that_is_not_equal_to_machine(self) -> None:
+        # Regression for a review finding. On Apple Silicon platform.processor()
+        # returns "arm" while platform.machine() returns "arm64", so guarding
+        # with `cpu_model == platform.machine()` let "arm" straight through --
+        # reintroducing, whenever sysctl is unavailable or times out, the exact
+        # value this module exists to keep out of published results.
+        with patch("benchbox.utils.environment.detect_cpu_info", return_value=(None, None)):
+            with patch("benchbox.utils.system_info.platform.processor", return_value="arm"):
+                with patch("benchbox.utils.system_info.platform.machine", return_value="arm64"):
+                    with patch("benchbox.utils.system_info._proc_cpuinfo_model", return_value=None):
+                        info = get_system_info()
+        assert info.cpu_model == "arm64 CPU"
+
+    @pytest.mark.parametrize(
+        "processor,machine",
+        [
+            ("arm", "arm64"),
+            ("ARM", "arm64"),
+            ("x86_64", "x86_64"),
+            ("amd64", "x86_64"),
+            ("i686", "i686"),
+            ("aarch64", "aarch64"),
+            ("  arm  ", "arm64"),
+        ],
+    )
+    def test_no_architecture_token_is_ever_published_as_a_model(self, processor, machine) -> None:
+        with patch("benchbox.utils.environment.detect_cpu_info", return_value=(None, None)):
+            with patch("benchbox.utils.system_info.platform.processor", return_value=processor):
+                with patch("benchbox.utils.system_info.platform.machine", return_value=machine):
+                    with patch("benchbox.utils.system_info._proc_cpuinfo_model", return_value=None):
+                        info = get_system_info()
+        assert info.cpu_model == f"{machine} CPU"
+
+    def test_keeps_a_real_model_that_merely_contains_an_arch_word(self) -> None:
+        # The guard must reject architecture TOKENS, not any string mentioning
+        # one. "ARMv8 Neoverse-N1" is a real model and must survive.
+        with patch("benchbox.utils.environment.detect_cpu_info", return_value=(None, None)):
+            with patch("benchbox.utils.system_info.platform.processor", return_value="ARMv8 Neoverse-N1"):
+                with patch("benchbox.utils.system_info.platform.machine", return_value="aarch64"):
+                    with patch("benchbox.utils.system_info._proc_cpuinfo_model", return_value=None):
+                        info = get_system_info()
+        assert info.cpu_model == "ARMv8 Neoverse-N1"
+
     def test_to_dict_emits_the_keys_the_environment_consumer_reads(self) -> None:
         # ClientHostEnvironment.from_system_profile reads cpu_count, memory_gb
         # and os_release. This dict previously emitted cpu_cores,


### PR DESCRIPTION
Follow-up to #1948. That PR landed the CPU identity read model, the facets, the
receipts and the `cpu_family` normalizer — but nothing populated any of it.

## Validated end to end, not by reading code

Ran a real benchmark and read the bundle it produced:

```
before:  "cpu_model": "arm"        (no cpu_vendor, no cpu_count, no memory_gb,
                                    "os": "Darwin" with no release)
after:   "cpu_model": "Apple M4",  "cpu_vendor": "Apple",
         "cpu_count": 10,          "memory_gb": 16.0,
         "os": "Darwin 25.6.0"
```

Then rebuilt the read model from that bundle:

```
tpch-duckdb-sf0.01-20260826-a20c633f   None       None            (old bundle)
tpch-duckdb-sf0.01-20260829-170b175c   Apple M4   apple_silicon   (fixed capture)
```

## Two defects in one seam

**The CPU source was wrong.** `get_system_info` took `cpu_model` from
`platform.processor()`, which on Darwin returns the bare architecture `"arm"`.
That is not a model — `normalize_cpu_family("arm")` returns the family
`"unknown"`. Every future run would have published a hardware axis that says
nothing, and `"unknown"` is worse than NULL: it looks populated, and it would
have passed a coverage gate as a genuine bucket.

`detect_cpu_info()` was already correct and returned `("Apple M4", "Apple")` on
this machine the whole time — it simply was not on this code path, because it
was reachable only when the entire system profile is `None`, and every
production caller passes a dict (`result_factory` and `base.py` both default to
`{}`).

**Three fields were dropped by a key-name mismatch.** `SystemInfo.to_dict`
emitted `cpu_cores` / `total_memory_gb` / `os_version`, while
`ClientHostEnvironment.from_system_profile` reads `cpu_count` / `memory_gb` /
`os_release`. All three were silently discarded on the way into every bundle —
which is exactly why published `client_host` blocks contain only `arch`, `os`
and `python`. The consumer's spellings are now emitted **alongside** the
originals, not instead of them, so the existing contract is unchanged.

## One deliberate non-change

The fallback in `from_system_profile` stays gated on a wholly absent profile.
Widening it to "fill whenever the value is missing" looks like the obvious fix
and is wrong: that constructor also runs on the **load** path, where
`_extract_system_profile` rebuilds a profile from a stored bundle. Detecting
there would stamp the CPU of whatever machine happens to re-derive an old
result onto that result's history — inventing hardware provenance for a run
that executed somewhere else. The gap is closed at capture instead.

I found this because a test caught it: widening the gate made
`test_environment_block_keeps_legacy_host_keys_and_adds_normalized_client_host`
fail with the local machine's CPU appearing in a synthetic remote profile.

## Two tests were pinning the bug

`test_get_system_info_empty_processor` and
`test_get_system_info_processor_fallback_to_machine` both asserted
`cpu_model == "Unknown"`. The first supplied `/proc/cpuinfo` data containing
`"Apple M1"` and then asserted the answer was `"Unknown"` — i.e. it locked in
the fact that `platform.processor() or "Unknown"` short-circuited the fallback
so the data it had just provided was read and discarded. Both now assert the
corrected behaviour, and the placeholder is `"<arch> CPU"` rather than a bare
architecture string that the family normalizer would mistake for a real model.

## Backfill is deliberately not included

No historical result recorded a CPU: 4 of 3,845 raw local results carry one,
and all four are from today (two of them my own validation runs). There is no
measured value to recover, so a backfill would have to invent one. That is a
separate decision about attested-vs-measured provenance, not a bug fix, and it
is being raised separately.

## Verification

- `make pr-preflight` — 28,534 passed, 19 skipped
- `tests/unit/utils/test_system_info.py` + `tests/unit/core/results/` — 1,136 passed
- End-to-end bundle and read-model output shown above
