### PR TITLE
fix(explorer): resolve measurement basis and harmonize limiter across compare views

### DIFF
--- a/results-explorer/src/components/ChartPanel.tsx
+++ b/results-explorer/src/components/ChartPanel.tsx
@@ -147,10 +147,29 @@ export function ChartPanel({
     !isBaselineControlled &&
     context.kind === "compare" &&
     (activeChart?.id === "normalized_speedup" || activeChart?.id === "diverging_bar");
-  const chartSummary = useMemo(
-    () => (summary ? filterSummaryForChartDataset(summary, activeEligibilityClass) : null),
-    [activeEligibilityClass, summary],
-  );
+  const chartSummary = useMemo(() => {
+    if (!summary) return null;
+    const base = filterSummaryForChartDataset(summary, activeEligibilityClass);
+    if (!queryFilter) return base;
+    const filteredQueryIds = queryFilter.filter((q) => base.query_ids.includes(q));
+    const filteredPlatforms = base.platforms.map((platform) => {
+      const filteredTimings: Record<string, number | null> = {};
+      for (const q of filteredQueryIds) {
+        if (q in platform.timings) {
+          filteredTimings[q] = platform.timings[q] ?? null;
+        }
+      }
+      return {
+        ...platform,
+        timings: filteredTimings,
+      };
+    });
+    return {
+      ...base,
+      query_ids: filteredQueryIds,
+      platforms: filteredPlatforms,
+    };
+  }, [activeEligibilityClass, summary, queryFilter]);
   const chartPlatformLabels = useMemo(
     () =>
       chartSummary
@@ -163,23 +182,17 @@ export function ChartPanel({
   );
   const compareRows = useMemo(() => {
     if (context.kind !== "compare" || !chartSummary) return [];
-    const queryIds = queryFilter
-      ? chartSummary.query_ids.filter((q) => queryFilter.includes(q))
-      : chartSummary.query_ids;
-    return queryIds.map((queryId) => ({
+    return chartSummary.query_ids.map((queryId) => ({
       queryId,
       timings: chartSummary.platforms.map((platform) => {
         const ms = platformTimingValue(platform, queryId);
         return ms !== null ? { ms, status: "pass" as const } : null;
       }),
     }));
-  }, [chartSummary, context, queryFilter]);
+  }, [chartSummary, context]);
   const compareGroups = useMemo(() => {
     if (context.kind !== "compare" || !chartSummary) return [];
-    const queryIds = queryFilter
-      ? chartSummary.query_ids.filter((q) => queryFilter.includes(q))
-      : chartSummary.query_ids;
-    return queryIds.map((queryId) => ({
+    return chartSummary.query_ids.map((queryId) => ({
       queryId,
       values: chartSummary.platforms.map((platform, index) => {
         const timing = platformTimingValue(platform, queryId);
@@ -190,7 +203,7 @@ export function ChartPanel({
         };
       }),
     }));
-  }, [chartPlatformLabels, chartSummary, context, queryFilter]);
+  }, [chartPlatformLabels, chartSummary, context]);
   const chartExclusionSummary = useMemo(
     () => (summary ? summarizeChartDatasetExclusions(summary.platforms, activeEligibilityClass) : []),
     [activeEligibilityClass, summary],
@@ -293,6 +306,10 @@ export function ChartPanel({
       <div id="chart-panel-chart" role="tabpanel" aria-label={`${activeGroup.label} chart`} data-chart-container>
         {chartDatasetEmpty ? (
           <ChartDatasetEmptyState chart={activeChart} summary={summary!} />
+        ) : queryFilter && chartSummary && chartSummary.query_ids.length === 0 ? (
+          <div class="panel-muted rounded p-6 text-center text-sm text-[var(--bb-data-fg-muted)]">
+            No queries match the selected filter.
+          </div>
         ) : (
           <>
             {renderChart(activeChart, {
@@ -495,16 +512,26 @@ function renderChart(
           })()}
           <GroupedQueryChart groups={compareGroups} />
         </div>
-      ) : null;
+      ) : (
+        <div class="panel-muted rounded p-6 text-center text-sm text-[var(--bb-data-fg-muted)]">
+          No queries match the selected filter.
+        </div>
+      );
     case "diverging_bar":
       return summary ? (
-        <DivergingBarChart
-          queries={compareRows}
-          results={summary.platforms.map((platform, index) => ({
-            platform: platformLabels[index] ?? platform.platform,
-          }))}
-          baselineIdx={baselineIdx}
-        />
+        compareRows.length > 0 ? (
+          <DivergingBarChart
+            queries={compareRows}
+            results={summary.platforms.map((platform, index) => ({
+              platform: platformLabels[index] ?? platform.platform,
+            }))}
+            baselineIdx={baselineIdx}
+          />
+        ) : (
+          <div class="panel-muted rounded p-6 text-center text-sm text-[var(--bb-data-fg-muted)]">
+            No queries match the selected filter.
+          </div>
+        )
       ) : null;
     case "summary_box":
       return (

--- a/results-explorer/src/components/ChartPanel.tsx
+++ b/results-explorer/src/components/ChartPanel.tsx
@@ -63,6 +63,7 @@ interface ChartPanelProps {
   // QueryHeatmap above the panel) pass the duplicated chart ids here so
   // the panel does not expose the same view as a redundant subtab.
   excludeChartIds?: readonly string[];
+  queryFilter?: readonly string[];
 }
 
 interface CompareQueryRow {
@@ -84,6 +85,7 @@ export function ChartPanel({
   suppressWinnerClaims = false,
   suppressionReason,
   excludeChartIds,
+  queryFilter,
 }: ChartPanelProps) {
   const charts = useMemo(() => {
     const applicable = applicableCharts(context);
@@ -161,17 +163,23 @@ export function ChartPanel({
   );
   const compareRows = useMemo(() => {
     if (context.kind !== "compare" || !chartSummary) return [];
-    return chartSummary.query_ids.map((queryId) => ({
+    const queryIds = queryFilter
+      ? chartSummary.query_ids.filter((q) => queryFilter.includes(q))
+      : chartSummary.query_ids;
+    return queryIds.map((queryId) => ({
       queryId,
       timings: chartSummary.platforms.map((platform) => {
         const ms = platformTimingValue(platform, queryId);
         return ms !== null ? { ms, status: "pass" as const } : null;
       }),
     }));
-  }, [chartSummary, context]);
+  }, [chartSummary, context, queryFilter]);
   const compareGroups = useMemo(() => {
     if (context.kind !== "compare" || !chartSummary) return [];
-    return chartSummary.query_ids.map((queryId) => ({
+    const queryIds = queryFilter
+      ? chartSummary.query_ids.filter((q) => queryFilter.includes(q))
+      : chartSummary.query_ids;
+    return queryIds.map((queryId) => ({
       queryId,
       values: chartSummary.platforms.map((platform, index) => {
         const timing = platformTimingValue(platform, queryId);
@@ -182,7 +190,7 @@ export function ChartPanel({
         };
       }),
     }));
-  }, [chartPlatformLabels, chartSummary, context]);
+  }, [chartPlatformLabels, chartSummary, context, queryFilter]);
   const chartExclusionSummary = useMemo(
     () => (summary ? summarizeChartDatasetExclusions(summary.platforms, activeEligibilityClass) : []),
     [activeEligibilityClass, summary],

--- a/results-explorer/src/components/ChartPanel.tsx
+++ b/results-explorer/src/components/ChartPanel.tsx
@@ -89,11 +89,12 @@ export function ChartPanel({
   queryFilter,
 }: ChartPanelProps) {
   const charts = useMemo(() => {
+    const exclude = new Set(excludeChartIds ?? []);
+    if (queryFilter) exclude.add("power_bar");
     const applicable = applicableCharts(context);
-    if (!excludeChartIds || excludeChartIds.length === 0) return applicable;
-    const exclude = new Set(excludeChartIds);
+    if (exclude.size === 0) return applicable;
     return applicable.filter((entry) => !exclude.has(entry.id));
-  }, [context, excludeChartIds]);
+  }, [context, excludeChartIds, queryFilter]);
   const chartGroups = useMemo(() => groupChartsByQuestion(charts), [charts]);
   const summary = useMemo(() => buildRenderableSummary(context), [context]);
   const historical = useMemo(
@@ -233,6 +234,10 @@ export function ChartPanel({
     [activeEligibilityClass, summary],
   );
   const chartDatasetEmpty = shouldShowChartDatasetEmpty(activeEligibilityClass, summary, chartSummary);
+  const chartBaselineIdx = remapBaselineIndex(summary, chartSummary, baselineIdx);
+  const selectedBaselineId = summary?.platforms[baselineIdx]?.result_id ?? null;
+  const baselineChartActive = activeChart?.id === "normalized_speedup" || activeChart?.id === "diverging_bar";
+  const selectedBaselineExcluded = baselineChartActive && selectedBaselineId !== null && chartBaselineIdx === null;
 
   if (activeChart === null || activeGroup === null) return null;
 
@@ -330,6 +335,15 @@ export function ChartPanel({
       <div id="chart-panel-chart" role="tabpanel" aria-label={`${activeGroup.label} chart`} data-chart-container>
         {chartDatasetEmpty ? (
           <ChartDatasetEmptyState chart={activeChart} summary={summary!} />
+        ) : selectedBaselineExcluded ? (
+          <div
+            role="status"
+            aria-label={`${activeChart.title} unavailable`}
+            class="panel-muted rounded p-6 text-center text-sm text-[var(--bb-data-fg-muted)]"
+          >
+            The selected baseline is excluded from this chart's comparable dataset. Choose a comparable baseline or
+            restore the full query selection.
+          </div>
         ) : queryFilter && chartSummary && chartSummary.query_ids.length === 0 ? (
           <div class="panel-muted rounded p-6 text-center text-sm text-[var(--bb-data-fg-muted)]">
             No queries match the selected filter.
@@ -342,7 +356,7 @@ export function ChartPanel({
               historical,
               compareRows,
               compareGroups,
-              baselineIdx,
+              baselineIdx: chartBaselineIdx ?? 0,
               platformLabels: chartPlatformLabels,
               suppressWinnerClaims:
                 suppressWinnerClaims || Boolean(queryFilter && (chartSummary?.query_ids.length ?? 0) < 2),
@@ -374,6 +388,17 @@ function chartButtonLabel(chart: ChartRegistryEntry): string {
 
 function normalizeBaselineIndex(platformCount: number, baselineIndex: number) {
   return baselineIndex >= 0 && baselineIndex < platformCount ? baselineIndex : 0;
+}
+
+export function remapBaselineIndex(
+  summary: BenchmarkSummary | null,
+  chartSummary: BenchmarkSummary | null,
+  baselineIndex: number,
+): number | null {
+  const selectedBaselineId = summary?.platforms[baselineIndex]?.result_id;
+  if (!selectedBaselineId || !chartSummary) return null;
+  const chartIndex = chartSummary.platforms.findIndex((platform) => platform.result_id === selectedBaselineId);
+  return chartIndex >= 0 ? chartIndex : null;
 }
 
 function shouldShowChartDatasetEmpty(

--- a/results-explorer/src/components/ChartPanel.tsx
+++ b/results-explorer/src/components/ChartPanel.tsx
@@ -168,21 +168,14 @@ export function ChartPanel({
         }
       }
       const geomean =
-        sharedValidQueryIds.length > 0
+        sharedValidQueryIds.length >= 2
           ? geomeanMs(sharedValidQueryIds.map((q) => platform.timings[q]!))
           : null;
-      const hasInsufficientQueries = Boolean(queryFilter && sharedValidQueryIds.length < 2);
       return {
         ...platform,
         timings: filteredTimings,
         display_geomean_ms: geomean,
         sample_geomean_ms: geomean,
-        comparison_exclusion_reason: hasInsufficientQueries
-          ? "insufficient_valid_queries"
-          : platform.comparison_exclusion_reason,
-        ranking_exclusion_reason: hasInsufficientQueries
-          ? "insufficient_valid_queries"
-          : platform.ranking_exclusion_reason,
       };
     });
     return {
@@ -341,8 +334,13 @@ export function ChartPanel({
               compareGroups,
               baselineIdx,
               platformLabels: chartPlatformLabels,
-              suppressWinnerClaims,
-              suppressionReason,
+              suppressWinnerClaims:
+                suppressWinnerClaims || Boolean(queryFilter && (chartSummary?.query_ids.length ?? 0) < 2),
+              suppressionReason:
+                suppressionReason ??
+                (Boolean(queryFilter && (chartSummary?.query_ids.length ?? 0) < 2)
+                  ? "Winner claims suppressed when fewer than 2 valid queries are selected"
+                  : undefined),
               queryFilter,
             })}
             {summary && chartSummary && chartSummary.platforms.length > 0 && chartExclusionSummary.length > 0 && (

--- a/results-explorer/src/components/ChartPanel.tsx
+++ b/results-explorer/src/components/ChartPanel.tsx
@@ -171,11 +171,18 @@ export function ChartPanel({
         sharedValidQueryIds.length > 0
           ? geomeanMs(sharedValidQueryIds.map((q) => platform.timings[q]!))
           : null;
+      const hasInsufficientQueries = Boolean(queryFilter && sharedValidQueryIds.length < 2);
       return {
         ...platform,
         timings: filteredTimings,
         display_geomean_ms: geomean,
         sample_geomean_ms: geomean,
+        comparison_exclusion_reason: hasInsufficientQueries
+          ? "insufficient_valid_queries"
+          : platform.comparison_exclusion_reason,
+        ranking_exclusion_reason: hasInsufficientQueries
+          ? "insufficient_valid_queries"
+          : platform.ranking_exclusion_reason,
       };
     });
     return {

--- a/results-explorer/src/components/ChartPanel.tsx
+++ b/results-explorer/src/components/ChartPanel.tsx
@@ -90,7 +90,10 @@ export function ChartPanel({
 }: ChartPanelProps) {
   const charts = useMemo(() => {
     const exclude = new Set(excludeChartIds ?? []);
-    if (queryFilter) exclude.add("power_bar");
+    if (queryFilter) {
+      exclude.add("power_bar");
+      exclude.add("cost_scatter");
+    }
     const applicable = applicableCharts(context);
     if (exclude.size === 0) return applicable;
     return applicable.filter((entry) => !exclude.has(entry.id));

--- a/results-explorer/src/components/ChartPanel.tsx
+++ b/results-explorer/src/components/ChartPanel.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useState } from "preact/hooks";
-import type { BenchmarkSummary } from "@/types";
+import type { BenchmarkSummary, RankingConfig } from "@/types";
 import {
   applicableCharts,
   buildRenderableSummary,
@@ -176,10 +176,20 @@ export function ChartPanel({
         timings: filteredTimings,
         display_geomean_ms: geomean,
         sample_geomean_ms: geomean,
+        power_score: queryFilter ? null : platform.power_score,
       };
     });
+    const ranking: RankingConfig | null =
+      queryFilter && base.ranking && base.ranking.primary_metric === "power_score"
+        ? {
+            primary_metric: "display_geomean_ms",
+            secondary_metric: base.ranking.secondary_metric,
+            primary_order: "asc",
+          }
+        : base.ranking;
     return {
       ...base,
+      ranking,
       query_ids: filteredQueryIds,
       platforms: filteredPlatforms,
     };

--- a/results-explorer/src/components/ChartPanel.tsx
+++ b/results-explorer/src/components/ChartPanel.tsx
@@ -32,6 +32,7 @@ import {
 } from "@/lib/runIdentity";
 import {
   buildLatencyBarScale,
+  geomeanMs,
   latencyScaleFraction,
   latencyScaleTicks,
 } from "@/lib/chartMath";
@@ -162,6 +163,7 @@ export function ChartPanel({
       return {
         ...platform,
         timings: filteredTimings,
+        display_geomean_ms: geomeanMs(Object.values(filteredTimings)),
       };
     });
     return {
@@ -322,6 +324,7 @@ export function ChartPanel({
               platformLabels: chartPlatformLabels,
               suppressWinnerClaims,
               suppressionReason,
+              queryFilter,
             })}
             {summary && chartSummary && chartSummary.platforms.length > 0 && chartExclusionSummary.length > 0 && (
               <ChartDatasetExclusionSummary
@@ -450,6 +453,7 @@ function renderChart(
     platformLabels,
     suppressWinnerClaims = false,
     suppressionReason,
+    queryFilter,
   }: {
     context: ChartContext;
     summary: BenchmarkSummary | null;
@@ -460,6 +464,7 @@ function renderChart(
     platformLabels: string[];
     suppressWinnerClaims?: boolean;
     suppressionReason?: string;
+    queryFilter?: readonly string[];
   },
 ) {
   switch (chart.id) {
@@ -470,9 +475,13 @@ function renderChart(
     case "distribution_box":
       return summary ? <DistributionBox summary={summary} /> : null;
     case "query_heatmap":
-      return summary ? <QueryHeatmap summary={summary} /> : null;
+      return summary ? (
+        <QueryHeatmap summary={summary} preserveOrder={Boolean(queryFilter)} />
+      ) : null;
     case "query_histogram":
-      return summary ? <QueryHistogram summary={summary} /> : null;
+      return summary ? (
+        <QueryHistogram summary={summary} preserveOrder={Boolean(queryFilter)} />
+      ) : null;
     case "cost_scatter":
       return summary ? <CostScatter summary={summary} /> : null;
     case "time_series":
@@ -585,7 +594,9 @@ function renderChart(
     case "cdf_chart":
       return summary ? <CDFChart summary={summary} /> : null;
     case "rank_table":
-      return summary ? <RankTable summary={summary} /> : null;
+      return summary ? (
+        <RankTable summary={summary} preserveOrder={Boolean(queryFilter)} />
+      ) : null;
     default:
       return null;
   }

--- a/results-explorer/src/components/ChartPanel.tsx
+++ b/results-explorer/src/components/ChartPanel.tsx
@@ -153,6 +153,13 @@ export function ChartPanel({
     const base = filterSummaryForChartDataset(summary, activeEligibilityClass);
     if (!queryFilter) return base;
     const filteredQueryIds = queryFilter.filter((q) => base.query_ids.includes(q));
+    // Invariant: compute aggregate geomeans over the query IDs valid across every platform in the cohort
+    const sharedValidQueryIds = filteredQueryIds.filter((q) =>
+      base.platforms.every((p) => {
+        const v = p.timings[q];
+        return v !== null && v !== undefined && Number.isFinite(v) && v > 0;
+      }),
+    );
     const filteredPlatforms = base.platforms.map((platform) => {
       const filteredTimings: Record<string, number | null> = {};
       for (const q of filteredQueryIds) {
@@ -160,10 +167,15 @@ export function ChartPanel({
           filteredTimings[q] = platform.timings[q] ?? null;
         }
       }
+      const geomean =
+        sharedValidQueryIds.length > 0
+          ? geomeanMs(sharedValidQueryIds.map((q) => platform.timings[q]!))
+          : null;
       return {
         ...platform,
         timings: filteredTimings,
-        display_geomean_ms: geomeanMs(Object.values(filteredTimings)),
+        display_geomean_ms: geomean,
+        sample_geomean_ms: geomean,
       };
     });
     return {

--- a/results-explorer/src/components/MultiRunHeatmap.tsx
+++ b/results-explorer/src/components/MultiRunHeatmap.tsx
@@ -162,7 +162,7 @@ export function MultiRunHeatmap({
   const ordered = queryFilter
     ? (queryFilter.map((id) => rowsByQueryId.get(id)).filter((r): r is HeatmapRow => r !== undefined))
     : filterHeatmapRows(all, effectiveLimiter, baselineIndex);
-  const shown = queryFilter ? ordered : ordered.slice(0, limit);
+  const shown = queryFilter || effectiveLimiter === "all" ? ordered : ordered.slice(0, limit);
   const runMissing = shown.reduce(
     (n, row) => n + row.cells.filter((c) => c.missingKind === "run_missing").length,
     0,

--- a/results-explorer/src/components/MultiRunHeatmap.tsx
+++ b/results-explorer/src/components/MultiRunHeatmap.tsx
@@ -229,15 +229,27 @@ export function MultiRunHeatmap({
                     style={cellStyle(cell.position)}
                     title={
                       cell.missingKind === "baseline_missing"
-                        ? `Baseline was not recorded for this query (${cell.timingMs !== null ? `${cell.timingMs.toFixed(1)} ms` : ""})`
+                        ? `Baseline was not recorded for this query; recorded candidate timing: ${cell.timingMs !== null ? `${cell.timingMs.toFixed(1)} ms` : "none"}`
                         : cell.missingKind === "run_missing"
                           ? "This run did not record this query"
                           : undefined
                     }
+                    aria-label={
+                      cell.missingKind === "baseline_missing" && cell.timingMs !== null
+                        ? `${cell.timingMs.toFixed(1)} ms (baseline missing, no ratio formed)`
+                        : undefined
+                    }
                     data-testid={`cell-${row.queryId}-${i}`}
                   >
                     {/* Value as text in every cell: colour is never the only encoding. */}
-                    {cellText(cell)}
+                    {cell.missingKind === "baseline_missing" && cell.timingMs !== null ? (
+                      <span>
+                        {cell.timingMs.toFixed(1)} ms{" "}
+                        <span class="text-[10px] text-[var(--bb-data-fg-subtle)]">(no base)</span>
+                      </span>
+                    ) : (
+                      cellText(cell)
+                    )}
                   </td>
                 ))}
               </tr>

--- a/results-explorer/src/components/MultiRunHeatmap.tsx
+++ b/results-explorer/src/components/MultiRunHeatmap.tsx
@@ -1,6 +1,10 @@
 import type { DetailResult } from "@/types";
 import { StatusBadge } from "@/components/StatusBadge";
-import { type QueryDiffLimiter, QUERY_DIFF_LIMITER_LABELS } from "@/components/QueryDiffTable";
+import {
+  DEFAULT_QUERY_DIFF_LIMIT,
+  type QueryDiffLimiter,
+  QUERY_DIFF_LIMITER_LABELS,
+} from "@/components/QueryDiffTable";
 import {
   DIVERGING_RATIO_CLAMP,
   divergingRatioPosition,
@@ -146,7 +150,7 @@ export function MultiRunHeatmap({
   results,
   baselineIndex,
   runLabels,
-  limit = 20,
+  limit = DEFAULT_QUERY_DIFF_LIMIT,
   limiter,
   orderByDisagreement = false,
   queryFilter,

--- a/results-explorer/src/components/MultiRunHeatmap.tsx
+++ b/results-explorer/src/components/MultiRunHeatmap.tsx
@@ -154,8 +154,9 @@ export function MultiRunHeatmap({
   if (results.length < 3) return null;
   const effectiveLimiter: QueryDiffLimiter = limiter ?? (orderByDisagreement ? "movement" : "all");
   const all = buildHeatmapRows(results, baselineIndex);
+  const rowsByQueryId = new Map(all.map((row) => [row.queryId, row]));
   const ordered = queryFilter
-    ? all.filter((row) => queryFilter.includes(row.queryId))
+    ? (queryFilter.map((id) => rowsByQueryId.get(id)).filter((r): r is HeatmapRow => r !== undefined))
     : filterHeatmapRows(all, effectiveLimiter, baselineIndex);
   const shown = queryFilter ? ordered : ordered.slice(0, limit);
   const runMissing = shown.reduce(

--- a/results-explorer/src/components/MultiRunHeatmap.tsx
+++ b/results-explorer/src/components/MultiRunHeatmap.tsx
@@ -33,12 +33,16 @@ export interface MultiRunHeatmapProps {
   limiter?: QueryDiffLimiter;
   /** Order rows by where the runs disagree most, rather than by query id. */
   orderByDisagreement?: boolean;
+  /** Explicit query IDs to display (from shared limiter selection). */
+  queryFilter?: readonly string[];
 }
 
 export interface HeatmapCell {
   ratio: number | null;
   /** [-1, 1] position on the diverging scale, or null when unanswerable. */
   position: number | null;
+  timingMs: number | null;
+  missingKind: "none" | "run_missing" | "baseline_missing";
 }
 
 export interface HeatmapRow {
@@ -62,8 +66,14 @@ export function buildHeatmapRows(
       const baseMs = baseline ? timingValueForQuery(baseline, queryId) : null;
       const cells: HeatmapCell[] = results.map((r) => {
         const ms = timingValueForQuery(r, queryId);
+        let missingKind: "none" | "run_missing" | "baseline_missing" = "none";
+        if (ms === null || ms <= 0) {
+          missingKind = "run_missing";
+        } else if (baseMs === null || baseMs <= 0) {
+          missingKind = "baseline_missing";
+        }
         const ratio = ms !== null && baseMs !== null && baseMs > 0 ? ms / baseMs : null;
-        return { ratio, position: divergingRatioPosition(ratio) };
+        return { ratio, position: divergingRatioPosition(ratio), timingMs: ms, missingKind };
       });
       return {
         queryId,
@@ -136,17 +146,24 @@ export function MultiRunHeatmap({
   results,
   baselineIndex,
   runLabels,
-  limit = 25,
+  limit = 20,
   limiter,
   orderByDisagreement = false,
+  queryFilter,
 }: MultiRunHeatmapProps) {
   if (results.length < 3) return null;
   const effectiveLimiter: QueryDiffLimiter = limiter ?? (orderByDisagreement ? "movement" : "all");
   const all = buildHeatmapRows(results, baselineIndex);
-  const ordered = filterHeatmapRows(all, effectiveLimiter, baselineIndex);
-  const shown = ordered.slice(0, limit);
-  const unrecorded = shown.reduce(
-    (n, row) => n + row.cells.filter((c) => c.ratio === null).length,
+  const ordered = queryFilter
+    ? all.filter((row) => queryFilter.includes(row.queryId))
+    : filterHeatmapRows(all, effectiveLimiter, baselineIndex);
+  const shown = queryFilter ? ordered : ordered.slice(0, limit);
+  const runMissing = shown.reduce(
+    (n, row) => n + row.cells.filter((c) => c.missingKind === "run_missing").length,
+    0,
+  );
+  const baselineMissing = shown.reduce(
+    (n, row) => n + row.cells.filter((c) => c.missingKind === "baseline_missing").length,
     0,
   );
 
@@ -168,19 +185,28 @@ export function MultiRunHeatmap({
         </StatusBadge>
       </div>
 
-      {unrecorded > 0 ? (
-        <p class="mb-2 text-xs text-[var(--bb-data-fg-subtle)]" data-testid="heatmap-unrecorded-note">
-          {`${unrecorded} ${unrecorded === 1 ? "cell is" : "cells are"} unrecorded: that run cannot answer the query under the current basis. Unrecorded is not parity, and is left uncoloured.`}
-        </p>
-      ) : null}
+      {(runMissing > 0 || baselineMissing > 0) && (
+        <div class="mb-2 space-y-1 text-xs text-[var(--bb-data-fg-subtle)]" data-testid="heatmap-unrecorded-note">
+          {runMissing > 0 && (
+            <p>
+              {`${runMissing} ${runMissing === 1 ? "cell is" : "cells are"} unrecorded: that run cannot answer the query under the current basis. Unrecorded is not parity, and is left uncoloured.`}
+            </p>
+          )}
+          {baselineMissing > 0 && (
+            <p>
+              {`${baselineMissing} ${baselineMissing === 1 ? "cell cannot" : "cells cannot"} form a ratio: the baseline did not record this query.`}
+            </p>
+          )}
+        </div>
+      )}
 
       <div class="overflow-x-auto">
-        <table role="grid" class="min-w-full w-max divide-y divide-[var(--bb-data-border)] text-sm">
+        <table class="min-w-full w-max divide-y divide-[var(--bb-data-border)] text-sm">
           <thead class="bg-[var(--bb-surface-data-muted)]">
-            <tr role="row">
-              <th role="columnheader" class="table-th">Query</th>
+            <tr>
+              <th scope="col" class="table-th">Query</th>
               {results.map((r, i) => (
-                <th key={r.result_id} role="columnheader" class="table-th">
+                <th key={r.result_id} scope="col" class="table-th">
                   {runLabels[i] ?? r.platform}
                   {i === baselineIndex ? " (baseline)" : ""}
                 </th>
@@ -189,14 +215,20 @@ export function MultiRunHeatmap({
           </thead>
           <tbody class="divide-y divide-[var(--bb-data-border)] bg-[var(--bb-surface-data)]">
             {shown.map((row) => (
-              <tr role="row" key={row.queryId}>
-                <td class="table-td font-mono font-medium">{row.queryId}</td>
+              <tr key={row.queryId}>
+                <th scope="row" class="table-td font-mono font-medium text-left">{row.queryId}</th>
                 {row.cells.map((cell, i) => (
                   <td
                     key={i}
-                    role="gridcell"
                     class="table-td font-mono text-xs"
                     style={cellStyle(cell.position)}
+                    title={
+                      cell.missingKind === "baseline_missing"
+                        ? `Baseline was not recorded for this query (${cell.timingMs !== null ? `${cell.timingMs.toFixed(1)} ms` : ""})`
+                        : cell.missingKind === "run_missing"
+                          ? "This run did not record this query"
+                          : undefined
+                    }
                     data-testid={`cell-${row.queryId}-${i}`}
                   >
                     {/* Value as text in every cell: colour is never the only encoding. */}

--- a/results-explorer/src/components/MultiRunStandings.tsx
+++ b/results-explorer/src/components/MultiRunStandings.tsx
@@ -34,6 +34,8 @@ export interface StandingRow {
   isBaseline: boolean;
   /** Inside the tie band, so neither faster nor slower may be claimed. */
   tied: boolean;
+  /** Competition rank ("1", "T-1", or "—" when unranked). */
+  rank: string;
 }
 
 /** Queries every selected run can answer. */
@@ -105,6 +107,7 @@ export function buildStandings(
       queriesWon: wins[i] ?? 0,
       isBaseline: i === baselineIndex,
       tied: ratio !== null && Math.abs(ratio - 1) < COMPARE_TIE_THRESHOLD,
+      rank: "—",
     };
   });
 
@@ -116,6 +119,35 @@ export function buildStandings(
     if (b.geomeanMs === null) return -1;
     return a.geomeanMs - b.geomeanMs;
   });
+
+  // Assign competition rank: tied rows receive "T-1", unranked rows receive "—"
+  let currentRank = 1;
+  for (let i = 0; i < rows.length; i++) {
+    const row = rows[i]!;
+    if (row.geomeanMs === null) {
+      row.rank = "—";
+      continue;
+    }
+    const prev = i > 0 ? rows[i - 1] : undefined;
+    const next = i < rows.length - 1 ? rows[i + 1] : undefined;
+    const prevMs = prev?.geomeanMs ?? null;
+    const nextMs = next?.geomeanMs ?? null;
+    const tiedPrev =
+      prevMs !== null &&
+      Math.abs(prevMs - row.geomeanMs) / Math.min(prevMs, row.geomeanMs) < COMPARE_TIE_THRESHOLD;
+    const tiedNext =
+      nextMs !== null &&
+      Math.abs(row.geomeanMs - nextMs) / Math.min(row.geomeanMs, nextMs) < COMPARE_TIE_THRESHOLD;
+
+    if (tiedPrev || tiedNext) {
+      row.rank = `T-${currentRank}`;
+    } else {
+      row.rank = String(currentRank);
+    }
+    if (!tiedNext) {
+      currentRank = i + 2;
+    }
+  }
 
   return { rows, sharedQueryIds: shared, totalQueryIds: all.size };
 }
@@ -149,18 +181,18 @@ export function MultiRunStandings({ results, baselineIndex, runLabels }: MultiRu
         <table class="min-w-full w-max divide-y divide-[var(--bb-data-border)] text-sm">
           <thead class="bg-[var(--bb-surface-data-muted)]">
             <tr>
-              <th class="table-th">Rank</th>
-              <th class="table-th">Run</th>
-              <th class="table-th">Hardware</th>
-              <th class="table-th">Geomean</th>
-              <th class="table-th">vs baseline</th>
-              <th class="table-th">Queries won</th>
+              <th scope="col" class="table-th">Rank</th>
+              <th scope="col" class="table-th">Run</th>
+              <th scope="col" class="table-th">Hardware</th>
+              <th scope="col" class="table-th">Geomean</th>
+              <th scope="col" class="table-th">vs baseline</th>
+              <th scope="col" class="table-th">Queries won</th>
             </tr>
           </thead>
           <tbody class="divide-y divide-[var(--bb-data-border)] bg-[var(--bb-surface-data)]">
-            {rows.map((row, i) => (
+            {rows.map((row) => (
               <tr key={row.resultId} class="hover:bg-[var(--bb-surface-data-muted)]">
-                <td class="table-td font-mono">{i + 1}</td>
+                <td class="table-td font-mono">{row.rank}</td>
                 <td class="table-td">
                   {row.label}
                   {row.isBaseline ? (

--- a/results-explorer/src/components/MultiRunStandings.tsx
+++ b/results-explorer/src/components/MultiRunStandings.tsx
@@ -120,33 +120,38 @@ export function buildStandings(
     return a.geomeanMs - b.geomeanMs;
   });
 
-  // Assign competition rank: tied rows receive "T-1", unranked rows receive "—"
-  let currentRank = 1;
-  for (let i = 0; i < rows.length; i++) {
-    const row = rows[i]!;
-    if (row.geomeanMs === null) {
-      row.rank = "—";
+  // Assign competition rank: tied rows receive "T-1", unranked rows receive "—".
+  // Tie groups are formed against the fixed group leader to prevent transitive chaining.
+  let i = 0;
+  while (i < rows.length) {
+    const leader = rows[i]!;
+    if (leader.geomeanMs === null) {
+      leader.rank = "—";
+      i++;
       continue;
     }
-    const prev = i > 0 ? rows[i - 1] : undefined;
-    const next = i < rows.length - 1 ? rows[i + 1] : undefined;
-    const prevMs = prev?.geomeanMs ?? null;
-    const nextMs = next?.geomeanMs ?? null;
-    const tiedPrev =
-      prevMs !== null &&
-      Math.abs(prevMs - row.geomeanMs) / Math.min(prevMs, row.geomeanMs) < COMPARE_TIE_THRESHOLD;
-    const tiedNext =
-      nextMs !== null &&
-      Math.abs(row.geomeanMs - nextMs) / Math.min(row.geomeanMs, nextMs) < COMPARE_TIE_THRESHOLD;
 
-    if (tiedPrev || tiedNext) {
-      row.rank = `T-${currentRank}`;
-    } else {
-      row.rank = String(currentRank);
+    const leaderMs = leader.geomeanMs;
+    const rankNum = i + 1;
+    let j = i + 1;
+    while (
+      j < rows.length &&
+      rows[j]!.geomeanMs !== null &&
+      Math.abs(rows[j]!.geomeanMs! - leaderMs) / Math.min(rows[j]!.geomeanMs!, leaderMs) < COMPARE_TIE_THRESHOLD
+    ) {
+      j++;
     }
-    if (!tiedNext) {
-      currentRank = i + 2;
+
+    const isTie = j > i + 1;
+    const rankLabel = isTie ? `T-${rankNum}` : String(rankNum);
+    for (let k = i; k < j; k++) {
+      rows[k]!.rank = rankLabel;
+      if (isTie) {
+        rows[k]!.tied = true;
+      }
     }
+
+    i = j;
   }
 
   return { rows, sharedQueryIds: shared, totalQueryIds: all.size };

--- a/results-explorer/src/components/MultiRunStandings.tsx
+++ b/results-explorer/src/components/MultiRunStandings.tsx
@@ -32,8 +32,10 @@ export interface StandingRow {
   ratioToBaseline: number | null;
   queriesWon: number;
   isBaseline: boolean;
-  /** Inside the tie band, so neither faster nor slower may be claimed. */
+  /** Inside the tie band against the baseline, so neither faster nor slower may be claimed. */
   tied: boolean;
+  /** Inside a tie band with other runs for its rank position. */
+  rankTied: boolean;
   /** Competition rank ("1", "T-1", or "—" when unranked). */
   rank: string;
 }
@@ -47,30 +49,14 @@ export function sharedQueryIdsFor(results: readonly DetailResult[]): string[] {
     .sort((a, b) => a.localeCompare(b, undefined, { numeric: true }));
 }
 
-export function buildStandings(
-  results: readonly DetailResult[],
-  baselineIndex: number,
-  runLabels: readonly string[],
-): { rows: StandingRow[]; sharedQueryIds: string[]; totalQueryIds: number } {
-  const shared = sharedQueryIdsFor(results);
-  const all = new Set<string>();
-  for (const r of results) for (const t of r.display_timings) all.add(t.query_id);
-
-  const perRun = results.map((r) => shared.map((q) => timingValueForQuery(r, q)));
-  const geomeans = perRun.map((values) => geomeanMs(values));
-  const baseGeomean = geomeans[baselineIndex] ?? null;
-
-  // Queries won: for each shared query, the run with the lowest value takes it.
-  // Reuses RankTable's semantics -- lower is faster, ties award no win rather
-  // than awarding one to each, so the counts still sum to at most the query
-  // count and cannot overstate any run.
+function countWinsPerPlatform(results: readonly DetailResult[], shared: string[]): number[] {
   const wins = new Array(results.length).fill(0) as number[];
-  shared.forEach((_q, qi) => {
+  shared.forEach((q) => {
     let best: number | null = null;
     let bestRuns: number[] = [];
-    perRun.forEach((values, ri) => {
-      const v = values[qi];
-      if (v === null || v === undefined) return;
+    results.forEach((r, ri) => {
+      const v = timingValueForQuery(r, q);
+      if (v === null) return;
       if (best === null || v < best) {
         best = v;
         bestRuns = [ri];
@@ -83,10 +69,25 @@ export function buildStandings(
       wins[winner] = (wins[winner] ?? 0) + 1;
     }
   });
+  return wins;
+}
+
+export function buildStandings(
+  results: readonly DetailResult[],
+  baselineIndex: number,
+  runLabels: readonly string[],
+): { rows: StandingRow[]; sharedQueryIds: string[]; totalQueryIds: number } {
+  const shared = sharedQueryIdsFor(results);
+  const geomeans = results.map((r) => geomeanMs(shared.map((q) => timingValueForQuery(r, q)!)));
+  const baselineGeomean = geomeans[baselineIndex] ?? null;
+  const wins = countWinsPerPlatform(results, shared);
+
+  const all = new Set<string>();
+  for (const r of results) for (const t of r.display_timings) all.add(t.query_id);
 
   const rows: StandingRow[] = results.map((r, i) => {
     const g = geomeans[i] ?? null;
-    const ratio = g !== null && baseGeomean !== null && baseGeomean > 0 ? g / baseGeomean : null;
+    const ratio = g !== null && baselineGeomean !== null && baselineGeomean > 0 ? g / baselineGeomean : null;
     const hw = r.environment?.cpu_model
       ? r.environment.cpu_model
       : r.environment?.cpu_family
@@ -107,6 +108,7 @@ export function buildStandings(
       queriesWon: wins[i] ?? 0,
       isBaseline: i === baselineIndex,
       tied: ratio !== null && Math.abs(ratio - 1) < COMPARE_TIE_THRESHOLD,
+      rankTied: false,
       rank: "—",
     };
   });
@@ -146,9 +148,7 @@ export function buildStandings(
     const rankLabel = isTie ? `T-${rankNum}` : String(rankNum);
     for (let k = i; k < j; k++) {
       rows[k]!.rank = rankLabel;
-      if (isTie) {
-        rows[k]!.tied = true;
-      }
+      rows[k]!.rankTied = isTie;
     }
 
     i = j;

--- a/results-explorer/src/components/QueryDiffTable.tsx
+++ b/results-explorer/src/components/QueryDiffTable.tsx
@@ -1,4 +1,5 @@
 import type { DetailResult } from "@/types";
+import { queryDisagreementSpread } from "@/lib/chartMath";
 import { isValidTimingValue, timingValueForQuery } from "@/lib/displayEligibility";
 import { formatSpeedup } from "@/lib/metricFormatters";
 import { formatRunIdentitiesForCohort } from "@/lib/runIdentity";
@@ -120,7 +121,9 @@ export function selectQueryIdsForLimiter(
 
     const bestRatio = Math.min(...ratios);
     const worstRatio = Math.max(...ratios);
-    const maxDisagreement = Math.max(...ratios.map((r) => Math.abs(Math.log2(r))));
+    const maxDisagreement =
+      queryDisagreementSpread([1, ...ratios]) ??
+      Math.max(...ratios.map((r) => Math.abs(Math.log2(r))));
     const maxDelta = Math.max(...deltas.map((d) => Math.abs(d)));
 
     return {

--- a/results-explorer/src/components/QueryDiffTable.tsx
+++ b/results-explorer/src/components/QueryDiffTable.tsx
@@ -74,6 +74,85 @@ export function applyQueryDiffLimiter(
 }
 
 /**
+ * Select and rank query IDs for a given limiter across comparison results.
+ *
+ * Provides a single shared query selection for the chart, the heatmap, and the table.
+ */
+export function selectQueryIdsForLimiter(
+  results: readonly DetailResult[],
+  baselineIndex: number,
+  limiter: QueryDiffLimiter,
+  topN: number = 20,
+): { queryIds: string[]; totalQueryCount: number } {
+  const allQueryIds = [
+    ...new Set(results.flatMap((r) => (r.display_timings ?? []).map((t) => t.query_id))),
+  ].sort((a, b) => a.localeCompare(b, undefined, { numeric: true }));
+
+  if (limiter === "all" || results.length < 2) {
+    return { queryIds: allQueryIds, totalQueryCount: allQueryIds.length };
+  }
+
+  const normalizedBaselineIndex = normalizeBaselineIndex(results, baselineIndex);
+  const baseline = results[normalizedBaselineIndex];
+  const candidates = results.filter((_, i) => i !== normalizedBaselineIndex);
+
+  // Queries where baseline has a valid timing and at least one candidate has a valid timing
+  const comparable = allQueryIds.filter((queryId) => {
+    const baseMs = baseline ? timingValueForQuery(baseline, queryId) : null;
+    if (baseMs === null || baseMs <= 0) return false;
+    return candidates.some((c) => {
+      const ms = timingValueForQuery(c, queryId);
+      return ms !== null && ms > 0;
+    });
+  });
+
+  const scored = comparable.map((queryId) => {
+    const baseMs = timingValueForQuery(baseline!, queryId)!;
+    const candidateTimings = candidates
+      .map((c) => timingValueForQuery(c, queryId))
+      .filter((ms): ms is number => ms !== null && ms > 0);
+
+    const ratios = candidateTimings.map((ms) => ms / baseMs);
+    const deltas = candidateTimings.map((ms) => ms - baseMs);
+
+    const bestRatio = Math.min(...ratios);
+    const worstRatio = Math.max(...ratios);
+    const maxDisagreement = Math.max(...ratios.map((r) => Math.abs(Math.log2(r))));
+    const maxDelta = Math.max(...deltas.map((d) => Math.abs(d)));
+
+    return {
+      queryId,
+      bestRatio,
+      worstRatio,
+      maxDisagreement,
+      maxDelta,
+    };
+  });
+
+  let filtered: typeof scored = [];
+  switch (limiter) {
+    case "speedups":
+      filtered = scored
+        .filter((s) => s.bestRatio < 1.0)
+        .sort((a, b) => a.bestRatio - b.bestRatio);
+      break;
+    case "slowdowns":
+      filtered = scored
+        .filter((s) => s.worstRatio > 1.0)
+        .sort((a, b) => b.worstRatio - a.worstRatio);
+      break;
+    case "movement":
+      filtered = [...scored].sort((a, b) => b.maxDisagreement - a.maxDisagreement || b.maxDelta - a.maxDelta);
+      break;
+  }
+
+  return {
+    queryIds: filtered.slice(0, Math.max(0, topN)).map((s) => s.queryId),
+    totalQueryCount: allQueryIds.length,
+  };
+}
+
+/**
  * The sentence every limiter state must carry, including the empty one.
  *
  * "No queries match" without a denominator leaves a reader unable to tell an
@@ -93,6 +172,7 @@ interface QueryDiffTableProps {
   suppressionReason?: string | null;
   limiter?: QueryDiffLimiter;
   topN?: number;
+  queryFilter?: readonly string[];
 }
 
 export function QueryDiffTable({
@@ -101,6 +181,7 @@ export function QueryDiffTable({
   suppressionReason = null,
   limiter = "all",
   topN = 20,
+  queryFilter,
 }: QueryDiffTableProps) {
   const scrollerRef = useRef<HTMLDivElement>(null);
   if (results.length < 2) return null;
@@ -119,7 +200,9 @@ export function QueryDiffTable({
     "table",
   );
   const allRows = buildQueryDiffRows(results, normalizedBaselineIndex, runLabels);
-  const rows = applyQueryDiffLimiter(allRows, limiter, topN);
+  const rows = queryFilter
+    ? allRows.filter((row) => queryFilter.includes(row.queryId))
+    : applyQueryDiffLimiter(allRows, limiter, topN);
   const uncomparableShown = rows.filter((row) => !row.comparable).length;
 
   return (
@@ -233,7 +316,7 @@ export function buildQueryDiffRows(
   });
 }
 
-function normalizeBaselineIndex(results: DetailResult[], baselineIndex: number) {
+function normalizeBaselineIndex(results: readonly DetailResult[], baselineIndex: number) {
   return results[baselineIndex] ? baselineIndex : 0;
 }
 

--- a/results-explorer/src/components/QueryDiffTable.tsx
+++ b/results-explorer/src/components/QueryDiffTable.tsx
@@ -46,6 +46,9 @@ export const QUERY_DIFF_LIMITER_LABELS: Record<QueryDiffLimiter, string> = {
   movement: "Largest movement",
 };
 
+/** Product contract: largest-query views show at most ten logical queries. */
+export const DEFAULT_QUERY_DIFF_LIMIT = 10;
+
 /**
  * Rank and cap the rows for a limiter.
  *
@@ -82,7 +85,7 @@ export function selectQueryIdsForLimiter(
   results: readonly DetailResult[],
   baselineIndex: number,
   limiter: QueryDiffLimiter,
-  topN: number = 20,
+  topN: number = DEFAULT_QUERY_DIFF_LIMIT,
 ): { queryIds: string[]; totalQueryCount: number } {
   const allQueryIds = [
     ...new Set(results.flatMap((r) => (r.display_timings ?? []).map((t) => t.query_id))),
@@ -180,7 +183,7 @@ export function QueryDiffTable({
   baselineIndex = 0,
   suppressionReason = null,
   limiter = "all",
-  topN = 20,
+  topN = DEFAULT_QUERY_DIFF_LIMIT,
   queryFilter,
 }: QueryDiffTableProps) {
   const scrollerRef = useRef<HTMLDivElement>(null);
@@ -209,7 +212,11 @@ export function QueryDiffTable({
   const rows = queryFilter
     ? queryFilter.flatMap((queryId) => rowsByQueryId.get(queryId) ?? [])
     : applyQueryDiffLimiter(allRows, limiter, topN);
-  const uncomparableShown = rows.filter((row) => !row.comparable).length;
+  const shownQueryCount = new Set(rows.map((row) => row.queryId)).size;
+  const totalQueryCount = rowsByQueryId.size;
+  const uncomparableShown = new Set(
+    rows.filter((row) => !row.comparable).map((row) => row.queryId),
+  ).size;
 
   return (
     <section class="card mb-8" aria-labelledby="query-diff-title">
@@ -223,8 +230,8 @@ export function QueryDiffTable({
             candidate is faster than baseline.
           </p>
         </div>
-        <StatusBadge role="comparison" tone="neutral" title={queryDiffCountSentence(rows.length, allRows.length, limiter)}>
-          {queryDiffCountSentence(rows.length, allRows.length, limiter)}
+        <StatusBadge role="comparison" tone="neutral" title={queryDiffCountSentence(shownQueryCount, totalQueryCount, limiter)}>
+          {queryDiffCountSentence(shownQueryCount, totalQueryCount, limiter)}
         </StatusBadge>
       </div>
 

--- a/results-explorer/src/components/QueryDiffTable.tsx
+++ b/results-explorer/src/components/QueryDiffTable.tsx
@@ -200,8 +200,14 @@ export function QueryDiffTable({
     "table",
   );
   const allRows = buildQueryDiffRows(results, normalizedBaselineIndex, runLabels);
+  const rowsByQueryId = new Map<string, QueryDiffRow[]>();
+  for (const row of allRows) {
+    const list = rowsByQueryId.get(row.queryId) ?? [];
+    list.push(row);
+    rowsByQueryId.set(row.queryId, list);
+  }
   const rows = queryFilter
-    ? allRows.filter((row) => queryFilter.includes(row.queryId))
+    ? queryFilter.flatMap((queryId) => rowsByQueryId.get(queryId) ?? [])
     : applyQueryDiffLimiter(allRows, limiter, topN);
   const uncomparableShown = rows.filter((row) => !row.comparable).length;
 

--- a/results-explorer/src/components/QueryHeatmap.tsx
+++ b/results-explorer/src/components/QueryHeatmap.tsx
@@ -110,6 +110,8 @@ interface QueryHeatmapProps {
    * `prefers-contrast: more` media query.
    */
   highContrast?: boolean;
+  /** When true, keeps query_ids in caller-provided order (e.g. limiter ranking). */
+  preserveOrder?: boolean;
 }
 
 const MOBILE_OUTLIER_LIMIT = 3;
@@ -137,9 +139,13 @@ export function QueryHeatmap({
   onSelectionChange,
   selectionLimitReasonId,
   highContrast = false,
+  preserveOrder = false,
 }: QueryHeatmapProps) {
   const { query_ids, platforms, ranking } = summary;
-  const sortedQueryIds = useMemo(() => sortQueryIds(query_ids), [query_ids]);
+  const sortedQueryIds = useMemo(
+    () => (preserveOrder ? [...query_ids] : sortQueryIds(query_ids)),
+    [query_ids, preserveOrder],
+  );
   const hasSelection = onSelectionChange !== undefined;
   const selectionAtCap = selectedIds !== undefined && selectedIds.size >= MAX_COMPARE_SELECTIONS;
   const gridRef = useRef<HTMLTableElement>(null);

--- a/results-explorer/src/components/QueryHistogram.tsx
+++ b/results-explorer/src/components/QueryHistogram.tsx
@@ -24,19 +24,21 @@ const PADDING_TOP = 8;
 
 interface Props {
   summary: BenchmarkSummary;
+  /** When true, keeps query_ids in caller-provided order (e.g. limiter ranking). */
+  preserveOrder?: boolean;
 }
 
 function fmtMs(ms: number): string {
   return formatLatencyMs(ms, { subMillisecond: "compact" }).valueText;
 }
 
-export function QueryHistogram({ summary }: Props) {
+export function QueryHistogram({ summary, preserveOrder = false }: Props) {
   const [containerRef, { width: containerWidth }] = useElementSize(300);
   const w = Math.max(containerWidth, 300);
 
   const { platforms, query_ids } = summary;
   if (platforms.length === 0 || query_ids.length === 0) return null;
-  const sortedQueryIds = sortQueryIds(query_ids);
+  const sortedQueryIds = preserveOrder ? query_ids : sortQueryIds(query_ids);
 
   // Split into panels
   const panels: string[][] = [];

--- a/results-explorer/src/components/RankTable.tsx
+++ b/results-explorer/src/components/RankTable.tsx
@@ -25,6 +25,8 @@ export { preserveUniqueAfterTruncation } from "@/lib/runIdentity";
 
 interface Props {
   summary: BenchmarkSummary;
+  /** When true, keeps query_ids in caller-provided order (e.g. limiter ranking). */
+  preserveOrder?: boolean;
 }
 
 function ordinal(n: number): string {
@@ -33,10 +35,10 @@ function ordinal(n: number): string {
   return `${n}${suffixes[(v - 20) % 10] ?? suffixes[v] ?? suffixes[0]}`;
 }
 
-export function RankTable({ summary }: Props) {
+export function RankTable({ summary, preserveOrder = false }: Props) {
   const { platforms, query_ids } = summary;
   if (platforms.length === 0 || query_ids.length === 0) return null;
-  const sortedQueryIds = sortQueryIds(query_ids);
+  const sortedQueryIds = preserveOrder ? query_ids : sortQueryIds(query_ids);
   const rankableCellCount = countRankableTimingCells(platforms, sortedQueryIds);
 
   if (rankableCellCount === 0) {

--- a/results-explorer/src/components/__tests__/ChartPanel.test.tsx
+++ b/results-explorer/src/components/__tests__/ChartPanel.test.tsx
@@ -1,6 +1,6 @@
 import { fireEvent, render, screen } from "@testing-library/preact";
 import { describe, expect, it } from "vitest";
-import { ChartPanel } from "@/components/ChartPanel";
+import { ChartPanel, remapBaselineIndex } from "@/components/ChartPanel";
 import type { ChartHistoricalEntry } from "@/lib/chartRegistry";
 import type {
   BenchmarkSummary,
@@ -825,5 +825,20 @@ describe("ChartPanel", () => {
     );
 
     expect(screen.queryByText(/5,000/)).toBeNull();
+    expect(screen.queryByRole("button", { name: "Power@Size Bar" })).toBeNull();
+  });
+
+  it("keeps a baseline bound to its result after an earlier platform is filtered", () => {
+    const summary = makeSummary({
+      platforms: [
+        makePlatformRow({ result_id: "excluded" }),
+        makePlatformRow({ result_id: "candidate" }),
+        makePlatformRow({ result_id: "baseline" }),
+      ],
+    });
+    const filtered = { ...summary, platforms: summary.platforms.slice(1) };
+
+    expect(remapBaselineIndex(summary, filtered, 2)).toBe(1);
+    expect(remapBaselineIndex(summary, filtered, 0)).toBeNull();
   });
 });

--- a/results-explorer/src/components/__tests__/ChartPanel.test.tsx
+++ b/results-explorer/src/components/__tests__/ChartPanel.test.tsx
@@ -727,6 +727,53 @@ describe("ChartPanel", () => {
     expect(screen.queryByText("Q2")).toBeNull();
   });
 
+  it("recomputes multi-run comparison-bar geomeans over the shared query filter", () => {
+    const details = [
+      makeDetail({
+        result_id: "a",
+        platform: "A",
+        display_geomean_ms: 999,
+        display_timings: [
+          { query_id: "Q1", display_ms: 10, sample_count: 3, is_valid_display_timing: true, timing_exclusion_reason: null },
+          { query_id: "Q2", display_ms: 100, sample_count: 3, is_valid_display_timing: true, timing_exclusion_reason: null },
+        ],
+      }),
+      makeDetail({
+        result_id: "b",
+        platform: "B",
+        display_geomean_ms: 999,
+        display_timings: [
+          { query_id: "Q1", display_ms: 20, sample_count: 3, is_valid_display_timing: true, timing_exclusion_reason: null },
+          { query_id: "Q2", display_ms: 100, sample_count: 3, is_valid_display_timing: true, timing_exclusion_reason: null },
+        ],
+      }),
+      makeDetail({
+        result_id: "c",
+        platform: "C",
+        display_geomean_ms: 999,
+        display_timings: [
+          { query_id: "Q1", display_ms: 40, sample_count: 3, is_valid_display_timing: true, timing_exclusion_reason: null },
+          { query_id: "Q2", display_ms: 100, sample_count: 3, is_valid_display_timing: true, timing_exclusion_reason: null },
+        ],
+      }),
+    ];
+    const { container } = render(
+      <ChartPanel
+        context={{ kind: "compare", results: details, primaryMetric: "display_geomean_ms" }}
+        queryFilter={["Q1"]}
+      />,
+    );
+
+    const titles = Array.from(container.querySelectorAll("rect title")).map((title) => title.textContent ?? "");
+    expect(titles.some((title) => title.includes("A") && title.includes("10 ms"))).toBe(true);
+    expect(titles.some((title) => title.includes("B") && title.includes("20 ms"))).toBe(true);
+    expect(titles.some((title) => title.includes("C") && title.includes("40 ms"))).toBe(true);
+    expect(titles.every((title) => !title.includes("999 ms"))).toBe(true);
+    // Compare summaries intentionally carry no persisted percentile statistics,
+    // so the global basis selector cannot expose a stale percentile ladder.
+    expect(screen.queryByRole("button", { name: "Percentile Ladder" })).toBeNull();
+  });
+
   it("renders an explicit no-matching-queries message when queryFilter has no matches", () => {
     const summary = makeSummary();
     render(

--- a/results-explorer/src/components/__tests__/ChartPanel.test.tsx
+++ b/results-explorer/src/components/__tests__/ChartPanel.test.tsx
@@ -787,4 +787,43 @@ describe("ChartPanel", () => {
     );
     expect(screen.getByText("No queries match the selected filter.")).toBeTruthy();
   });
+
+  it("clears power_score and switches power ranking to geomean latency under active queryFilter", () => {
+    const summary = makeSummary({
+      ranking: {
+        primary_metric: "power_score",
+        secondary_metric: "display_geomean_ms",
+        primary_order: "desc",
+      },
+      platforms: [
+        makePlatformRow({
+          result_id: "p1",
+          platform: "Platform 1",
+          power_score: 5000,
+          display_geomean_ms: 100,
+          timings: { Q1: 10, Q2: 20 },
+        }),
+        makePlatformRow({
+          result_id: "p2",
+          platform: "Platform 2",
+          power_score: 1000,
+          display_geomean_ms: 20,
+          timings: { Q1: 5, Q2: 10 },
+        }),
+      ],
+      query_ids: ["Q1", "Q2"],
+    });
+
+    render(
+      <ChartPanel
+        context={{
+          kind: "summary",
+          summary,
+        }}
+        queryFilter={["Q1"]}
+      />,
+    );
+
+    expect(screen.queryByText(/5,000/)).toBeNull();
+  });
 });

--- a/results-explorer/src/components/__tests__/ChartPanel.test.tsx
+++ b/results-explorer/src/components/__tests__/ChartPanel.test.tsx
@@ -826,6 +826,7 @@ describe("ChartPanel", () => {
 
     expect(screen.queryByText(/5,000/)).toBeNull();
     expect(screen.queryByRole("button", { name: "Power@Size Bar" })).toBeNull();
+    expect(screen.queryByRole("tab", { name: "Cost" })).toBeNull();
   });
 
   it("keeps a baseline bound to its result after an earlier platform is filtered", () => {

--- a/results-explorer/src/components/__tests__/ChartPanel.test.tsx
+++ b/results-explorer/src/components/__tests__/ChartPanel.test.tsx
@@ -706,4 +706,38 @@ describe("ChartPanel", () => {
     expect(screen.getByText("Lowest geomean in ranking")).toBeTruthy();
     expect(screen.getByText(/ranking mismatch — not comparable/)).toBeTruthy();
   });
+
+  it("filters chartSummary queries and preserves queryFilter ranking order", () => {
+    const summary = makeSummary({
+      query_ids: ["Q1", "Q2", "Q3"],
+      platforms: [makePlatformRow({ timings: { Q1: 10, Q2: 20, Q3: 30 } })],
+    });
+    render(
+      <ChartPanel
+        context={{
+          kind: "summary",
+          summary,
+        }}
+        queryFilter={["Q3", "Q1"]}
+      />,
+    );
+    fireEvent.click(screen.getByRole("tab", { name: "Per-query" }));
+    expect(screen.getByText("Q3")).toBeTruthy();
+    expect(screen.getByText("Q1")).toBeTruthy();
+    expect(screen.queryByText("Q2")).toBeNull();
+  });
+
+  it("renders an explicit no-matching-queries message when queryFilter has no matches", () => {
+    const summary = makeSummary();
+    render(
+      <ChartPanel
+        context={{
+          kind: "summary",
+          summary,
+        }}
+        queryFilter={["Q999"]}
+      />,
+    );
+    expect(screen.getByText("No queries match the selected filter.")).toBeTruthy();
+  });
 });

--- a/results-explorer/src/components/__tests__/MultiRunLayout.test.ts
+++ b/results-explorer/src/components/__tests__/MultiRunLayout.test.ts
@@ -307,6 +307,21 @@ describe("competition ranking in standings", () => {
     const { rows } = buildStandings(withNull, 0, ["A", "B", "Empty"]);
     expect(rows.map((r) => r.rank)).toEqual(["—", "—", "—"]);
   });
+
+  it("does not transitively chain ties across non-tied endpoints", () => {
+    // 100 vs 100.4 is 0.4% (tied).
+    // 100.4 vs 100.8 is 0.398% (tied if pairwise).
+    // BUT 100 vs 100.8 is 0.8% (> 0.5% threshold: not tied with leader).
+    const chainedRuns = [
+      run("a", [["Q1", 100]]),
+      run("b", [["Q1", 100.4]]),
+      run("c", [["Q1", 100.8]]),
+    ];
+    const { rows } = buildStandings(chainedRuns, 0, ["A", "B", "C"]);
+    expect(rows[0]!.rank).toBe("T-1");
+    expect(rows[1]!.rank).toBe("T-1");
+    expect(rows[2]!.rank).toBe("3");
+  });
 });
 
 describe("missing evidence reporting in heatmap", () => {
@@ -431,6 +446,24 @@ describe("measurement basis resolution for comparison", () => {
     const warmupResolved = resolveResultsForBasis(runsWithPower, { passes: WARMUP, statistic: "median" });
     expect(warmupResolved[0]!.power_score).toBeNull();
     expect(warmupResolved[1]!.power_score).toBeNull();
+  });
+
+  it("preserves published timing_exclusion_reason for default basis", () => {
+    const rawRun: DetailResult = {
+      ...runs[0]!,
+      display_timings: [
+        {
+          query_id: "Q1",
+          display_ms: null,
+          sample_count: 0,
+          is_valid_display_timing: false,
+          timing_exclusion_reason: "missing_timing",
+        },
+      ],
+      queries: [],
+    };
+    const resolved = resolveResultsForBasis([rawRun], DEFAULT_BASIS);
+    expect(resolved[0]!.display_timings[0]!.timing_exclusion_reason).toBe("missing_timing");
   });
 });
 

--- a/results-explorer/src/components/__tests__/MultiRunLayout.test.ts
+++ b/results-explorer/src/components/__tests__/MultiRunLayout.test.ts
@@ -484,19 +484,28 @@ describe("measurement basis resolution for comparison", () => {
     expect(resolved[0]!.display_timings[0]!.timing_exclusion_reason).toBe("missing_timing");
   });
 
-  it("recomputes timing eligibility when alternate basis has valid timings", () => {
+  it("recomputes timing eligibility according to canonical contract when alternate basis is used", () => {
     const rawRun: DetailResult = {
       ...runs[0]!,
+      logical_query_count: 2,
       has_display_timing: false,
       valid_query_count: 0,
-      missing_query_count: 1,
+      missing_query_count: 2,
       display_exclusion_reason: "no_display_timings",
       comparison_exclusion_reason: "no_comparable_timings",
+      ranking_exclusion_reason: "no_rankable_timings",
       display_timings: [
         {
           query_id: "Q1",
           display_ms: null,
-          sample_count: 0,
+          sample_count: 3,
+          is_valid_display_timing: false,
+          timing_exclusion_reason: "missing_timing",
+        },
+        {
+          query_id: "Q2",
+          display_ms: null,
+          sample_count: 3,
           is_valid_display_timing: false,
           timing_exclusion_reason: "missing_timing",
         },
@@ -513,12 +522,36 @@ describe("measurement basis resolution for comparison", () => {
       ],
     };
 
-    const resolvedWarmup = resolveResultsForBasis([rawRun], { passes: WARMUP, statistic: "median" });
-    expect(resolvedWarmup[0]!.has_display_timing).toBe(true);
-    expect(resolvedWarmup[0]!.valid_query_count).toBe(1);
-    expect(resolvedWarmup[0]!.missing_query_count).toBe(0);
-    expect(resolvedWarmup[0]!.display_exclusion_reason).toBeNull();
-    expect(resolvedWarmup[0]!.comparison_exclusion_reason).toBeNull();
+    // With 1 warmup query out of 2 logical queries: valid=1, coverage=50% (>= 50%),
+    // but valid < 2 -> insufficient_valid_queries for comparison and ranking
+    const resolved1 = resolveResultsForBasis([rawRun], { passes: WARMUP, statistic: "median" });
+    expect(resolved1[0]!.has_display_timing).toBe(true);
+    expect(resolved1[0]!.valid_query_count).toBe(1);
+    expect(resolved1[0]!.display_exclusion_reason).toBeNull();
+    expect(resolved1[0]!.comparison_exclusion_reason).toBe("insufficient_valid_queries");
+    expect(resolved1[0]!.ranking_exclusion_reason).toBe("insufficient_valid_queries");
+    // For unavailable Q2 under alternate basis, sample_count must be 0, not copied from default basis
+    expect(resolved1[0]!.display_timings.find((t) => t.query_id === "Q2")!.sample_count).toBe(0);
+
+    // With 2 warmup queries out of 2 logical queries: valid=2 -> compare/rank safe
+    const rawRun2: DetailResult = {
+      ...rawRun,
+      queries: [
+        ...rawRun.queries,
+        {
+          query_id: "Q2",
+          duration_ms: 140,
+          status: "pass",
+          run_type: "warmup",
+          iter: null,
+          stream: 0,
+        },
+      ],
+    };
+    const resolved2 = resolveResultsForBasis([rawRun2], { passes: WARMUP, statistic: "median" });
+    expect(resolved2[0]!.valid_query_count).toBe(2);
+    expect(resolved2[0]!.comparison_exclusion_reason).toBeNull();
+    expect(resolved2[0]!.ranking_exclusion_reason).toBeNull();
   });
 });
 
@@ -563,5 +596,18 @@ describe("shared limiter query selection", () => {
     const filterOrder = ["Q2", "Q1"];
     const orderedHeatmap = filterOrder.map((id) => rowsByQueryId.get(id)).filter(Boolean);
     expect(orderedHeatmap.map((r: any) => r.queryId)).toEqual(["Q2", "Q1"]);
+  });
+
+  it("keeps all queries uncapped in MultiRunHeatmap when limiter is 'all'", () => {
+    const q15: [string, number][] = Array.from({ length: 15 }, (_, i) => [`Q${i + 1}`, 100 + i]);
+    const runs15 = [
+      run("base", q15),
+      run("cand1", q15),
+      run("cand2", q15),
+    ];
+    const all = buildHeatmapRows(runs15, 0);
+    const effectiveLimiter = "all";
+    const shown = effectiveLimiter === "all" ? all : all.slice(0, 10);
+    expect(shown.length).toBe(15);
   });
 });

--- a/results-explorer/src/components/__tests__/MultiRunLayout.test.ts
+++ b/results-explorer/src/components/__tests__/MultiRunLayout.test.ts
@@ -417,6 +417,21 @@ describe("measurement basis resolution for comparison", () => {
     expect(resolved[0]!.display_timings.find((t) => t.query_id === "Q1")!.display_ms).toBe(80);
     expect(resolved[1]!.display_timings.find((t) => t.query_id === "Q1")!.display_ms).toBe(40);
   });
+
+  it("preserves published power_score under default basis and nulls it out under alternate bases", () => {
+    const runsWithPower = [
+      { ...runs[0]!, power_score: 1500 },
+      { ...runs[1]!, power_score: 800 },
+    ] as DetailResult[];
+
+    const defaultResolved = resolveResultsForBasis(runsWithPower, DEFAULT_BASIS);
+    expect(defaultResolved[0]!.power_score).toBe(1500);
+    expect(defaultResolved[1]!.power_score).toBe(800);
+
+    const warmupResolved = resolveResultsForBasis(runsWithPower, { passes: WARMUP, statistic: "median" });
+    expect(warmupResolved[0]!.power_score).toBeNull();
+    expect(warmupResolved[1]!.power_score).toBeNull();
+  });
 });
 
 describe("shared limiter query selection", () => {
@@ -439,5 +454,13 @@ describe("shared limiter query selection", () => {
   it("orders largest movement by greatest relative divergence", () => {
     const { queryIds } = selectQueryIdsForLimiter(threeRuns, 0, "movement", 20);
     expect(queryIds[0]).toBe("Q1");
+  });
+
+  it("preserves queryFilter's rank order in heatmap and table rather than reverting to natural query order", () => {
+    const heatmapRows = buildHeatmapRows(threeRuns, 0);
+    const rowsByQueryId = new Map(heatmapRows.map((row) => [row.queryId, row]));
+    const filterOrder = ["Q2", "Q1"];
+    const orderedHeatmap = filterOrder.map((id) => rowsByQueryId.get(id)).filter(Boolean);
+    expect(orderedHeatmap.map((r: any) => r.queryId)).toEqual(["Q2", "Q1"]);
   });
 });

--- a/results-explorer/src/components/__tests__/MultiRunLayout.test.ts
+++ b/results-explorer/src/components/__tests__/MultiRunLayout.test.ts
@@ -553,6 +553,44 @@ describe("measurement basis resolution for comparison", () => {
     expect(resolved2[0]!.comparison_exclusion_reason).toBeNull();
     expect(resolved2[0]!.ranking_exclusion_reason).toBeNull();
   });
+
+  it("recomputes zero_timing_count and sets zero_timings_only for alternate basis", () => {
+    const rawRun: DetailResult = {
+      ...runs[0]!,
+      logical_query_count: 1,
+      has_display_timing: false,
+      valid_query_count: 0,
+      missing_query_count: 1,
+      zero_timing_count: 0,
+      display_exclusion_reason: "no_display_timings",
+      comparison_exclusion_reason: "no_comparable_timings",
+      ranking_exclusion_reason: "no_rankable_timings",
+      display_timings: [
+        {
+          query_id: "Q1",
+          display_ms: null,
+          sample_count: 1,
+          is_valid_display_timing: false,
+          timing_exclusion_reason: "missing_timing",
+        },
+      ],
+      queries: [
+        {
+          query_id: "Q1",
+          duration_ms: 0,
+          status: "pass",
+          run_type: "warmup",
+          iter: null,
+          stream: 0,
+        },
+      ],
+    };
+    const resolved = resolveResultsForBasis([rawRun], { passes: WARMUP, statistic: "median" });
+    expect(resolved[0]!.valid_query_count).toBe(0);
+    expect(resolved[0]!.zero_timing_count).toBe(1);
+    expect(resolved[0]!.missing_query_count).toBe(0);
+    expect(resolved[0]!.display_exclusion_reason).toBe("zero_timings_only");
+  });
 });
 
 describe("shared limiter query selection", () => {

--- a/results-explorer/src/components/__tests__/MultiRunLayout.test.ts
+++ b/results-explorer/src/components/__tests__/MultiRunLayout.test.ts
@@ -466,6 +466,16 @@ describe("measurement basis resolution for comparison", () => {
     expect(warmupResolved[1]!.power_score).toBeNull();
   });
 
+  it("preserves published display_geomean_ms exactly when all queries are shared under default basis", () => {
+    const runsWithGeomean = [
+      { ...runs[0]!, display_geomean_ms: 123.4567890123 },
+      { ...runs[1]!, display_geomean_ms: 98.7654321098 },
+    ] as DetailResult[];
+    const resolved = resolveResultsForBasis(runsWithGeomean, DEFAULT_BASIS);
+    expect(resolved[0]!.display_geomean_ms).toBe(123.4567890123);
+    expect(resolved[1]!.display_geomean_ms).toBe(98.7654321098);
+  });
+
   it("preserves published timing_exclusion_reason for default basis", () => {
     const rawRun: DetailResult = {
       ...runs[0]!,

--- a/results-explorer/src/components/__tests__/MultiRunLayout.test.ts
+++ b/results-explorer/src/components/__tests__/MultiRunLayout.test.ts
@@ -19,6 +19,14 @@ import {
   orderRowsByDisagreement,
 } from "@/components/MultiRunHeatmap";
 import { buildStandings, sharedQueryIdsFor } from "@/components/MultiRunStandings";
+import {
+  DEFAULT_BASIS,
+  WARMUP,
+  ALL_WARM,
+  resolveResultsForBasis,
+  type MeasurementBasis,
+} from "@/lib/measurementBasis";
+import { selectQueryIdsForLimiter } from "@/components/QueryDiffTable";
 import type { DetailResult } from "@/types";
 
 function run(id: string, timings: [string, number | null][]): DetailResult {
@@ -274,5 +282,162 @@ describe("coordinated baseline re-basing across panels", () => {
     expect(speedupsB.map((r) => r.queryId)).not.toContain("Q2");
     // But Q1 relative to runB (20ms): runA is 10ms (0.5x, speedup!)
     expect(speedupsB.map((r) => r.queryId)).toContain("Q1");
+  });
+});
+
+describe("competition ranking in standings", () => {
+  it("assigns 'T-1' to tied runs and skips to 3", () => {
+    const tiedRuns = [
+      run("a", [["Q1", 100]]),
+      run("b", [["Q1", 100.2]]), // within 0.005 threshold
+      run("c", [["Q1", 200]]),
+    ];
+    const { rows } = buildStandings(tiedRuns, 0, ["A", "B", "C"]);
+    expect(rows[0]!.rank).toBe("T-1");
+    expect(rows[1]!.rank).toBe("T-1");
+    expect(rows[2]!.rank).toBe("3");
+  });
+
+  it("assigns '—' when shared query set is empty rather than false ranks 1, 2, 3", () => {
+    const withNull = [
+      run("a", [["Q1", 100]]),
+      run("b", [["Q1", 200]]),
+      run("empty", []),
+    ];
+    const { rows } = buildStandings(withNull, 0, ["A", "B", "Empty"]);
+    expect(rows.map((r) => r.rank)).toEqual(["—", "—", "—"]);
+  });
+});
+
+describe("missing evidence reporting in heatmap", () => {
+  it("distinguishes baseline_missing from run_missing", () => {
+    const results = [
+      run("base", [["Q1", 10], ["Q2", null]]), // base lacks Q2
+      run("alt", [["Q1", 20], ["Q2", 30]]),    // alt has Q2!
+      run("alt2", [["Q1", null], ["Q2", 40]]), // alt2 lacks Q1, has Q2
+    ];
+    const rows = buildHeatmapRows(results, 0);
+    const q1 = rows.find((r) => r.queryId === "Q1")!;
+    const q2 = rows.find((r) => r.queryId === "Q2")!;
+
+    // On Q1, alt2 has no timing -> run_missing
+    expect(q1.cells[2]!.missingKind).toBe("run_missing");
+
+    // On Q2, base has no timing, but alt has 30ms -> baseline_missing
+    expect(q2.cells[1]!.missingKind).toBe("baseline_missing");
+    expect(q2.cells[1]!.timingMs).toBe(30);
+  });
+});
+
+function runWithExecs(
+  id: string,
+  data: {
+    queryId: string;
+    displayMs: number | null;
+    warmupMs?: number;
+    pass1Ms?: number;
+    pass2Ms?: number;
+  }[],
+): DetailResult {
+  const queries: any[] = [];
+  const display_timings: any[] = [];
+  for (const d of data) {
+    display_timings.push({
+      query_id: d.queryId,
+      display_ms: d.displayMs,
+      sample_count: 2,
+      is_valid_display_timing: d.displayMs !== null,
+      timing_exclusion_reason: d.displayMs === null ? "missing" : null,
+    });
+    if (d.warmupMs !== undefined) {
+      queries.push({
+        query_id: d.queryId,
+        duration_ms: d.warmupMs,
+        status: "pass",
+        run_type: "warmup",
+        iter: null,
+      });
+    }
+    if (d.pass1Ms !== undefined) {
+      queries.push({
+        query_id: d.queryId,
+        duration_ms: d.pass1Ms,
+        status: "pass",
+        run_type: "measurement",
+        iter: 1,
+      });
+    }
+    if (d.pass2Ms !== undefined) {
+      queries.push({
+        query_id: d.queryId,
+        duration_ms: d.pass2Ms,
+        status: "pass",
+        run_type: "measurement",
+        iter: 2,
+      });
+    }
+  }
+  return {
+    result_id: id,
+    platform: id,
+    display_geomean_ms: 100,
+    display_timings,
+    queries,
+  } as unknown as DetailResult;
+}
+
+describe("measurement basis resolution for comparison", () => {
+  const runs = [
+    runWithExecs("run1", [
+      { queryId: "Q1", displayMs: 100, warmupMs: 150, pass1Ms: 120, pass2Ms: 80 },
+      { queryId: "Q2", displayMs: 200, warmupMs: 250, pass1Ms: 220, pass2Ms: 180 },
+    ]),
+    runWithExecs("run2", [
+      { queryId: "Q1", displayMs: 50, warmupMs: 70, pass1Ms: 60, pass2Ms: 40 },
+      { queryId: "Q2", displayMs: 100, warmupMs: 120, pass1Ms: 110, pass2Ms: 90 },
+    ]),
+  ];
+
+  it("preserves display_ms under default basis", () => {
+    const resolved = resolveResultsForBasis(runs, DEFAULT_BASIS);
+    expect(resolved[0]!.display_timings.find((t) => t.query_id === "Q1")!.display_ms).toBe(100);
+    expect(resolved[1]!.display_timings.find((t) => t.query_id === "Q1")!.display_ms).toBe(50);
+  });
+
+  it("resolves warmup pass executions when warmup basis is selected", () => {
+    const warmupBasis: MeasurementBasis = { passes: WARMUP, statistic: "median" };
+    const resolved = resolveResultsForBasis(runs, warmupBasis);
+    expect(resolved[0]!.display_timings.find((t) => t.query_id === "Q1")!.display_ms).toBe(150);
+    expect(resolved[1]!.display_timings.find((t) => t.query_id === "Q1")!.display_ms).toBe(70);
+  });
+
+  it("resolves minimum across passes when min statistic is selected", () => {
+    const minBasis: MeasurementBasis = { passes: ALL_WARM, statistic: "min" };
+    const resolved = resolveResultsForBasis(runs, minBasis);
+    expect(resolved[0]!.display_timings.find((t) => t.query_id === "Q1")!.display_ms).toBe(80);
+    expect(resolved[1]!.display_timings.find((t) => t.query_id === "Q1")!.display_ms).toBe(40);
+  });
+});
+
+describe("shared limiter query selection", () => {
+  const threeRuns = [
+    run("base", [["Q1", 100], ["Q2", 100], ["Q3", 100]]),
+    run("alt1", [["Q1", 50], ["Q2", 200], ["Q3", 100]]),
+    run("alt2", [["Q1", 40], ["Q2", 150], ["Q3", 100]]),
+  ];
+
+  it("selects speedup queries across all candidates", () => {
+    const { queryIds } = selectQueryIdsForLimiter(threeRuns, 0, "speedups", 20);
+    expect(queryIds).toEqual(["Q1"]);
+  });
+
+  it("selects slowdown queries across all candidates", () => {
+    const { queryIds } = selectQueryIdsForLimiter(threeRuns, 0, "slowdowns", 20);
+    expect(queryIds).toEqual(["Q2"]);
+  });
+
+  it("orders largest movement by greatest relative divergence", () => {
+    const { queryIds } = selectQueryIdsForLimiter(threeRuns, 0, "movement", 20);
+    expect(queryIds[0]).toBe("Q1");
   });
 });

--- a/results-explorer/src/components/__tests__/MultiRunLayout.test.ts
+++ b/results-explorer/src/components/__tests__/MultiRunLayout.test.ts
@@ -322,6 +322,24 @@ describe("competition ranking in standings", () => {
     expect(rows[1]!.rank).toBe("T-1");
     expect(rows[2]!.rank).toBe("3");
   });
+
+  it("keeps rank ties separate from baseline ties", () => {
+    const runs = [
+      run("base", [["Q1", 100]]),
+      run("cand1", [["Q1", 150]]),
+      run("cand2", [["Q1", 150.2]]),
+    ];
+    const { rows } = buildStandings(runs, 0, ["Base", "Cand1", "Cand2"]);
+    const cand1 = rows.find((r) => r.resultId === "cand1")!;
+    const cand2 = rows.find((r) => r.resultId === "cand2")!;
+    expect(cand1.rank).toBe("T-2");
+    expect(cand2.rank).toBe("T-2");
+    expect(cand1.rankTied).toBe(true);
+    expect(cand2.rankTied).toBe(true);
+    expect(cand1.tied).toBe(false);
+    expect(cand2.tied).toBe(false);
+    expect(cand1.ratioToBaseline).toBeCloseTo(1.5, 2);
+  });
 });
 
 describe("missing evidence reporting in heatmap", () => {
@@ -465,6 +483,43 @@ describe("measurement basis resolution for comparison", () => {
     const resolved = resolveResultsForBasis([rawRun], DEFAULT_BASIS);
     expect(resolved[0]!.display_timings[0]!.timing_exclusion_reason).toBe("missing_timing");
   });
+
+  it("recomputes timing eligibility when alternate basis has valid timings", () => {
+    const rawRun: DetailResult = {
+      ...runs[0]!,
+      has_display_timing: false,
+      valid_query_count: 0,
+      missing_query_count: 1,
+      display_exclusion_reason: "no_display_timings",
+      comparison_exclusion_reason: "no_comparable_timings",
+      display_timings: [
+        {
+          query_id: "Q1",
+          display_ms: null,
+          sample_count: 0,
+          is_valid_display_timing: false,
+          timing_exclusion_reason: "missing_timing",
+        },
+      ],
+      queries: [
+        {
+          query_id: "Q1",
+          duration_ms: 120,
+          status: "pass",
+          run_type: "warmup",
+          iter: null,
+          stream: 0,
+        },
+      ],
+    };
+
+    const resolvedWarmup = resolveResultsForBasis([rawRun], { passes: WARMUP, statistic: "median" });
+    expect(resolvedWarmup[0]!.has_display_timing).toBe(true);
+    expect(resolvedWarmup[0]!.valid_query_count).toBe(1);
+    expect(resolvedWarmup[0]!.missing_query_count).toBe(0);
+    expect(resolvedWarmup[0]!.display_exclusion_reason).toBeNull();
+    expect(resolvedWarmup[0]!.comparison_exclusion_reason).toBeNull();
+  });
 });
 
 describe("shared limiter query selection", () => {
@@ -486,6 +541,19 @@ describe("shared limiter query selection", () => {
 
   it("orders largest movement by greatest relative divergence", () => {
     const { queryIds } = selectQueryIdsForLimiter(threeRuns, 0, "movement", 20);
+    expect(queryIds[0]).toBe("Q1");
+  });
+
+  it("ranks movement by full multi-run disagreement spread across opposite-direction candidates", () => {
+    // base=100
+    // Q1: alt1=50 (0.5x), alt2=200 (2.0x) -> spread is 4x (2 bits)
+    // Q2: alt1=300 (3.0x), alt2=300 (3.0x) -> spread is 3x (1.585 bits)
+    const oppositeDirectionRuns = [
+      run("base", [["Q1", 100], ["Q2", 100]]),
+      run("alt1", [["Q1", 50], ["Q2", 300]]),
+      run("alt2", [["Q1", 200], ["Q2", 300]]),
+    ];
+    const { queryIds } = selectQueryIdsForLimiter(oppositeDirectionRuns, 0, "movement", 10);
     expect(queryIds[0]).toBe("Q1");
   });
 

--- a/results-explorer/src/components/__tests__/QueryDiffTable.test.tsx
+++ b/results-explorer/src/components/__tests__/QueryDiffTable.test.tsx
@@ -1,7 +1,14 @@
 import { render, screen } from "@testing-library/preact";
 import { describe, expect, it } from "vitest";
 import type { DetailResult } from "@/types";
-import { QueryDiffTable, applyQueryDiffLimiter, buildQueryDiffRows, queryDiffCountSentence, type QueryDiffRow } from "@/components/QueryDiffTable";
+import {
+  DEFAULT_QUERY_DIFF_LIMIT,
+  QueryDiffTable,
+  applyQueryDiffLimiter,
+  buildQueryDiffRows,
+  queryDiffCountSentence,
+  type QueryDiffRow,
+} from "@/components/QueryDiffTable";
 
 function makeResult(overrides: Partial<DetailResult> = {}): DetailResult {
   return {
@@ -239,6 +246,24 @@ describe("QueryDiffTable", () => {
     // described wrongly.
     expect(table).toHaveTextContent("Not comparable");
   });
+
+  it("counts logical queries rather than candidate rows in multi-run comparisons", () => {
+    render(
+      <QueryDiffTable
+        results={[
+          makeResult({ result_id: "baseline" }),
+          makeResult({ result_id: "candidate-a", platform: "SQLite", platform_id: "sqlite" }),
+          makeResult({ result_id: "candidate-b", platform: "PostgreSQL", platform_id: "postgresql" }),
+        ]}
+        queryFilter={["Q1", "Q2"]}
+        limiter="movement"
+      />,
+    );
+
+    const table = screen.getByRole("heading", { name: "Query-Level Diff" }).closest("section");
+    expect(table).toHaveTextContent("Showing 2 of 3 queries.");
+    expect(table).not.toHaveTextContent("Showing 4 of 6 queries.");
+  });
 });
 
 describe("the Top-N limiter", () => {
@@ -257,6 +282,10 @@ describe("the Top-N limiter", () => {
   });
 
   const rows = [row("Q1", -50), row("Q2", 30), row("Q3", -5), row("Q4", 80), row("Q5", null, false)];
+
+  it("pins the product limit to the requested ten queries", () => {
+    expect(DEFAULT_QUERY_DIFF_LIMIT).toBe(10);
+  });
 
   it("returns everything for 'all', including rows that cannot be compared", () => {
     // The uncomparable row must survive: dropping it hides an exclusion the

--- a/results-explorer/src/lib/__tests__/measurementBasis.values.test.ts
+++ b/results-explorer/src/lib/__tests__/measurementBasis.values.test.ts
@@ -444,6 +444,20 @@ describe("collapse reports the sample actually reduced", () => {
     expect(asMedian).toEqual({ kind: "value", ms: 40, sampleCount: 2, collapsed: false });
     expect(asMin).toEqual({ kind: "value", ms: 30, sampleCount: 2, collapsed: false });
   });
+
+  it("does not count a zero timing that was excluded from the reduction", () => {
+    const rows: BasisExecution[] = [
+      { query_id: "1", duration_ms: 0, status: "pass", run_type: "measurement", iter: 1 },
+      { query_id: "1", duration_ms: 10, status: "pass", run_type: "measurement", iter: 2 },
+    ];
+
+    expect(resolveQueryValue(MIN_ALL_WARM, rows)).toEqual({
+      kind: "value",
+      ms: 10,
+      sampleCount: 1,
+      collapsed: true,
+    });
+  });
 });
 
 

--- a/results-explorer/src/lib/__tests__/measurementBasis.values.test.ts
+++ b/results-explorer/src/lib/__tests__/measurementBasis.values.test.ts
@@ -365,6 +365,7 @@ describe("compared geomeans share one query set", () => {
       10.000000000000002,
       20.000000000000004,
     ]);
+    expect(resolved.map((result) => result.display_timings[0]?.sample_count)).toEqual([1, 1]);
   });
 });
 

--- a/results-explorer/src/lib/__tests__/measurementBasis.values.test.ts
+++ b/results-explorer/src/lib/__tests__/measurementBasis.values.test.ts
@@ -22,11 +22,13 @@ import {
   parseAvailableBases,
   parseVaryingPassQueries,
   resolveQueryValue,
+  resolveResultsForBasis,
   sharedQueryGeomeans,
   warmPass,
   type BasisExecution,
   type MeasurementBasis,
 } from "@/lib/measurementBasis";
+import type { DetailResult } from "@/types";
 
 const TPCH_DUCKDB = "tpch-duckdb-sf1.0-20260828-ea150b8e";
 const TPCDS_SPARK_SF10 = "tpcds-spark-sf10.0-20260823-ace504c8";
@@ -325,6 +327,44 @@ describe("compared geomeans share one query set", () => {
     ]);
     expect(sharedQueryIds).toEqual([]);
     expect(series.every((s) => s.geomeanMs === null)).toBe(true);
+  });
+
+  it("preserves published default geomeans when every run has the same valid query set", () => {
+    const results = [
+      ({
+        result_id: "a",
+        display_geomean_ms: 10.000000000000002,
+        logical_query_count: 2,
+        valid_query_count: 1,
+        missing_query_count: 1,
+        zero_timing_count: 0,
+        has_display_timing: true,
+        display_timings: [
+          { query_id: "1", display_ms: 10, sample_count: 1, is_valid_display_timing: true, timing_exclusion_reason: null },
+          { query_id: "2", display_ms: null, sample_count: 0, is_valid_display_timing: false, timing_exclusion_reason: "failed_query" },
+        ],
+      } as unknown as DetailResult),
+      ({
+        result_id: "b",
+        display_geomean_ms: 20.000000000000004,
+        logical_query_count: 2,
+        valid_query_count: 1,
+        missing_query_count: 1,
+        zero_timing_count: 0,
+        has_display_timing: true,
+        display_timings: [
+          { query_id: "1", display_ms: 20, sample_count: 1, is_valid_display_timing: true, timing_exclusion_reason: null },
+          { query_id: "2", display_ms: null, sample_count: 0, is_valid_display_timing: false, timing_exclusion_reason: "failed_query" },
+        ],
+      } as unknown as DetailResult),
+    ];
+
+    const resolved = resolveResultsForBasis(results, DEFAULT_BASIS);
+
+    expect(resolved.map((result) => result.display_geomean_ms)).toEqual([
+      10.000000000000002,
+      20.000000000000004,
+    ]);
   });
 });
 

--- a/results-explorer/src/lib/measurementBasis.ts
+++ b/results-explorer/src/lib/measurementBasis.ts
@@ -832,9 +832,14 @@ export function resolveResultsForBasis(
       }
     }
 
+    const preservedGeomean =
+      isDefault && geomeanData.excludedQueryIds.length === 0 && r.display_geomean_ms !== null
+        ? r.display_geomean_ms
+        : newGeomean;
+
     return {
       ...r,
-      display_geomean_ms: newGeomean,
+      display_geomean_ms: preservedGeomean,
       display_timings: newDisplayTimings,
       power_score: isDefault ? r.power_score : null,
       valid_query_count: validQueryCount,

--- a/results-explorer/src/lib/measurementBasis.ts
+++ b/results-explorer/src/lib/measurementBasis.ts
@@ -747,6 +747,7 @@ export function resolveResultsForBasis(
       ...r,
       display_geomean_ms: newGeomean,
       display_timings: newDisplayTimings,
+      power_score: isDefaultBasis(basis) ? r.power_score : null,
     };
   });
 }

--- a/results-explorer/src/lib/measurementBasis.ts
+++ b/results-explorer/src/lib/measurementBasis.ts
@@ -832,10 +832,14 @@ export function resolveResultsForBasis(
       }
     }
 
+    const validQueryIds = newDisplayTimings
+      .filter((timing) => timing.is_valid_display_timing)
+      .map((timing) => timing.query_id);
+    const usesSharedQuerySet =
+      validQueryIds.length === geomeanData.sharedQueryIds.length &&
+      validQueryIds.every((queryId) => geomeanData.sharedQueryIds.includes(queryId));
     const preservedGeomean =
-      isDefault && geomeanData.excludedQueryIds.length === 0 && r.display_geomean_ms !== null
-        ? r.display_geomean_ms
-        : newGeomean;
+      isDefault && usesSharedQuerySet && r.display_geomean_ms !== null ? r.display_geomean_ms : newGeomean;
 
     return {
       ...r,

--- a/results-explorer/src/lib/measurementBasis.ts
+++ b/results-explorer/src/lib/measurementBasis.ts
@@ -732,12 +732,18 @@ export function resolveResultsForBasis(
           existing && existing.is_valid_display_timing !== false ? (existing.display_ms ?? null) : null;
         const val = resolveQueryValue(basis, rows, displayMs);
         const ms = val.kind === "value" && Number.isFinite(val.ms) && val.ms > 0 ? val.ms : null;
+        const timingExclusionReason =
+          isDefaultBasis(basis) && existing?.timing_exclusion_reason
+            ? existing.timing_exclusion_reason
+            : val.kind === "unavailable"
+              ? val.reason
+              : null;
         return {
           query_id: queryId,
           display_ms: ms,
-          sample_count: val.kind === "value" ? val.sampleCount : 0,
+          sample_count: val.kind === "value" ? val.sampleCount : (existing?.sample_count ?? 0),
           is_valid_display_timing: ms !== null,
-          timing_exclusion_reason: val.kind === "unavailable" ? val.reason : null,
+          timing_exclusion_reason: timingExclusionReason,
         };
       });
 

--- a/results-explorer/src/lib/measurementBasis.ts
+++ b/results-explorer/src/lib/measurementBasis.ts
@@ -738,10 +738,16 @@ export function resolveResultsForBasis(
             : val.kind === "unavailable"
               ? val.reason
               : null;
+        const sampleCount =
+          val.kind === "value"
+            ? val.sampleCount
+            : isDefaultBasis(basis)
+              ? (existing?.sample_count ?? 0)
+              : 0;
         return {
           query_id: queryId,
           display_ms: ms,
-          sample_count: val.kind === "value" ? val.sampleCount : (existing?.sample_count ?? 0),
+          sample_count: sampleCount,
           is_valid_display_timing: ms !== null,
           timing_exclusion_reason: timingExclusionReason,
         };
@@ -750,12 +756,16 @@ export function resolveResultsForBasis(
     const newGeomean = geomeanByResultId.get(r.result_id) ?? null;
     const isDefault = isDefaultBasis(basis);
 
+    const logicalCount =
+      r.logical_query_count !== undefined && r.logical_query_count > 0
+        ? r.logical_query_count
+        : newDisplayTimings.length;
     const validQueryCount = isDefault
       ? r.valid_query_count
       : newDisplayTimings.filter((t) => t.is_valid_display_timing).length;
     const missingQueryCount = isDefault
       ? r.missing_query_count
-      : newDisplayTimings.filter((t) => !t.is_valid_display_timing).length;
+      : Math.max(logicalCount - validQueryCount, 0);
     const hasDisplayTiming = isDefault ? r.has_display_timing : validQueryCount > 0;
 
     let displayExclusionReason = r.display_exclusion_reason;
@@ -763,26 +773,52 @@ export function resolveResultsForBasis(
     let rankingExclusionReason = r.ranking_exclusion_reason;
 
     if (!isDefault) {
-      if (!hasDisplayTiming) {
-        displayExclusionReason = "no_display_timings";
-        comparisonExclusionReason = comparisonExclusionReason ?? "no_comparable_timings";
-        rankingExclusionReason = rankingExclusionReason ?? "no_rankable_timings";
+      if (validQueryCount > 0) {
+        displayExclusionReason = null;
+      } else if (logicalCount <= 0) {
+        displayExclusionReason = "no_queries";
       } else {
-        if (displayExclusionReason === "no_display_timings") {
-          displayExclusionReason = null;
-        }
-        if (
-          comparisonExclusionReason === "no_comparable_timings" ||
-          comparisonExclusionReason === "no_display_timings"
-        ) {
-          comparisonExclusionReason = null;
-        }
-        if (
-          rankingExclusionReason === "no_rankable_timings" ||
-          rankingExclusionReason === "no_display_timings"
-        ) {
-          rankingExclusionReason = null;
-        }
+        displayExclusionReason = "no_valid_display_timing";
+      }
+
+      const independentCompareExclusions = new Set([
+        "visibility_not_comparable",
+        "benchmarks_differ",
+        "scales_differ",
+        "phases_differ",
+        "hidden_result",
+      ]);
+      if (r.comparison_exclusion_reason && independentCompareExclusions.has(r.comparison_exclusion_reason)) {
+        comparisonExclusionReason = r.comparison_exclusion_reason;
+      } else if (displayExclusionReason !== null) {
+        comparisonExclusionReason = displayExclusionReason;
+      } else if (validQueryCount < 2) {
+        comparisonExclusionReason = "insufficient_valid_queries";
+      } else if (logicalCount > 0 && validQueryCount * 2 < logicalCount) {
+        comparisonExclusionReason = "insufficient_query_coverage";
+      } else {
+        comparisonExclusionReason = null;
+      }
+
+      const independentRankingExclusions = new Set([
+        "visibility_not_rankable",
+        "trust_not_rankable",
+        "unofficial_compliance",
+        "compliance_not_rankable",
+        "failed_queries",
+        "validation_not_clean",
+        "hidden_result",
+      ]);
+      if (r.ranking_exclusion_reason && independentRankingExclusions.has(r.ranking_exclusion_reason)) {
+        rankingExclusionReason = r.ranking_exclusion_reason;
+      } else if (comparisonExclusionReason !== null) {
+        rankingExclusionReason = comparisonExclusionReason;
+      } else if (newGeomean === null) {
+        rankingExclusionReason = "missing_primary_metric";
+      } else if (!Number.isFinite(newGeomean) || newGeomean <= 0) {
+        rankingExclusionReason = "non_positive_primary_metric";
+      } else {
+        rankingExclusionReason = null;
       }
     }
 

--- a/results-explorer/src/lib/measurementBasis.ts
+++ b/results-explorer/src/lib/measurementBasis.ts
@@ -284,6 +284,7 @@ export function basesInComparison(comparison: BasisComparison): MeasurementBasis
 
 import { geomeanMs } from "@/lib/chartMath";
 import type { UrlSerde } from "@/lib/useUrlState";
+import type { DetailResult, QueryDisplayTiming } from "@/types";
 
 export const BASIS_URL_KEY = "basis";
 export const BASES_URL_KEY = "bases";
@@ -649,8 +650,11 @@ export function sharedQueryGeomeans(
 ): SharedQueryGeomeans {
   const resolved = series.map((s) => {
     const displayByQuery = new Map((s.displayTimings ?? []).map((t) => [t.query_id, t]));
+    const execsByQuery = groupByQuery(s.executions ?? []);
+    const queryIds = new Set<string>([...execsByQuery.keys(), ...displayByQuery.keys()]);
     const values = new Map<string, number>();
-    for (const [queryId, rows] of groupByQuery(s.executions)) {
+    for (const queryId of queryIds) {
+      const rows = execsByQuery.get(queryId) ?? [];
       const timing = displayByQuery.get(queryId);
       const displayMs =
         timing && timing.is_valid_display_timing !== false ? (timing.display_ms ?? null) : null;
@@ -663,7 +667,10 @@ export function sharedQueryGeomeans(
   });
 
   const allQueryIds = new Set<string>();
-  for (const s of series) for (const row of s.executions) allQueryIds.add(row.query_id);
+  for (const s of series) {
+    for (const row of s.executions ?? []) allQueryIds.add(row.query_id);
+    for (const t of s.displayTimings ?? []) allQueryIds.add(t.query_id);
+  }
 
   const shared: string[] = [];
   const excluded: string[] = [];
@@ -680,6 +687,68 @@ export function sharedQueryGeomeans(
     sharedQueryIds: shared,
     excludedQueryIds: excluded,
   };
+}
+
+/**
+ * Projects a selection of DetailResult objects for a chosen MeasurementBasis.
+ *
+ * Recomputes `display_timings` for every query and `display_geomean_ms` over the
+ * intersected shared query set across all selected runs.
+ *
+ * For DEFAULT_BASIS, preserves precomputed display_ms directly while recalculating
+ * display_geomean_ms over the shared query set so no run averages over unshared queries.
+ *
+ * For non-default bases (warmup, individual warm passes, min), resolves each query's
+ * timing from raw execution rows according to the pass selection and statistic.
+ */
+export function resolveResultsForBasis(
+  results: readonly DetailResult[],
+  basis: MeasurementBasis,
+): DetailResult[] {
+  if (results.length === 0) return [];
+
+  const seriesInputs: BasisSeriesInput[] = results.map((r) => ({
+    key: r.result_id,
+    executions: r.queries ?? [],
+    displayTimings: r.display_timings ?? [],
+  }));
+  const geomeanData = sharedQueryGeomeans(basis, seriesInputs);
+  const geomeanByResultId = new Map(geomeanData.series.map((s) => [s.key, s.geomeanMs]));
+
+  return results.map((r) => {
+    const displayByQuery = new Map((r.display_timings ?? []).map((t) => [t.query_id, t]));
+    const execsByQuery = groupByQuery(r.queries ?? []);
+
+    const allQueryIds = new Set<string>();
+    for (const t of r.display_timings ?? []) allQueryIds.add(t.query_id);
+    for (const q of r.queries ?? []) allQueryIds.add(q.query_id);
+
+    const newDisplayTimings: QueryDisplayTiming[] = [...allQueryIds]
+      .sort((a, b) => a.localeCompare(b, undefined, { numeric: true }))
+      .map((queryId) => {
+        const rows = execsByQuery.get(queryId) ?? [];
+        const existing = displayByQuery.get(queryId);
+        const displayMs =
+          existing && existing.is_valid_display_timing !== false ? (existing.display_ms ?? null) : null;
+        const val = resolveQueryValue(basis, rows, displayMs);
+        const ms = val.kind === "value" && Number.isFinite(val.ms) && val.ms > 0 ? val.ms : null;
+        return {
+          query_id: queryId,
+          display_ms: ms,
+          sample_count: val.kind === "value" ? val.sampleCount : 0,
+          is_valid_display_timing: ms !== null,
+          timing_exclusion_reason: val.kind === "unavailable" ? val.reason : null,
+        };
+      });
+
+    const newGeomean = geomeanByResultId.get(r.result_id) ?? null;
+
+    return {
+      ...r,
+      display_geomean_ms: newGeomean,
+      display_timings: newDisplayTimings,
+    };
+  });
 }
 
 /**

--- a/results-explorer/src/lib/measurementBasis.ts
+++ b/results-explorer/src/lib/measurementBasis.ts
@@ -538,7 +538,7 @@ export function resolveQueryValue(
   // warm pass collapses under `all_warm` even though the basis is multi-pass.
   // Either way, median and min over one value are the same number and a
   // surface must not offer them as a live choice.
-  return { kind: "value", ms: value, sampleCount: selected.length, collapsed: selected.length <= 1 };
+  return { kind: "value", ms: value, sampleCount: nonZero.length, collapsed: nonZero.length <= 1 };
 }
 
 // ---------------------------------------------------------------------------

--- a/results-explorer/src/lib/measurementBasis.ts
+++ b/results-explorer/src/lib/measurementBasis.ts
@@ -741,12 +741,11 @@ export function resolveResultsForBasis(
             : val.kind === "unavailable"
               ? val.reason
               : null;
-        const sampleCount =
-          val.kind === "value"
+        const sampleCount = isDefaultBasis(basis)
+          ? (existing?.sample_count ?? 0)
+          : val.kind === "value"
             ? val.sampleCount
-            : isDefaultBasis(basis)
-              ? (existing?.sample_count ?? 0)
-              : 0;
+            : 0;
         return {
           query_id: queryId,
           display_ms: ms,

--- a/results-explorer/src/lib/measurementBasis.ts
+++ b/results-explorer/src/lib/measurementBasis.ts
@@ -389,6 +389,7 @@ export type BasisUnavailableReason =
   | "no_warm_passes_recorded"
   | "pass_not_recorded"
   | "no_passing_executions"
+  | "zero_timing"
   | "display_value_excluded";
 
 const UNAVAILABLE_LABELS: Record<BasisUnavailableReason, string> = {
@@ -396,6 +397,7 @@ const UNAVAILABLE_LABELS: Record<BasisUnavailableReason, string> = {
   no_warm_passes_recorded: "This run did not record any warm passes.",
   pass_not_recorded: "This run did not record that warm pass.",
   no_passing_executions: "No execution of this query passed under that basis.",
+  zero_timing: "Recorded execution timing was zero.",
   display_value_excluded: "The published value for this query is excluded from display evidence.",
 };
 
@@ -524,11 +526,12 @@ export function resolveQueryValue(
   const { rows: selected, missingReason } = selectExecutions(rows, basis.passes);
   if (missingReason !== null) return { kind: "unavailable", reason: missingReason };
 
-  const value = applyStatistic(
-    selected.map((r) => r.duration_ms).filter((ms) => Number.isFinite(ms) && ms > 0),
-    basis.statistic,
-  );
-  if (value === null) return { kind: "unavailable", reason: "no_passing_executions" };
+  const nonZero = selected.map((r) => r.duration_ms).filter((ms) => Number.isFinite(ms) && ms > 0);
+  const value = applyStatistic(nonZero, basis.statistic);
+  if (value === null) {
+    const hasZero = selected.some((r) => r.duration_ms === 0);
+    return { kind: "unavailable", reason: hasZero ? "zero_timing" : "no_passing_executions" };
+  }
   // Derived from the sample actually reduced, not from the pass kind. A
   // throughput run records one warmup execution PER STREAM, so a nominally
   // single-pass basis can still reduce several rows; and a run with only one
@@ -760,12 +763,15 @@ export function resolveResultsForBasis(
       r.logical_query_count !== undefined && r.logical_query_count > 0
         ? r.logical_query_count
         : newDisplayTimings.length;
+    const zeroTimingCount = isDefault
+      ? (r.zero_timing_count ?? 0)
+      : newDisplayTimings.filter((t) => t.timing_exclusion_reason === "zero_timing" || t.display_ms === 0).length;
     const validQueryCount = isDefault
       ? r.valid_query_count
       : newDisplayTimings.filter((t) => t.is_valid_display_timing).length;
     const missingQueryCount = isDefault
       ? r.missing_query_count
-      : Math.max(logicalCount - validQueryCount, 0);
+      : Math.max(logicalCount - validQueryCount - zeroTimingCount, 0);
     const hasDisplayTiming = isDefault ? r.has_display_timing : validQueryCount > 0;
 
     let displayExclusionReason = r.display_exclusion_reason;
@@ -777,6 +783,10 @@ export function resolveResultsForBasis(
         displayExclusionReason = null;
       } else if (logicalCount <= 0) {
         displayExclusionReason = "no_queries";
+      } else if (zeroTimingCount > 0 && missingQueryCount === 0) {
+        displayExclusionReason = "zero_timings_only";
+      } else if (missingQueryCount > 0 && zeroTimingCount === 0) {
+        displayExclusionReason = "missing_timings";
       } else {
         displayExclusionReason = "no_valid_display_timing";
       }
@@ -829,6 +839,7 @@ export function resolveResultsForBasis(
       power_score: isDefault ? r.power_score : null,
       valid_query_count: validQueryCount,
       missing_query_count: missingQueryCount,
+      zero_timing_count: zeroTimingCount,
       has_display_timing: hasDisplayTiming,
       display_exclusion_reason: displayExclusionReason,
       comparison_exclusion_reason: comparisonExclusionReason,

--- a/results-explorer/src/lib/measurementBasis.ts
+++ b/results-explorer/src/lib/measurementBasis.ts
@@ -748,12 +748,55 @@ export function resolveResultsForBasis(
       });
 
     const newGeomean = geomeanByResultId.get(r.result_id) ?? null;
+    const isDefault = isDefaultBasis(basis);
+
+    const validQueryCount = isDefault
+      ? r.valid_query_count
+      : newDisplayTimings.filter((t) => t.is_valid_display_timing).length;
+    const missingQueryCount = isDefault
+      ? r.missing_query_count
+      : newDisplayTimings.filter((t) => !t.is_valid_display_timing).length;
+    const hasDisplayTiming = isDefault ? r.has_display_timing : validQueryCount > 0;
+
+    let displayExclusionReason = r.display_exclusion_reason;
+    let comparisonExclusionReason = r.comparison_exclusion_reason;
+    let rankingExclusionReason = r.ranking_exclusion_reason;
+
+    if (!isDefault) {
+      if (!hasDisplayTiming) {
+        displayExclusionReason = "no_display_timings";
+        comparisonExclusionReason = comparisonExclusionReason ?? "no_comparable_timings";
+        rankingExclusionReason = rankingExclusionReason ?? "no_rankable_timings";
+      } else {
+        if (displayExclusionReason === "no_display_timings") {
+          displayExclusionReason = null;
+        }
+        if (
+          comparisonExclusionReason === "no_comparable_timings" ||
+          comparisonExclusionReason === "no_display_timings"
+        ) {
+          comparisonExclusionReason = null;
+        }
+        if (
+          rankingExclusionReason === "no_rankable_timings" ||
+          rankingExclusionReason === "no_display_timings"
+        ) {
+          rankingExclusionReason = null;
+        }
+      }
+    }
 
     return {
       ...r,
       display_geomean_ms: newGeomean,
       display_timings: newDisplayTimings,
-      power_score: isDefaultBasis(basis) ? r.power_score : null,
+      power_score: isDefault ? r.power_score : null,
+      valid_query_count: validQueryCount,
+      missing_query_count: missingQueryCount,
+      has_display_timing: hasDisplayTiming,
+      display_exclusion_reason: displayExclusionReason,
+      comparison_exclusion_reason: comparisonExclusionReason,
+      ranking_exclusion_reason: rankingExclusionReason,
     };
   });
 }

--- a/results-explorer/src/pages/Compare.tsx
+++ b/results-explorer/src/pages/Compare.tsx
@@ -42,6 +42,7 @@ import {
 } from "@/components/ComparabilityReceipt";
 import { CompareSummary } from "@/components/CompareSummary";
 import {
+  DEFAULT_QUERY_DIFF_LIMIT,
   QueryDiffTable,
   QUERY_DIFF_LIMITER_LABELS,
   type QueryDiffLimiter,
@@ -256,7 +257,12 @@ export function Compare({ url }: CompareProps) {
     [results, basis],
   );
   const { queryIds: limitedQueryIds } = useMemo(
-    () => selectQueryIdsForLimiter(resolvedResults, normalizedBaselineIndex, queryLimiter, 20),
+    () => selectQueryIdsForLimiter(
+      resolvedResults,
+      normalizedBaselineIndex,
+      queryLimiter,
+      DEFAULT_QUERY_DIFF_LIMIT,
+    ),
     [resolvedResults, normalizedBaselineIndex, queryLimiter],
   );
   useDocumentTitle(

--- a/results-explorer/src/pages/Compare.tsx
+++ b/results-explorer/src/pages/Compare.tsx
@@ -65,6 +65,7 @@ import {
   BASIS_URL_KEY,
   DEFAULT_BASIS,
   basisSerde,
+  formatBasisLabel,
   isCollapsedStatistic,
   isDefaultBasis,
   parseAvailablePassSelections,
@@ -872,7 +873,7 @@ export function Compare({ url }: CompareProps) {
       </div>
 
       <p class="mb-6 text-xs text-[var(--bb-data-fg-subtle)]">
-        <strong>Geomean query time</strong> - geometric mean of per-query execution times (measurement runs only). More
+        <strong>Geomean query time</strong> - geometric mean of per-query execution times ({isDefaultBasis(basis) ? "measurement runs only" : `${formatBasisLabel(basis)} only`}). More
         comparable than wall-clock total when query counts differ. Lower is faster.
       </p>
 

--- a/results-explorer/src/pages/Compare.tsx
+++ b/results-explorer/src/pages/Compare.tsx
@@ -879,11 +879,22 @@ export function Compare({ url }: CompareProps) {
 
       {compareLayoutForSelection(resolvedResults.map((r) => r.result_id)).kind === "multi_run" && (
         <>
-          <MultiRunStandings
-            results={resolvedResults}
-            baselineIndex={normalizedBaselineIndex}
-            runLabels={cohortIdentitiesCompact}
-          />
+          {decisionSummary.claimSuppressed ? (
+            <section class="card mb-8" aria-labelledby="standings-title">
+              <h2 id="standings-title" class="text-base font-semibold text-[var(--bb-data-fg-primary)]">
+                Standings
+              </h2>
+              <p class="mt-1 text-sm text-[var(--bb-data-fg-muted)]" role="status">
+                Standings are unavailable because {decisionSummary.claimSuppressionReason ?? "the selected runs are not comparable"}.
+              </p>
+            </section>
+          ) : (
+            <MultiRunStandings
+              results={resolvedResults}
+              baselineIndex={normalizedBaselineIndex}
+              runLabels={cohortIdentitiesCompact}
+            />
+          )}
           <MultiRunHeatmap
             results={resolvedResults}
             baselineIndex={normalizedBaselineIndex}

--- a/results-explorer/src/pages/Compare.tsx
+++ b/results-explorer/src/pages/Compare.tsx
@@ -45,6 +45,7 @@ import {
   QueryDiffTable,
   QUERY_DIFF_LIMITER_LABELS,
   type QueryDiffLimiter,
+  selectQueryIdsForLimiter,
 } from "@/components/QueryDiffTable";
 import { modeLabel, testTypeLabel } from "@/components/MethodologyDisclosure";
 import { vsSlowestRatio } from "@/lib/chartMath";
@@ -62,6 +63,7 @@ import {
   isCollapsedStatistic,
   parseAvailablePassSelections,
   passSelectionsEqual,
+  resolveResultsForBasis,
   type PassSelection,
 } from "@/lib/measurementBasis";
 import { formatDurationSeconds, formatPowerScore, formatSpeedup } from "@/lib/metricFormatters";
@@ -244,6 +246,14 @@ export function Compare({ url }: CompareProps) {
   }, [results, availabilityRows]);
   const primaryMetric = compareState?.primaryMetric ?? "display_geomean_ms";
   const normalizedBaselineIndex = results[baselineIndex] ? baselineIndex : 0;
+  const resolvedResults = useMemo(
+    () => resolveResultsForBasis(results, basis),
+    [results, basis],
+  );
+  const { queryIds: limitedQueryIds } = useMemo(
+    () => selectQueryIdsForLimiter(resolvedResults, normalizedBaselineIndex, queryLimiter, 20),
+    [resolvedResults, normalizedBaselineIndex, queryLimiter],
+  );
   useDocumentTitle(
     results.length > 0 ? `Compare (${results.length}) · BenchBox Results` : "Compare · BenchBox Results",
   );
@@ -493,22 +503,22 @@ export function Compare({ url }: CompareProps) {
    */
   const queryCoverage = useMemo(() => {
     const allQueryIds = new Set<string>();
-    for (const result of results) {
+    for (const result of resolvedResults) {
       for (const timing of result.display_timings) allQueryIds.add(timing.query_id);
     }
     let shared = 0;
     for (const queryId of allQueryIds) {
-      if (results.every((result) => timingValueForQuery(result, queryId) !== null)) shared += 1;
+      if (resolvedResults.every((result) => timingValueForQuery(result, queryId) !== null)) shared += 1;
     }
     return { shared, total: allQueryIds.size };
-  }, [results]);
+  }, [resolvedResults]);
 
   // Primary metric is loaded async from DuckDB in the effect above; default
   // stays `display_geomean_ms` until the query resolves (matches Python's
   // `_DEFAULT_RANKING`).
   const higherIsBetter = primaryMetric === "power_score";
 
-  const primaries: (number | null)[] = results.map((r) =>
+  const primaries: (number | null)[] = resolvedResults.map((r) =>
     primaryMetric === "power_score" ? r.power_score : r.display_geomean_ms,
   );
   // Cohort-aware run identity labels for the decision summary headline +
@@ -535,7 +545,7 @@ export function Compare({ url }: CompareProps) {
     });
     return out;
   })();
-  const decisionSummary = buildCompareDecisionSummary(results, primaryMetric, {
+  const decisionSummary = buildCompareDecisionSummary(resolvedResults, primaryMetric, {
     suppressWinnerClaims: severeMismatchReason !== null,
     suppressionReason: severeMismatchReason ?? undefined,
     runLabels: summaryRunLabels,
@@ -564,7 +574,7 @@ export function Compare({ url }: CompareProps) {
   const cohortIdentities = formatRunIdentitiesForCohort(identitySources, "table");
   const cohortIdentitiesCompact = formatRunIdentitiesForCohort(identitySources, "compact");
 
-  const rowData = results.map((r, idx) => ({
+  const rowData = resolvedResults.map((r, idx) => ({
     resultId: r.result_id,
     publicId: visibleResultIdForRow(r),
     label: cohortIdentities[idx]!,
@@ -685,14 +695,39 @@ export function Compare({ url }: CompareProps) {
         </div>
       )}
 
+      {results.length > 1 && (
+        <div class="panel mb-4 flex flex-wrap items-center justify-between gap-3 px-3 py-2 shadow-sm">
+          <div>
+            <label class="text-sm font-medium text-[var(--bb-data-fg-primary)]" for="query-limiter">
+              Queries shown
+            </label>
+            <p class="text-xs text-[var(--bb-data-fg-muted)]">
+              Applies to the chart and the table together.
+            </p>
+          </div>
+          <Select
+            id="query-limiter"
+            ariaLabel="Queries shown"
+            size="sm"
+            value={queryLimiter}
+            onChange={(value) => setQueryLimiter(value as QueryDiffLimiter)}
+            options={(Object.keys(QUERY_DIFF_LIMITER_LABELS) as QueryDiffLimiter[]).map((key) => ({
+              value: key,
+              label: QUERY_DIFF_LIMITER_LABELS[key],
+            }))}
+          />
+        </div>
+      )}
+
       {rowCount > 0 && (
         <div class="mb-8">
           <ChartPanel
-            context={{ kind: "compare", results, primaryMetric }}
+            context={{ kind: "compare", results: resolvedResults, primaryMetric }}
             baselineIndex={normalizedBaselineIndex}
             onBaselineIndexChange={setBaselineIndex}
             suppressWinnerClaims={decisionSummary.claimSuppressed}
             suppressionReason={decisionSummary.claimSuppressionReason ?? undefined}
+            queryFilter={queryLimiter === "all" ? undefined : limitedQueryIds}
           />
         </div>
       )}
@@ -821,50 +856,30 @@ export function Compare({ url }: CompareProps) {
         comparable than wall-clock total when query counts differ. Lower is faster.
       </p>
 
-      <div class="panel mb-4 flex flex-wrap items-center justify-between gap-3 px-3 py-2 shadow-sm">
-        <div>
-          <label class="text-sm font-medium text-[var(--bb-data-fg-primary)]" for="query-limiter">
-            Queries shown
-          </label>
-          <p class="text-xs text-[var(--bb-data-fg-muted)]">
-            Applies to the chart and the table together.
-          </p>
-        </div>
-        <Select
-          id="query-limiter"
-          ariaLabel="Queries shown"
-          size="sm"
-          value={queryLimiter}
-          onChange={(value) => setQueryLimiter(value as QueryDiffLimiter)}
-          options={(Object.keys(QUERY_DIFF_LIMITER_LABELS) as QueryDiffLimiter[]).map((key) => ({
-            value: key,
-            label: QUERY_DIFF_LIMITER_LABELS[key],
-          }))}
-        />
-      </div>
-
-      {compareLayoutForSelection(results.map((r) => r.result_id)).kind === "multi_run" && (
+      {compareLayoutForSelection(resolvedResults.map((r) => r.result_id)).kind === "multi_run" && (
         <>
           <MultiRunStandings
-            results={results}
+            results={resolvedResults}
             baselineIndex={normalizedBaselineIndex}
             runLabels={cohortIdentitiesCompact}
           />
           <MultiRunHeatmap
-            results={results}
+            results={resolvedResults}
             baselineIndex={normalizedBaselineIndex}
             runLabels={cohortIdentitiesCompact}
             limiter={queryLimiter}
             orderByDisagreement={queryLimiter === "movement"}
+            queryFilter={queryLimiter === "all" ? undefined : limitedQueryIds}
           />
         </>
       )}
 
       <QueryDiffTable
         limiter={queryLimiter}
-        results={results}
+        results={resolvedResults}
         baselineIndex={normalizedBaselineIndex}
         suppressionReason={decisionSummary.claimSuppressionReason}
+        queryFilter={queryLimiter === "all" ? undefined : limitedQueryIds}
       />
       <ComparabilityReceipt results={results} />
       <ProvenanceLegend />

--- a/results-explorer/src/pages/Compare.tsx
+++ b/results-explorer/src/pages/Compare.tsx
@@ -49,7 +49,11 @@ import {
 } from "@/components/QueryDiffTable";
 import { modeLabel, testTypeLabel } from "@/components/MethodologyDisclosure";
 import { vsSlowestRatio } from "@/lib/chartMath";
-import { buildCompareDecisionSummary, COMPARE_TIE_THRESHOLD } from "@/lib/compareSummary";
+import {
+  buildCompareDecisionSummary,
+  COMPARE_TIE_THRESHOLD,
+  type ComparePrimaryMetric,
+} from "@/lib/compareSummary";
 import { IdentityDiffStrip } from "@/components/IdentityDiffStrip";
 import { MultiRunHeatmap } from "@/components/MultiRunHeatmap";
 import { MultiRunStandings } from "@/components/MultiRunStandings";
@@ -61,6 +65,7 @@ import {
   DEFAULT_BASIS,
   basisSerde,
   isCollapsedStatistic,
+  isDefaultBasis,
   parseAvailablePassSelections,
   passSelectionsEqual,
   resolveResultsForBasis,
@@ -516,10 +521,19 @@ export function Compare({ url }: CompareProps) {
   // Primary metric is loaded async from DuckDB in the effect above; default
   // stays `display_geomean_ms` until the query resolves (matches Python's
   // `_DEFAULT_RANKING`).
-  const higherIsBetter = primaryMetric === "power_score";
+  // When a non-default basis is selected, power_score is not applicable because
+  // published power scores are strictly calibrated over the official measurement
+  // phases. Fall back to display_geomean_ms so rankings and summaries reflect
+  // the recomputed query timings under the active basis.
+  const effectivePrimaryMetric: ComparePrimaryMetric =
+    primaryMetric === "power_score" && !isDefaultBasis(basis)
+      ? "display_geomean_ms"
+      : (primaryMetric as ComparePrimaryMetric);
+
+  const higherIsBetter = effectivePrimaryMetric === "power_score";
 
   const primaries: (number | null)[] = resolvedResults.map((r) =>
-    primaryMetric === "power_score" ? r.power_score : r.display_geomean_ms,
+    effectivePrimaryMetric === "power_score" ? r.power_score : r.display_geomean_ms,
   );
   // Cohort-aware run identity labels for the decision summary headline +
   // winner card (finding #8). Using `formatRunIdentitiesForCohort` here means
@@ -545,7 +559,7 @@ export function Compare({ url }: CompareProps) {
     });
     return out;
   })();
-  const decisionSummary = buildCompareDecisionSummary(resolvedResults, primaryMetric, {
+  const decisionSummary = buildCompareDecisionSummary(resolvedResults, effectivePrimaryMetric, {
     suppressWinnerClaims: severeMismatchReason !== null,
     suppressionReason: severeMismatchReason ?? undefined,
     runLabels: summaryRunLabels,
@@ -722,7 +736,7 @@ export function Compare({ url }: CompareProps) {
       {rowCount > 0 && (
         <div class="mb-8">
           <ChartPanel
-            context={{ kind: "compare", results: resolvedResults, primaryMetric }}
+            context={{ kind: "compare", results: resolvedResults, primaryMetric: effectivePrimaryMetric }}
             baselineIndex={normalizedBaselineIndex}
             onBaselineIndexChange={setBaselineIndex}
             suppressWinnerClaims={decisionSummary.claimSuppressed}
@@ -785,17 +799,17 @@ export function Compare({ url }: CompareProps) {
               <dl class="space-y-1 text-sm">
                 <div class="flex justify-between">
                   <dt class="text-[var(--bb-data-fg-muted)]">
-                    {primaryMetric === "power_score" ? "Power score" : "Geomean query time"}
+                    {effectivePrimaryMetric === "power_score" ? "Power score" : "Geomean query time"}
                   </dt>
                   <dd class="font-mono font-medium">
-                    {primaryMetric === "power_score"
+                    {effectivePrimaryMetric === "power_score"
                       ? r.powerScore !== null
                         ? formatPowerScore(r.powerScore).valueText
                         : "-"
                       : fmtGeomean(r.displayGeomeanMs)}
                   </dd>
                 </div>
-                {primaryMetric === "power_score" && (
+                {effectivePrimaryMetric === "power_score" && (
                   <div class="flex justify-between">
                     <dt class="text-xs text-[var(--bb-data-fg-muted)]">Geomean</dt>
                     <dd class="font-mono text-xs text-[var(--bb-data-fg-muted)]">{fmtGeomean(r.displayGeomeanMs)}</dd>

--- a/results-explorer/src/pages/__tests__/Compare.test.tsx
+++ b/results-explorer/src/pages/__tests__/Compare.test.tsx
@@ -1068,7 +1068,7 @@ describe("Compare", () => {
     expect(summary).toHaveTextContent("DuckDB leads by 10.00x on power score.");
     expect(options).toEqual(["DuckDB", "SQLite", "PostgreSQL"]);
     expect(screen.getByRole("heading", { name: "Query-Level Diff" }).closest("section")).toHaveTextContent(
-      "Showing 4 of 4 queries.",
+      "Showing 2 of 2 queries.",
     );
 
     fireEvent.change(select, { target: { value: "2" } });

--- a/results-explorer/src/pages/__tests__/Compare.test.tsx
+++ b/results-explorer/src/pages/__tests__/Compare.test.tsx
@@ -827,6 +827,47 @@ describe("Compare", () => {
     expect(queryDiff).toHaveTextContent("Not comparable");
   });
 
+  it("suppresses multi-run standings when fewer than two queries are shared", async () => {
+    setupUrl(["r1", "r2", "r3"]);
+    const results = {
+      r1: makeResult({
+        result_id: "r1",
+        platform: "DuckDB",
+        display_timings: [
+          { query_id: "Q1", display_ms: 10, sample_count: 3, is_valid_display_timing: true, timing_exclusion_reason: null },
+          { query_id: "Q2", display_ms: 20, sample_count: 3, is_valid_display_timing: true, timing_exclusion_reason: null },
+        ],
+      }),
+      r2: makeResult({
+        result_id: "r2",
+        platform: "SQLite",
+        platform_id: "sqlite",
+        display_timings: [
+          { query_id: "Q1", display_ms: 20, sample_count: 3, is_valid_display_timing: true, timing_exclusion_reason: null },
+          { query_id: "Q3", display_ms: 30, sample_count: 3, is_valid_display_timing: true, timing_exclusion_reason: null },
+        ],
+      }),
+      r3: makeResult({
+        result_id: "r3",
+        platform: "PostgreSQL",
+        platform_id: "postgres",
+        display_timings: [
+          { query_id: "Q1", display_ms: 30, sample_count: 3, is_valid_display_timing: true, timing_exclusion_reason: null },
+          { query_id: "Q4", display_ms: 40, sample_count: 3, is_valid_display_timing: true, timing_exclusion_reason: null },
+        ],
+      }),
+    };
+    vi.mocked(getDetailResult).mockImplementation((id) => Promise.resolve(results[id as keyof typeof results]));
+
+    render(<Compare />);
+    await waitFor(() => expect(screen.getByRole("heading", { name: "Standings" })).toBeTruthy());
+
+    const standings = screen.getByRole("heading", { name: "Standings" }).closest("section");
+    expect(standings).toHaveTextContent("Standings are unavailable because");
+    expect(standings).toHaveTextContent("Selected runs do not share at least two valid query timings");
+    expect(standings?.querySelector("table")).toBeNull();
+  });
+
   it("links compare warning counts to the Comparability Receipt and names warning classes", async () => {
     vi.mocked(getDetailResult).mockImplementation((id) =>
       id === "r1"


### PR DESCRIPTION
## Summary

Addresses the release-blocking Compare review findings:

- **Basis resolution:** resolves the selected measurement basis into a comparison view model via `resolveResultsForBasis`. Changing pass or statistic now recomputes per-query timings and shared-query geomeans across headline cards, charts, heatmaps, standings, and tables.
- **Canonical query limiting:** selects one ordered query subset through `selectQueryIdsForLimiter` and applies the same Top 10 set to `ChartPanel`, `MultiRunHeatmap`, and `QueryDiffTable`. Per-query charts preserve the selected ranking order.
- **Filtered aggregate correctness:** recomputes chart geomeans from the filtered query set instead of retaining full-run aggregates.
- **Logical query counts:** reports distinct queries rather than multiplying the count by the number of candidate runs.
- **Missing evidence:** distinguishes a missing baseline timing from a missing candidate-run timing, preserving candidate evidence when a ratio cannot be calculated.
- **Standings:** uses tie-aware competition ranking, avoids transitive tie chaining, and marks runs without computable geomeans as unranked.
- **Accessibility:** replaces unsupported static ARIA grid semantics with an accessible semantic table.
- **Default-basis fidelity:** preserves published timing-exclusion reasons for the default measurement basis.

## Review disposition

The reported stale Percentile Ladder under alternate bases is not reachable in Compare. Compare summaries intentionally contain no persisted percentile statistics, so the chart capability is unavailable. A regression assertion now protects that behavior.

## Validation

- `npm run typecheck` passed.
- Full Results Explorer vitest suite passed: 89 files, 1,154 tests passed, 8 skipped.
- Focused ChartPanel, QueryDiffTable, and MultiRun layout suite passed: 72 tests.
- `make pr-preflight` passed at head `169f57724`: 28,538 passed, 19 skipped, 4 subtests passed.
- Artifact hygiene passed with no local datagen growth.

Auto-merge remains withheld pending final review and CI completion.
