### PR TITLE
feat(explorer): add multi-run compare layout with baseline, ratio heatmap and standings

### DIFF
--- a/results-explorer/src/components/IdentityDiffStrip.tsx
+++ b/results-explorer/src/components/IdentityDiffStrip.tsx
@@ -20,10 +20,12 @@ import { buildComparabilityFields, type ComparabilityField } from "@/components/
  */
 export interface IdentityDiffStripProps {
   results: DetailResult[];
+  baselineIndex?: number;
+  runLabels?: readonly string[];
 }
 
 /** The axes this strip reports, in reading order, by their receipt labels. */
-const STRIP_AXES = [
+export const STRIP_AXES = [
   "Platform version",
   "Driver version",
   "Architecture",
@@ -32,7 +34,7 @@ const STRIP_AXES = [
   "Memory",
 ] as const;
 
-const AXIS_DISPLAY_LABEL: Record<(typeof STRIP_AXES)[number], string> = {
+export const AXIS_DISPLAY_LABEL: Record<(typeof STRIP_AXES)[number], string> = {
   "Platform version": "Engine version",
   "Driver version": "Driver",
   Architecture: "Architecture",
@@ -40,6 +42,23 @@ const AXIS_DISPLAY_LABEL: Record<(typeof STRIP_AXES)[number], string> = {
   "CPU model": "CPU model",
   Memory: "Memory",
 };
+
+export function axisValueForRun(axis: (typeof STRIP_AXES)[number], result: DetailResult): string {
+  switch (axis) {
+    case "Platform version":
+      return result.platform_version && result.platform_version !== "" ? result.platform_version : "Not recorded";
+    case "Driver version":
+      return result.driver_version && result.driver_version !== "" ? result.driver_version : "Not recorded";
+    case "Architecture":
+      return result.environment?.arch && result.environment.arch !== "" ? result.environment.arch : "Not recorded";
+    case "CPU family":
+      return result.environment?.cpu_family && result.environment.cpu_family !== "" ? result.environment.cpu_family : "Not recorded";
+    case "CPU model":
+      return result.environment?.cpu_model && result.environment.cpu_model !== "" ? result.environment.cpu_model : "Not recorded";
+    case "Memory":
+      return result.environment?.memory_gb !== undefined ? `${result.environment.memory_gb} GB` : "Not recorded";
+  }
+}
 
 export function identityStripFields(results: DetailResult[]): ComparabilityField[] {
   if (results.length === 0) return [];
@@ -66,11 +85,77 @@ function statusWord(status: ComparabilityField["status"]): string {
   return "Same";
 }
 
-export function IdentityDiffStrip({ results }: IdentityDiffStripProps) {
+export function IdentityDiffStrip({ results, baselineIndex = 0, runLabels }: IdentityDiffStripProps) {
   if (results.length < 2) return null;
   const fields = identityStripFields(results);
   if (fields.length === 0) return null;
   const diffCount = fields.filter((f) => f.status === "diff").length;
+
+  if (results.length > 2) {
+    const baseIndex = results[baselineIndex] ? baselineIndex : 0;
+    const baselineRun = results[baseIndex];
+
+    return (
+      <section class="panel mb-4 px-3 py-2 shadow-sm" aria-label="Engine and hardware identity">
+        <div class="flex flex-wrap items-center justify-between gap-2">
+          <h2 class="text-sm font-medium text-[var(--bb-data-fg-primary)]">Engine and hardware</h2>
+          <p class="text-xs text-[var(--bb-data-fg-muted)]">
+            {diffCount === 0
+              ? "These runs match on every axis below, so the difference is not explained by them."
+              : `${diffCount} of ${fields.length} ${diffCount === 1 ? "axis varies" : "axes vary"} across the whole selection.`}
+          </p>
+        </div>
+        <div class="mt-2 overflow-x-auto">
+          <table role="table" class="min-w-full w-max divide-y divide-[var(--bb-data-border)] text-sm">
+            <thead class="bg-[var(--bb-surface-data-muted)]">
+              <tr>
+                <th class="table-th">Axis</th>
+                {results.map((r, i) => (
+                  <th key={r.result_id} class="table-th">
+                    {runLabels?.[i] ?? r.platform}
+                    {i === baseIndex ? " (baseline)" : ""}
+                  </th>
+                ))}
+              </tr>
+            </thead>
+            <tbody class="divide-y divide-[var(--bb-data-border)] bg-[var(--bb-surface-data)]">
+              {fields.map((field) => {
+                const axis = field.label as (typeof STRIP_AXES)[number];
+                const baseVal = baselineRun ? axisValueForRun(axis, baselineRun) : "Not recorded";
+                return (
+                  <tr key={field.label}>
+                    <td class="table-td font-medium text-[var(--bb-data-fg-primary)]">
+                      {AXIS_DISPLAY_LABEL[axis] ?? field.label}
+                    </td>
+                    {results.map((r, i) => {
+                      const val = axisValueForRun(axis, r);
+                      const isBase = i === baseIndex;
+                      const isMissing = val === "Not recorded" || baseVal === "Not recorded";
+                      const isDiff = !isBase && !isMissing && val !== baseVal;
+                      const status = isBase ? "baseline" : isMissing ? "missing" : isDiff ? "diff" : "match";
+                      return (
+                        <td key={r.result_id} class="table-td text-xs" data-testid={`matrix-cell-${axis}-${i}`}>
+                          <div class="flex items-center justify-between gap-2">
+                            <span class="break-words font-mono text-[var(--bb-data-fg-primary)]">{val}</span>
+                            <StatusBadge
+                              role="comparison"
+                              tone={status === "diff" ? "warning" : status === "match" ? "success" : "neutral"}
+                            >
+                              {status === "baseline" ? "Baseline" : statusWord(status)}
+                            </StatusBadge>
+                          </div>
+                        </td>
+                      );
+                    })}
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+        </div>
+      </section>
+    );
+  }
 
   return (
     <section class="panel mb-4 px-3 py-2 shadow-sm" aria-label="Engine and hardware identity">

--- a/results-explorer/src/components/MultiRunHeatmap.tsx
+++ b/results-explorer/src/components/MultiRunHeatmap.tsx
@@ -1,0 +1,213 @@
+import type { DetailResult } from "@/types";
+import { StatusBadge } from "@/components/StatusBadge";
+import { type QueryDiffLimiter, QUERY_DIFF_LIMITER_LABELS } from "@/components/QueryDiffTable";
+import {
+  DIVERGING_RATIO_CLAMP,
+  divergingRatioPosition,
+  queryDisagreementSpread,
+} from "@/lib/chartMath";
+import { timingValueForQuery } from "@/lib/displayEligibility";
+
+/**
+ * Query x run heatmap of ratios against the chosen baseline.
+ *
+ * DIVERGING, not sequential, and that is the whole reason this is a separate
+ * component from QueryHeatmap rather than a mode of it. QueryHeatmap encodes
+ * magnitude from a floor (ratio-to-fastest, always >= 1), where a single-hue
+ * ramp is correct. This encodes direction from a midpoint, where polarity --
+ * faster or slower than baseline -- is the point. A sequential ramp would paint
+ * 0.5x and 2.0x as different intensities of one hue and lose the sign, which is
+ * the one thing this chart exists to show. See w0.log for the full decision.
+ *
+ * Reused from QueryHeatmap deliberately: role="grid" / role="gridcell"
+ * semantics and the practice of carrying the value as TEXT in every cell, so
+ * colour is never the only encoding.
+ */
+export interface MultiRunHeatmapProps {
+  results: DetailResult[];
+  baselineIndex: number;
+  runLabels: readonly string[];
+  /** How many query rows to render; the caption always names the total. */
+  limit?: number;
+  /** Filter or ordering to apply to query rows. */
+  limiter?: QueryDiffLimiter;
+  /** Order rows by where the runs disagree most, rather than by query id. */
+  orderByDisagreement?: boolean;
+}
+
+export interface HeatmapCell {
+  ratio: number | null;
+  /** [-1, 1] position on the diverging scale, or null when unanswerable. */
+  position: number | null;
+}
+
+export interface HeatmapRow {
+  queryId: string;
+  cells: HeatmapCell[];
+  /** Log-space spread across runs; null when fewer than two could answer. */
+  disagreement: number | null;
+}
+
+export function buildHeatmapRows(
+  results: readonly DetailResult[],
+  baselineIndex: number,
+): HeatmapRow[] {
+  const queryIds = new Set<string>();
+  for (const r of results) for (const t of r.display_timings) queryIds.add(t.query_id);
+  const baseline = results[baselineIndex];
+
+  return [...queryIds]
+    .sort((a, b) => a.localeCompare(b, undefined, { numeric: true }))
+    .map((queryId) => {
+      const baseMs = baseline ? timingValueForQuery(baseline, queryId) : null;
+      const cells: HeatmapCell[] = results.map((r) => {
+        const ms = timingValueForQuery(r, queryId);
+        const ratio = ms !== null && baseMs !== null && baseMs > 0 ? ms / baseMs : null;
+        return { ratio, position: divergingRatioPosition(ratio) };
+      });
+      return {
+        queryId,
+        cells,
+        disagreement: queryDisagreementSpread(cells.map((c) => c.ratio)),
+      };
+    });
+}
+
+/** Rows ordered by disagreement, unanswerable-heavy rows last. */
+export function orderRowsByDisagreement(rows: readonly HeatmapRow[]): HeatmapRow[] {
+  return [...rows].sort((a, b) => {
+    if (a.disagreement === null && b.disagreement === null) return 0;
+    if (a.disagreement === null) return 1;
+    if (b.disagreement === null) return -1;
+    return b.disagreement - a.disagreement;
+  });
+}
+
+/** Filter and rank heatmap rows according to the chosen limiter. */
+export function filterHeatmapRows(
+  rows: readonly HeatmapRow[],
+  limiter: QueryDiffLimiter = "all",
+  baselineIndex: number = 0,
+): HeatmapRow[] {
+  if (limiter === "all") return [...rows];
+  if (limiter === "movement") return orderRowsByDisagreement(rows);
+
+  if (limiter === "speedups") {
+    const speedupRows = rows.filter((r) =>
+      r.cells.some((c, i) => i !== baselineIndex && c.ratio !== null && c.ratio < 1),
+    );
+    return speedupRows.sort((a, b) => {
+      const minA = Math.min(...a.cells.map((c, i) => (i !== baselineIndex && c.ratio !== null ? c.ratio : 1)));
+      const minB = Math.min(...b.cells.map((c, i) => (i !== baselineIndex && c.ratio !== null ? c.ratio : 1)));
+      return minA - minB;
+    });
+  }
+
+  if (limiter === "slowdowns") {
+    const slowdownRows = rows.filter((r) =>
+      r.cells.some((c, i) => i !== baselineIndex && c.ratio !== null && c.ratio > 1),
+    );
+    return slowdownRows.sort((a, b) => {
+      const maxA = Math.max(...a.cells.map((c, i) => (i !== baselineIndex && c.ratio !== null ? c.ratio : 1)));
+      const maxB = Math.max(...b.cells.map((c, i) => (i !== baselineIndex && c.ratio !== null ? c.ratio : 1)));
+      return maxB - maxA;
+    });
+  }
+
+  return [...rows];
+}
+
+function cellStyle(position: number | null): string {
+  if (position === null) return "";
+  // Two hues around a neutral midpoint. Emitted as CSS custom properties for
+  // the same reason QueryHeatmap does it: dark mode and prefers-contrast
+  // override without touching this component.
+  const hue = position < 0 ? 150 : 15;
+  const lightness = 95 - Math.abs(position) * 35;
+  return `--cell-hue:${hue}; --cell-lightness:${lightness.toFixed(1)}%; background-color: hsl(${hue} 60% ${lightness.toFixed(1)}%);`;
+}
+
+function cellText(cell: HeatmapCell): string {
+  if (cell.ratio === null) return "—";
+  return `${cell.ratio.toFixed(2)}x`;
+}
+
+export function MultiRunHeatmap({
+  results,
+  baselineIndex,
+  runLabels,
+  limit = 25,
+  limiter,
+  orderByDisagreement = false,
+}: MultiRunHeatmapProps) {
+  if (results.length < 3) return null;
+  const effectiveLimiter: QueryDiffLimiter = limiter ?? (orderByDisagreement ? "movement" : "all");
+  const all = buildHeatmapRows(results, baselineIndex);
+  const ordered = filterHeatmapRows(all, effectiveLimiter, baselineIndex);
+  const shown = ordered.slice(0, limit);
+  const unrecorded = shown.reduce(
+    (n, row) => n + row.cells.filter((c) => c.ratio === null).length,
+    0,
+  );
+
+  return (
+    <section class="card mb-8" aria-labelledby="multi-run-heatmap-title">
+      <div class="mb-3 flex flex-wrap items-start justify-between gap-2">
+        <div>
+          <h2 id="multi-run-heatmap-title" class="text-base font-semibold text-[var(--bb-data-fg-primary)]">
+            Query by run
+          </h2>
+          <p class="mt-1 text-xs text-[var(--bb-data-fg-muted)]" data-testid="heatmap-caption">
+            {shown.length === 0 && effectiveLimiter !== "all"
+              ? `No queries match ${QUERY_DIFF_LIMITER_LABELS[effectiveLimiter].toLowerCase()} — showing 0 of ${all.length}.`
+              : `Ratio against ${runLabels[baselineIndex] ?? "the baseline"} — below 1.00x is faster. Showing ${shown.length} of ${all.length} ${all.length === 1 ? "query" : "queries"}.`}
+          </p>
+        </div>
+        <StatusBadge role="comparison" tone="neutral">
+          {`Scale saturates at ${DIVERGING_RATIO_CLAMP}x`}
+        </StatusBadge>
+      </div>
+
+      {unrecorded > 0 ? (
+        <p class="mb-2 text-xs text-[var(--bb-data-fg-subtle)]" data-testid="heatmap-unrecorded-note">
+          {`${unrecorded} ${unrecorded === 1 ? "cell is" : "cells are"} unrecorded: that run cannot answer the query under the current basis. Unrecorded is not parity, and is left uncoloured.`}
+        </p>
+      ) : null}
+
+      <div class="overflow-x-auto">
+        <table role="grid" class="min-w-full w-max divide-y divide-[var(--bb-data-border)] text-sm">
+          <thead class="bg-[var(--bb-surface-data-muted)]">
+            <tr role="row">
+              <th role="columnheader" class="table-th">Query</th>
+              {results.map((r, i) => (
+                <th key={r.result_id} role="columnheader" class="table-th">
+                  {runLabels[i] ?? r.platform}
+                  {i === baselineIndex ? " (baseline)" : ""}
+                </th>
+              ))}
+            </tr>
+          </thead>
+          <tbody class="divide-y divide-[var(--bb-data-border)] bg-[var(--bb-surface-data)]">
+            {shown.map((row) => (
+              <tr role="row" key={row.queryId}>
+                <td class="table-td font-mono font-medium">{row.queryId}</td>
+                {row.cells.map((cell, i) => (
+                  <td
+                    key={i}
+                    role="gridcell"
+                    class="table-td font-mono text-xs"
+                    style={cellStyle(cell.position)}
+                    data-testid={`cell-${row.queryId}-${i}`}
+                  >
+                    {/* Value as text in every cell: colour is never the only encoding. */}
+                    {cellText(cell)}
+                  </td>
+                ))}
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </section>
+  );
+}

--- a/results-explorer/src/components/MultiRunStandings.tsx
+++ b/results-explorer/src/components/MultiRunStandings.tsx
@@ -1,0 +1,189 @@
+import type { DetailResult } from "@/types";
+import { StatusBadge } from "@/components/StatusBadge";
+import { geomeanMs } from "@/lib/chartMath";
+import { timingValueForQuery } from "@/lib/displayEligibility";
+import { COMPARE_TIE_THRESHOLD } from "@/lib/compareSummary";
+import { fmtGeomean } from "@/utils";
+
+/**
+ * Standings for a three-to-four run comparison.
+ *
+ * A multi-run selection is a ranking problem, not a diff: the reader wants an
+ * order and a margin, which 309 undifferentiated diff rows cannot give them.
+ *
+ * Every geomean here is computed over the SAME intersected query set, and the
+ * caption states its size and how it was chosen. A standings table whose rows
+ * were each averaged over a different query set would be an ordering of
+ * incomparable numbers presented as a ranking.
+ */
+export interface MultiRunStandingsProps {
+  results: DetailResult[];
+  baselineIndex: number;
+  runLabels: readonly string[];
+}
+
+export interface StandingRow {
+  resultId: string;
+  label: string;
+  engine: string;
+  hardware: string;
+  geomeanMs: number | null;
+  /** Ratio against the baseline: <1 faster, >1 slower. */
+  ratioToBaseline: number | null;
+  queriesWon: number;
+  isBaseline: boolean;
+  /** Inside the tie band, so neither faster nor slower may be claimed. */
+  tied: boolean;
+}
+
+/** Queries every selected run can answer. */
+export function sharedQueryIdsFor(results: readonly DetailResult[]): string[] {
+  const all = new Set<string>();
+  for (const r of results) for (const t of r.display_timings) all.add(t.query_id);
+  return [...all]
+    .filter((q) => results.every((r) => timingValueForQuery(r, q) !== null))
+    .sort((a, b) => a.localeCompare(b, undefined, { numeric: true }));
+}
+
+export function buildStandings(
+  results: readonly DetailResult[],
+  baselineIndex: number,
+  runLabels: readonly string[],
+): { rows: StandingRow[]; sharedQueryIds: string[]; totalQueryIds: number } {
+  const shared = sharedQueryIdsFor(results);
+  const all = new Set<string>();
+  for (const r of results) for (const t of r.display_timings) all.add(t.query_id);
+
+  const perRun = results.map((r) => shared.map((q) => timingValueForQuery(r, q)));
+  const geomeans = perRun.map((values) => geomeanMs(values));
+  const baseGeomean = geomeans[baselineIndex] ?? null;
+
+  // Queries won: for each shared query, the run with the lowest value takes it.
+  // Reuses RankTable's semantics -- lower is faster, ties award no win rather
+  // than awarding one to each, so the counts still sum to at most the query
+  // count and cannot overstate any run.
+  const wins = new Array(results.length).fill(0) as number[];
+  shared.forEach((_q, qi) => {
+    let best: number | null = null;
+    let bestRuns: number[] = [];
+    perRun.forEach((values, ri) => {
+      const v = values[qi];
+      if (v === null || v === undefined) return;
+      if (best === null || v < best) {
+        best = v;
+        bestRuns = [ri];
+      } else if (v === best) {
+        bestRuns.push(ri);
+      }
+    });
+    if (bestRuns.length === 1) {
+      const winner = bestRuns[0]!;
+      wins[winner] = (wins[winner] ?? 0) + 1;
+    }
+  });
+
+  const rows: StandingRow[] = results.map((r, i) => {
+    const g = geomeans[i] ?? null;
+    const ratio = g !== null && baseGeomean !== null && baseGeomean > 0 ? g / baseGeomean : null;
+    const hw = r.environment?.cpu_model
+      ? r.environment.cpu_model
+      : r.environment?.cpu_family
+      ? r.environment.cpu_family
+      : r.environment?.arch
+      ? r.environment.arch
+      : "Not recorded";
+    const mem = r.environment?.memory_gb !== undefined ? ` · ${r.environment.memory_gb} GB` : "";
+    const hardware = hw === "Not recorded" ? "Not recorded" : `${hw}${mem}`;
+    const engine = r.platform_version ? `${r.platform} v${r.platform_version}` : r.platform;
+    return {
+      resultId: r.result_id,
+      label: runLabels[i] ?? r.platform,
+      engine,
+      hardware,
+      geomeanMs: g,
+      ratioToBaseline: ratio,
+      queriesWon: wins[i] ?? 0,
+      isBaseline: i === baselineIndex,
+      tied: ratio !== null && Math.abs(ratio - 1) < COMPARE_TIE_THRESHOLD,
+    };
+  });
+
+  // Rank by geomean, faster first. Rows without a geomean sort last rather
+  // than being dropped -- a run that could not be reduced is still selected.
+  rows.sort((a, b) => {
+    if (a.geomeanMs === null && b.geomeanMs === null) return 0;
+    if (a.geomeanMs === null) return 1;
+    if (b.geomeanMs === null) return -1;
+    return a.geomeanMs - b.geomeanMs;
+  });
+
+  return { rows, sharedQueryIds: shared, totalQueryIds: all.size };
+}
+
+function ratioText(row: StandingRow): string {
+  if (row.isBaseline) return "baseline";
+  if (row.ratioToBaseline === null) return "—";
+  if (row.tied) return "tied";
+  return `${row.ratioToBaseline.toFixed(2)}x`;
+}
+
+export function MultiRunStandings({ results, baselineIndex, runLabels }: MultiRunStandingsProps) {
+  if (results.length < 3) return null;
+  const { rows, sharedQueryIds, totalQueryIds } = buildStandings(results, baselineIndex, runLabels);
+  const excluded = totalQueryIds - sharedQueryIds.length;
+
+  return (
+    <section class="card mb-8" aria-labelledby="standings-title">
+      <div class="mb-3">
+        <h2 id="standings-title" class="text-base font-semibold text-[var(--bb-data-fg-primary)]">
+          Standings
+        </h2>
+        <p class="mt-1 text-xs text-[var(--bb-data-fg-muted)]" data-testid="standings-caption">
+          {`Ranked by geometric mean over the ${sharedQueryIds.length} of ${totalQueryIds} queries every run can answer.`}
+          {excluded > 0
+            ? ` ${excluded} ${excluded === 1 ? "query is" : "queries are"} excluded from every run so the geomeans compare like with like.`
+            : ""}
+        </p>
+      </div>
+      <div class="overflow-x-auto">
+        <table class="min-w-full w-max divide-y divide-[var(--bb-data-border)] text-sm">
+          <thead class="bg-[var(--bb-surface-data-muted)]">
+            <tr>
+              <th class="table-th">Rank</th>
+              <th class="table-th">Run</th>
+              <th class="table-th">Hardware</th>
+              <th class="table-th">Geomean</th>
+              <th class="table-th">vs baseline</th>
+              <th class="table-th">Queries won</th>
+            </tr>
+          </thead>
+          <tbody class="divide-y divide-[var(--bb-data-border)] bg-[var(--bb-surface-data)]">
+            {rows.map((row, i) => (
+              <tr key={row.resultId} class="hover:bg-[var(--bb-surface-data-muted)]">
+                <td class="table-td font-mono">{i + 1}</td>
+                <td class="table-td">
+                  {row.label}
+                  {row.isBaseline ? (
+                    <StatusBadge role="comparison" tone="neutral" class="ml-2">
+                      Baseline
+                    </StatusBadge>
+                  ) : null}
+                </td>
+                <td class="table-td text-xs text-[var(--bb-data-fg-muted)]">
+                  {row.hardware}
+                </td>
+                <td class="table-td font-mono">
+                  {row.geomeanMs !== null ? fmtGeomean(row.geomeanMs) : "—"}
+                </td>
+                <td class="table-td font-mono" data-testid={`ratio-${row.resultId}`}>
+                  {ratioText(row)}
+                </td>
+                <td class="table-td font-mono">{row.queriesWon}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </section>
+  );
+}

--- a/results-explorer/src/components/__tests__/IdentityDiffStrip.test.tsx
+++ b/results-explorer/src/components/__tests__/IdentityDiffStrip.test.tsx
@@ -97,6 +97,48 @@ describe("runs without CPU data", () => {
   });
 });
 
+describe("multi-run identity matrix (N > 2 runs)", () => {
+  it("renders a matrix with one row per axis and one column per run", () => {
+    const r1 = run({ result_id: "r1", platform_version: "1.0.0" });
+    const r2 = run({ result_id: "r2", platform_version: "2.0.0" });
+    const r3 = run({ result_id: "r3", platform_version: "1.0.0" });
+    render(<IdentityDiffStrip results={[r1, r2, r3]} baselineIndex={0} runLabels={["Run 1", "Run 2", "Run 3"]} />);
+
+    expect(screen.getByText("Run 1 (baseline)")).toBeTruthy();
+    expect(screen.getByText("Run 2")).toBeTruthy();
+    expect(screen.getByText("Run 3")).toBeTruthy();
+    expect(screen.getByText("Engine version")).toBeTruthy();
+    expect(screen.getByText("Architecture")).toBeTruthy();
+    expect(screen.getByText(/1 of 6 axis varies across the whole selection/)).toBeTruthy();
+  });
+
+  it("marks differing cells relative to baseline and identifies matching cells", () => {
+    const r1 = run({ result_id: "r1", platform_version: "1.0.0" });
+    const r2 = run({ result_id: "r2", platform_version: "2.0.0" });
+    const r3 = run({ result_id: "r3", platform_version: "1.0.0" });
+    render(<IdentityDiffStrip results={[r1, r2, r3]} baselineIndex={0} runLabels={["Run 1", "Run 2", "Run 3"]} />);
+
+    const cellDiff = screen.getByTestId("matrix-cell-Platform version-1");
+    expect(cellDiff.textContent).toContain("Differs");
+    expect(cellDiff.textContent).toContain("2.0.0");
+
+    const cellMatch = screen.getByTestId("matrix-cell-Platform version-2");
+    expect(cellMatch.textContent).toContain("Same");
+    expect(cellMatch.textContent).toContain("1.0.0");
+  });
+
+  it("renders 'not recorded' rather than 'differs' when a run lacks CPU data", () => {
+    const r1 = run({ result_id: "r1" });
+    const r2 = run({ result_id: "r2", environment: { arch: "arm64" } as any });
+    const r3 = run({ result_id: "r3" });
+    render(<IdentityDiffStrip results={[r1, r2, r3]} baselineIndex={0} />);
+
+    const missingCell = screen.getByTestId("matrix-cell-CPU family-1");
+    expect(missingCell.textContent).toContain("Not recorded");
+    expect(missingCell.textContent).not.toContain("Differs");
+  });
+});
+
 describe("rendering guards", () => {
   it("renders nothing for a single run", () => {
     const { container } = render(<IdentityDiffStrip results={[run()]} />);

--- a/results-explorer/src/components/__tests__/MultiRunLayout.test.ts
+++ b/results-explorer/src/components/__tests__/MultiRunLayout.test.ts
@@ -1,0 +1,278 @@
+/**
+ * The three-to-four run layout: diverging heatmap and standings.
+ *
+ * A multi-run selection is a ranking problem, not a diff. These tests pin the
+ * two properties that make the ranking honest -- one shared query set, and a
+ * scale that preserves polarity.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import {
+  DIVERGING_RATIO_CLAMP,
+  divergingRatioPosition,
+  queryDisagreementSpread,
+} from "@/lib/chartMath";
+import {
+  buildHeatmapRows,
+  filterHeatmapRows,
+  orderRowsByDisagreement,
+} from "@/components/MultiRunHeatmap";
+import { buildStandings, sharedQueryIdsFor } from "@/components/MultiRunStandings";
+import type { DetailResult } from "@/types";
+
+function run(id: string, timings: [string, number | null][]): DetailResult {
+  return {
+    result_id: id,
+    platform: id,
+    display_timings: timings.map(([query_id, display_ms]) => ({
+      query_id,
+      display_ms,
+      sample_count: 3,
+      is_valid_display_timing: display_ms !== null,
+      timing_exclusion_reason: display_ms === null ? "missing_timing" : null,
+    })),
+  } as unknown as DetailResult;
+}
+
+describe("the diverging scale", () => {
+  it("puts parity at the neutral midpoint", () => {
+    expect(divergingRatioPosition(1)).toBe(0);
+  });
+
+  it("signs faster negative and slower positive", () => {
+    expect(divergingRatioPosition(0.5)).toBeLessThan(0);
+    expect(divergingRatioPosition(2)).toBeGreaterThan(0);
+  });
+
+  it("is symmetric in log space, so a 2x speedup and 2x slowdown are equal and opposite", () => {
+    // On a linear ratio scale they would not be: 0.5 is 0.5 below parity while
+    // 2.0 is 1.0 above it, which would render slowdowns as visually larger.
+    const faster = divergingRatioPosition(0.5)!;
+    const slower = divergingRatioPosition(2)!;
+    expect(faster).toBeCloseTo(-slower, 12);
+  });
+
+  it("saturates rather than compressing everything near parity", () => {
+    expect(divergingRatioPosition(DIVERGING_RATIO_CLAMP)).toBeCloseTo(1, 12);
+    expect(divergingRatioPosition(1000)).toBe(1);
+    expect(divergingRatioPosition(0.0001)).toBe(-1);
+  });
+
+  it("returns null for an unanswerable ratio rather than parity", () => {
+    // Defaulting to 0 would paint "we do not know" in the same colour as
+    // "identical to baseline" -- the specific misreading this must not invite.
+    expect(divergingRatioPosition(null)).toBeNull();
+    expect(divergingRatioPosition(0)).toBeNull();
+    expect(divergingRatioPosition(Number.NaN)).toBeNull();
+    expect(divergingRatioPosition(-1)).toBeNull();
+  });
+});
+
+describe("disagreement spread", () => {
+  it("measures the log-space spread across runs", () => {
+    expect(queryDisagreementSpread([1, 2])).toBeCloseTo(1, 12);
+    expect(queryDisagreementSpread([0.5, 2])).toBeCloseTo(2, 12);
+  });
+
+  it("has no value when only one run could answer", () => {
+    // Reporting 0 would rank a query only one run answered as perfect
+    // consensus, putting it above genuinely-agreed queries.
+    expect(queryDisagreementSpread([1, null])).toBeNull();
+    expect(queryDisagreementSpread([])).toBeNull();
+  });
+});
+
+describe("the heatmap grid", () => {
+  const results = [
+    run("a", [["Q1", 10], ["Q2", 20]]),
+    run("b", [["Q1", 20], ["Q2", 20]]),
+    run("c", [["Q1", 5], ["Q2", null]]),
+  ];
+
+  it("expresses every cell as a ratio against the chosen baseline", () => {
+    const rows = buildHeatmapRows(results, 0);
+    const q1 = rows.find((r) => r.queryId === "Q1")!;
+    expect(q1.cells.map((c) => c.ratio)).toEqual([1, 2, 0.5]);
+  });
+
+  it("re-bases when the baseline changes", () => {
+    // Baseline drives everything downstream; no panel may keep the old one.
+    const rebased = buildHeatmapRows(results, 1);
+    const q1 = rebased.find((r) => r.queryId === "Q1")!;
+    expect(q1.cells.map((c) => c.ratio)).toEqual([0.5, 1, 0.25]);
+  });
+
+  it("marks a cell the run cannot answer as unrecorded, not parity", () => {
+    const rows = buildHeatmapRows(results, 0);
+    const q2 = rows.find((r) => r.queryId === "Q2")!;
+    expect(q2.cells[2]!.ratio).toBeNull();
+    expect(q2.cells[2]!.position).toBeNull();
+  });
+
+  it("orders by disagreement when asked, with unanswerable rows last", () => {
+    const ordered = orderRowsByDisagreement(buildHeatmapRows(results, 0));
+    expect(ordered[0]!.queryId).toBe("Q1");
+  });
+});
+
+describe("standings", () => {
+  const results = [
+    run("fast", [["Q1", 10], ["Q2", 10]]),
+    run("mid", [["Q1", 20], ["Q2", 20]]),
+    run("slow", [["Q1", 40], ["Q2", 40]]),
+  ];
+
+  it("ranks by geomean, faster first", () => {
+    const { rows } = buildStandings(results, 0, ["fast", "mid", "slow"]);
+    expect(rows.map((r) => r.resultId)).toEqual(["fast", "mid", "slow"]);
+  });
+
+  it("computes every geomean over the same shared query set", () => {
+    const withGap = [...results, run("gap", [["Q1", 15], ["Q2", null]])];
+    const { sharedQueryIds, totalQueryIds } = buildStandings(withGap, 0, ["a", "b", "c", "d"]);
+    // Q2 leaves EVERY run's denominator, not just the run that lacked it.
+    expect(sharedQueryIds).toEqual(["Q1"]);
+    expect(totalQueryIds).toBe(2);
+  });
+
+  it("re-bases the ratio column when the baseline changes", () => {
+    const first = buildStandings(results, 0, ["fast", "mid", "slow"]).rows;
+    const second = buildStandings(results, 1, ["fast", "mid", "slow"]).rows;
+    expect(first.find((r) => r.resultId === "mid")!.ratioToBaseline).toBeCloseTo(2, 12);
+    expect(second.find((r) => r.resultId === "mid")!.ratioToBaseline).toBeCloseTo(1, 12);
+    expect(second.find((r) => r.resultId === "mid")!.isBaseline).toBe(true);
+  });
+
+  it("awards a query to a single fastest run and no one on a tie", () => {
+    // Ties awarding a win to each would let the counts exceed the query count
+    // and overstate every tied run.
+    const tied = [run("x", [["Q1", 10]]), run("y", [["Q1", 10]]), run("z", [["Q1", 20]])];
+    const { rows } = buildStandings(tied, 0, ["x", "y", "z"]);
+    expect(rows.reduce((n, r) => n + r.queriesWon, 0)).toBe(0);
+  });
+
+  it("applies the head-to-head tie band so a near-parity run is not called faster", () => {
+    const near = [
+      run("a", [["Q1", 100]]),
+      run("b", [["Q1", 100.2]]),
+      run("c", [["Q1", 200]]),
+    ];
+    const { rows } = buildStandings(near, 0, ["a", "b", "c"]);
+    expect(rows.find((r) => r.resultId === "b")!.tied).toBe(true);
+    expect(rows.find((r) => r.resultId === "c")!.tied).toBe(false);
+  });
+
+  it("keeps a run with no geomean rather than dropping it", () => {
+    const withNull = [...results, run("empty", [])];
+    const { rows } = buildStandings(withNull, 0, ["a", "b", "c", "d"]);
+    expect(rows).toHaveLength(4);
+    expect(rows.at(-1)!.resultId).toBe("empty");
+  });
+
+  it("shares one query-set helper with the heatmap", () => {
+    expect(sharedQueryIdsFor(results)).toEqual(["Q1", "Q2"]);
+  });
+
+  it("populates engine and hardware fields on standing rows", () => {
+    const withHw = [
+      {
+        ...results[0],
+        platform_version: "1.2.0",
+        environment: { arch: "arm64", cpu_model: "Apple M4", memory_gb: 16 },
+      } as DetailResult,
+      results[1]!,
+      results[2]!,
+    ];
+    const { rows } = buildStandings(withHw, 0, ["fast", "mid", "slow"]);
+    const first = rows.find((r) => r.resultId === "fast")!;
+    expect(first.engine).toBe("fast v1.2.0");
+    expect(first.hardware).toBe("Apple M4 · 16 GB");
+  });
+});
+
+describe("heatmap limiter filtering", () => {
+  const results = [
+    run("base", [
+      ["Q1", 100],
+      ["Q2", 100],
+      ["Q3", 100],
+    ]),
+    run("alt1", [
+      ["Q1", 50], // 0.5x speedup
+      ["Q2", 200], // 2.0x slowdown
+      ["Q3", 100], // 1.0x parity
+    ]),
+    run("alt2", [
+      ["Q1", 40], // 0.4x speedup
+      ["Q2", 150], // 1.5x slowdown
+      ["Q3", 100], // 1.0x parity
+    ]),
+  ];
+
+  it("filters to speedup queries when limiter is 'speedups'", () => {
+    const rows = buildHeatmapRows(results, 0);
+    const speedups = filterHeatmapRows(rows, "speedups", 0);
+    expect(speedups.map((r) => r.queryId)).toEqual(["Q1"]);
+  });
+
+  it("filters to slowdown queries when limiter is 'slowdowns'", () => {
+    const rows = buildHeatmapRows(results, 0);
+    const slowdowns = filterHeatmapRows(rows, "slowdowns", 0);
+    expect(slowdowns.map((r) => r.queryId)).toEqual(["Q2"]);
+  });
+
+  it("orders by disagreement when limiter is 'movement'", () => {
+    const rows = buildHeatmapRows(results, 0);
+    const movement = filterHeatmapRows(rows, "movement", 0);
+    expect(movement[0]!.queryId).toBe("Q1"); // spread between 0.4x and 1.0x (1.32) > 1.0x and 2.0x (1.0)
+  });
+});
+
+describe("coordinated baseline re-basing across panels", () => {
+  const results = [
+    run("runA", [
+      ["Q1", 10],
+      ["Q2", 100],
+    ]),
+    run("runB", [
+      ["Q1", 20],
+      ["Q2", 50],
+    ]),
+    run("runC", [
+      ["Q1", 30],
+      ["Q2", 200],
+    ]),
+  ];
+
+  it("re-bases heatmap ratios, standings, and speedup filters together when baseline switches", () => {
+    // Baseline = runA (index 0)
+    const heatmapA = buildHeatmapRows(results, 0);
+    const standingsA = buildStandings(results, 0, ["A", "B", "C"]);
+    const speedupsA = filterHeatmapRows(heatmapA, "speedups", 0);
+
+    expect(standingsA.rows.find((r) => r.resultId === "runA")!.isBaseline).toBe(true);
+    expect(standingsA.rows.find((r) => r.resultId === "runA")!.ratioToBaseline).toBe(1);
+    // On Q2: runA=100, runB=50 (0.5x, speedup), runC=200 (2.0x, slowdown)
+    expect(speedupsA.map((r) => r.queryId)).toContain("Q2");
+
+    // Baseline switches to runB (index 1)
+    const heatmapB = buildHeatmapRows(results, 1);
+    const standingsB = buildStandings(results, 1, ["A", "B", "C"]);
+    const speedupsB = filterHeatmapRows(heatmapB, "speedups", 1);
+
+    // Standings panel: runB is now baseline, runA is not
+    expect(standingsB.rows.find((r) => r.resultId === "runB")!.isBaseline).toBe(true);
+    expect(standingsB.rows.find((r) => r.resultId === "runA")!.isBaseline).toBe(false);
+
+    // Heatmap panel: Q2 relative to runB (50ms): runA=100ms (2.0x, slowdown!), runB=1.0x, runC=200ms (4.0x, slowdown)
+    const q2HeatmapB = heatmapB.find((r) => r.queryId === "Q2")!;
+    expect(q2HeatmapB.cells[0]!.ratio).toBeCloseTo(2, 6); // runA is now 2x slower than runB
+    expect(q2HeatmapB.cells[1]!.ratio).toBeCloseTo(1, 6); // runB is baseline
+
+    // Limiter panel: Q2 is no longer a speedup against runB!
+    expect(speedupsB.map((r) => r.queryId)).not.toContain("Q2");
+    // But Q1 relative to runB (20ms): runA is 10ms (0.5x, speedup!)
+    expect(speedupsB.map((r) => r.queryId)).toContain("Q1");
+  });
+});

--- a/results-explorer/src/lib/chartMath.ts
+++ b/results-explorer/src/lib/chartMath.ts
@@ -489,3 +489,73 @@ export function computePercentile(values: number[], p: number): number | null {
   if (f === c) return sorted[Math.round(k)]!;
   return sorted[f]! * (c - k) + sorted[c]! * (k - f);
 }
+
+// ---------------------------------------------------------------------------
+// Diverging ratio scale (multi-run heatmap)
+//
+// NO PYTHON COUNTERPART, deliberately. `chartMath.parity.test.ts` asserts the
+// helpers above are byte-identical to their Python references; this one is
+// additive and has no reference to match, because the multi-run heatmap is a
+// browser-only surface with no ASCII equivalent. Stated here so a future reader
+// does not go looking for the Python side and conclude it was lost.
+// ---------------------------------------------------------------------------
+
+/**
+ * Ratio at which the diverging scale saturates, in either direction.
+ *
+ * 4x matches the point where per-query differences stop being informative and
+ * start being outliers: beyond it the cell is already unambiguous, and letting
+ * the ramp keep going would compress everything nearer parity into a narrow
+ * band of indistinguishable colour.
+ */
+export const DIVERGING_RATIO_CLAMP = 4;
+
+/**
+ * Map a baseline-relative ratio to [-1, 1] for a two-hue diverging scale.
+ *
+ *   ratio < 1  (faster than baseline) -> negative
+ *   ratio = 1  (parity)               -> 0, the neutral midpoint
+ *   ratio > 1  (slower than baseline) -> positive
+ *
+ * SYMMETRIC IN LOG SPACE, which is the property that makes the chart honest: a
+ * 2x slowdown and a 2x speedup are the same distance from the midpoint in
+ * opposite directions. On a linear ratio scale they would not be -- 0.5 is 0.5
+ * below parity while 2.0 is 1.0 above it -- so a linear mapping would render
+ * slowdowns as visually larger than the equivalent speedups.
+ *
+ * Returns null for a ratio that is not a positive finite number, so an
+ * unanswerable cell can be rendered as unrecorded rather than as parity.
+ * Defaulting it to 0 would paint "we do not know" in the same colour as
+ * "identical to baseline", which is the specific misreading this chart must
+ * not invite.
+ */
+export function divergingRatioPosition(
+  ratio: number | null | undefined,
+  clamp: number = DIVERGING_RATIO_CLAMP,
+): number | null {
+  if (ratio === null || ratio === undefined) return null;
+  if (!Number.isFinite(ratio) || ratio <= 0) return null;
+  const limit = Math.log2(Math.max(clamp, 1 + Number.EPSILON));
+  const position = Math.log2(ratio) / limit;
+  return Math.max(-1, Math.min(1, position));
+}
+
+/**
+ * How much the runs disagree on a query, as the spread of their ratios.
+ *
+ * Log-space again, for the same reason: the disagreement between 0.5x and 2.0x
+ * is the same magnitude as between 1x and 4x, and a linear spread would rank
+ * the second as twice the first.
+ *
+ * Returns null when fewer than two runs produced a usable ratio -- a query only
+ * one run could answer has no disagreement to measure, and reporting 0 would
+ * rank it as perfect consensus.
+ */
+export function queryDisagreementSpread(ratios: readonly (number | null | undefined)[]): number | null {
+  const usable = ratios.filter(
+    (r): r is number => r !== null && r !== undefined && Number.isFinite(r) && r > 0,
+  );
+  if (usable.length < 2) return null;
+  const logs = usable.map((r) => Math.log2(r));
+  return Math.max(...logs) - Math.min(...logs);
+}

--- a/results-explorer/src/pages/Compare.tsx
+++ b/results-explorer/src/pages/Compare.tsx
@@ -50,6 +50,8 @@ import { modeLabel, testTypeLabel } from "@/components/MethodologyDisclosure";
 import { vsSlowestRatio } from "@/lib/chartMath";
 import { buildCompareDecisionSummary, COMPARE_TIE_THRESHOLD } from "@/lib/compareSummary";
 import { IdentityDiffStrip } from "@/components/IdentityDiffStrip";
+import { MultiRunHeatmap } from "@/components/MultiRunHeatmap";
+import { MultiRunStandings } from "@/components/MultiRunStandings";
 import { MeasurementBasisBar } from "@/components/MeasurementBasisBar";
 import { useUrlState } from "@/lib/useUrlState";
 import { getResultBasisAvailability } from "@/lib/duckdbQueries";
@@ -577,6 +579,7 @@ export function Compare({ url }: CompareProps) {
     totalDurationS: r.total_duration_s,
     driverVersion: r.driver_version,
   }));
+  const isMultiRun = compareLayoutForSelection(results.map((r) => r.result_id)).kind === "multi_run";
 
   function handleShare() {
     navigator.clipboard
@@ -644,7 +647,11 @@ export function Compare({ url }: CompareProps) {
         suppressionReason={decisionSummary.claimSuppressionReason}
       />
       <CompareSummary summary={decisionSummary} />
-      <IdentityDiffStrip results={results} />
+      <IdentityDiffStrip
+        results={results}
+        baselineIndex={normalizedBaselineIndex}
+        runLabels={cohortIdentitiesCompact}
+      />
       {results.length > 1 && (
         <MeasurementBasisBar
           basis={basis}
@@ -713,7 +720,21 @@ export function Compare({ url }: CompareProps) {
               style={{ borderTopColor: color, borderTopWidth: "3px" }}
             >
               <div class="mb-2 flex items-center justify-between">
-                <span class="font-semibold text-[var(--bb-data-fg-primary)]">{r.label}</span>
+                {isMultiRun ? (
+                  <label class="flex items-center gap-1.5 cursor-pointer text-xs font-medium text-[var(--bb-data-fg-primary)]">
+                    <input
+                      type="radio"
+                      name="compare-baseline-radio"
+                      checked={i === normalizedBaselineIndex}
+                      onChange={() => setBaselineIndex(i)}
+                      aria-label={`Set ${r.label} as baseline`}
+                      data-testid={`baseline-radio-${r.resultId}`}
+                    />
+                    <span class="font-semibold">{r.label}</span>
+                  </label>
+                ) : (
+                  <span class="font-semibold text-[var(--bb-data-fg-primary)]">{r.label}</span>
+                )}
                 <div class="flex flex-wrap gap-1">
                   <TrustBadge trustLabel={r.trustLabel} compact />
                   <FundingChip funding={r.funding} compact />
@@ -821,6 +842,23 @@ export function Compare({ url }: CompareProps) {
           }))}
         />
       </div>
+
+      {compareLayoutForSelection(results.map((r) => r.result_id)).kind === "multi_run" && (
+        <>
+          <MultiRunStandings
+            results={results}
+            baselineIndex={normalizedBaselineIndex}
+            runLabels={cohortIdentitiesCompact}
+          />
+          <MultiRunHeatmap
+            results={results}
+            baselineIndex={normalizedBaselineIndex}
+            runLabels={cohortIdentitiesCompact}
+            limiter={queryLimiter}
+            orderByDisagreement={queryLimiter === "movement"}
+          />
+        </>
+      )}
 
       <QueryDiffTable
         limiter={queryLimiter}


### PR DESCRIPTION
Implements `explorer-basis-compare-multi-run-layout` (w0–w4).

The routing seam (`compareLayoutForSelection`) routes three- and four-run selections to the multi-run layout. This provides the multi-run compare experience: baseline selection driving all panels, a diverging ratio heatmap, an identity matrix across N runs, and a standings table.

## Diverging heatmap (w3)

- Implemented in `MultiRunHeatmap.tsx`, reusing `QueryHeatmap`'s accessibility model (`role="grid"`, `role="gridcell"`) and text-in-every-cell guarantee.
- Uses the diverging scale added to `chartMath.ts` (`divergingRatioPosition`, `queryDisagreementSpread`). Symmetric in log space so a 2× speedup and 2× slowdown have equal and opposite visual weight. Saturated at 4×.
- Unanswerable cells are marked as unrecorded rather than parity (uncoloured, `"—"`).
- Applies the Top-N limiter (`all`, `movement`, `speedups`, `slowdowns`) with clear shown/total counts in every state.

## Standings table (w4)

- Implemented in `MultiRunStandings.tsx`. Ranks by geomean (faster first).
- Displays run, hardware, geomean, ratio against baseline, and queries won.
- Baseline row is explicitly marked with a badge.
- Caption states the size of the shared query set and excluded queries.
- Reuses `RankTable` win-counting semantics and applies the head-to-head tie band.

## Identity matrix across N runs (w2)

- `IdentityDiffStrip.tsx` renders a matrix table when more than two runs are selected (one row per axis, one column per run).
- Marks differing cells relative to baseline, and reports how many axes vary across the whole selection.
- A run with no CPU data reads "Not recorded" rather than "Differs", preserving comparability semantics.
- For two-run comparisons, preserves the existing two-run strip unchanged.

## Coordinated baseline re-basing (w1)

- Run cards render a baseline radio button in multi-run mode; basis bar is reused unchanged with its lock affordance.
- Baseline selection drives everything downstream: switching baseline re-bases the heatmap ratios, standings table, and Top-N filters together.

## Verification

All 5 verification steps pass:
- `cd results-explorer && npm test` — 89 test files passed (1138 passed, 8 skipped)
- `npx vitest run src/__tests__/parity/chartMath.parity.test.ts src/__tests__/chartMath.scale.test.ts` — 90 passed
- `npx vitest run src/components/__tests__/QueryHeatmap.test.tsx` — 29 passed
- `cd results-explorer && npm run typecheck` — clean
- `cat _project/verification-logs/explorer-basis-compare-multi-run-layout/w0.log` — verified

Plus `make pr-preflight` — 28,538 passed, `check-scope` clean.
