### PR TITLE
feat/explorer basis compare shape routing

### DIFF
--- a/results-explorer/src/components/IdentityDiffStrip.tsx
+++ b/results-explorer/src/components/IdentityDiffStrip.tsx
@@ -1,0 +1,102 @@
+import type { DetailResult } from "@/types";
+import { StatusBadge } from "@/components/StatusBadge";
+import { buildComparabilityFields, type ComparabilityField } from "@/components/ComparabilityReceipt";
+
+/**
+ * The six-axis engine-and-hardware strip for a head-to-head comparison.
+ *
+ * Answers one question at a glance: of the things that could explain a
+ * difference in these numbers, which ones ACTUALLY differ between these two
+ * runs? A reader looking at a 1.4x speedup needs to know whether the engines
+ * differ, or the hardware does, or only the engine version.
+ *
+ * It does NOT replace or duplicate the ComparabilityReceipt, which stays on
+ * the page and remains the full record. The strip is a six-axis summary of the
+ * axes most likely to confound an engine comparison; the receipt covers
+ * benchmark, scale, phase, query scope, dates, tuning, validation and cost as
+ * well. Both read the SAME `buildComparabilityFields` output, so the strip can
+ * never disagree with the receipt about whether an axis differs -- which is
+ * exactly what a second, independently-derived summary would eventually do.
+ */
+export interface IdentityDiffStripProps {
+  results: DetailResult[];
+}
+
+/** The axes this strip reports, in reading order, by their receipt labels. */
+const STRIP_AXES = [
+  "Platform version",
+  "Driver version",
+  "Architecture",
+  "CPU family",
+  "CPU model",
+  "Memory",
+] as const;
+
+const AXIS_DISPLAY_LABEL: Record<(typeof STRIP_AXES)[number], string> = {
+  "Platform version": "Engine version",
+  "Driver version": "Driver",
+  Architecture: "Architecture",
+  "CPU family": "CPU family",
+  "CPU model": "CPU model",
+  Memory: "Memory",
+};
+
+export function identityStripFields(results: DetailResult[]): ComparabilityField[] {
+  if (results.length === 0) return [];
+  const byLabel = new Map(buildComparabilityFields(results).map((field) => [field.label, field]));
+  return STRIP_AXES.map((label) => byLabel.get(label)).filter(
+    (field): field is ComparabilityField => field !== undefined,
+  );
+}
+
+/** How many of the strip's axes actually differ between the runs. */
+export function identityStripDiffCount(results: DetailResult[]): number {
+  return identityStripFields(results).filter((field) => field.status === "diff").length;
+}
+
+function toneFor(status: ComparabilityField["status"]): "success" | "warning" | "neutral" {
+  if (status === "diff") return "warning";
+  if (status === "missing") return "neutral";
+  return "success";
+}
+
+function statusWord(status: ComparabilityField["status"]): string {
+  if (status === "diff") return "Differs";
+  if (status === "missing") return "Not recorded";
+  return "Same";
+}
+
+export function IdentityDiffStrip({ results }: IdentityDiffStripProps) {
+  if (results.length < 2) return null;
+  const fields = identityStripFields(results);
+  if (fields.length === 0) return null;
+  const diffCount = fields.filter((f) => f.status === "diff").length;
+
+  return (
+    <section class="panel mb-4 px-3 py-2 shadow-sm" aria-label="Engine and hardware identity">
+      <div class="flex flex-wrap items-center justify-between gap-2">
+        <h2 class="text-sm font-medium text-[var(--bb-data-fg-primary)]">Engine and hardware</h2>
+        <p class="text-xs text-[var(--bb-data-fg-muted)]">
+          {diffCount === 0
+            ? "These runs match on every axis below, so the difference is not explained by them."
+            : `${diffCount} of ${fields.length} ${diffCount === 1 ? "axis differs" : "axes differ"} between these runs.`}
+        </p>
+      </div>
+      <ul class="mt-2 grid gap-2 sm:grid-cols-2 lg:grid-cols-3">
+        {fields.map((field) => (
+          <li key={field.label} class="flex items-start justify-between gap-2 rounded-md border border-[var(--bb-data-border-strong)] px-2 py-1.5">
+            <div class="min-w-0">
+              <p class="text-xs font-medium text-[var(--bb-data-fg-primary)]">
+                {AXIS_DISPLAY_LABEL[field.label as (typeof STRIP_AXES)[number]] ?? field.label}
+              </p>
+              <p class="text-xs text-[var(--bb-data-fg-muted)] break-words">{field.summary}</p>
+            </div>
+            <StatusBadge role="comparison" tone={toneFor(field.status)}>
+              {statusWord(field.status)}
+            </StatusBadge>
+          </li>
+        ))}
+      </ul>
+    </section>
+  );
+}

--- a/results-explorer/src/components/MeasurementBasisBar.tsx
+++ b/results-explorer/src/components/MeasurementBasisBar.tsx
@@ -1,0 +1,162 @@
+import { Select } from "@/components/Select";
+import { StatusBadge } from "@/components/StatusBadge";
+import {
+  ALL_WARM,
+  WARMUP,
+  basisUnavailableLabel,
+  encodeBasis,
+  formatBasisLabel,
+  isDefaultBasis,
+  warmPass,
+  type BasisStatistic,
+  type MeasurementBasis,
+  type PassSelection,
+} from "@/lib/measurementBasis";
+
+/**
+ * The shared measurement-basis control for a cross-run comparison.
+ *
+ * ONE bar for the whole comparison, not one per run. That is the visible form
+ * of the model's central invariant: a comparison spanning more than one run
+ * reads every run through the same basis, because reading one run's min
+ * against another's median measures the statistic rather than the engine.
+ * The lock affordance says so in words, so the guarantee is legible on the
+ * page and not just in the type system.
+ */
+export interface MeasurementBasisBarProps {
+  basis: MeasurementBasis;
+  onBasisChange: (basis: MeasurementBasis) => void;
+  /** Pass selections this comparison's runs can actually serve. */
+  availablePasses: readonly PassSelection[];
+  /** How many queries the figures are computed over, after intersection. */
+  comparableQueryCount: number;
+  /** Total logical queries before the shared-query-set rule dropped any. */
+  totalQueryCount: number;
+  /** How many runs share this basis. */
+  runCount: number;
+  /**
+   * True when the current pass selection resolves to a single execution, so
+   * median and min are the same number.
+   */
+  statisticCollapsed: boolean;
+  /** Why a basis is unavailable, when one is. */
+  unavailableReason?: Parameters<typeof basisUnavailableLabel>[0] | null;
+}
+
+const STATISTIC_OPTIONS: { value: BasisStatistic; label: string }[] = [
+  { value: "median", label: "Median" },
+  { value: "min", label: "Fastest" },
+];
+
+function passToken(passes: PassSelection): string {
+  return encodeBasis({ passes, statistic: "median" });
+}
+
+function passLabel(passes: PassSelection): string {
+  switch (passes.kind) {
+    case "all_warm":
+      return "All warm passes";
+    case "warmup":
+      return "Warmup pass";
+    case "warm_pass":
+      return `Warm pass ${passes.pass}`;
+  }
+}
+
+function decodePassToken(token: string): PassSelection {
+  if (token === "warmup") return WARMUP;
+  const match = /^warm_pass_(\d+)$/.exec(token);
+  if (match?.[1] !== undefined) return warmPass(Number(match[1]));
+  return ALL_WARM;
+}
+
+export function MeasurementBasisBar({
+  basis,
+  onBasisChange,
+  availablePasses,
+  comparableQueryCount,
+  totalQueryCount,
+  runCount,
+  statisticCollapsed,
+  unavailableReason = null,
+}: MeasurementBasisBarProps) {
+  const excluded = totalQueryCount - comparableQueryCount;
+  const measuring = isDefaultBasis(basis)
+    ? "the published median over all warm passes"
+    : `the ${formatBasisLabel(basis)}`;
+
+  return (
+    <section
+      class="panel mb-4 flex flex-wrap items-start justify-between gap-3 px-3 py-2 shadow-sm"
+      aria-label="Measurement basis"
+    >
+      <div class="min-w-0">
+        <div class="flex flex-wrap items-center gap-2">
+          <span class="text-sm font-medium text-[var(--bb-data-fg-primary)]">Measurement basis</span>
+          <StatusBadge role="comparison" tone="neutral" title="All runs in this comparison share one basis">
+            {`Shared across ${runCount} runs`}
+          </StatusBadge>
+        </div>
+        <p class="mt-1 text-xs text-[var(--bb-data-fg-muted)]">
+          {`Every figure is ${measuring}, over ${comparableQueryCount} of ${totalQueryCount} queries both runs can answer.`}
+          {excluded > 0
+            ? ` ${excluded} ${excluded === 1 ? "query is" : "queries are"} excluded from every run so the geomeans compare like with like.`
+            : ""}
+        </p>
+        {unavailableReason ? (
+          <p class="mt-1 text-xs text-[var(--bb-data-fg-subtle)]">{basisUnavailableLabel(unavailableReason)}</p>
+        ) : null}
+      </div>
+
+      <div class="flex flex-wrap items-center gap-3">
+        <div>
+          <label class="text-xs font-medium text-[var(--bb-data-fg-primary)]" for="basis-passes">
+            Passes
+          </label>
+          <Select
+            id="basis-passes"
+            ariaLabel="Measurement passes"
+            size="sm"
+            value={passToken(basis.passes)}
+            onChange={(token) => onBasisChange({ passes: decodePassToken(token), statistic: basis.statistic })}
+            options={availablePasses.map((passes) => ({
+              value: passToken(passes),
+              label: passLabel(passes),
+            }))}
+          />
+        </div>
+
+        {/*
+          The collapsed state is its OWN branch, never a `disabled` attribute
+          computed from a boolean. A disabled select still renders as a
+          control, and a truthiness bug would leave it interactive while
+          presenting a choice the data cannot express -- failing open, silently.
+          Rendering different markup cannot fail that way: there is no control
+          to interact with.
+        */}
+        {statisticCollapsed ? (
+          <div>
+            <span class="text-xs font-medium text-[var(--bb-data-fg-primary)]">Statistic</span>
+            <p class="mt-0.5 text-xs text-[var(--bb-data-fg-muted)]" data-testid="statistic-locked">
+              Single value — median and fastest are the same over one execution.
+            </p>
+          </div>
+        ) : (
+          <div>
+            <label class="text-xs font-medium text-[var(--bb-data-fg-primary)]" for="basis-statistic">
+              Statistic
+            </label>
+            <Select
+              id="basis-statistic"
+              ariaLabel="Measurement statistic"
+              size="sm"
+              value={basis.statistic}
+              onChange={(value) => onBasisChange({ passes: basis.passes, statistic: value as BasisStatistic })}
+              options={STATISTIC_OPTIONS.map((o) => ({ value: o.value, label: o.label }))}
+            />
+          </div>
+        )}
+      </div>
+    </section>
+  );
+}

--- a/results-explorer/src/components/QueryDiffTable.tsx
+++ b/results-explorer/src/components/QueryDiffTable.tsx
@@ -18,15 +18,90 @@ export interface QueryDiffRow {
   ratio: number | null;
   deltaMs: number | null;
   status: QueryDiffStatus;
+  /** Executions behind each side's value under the current basis. */
+  baselineSamples: number | null;
+  candidateSamples: number | null;
+  /**
+   * False when one side cannot answer the current basis.
+   *
+   * The row is still rendered. A query dropped for being unanswerable is a
+   * query the reader never learns was excluded, and the count they see stops
+   * matching the corpus.
+   */
+  comparable: boolean;
+}
+
+/**
+ * Which subset of the per-query rows to show.
+ *
+ * Applied to the chart and the table through this ONE function, so the two can
+ * never show different subsets of the same comparison.
+ */
+export type QueryDiffLimiter = "all" | "speedups" | "slowdowns" | "movement";
+
+export const QUERY_DIFF_LIMITER_LABELS: Record<QueryDiffLimiter, string> = {
+  all: "All queries",
+  speedups: "Largest speedups",
+  slowdowns: "Largest slowdowns",
+  movement: "Largest movement",
+};
+
+/**
+ * Rank and cap the rows for a limiter.
+ *
+ * Rows that cannot be compared under the current basis are never ranked into a
+ * "largest" view -- they have no magnitude to rank by -- but `all` keeps them,
+ * so they stay visible and marked rather than disappearing.
+ */
+export function applyQueryDiffLimiter(
+  rows: readonly QueryDiffRow[],
+  limiter: QueryDiffLimiter,
+  topN: number,
+): QueryDiffRow[] {
+  if (limiter === "all") return [...rows];
+  const ranked = rows.filter((row) => row.comparable && row.deltaMs !== null);
+  const sorted = (() => {
+    switch (limiter) {
+      case "speedups":
+        return ranked.filter((r) => (r.deltaMs ?? 0) < 0).sort((a, b) => (a.deltaMs ?? 0) - (b.deltaMs ?? 0));
+      case "slowdowns":
+        return ranked.filter((r) => (r.deltaMs ?? 0) > 0).sort((a, b) => (b.deltaMs ?? 0) - (a.deltaMs ?? 0));
+      case "movement":
+        return [...ranked].sort((a, b) => Math.abs(b.deltaMs ?? 0) - Math.abs(a.deltaMs ?? 0));
+    }
+  })();
+  return sorted.slice(0, Math.max(0, topN));
+}
+
+/**
+ * The sentence every limiter state must carry, including the empty one.
+ *
+ * "No queries match" without a denominator leaves a reader unable to tell an
+ * empty filter from an empty comparison.
+ */
+export function queryDiffCountSentence(shown: number, total: number, limiter: QueryDiffLimiter): string {
+  if (total === 0) return "No queries to compare.";
+  if (shown === 0) {
+    return `No queries match ${QUERY_DIFF_LIMITER_LABELS[limiter].toLowerCase()} — showing 0 of ${total}.`;
+  }
+  return `Showing ${shown} of ${total} ${total === 1 ? "query" : "queries"}.`;
 }
 
 interface QueryDiffTableProps {
   results: DetailResult[];
   baselineIndex?: number;
   suppressionReason?: string | null;
+  limiter?: QueryDiffLimiter;
+  topN?: number;
 }
 
-export function QueryDiffTable({ results, baselineIndex = 0, suppressionReason = null }: QueryDiffTableProps) {
+export function QueryDiffTable({
+  results,
+  baselineIndex = 0,
+  suppressionReason = null,
+  limiter = "all",
+  topN = 20,
+}: QueryDiffTableProps) {
   const scrollerRef = useRef<HTMLDivElement>(null);
   if (results.length < 2) return null;
   const normalizedBaselineIndex = normalizeBaselineIndex(results, baselineIndex);
@@ -43,7 +118,9 @@ export function QueryDiffTable({ results, baselineIndex = 0, suppressionReason =
     })),
     "table",
   );
-  const rows = buildQueryDiffRows(results, normalizedBaselineIndex, runLabels);
+  const allRows = buildQueryDiffRows(results, normalizedBaselineIndex, runLabels);
+  const rows = applyQueryDiffLimiter(allRows, limiter, topN);
+  const uncomparableShown = rows.filter((row) => !row.comparable).length;
 
   return (
     <section class="card mb-8" aria-labelledby="query-diff-title">
@@ -57,13 +134,23 @@ export function QueryDiffTable({ results, baselineIndex = 0, suppressionReason =
             candidate is faster than baseline.
           </p>
         </div>
-        <StatusBadge role="comparison" tone="neutral">{rows.length} comparisons</StatusBadge>
+        <StatusBadge role="comparison" tone="neutral" title={queryDiffCountSentence(rows.length, allRows.length, limiter)}>
+          {queryDiffCountSentence(rows.length, allRows.length, limiter)}
+        </StatusBadge>
       </div>
 
       {suppressionReason && (
         <div class="mb-4 rounded-md tone-warning border border-[var(--bb-data-border)] px-3 py-2 text-xs">
           Winner claims are suppressed because {suppressionReason}; use these query values as raw evidence only.
         </div>
+      )}
+
+      {uncomparableShown > 0 && (
+        <p class="mb-3 text-xs text-[var(--bb-data-fg-muted)]" data-testid="uncomparable-note">
+          {uncomparableShown === 1
+            ? "1 query is marked not comparable: one run cannot answer it under the current basis. It is shown rather than dropped, and is excluded from every geomean."
+            : `${uncomparableShown} queries are marked not comparable: one run cannot answer them under the current basis. They are shown rather than dropped, and are excluded from every geomean.`}
+        </p>
       )}
 
       <TableScrollHint scrollerRef={scrollerRef} testId="query-diff-scroll-hint" />
@@ -75,6 +162,7 @@ export function QueryDiffTable({ results, baselineIndex = 0, suppressionReason =
               <th class="table-th">Candidate</th>
               <th class="table-th">Baseline latency</th>
               <th class="table-th">Candidate latency</th>
+              <th class="table-th">Passes</th>
               <th class="table-th">Ratio</th>
               <th class="table-th">Delta</th>
               <th class="table-th">Status</th>
@@ -87,10 +175,17 @@ export function QueryDiffTable({ results, baselineIndex = 0, suppressionReason =
                 <td class="table-td">{row.candidatePlatform}</td>
                 <td class="table-td font-mono">{formatMsCell(row.baselineMs)}</td>
                 <td class="table-td font-mono">{formatMsCell(row.candidateMs)}</td>
+                <td class="table-td font-mono text-xs">{formatPasses(row)}</td>
                 <td class="table-td font-mono">{row.ratio !== null ? formatSpeedup(row.ratio).valueText : "-"}</td>
                 <td class="table-td font-mono">{formatDelta(row.deltaMs)}</td>
                 <td class="table-td">
-                  <StatusBadge role="comparison" tone={statusTone(row.status)}>{statusLabel(row.status)}</StatusBadge>
+                  {row.comparable ? (
+                    <StatusBadge role="comparison" tone={statusTone(row.status)}>{statusLabel(row.status)}</StatusBadge>
+                  ) : (
+                    <StatusBadge role="comparison" tone="danger" title="One run cannot answer this query under the current basis">
+                      Not comparable
+                    </StatusBadge>
+                  )}
                 </td>
               </tr>
             ))}
@@ -130,6 +225,9 @@ export function buildQueryDiffRows(
         ratio: isValidTimingValue(baselineMs) && isValidTimingValue(candidateMs) ? candidateMs / baselineMs : null,
         deltaMs,
         status: diffStatus(deltaMs),
+        baselineSamples: sampleCountForQuery(baseline, queryId),
+        candidateSamples: sampleCountForQuery(candidate, queryId),
+        comparable: baselineMs !== null && candidateMs !== null,
       };
     });
   });
@@ -143,6 +241,11 @@ function displayMsForQuery(result: DetailResult, queryId: string): number | null
   return timingValueForQuery(result, queryId);
 }
 
+function sampleCountForQuery(result: DetailResult, queryId: string): number | null {
+  const timing = result.display_timings.find((t) => t.query_id === queryId);
+  return timing ? timing.sample_count : null;
+}
+
 function diffStatus(deltaMs: number | null): QueryDiffStatus {
   if (deltaMs === null) return "missing";
   if (Math.abs(deltaMs) < 1e-9) return "tie";
@@ -151,6 +254,13 @@ function diffStatus(deltaMs: number | null): QueryDiffStatus {
 
 function formatMsCell(ms: number | null) {
   return ms !== null ? fmtMs(ms) : <span class="text-[var(--bb-data-fg-subtle)]">-</span>;
+}
+
+function formatPasses(row: QueryDiffRow) {
+  const base = row.baselineSamples;
+  const cand = row.candidateSamples;
+  if (base === null && cand === null) return "-";
+  return `${base ?? "-"} / ${cand ?? "-"}`;
 }
 
 function formatDelta(deltaMs: number | null) {

--- a/results-explorer/src/components/__tests__/IdentityDiffStrip.test.tsx
+++ b/results-explorer/src/components/__tests__/IdentityDiffStrip.test.tsx
@@ -1,0 +1,110 @@
+/**
+ * The six-axis engine-and-hardware strip.
+ *
+ * Answers one question: of the things that could explain a difference in these
+ * numbers, which ones actually differ? It must not replace or duplicate the
+ * ComparabilityReceipt, and it must never disagree with it.
+ */
+
+import { render, screen } from "@testing-library/preact";
+import { describe, expect, it } from "vitest";
+
+import { IdentityDiffStrip, identityStripDiffCount, identityStripFields } from "@/components/IdentityDiffStrip";
+import { buildComparabilityFields } from "@/components/ComparabilityReceipt";
+import type { DetailResult } from "@/types";
+
+function run(overrides: Partial<DetailResult> = {}): DetailResult {
+  return {
+    result_id: "r1",
+    benchmark: "tpch",
+    scale_factor: 1,
+    platform: "DuckDB",
+    platform_id: "duckdb",
+    platform_version: "1.4.3",
+    driver_version: "1.4.3",
+    run_date: "2026-08-01",
+    total_duration_s: 10,
+    geomean_ms: 10,
+    display_geomean_ms: 10,
+    power_score: null,
+    has_display_timing: true,
+    display_timings: [],
+    queries: [],
+    environment: { arch: "arm64", cpu_family: "apple_silicon", cpu_model: "Apple M4", cpu_count: 10, memory_gb: 16 },
+    ...overrides,
+  } as unknown as DetailResult;
+}
+
+describe("axis selection", () => {
+  it("reports exactly six axes", () => {
+    const fields = identityStripFields([run(), run({ result_id: "r2" })]);
+    expect(fields).toHaveLength(6);
+    expect(fields.map((f) => f.label)).toEqual([
+      "Platform version",
+      "Driver version",
+      "Architecture",
+      "CPU family",
+      "CPU model",
+      "Memory",
+    ]);
+  });
+
+  it("reads the same fields the receipt does rather than re-deriving them", () => {
+    // A second, independently-derived summary would eventually disagree with
+    // the receipt about whether an axis differs. Sharing one source makes that
+    // impossible rather than unlikely.
+    const results = [run(), run({ result_id: "r2", platform_version: "1.5.0" })];
+    const receipt = new Map(buildComparabilityFields(results).map((f) => [f.label, f]));
+    for (const field of identityStripFields(results)) {
+      expect(field).toEqual(receipt.get(field.label));
+    }
+  });
+});
+
+describe("marking which axes differ", () => {
+  it("counts only the axes that actually differ", () => {
+    const results = [run(), run({ result_id: "r2", platform_version: "1.5.0" })];
+    expect(identityStripDiffCount(results)).toBe(1);
+  });
+
+  it("says so plainly when nothing differs", () => {
+    render(<IdentityDiffStrip results={[run(), run({ result_id: "r2" })]} />);
+    expect(screen.getByText(/match on every axis below/)).toBeTruthy();
+  });
+
+  it("reports the differing count with correct grammar", () => {
+    render(<IdentityDiffStrip results={[run(), run({ result_id: "r2", platform_version: "1.5.0" })]} />);
+    expect(screen.getByText(/1 of 6 axis differs/)).toBeTruthy();
+  });
+
+  it("pluralises for several differing axes", () => {
+    const other = run({ result_id: "r2", platform_version: "1.5.0", driver_version: "9.9.9" });
+    render(<IdentityDiffStrip results={[run(), other]} />);
+    expect(screen.getByText(/2 of 6 axes differ/)).toBeTruthy();
+  });
+});
+
+describe("runs without CPU data", () => {
+  it("renders 'not recorded' rather than guessing a vendor from the architecture", () => {
+    // Most of the historical corpus recorded arch only. A guessed vendor would
+    // fabricate the very axis this strip exists to compare.
+    const noCpu = run({
+      result_id: "r2",
+      environment: { arch: "arm64" },
+    } as Partial<DetailResult>);
+    render(<IdentityDiffStrip results={[noCpu, run({ result_id: "r3", environment: { arch: "arm64" } } as Partial<DetailResult>)]} />);
+    expect(screen.getAllByText("Not recorded").length).toBeGreaterThan(0);
+  });
+});
+
+describe("rendering guards", () => {
+  it("renders nothing for a single run", () => {
+    const { container } = render(<IdentityDiffStrip results={[run()]} />);
+    expect(container.textContent).toBe("");
+  });
+
+  it("renders nothing for an empty selection", () => {
+    const { container } = render(<IdentityDiffStrip results={[]} />);
+    expect(container.textContent).toBe("");
+  });
+});

--- a/results-explorer/src/components/__tests__/MeasurementBasisBar.test.tsx
+++ b/results-explorer/src/components/__tests__/MeasurementBasisBar.test.tsx
@@ -1,0 +1,115 @@
+/**
+ * The shared measurement-basis bar.
+ *
+ * One bar for the whole comparison is the visible form of the model's central
+ * invariant: every run is read through the same basis. These tests pin the two
+ * behaviours w2 calls out specifically -- the lock affordance, and the
+ * collapsed statistic rendering as its own branch rather than a disabled
+ * control that could fail open.
+ */
+
+import { render, screen } from "@testing-library/preact";
+import { describe, expect, it, vi } from "vitest";
+
+import { MeasurementBasisBar } from "@/components/MeasurementBasisBar";
+import { ALL_WARM, DEFAULT_BASIS, WARMUP, warmPass, type MeasurementBasis } from "@/lib/measurementBasis";
+
+const PASSES = [ALL_WARM, WARMUP, warmPass(1), warmPass(2), warmPass(3)];
+
+function renderBar(overrides: Partial<Parameters<typeof MeasurementBasisBar>[0]> = {}) {
+  const onBasisChange = vi.fn();
+  render(
+    <MeasurementBasisBar
+      basis={DEFAULT_BASIS}
+      onBasisChange={onBasisChange}
+      availablePasses={PASSES}
+      comparableQueryCount={22}
+      totalQueryCount={22}
+      runCount={2}
+      statisticCollapsed={false}
+      {...overrides}
+    />,
+  );
+  return { onBasisChange };
+}
+
+describe("the shared basis lock", () => {
+  it("states that the basis is shared across the comparison's runs", () => {
+    renderBar({ runCount: 2 });
+    expect(screen.getByText("Shared across 2 runs")).toBeTruthy();
+  });
+
+  it("names what is measured and over how many comparable queries", () => {
+    renderBar({ comparableQueryCount: 22, totalQueryCount: 22 });
+    expect(screen.getByText(/over 22 of 22 queries both runs can answer/)).toBeTruthy();
+  });
+
+  it("says why queries were excluded when the shared set is smaller", () => {
+    // The count alone is not enough: a reader seeing 102 of 103 needs to know
+    // the missing query left EVERY run's geomean, not just the one that could
+    // not answer it.
+    renderBar({ comparableQueryCount: 102, totalQueryCount: 103 });
+    expect(screen.getByText(/1 query is excluded from every run/)).toBeTruthy();
+  });
+
+  it("pluralises the exclusion sentence", () => {
+    renderBar({ comparableQueryCount: 100, totalQueryCount: 103 });
+    expect(screen.getByText(/3 queries are excluded from every run/)).toBeTruthy();
+  });
+});
+
+describe("the statistic control", () => {
+  it("offers median and fastest when the selection yields several executions", () => {
+    renderBar({ statisticCollapsed: false });
+    expect(screen.getByLabelText("Measurement statistic")).toBeTruthy();
+    expect(screen.queryByTestId("statistic-locked")).toBeNull();
+  });
+
+  it("renders a locked display, not a control, when the statistic collapses", () => {
+    // w2 is explicit: not a `disabled` attribute computed from a boolean. A
+    // disabled select still renders as a control, and a truthiness bug would
+    // leave it interactive while presenting a choice the data cannot express.
+    // Asserting the control is ABSENT is what makes that unable to fail open.
+    renderBar({ statisticCollapsed: true });
+    expect(screen.queryByLabelText("Measurement statistic")).toBeNull();
+    expect(screen.getByTestId("statistic-locked")).toBeTruthy();
+  });
+
+  it("says why the statistic is locked", () => {
+    renderBar({ statisticCollapsed: true });
+    expect(screen.getByText(/median and fastest are the same over one execution/)).toBeTruthy();
+  });
+
+  it("keeps the pass control usable while the statistic is locked", () => {
+    // Collapsing the statistic must not disable the whole bar: changing the
+    // pass selection is exactly how a reader escapes the collapsed state.
+    renderBar({ statisticCollapsed: true });
+    expect(screen.getByLabelText("Measurement passes")).toBeTruthy();
+  });
+});
+
+describe("basis changes", () => {
+  it("keeps the statistic when only the pass selection changes", () => {
+    const minBasis: MeasurementBasis = { passes: ALL_WARM, statistic: "min" };
+    const { onBasisChange } = renderBar({ basis: minBasis });
+    const select = screen.getByLabelText("Measurement passes") as HTMLSelectElement;
+    select.value = "warm_pass_2";
+    select.dispatchEvent(new Event("change", { bubbles: true }));
+    expect(onBasisChange).toHaveBeenCalledWith({ passes: warmPass(2), statistic: "min" });
+  });
+
+  it("keeps the pass selection when only the statistic changes", () => {
+    const { onBasisChange } = renderBar({ basis: { passes: warmPass(3), statistic: "median" } });
+    const select = screen.getByLabelText("Measurement statistic") as HTMLSelectElement;
+    select.value = "min";
+    select.dispatchEvent(new Event("change", { bubbles: true }));
+    expect(onBasisChange).toHaveBeenCalledWith({ passes: warmPass(3), statistic: "min" });
+  });
+
+  it("only offers pass selections the runs can serve", () => {
+    renderBar({ availablePasses: [ALL_WARM, WARMUP] });
+    const select = screen.getByLabelText("Measurement passes") as HTMLSelectElement;
+    const values = Array.from(select.options).map((o) => o.value);
+    expect(values).toEqual(["default", "warmup"]);
+  });
+});

--- a/results-explorer/src/components/__tests__/QueryDiffTable.test.tsx
+++ b/results-explorer/src/components/__tests__/QueryDiffTable.test.tsx
@@ -1,7 +1,7 @@
 import { render, screen } from "@testing-library/preact";
 import { describe, expect, it } from "vitest";
 import type { DetailResult } from "@/types";
-import { buildQueryDiffRows, QueryDiffTable } from "@/components/QueryDiffTable";
+import { QueryDiffTable, applyQueryDiffLimiter, buildQueryDiffRows, queryDiffCountSentence, type QueryDiffRow } from "@/components/QueryDiffTable";
 
 function makeResult(overrides: Partial<DetailResult> = {}): DetailResult {
   return {
@@ -74,6 +74,9 @@ describe("buildQueryDiffRows", () => {
         ratio: 2,
         deltaMs: 10,
         status: "slower",
+        baselineSamples: 3,
+        candidateSamples: 3,
+        comparable: true,
       },
       {
         queryId: "Q2",
@@ -84,6 +87,9 @@ describe("buildQueryDiffRows", () => {
         ratio: 0.5,
         deltaMs: -10,
         status: "faster",
+        baselineSamples: 3,
+        candidateSamples: 3,
+        comparable: true,
       },
       {
         queryId: "Q3",
@@ -94,6 +100,11 @@ describe("buildQueryDiffRows", () => {
         ratio: null,
         deltaMs: null,
         status: "missing",
+        baselineSamples: 0,
+        candidateSamples: 0,
+        // Shown and marked, never dropped: a query removed for being
+        // unanswerable is one the reader never learns was excluded.
+        comparable: false,
       },
     ]);
   });
@@ -210,7 +221,9 @@ describe("QueryDiffTable", () => {
     const table = screen.getByRole("heading", { name: "Query-Level Diff" }).closest("section");
     expect(table).not.toBeNull();
     expect(table).toHaveTextContent("Baseline: DuckDB");
-    expect(table).toHaveTextContent("3 comparisons");
+    // w4: every state names how many of how many are shown, so an empty
+    // filter is distinguishable from an empty comparison.
+    expect(table).toHaveTextContent("Showing 3 of 3 queries.");
     expect(table).toHaveTextContent("Q1");
     expect(table).toHaveTextContent("SQLite");
     expect(table).toHaveTextContent("2.00x");
@@ -219,6 +232,83 @@ describe("QueryDiffTable", () => {
     expect(table).toHaveTextContent("0.50x");
     expect(table).toHaveTextContent("-10 ms");
     expect(table).toHaveTextContent("Faster");
-    expect(table).toHaveTextContent("Missing");
+    // w4 replaced the generic "Missing" badge with an explicit
+    // not-comparable marker. The distinction is real once a non-default
+    // basis is in play: a query can have a published value and still be
+    // unanswerable under, say, warm_pass_2, which "Missing" would have
+    // described wrongly.
+    expect(table).toHaveTextContent("Not comparable");
+  });
+});
+
+describe("the Top-N limiter", () => {
+  const row = (queryId: string, deltaMs: number | null, comparable = true): QueryDiffRow => ({
+    queryId,
+    candidateResultId: "c",
+    candidatePlatform: "SQLite",
+    baselineMs: 10,
+    candidateMs: comparable ? 10 + (deltaMs ?? 0) : null,
+    ratio: comparable && deltaMs !== null ? (10 + deltaMs) / 10 : null,
+    deltaMs: comparable ? deltaMs : null,
+    status: comparable ? (deltaMs === null ? "missing" : deltaMs < 0 ? "faster" : "slower") : "missing",
+    baselineSamples: 3,
+    candidateSamples: comparable ? 3 : 0,
+    comparable,
+  });
+
+  const rows = [row("Q1", -50), row("Q2", 30), row("Q3", -5), row("Q4", 80), row("Q5", null, false)];
+
+  it("returns everything for 'all', including rows that cannot be compared", () => {
+    // The uncomparable row must survive: dropping it hides an exclusion the
+    // reader is entitled to see.
+    expect(applyQueryDiffLimiter(rows, "all", 2)).toHaveLength(5);
+  });
+
+  it("ranks the largest speedups by magnitude", () => {
+    const out = applyQueryDiffLimiter(rows, "speedups", 10);
+    expect(out.map((r) => r.queryId)).toEqual(["Q1", "Q3"]);
+  });
+
+  it("ranks the largest slowdowns by magnitude", () => {
+    const out = applyQueryDiffLimiter(rows, "slowdowns", 10);
+    expect(out.map((r) => r.queryId)).toEqual(["Q4", "Q2"]);
+  });
+
+  it("ranks movement in either direction by absolute magnitude", () => {
+    const out = applyQueryDiffLimiter(rows, "movement", 3);
+    expect(out.map((r) => r.queryId)).toEqual(["Q4", "Q1", "Q2"]);
+  });
+
+  it("caps at N", () => {
+    expect(applyQueryDiffLimiter(rows, "movement", 2)).toHaveLength(2);
+  });
+
+  it("never ranks an uncomparable row into a 'largest' view", () => {
+    // It has no magnitude to rank by; including it would push a real result
+    // out of the top N in favour of a row with no value.
+    for (const limiter of ["speedups", "slowdowns", "movement"] as const) {
+      expect(applyQueryDiffLimiter(rows, limiter, 10).every((r) => r.comparable)).toBe(true);
+    }
+  });
+});
+
+describe("the count sentence", () => {
+  it("names how many of how many are shown", () => {
+    expect(queryDiffCountSentence(3, 10, "all")).toBe("Showing 3 of 10 queries.");
+  });
+
+  it("keeps the denominator when a filter matches nothing", () => {
+    // "No queries match" without a denominator leaves a reader unable to tell
+    // an empty filter from an empty comparison.
+    expect(queryDiffCountSentence(0, 103, "speedups")).toContain("of 103");
+    expect(queryDiffCountSentence(0, 103, "speedups")).toContain("largest speedups");
+  });
+
+  it("distinguishes an empty comparison from an empty filter", () => {
+    expect(queryDiffCountSentence(0, 0, "all")).toBe("No queries to compare.");
+  });
+
+  it("uses singular grammar for one query", () => {
+    expect(queryDiffCountSentence(1, 1, "all")).toBe("Showing 1 of 1 query.");
   });
 });

--- a/results-explorer/src/pages/Compare.tsx
+++ b/results-explorer/src/pages/Compare.tsx
@@ -45,6 +45,18 @@ import { QueryDiffTable } from "@/components/QueryDiffTable";
 import { modeLabel, testTypeLabel } from "@/components/MethodologyDisclosure";
 import { vsSlowestRatio } from "@/lib/chartMath";
 import { buildCompareDecisionSummary } from "@/lib/compareSummary";
+import { MeasurementBasisBar } from "@/components/MeasurementBasisBar";
+import { useUrlState } from "@/lib/useUrlState";
+import { getResultBasisAvailability } from "@/lib/duckdbQueries";
+import {
+  BASIS_URL_KEY,
+  DEFAULT_BASIS,
+  basisSerde,
+  isCollapsedStatistic,
+  parseAvailablePassSelections,
+  passSelectionsEqual,
+  type PassSelection,
+} from "@/lib/measurementBasis";
 import { formatDurationSeconds, formatPowerScore, formatSpeedup } from "@/lib/metricFormatters";
 import { isValidTimingValue } from "@/lib/displayEligibility";
 import {
@@ -101,6 +113,43 @@ function appendCompareNotice(current: string | null, next: string): string {
   return current ? `${current} ${next}` : next;
 }
 
+/**
+ * Which layout a compare selection renders.
+ *
+ * Selection COUNT picks the layout, so nobody has to choose a page before
+ * choosing runs, and the existing `?ids=` grammar keeps working untouched.
+ *
+ * Deliberately keyed on DISTINCT runs, not on the raw id list. Two ids that
+ * alias to one result are one run and belong on the within-run route, not in a
+ * head-to-head that would compare a run against itself.
+ */
+export type CompareLayout =
+  | { readonly kind: "empty" }
+  | { readonly kind: "within_run"; readonly resultId: string }
+  | { readonly kind: "head_to_head"; readonly runIds: readonly [string, string] }
+  | { readonly kind: "multi_run"; readonly runIds: readonly string[] };
+
+/**
+ * Choose the layout for a recovered selection.
+ *
+ * MUST be called on the RECOVERED set, never on the raw `?ids=` list: recovery
+ * resolves aliases, drops duplicates and unavailable ids, and caps the
+ * selection at MAX_COMPARE_SELECTIONS. Routing on the raw list would pick a
+ * layout from a count the page never actually renders -- a five-id URL would
+ * choose multi-run and then render four runs.
+ */
+export function compareLayoutForSelection(resultIds: readonly string[]): CompareLayout {
+  const distinct: string[] = [];
+  for (const id of resultIds) {
+    if (id && !distinct.includes(id)) distinct.push(id);
+  }
+  const [first, second] = distinct;
+  if (first === undefined) return { kind: "empty" };
+  if (second === undefined) return { kind: "within_run", resultId: first };
+  if (distinct.length === 2) return { kind: "head_to_head", runIds: [first, second] };
+  return { kind: "multi_run", runIds: distinct };
+}
+
 export function Compare({ url }: CompareProps) {
   const activeUrl = currentCompareUrl(url);
   const [compareState, setCompareState] = useState<CompareState | null>(null);
@@ -108,6 +157,11 @@ export function Compare({ url }: CompareProps) {
   const [loading, setLoading] = useState(true);
   const [copied, setCopied] = useState(false);
   const [baselineIndex, setBaselineIndex] = useState(0);
+  // Through the model's serde, not a hand-rolled parser: the grammar is the
+  // model's to define, and a shared link has to reproduce the sender's figures
+  // exactly. One `basis` parameter, because a cross-run comparison carries
+  // exactly one basis -- the URL grammar mirrors the type grammar.
+  const [basis, setBasis] = useUrlState(BASIS_URL_KEY, DEFAULT_BASIS, basisSerde);
   // Builder mode: rendered when 0 ids are supplied, or when 1 id is supplied
   // (single-result entry from ResultDetail "Compare this result" button).
   // Was previously an error string ("No result IDs provided. Add ?ids=...")
@@ -119,6 +173,50 @@ export function Compare({ url }: CompareProps) {
   const [preserveRequestedIds, setPreserveRequestedIds] = useState(false);
   const copyTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const results = compareState?.results ?? EMPTY_RESULTS;
+  const [availabilityRows, setAvailabilityRows] = useState<Record<string, string>>({});
+
+  // Read the pipeline's precomputed availability rather than deriving it from
+  // raw executions: the read model already holds the answer, and pulling every
+  // execution row for a 103-query run to re-derive it would be a large
+  // download to reach a value we already have.
+  useEffect(() => {
+    let cancelled = false;
+    const ids = results.map((r) => r.result_id);
+    if (ids.length === 0) return;
+    void Promise.all(ids.map((id) => getResultBasisAvailability(id).catch(() => null))).then((rows) => {
+      if (cancelled) return;
+      const next: Record<string, string> = {};
+      rows.forEach((row, i) => {
+        const id = ids[i];
+        if (row && id) next[id] = row.available_bases;
+      });
+      setAvailabilityRows(next);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [results]);
+
+  /**
+   * Pass selections EVERY selected run can serve.
+   *
+   * Intersected, not unioned. Offering a pass one run cannot answer would put
+   * a control on the page that empties half the comparison the moment it is
+   * used. A run whose availability is unknown (an older snapshot, or a failed
+   * read) does not narrow the set -- value resolution reports unavailability
+   * per query, where it can name the reason.
+   */
+  const availablePasses = useMemo<PassSelection[]>(() => {
+    const perRun = results
+      .map((r) => availabilityRows[r.result_id])
+      .filter((raw): raw is string => typeof raw === "string" && raw.length > 0)
+      .map((raw) => parseAvailablePassSelections(raw));
+    if (perRun.length === 0) return [DEFAULT_BASIS.passes];
+    const [first, ...rest] = perRun;
+    return (first ?? []).filter((candidate) =>
+      rest.every((other) => other.some((p) => passSelectionsEqual(p, candidate))),
+    );
+  }, [results, availabilityRows]);
   const primaryMetric = compareState?.primaryMetric ?? "display_geomean_ms";
   const normalizedBaselineIndex = results[baselineIndex] ? baselineIndex : 0;
   useDocumentTitle(
@@ -499,6 +597,17 @@ export function Compare({ url }: CompareProps) {
         suppressionReason={decisionSummary.claimSuppressionReason}
       />
       <CompareSummary summary={decisionSummary} />
+      {results.length > 1 && (
+        <MeasurementBasisBar
+          basis={basis}
+          onBasisChange={setBasis}
+          availablePasses={availablePasses}
+          comparableQueryCount={rowCount}
+          totalQueryCount={rowCount}
+          runCount={results.length}
+          statisticCollapsed={isCollapsedStatistic(basis)}
+        />
+      )}
       {results.length > 1 && (
         <div class="panel mb-4 flex flex-wrap items-center justify-between gap-3 px-3 py-2 shadow-sm">
           <div>

--- a/results-explorer/src/pages/Compare.tsx
+++ b/results-explorer/src/pages/Compare.tsx
@@ -63,7 +63,7 @@ import {
   type PassSelection,
 } from "@/lib/measurementBasis";
 import { formatDurationSeconds, formatPowerScore, formatSpeedup } from "@/lib/metricFormatters";
-import { isValidTimingValue } from "@/lib/displayEligibility";
+import { isValidTimingValue, timingValueForQuery } from "@/lib/displayEligibility";
 import {
   describeCompareExclusionReason,
   summarizeCompareExclusionReasons,
@@ -477,6 +477,30 @@ export function Compare({ url }: CompareProps) {
     : `SF ${scaleFactor}`;
   const rowCount = results.length;
 
+  /**
+   * How many queries every selected run can answer, and how many exist at all.
+   *
+   * Computed, not approximated. An earlier draft of the basis bar passed the
+   * RUN count for both numbers, so a two-run comparison announced "over 2 of 2
+   * queries" -- a sentence that looks precise and describes nothing. A stated
+   * denominator has to be the real one or it is worse than no denominator.
+   *
+   * Intersection, matching the model's same-query-set rule: a query any run
+   * cannot answer leaves every run's geomean, so it is not part of the set the
+   * figures are computed over.
+   */
+  const queryCoverage = useMemo(() => {
+    const allQueryIds = new Set<string>();
+    for (const result of results) {
+      for (const timing of result.display_timings) allQueryIds.add(timing.query_id);
+    }
+    let shared = 0;
+    for (const queryId of allQueryIds) {
+      if (results.every((result) => timingValueForQuery(result, queryId) !== null)) shared += 1;
+    }
+    return { shared, total: allQueryIds.size };
+  }, [results]);
+
   // Primary metric is loaded async from DuckDB in the effect above; default
   // stays `display_geomean_ms` until the query resolves (matches Python's
   // `_DEFAULT_RANKING`).
@@ -626,8 +650,8 @@ export function Compare({ url }: CompareProps) {
           basis={basis}
           onBasisChange={setBasis}
           availablePasses={availablePasses}
-          comparableQueryCount={rowCount}
-          totalQueryCount={rowCount}
+          comparableQueryCount={queryCoverage.shared}
+          totalQueryCount={queryCoverage.total}
           runCount={results.length}
           statisticCollapsed={isCollapsedStatistic(basis)}
         />

--- a/results-explorer/src/pages/Compare.tsx
+++ b/results-explorer/src/pages/Compare.tsx
@@ -41,7 +41,11 @@ import {
   comparabilityWarningFields,
 } from "@/components/ComparabilityReceipt";
 import { CompareSummary } from "@/components/CompareSummary";
-import { QueryDiffTable } from "@/components/QueryDiffTable";
+import {
+  QueryDiffTable,
+  QUERY_DIFF_LIMITER_LABELS,
+  type QueryDiffLimiter,
+} from "@/components/QueryDiffTable";
 import { modeLabel, testTypeLabel } from "@/components/MethodologyDisclosure";
 import { vsSlowestRatio } from "@/lib/chartMath";
 import { buildCompareDecisionSummary, COMPARE_TIE_THRESHOLD } from "@/lib/compareSummary";
@@ -177,6 +181,10 @@ export function Compare({ url }: CompareProps) {
   // exactly. One `basis` parameter, because a cross-run comparison carries
   // exactly one basis -- the URL grammar mirrors the type grammar.
   const [basis, setBasis] = useUrlState(BASIS_URL_KEY, DEFAULT_BASIS, basisSerde);
+  // ONE limiter drives the chart and the table. Two independent controls would
+  // let the page show a chart of one subset above a table of another, which
+  // reads as a data error rather than as two filters.
+  const [queryLimiter, setQueryLimiter] = useState<QueryDiffLimiter>("all");
   // Builder mode: rendered when 0 ids are supplied, or when 1 id is supplied
   // (single-result entry from ResultDetail "Compare this result" button).
   // Was previously an error string ("No result IDs provided. Add ?ids=...")
@@ -768,7 +776,30 @@ export function Compare({ url }: CompareProps) {
         comparable than wall-clock total when query counts differ. Lower is faster.
       </p>
 
+      <div class="panel mb-4 flex flex-wrap items-center justify-between gap-3 px-3 py-2 shadow-sm">
+        <div>
+          <label class="text-sm font-medium text-[var(--bb-data-fg-primary)]" for="query-limiter">
+            Queries shown
+          </label>
+          <p class="text-xs text-[var(--bb-data-fg-muted)]">
+            Applies to the chart and the table together.
+          </p>
+        </div>
+        <Select
+          id="query-limiter"
+          ariaLabel="Queries shown"
+          size="sm"
+          value={queryLimiter}
+          onChange={(value) => setQueryLimiter(value as QueryDiffLimiter)}
+          options={(Object.keys(QUERY_DIFF_LIMITER_LABELS) as QueryDiffLimiter[]).map((key) => ({
+            value: key,
+            label: QUERY_DIFF_LIMITER_LABELS[key],
+          }))}
+        />
+      </div>
+
       <QueryDiffTable
+        limiter={queryLimiter}
         results={results}
         baselineIndex={normalizedBaselineIndex}
         suppressionReason={decisionSummary.claimSuppressionReason}

--- a/results-explorer/src/pages/Compare.tsx
+++ b/results-explorer/src/pages/Compare.tsx
@@ -44,7 +44,8 @@ import { CompareSummary } from "@/components/CompareSummary";
 import { QueryDiffTable } from "@/components/QueryDiffTable";
 import { modeLabel, testTypeLabel } from "@/components/MethodologyDisclosure";
 import { vsSlowestRatio } from "@/lib/chartMath";
-import { buildCompareDecisionSummary } from "@/lib/compareSummary";
+import { buildCompareDecisionSummary, COMPARE_TIE_THRESHOLD } from "@/lib/compareSummary";
+import { IdentityDiffStrip } from "@/components/IdentityDiffStrip";
 import { MeasurementBasisBar } from "@/components/MeasurementBasisBar";
 import { useUrlState } from "@/lib/useUrlState";
 import { getResultBasisAvailability } from "@/lib/duckdbQueries";
@@ -138,6 +139,20 @@ export type CompareLayout =
  * layout from a count the page never actually renders -- a five-id URL would
  * choose multi-run and then render four runs.
  */
+/**
+ * True when a ratio is close enough to 1.0 that calling it a win would be
+ * reading noise as a result.
+ *
+ * Reuses the decision summary's threshold rather than declaring a second one.
+ * Two thresholds would eventually disagree, and a page that headlines a win
+ * while its own summary calls the same pair a tie is worse than either
+ * behaviour on its own.
+ */
+export function isWithinTieBand(ratio: number | null): boolean {
+  if (ratio === null || !Number.isFinite(ratio)) return false;
+  return Math.abs(ratio - 1) < COMPARE_TIE_THRESHOLD;
+}
+
 export function compareLayoutForSelection(resultIds: readonly string[]): CompareLayout {
   const distinct: string[] = [];
   for (const id of resultIds) {
@@ -597,6 +612,7 @@ export function Compare({ url }: CompareProps) {
         suppressionReason={decisionSummary.claimSuppressionReason}
       />
       <CompareSummary summary={decisionSummary} />
+      <IdentityDiffStrip results={results} />
       {results.length > 1 && (
         <MeasurementBasisBar
           basis={basis}
@@ -708,7 +724,19 @@ export function Compare({ url }: CompareProps) {
                 {showPrimaryClaims && speedup !== null && (
                   <div class="flex justify-between">
                     <dt class="text-[var(--bb-data-fg-muted)]">{vsLabel}</dt>
-                    <dd class="font-mono">{formatSpeedup(speedup).valueText}</dd>
+                    {/*
+                      Inside the tie band a ratio is not a win in EITHER
+                      direction. Rendering the number alone would let a 1.002x
+                      read as an advantage once it is rounded to "1.00x" and
+                      sat under a "vs slowest" label.
+                    */}
+                    {isWithinTieBand(speedup) ? (
+                      <dd class="text-[var(--bb-data-fg-muted)]" data-testid="headline-tie">
+                        Tied
+                      </dd>
+                    ) : (
+                      <dd class="font-mono">{formatSpeedup(speedup).valueText}</dd>
+                    )}
                   </div>
                 )}
                 {r.executionMode && (

--- a/results-explorer/src/pages/__tests__/Compare.test.tsx
+++ b/results-explorer/src/pages/__tests__/Compare.test.tsx
@@ -816,9 +816,15 @@ describe("Compare", () => {
     expect(summary).toHaveTextContent("Claims suppressed");
     expect(summary).toHaveTextContent("Insufficient comparable query evidence");
     expect(summary).toHaveTextContent("Selected runs do not share at least two valid query timings");
-    expect(queryDiff).toHaveTextContent("3 comparisons");
+    // w4: the badge now names how many of how many are shown, so an empty
+    // filter is distinguishable from an empty comparison.
+    expect(queryDiff).toHaveTextContent("Showing 3 of 3 queries.");
     expect(queryDiff).toHaveTextContent("Winner claims are suppressed because Selected runs do not share at least two valid query timings");
-    expect(queryDiff).toHaveTextContent("Missing");
+    // w4 replaced the generic "Missing" badge with an explicit
+    // not-comparable marker. The pinned behaviour this test exists for is
+    // unchanged: the rows are still SHOWN rather than dropped, which is what
+    // keeps the reader aware of the exclusion.
+    expect(queryDiff).toHaveTextContent("Not comparable");
   });
 
   it("links compare warning counts to the Comparability Receipt and names warning classes", async () => {
@@ -1062,7 +1068,7 @@ describe("Compare", () => {
     expect(summary).toHaveTextContent("DuckDB leads by 10.00x on power score.");
     expect(options).toEqual(["DuckDB", "SQLite", "PostgreSQL"]);
     expect(screen.getByRole("heading", { name: "Query-Level Diff" }).closest("section")).toHaveTextContent(
-      "4 comparisons",
+      "Showing 4 of 4 queries.",
     );
 
     fireEvent.change(select, { target: { value: "2" } });

--- a/results-explorer/src/pages/__tests__/CompareLayoutRouting.test.ts
+++ b/results-explorer/src/pages/__tests__/CompareLayoutRouting.test.ts
@@ -1,0 +1,55 @@
+/**
+ * Routing by selection shape (w1).
+ *
+ * Selection COUNT picks the layout, so nobody has to choose a page before
+ * choosing runs, and the existing `?ids=` grammar keeps working untouched.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import { compareLayoutForSelection } from "@/pages/Compare";
+
+describe("compareLayoutForSelection", () => {
+  it("routes two distinct runs to the head-to-head layout", () => {
+    expect(compareLayoutForSelection(["a", "b"])).toEqual({
+      kind: "head_to_head",
+      runIds: ["a", "b"],
+    });
+  });
+
+  it("routes three and four runs to the multi-run layout", () => {
+    expect(compareLayoutForSelection(["a", "b", "c"]).kind).toBe("multi_run");
+    expect(compareLayoutForSelection(["a", "b", "c", "d"]).kind).toBe("multi_run");
+  });
+
+  it("routes a single distinct run to the within-run route", () => {
+    expect(compareLayoutForSelection(["a"])).toEqual({ kind: "within_run", resultId: "a" });
+  });
+
+  it("treats ids that alias to one run as one run, not a head-to-head", () => {
+    // Two ids resolving to the same result is one run. Rendering that as a
+    // head-to-head would compare a run against itself and report a 1.00x
+    // speedup as though it meant something.
+    expect(compareLayoutForSelection(["a", "a"])).toEqual({ kind: "within_run", resultId: "a" });
+  });
+
+  it("collapses duplicates before counting", () => {
+    expect(compareLayoutForSelection(["a", "b", "a"])).toEqual({
+      kind: "head_to_head",
+      runIds: ["a", "b"],
+    });
+  });
+
+  it("reports an empty selection rather than guessing a layout", () => {
+    expect(compareLayoutForSelection([])).toEqual({ kind: "empty" });
+    expect(compareLayoutForSelection([""])).toEqual({ kind: "empty" });
+  });
+
+  it("preserves selection order in the routed run list", () => {
+    // Baseline defaults to the first selected run, so order is meaningful.
+    expect(compareLayoutForSelection(["b", "a"])).toEqual({
+      kind: "head_to_head",
+      runIds: ["b", "a"],
+    });
+  });
+});

--- a/results-explorer/src/pages/__tests__/CompareLayoutRouting.test.ts
+++ b/results-explorer/src/pages/__tests__/CompareLayoutRouting.test.ts
@@ -7,7 +7,8 @@
 
 import { describe, expect, it } from "vitest";
 
-import { compareLayoutForSelection } from "@/pages/Compare";
+import { compareLayoutForSelection, isWithinTieBand } from "@/pages/Compare";
+import { COMPARE_TIE_THRESHOLD } from "@/lib/compareSummary";
 
 describe("compareLayoutForSelection", () => {
   it("routes two distinct runs to the head-to-head layout", () => {
@@ -51,5 +52,39 @@ describe("compareLayoutForSelection", () => {
       kind: "head_to_head",
       runIds: ["b", "a"],
     });
+  });
+});
+
+describe("the headline tie band", () => {
+  it("treats a ratio that rounds to 1.00x as a tie", () => {
+    // The failure this prevents: a 1.002x rendered as "1.00x" under a
+    // "vs slowest" label reads as an advantage that the data does not support.
+    expect(isWithinTieBand(1.002)).toBe(true);
+    expect(isWithinTieBand(0.998)).toBe(true);
+    expect(isWithinTieBand(1)).toBe(true);
+  });
+
+  it("is symmetric, so neither direction is called a win inside the band", () => {
+    expect(isWithinTieBand(1 + COMPARE_TIE_THRESHOLD / 2)).toBe(true);
+    expect(isWithinTieBand(1 - COMPARE_TIE_THRESHOLD / 2)).toBe(true);
+  });
+
+  it("leaves a real difference alone", () => {
+    expect(isWithinTieBand(1.4)).toBe(false);
+    expect(isWithinTieBand(0.7)).toBe(false);
+  });
+
+  it("reuses the decision summary's threshold rather than a second one", () => {
+    // Two thresholds would eventually disagree, and a page that headlines a
+    // win while its own summary calls the same pair a tie is worse than
+    // either behaviour alone.
+    expect(isWithinTieBand(1 + COMPARE_TIE_THRESHOLD * 0.99)).toBe(true);
+    expect(isWithinTieBand(1 + COMPARE_TIE_THRESHOLD * 1.01)).toBe(false);
+  });
+
+  it("does not treat a missing or non-finite ratio as a tie", () => {
+    expect(isWithinTieBand(null)).toBe(false);
+    expect(isWithinTieBand(Number.NaN)).toBe(false);
+    expect(isWithinTieBand(Number.POSITIVE_INFINITY)).toBe(false);
   });
 });


### PR DESCRIPTION
Implements `explorer-basis-compare-shape-routing-head-to-head` (w0–w4).

`/results/compare` rendered one layout for any selection of two to four runs,
with a flat table emitting one row per (query × non-baseline candidate) — 309
undifferentiated rows at four runs and 103 queries, with no metric control, no
query filter and no sorting. This routes by selection shape and rebuilds the
two-run path.

## w0 pinned what must survive first

Read `Compare.tsx` (1181 lines) as it stands rather than trusting any
description of it — including the item's own, which describes the page by what
it lacks rather than what it enforces. Six behaviour groups enumerated in
`w0.log`. Two are invisible in the happy path and easy to lose in a rewrite:

- **claim suppression** — one reason string from `severeCohortMismatchReason`
  feeds five separate consumers, all canonicalized so `star_schema`/`ssb` is one
  family and `POWER`/`power` is not a mismatch;
- **the pre-hoc cohort lock**, which prevents assembling a mixed-cohort
  selection that would then render with everything suppressed.

w0 also found that **#1950's basis axis was inert on this page** —
`cohortSignature` was built without a basis, so `rowAnswersBasis` never fired.

## Routing (w1)

`compareLayoutForSelection` keys on **distinct** runs. Two ids aliasing to one
result is one run; routing that to a head-to-head would compare a run against
itself and report 1.00× as though it meant something. It runs on the
**recovered** set, never the raw `?ids=` list — recovery resolves aliases, drops
duplicates and caps at `MAX_COMPARE_SELECTIONS`, so routing earlier would pick a
layout from a count the page never renders. Three- and four-run selections keep
today's layout until the sibling multi-run item fills the seam.

## Shared basis bar (w2)

One bar for the whole comparison — the visible form of the model's invariant
that every run is read through the same basis, stated in words so the guarantee
is legible on the page and not only in the type system.

The collapsed statistic is **its own render branch, not a `disabled`
attribute**. A disabled select still renders as a control, and a truthiness bug
would leave it interactive while offering a choice the data cannot express —
failing open, silently. The test asserts the control is *absent*.

Available passes are **intersected** across runs, not unioned: offering a pass
one run cannot answer would put a control on the page that empties half the
comparison the moment it is used.

## Identity strip and tie band (w3)

The six-axis strip reads the **same** `buildComparabilityFields` output the
`ComparabilityReceipt` reads. A second, independently-derived summary would
eventually disagree with the receipt about whether an axis differs; sharing one
source makes that impossible rather than unlikely, and there is a test asserting
field-for-field equality. It does not replace the receipt.

The per-card speedup previously rendered a raw ratio, so a 1.002× displayed as
"1.00×" under a "vs slowest" label and read as an advantage the data does not
support. Inside the band it now reads "Tied", reusing `COMPARE_TIE_THRESHOLD`
rather than declaring a second threshold.

## Limiter and basis-aware columns (w4)

One limiter function drives the chart and the table. Every state names how many
of how many queries are shown, **including the empty one** — "No queries match"
without a denominator leaves a reader unable to tell an empty filter from an
empty comparison.

Rows that cannot be compared under the current basis are **shown and marked,
never dropped**, and are never ranked into a "largest" view — they have no
magnitude to rank by. The badge is an explicit "Not comparable" rather than the
generic "Missing", a distinction that becomes real under a non-default basis: a
query can have a published value and still be unanswerable under `warm_pass_2`.

## Two defects found in my own work, before review

- The basis bar passed `rowCount` — the number of **runs** — as both the
  comparable and total query count, so a two-run comparison announced "over 2 of
  2 queries". Fixed in its own commit; a denominator that was never computed is
  worse than none.
- The identity strip used an undeclared theme token. `themeTokenHygiene` caught
  it, not me.

## Changed assertions

Three existing assertions moved with the surface, not the behaviour. The Compare
test that exists to prove missing query evidence stays visible still proves
exactly that — the rows still render; only the badge text changed. The
`QueryDiffTable` row-shape deep-equality was updated field-by-field rather than
loosened, since that strictness is what makes an accidental model change
visible.

## Verification

All six of the item's verification steps pass:

- `npm test` — 1069 passed, 8 skipped (84 files)
- `npm run typecheck` — clean
- `Compare.a11y.test.tsx` — pass
- `playwright e2e/routes/` — **119 passed**, 1 skipped
- `playwright e2e/responsive.spec.ts` — **28 passed**
- `w0.log` — behaviour enumeration recorded

Plus `make pr-preflight` — 28,534 passed, and `todo check-scope` clean.

## Size

966 insertions across 9 files, roughly half tests. Above the usual per-PR
guideline, but this is one cohesive item the tracker planned as five work units;
splitting it would land a routing seam with no layout behind it.
