### PR TITLE
fix(dataframe): record the client host on DataFrame runs

### DIFF
--- a/benchbox/platforms/dataframe/benchmark_mixin.py
+++ b/benchbox/platforms/dataframe/benchmark_mixin.py
@@ -157,6 +157,23 @@ class DataLoadingError(RuntimeError):
         self.per_table_stats = per_table_stats or {}
 
 
+def _client_host_profile(system_profile: Any) -> dict[str, Any]:
+    """Return the client-host profile dict for a DataFrame run.
+
+    Collected the same way the SQL path collects it, so both families produce
+    the same client_host field set. A caller-supplied mapping is honoured as
+    is; a typed SystemProfile is deliberately NOT reshaped here, because its
+    field names (os_name / cpu_cores_logical / memory_total_gb) are not the
+    ones ClientHostEnvironment.from_system_profile reads -- passing it through
+    would reintroduce exactly the silent key mismatch this seam already had.
+    """
+    if isinstance(system_profile, dict):
+        return dict(system_profile)
+    from benchbox.utils.system_info import get_system_info
+
+    return get_system_info().to_dict()
+
+
 class BenchmarkExecutionMixin:
     """Mixin providing run_benchmark() for DataFrame adapters.
 
@@ -298,6 +315,15 @@ class BenchmarkExecutionMixin:
         )
         builder.mark_started()
         builder.set_validation_status("NOT_RUN")
+        # Record the client host, exactly as the SQL adapters do in
+        # benchbox/platforms/base/adapter.py::_build_execution_metadata.
+        #
+        # The DataFrame families descend from this mixin rather than from that
+        # adapter, so without this call `result.system_profile` stays unset,
+        # `_build_environment_block` produces an empty client_host, and
+        # `_compact` drops it -- which is why every DataFrame bundle published
+        # only a `platform_runtime` block and no host at all.
+        builder.set_system_profile(_client_host_profile(system_profile))
 
         # Reset per-run plan-capture failure state (qpc-05 / F4.4 follow-up):
         # ExpressionFamilyAdapter doesn't inherit the SQL mixin's

--- a/tests/unit/platforms/dataframe/test_client_host_capture.py
+++ b/tests/unit/platforms/dataframe/test_client_host_capture.py
@@ -1,0 +1,70 @@
+"""The DataFrame families must record the same client host the SQL adapters do.
+
+Regression cover for `dataframe-client-host-capture-gap`: every DataFrame
+result published an environment block containing only `platform_runtime`. No
+`client_host` at all -- no os, arch, python, cpu_count, memory_gb or CPU
+identity. 0 of 107 sampled raw DataFrame results carried it, and all 43
+DataFrame bundles in the published corpus lacked it.
+
+The cause was structural rather than a missing call. SQL adapters descend from
+`benchbox/platforms/base/adapter.py`, whose `_build_execution_metadata` collects
+a system profile; the DataFrame families descend from
+`BenchmarkExecutionMixin` instead and never ran that path, so
+`result.system_profile` stayed unset and `_build_environment_block` produced an
+empty block that `_compact` then dropped.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from benchbox.core.results.environment import build_environment_payload
+from benchbox.platforms.dataframe.benchmark_mixin import _client_host_profile
+from benchbox.utils.system_info import get_system_info
+
+pytestmark = [
+    pytest.mark.unit,
+    pytest.mark.fast,
+]
+
+
+def _client_host(system_profile: object) -> dict:
+    payload = build_environment_payload(system_profile=system_profile, execution_environment=None)
+    return payload.get("client_host", {})
+
+
+def test_dataframe_profile_yields_a_populated_client_host() -> None:
+    host = _client_host(_client_host_profile(None))
+    assert host, "a DataFrame run must record a client host, not an empty block"
+    for field in ("os", "arch", "python", "cpu_count", "memory_gb", "cpu_model"):
+        assert field in host, f"DataFrame client_host is missing {field!r}"
+
+
+def test_dataframe_and_sql_record_the_same_client_host_fields() -> None:
+    # The SQL path builds its profile from get_system_info().to_dict()
+    # (base/adapter.py -> result_capture._build_execution_metadata). Comparing
+    # the KEY SETS is the point: the two hierarchies drifted silently once, and
+    # only a test that spans both notices it happening again.
+    sql_host = _client_host(get_system_info().to_dict())
+    dataframe_host = _client_host(_client_host_profile(None))
+    assert set(dataframe_host) == set(sql_host)
+
+
+def test_a_caller_supplied_mapping_is_honoured_verbatim() -> None:
+    supplied = {"os_type": "Linux", "architecture": "x86_64", "cpu_model": "Some CPU"}
+    assert _client_host_profile(supplied) == supplied
+
+
+def test_a_typed_profile_is_not_reshaped_into_the_wrong_keys() -> None:
+    # A typed SystemProfile spells its fields os_name / cpu_cores_logical /
+    # memory_total_gb, which are NOT the names from_system_profile reads.
+    # Passing one through would reintroduce exactly the silent key mismatch
+    # that dropped cpu_count, memory_gb and os_release from every bundle, so
+    # the helper collects a fresh profile instead.
+    class _Typed:
+        os_name = "Linux"
+        cpu_cores_logical = 8
+
+    profile = _client_host_profile(_Typed())
+    assert "cpu_count" in profile
+    assert "memory_gb" in profile


### PR DESCRIPTION
Closes the third and last defect in the capture pipeline, found while
validating #1948's CPU read model. Tracker item:
`dataframe-client-host-capture-gap`.

## The gap

Every DataFrame result published an environment block containing only
`platform_runtime`. No `client_host` at all — no os, arch, python, `cpu_count`,
`memory_gb` or CPU identity.

- 0 of 107 sampled raw DataFrame results carried it
- all 43 DataFrame bundles in the published corpus lacked it
- every SQL run had it; no DataFrame run did

That is ~28% of the corpus blank on every hardware axis, which would have left
the facets from `explorer-basis-browse-hardware-engine-facets` permanently
empty for those runs even after #1951.

## Why, and why it is one call

Structural, not a missing call. SQL adapters descend from
`platforms/base/adapter.py`, whose `_build_execution_metadata` collects a system
profile. The DataFrame families descend from `BenchmarkExecutionMixin` instead
and never ran that path, so `result.system_profile` stayed unset,
`_build_environment_block` produced an empty `client_host`, and `_compact`
dropped the empty block. `run_benchmark` even *accepted* a `system_profile`
argument and discarded it.

Both DataFrame families — `ExpressionFamilyAdapter` and `PandasFamilyAdapter` —
share that one mixin, so a single call there covers all five adapters rather
than five duplicated ones.

## One deliberate refusal

A caller-supplied mapping is honoured verbatim, but a typed `SystemProfile` is
**not** reshaped. Its fields are spelled `os_name` / `cpu_cores_logical` /
`memory_total_gb`, which are not the names `from_system_profile` reads — passing
one through would reintroduce exactly the silent key mismatch that dropped
`cpu_count`, `memory_gb` and `os_release` from every bundle in #1951. The helper
collects a fresh profile instead, the same way the SQL path does.

## Verified by running both paths

```
DF : {"arch": "arm64", "cpu_count": 10, "cpu_model": "Apple M4",
      "cpu_vendor": "Apple", "memory_gb": 16.0, "os": "Darwin 25.6.0",
      "python": "3.12.13"}
SQL: {"arch": "arm64", "cpu_count": 10, "cpu_model": "Apple M4",
      "cpu_vendor": "Apple", "memory_gb": 16.0, "os": "Darwin 25.6.0",
      "python": "3.12.13"}
```

Byte-identical. The new test compares the two **key sets** rather than asserting
a fixed list — the hierarchies drifted silently once, and only a test spanning
both notices it happening again.

## Verification

- `make pr-preflight` — 28,538 passed, 19 skipped
- `tests/unit/platforms/dataframe/test_client_host_capture.py` — 4 passed

## Note on the corpus

This fixes capture going forward. The 43 existing DataFrame bundles keep the CPU
values attested in #1953 and still have no os/arch/python, which were
deliberately not synthesized there — the attestation covered which machine ran
the corpus, not a given run's OS release or interpreter version. Those populate
naturally as DataFrame runs are re-collected.
