### PR TITLE
feat(explorer): browse by engine version and state the basis on index pages

### DIFF
--- a/results-explorer/src/lib/queryFilters.ts
+++ b/results-explorer/src/lib/queryFilters.ts
@@ -320,3 +320,73 @@ function renderSqlLiteral(value: unknown): string {
   const escaped = String(value).split("\\").join("\\\\").split("'").join("''");
   return `'${escaped}'`;
 }
+
+// ---------------------------------------------------------------------------
+// Presentation-only grouping for the cohort index tables
+// ---------------------------------------------------------------------------
+
+/**
+ * How to split cohort rows into labelled groups.
+ *
+ * PRESENTATION ONLY. Grouping rearranges rows; it never changes how a rank is
+ * computed or which rows are ranking-eligible. Ranking semantics are governed
+ * by a separate contract with its own release gate, and a grouping control that
+ * quietly reordered or re-filtered would become a second, hidden ranking policy.
+ */
+export type CohortGroupBy = "none" | "engine_version";
+
+export const COHORT_GROUP_BY_LABELS: Record<CohortGroupBy, string> = {
+  none: "No grouping",
+  engine_version: "Engine version",
+};
+
+export interface CohortGroup<T> {
+  key: string;
+  label: string;
+  rows: T[];
+}
+
+/** Rows lacking the grouping value collect here rather than vanishing. */
+export const UNGROUPED_LABEL = "Not recorded";
+
+/**
+ * Split rows into labelled groups, preserving input order within each group.
+ *
+ * Stability matters: the caller has already sorted by rank, so preserving
+ * order is what makes "grouping does not change ranking" true in the rendered
+ * output and not merely in principle.
+ *
+ * A row whose grouping value is absent goes to an explicit "Not recorded"
+ * group. Dropping it would let a filter silently shrink the cohort, and the
+ * per-group counts would then not sum to the total the page states.
+ */
+export function groupCohortRows<T>(
+  rows: readonly T[],
+  groupBy: CohortGroupBy,
+  readValue: (row: T) => string | null | undefined,
+): CohortGroup<T>[] {
+  if (groupBy === "none") {
+    return [{ key: "all", label: "All runs", rows: [...rows] }];
+  }
+  const groups = new Map<string, T[]>();
+  for (const row of rows) {
+    const raw = readValue(row);
+    const key = raw === null || raw === undefined || raw === "" ? UNGROUPED_LABEL : raw;
+    const bucket = groups.get(key);
+    if (bucket) bucket.push(row);
+    else groups.set(key, [row]);
+  }
+  // "Not recorded" sorts last; everything else keeps a stable natural order.
+  return [...groups.entries()]
+    .sort(([a], [b]) => {
+      if (a === UNGROUPED_LABEL) return 1;
+      if (b === UNGROUPED_LABEL) return -1;
+      return a.localeCompare(b, undefined, { numeric: true });
+    })
+    .map(([key, groupRows]) => ({ key, label: key, rows: groupRows }));
+}
+
+/** Total across groups, for asserting the split lost nothing. */
+export function cohortGroupTotal<T>(groups: readonly CohortGroup<T>[]): number {
+  return groups.reduce((sum, group) => sum + group.rows.length, 0);
+}

--- a/results-explorer/src/pages/BenchmarkIndex.tsx
+++ b/results-explorer/src/pages/BenchmarkIndex.tsx
@@ -1044,6 +1044,17 @@ function ListTable({
       <div class="border-b border-[var(--bb-data-border)] bg-[var(--bb-surface-data)] px-4 py-3 text-sm text-[var(--bb-data-fg-muted)]">
         Showing {visibleRows.length.toLocaleString()} of {filtered.length.toLocaleString()} results for SF {scaleFactor}
       </div>
+      {/*
+        The basis statement, per w3. A leaderboard that does not say what its
+        numbers mean is the same defect the compare work is fixing.
+
+        The median-or-min CONTROL is deferred, not forgotten -- see w0.log and
+        deferral #724 for the measurement and the reason.
+      */}
+      <p class="mb-3 text-xs text-[var(--bb-data-fg-muted)]" data-testid="basis-statement">
+        Every figure below uses the published measurement basis: the median of each run's warm
+        passes per query, then the geometric mean across queries. Warmup passes are excluded.
+      </p>
       <table class="min-w-full divide-y divide-[var(--bb-data-border)]">
         <thead class="bg-[var(--bb-surface-data-muted)]">
           <tr>

--- a/results-explorer/src/pages/Home.tsx
+++ b/results-explorer/src/pages/Home.tsx
@@ -20,7 +20,7 @@ import { ProvenanceLegend } from "@/components/ProvenanceLegend";
 import {
   FACET_KEYS,
   useFacetState,
-  type FacetKey,
+  type ExplorerFacetKey,
   type FacetState,
 } from "@/lib/facetModel";
 import {
@@ -743,12 +743,31 @@ function SkeletonSelect({ label }: { label: string }) {
 }
 
 interface ActiveFacetSummary {
-  key: FacetKey;
+  // Widened to ExplorerFacetKey so the engine-version chip, which is a
+  // hardware facet key, can be summarized alongside the core ones.
+  key: ExplorerFacetKey;
   label: string;
   value: string;
 }
 
-const FACET_LABELS: Record<FacetKey, string> = {
+/**
+ * Facets rendered as active chips on this page.
+ *
+ * FACET_KEYS is the core set. `platform_version` is added because w0's coverage
+ * gate cleared it (7 populated buckets) and the state, URL and SQL plumbing for
+ * it already exist from the hardware read-model item -- only the rendering was
+ * missing.
+ *
+ * `arch` and `cpu_family` are DELIBERATELY absent. Each has exactly one
+ * populated bucket across the whole corpus, and a single-bucket chip implies a
+ * choice the data cannot offer. `cpu_family` is the sharper case: since the
+ * attestation backfill it reads "apple_silicon (151)", which looks like real
+ * coverage rather than like an empty facet, so a chip would actively mislead.
+ * They ship as columns instead -- see w0.log.
+ */
+const RENDERED_FACET_KEYS = [...FACET_KEYS, "platform_version"] as const;
+
+const FACET_LABELS: Record<ExplorerFacetKey, string> = {
   benchmark: "Benchmark",
   scale_factor: "Scale factor",
   phase: "Phase",
@@ -764,6 +783,12 @@ const FACET_LABELS: Record<FacetKey, string> = {
   storage_format: "Storage format",
   cost_status: "Cost status",
   date_window: "Date window",
+  platform_version: "Engine version",
+  // Labelled but NOT in RENDERED_FACET_KEYS: single-bucket facets ship as
+  // columns, not chips. The label exists so a URL that already carries one
+  // still summarizes readably.
+  arch: "Architecture",
+  cpu_family: "CPU family",
 };
 
 function ActiveLeaderboardSummary({
@@ -979,7 +1004,7 @@ function summarizeActiveFacets(
   platformIdToName: ReadonlyMap<string, string>,
 ): ActiveFacetSummary[] {
   const summaries: ActiveFacetSummary[] = [];
-  for (const key of FACET_KEYS) {
+  for (const key of RENDERED_FACET_KEYS) {
     const value = facets[key];
     if (Array.isArray(value)) {
       if (value.length === 0) continue;
@@ -1000,7 +1025,7 @@ function summarizeActiveFacets(
 }
 
 function formatFacetValue(
-  key: FacetKey,
+  key: ExplorerFacetKey,
   value: string,
   platformIdToName: ReadonlyMap<string, string>,
 ): string {

--- a/results-explorer/src/pages/PlatformIndex.tsx
+++ b/results-explorer/src/pages/PlatformIndex.tsx
@@ -724,6 +724,14 @@ export function PlatformIndex({ platform = "" }: PlatformIndexProps) {
             />
           </div>
           <div ref={resultsScrollerRef} class="overflow-x-auto" data-testid="platform-results-scroll-container">
+          {/*
+          Basis statement, per w3. Same wording as BenchmarkIndex so the two
+          leaderboards cannot describe the same reduction differently.
+          */}
+          <p class="mb-3 text-xs text-[var(--bb-data-fg-muted)]" data-testid="basis-statement">
+          Every figure below uses the published measurement basis: the median of each run's warm
+          passes per query, then the geometric mean across queries. Warmup passes are excluded.
+          </p>
           <DataTable
             ariaLabel={`${platformDisplayName} results`}
             ariaColCount={platformColumnCount}

--- a/results-explorer/src/pages/__tests__/CohortGrouping.test.ts
+++ b/results-explorer/src/pages/__tests__/CohortGrouping.test.ts
@@ -1,0 +1,117 @@
+/**
+ * Grouping the cohort index tables.
+ *
+ * The load-bearing claim is that grouping is PRESENTATION ONLY: it rearranges
+ * rows and never changes how a rank is computed or which rows are eligible.
+ * Ranking semantics have their own contract and release gate, so a grouping
+ * control that quietly reordered or re-filtered would become a second, hidden
+ * ranking policy.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import {
+  COHORT_GROUP_BY_LABELS,
+  UNGROUPED_LABEL,
+  cohortGroupTotal,
+  groupCohortRows,
+} from "@/lib/queryFilters";
+
+interface Row {
+  id: string;
+  rank: number;
+  engine: string | null;
+  eligible: boolean;
+}
+
+// Already rank-sorted, as the page hands them over.
+const rows: Row[] = [
+  { id: "a", rank: 1, engine: "1.4.3", eligible: true },
+  { id: "b", rank: 2, engine: "1.3.2", eligible: true },
+  { id: "c", rank: 3, engine: "1.4.3", eligible: false },
+  { id: "d", rank: 4, engine: null, eligible: true },
+];
+
+const byEngine = (r: Row) => r.engine;
+
+describe("grouping is presentation only", () => {
+  it("loses no rows", () => {
+    const groups = groupCohortRows(rows, "engine_version", byEngine);
+    expect(cohortGroupTotal(groups)).toBe(rows.length);
+  });
+
+  it("leaves ranking order unchanged across the full set", () => {
+    // Flattening the groups must yield the same MULTISET, and within any
+    // group the relative rank order must be preserved. That is what makes
+    // "grouping does not change ranking" true in the rendered output.
+    const groups = groupCohortRows(rows, "engine_version", byEngine);
+    const flat = groups.flatMap((g) => g.rows);
+    expect(flat.map((r) => r.id).sort()).toEqual(rows.map((r) => r.id).sort());
+    for (const group of groups) {
+      const ranks = group.rows.map((r) => r.rank);
+      expect([...ranks].sort((x, y) => x - y)).toEqual(ranks);
+    }
+  });
+
+  it("leaves eligibility untouched", () => {
+    const groups = groupCohortRows(rows, "engine_version", byEngine);
+    const flat = groups.flatMap((g) => g.rows);
+    for (const row of rows) {
+      expect(flat.find((r) => r.id === row.id)!.eligible).toBe(row.eligible);
+    }
+  });
+
+  it("does not filter out ranking-ineligible rows", () => {
+    // Grouping narrows nothing. An ineligible row is still part of the cohort
+    // and still has to be visible in it.
+    const groups = groupCohortRows(rows, "engine_version", byEngine);
+    expect(groups.flatMap((g) => g.rows).some((r) => !r.eligible)).toBe(true);
+  });
+});
+
+describe("group composition", () => {
+  it("returns one group when grouping is off", () => {
+    const groups = groupCohortRows(rows, "none", byEngine);
+    expect(groups).toHaveLength(1);
+    expect(groups[0]!.rows).toHaveLength(rows.length);
+  });
+
+  it("labels each group by its value and counts per group", () => {
+    const groups = groupCohortRows(rows, "engine_version", byEngine);
+    const byLabel = new Map(groups.map((g) => [g.label, g.rows.length]));
+    expect(byLabel.get("1.3.2")).toBe(1);
+    expect(byLabel.get("1.4.3")).toBe(2);
+  });
+
+  it("collects rows with no recorded value rather than dropping them", () => {
+    // Dropping them would let grouping silently shrink the cohort, and the
+    // per-group counts would stop summing to the total the page states.
+    const groups = groupCohortRows(rows, "engine_version", byEngine);
+    expect(groups.find((g) => g.label === UNGROUPED_LABEL)!.rows).toHaveLength(1);
+  });
+
+  it("sorts 'Not recorded' last", () => {
+    const groups = groupCohortRows(rows, "engine_version", byEngine);
+    expect(groups.at(-1)!.label).toBe(UNGROUPED_LABEL);
+  });
+
+  it("orders versions naturally, so 1.10 follows 1.9", () => {
+    const versioned: Row[] = [
+      { id: "x", rank: 1, engine: "1.10.0", eligible: true },
+      { id: "y", rank: 2, engine: "1.9.0", eligible: true },
+    ];
+    const groups = groupCohortRows(versioned, "engine_version", byEngine);
+    expect(groups.map((g) => g.label)).toEqual(["1.9.0", "1.10.0"]);
+  });
+
+  it("treats an empty string as not recorded", () => {
+    const blank: Row[] = [{ id: "z", rank: 1, engine: "", eligible: true }];
+    expect(groupCohortRows(blank, "engine_version", byEngine)[0]!.label).toBe(UNGROUPED_LABEL);
+  });
+
+  it("offers only the grouping modes the data can support", () => {
+    // w0's coverage gate cleared engine version alone; architecture and CPU
+    // are single-bucket and are not offered as grouping axes.
+    expect(Object.keys(COHORT_GROUP_BY_LABELS).sort()).toEqual(["engine_version", "none"]);
+  });
+});

--- a/results-explorer/src/pages/__tests__/HomeHardwareFacets.test.ts
+++ b/results-explorer/src/pages/__tests__/HomeHardwareFacets.test.ts
@@ -1,0 +1,38 @@
+/**
+ * The hardware/engine facet chips on the index pages.
+ *
+ * w0's coverage gate cleared exactly one: engine version (7 populated
+ * buckets). `arch` and `cpu_family` each have a single populated bucket and
+ * ship as columns instead — a single-bucket chip implies a choice the data
+ * cannot offer.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import { ALL_FACET_KEYS, CORE_FACET_KEYS, HARDWARE_FACET_KEYS } from "@/lib/facetModel";
+
+describe("the coverage gate, encoded", () => {
+  it("keeps every hardware key available in the model", () => {
+    // The gate governs which chips RENDER, not which facets exist. URL state,
+    // aliases and the SQL clause builder must keep working for all of them, so
+    // a link someone already holds does not stop resolving.
+    expect(HARDWARE_FACET_KEYS).toContain("platform_version");
+    expect(HARDWARE_FACET_KEYS).toContain("arch");
+    expect(HARDWARE_FACET_KEYS).toContain("cpu_family");
+  });
+
+  it("composes core and hardware keys without dropping any", () => {
+    for (const key of [...CORE_FACET_KEYS, ...HARDWARE_FACET_KEYS]) {
+      expect(ALL_FACET_KEYS).toContain(key);
+    }
+    expect(ALL_FACET_KEYS.length).toBe(CORE_FACET_KEYS.length + HARDWARE_FACET_KEYS.length);
+  });
+
+  it("does not silently promote a hardware key into the core set", () => {
+    // CORE_FACET_KEYS is what pages iterate by default. A hardware key
+    // appearing there would ship a chip without passing the coverage gate.
+    for (const key of HARDWARE_FACET_KEYS) {
+      expect(CORE_FACET_KEYS).not.toContain(key);
+    }
+  });
+});


### PR DESCRIPTION
Implements `explorer-basis-browse-hardware-engine-facets` (w0–w3).

The corpus could not answer "show me arm64 versus x86_64 across engines"
without opening the Query workbench and writing SQL. This makes engine version
browsable, adds presentation-only grouping, and states the measurement basis on
the leaderboards.

## The coverage gate cleared exactly one facet

| facet | non-null buckets | verdict |
| --- | --- | --- |
| `platform_version` | 7 | **ship chip** |
| `arch` | 1 (arm64) | column only |
| `cpu_family` | 1 (apple_silicon) | column only |

**The gate's answer did not change between my first and second evaluation, but
its reason did — and that is the part worth keeping.** `cpu_family` was NULL for
all 151 results when I first looked: *zero* buckets. #1953's attestation backfill
then populated it for every result from one attested machine, so it became
*one*.

An empty facet is visibly empty. A facet that is 100% populated with a single
value **looks like real coverage** — a chip reading `apple_silicon (151)` would
invite a reader to believe the corpus spans CPU families and that they had
filtered to one. It doesn't, and they hadn't. The later shape is the worse
hazard, so `w0.log` records the reason rather than only the verdict.

`arch` and `cpu_family` keep their labels despite not rendering as chips, so a
URL someone already holds still summarizes readably.

## Grouping is presentation only, and the tests say so

Not asserted in a comment: flattening the groups yields the same multiset, rank
order is preserved *within* each group, eligibility is untouched, and
ranking-ineligible rows are **not** filtered out.

Rows with no recorded value collect in an explicit "Not recorded" group sorted
last. Dropping them would let grouping silently shrink the cohort so per-group
counts stopped summing to the total the page states.

## Two pieces deferred, both verified rather than assumed

**Architecture and CPU columns (#723).** `benchmark_rankings` carries no hardware
column at all; `platform_index_rows` carries only `driver_version`. The hardware
lives in `result_environment` / `result_detail_metrics` — per-result detail
tables neither index page queries.

**The median-or-min control (#724).** Deferred on w3's own decision gate, but for
**query shape, not data volume**:

| | |
| --- | --- |
| largest cohort | 12 runs / **972 execution rows** |
| whole corpus | 22,136 rows |
| native DuckDB fetch | **3 ms** |
| interaction budget | 500 ms p50 / 1000 ms p95 |

Volume is nowhere near the limit. The problem is that a non-default basis for a
cohort is **N queries** where N is the run count — 12 today, growing with the
corpus — because the only accessor is `getQueryExecutions(resultId)`.

Both fixes live outside this item's allowlist (`explorer_pipeline/` and
`duckdbQueries.ts`) and are now covered by
`explorer-index-read-model-hardware-and-executions`.

**Neither was worked around by looping the per-result accessor.** That is
exactly the N-query shape the budget is at risk from, and shipping it to find
out would use the leaderboard as the experiment. The gate's fallback path is
taken as written: statement ships, measurement recorded, control deferred.

The basis statement uses identical wording on both index pages, so the two
leaderboards cannot describe the same reduction differently.

## Verification

All five verification steps pass:

- `npm test` — 1112 passed, 8 skipped (88 files)
- `npm run typecheck` — clean
- a11y suites for both index pages — pass
- `playwright e2e/responsive.spec.ts` — **28 passed**
- `w0.log` — coverage gate and the w3 measurement recorded

Plus `make pr-preflight` — 28,538 passed, `check-scope` clean.
