### PR TITLE
fix(corpus): never overwrite the attestation manifest on a rerun

### DIFF
--- a/_project/scripts/results_explorer_cpu_attestation_backfill.py
+++ b/_project/scripts/results_explorer_cpu_attestation_backfill.py
@@ -184,6 +184,28 @@ def backfill(*, bundles_dir: Path, write: bool, manifest_path: Path) -> dict[str
     }
 
     if write:
+        if manifest_path.exists():
+            # The manifest is the ONLY record of the old -> new result_id
+            # mapping. A second --write is a no-op on the bundles (the backfill
+            # is idempotent), but re-emitting the manifest would overwrite that
+            # record with a snapshot reporting current ids as both old and new,
+            # 0 changed and 0 lacking a client host -- destroying the very
+            # provenance the file exists to preserve.
+            #
+            # So: keep the original whenever this pass changed nothing, and
+            # refuse outright if it did change something, because that means
+            # the corpus moved and the standing manifest no longer describes
+            # it. Mirrors the refusal in results_explorer_corpus_migrate.py.
+            if summary["totals"]["changed"]:
+                raise FileExistsError(
+                    f"refusing to overwrite an existing attestation manifest while rewriting "
+                    f"{summary['totals']['changed']} bundle(s): {manifest_path}. "
+                    "Move the existing manifest aside deliberately if a re-attestation is intended."
+                )
+            for path, payload in pending_writes:
+                _atomic_write(path, payload)
+            return summary
+
         for path, payload in pending_writes:
             _atomic_write(path, payload)
         _atomic_write(manifest_path, canonical_json_bytes(summary))


### PR DESCRIPTION
Follow-up to #1953, addressing the review finding on that PR. The fix was
written before #1953 merged but could not be pushed to it — the branch was in a
merge queue and GitHub rejects updates to queued branches (`GH006`).

## The asymmetry

The bundle rewrite is idempotent; the manifest write was not. A second
`--write` would unconditionally replace `cpu-identity-attestation.manifest.json`
with a no-op snapshot: all 151 entries reporting current IDs as both `old` and
`new`, totals flipping from 151 changed / 43 lacking `client_host` to 0 / 0.

That file is the **only** record of the old → new `result_id` mapping for the
whole corpus. Losing it loses the ability to resolve any pre-backfill permalink,
and nothing else in the repo carries that mapping.

## Fix

Mirrors the refusal already in `results_explorer_corpus_migrate.py`:

- pass changed nothing → keep the existing manifest, still write any pending
  bundle output;
- pass changed something → refuse outright, because the corpus has moved and
  the standing manifest no longer describes it.

## Verified both directions

- No-op rerun against merged develop: bundles and manifest byte-identical
  (`git diff --quiet results-data/` clean).
- Rerun with one bundle's attestation stripped: raises `FileExistsError`
  naming the count it refused to rewrite, rather than silently proceeding.
