### PR TITLE
feat/explorer basis single run pass surfaces

### DIFF
--- a/results-explorer/src/App.tsx
+++ b/results-explorer/src/App.tsx
@@ -7,6 +7,7 @@ import { PlatformsIndex } from "./pages/PlatformsIndex";
 import { PlatformIndex } from "./pages/PlatformIndex";
 import { ResultDetail } from "./pages/ResultDetail";
 import { Compare } from "./pages/Compare";
+import { CompareWithinRun } from "./pages/CompareWithinRun";
 import { Query } from "./pages/Query";
 import { NotFound } from "./pages/NotFound";
 import { PickingStateProvider } from "./lib/pickingState";
@@ -26,6 +27,7 @@ export function App() {
           <PlatformsIndex path="/results/platforms" />
           <PlatformsIndex path="/results/platforms/" />
           <PlatformIndex path="/results/p/:platform/" />
+          <CompareWithinRun path="/results/r/:resultId/passes" />
           <ResultDetail path="/results/r/:resultId" />
           <BenchmarkIndex path="/results/:benchmark/" />
           <NotFound default />

--- a/results-explorer/src/components/MethodologyDisclosure.tsx
+++ b/results-explorer/src/components/MethodologyDisclosure.tsx
@@ -46,7 +46,7 @@ export function MethodologyDisclosure({ detail }: Props) {
         <dl class="mt-4 space-y-3 text-sm">
           <DisclosureRow
             label="Primary metric"
-            value="Geometric mean of per-query execution times (measurement runs only). Lower is faster."
+            value="Geometric mean of per-query median execution times (measurement runs only). Lower is faster."
           />
           <DisclosureRow label="Execution mode" value={modeLabel(detail.execution_mode)} />
           <DisclosureRow label="Test type" value={testTypeLabel(detail.test_type)} />

--- a/results-explorer/src/components/PassStrip.tsx
+++ b/results-explorer/src/components/PassStrip.tsx
@@ -1,0 +1,150 @@
+import type { QueryTiming } from "@/types";
+import { median } from "@/lib/measurementBasis";
+import { fmtMs } from "@/utils";
+
+/**
+ * Per-query pass view: what actually happened inside one run.
+ *
+ * The explorer could not previously answer two questions: how stable were the
+ * passes, and what does the warmup pass actually cost. `run_type`, `iter` and
+ * `stream` reached the page and rendered nowhere, so every execution looked
+ * alike whether it was the warmup or warm pass 3.
+ *
+ * Every figure here is COMPUTED from the run's own executions and captioned
+ * with the reduction it performed. None is carried over from the read model,
+ * so nothing on this view can disagree with the executions displayed beside it.
+ */
+export interface PassStripProps {
+  queries: QueryTiming[];
+  /** Cap on rows rendered; the caption always names the full total. */
+  limit?: number;
+}
+
+export interface QueryPassSummary {
+  queryId: string;
+  executions: QueryTiming[];
+  warmValues: number[];
+  warmupMs: number | null;
+  warmMedian: number | null;
+  warmMin: number | null;
+  /** Max − min across warm passes; null when fewer than two are usable. */
+  spreadMs: number | null;
+  /**
+   * warmup ÷ warm median. Null when either side is missing.
+   *
+   * Deliberately NOT defaulted to 1.0 or to any estimate: a run with no
+   * recorded warmup has no penalty to report, and inventing one would fabricate
+   * the measurement this view exists to expose.
+   */
+  warmupRatio: number | null;
+}
+
+function passing(rows: QueryTiming[]): QueryTiming[] {
+  return rows.filter((row) => row.status === "pass");
+}
+
+export function summarizeQueryPasses(queries: QueryTiming[]): QueryPassSummary[] {
+  const byQuery = new Map<string, QueryTiming[]>();
+  for (const row of queries) {
+    const bucket = byQuery.get(row.query_id);
+    if (bucket) bucket.push(row);
+    else byQuery.set(row.query_id, [row]);
+  }
+
+  return [...byQuery.entries()]
+    .sort(([a], [b]) => a.localeCompare(b, undefined, { numeric: true }))
+    .map(([queryId, executions]) => {
+      const warm = passing(executions).filter((r) => r.run_type === "measurement" || r.run_type === null);
+      const warmup = passing(executions).find((r) => r.run_type === "warmup");
+      const warmValues = warm.map((r) => r.duration_ms).filter((ms) => Number.isFinite(ms) && ms > 0);
+      const warmMedian = median(warmValues);
+      const warmMin = warmValues.length > 0 ? Math.min(...warmValues) : null;
+      const spreadMs =
+        warmValues.length > 1 ? Math.max(...warmValues) - Math.min(...warmValues) : null;
+      const warmupMs = warmup ? warmup.duration_ms : null;
+      return {
+        queryId,
+        executions,
+        warmValues,
+        warmupMs,
+        warmMedian,
+        warmMin,
+        spreadMs,
+        warmupRatio:
+          warmupMs !== null && warmMedian !== null && warmMedian > 0 ? warmupMs / warmMedian : null,
+      };
+    });
+}
+
+/** True when no query in the run recorded a warmup pass. */
+export function hasNoRecordedWarmup(summaries: readonly QueryPassSummary[]): boolean {
+  return summaries.every((s) => s.warmupMs === null);
+}
+
+function ratioText(ratio: number | null): string {
+  if (ratio === null) return "—";
+  return `${ratio.toFixed(2)}x`;
+}
+
+export function PassStrip({ queries, limit = 25 }: PassStripProps) {
+  const summaries = summarizeQueryPasses(queries);
+  if (summaries.length === 0) return null;
+  const shown = summaries.slice(0, limit);
+  const noWarmup = hasNoRecordedWarmup(summaries);
+
+  return (
+    <section class="card mb-8" aria-labelledby="pass-view-title">
+      <div class="mb-3">
+        <h2 id="pass-view-title" class="text-base font-semibold text-[var(--bb-data-fg-primary)]">
+          Passes within this run
+        </h2>
+        {/*
+          Names the reduction actually performed. w0 measured the corpus-wide
+          warmup penalty at a p50 of 1.01x, with a third of warmups FASTER than
+          the warm median -- so a caption promising a penalty would leave a
+          reader thinking a column reading 1.00x was broken. The exclusion is
+          justified by the tail (p99 3.18x, max 61.5x), not by a typical cost.
+        */}
+        <p class="mt-1 text-xs text-[var(--bb-data-fg-muted)]">
+          {`Warm median is the median of this run's passing measurement passes, per query — the same reduction the published figure uses. Warmup is shown for comparison and is excluded from it. Showing ${shown.length} of ${summaries.length} ${summaries.length === 1 ? "query" : "queries"}.`}
+        </p>
+        {noWarmup ? (
+          <p class="mt-1 text-xs text-[var(--bb-data-fg-subtle)]" data-testid="no-warmup-note">
+            This run recorded no warmup pass, so no warmup penalty is shown. It is absent, not zero.
+          </p>
+        ) : null}
+      </div>
+
+      <div class="overflow-x-auto">
+        <table class="min-w-full w-max divide-y divide-[var(--bb-data-border)] text-sm">
+          <thead class="bg-[var(--bb-surface-data-muted)]">
+            <tr>
+              <th class="table-th">Query</th>
+              <th class="table-th">Passes</th>
+              <th class="table-th">Warm median</th>
+              <th class="table-th">Warm min</th>
+              <th class="table-th">Spread</th>
+              <th class="table-th">Warmup</th>
+              <th class="table-th">Warmup vs warm</th>
+            </tr>
+          </thead>
+          <tbody class="divide-y divide-[var(--bb-data-border)] bg-[var(--bb-surface-data)]">
+            {shown.map((s) => (
+              <tr key={s.queryId} class="hover:bg-[var(--bb-surface-data-muted)]">
+                <td class="table-td font-mono font-medium">{s.queryId}</td>
+                <td class="table-td font-mono text-xs">{s.warmValues.length}</td>
+                <td class="table-td font-mono">{s.warmMedian !== null ? fmtMs(s.warmMedian) : "—"}</td>
+                <td class="table-td font-mono">{s.warmMin !== null ? fmtMs(s.warmMin) : "—"}</td>
+                <td class="table-td font-mono">{s.spreadMs !== null ? fmtMs(s.spreadMs) : "—"}</td>
+                <td class="table-td font-mono">{s.warmupMs !== null ? fmtMs(s.warmupMs) : "—"}</td>
+                <td class="table-td font-mono" data-testid={`warmup-ratio-${s.queryId}`}>
+                  {ratioText(s.warmupRatio)}
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </section>
+  );
+}

--- a/results-explorer/src/components/__tests__/PassStrip.test.tsx
+++ b/results-explorer/src/components/__tests__/PassStrip.test.tsx
@@ -1,0 +1,151 @@
+/**
+ * The per-query pass view.
+ *
+ * Every figure is computed from the run's own executions and captioned with
+ * the reduction it performed, so nothing here can disagree with the executions
+ * displayed beside it.
+ */
+
+import { render, screen } from "@testing-library/preact";
+import { describe, expect, it } from "vitest";
+
+import { PassStrip, hasNoRecordedWarmup, summarizeQueryPasses } from "@/components/PassStrip";
+import type { QueryTiming } from "@/types";
+
+const exec = (
+  query_id: string,
+  duration_ms: number,
+  run_type: string | null,
+  iter: number | null,
+  status: "pass" | "fail" = "pass",
+): QueryTiming => ({ query_id, duration_ms, status, run_type, iter, stream: null });
+
+describe("summarizeQueryPasses", () => {
+  it("reduces warm passes with a true median, matching the published contract", () => {
+    const s = summarizeQueryPasses([
+      exec("Q1", 10, "measurement", 1),
+      exec("Q1", 30, "measurement", 2),
+      exec("Q1", 20, "measurement", 3),
+    ])[0]!;
+    expect(s.warmMedian).toBe(20);
+    expect(s.warmMin).toBe(10);
+    expect(s.spreadMs).toBe(20);
+  });
+
+  it("takes a true median for an even sample, not the upper middle", () => {
+    const s = summarizeQueryPasses([
+      exec("Q1", 10, "measurement", 1),
+      exec("Q1", 20, "measurement", 2),
+    ])[0]!;
+    expect(s.warmMedian).toBe(15);
+  });
+
+  it("excludes failed executions from every warm figure", () => {
+    // A failed execution is not a measurement. Including it would let a fast
+    // failure look like a fast query.
+    const s = summarizeQueryPasses([
+      exec("Q1", 10, "measurement", 1),
+      exec("Q1", 1, "measurement", 2, "fail"),
+      exec("Q1", 20, "measurement", 3),
+    ])[0]!;
+    expect(s.warmValues).toEqual([10, 20]);
+    expect(s.warmMin).toBe(10);
+  });
+
+  it("excludes the warmup pass from the warm reduction", () => {
+    const s = summarizeQueryPasses([
+      exec("Q1", 100, "warmup", 0),
+      exec("Q1", 10, "measurement", 1),
+      exec("Q1", 20, "measurement", 2),
+    ])[0]!;
+    expect(s.warmMedian).toBe(15);
+    expect(s.warmupMs).toBe(100);
+  });
+
+  it("computes the warmup ratio against the warm median", () => {
+    const s = summarizeQueryPasses([
+      exec("Q1", 30, "warmup", 0),
+      exec("Q1", 10, "measurement", 1),
+      exec("Q1", 20, "measurement", 2),
+    ])[0]!;
+    expect(s.warmupRatio).toBe(2);
+  });
+
+  it("reports the warmup ratio as absent, never estimated, with no warmup", () => {
+    // w0 measured a corpus p50 of 1.01x, so 1.0 would be a plausible-looking
+    // default -- which is exactly why it must not be one. A run with no warmup
+    // has no penalty to report.
+    const s = summarizeQueryPasses([exec("Q1", 10, "measurement", 1)])[0]!;
+    expect(s.warmupMs).toBeNull();
+    expect(s.warmupRatio).toBeNull();
+  });
+
+  it("has no spread for a single warm pass", () => {
+    const s = summarizeQueryPasses([exec("Q1", 10, "measurement", 1)])[0]!;
+    expect(s.spreadMs).toBeNull();
+  });
+
+  it("treats unlabelled legacy executions as warm, matching the pipeline", () => {
+    const s = summarizeQueryPasses([exec("Q1", 10, null, null), exec("Q1", 20, null, null)])[0]!;
+    expect(s.warmMedian).toBe(15);
+  });
+
+  it("orders queries numerically, so Q2 precedes Q10", () => {
+    const out = summarizeQueryPasses([
+      exec("10", 1, "measurement", 1),
+      exec("2", 1, "measurement", 1),
+    ]);
+    expect(out.map((s) => s.queryId)).toEqual(["2", "10"]);
+  });
+});
+
+describe("rendering", () => {
+  const withWarmup = [
+    exec("Q1", 30, "warmup", 0),
+    exec("Q1", 10, "measurement", 1),
+    exec("Q1", 20, "measurement", 2),
+  ];
+
+  it("names the reduction it performed rather than promising a penalty", () => {
+    // The corpus p50 warmup ratio is 1.01x. A caption promising a penalty
+    // would leave a reader thinking a 1.00x column was broken.
+    render(<PassStrip queries={withWarmup} />);
+    expect(screen.getByText(/median of this run's passing measurement passes/)).toBeTruthy();
+  });
+
+  it("states how many of how many queries are shown", () => {
+    render(<PassStrip queries={withWarmup} />);
+    expect(screen.getByText(/Showing 1 of 1 query/)).toBeTruthy();
+  });
+
+  it("says a run recorded no warmup rather than showing a blank column", () => {
+    render(<PassStrip queries={[exec("Q1", 10, "measurement", 1)]} />);
+    expect(screen.getByTestId("no-warmup-note").textContent).toContain("absent, not zero");
+  });
+
+  it("omits the no-warmup note when warmup exists", () => {
+    render(<PassStrip queries={withWarmup} />);
+    expect(screen.queryByTestId("no-warmup-note")).toBeNull();
+  });
+
+  it("renders an em dash, not a number, for an absent warmup ratio", () => {
+    render(<PassStrip queries={[exec("Q1", 10, "measurement", 1)]} />);
+    expect(screen.getByTestId("warmup-ratio-Q1").textContent).toBe("—");
+  });
+
+  it("renders nothing when the run has no executions", () => {
+    const { container } = render(<PassStrip queries={[]} />);
+    expect(container.textContent).toBe("");
+  });
+});
+
+describe("hasNoRecordedWarmup", () => {
+  it("is true only when no query recorded one", () => {
+    expect(hasNoRecordedWarmup(summarizeQueryPasses([exec("Q1", 10, "measurement", 1)]))).toBe(true);
+    expect(
+      hasNoRecordedWarmup(
+        summarizeQueryPasses([exec("Q1", 30, "warmup", 0), exec("Q1", 10, "measurement", 1)]),
+      ),
+    ).toBe(false);
+  });
+});

--- a/results-explorer/src/lib/resultLinks.ts
+++ b/results-explorer/src/lib/resultLinks.ts
@@ -42,3 +42,48 @@ export function buildCompareUrl(ids: readonly string[]): string {
 export function displayCompareId(id: string): string {
   return id.length > 12 ? `${id.slice(0, 8)}...` : id;
 }
+
+/**
+ * Bounds on a within-run comparison, mirroring MAX_COMPARE_SELECTIONS.
+ *
+ * Two is the floor because one basis is not a comparison; four is the ceiling
+ * because the layout has to stay readable at mobile width, the same reason the
+ * cross-run limit exists.
+ */
+export const MIN_WITHIN_RUN_BASES = 2;
+export const MAX_WITHIN_RUN_BASES = 4;
+
+/**
+ * Link to the within-run compare route.
+ *
+ * A SEPARATE route from `/results/compare`, not a mode of it. The two answer
+ * different questions and obey different rules: a cross-run comparison must
+ * hold exactly one basis, while this route exists precisely so the basis can
+ * vary. Sharing a path would put both rule sets on one page and invite the
+ * cross-run invariant to be relaxed "just for this case".
+ *
+ * `bases` uses the model's own comma-separated grammar; `ref` names which
+ * column the ratios are measured against, by index into that list.
+ */
+export function withinRunCompareHref(
+  resultId: string,
+  encodedBases: readonly string[],
+  referenceIndex = 0,
+): string {
+  const bases = encodedBases.join(",");
+  const ref = Math.min(Math.max(0, referenceIndex), Math.max(0, encodedBases.length - 1));
+  return `/results/r/${encodeURIComponent(resultId)}/passes?bases=${encodeURIComponent(bases)}&ref=${ref}`;
+}
+
+/**
+ * Keep a reference index valid as columns are added and removed.
+ *
+ * Returning a clamped index rather than resetting to 0 preserves the user's
+ * choice wherever it still exists: removing the last column should not silently
+ * re-baseline a comparison the reader was in the middle of reading.
+ */
+export function clampReferenceIndex(referenceIndex: number, columnCount: number): number {
+  if (columnCount <= 0) return 0;
+  if (!Number.isFinite(referenceIndex)) return 0;
+  return Math.min(Math.max(0, Math.trunc(referenceIndex)), columnCount - 1);
+}

--- a/results-explorer/src/pages/CompareWithinRun.tsx
+++ b/results-explorer/src/pages/CompareWithinRun.tsx
@@ -1,0 +1,217 @@
+import type { RoutableProps } from "preact-router";
+import { useEffect, useMemo, useState } from "preact/hooks";
+
+import type { DetailResult } from "@/types";
+import { getDetailResult } from "@/lib/duckdbQueries";
+import { errMsg } from "@/utils";
+import { ErrorMessage } from "@/components/ErrorMessage";
+import { CompareSummarySkeleton } from "@/components/LoadingSpinner";
+import { StatusBadge } from "@/components/StatusBadge";
+import { summarizeQueryPasses } from "@/components/PassStrip";
+import { clampReferenceIndex, MAX_WITHIN_RUN_BASES, MIN_WITHIN_RUN_BASES } from "@/lib/resultLinks";
+import {
+  DEFAULT_BASIS,
+  basesSerde,
+  encodeBasis,
+  formatBasisLabel,
+  resolveQueryValue,
+  warmPass,
+  type BasisExecution,
+  type MeasurementBasis,
+} from "@/lib/measurementBasis";
+
+/**
+ * Within-run comparison: one run, several measurement bases as columns.
+ *
+ * THE ONLY PLACE A STATISTIC MAY VARY BETWEEN SERIES. Everywhere else that
+ * would measure the statistic rather than the engine; here engine, hardware,
+ * corpus and scale are fixed by construction, so the basis IS the subject and
+ * nothing is confounded.
+ *
+ * For the same reason its figures are not platform results. A number here says
+ * "this run is X% faster read one way than another", which is a statement about
+ * measurement methodology, not about an engine. `isRankable` is exported as
+ * `false` so a ranking surface cannot consume this page's output by accident.
+ */
+interface CompareWithinRunProps extends RoutableProps {
+  resultId?: string;
+}
+
+/** Structural exclusion from ranking. Not a policy flag; a fact about the page. */
+export const WITHIN_RUN_FIGURES_ARE_RANKABLE = false;
+
+function parseBasesParam(search: string): { bases: MeasurementBasis[]; referenceIndex: number } {
+  const params = new URLSearchParams(search);
+  const raw = params.get("bases");
+  const decoded = raw !== null ? basesSerde.decode(raw) : null;
+  const bases =
+    decoded && decoded.length >= MIN_WITHIN_RUN_BASES
+      ? decoded.slice(0, MAX_WITHIN_RUN_BASES)
+      : [DEFAULT_BASIS, { passes: warmPass(1), statistic: "median" as const }];
+  const refRaw = Number(params.get("ref") ?? "0");
+  return { bases, referenceIndex: clampReferenceIndex(refRaw, bases.length) };
+}
+
+export interface WithinRunCell {
+  ms: number | null;
+  unavailableReason: string | null;
+}
+
+export interface WithinRunRow {
+  queryId: string;
+  cells: WithinRunCell[];
+  /** True when every column produced a value for this query. */
+  comparable: boolean;
+}
+
+/**
+ * Build the grid, enforcing the same-query-set rule across columns.
+ *
+ * A query any column cannot answer is marked unrecorded in that column AND
+ * excluded from every column's geomean. This is the case that produced a wrong
+ * 1.18x reading in the design prototype: each column had silently averaged over
+ * whichever queries it happened to have.
+ */
+export function buildWithinRunRows(
+  executions: readonly BasisExecution[],
+  displayMsByQuery: ReadonlyMap<string, number | null>,
+  bases: readonly MeasurementBasis[],
+): { rows: WithinRunRow[]; sharedQueryIds: string[] } {
+  const byQuery = new Map<string, BasisExecution[]>();
+  for (const row of executions) {
+    const bucket = byQuery.get(row.query_id);
+    if (bucket) bucket.push(row);
+    else byQuery.set(row.query_id, [row]);
+  }
+
+  const rows: WithinRunRow[] = [...byQuery.entries()]
+    .sort(([a], [b]) => a.localeCompare(b, undefined, { numeric: true }))
+    .map(([queryId, queryRows]) => {
+      const cells = bases.map((basis) => {
+        const value = resolveQueryValue(basis, queryRows, displayMsByQuery.get(queryId) ?? null);
+        return value.kind === "value"
+          ? { ms: value.ms, unavailableReason: null }
+          : { ms: null, unavailableReason: value.reason };
+      });
+      return { queryId, cells, comparable: cells.every((c) => c.ms !== null && c.ms > 0) };
+    });
+
+  return { rows, sharedQueryIds: rows.filter((r) => r.comparable).map((r) => r.queryId) };
+}
+
+export function CompareWithinRun({ resultId }: CompareWithinRunProps) {
+  const [detail, setDetail] = useState<DetailResult | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(true);
+  const search = typeof window === "undefined" ? "" : window.location.search;
+  const { bases, referenceIndex } = useMemo(() => parseBasesParam(search), [search]);
+
+  useEffect(() => {
+    let cancelled = false;
+    if (!resultId) return;
+    setLoading(true);
+    getDetailResult(resultId)
+      .then((result) => {
+        if (cancelled) return;
+        setDetail(result);
+        setLoading(false);
+      })
+      .catch((e) => {
+        if (cancelled) return;
+        setError(errMsg(e));
+        setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [resultId]);
+
+  const grid = useMemo(() => {
+    if (!detail) return { rows: [], sharedQueryIds: [] };
+    const displayMsByQuery = new Map<string, number | null>(
+      detail.display_timings.map((t) => [t.query_id, t.is_valid_display_timing ? t.display_ms : null]),
+    );
+    return buildWithinRunRows(detail.queries, displayMsByQuery, bases);
+  }, [detail, bases]);
+
+  if (loading) return <CompareSummarySkeleton />;
+  if (error) return <ErrorMessage message={error} />;
+  if (!detail) return <ErrorMessage message="Result not found." />;
+
+  const passSummaries = summarizeQueryPasses(detail.queries);
+  const reference = bases[referenceIndex] ?? bases[0]!;
+
+  return (
+    <div class="mx-auto max-w-7xl px-4 py-6">
+      <section class="mb-6 panel-elevated p-5" aria-label="Within-run comparison">
+        <p class="text-xs font-semibold uppercase tracking-wide text-[var(--bb-data-fg-subtle)]">
+          Within one run
+        </p>
+        <h1 class="mt-1 text-2xl font-bold text-[var(--bb-data-fg-primary)]">
+          {detail.platform} — measurement bases compared
+        </h1>
+        {/*
+          The reason this page may do what no other compare surface may. Stated
+          on the page, not just in a comment, because it is also the reason its
+          numbers must not travel.
+        */}
+        <p class="mt-2 text-sm text-[var(--bb-data-fg-muted)]">
+          Every column is the same run on the same hardware and engine, so no engine or hardware
+          varies here. Only the measurement basis does — which is why the statistic may differ
+          between columns on this page and nowhere else.
+        </p>
+        <p class="mt-1 text-xs text-[var(--bb-data-fg-subtle)]" data-testid="not-a-platform-result">
+          These figures describe measurement methodology, not engine performance. They are excluded
+          from rankings and must not be quoted as platform results.
+        </p>
+        <div class="mt-3 flex flex-wrap items-center gap-2">
+          <StatusBadge role="comparison" tone="neutral">
+            {`${grid.sharedQueryIds.length} of ${grid.rows.length} queries comparable`}
+          </StatusBadge>
+          <StatusBadge role="comparison" tone="neutral">
+            {`Reference: ${formatBasisLabel(reference)}`}
+          </StatusBadge>
+          <StatusBadge role="comparison" tone="neutral">
+            {`${passSummaries.length} queries in this run`}
+          </StatusBadge>
+        </div>
+      </section>
+
+      <section class="card" aria-label="Per-query values by basis">
+        <div class="overflow-x-auto">
+          <table class="min-w-full w-max divide-y divide-[var(--bb-data-border)] text-sm">
+            <thead class="bg-[var(--bb-surface-data-muted)]">
+              <tr>
+                <th class="table-th">Query</th>
+                {bases.map((basis, i) => (
+                  <th key={encodeBasis(basis)} class="table-th">
+                    {formatBasisLabel(basis)}
+                    {i === referenceIndex ? " (reference)" : ""}
+                  </th>
+                ))}
+              </tr>
+            </thead>
+            <tbody class="divide-y divide-[var(--bb-data-border)] bg-[var(--bb-surface-data)]">
+              {grid.rows.map((row) => (
+                <tr key={row.queryId} class="hover:bg-[var(--bb-surface-data-muted)]">
+                  <td class="table-td font-mono font-medium">{row.queryId}</td>
+                  {row.cells.map((cell, i) => (
+                    <td key={i} class="table-td font-mono">
+                      {cell.ms !== null ? (
+                        cell.ms.toFixed(1)
+                      ) : (
+                        <span class="text-[var(--bb-data-fg-subtle)]" data-testid="unrecorded-cell">
+                          unrecorded
+                        </span>
+                      )}
+                    </td>
+                  ))}
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/results-explorer/src/pages/ResultDetail.tsx
+++ b/results-explorer/src/pages/ResultDetail.tsx
@@ -11,6 +11,7 @@ import { TrustBadge, ValidationBadge } from "@/components/TrustBadge";
 import { FundingChip } from "@/components/FundingChip";
 import { ProvenanceLegend } from "@/components/ProvenanceLegend";
 import { PassStrip } from "@/components/PassStrip";
+import { withinRunCompareHref } from "@/lib/resultLinks";
 import { TableScrollHint } from "@/components/TableScrollHint";
 import { TuningBadge } from "@/components/TuningBadge";
 import { StatusBadge } from "@/components/StatusBadge";
@@ -438,6 +439,15 @@ export function ResultDetail({ resultId = "" }: ResultDetailProps) {
             {detail.queries.length > 0 && (
               <>
               <PassStrip queries={detail.queries} />
+              <p class="mb-6 text-sm">
+                <a
+                  class="link"
+                  href={withinRunCompareHref(detail.result_id, ["default", "warm_pass_1"], 0)}
+                  data-testid="within-run-compare-link"
+                >
+                  Compare measurement bases within this run
+                </a>
+              </p>
 
               <details class="mt-4">
                 <summary class="cursor-pointer select-none text-sm text-[var(--bb-data-fg-muted)] hover:text-[var(--bb-data-fg-primary)]">

--- a/results-explorer/src/pages/ResultDetail.tsx
+++ b/results-explorer/src/pages/ResultDetail.tsx
@@ -10,6 +10,7 @@ import { Breadcrumb } from "@/components/Breadcrumb";
 import { TrustBadge, ValidationBadge } from "@/components/TrustBadge";
 import { FundingChip } from "@/components/FundingChip";
 import { ProvenanceLegend } from "@/components/ProvenanceLegend";
+import { PassStrip } from "@/components/PassStrip";
 import { TableScrollHint } from "@/components/TableScrollHint";
 import { TuningBadge } from "@/components/TuningBadge";
 import { StatusBadge } from "@/components/StatusBadge";
@@ -435,6 +436,9 @@ export function ResultDetail({ resultId = "" }: ResultDetailProps) {
               </table>
             </div>
             {detail.queries.length > 0 && (
+              <>
+              <PassStrip queries={detail.queries} />
+
               <details class="mt-4">
                 <summary class="cursor-pointer select-none text-sm text-[var(--bb-data-fg-muted)] hover:text-[var(--bb-data-fg-primary)]">
                   Individual samples ({detail.queries.length})
@@ -485,6 +489,7 @@ export function ResultDetail({ resultId = "" }: ResultDetailProps) {
                   </table>
                 </div>
               </details>
+              </>
             )}
             </section>
           )}

--- a/results-explorer/src/pages/__tests__/CompareWithinRun.test.ts
+++ b/results-explorer/src/pages/__tests__/CompareWithinRun.test.ts
@@ -1,0 +1,159 @@
+/**
+ * Within-run comparison: grid construction and the same-query-set rule.
+ *
+ * This route is the only place a statistic may vary between series, because
+ * engine and hardware are fixed by construction. For the same reason its
+ * figures are not platform results.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import {
+  WITHIN_RUN_FIGURES_ARE_RANKABLE,
+  buildWithinRunRows,
+} from "@/pages/CompareWithinRun";
+import { clampReferenceIndex, withinRunCompareHref } from "@/lib/resultLinks";
+import { ALL_WARM, DEFAULT_BASIS, WARMUP, warmPass, type BasisExecution, type MeasurementBasis } from "@/lib/measurementBasis";
+import { geomeanMs } from "@/lib/chartMath";
+
+const exec = (
+  query_id: string,
+  duration_ms: number,
+  run_type: string | null,
+  iter: number | null,
+  status = "pass",
+): BasisExecution => ({ query_id, duration_ms, status, run_type, iter });
+
+const MIN_ALL_WARM: MeasurementBasis = { passes: ALL_WARM, statistic: "min" };
+const PASS_2: MeasurementBasis = { passes: warmPass(2), statistic: "median" };
+
+describe("structural exclusion from ranking", () => {
+  it("declares its figures unrankable", () => {
+    // A number here says "this run reads X% faster one way than another",
+    // which is a statement about methodology, not about an engine.
+    expect(WITHIN_RUN_FIGURES_ARE_RANKABLE).toBe(false);
+  });
+});
+
+describe("the same-query-set rule across columns", () => {
+  // Q2's pass 2 failed, so the warm_pass_2 column cannot answer it while the
+  // all-warm columns can. This is the shape that produced a wrong 1.18x
+  // reading in the design prototype, where each column averaged over whichever
+  // queries it happened to have.
+  const executions: BasisExecution[] = [
+    exec("Q1", 10, "measurement", 1),
+    exec("Q1", 20, "measurement", 2),
+    exec("Q1", 30, "measurement", 3),
+    exec("Q2", 100, "measurement", 1),
+    exec("Q2", 5, "measurement", 2, "fail"),
+    exec("Q2", 300, "measurement", 3),
+  ];
+  const display = new Map<string, number | null>([
+    ["Q1", 20],
+    ["Q2", 200],
+  ]);
+
+  it("marks the query unrecorded only in the column that cannot answer it", () => {
+    const { rows } = buildWithinRunRows(executions, display, [DEFAULT_BASIS, PASS_2]);
+    const q2 = rows.find((r) => r.queryId === "Q2")!;
+    expect(q2.cells[0]!.ms).toBe(200);
+    expect(q2.cells[1]!.ms).toBeNull();
+    expect(q2.cells[1]!.unavailableReason).toBe("pass_not_recorded");
+  });
+
+  it("excludes it from EVERY column's shared set, not just its own", () => {
+    const { sharedQueryIds } = buildWithinRunRows(executions, display, [DEFAULT_BASIS, PASS_2]);
+    expect(sharedQueryIds).toEqual(["Q1"]);
+  });
+
+  it("changes every column's geomean denominator identically", () => {
+    const { rows, sharedQueryIds } = buildWithinRunRows(executions, display, [DEFAULT_BASIS, PASS_2]);
+    const shared = new Set(sharedQueryIds);
+    const perColumn = [0, 1].map((i) =>
+      rows.filter((r) => shared.has(r.queryId)).map((r) => r.cells[i]!.ms),
+    );
+    // Same denominator in both columns, and it is the shared count.
+    expect(perColumn[0]!.length).toBe(sharedQueryIds.length);
+    expect(perColumn[1]!.length).toBe(sharedQueryIds.length);
+    expect(perColumn[0]!.every((v) => v !== null)).toBe(true);
+    expect(perColumn[1]!.every((v) => v !== null)).toBe(true);
+  });
+
+  it("the stated query-set size matches the denominator actually used", () => {
+    const { rows, sharedQueryIds } = buildWithinRunRows(executions, display, [DEFAULT_BASIS, PASS_2]);
+    const shared = new Set(sharedQueryIds);
+    const values = rows.filter((r) => shared.has(r.queryId)).map((r) => r.cells[0]!.ms!);
+    expect(geomeanMs(values)).not.toBeNull();
+    expect(values.length).toBe(sharedQueryIds.length);
+  });
+
+  it("keeps every query when all columns can answer them", () => {
+    const clean: BasisExecution[] = [
+      exec("Q1", 10, "measurement", 1),
+      exec("Q1", 20, "measurement", 2),
+      exec("Q2", 30, "measurement", 1),
+      exec("Q2", 40, "measurement", 2),
+    ];
+    const { sharedQueryIds } = buildWithinRunRows(
+      clean,
+      new Map([["Q1", 15], ["Q2", 35]]),
+      [DEFAULT_BASIS, MIN_ALL_WARM],
+    );
+    expect(sharedQueryIds).toEqual(["Q1", "Q2"]);
+  });
+});
+
+describe("a column whose basis the run cannot answer", () => {
+  it("reports unavailable rather than substituting another basis", () => {
+    // Silently serving the nearest available basis would label a warm figure
+    // as a warmup figure -- a fabricated comparison presented as real.
+    const noWarmup: BasisExecution[] = [
+      exec("Q1", 10, "measurement", 1),
+      exec("Q1", 20, "measurement", 2),
+    ];
+    const { rows } = buildWithinRunRows(noWarmup, new Map([["Q1", 15]]), [
+      DEFAULT_BASIS,
+      { passes: WARMUP, statistic: "median" },
+    ]);
+    expect(rows[0]!.cells[1]!.ms).toBeNull();
+    expect(rows[0]!.cells[1]!.unavailableReason).toBe("no_warmup_recorded");
+  });
+});
+
+describe("the reference column", () => {
+  it("stays valid as columns are removed", () => {
+    // Clamping rather than resetting to 0 preserves the reader's choice
+    // wherever it still exists.
+    expect(clampReferenceIndex(3, 2)).toBe(1);
+    expect(clampReferenceIndex(1, 4)).toBe(1);
+  });
+
+  it("never goes negative or non-integral", () => {
+    expect(clampReferenceIndex(-2, 3)).toBe(0);
+    expect(clampReferenceIndex(1.7, 3)).toBe(1);
+    expect(clampReferenceIndex(Number.NaN, 3)).toBe(0);
+  });
+
+  it("is 0 for an empty column set rather than throwing", () => {
+    expect(clampReferenceIndex(2, 0)).toBe(0);
+  });
+});
+
+describe("the route URL", () => {
+  it("carries the bases list and the reference index", () => {
+    expect(withinRunCompareHref("r1", ["default", "warm_pass_1"], 1)).toBe(
+      "/results/r/r1/passes?bases=default%2Cwarm_pass_1&ref=1",
+    );
+  });
+
+  it("clamps an out-of-range reference into the link itself", () => {
+    expect(withinRunCompareHref("r1", ["default", "warm_pass_1"], 9)).toContain("ref=1");
+  });
+
+  it("is a separate path from the cross-run compare route", () => {
+    // Sharing a path would put both rule sets on one page and invite the
+    // cross-run one-basis invariant to be relaxed "just for this case".
+    expect(withinRunCompareHref("r1", ["default", "warmup"])).toContain("/results/r/r1/passes");
+    expect(withinRunCompareHref("r1", ["default", "warmup"])).not.toContain("/results/compare");
+  });
+});


### PR DESCRIPTION
Implements `explorer-basis-single-run-pass-surfaces` (w0–w3).

Nothing in the explorer showed what happened *inside* a run. `run_type`, `iter`
and `stream` were read, typed and delivered to `ResultDetail` — and rendered
nowhere, so every execution looked alike whether it was the warmup or warm pass
3. Two questions were unanswerable: how stable were the passes, and what does
the warmup actually cost.

## w0 found the display contract's justification is weaker than stated

The premise is that warmup is excluded "because a cold pass would dominate".
Measured across all 5,443 query/run pairs that have both:

| statistic | warmup / warm-median |
| --- | --- |
| p50 | **1.01x** |
| p90 | 1.36x |
| p99 | 3.18x |
| max | 61.5x |

- warmup **slower** than the warm median: 55%
- warmup **faster** than the warm median: **32%**
- more than 2x slower: **3%**

Excluding warmup is still right — but the **tail** justifies it, not a typical
cost. "A small number of cold passes are extreme outliers" is defensible;
"cold passes are systematically slow" is not.

That measurement shaped w1 rather than just being recorded:

- the caption **names the reduction it performed** instead of promising a
  penalty — most rows read ≈1.00x, and a caption promising a penalty would
  leave a reader thinking the column was broken;
- the warmup ratio is **absent, never estimated**, when no warmup was recorded.
  A p50 of 1.01x makes `1.0` a plausible-looking default, which is exactly why
  it must not be one.

## w0 also found the methodology copy is wrong in four places

Four of five sites say "geometric mean of per-query execution times" — a
reduction with one time per query. It is a geomean of per-query **medians**.
`BenchmarkIndex` is the only accurate one.

This was invisible until now: this PR is what first shows a query has several
executions, so it is what makes the wording falsifiable from the UI.

**I over-reached fixing it and the tooling caught me.** I edited all four;
`check-scope` flagged three as outside this item (`Compare.tsx` is
`do_not_modify` here, `Home`/`PlatformIndex` outside the allowlist). Reverted,
kept the in-scope `MethodologyDisclosure.tsx` fix, recorded deferral #722, and
promoted it to `explorer-default-basis-copy-reconciliation` — a dedicated item
because no single existing item owns all three files, and splitting one wording
fix across two would leave the copy inconsistent for however long the second
lagged.

## The within-run route (w2)

The **only** place a statistic may vary between series. Everywhere else that
measures the statistic rather than the engine; here engine, hardware, corpus and
scale are fixed by construction, so the basis *is* the subject.

For exactly that reason its figures are not platform results.
`WITHIN_RUN_FIGURES_ARE_RANKABLE` is exported `false` so a ranking surface
cannot consume them by accident, and the page says so in words too.

A **separate route**, not a mode of `/results/compare`. The two obey opposite
rules — cross-run must hold exactly one basis, this exists so the basis can vary
— and sharing a path would invite the cross-run invariant to be relaxed "just
for this case". Registered *before* `/results/r/:resultId`, or preact-router
matches the detail page first and the route never resolves.

The reference column is **clamped** as columns are removed, not reset to zero:
removing the last column should not silently re-baseline a comparison the reader
is mid-way through.

## Same-query-set discipline (w3)

A query any column cannot answer is marked unrecorded in that column **and**
excluded from every column's shared set. That is the shape that produced a wrong
1.18x reading in the design prototype, where each column silently averaged over
whichever queries it happened to have. The test builds that exact case from a
failed pass 2.

A column whose basis the run cannot answer reports unavailable rather than
substituting the nearest — serving a warm figure under a warmup heading is a
fabricated comparison presented as real.

## Verification

All four verification steps pass:

- `npm test` — 1098 passed, 8 skipped (86 files)
- `npm run typecheck && vitest run src/pages/__tests__/` — clean
- `playwright e2e/routes/` — **119 passed**, 1 skipped
- `w0.log` recorded

Plus `make pr-preflight` — 28,538 passed, and `check-scope` clean.
