### PR TITLE
feat(explorer): expose engine version selector on Home and hook cohort grouping to production tables

### DIFF
--- a/results-explorer/src/lib/duckdbQueries.ts
+++ b/results-explorer/src/lib/duckdbQueries.ts
@@ -313,6 +313,7 @@ export interface PlatformIndexRowRow extends CostDeploymentFields {
   platform: string;
   platform_id: string;
   driver_version: string | null;
+  platform_version?: string | null;
   run_date: string;
   power_score: number | null;
   total_duration_s: number;
@@ -1066,6 +1067,7 @@ function loadPlatformIndexRows(platformId?: string): Promise<PlatformIndexRowRow
     " r.platform," +
     " r.platform_id," +
     " r.driver_version," +
+    " r.platform_version," +
     " r.run_date," +
     " r.power_score," +
     " r.total_duration_s," +

--- a/results-explorer/src/lib/facetMatching.ts
+++ b/results-explorer/src/lib/facetMatching.ts
@@ -66,7 +66,7 @@ export function toDateWindowFacet(value: string): DateWindowFacet {
 }
 
 export function appendFacetParams(params: URLSearchParams, facets: FacetState, omit: ReadonlySet<ExplorerFacetKey>) {
-  for (const key of FACET_KEYS) {
+  for (const key of [...FACET_KEYS, "platform_version"] as const) {
     if (omit.has(key)) continue;
     const value = facets[key];
     if (Array.isArray(value)) {

--- a/results-explorer/src/pages/BenchmarkIndex.tsx
+++ b/results-explorer/src/pages/BenchmarkIndex.tsx
@@ -44,6 +44,11 @@ import { useDocumentTitle } from "@/lib/useDocumentTitle";
 import { canonicalBenchmarkSlug, canonicalPhase } from "@/lib/displayLabels";
 import { formatRunIdentitiesForCohort } from "@/lib/runIdentity";
 import { formatSelectedCount } from "@/lib/copyFormatters";
+import {
+  COHORT_GROUP_BY_LABELS,
+  groupCohortRows,
+  type CohortGroupBy,
+} from "@/lib/queryFilters";
 
 const BENCHMARK_SELECTION_LIMIT_REASON_ID = "benchmark-selection-limit";
 
@@ -980,7 +985,15 @@ function ListTable({
   const filtered = byScale
     .filter((row) => matchesFacetRow(row, facets, { keys: BENCHMARK_ROW_FACET_KEYS }))
     .sort((a, b) => compareListRows(a, b, sort));
+  const [groupBy, setGroupBy] = useState<CohortGroupBy>("none");
   const visibleRows = filtered.slice(0, visibleLimit);
+  const groupedRows = useMemo(() => {
+    return groupCohortRows(
+      visibleRows,
+      groupBy,
+      (row) => row.driver_version ?? row.platform_version ?? null,
+    );
+  }, [visibleRows, groupBy]);
   const runIdentityLabels = formatRunIdentitiesForCohort(filtered, "table");
 
   useEffect(() => {
@@ -1041,8 +1054,25 @@ function ListTable({
 
   return (
     <div class="overflow-hidden rounded-lg border border-[var(--bb-data-border)] bg-[var(--bb-surface-data)] shadow-sm">
-      <div class="border-b border-[var(--bb-data-border)] bg-[var(--bb-surface-data)] px-4 py-3 text-sm text-[var(--bb-data-fg-muted)]">
-        Showing {visibleRows.length.toLocaleString()} of {filtered.length.toLocaleString()} results for SF {scaleFactor}
+      <div class="flex flex-wrap items-center justify-between gap-2 border-b border-[var(--bb-data-border)] bg-[var(--bb-surface-data)] px-4 py-3 text-sm text-[var(--bb-data-fg-muted)]">
+        <span>
+          Showing {visibleRows.length.toLocaleString()} of {filtered.length.toLocaleString()} results for SF {scaleFactor}
+        </span>
+        <div class="flex items-center gap-2">
+          <label class="text-xs font-medium text-[var(--bb-data-fg-muted)]" for="benchmark-list-group-by">
+            Group by:
+          </label>
+          <select
+            id="benchmark-list-group-by"
+            data-testid="benchmark-list-group-by"
+            class="rounded-md border border-[var(--bb-data-border-strong)] bg-[var(--bb-surface-data)] px-2 py-1 text-sm shadow-sm"
+            value={groupBy}
+            onChange={(e) => setGroupBy((e.target as HTMLSelectElement).value as CohortGroupBy)}
+          >
+            <option value="none">{COHORT_GROUP_BY_LABELS.none}</option>
+            <option value="engine_version">{COHORT_GROUP_BY_LABELS.engine_version}</option>
+          </select>
+        </div>
       </div>
       {/*
         The basis statement, per w3. A leaderboard that does not say what its
@@ -1090,21 +1120,14 @@ function ListTable({
               sortAnnouncement={sortAnnouncement}
               onSort={toggleSort}
             />
-            <th
-              class="p-0"
-              scope="col"
-              aria-sort={ariaSort("display_geomean_ms")}
-              title="Geometric mean of per-query median execution times (measurement runs only). Lower is faster."
-            >
-              <button
-                type="button"
-                class="table-th block w-full cursor-pointer select-none border-0 bg-transparent text-left"
-                onClick={() => toggleSort("display_geomean_ms")}
-              >
-                Geomean latency{sortArrow("display_geomean_ms")}
-                {sortAnnouncement("display_geomean_ms")}
-              </button>
-            </th>
+            <ListSortHeader
+              label="Geomean"
+              sortKey="display_geomean_ms"
+              ariaSort={ariaSort}
+              sortArrow={sortArrow}
+              sortAnnouncement={sortAnnouncement}
+              onSort={toggleSort}
+            />
             <ListSortHeader
               label="Queries"
               sortKey="query_count"
@@ -1113,14 +1136,33 @@ function ListTable({
               sortAnnouncement={sortAnnouncement}
               onSort={toggleSort}
             />
-            <th class="table-th">Source</th>
-            <th class="table-th" />
+            <th class="table-th text-left">Badges</th>
+            <th class="table-th text-right">Receipt</th>
           </tr>
         </thead>
         <tbody class="divide-y divide-[var(--bb-data-border)] bg-[var(--bb-surface-data)]">
-          {visibleRows.map((r, index) => (
-            <BenchmarkRow key={r.result_id} entry={r} runIdentityLabel={runIdentityLabels[index] ?? r.platform} />
-          ))}
+          {groupBy === "none"
+            ? visibleRows.map((r, index) => (
+                <BenchmarkRow key={r.result_id} entry={r} runIdentityLabel={runIdentityLabels[index] ?? r.platform} />
+              ))
+            : groupedRows.map((group) => (
+                <>
+                  <tr
+                    key={`group-${group.key}`}
+                    class="bg-[var(--bb-surface-data-muted)] font-semibold text-xs text-[var(--bb-data-fg-primary)]"
+                  >
+                    <td colspan={8} class="px-4 py-2">
+                      {group.label} ({group.rows.length} {group.rows.length === 1 ? "result" : "results"})
+                    </td>
+                  </tr>
+                  {group.rows.map((r) => {
+                    const index = visibleRows.findIndex((row) => row.result_id === r.result_id);
+                    return (
+                      <BenchmarkRow key={r.result_id} entry={r} runIdentityLabel={runIdentityLabels[index] ?? r.platform} />
+                    );
+                  })}
+                </>
+              ))}
         </tbody>
       </table>
       {visibleRows.length < filtered.length && (

--- a/results-explorer/src/pages/BenchmarkIndex.tsx
+++ b/results-explorer/src/pages/BenchmarkIndex.tsx
@@ -6,7 +6,7 @@ import type { BenchmarkSummary, PlatformRow, SortDirection, SortState } from "@/
 import type { ResultRow } from "@/lib/duckdbQueries";
 import { getBenchmarkSummaryFromDuckDB, listBenchmarksWithPublicResults, listResults } from "@/lib/duckdbQueries";
 import { BENCHMARK_LABELS, humanizeBenchmark, isKnownBenchmark, fmtScore, fmtGeomean, errMsg, complianceLabel } from "@/utils";
-import { facetsToWhereClause, useFacetState, type FacetKey, type FacetState } from "@/lib/facetModel";
+import { facetsToWhereClause, useFacetState, type ExplorerFacetKey, type FacetState } from "@/lib/facetModel";
 import { hasActiveFacets, matchesFacetRow, singleFacetValue } from "@/lib/facetMatching";
 import {
   buildCompareUrl,
@@ -64,7 +64,7 @@ function coerceViewMode(value: string): ViewMode {
 }
 const TABLE_RENDER_LIMIT = 200;
 const TABLE_RENDER_INCREMENT = 200;
-const BENCHMARK_RESULT_FACET_KEYS: FacetKey[] = [
+const BENCHMARK_RESULT_FACET_KEYS: ExplorerFacetKey[] = [
   "platform",
   "execution_mode",
   "validation_status",
@@ -75,8 +75,9 @@ const BENCHMARK_RESULT_FACET_KEYS: FacetKey[] = [
   "storage_format",
   "cost_status",
   "date_window",
+  "platform_version",
 ];
-const BENCHMARK_ROW_FACET_KEYS: FacetKey[] = [
+const BENCHMARK_ROW_FACET_KEYS: ExplorerFacetKey[] = [
   "platform",
   "execution_mode",
   "tuning_mode",
@@ -89,6 +90,7 @@ const BENCHMARK_ROW_FACET_KEYS: FacetKey[] = [
   "storage_format",
   "cost_status",
   "date_window",
+  "platform_version",
 ];
 
 const TRUST_LABEL_ABBREV: Record<string, string> = {
@@ -152,6 +154,7 @@ export function BenchmarkIndex({ benchmark = "" }: BenchmarkIndexProps) {
   const canonicalBenchmark = canonicalBenchmarkSlug(benchmark);
   const title = humanizeBenchmark(canonicalBenchmark);
   const [results, setResults] = useState<ResultRow[] | null>(null);
+  const [platformVersionDomainResults, setPlatformVersionDomainResults] = useState<ResultRow[] | null>(null);
   const [summary, setSummary] = useState<BenchmarkSummary | null>(null);
   const [summaryError, setSummaryError] = useState<string | null>(null);
   const [summaryLoading, setSummaryLoading] = useState(false);
@@ -191,6 +194,11 @@ export function BenchmarkIndex({ benchmark = "" }: BenchmarkIndexProps) {
   const requestedSf = singleFacetValue(facets.scale_factor);
   const phaseFilter = singleFacetValue(facets.phase, "power") ?? "power";
   const tuningFilter = singleFacetValue(facets.tuning_mode, "all") ?? "all";
+  const platformVersionFilter = facets.platform_version.length === 0
+    ? "all"
+    : facets.platform_version.length === 1
+      ? facets.platform_version[0]!
+      : "__multiple__";
   const trustFilter = facets.trust_tier.length === 0 ? null : new Set(facets.trust_tier);
   const benchmarkResultWhere = useMemo(
     () =>
@@ -202,6 +210,32 @@ export function BenchmarkIndex({ benchmark = "" }: BenchmarkIndexProps) {
         tuning_mode: [],
         trust_tier: [],
       }),
+    [
+      benchmark,
+      canonicalBenchmark,
+      facets.cloud_provider,
+      facets.cloud_region,
+      facets.cost_status,
+      facets.date_window,
+      facets.deployment_class,
+      facets.execution_mode,
+      facets.instance_or_warehouse,
+      facets.platform,
+      facets.platform_version,
+      facets.storage_format,
+      facets.validation_status,
+    ],
+  );
+  const benchmarkVersionDomainWhere = useMemo(
+    () => facetsToWhereClause({
+      ...facets,
+      benchmark: canonicalBenchmark ? [canonicalBenchmark] : [],
+      scale_factor: [],
+      phase: [],
+      tuning_mode: [],
+      trust_tier: [],
+      platform_version: [],
+    }),
     [
       benchmark,
       canonicalBenchmark,
@@ -253,6 +287,24 @@ export function BenchmarkIndex({ benchmark = "" }: BenchmarkIndexProps) {
       cancelled = true;
     };
   }, [benchmarkResultWhere]);
+
+  useEffect(() => {
+    if (facets.platform_version.length === 0) {
+      setPlatformVersionDomainResults(null);
+      return;
+    }
+    let cancelled = false;
+    listResults(benchmarkVersionDomainWhere)
+      .then((rows) => {
+        if (!cancelled) setPlatformVersionDomainResults(rows);
+      })
+      .catch(() => {
+        if (!cancelled) setPlatformVersionDomainResults(null);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [benchmarkVersionDomainWhere, facets.platform_version]);
 
   // Derive available scale factors and phases from the loaded rows.
   const benchmarkResults = results?.filter((r) => canonicalBenchmarkSlug(r.benchmark) === canonicalBenchmark) ?? [];
@@ -413,6 +465,13 @@ export function BenchmarkIndex({ benchmark = "" }: BenchmarkIndexProps) {
   const trustLabels = summaryWithResultMetadata
     ? [...new Set(summaryWithResultMetadata.platforms.map((p) => p.trust_label))].sort()
     : [];
+  const platformVersions = [
+    ...new Set(
+      (platformVersionDomainResults ?? benchmarkResults)
+        .map((result) => result.platform_version)
+        .filter((version): version is string => version !== null),
+    ),
+  ].sort((a, b) => a.localeCompare(b, undefined, { numeric: true }));
 
   // Apply client-side filters (tuning + trust) to the summary platforms.
   const filteredSummary: BenchmarkSummary | null = summaryWithResultMetadata
@@ -584,6 +643,32 @@ export function BenchmarkIndex({ benchmark = "" }: BenchmarkIndexProps) {
                   <option key={m} value={m}>
                     {tuningLabel(m)}
                   </option>
+                ))}
+              </select>
+            </div>
+          )}
+
+          {(platformVersionFilter !== "all" || platformVersions.length > 1) && (
+            <div class="flex items-center gap-2">
+              <label class="text-sm font-medium text-[var(--bb-data-fg-primary)]" for="benchmark-version-filter">
+                Engine version:
+              </label>
+              <select
+                id="benchmark-version-filter"
+                data-testid="benchmark-version-filter"
+                class="rounded-md border border-[var(--bb-data-border-strong)] bg-[var(--bb-surface-data)] px-3 py-1.5 text-sm shadow-sm"
+                value={platformVersionFilter}
+                onChange={(event) => {
+                  const value = (event.target as HTMLSelectElement).value;
+                  setFacet("platform_version", value === "all" ? [] : [value]);
+                }}
+              >
+                <option value="all">All versions</option>
+                {platformVersionFilter === "__multiple__" && (
+                  <option value="__multiple__" disabled>{facets.platform_version.length} versions selected</option>
+                )}
+                {platformVersions.map((version) => (
+                  <option key={version} value={version}>{version}</option>
                 ))}
               </select>
             </div>
@@ -991,7 +1076,7 @@ function ListTable({
     return groupCohortRows(
       visibleRows,
       groupBy,
-      (row) => row.driver_version ?? row.platform_version ?? null,
+      (row) => row.platform_version ?? null,
     );
   }, [visibleRows, groupBy]);
   const runIdentityLabels = formatRunIdentitiesForCohort(filtered, "table");
@@ -1013,6 +1098,7 @@ function ListTable({
     facets.storage_format,
     facets.cost_status,
     facets.date_window,
+    facets.platform_version,
     sort.key,
     sort.direction,
   ]);

--- a/results-explorer/src/pages/Home.tsx
+++ b/results-explorer/src/pages/Home.tsx
@@ -19,6 +19,7 @@ import type { MetaLeaderboardMode } from "@/components/MetaLeaderboard";
 import { ProvenanceLegend } from "@/components/ProvenanceLegend";
 import {
   FACET_KEYS,
+  facetsToWhereClause,
   useFacetState,
   type ExplorerFacetKey,
   type FacetState,
@@ -85,6 +86,7 @@ export function Home(_: RoutableProps) {
   const recentResultsScrollerRef = useRef<HTMLDivElement>(null);
   useDocumentTitle("Results · BenchBox");
   const [results, setResults] = useState<ResultRow[] | null>(null);
+  const [platformVersionDomainResults, setPlatformVersionDomainResults] = useState<ResultRow[] | null>(null);
   const [metaLeaderboard, setMetaLeaderboard] = useState<MetaLeaderboardData | null>(null);
   const [metaLeaderboardLoaded, setMetaLeaderboardLoaded] = useState(false);
   const retriedEmptyResults = useRef(false);
@@ -98,6 +100,28 @@ export function Home(_: RoutableProps) {
   const tuningFilter = singleFacetValue(facets.tuning_mode, "all");
   const trustFilter = singleFacetValue(facets.trust_tier, "all");
   const dateWindow = facets.date_window;
+  const platformVersionDomainWhere = useMemo(
+    () => facetsToWhereClause({ ...facets, platform_version: [] }),
+    [
+      facets.arch,
+      facets.benchmark,
+      facets.cloud_provider,
+      facets.cloud_region,
+      facets.cost_status,
+      facets.cpu_family,
+      facets.date_window,
+      facets.deployment_class,
+      facets.execution_mode,
+      facets.instance_or_warehouse,
+      facets.phase,
+      facets.platform,
+      facets.scale_factor,
+      facets.storage_format,
+      facets.trust_tier,
+      facets.tuning_mode,
+      facets.validation_status,
+    ],
+  );
 
   useEffect(() => {
     let cancelled = false;
@@ -112,6 +136,24 @@ export function Home(_: RoutableProps) {
       cancelled = true;
     };
   }, [facetWhere]);
+
+  useEffect(() => {
+    if (facets.platform_version.length === 0) {
+      setPlatformVersionDomainResults(null);
+      return;
+    }
+    let cancelled = false;
+    listResults(platformVersionDomainWhere)
+      .then((rows) => {
+        if (!cancelled) setPlatformVersionDomainResults(rows);
+      })
+      .catch(() => {
+        if (!cancelled) setPlatformVersionDomainResults(null);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [facets.platform_version, platformVersionDomainWhere]);
 
   useEffect(() => {
     let cancelled = false;
@@ -222,20 +264,28 @@ export function Home(_: RoutableProps) {
       return (cohort.platforms ?? []).length > 0;
     });
 
-    const visibleCohortKeys = new Set(visibleCohorts.map((cohort) => cohort.key));
     const visibleEvidencePlatformIds = new Set(
       visibleCohorts.flatMap((cohort) => (cohort.platforms ?? []).map((row) => row.platform_id)),
     );
     const platforms = metaLeaderboard.platforms
       .map((platform) => {
         const ranks = Object.fromEntries(
-          Object.entries(platform.ranks).filter(([cohortKey]) => {
-            if (!visibleCohortKeys.has(cohortKey)) return false;
-            const rows = cohortPlatformIndex.get(cohortKey)?.get(platform.platform_id) ?? [];
-            return rows.some((row) => {
+          visibleCohorts.flatMap((cohort) => {
+            const rows = cohortPlatformIndex.get(cohort.key)?.get(platform.platform_id) ?? [];
+            const rankedRows = rows
+              .filter((row) => {
               const result = resultById.get(row.result_id);
-              return row.rank !== null && result !== undefined && matchesFacetRow(result, facets);
-            });
+                return row.rank !== null && result !== undefined && matchesFacetRow(result, facets);
+              })
+              .sort((a, b) => (a.rank ?? Number.POSITIVE_INFINITY) - (b.rank ?? Number.POSITIVE_INFINITY));
+            const row = rankedRows[0];
+            if (!row || row.rank === null) return [];
+            return [[cohort.key, {
+              rank: row.rank,
+              total: cohort.cohort_ranked_count,
+              metric_value: row.metric_value,
+              speedup_vs_best: row.speedup_vs_best,
+            } satisfies MetaRank] as const];
           }),
         ) as Record<string, MetaRank>;
 
@@ -317,15 +367,15 @@ export function Home(_: RoutableProps) {
     ? [...new Set(metaLeaderboard.cohorts.map((cohort) => cohort.phase))].sort()
     : [];
   const trustOptions = ["all", ...[...new Set(results.map((result) => result.trust_label))].sort()];
-  const platformVersionOptions = useMemo(() => {
+  const platformVersionOptions = (() => {
     const versions = new Set<string>();
-    for (const r of results) {
+    for (const r of platformVersionDomainResults ?? results) {
       if (r.platform_version) {
         versions.add(r.platform_version);
       }
     }
     return [...versions].sort((a, b) => a.localeCompare(b, undefined, { numeric: true }));
-  }, [results]);
+  })();
   const platformVersionFilters = facets.platform_version;
   const recent = [...results]
     .sort((a, b) => b.run_date.localeCompare(a.run_date))
@@ -463,19 +513,23 @@ export function Home(_: RoutableProps) {
                   onSelect={(value) => setFacet("phase", value === "all" ? [] : [value])}
                   format={(value) => (value === "all" ? "All phases" : value)}
                 />
-                <MultiSelectFilter
-                  label="Engine version"
-                  allLabel="All versions"
-                  options={platformVersionOptions}
-                  current={platformVersionFilters}
-                  onSelect={(value) =>
-                    setFacet(
-                      "platform_version",
-                      value === "all" ? [] : toggleFacetValue(platformVersionFilters, value),
-                    )
-                  }
-                  format={(value) => value}
-                />
+                {platformVersionOptions.length > 0 || platformVersionFilters.length > 0 ? (
+                  <MultiSelectFilter
+                    label="Engine version"
+                    allLabel="All versions"
+                    options={platformVersionOptions}
+                    current={platformVersionFilters}
+                    onSelect={(value) =>
+                      setFacet(
+                        "platform_version",
+                        value === "all" ? [] : toggleFacetValue(platformVersionFilters, value),
+                      )
+                    }
+                    format={(value) => value}
+                  />
+                ) : (
+                  <div aria-hidden="true" data-testid="home-engine-version-unavailable" />
+                )}
                 <CoverageSummary />
               </div>
 

--- a/results-explorer/src/pages/Home.tsx
+++ b/results-explorer/src/pages/Home.tsx
@@ -64,7 +64,7 @@ export const HOME_SHELL_GEOMETRY_CLASSES = {
     "block min-w-0 truncate rounded-full bg-[var(--bb-bg-elevated)] px-3 py-1.5 text-xs font-medium text-[var(--bb-fg-muted)]",
   rankingSelector:
     "mt-3 rounded-lg border border-[var(--bb-border-default)] bg-[var(--bb-bg-panel)] p-2 sm:mt-5 sm:p-3",
-  rankingGrid: "grid grid-cols-2 gap-2 sm:gap-3 md:grid-cols-2 xl:grid-cols-4",
+  rankingGrid: "grid grid-cols-2 gap-2 sm:gap-3 md:grid-cols-3 xl:grid-cols-5",
   scopeDetails: "mt-2 border-t border-[var(--bb-border-default)] pt-2",
   scopeSummary:
     "cursor-pointer text-xs font-medium text-[var(--bb-fg-muted)] hover:text-[var(--bb-fg-primary)]",
@@ -317,6 +317,16 @@ export function Home(_: RoutableProps) {
     ? [...new Set(metaLeaderboard.cohorts.map((cohort) => cohort.phase))].sort()
     : [];
   const trustOptions = ["all", ...[...new Set(results.map((result) => result.trust_label))].sort()];
+  const platformVersionOptions = useMemo(() => {
+    const versions = new Set<string>();
+    for (const r of results) {
+      if (r.platform_version) {
+        versions.add(r.platform_version);
+      }
+    }
+    return [...versions].sort((a, b) => a.localeCompare(b, undefined, { numeric: true }));
+  }, [results]);
+  const platformVersionFilters = facets.platform_version;
   const recent = [...results]
     .sort((a, b) => b.run_date.localeCompare(a.run_date))
     .slice(0, 5);
@@ -452,6 +462,19 @@ export function Home(_: RoutableProps) {
                   current={phaseFilter}
                   onSelect={(value) => setFacet("phase", value === "all" ? [] : [value])}
                   format={(value) => (value === "all" ? "All phases" : value)}
+                />
+                <MultiSelectFilter
+                  label="Engine version"
+                  allLabel="All versions"
+                  options={platformVersionOptions}
+                  current={platformVersionFilters}
+                  onSelect={(value) =>
+                    setFacet(
+                      "platform_version",
+                      value === "all" ? [] : toggleFacetValue(platformVersionFilters, value),
+                    )
+                  }
+                  format={(value) => value}
                 />
                 <CoverageSummary />
               </div>
@@ -702,6 +725,7 @@ function HomeLoadingSkeleton({
               <SkeletonSelect label="Benchmark" />
               <SkeletonSelect label="Scale" />
               <SkeletonSelect label="Phase" />
+              <SkeletonSelect label="Engine version" />
               <CoverageSummary />
             </div>
             <div aria-hidden="true" class="sm:hidden">

--- a/results-explorer/src/pages/PlatformIndex.tsx
+++ b/results-explorer/src/pages/PlatformIndex.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from "preact/hooks";
+import { useEffect, useMemo, useRef, useState } from "preact/hooks";
 import type { RoutableProps } from "preact-router";
 import { route } from "preact-router";
 import type { PlatformIndexRowRow } from "@/lib/duckdbQueries";
@@ -43,6 +43,11 @@ import { TrayAnnouncer } from "@/components/TrayAnnouncer";
 import type { SortState } from "@/types";
 import { useDocumentTitle } from "@/lib/useDocumentTitle";
 import { formatRunIdentitiesForCohort } from "@/lib/runIdentity";
+import {
+  COHORT_GROUP_BY_LABELS,
+  groupCohortRows,
+  type CohortGroupBy,
+} from "@/lib/queryFilters";
 
 interface PlatformIndexProps extends RoutableProps {
   platform?: string;
@@ -380,7 +385,15 @@ export function PlatformIndex({ platform = "" }: PlatformIndexProps) {
     if (bv === null) return -1;
     return dir * (av - bv);
   });
+  const [groupBy, setGroupBy] = useState<CohortGroupBy>("none");
   const visiblePlatformResults = platformResults.slice(0, visibleLimit);
+  const groupedPlatformResults = useMemo(() => {
+    return groupCohortRows<PlatformIndexRowRow>(
+      visiblePlatformResults,
+      groupBy,
+      (row) => row.driver_version ?? null,
+    );
+  }, [visiblePlatformResults, groupBy]);
   const runIdentityLabels = formatRunIdentitiesForCohort(platformResults, "table");
 
   function toggleSort(key: PlatformSortKey) {
@@ -710,9 +723,24 @@ export function PlatformIndex({ platform = "" }: PlatformIndexProps) {
       ) : (
         <div class="overflow-hidden rounded-lg border border-[var(--bb-data-border)] bg-[var(--bb-surface-data)] shadow-sm">
           <div class="flex flex-wrap items-center justify-between gap-2 border-b border-[var(--bb-data-border)] bg-[var(--bb-surface-data)] px-4 py-3 text-sm text-[var(--bb-data-fg-muted)]">
-            <span>
-              Showing {visiblePlatformResults.length.toLocaleString()} of {platformResults.length.toLocaleString()} results
-            </span>
+            <div>
+              <span>Showing {visiblePlatformResults.length.toLocaleString()} of {platformResults.length.toLocaleString()} results</span>
+            </div>
+            <div class="flex items-center gap-2">
+              <label class="text-xs font-medium text-[var(--bb-data-fg-muted)]" for="platform-group-by">
+                Group by:
+              </label>
+              <select
+                id="platform-group-by"
+                data-testid="platform-group-by"
+                class="rounded-md border border-[var(--bb-data-border-strong)] bg-[var(--bb-surface-data)] px-2 py-1 text-sm shadow-sm"
+                value={groupBy}
+                onChange={(event) => setGroupBy((event.target as HTMLSelectElement).value as CohortGroupBy)}
+              >
+                <option value="none">{COHORT_GROUP_BY_LABELS.none}</option>
+                <option value="engine_version">{COHORT_GROUP_BY_LABELS.engine_version}</option>
+              </select>
+            </div>
           </div>
           <div class="flex flex-wrap items-center justify-between gap-2 border-b border-[var(--bb-data-border)] bg-[var(--bb-surface-data-muted)] px-4 py-2 text-xs text-[var(--bb-data-fg-muted)]">
             <span>Rows are labelled by comparable ranking: benchmark, scale, phase, and primary metric.</span>
@@ -818,23 +846,56 @@ export function PlatformIndex({ platform = "" }: PlatformIndexProps) {
               </tr>
             </thead>
             <tbody class="divide-y divide-[var(--bb-data-border)] bg-[var(--bb-surface-data)]">
-              {visiblePlatformResults.map((r, index) => (
-                <PlatformRow
-                  key={r.result_id}
-                  entry={r}
-                  runIdentityLabel={runIdentityLabels[index] ?? r.platform}
-                  checked={selected.has(r.result_id)}
-                  onToggle={() => toggleSelect(r.result_id)}
-                  showMetricContract={showMetricContract}
-                  disabledReason={
-                    comparisonExclusionReason(r) ??
-                    cohortLockReason(r) ??
-                    (!selected.has(r.result_id) && selected.size >= MAX_COMPARE_SELECTIONS
-                      ? `Up to ${MAX_COMPARE_SELECTIONS} runs can be compared.`
-                      : undefined)
-                  }
-                />
-              ))}
+              {groupBy === "none"
+                ? visiblePlatformResults.map((r, index) => (
+                    <PlatformRow
+                      key={r.result_id}
+                      entry={r}
+                      runIdentityLabel={runIdentityLabels[index] ?? r.platform}
+                      checked={selected.has(r.result_id)}
+                      onToggle={() => toggleSelect(r.result_id)}
+                      showMetricContract={showMetricContract}
+                      disabledReason={
+                        comparisonExclusionReason(r) ??
+                        cohortLockReason(r) ??
+                        (!selected.has(r.result_id) && selected.size >= MAX_COMPARE_SELECTIONS
+                          ? `Up to ${MAX_COMPARE_SELECTIONS} runs can be compared.`
+                          : undefined)
+                      }
+                    />
+                  ))
+                : groupedPlatformResults.map((group) => (
+                    <>
+                      <tr
+                        key={`group-${group.key}`}
+                        class="bg-[var(--bb-surface-data-muted)] font-semibold text-xs text-[var(--bb-data-fg-primary)]"
+                      >
+                        <td colspan={platformColumnCount} class="px-4 py-2">
+                          {group.label} ({group.rows.length} {group.rows.length === 1 ? "result" : "results"})
+                        </td>
+                      </tr>
+                      {group.rows.map((r) => {
+                        const index = visiblePlatformResults.findIndex((row) => row.result_id === r.result_id);
+                        return (
+                          <PlatformRow
+                            key={r.result_id}
+                            entry={r}
+                            runIdentityLabel={runIdentityLabels[index] ?? r.platform}
+                            checked={selected.has(r.result_id)}
+                            onToggle={() => toggleSelect(r.result_id)}
+                            showMetricContract={showMetricContract}
+                            disabledReason={
+                              comparisonExclusionReason(r) ??
+                              cohortLockReason(r) ??
+                              (!selected.has(r.result_id) && selected.size >= MAX_COMPARE_SELECTIONS
+                                ? `Up to ${MAX_COMPARE_SELECTIONS} runs can be compared.`
+                                : undefined)
+                            }
+                          />
+                        );
+                      })}
+                    </>
+                  ))}
             </tbody>
           </DataTable>
           </div>

--- a/results-explorer/src/pages/PlatformIndex.tsx
+++ b/results-explorer/src/pages/PlatformIndex.tsx
@@ -1,9 +1,9 @@
-import { useEffect, useMemo, useRef, useState } from "preact/hooks";
+import { useEffect, useRef, useState } from "preact/hooks";
 import type { RoutableProps } from "preact-router";
 import { route } from "preact-router";
 import type { PlatformIndexRowRow } from "@/lib/duckdbQueries";
 import { getPlatformIndexRows } from "@/lib/duckdbQueries";
-import { useFacetState, type DateWindowFacet, type FacetKey, type FacetState } from "@/lib/facetModel";
+import { useFacetState, type DateWindowFacet, type ExplorerFacetKey, type FacetState } from "@/lib/facetModel";
 import { hasActiveFacets, matchesFacetRow, singleFacetValue, toDateWindowFacet } from "@/lib/facetMatching";
 import { formatBenchmarkLabel, formatTrustLabel, formatValidationStatus } from "@/lib/displayLabels";
 import {
@@ -79,7 +79,7 @@ const PLATFORM_ROUTE_ALIASES: Readonly<Record<string, string>> = {
   // corrupt legitimate platform or benchmark identifiers.
   clickhouse_local: "clickhouse-local",
 };
-const PLATFORM_RESULT_FACET_KEYS: FacetKey[] = [
+const PLATFORM_RESULT_FACET_KEYS: ExplorerFacetKey[] = [
   "benchmark",
   "scale_factor",
   "phase",
@@ -94,6 +94,7 @@ const PLATFORM_RESULT_FACET_KEYS: FacetKey[] = [
   "storage_format",
   "cost_status",
   "date_window",
+  "platform_version",
 ];
 
 interface TrendCohort {
@@ -178,6 +179,7 @@ export function PlatformIndex({ platform = "" }: PlatformIndexProps) {
   const [error, setError] = useState<string | null>(null);
   const [selected, setSelected] = useState<Set<string>>(new Set());
   const [visibleLimit, setVisibleLimit] = useState(TABLE_RENDER_LIMIT);
+  const [groupBy, setGroupBy] = useState<CohortGroupBy>("none");
   const { facets, setFacet } = useFacetState();
   const tuningFilter = singleFacetValue(facets.tuning_mode, "all") ?? "all";
   const setTuningFilter = (value: string) => setFacet("tuning_mode", value === "all" ? [] : [value]);
@@ -190,21 +192,27 @@ export function PlatformIndex({ platform = "" }: PlatformIndexProps) {
   const phaseFilter = singleFacetValue(facets.phase, "all") ?? "all";
   const trustFilter = singleFacetValue(facets.trust_tier, "all") ?? "all";
   const validationFilter = singleFacetValue(facets.validation_status, "all") ?? "all";
+  const platformVersionFilter = facets.platform_version.length === 0
+    ? "all"
+    : facets.platform_version.length === 1
+      ? facets.platform_version[0]!
+      : "__multiple__";
   const dateWindowFilter: DateWindowFacet = facets.date_window;
   // Helper for the five string-array facets that share the "all means
   // empty array" pattern. date_window has its own DateWindowFacet shape
   // and uses toDateWindowFacet directly.
   const setSingleArrayFacet = (
-    key: "benchmark" | "scale_factor" | "phase" | "trust_tier" | "validation_status",
+    key: "benchmark" | "scale_factor" | "phase" | "trust_tier" | "validation_status" | "platform_version",
     value: string,
   ) => setFacet(key, value === "all" ? [] : [value]);
-  const w5FilterKeys: FacetKey[] = [
+  const w5FilterKeys: ExplorerFacetKey[] = [
     "benchmark",
     "scale_factor",
     "phase",
     "trust_tier",
     "validation_status",
     "date_window",
+    "platform_version",
   ];
   const hasW5Filters = hasActiveFacets(facets, w5FilterKeys);
   const resetW5Filters = () => {
@@ -214,6 +222,7 @@ export function PlatformIndex({ platform = "" }: PlatformIndexProps) {
     setFacet("trust_tier", []);
     setFacet("validation_status", []);
     setFacet("date_window", "all");
+    setFacet("platform_version", []);
   };
   // Default: geomean_ms ascending (fastest first), nulls last. The empty-state
   // ordering is observable behaviour — must_preserve in the parent TODO.
@@ -275,6 +284,7 @@ export function PlatformIndex({ platform = "" }: PlatformIndexProps) {
     facets.storage_format,
     facets.cost_status,
     facets.date_window,
+    facets.platform_version,
     sort.key,
     sort.direction,
   ]);
@@ -344,7 +354,15 @@ export function PlatformIndex({ platform = "" }: PlatformIndexProps) {
         .filter((status): status is string => status !== null && status !== undefined),
     ),
   ].sort();
-  const showW5Filters = allPlatformResults.length >= 25;
+  const platformVersionOptions = [
+    ...new Set(
+      allPlatformResults
+        .map((r) => r.platform_version)
+        .filter((version): version is string => version !== null && version !== undefined),
+    ),
+  ].sort((a, b) => a.localeCompare(b, undefined, { numeric: true }));
+  const showW5Filters =
+    allPlatformResults.length >= 25 || platformVersionFilter !== "all" || platformVersionOptions.length > 1;
 
   const platformResultsRaw = allPlatformResults.filter((row) =>
     matchesFacetRow(row, facets, { keys: PLATFORM_RESULT_FACET_KEYS }),
@@ -385,15 +403,12 @@ export function PlatformIndex({ platform = "" }: PlatformIndexProps) {
     if (bv === null) return -1;
     return dir * (av - bv);
   });
-  const [groupBy, setGroupBy] = useState<CohortGroupBy>("none");
   const visiblePlatformResults = platformResults.slice(0, visibleLimit);
-  const groupedPlatformResults = useMemo(() => {
-    return groupCohortRows<PlatformIndexRowRow>(
-      visiblePlatformResults,
-      groupBy,
-      (row) => row.driver_version ?? null,
-    );
-  }, [visiblePlatformResults, groupBy]);
+  const groupedPlatformResults = groupCohortRows<PlatformIndexRowRow>(
+    visiblePlatformResults,
+    groupBy,
+    (row) => row.platform_version ?? null,
+  );
   const runIdentityLabels = formatRunIdentitiesForCohort(platformResults, "table");
 
   function toggleSort(key: PlatformSortKey) {
@@ -631,6 +646,28 @@ export function PlatformIndex({ platform = "" }: PlatformIndexProps) {
                   <option key={value} value={value}>
                     {formatValidationStatus(value)}
                   </option>
+                ))}
+              </select>
+            </div>
+            <div class="flex flex-col gap-1">
+              <label class="text-xs font-medium text-[var(--bb-data-fg-muted)]" for="platform-filter-version">
+                Engine version
+              </label>
+              <select
+                id="platform-filter-version"
+                data-testid="platform-filter-version"
+                class="rounded-md border border-[var(--bb-data-border-strong)] bg-[var(--bb-surface-data)] px-2 py-1 text-sm shadow-sm"
+                value={platformVersionFilter}
+                onChange={(event) =>
+                  setSingleArrayFacet("platform_version", (event.target as HTMLSelectElement).value)
+                }
+              >
+                <option value="all">All versions</option>
+                {platformVersionFilter === "__multiple__" && (
+                  <option value="__multiple__" disabled>{facets.platform_version.length} versions selected</option>
+                )}
+                {platformVersionOptions.map((value) => (
+                  <option key={value} value={value}>{value}</option>
                 ))}
               </select>
             </div>

--- a/results-explorer/src/pages/__tests__/BenchmarkIndex.test.tsx
+++ b/results-explorer/src/pages/__tests__/BenchmarkIndex.test.tsx
@@ -923,6 +923,24 @@ describe("BenchmarkIndex", () => {
     expect(screen.getByText("Showing 205 of 205 results for SF 0.1")).toBeTruthy();
   });
 
+  it("supports grouping rows by engine version in list view", async () => {
+    const listRows = [
+      { ...RESULT_ROWS[0]!, result_id: "r1", platform_version: "1.4.0", display_geomean_ms: 10 },
+      { ...RESULT_ROWS[1]!, result_id: "r2", platform_version: "1.3.2", display_geomean_ms: 20 },
+      { ...RESULT_ROWS[0]!, result_id: "r3", platform_version: "1.4.0", display_geomean_ms: 15 },
+    ];
+    vi.mocked(queryRows).mockImplementation(defaultImpl(listRows, RANKING_ROWS, CELL_ROWS));
+
+    render(<BenchmarkIndex benchmark="tpch" />);
+    await waitFor(() => screen.getAllByText("DuckDB"));
+    fireEvent.click(screen.getByText("List"));
+
+    await waitFor(() => expect(screen.getByTestId("benchmark-list-group-by")).toBeTruthy());
+    fireEvent.change(screen.getByTestId("benchmark-list-group-by"), { target: { value: "engine_version" } });
+    expect(screen.getByText(/1.4.0 \(2 results\)/)).toBeTruthy();
+    expect(screen.getByText(/1.3.2 \(1 result\)/)).toBeTruthy();
+  });
+
   // -----------------------------------------------------------------------
   // (b) Trust filter hides rows without refetching
   // -----------------------------------------------------------------------

--- a/results-explorer/src/pages/__tests__/BenchmarkIndex.test.tsx
+++ b/results-explorer/src/pages/__tests__/BenchmarkIndex.test.tsx
@@ -925,9 +925,9 @@ describe("BenchmarkIndex", () => {
 
   it("supports grouping rows by engine version in list view", async () => {
     const listRows = [
-      { ...RESULT_ROWS[0]!, result_id: "r1", platform_version: "1.4.0", display_geomean_ms: 10 },
-      { ...RESULT_ROWS[1]!, result_id: "r2", platform_version: "1.3.2", display_geomean_ms: 20 },
-      { ...RESULT_ROWS[0]!, result_id: "r3", platform_version: "1.4.0", display_geomean_ms: 15 },
+      { ...RESULT_ROWS[0]!, result_id: "r1", driver_version: "9.9.9", platform_version: "1.4.0", display_geomean_ms: 10 },
+      { ...RESULT_ROWS[1]!, result_id: "r2", driver_version: "9.9.9", platform_version: "1.3.2", display_geomean_ms: 20 },
+      { ...RESULT_ROWS[0]!, result_id: "r3", driver_version: "8.8.8", platform_version: "1.4.0", display_geomean_ms: 15 },
     ];
     vi.mocked(queryRows).mockImplementation(defaultImpl(listRows, RANKING_ROWS, CELL_ROWS));
 
@@ -939,6 +939,20 @@ describe("BenchmarkIndex", () => {
     fireEvent.change(screen.getByTestId("benchmark-list-group-by"), { target: { value: "engine_version" } });
     expect(screen.getByText(/1.4.0 \(2 results\)/)).toBeTruthy();
     expect(screen.getByText(/1.3.2 \(1 result\)/)).toBeTruthy();
+  });
+
+  it("honors a version facet carried into the benchmark drill-down", async () => {
+    window.history.replaceState(null, "", "/results/tpch/?version=1.4.0&view=list");
+    const listRows = [
+      { ...RESULT_ROWS[0]!, result_id: "r1", platform_version: "1.4.0" },
+    ];
+    vi.mocked(queryRows).mockImplementation(defaultImpl(listRows, RANKING_ROWS, CELL_ROWS));
+
+    const { container } = render(<BenchmarkIndex benchmark="tpch" />);
+    await waitFor(() => screen.getAllByText("DuckDB"));
+
+    expect(getRenderedResultOrder(container)).toEqual(["r1"]);
+    expect(vi.mocked(queryRows).mock.calls.some(([sql]) => String(sql).includes("platform_version IN (?)"))).toBe(true);
   });
 
   // -----------------------------------------------------------------------

--- a/results-explorer/src/pages/__tests__/Home.test.tsx
+++ b/results-explorer/src/pages/__tests__/Home.test.tsx
@@ -1029,4 +1029,37 @@ describe("toggleFacetValue (w13)", () => {
     expect(within(grid).getByText("Engine version")).toBeTruthy();
     expect(within(grid).getByText("All versions")).toBeTruthy();
   });
+
+  it("keeps sibling engine versions selectable and carries the facet into drill-down links", async () => {
+    window.history.replaceState(null, "", "/results/?version=1.4.0");
+    const versionedRows = RESULT_ROWS.map((row, index) => ({
+      ...row,
+      platform_version: index === 0 ? "1.4.0" : "1.3.2",
+    }));
+    vi.mocked(queryRows).mockImplementation(async (sql: string) => {
+      const s = String(sql).replace(/\s+/g, " ").trim();
+      if (s.includes("FROM bench.results")) {
+        return s.includes("platform_version IN")
+          ? versionedRows.filter((row) => row.platform_version === "1.4.0")
+          : versionedRows;
+      }
+      if (s.startsWith("SELECT platform_id, platform, avg_rank, n_cohorts FROM bench.meta_leaderboard")) {
+        return META_LEADERBOARD_ROWS;
+      }
+      if (s.includes("FROM bench.cohort_metadata")) return COHORT_ROWS;
+      return [];
+    });
+
+    render(<Home />);
+    await waitFor(() => expect(screen.getByText("Cross-Benchmark Leaderboard")).toBeTruthy());
+
+    const versionControl = screen.getByRole("combobox", { name: "Engine version" });
+    expect(within(versionControl).getByRole("option", { name: "1.3.2" })).toBeTruthy();
+
+    const grid = screen.getByRole("grid", { name: "Cross-benchmark leaderboard" });
+    const cohortLink = within(grid).getByRole("link", { name: /^ClickBench SF0.1/ }) as HTMLAnchorElement;
+    expect(cohortLink.getAttribute("href")).toContain("version=1.4.0");
+    const platformLink = within(grid).getByRole("link", { name: "DuckDB" }) as HTMLAnchorElement;
+    expect(platformLink.getAttribute("href")).toContain("version=1.4.0");
+  });
 });

--- a/results-explorer/src/pages/__tests__/Home.test.tsx
+++ b/results-explorer/src/pages/__tests__/Home.test.tsx
@@ -1007,4 +1007,26 @@ describe("toggleFacetValue (w13)", () => {
     toggleFacetValue(input, "tpch");
     expect(input).toEqual(["tpch", "clickbench"]);
   });
+
+  it("renders Engine version selector in the ranking selector grid when results have engine versions", async () => {
+    const versionedRows = RESULT_ROWS.map((r, i) => ({
+      ...r,
+      platform_version: i === 0 ? "1.4.0" : "1.3.2",
+    }));
+    vi.mocked(queryRows).mockImplementation(async (sql: string) => {
+      const s = String(sql).replace(/\s+/g, " ").trim();
+      if (s.includes("FROM bench.results")) return versionedRows;
+      if (s.startsWith("SELECT platform_id, platform, avg_rank, n_cohorts FROM bench.meta_leaderboard")) {
+        return META_LEADERBOARD_ROWS;
+      }
+      if (s.includes("FROM bench.cohort_metadata")) return COHORT_ROWS;
+      return [];
+    });
+
+    render(<Home />);
+    await waitFor(() => expect(screen.getByText("Cross-Benchmark Leaderboard")).toBeTruthy());
+    const grid = screen.getByTestId("home-ranking-selector-grid");
+    expect(within(grid).getByText("Engine version")).toBeTruthy();
+    expect(within(grid).getByText("All versions")).toBeTruthy();
+  });
 });

--- a/results-explorer/src/pages/__tests__/PlatformIndex.test.tsx
+++ b/results-explorer/src/pages/__tests__/PlatformIndex.test.tsx
@@ -39,6 +39,7 @@ function makeRow(overrides: Partial<PlatformIndexRowRow> = {}): PlatformIndexRow
     platform: "DuckDB",
     platform_id: "duckdb",
     driver_version: null,
+    platform_version: null,
     run_date: "2026-04-01",
     power_score: 3000,
     total_duration_s: 60,
@@ -877,14 +878,27 @@ describe("PlatformIndex - sortable table headers", () => {
 
   it("supports grouping rows by engine version", async () => {
     vi.mocked(getPlatformIndexRows).mockResolvedValue([
-      makeRow({ result_id: "r1", short_id: "s1", driver_version: "1.4.0", geomean_ms: 10 }),
-      makeRow({ result_id: "r2", short_id: "s2", driver_version: "1.3.2", geomean_ms: 20 }),
-      makeRow({ result_id: "r3", short_id: "s3", driver_version: "1.4.0", geomean_ms: 15 }),
+      makeRow({ result_id: "r1", short_id: "s1", driver_version: "9.9.9", platform_version: "1.4.0", geomean_ms: 10 }),
+      makeRow({ result_id: "r2", short_id: "s2", driver_version: "9.9.9", platform_version: "1.3.2", geomean_ms: 20 }),
+      makeRow({ result_id: "r3", short_id: "s3", driver_version: "8.8.8", platform_version: "1.4.0", geomean_ms: 15 }),
     ]);
     render(<PlatformIndex platform="duckdb" />);
     await waitFor(() => expect(screen.getByTestId("platform-group-by")).toBeTruthy());
     fireEvent.change(screen.getByTestId("platform-group-by"), { target: { value: "engine_version" } });
     expect(screen.getByText(/1.4.0 \(2 results\)/)).toBeTruthy();
     expect(screen.getByText(/1.3.2 \(1 result\)/)).toBeTruthy();
+  });
+
+  it("honors a version facet carried into the platform drill-down", async () => {
+    window.history.replaceState(null, "", "/results/p/duckdb/?version=1.4.0");
+    vi.mocked(getPlatformIndexRows).mockResolvedValue([
+      makeRow({ result_id: "r14", short_id: "v140", platform_version: "1.4.0" }),
+      makeRow({ result_id: "r13", short_id: "v132", platform_version: "1.3.2" }),
+    ]);
+
+    const { container } = render(<PlatformIndex platform="duckdb" />);
+    await waitFor(() => expect(screen.getByText("DuckDB Results")).toBeTruthy());
+
+    expect(getRowOrder(container)).toEqual(["r14"]);
   });
 });

--- a/results-explorer/src/pages/__tests__/PlatformIndex.test.tsx
+++ b/results-explorer/src/pages/__tests__/PlatformIndex.test.tsx
@@ -874,4 +874,17 @@ describe("PlatformIndex - sortable table headers", () => {
     await waitFor(() => expect(screen.getByText("DuckDB Results")).toBeTruthy());
     expect(screen.getByTestId("provenance-legend")).toBeTruthy();
   });
+
+  it("supports grouping rows by engine version", async () => {
+    vi.mocked(getPlatformIndexRows).mockResolvedValue([
+      makeRow({ result_id: "r1", short_id: "s1", driver_version: "1.4.0", geomean_ms: 10 }),
+      makeRow({ result_id: "r2", short_id: "s2", driver_version: "1.3.2", geomean_ms: 20 }),
+      makeRow({ result_id: "r3", short_id: "s3", driver_version: "1.4.0", geomean_ms: 15 }),
+    ]);
+    render(<PlatformIndex platform="duckdb" />);
+    await waitFor(() => expect(screen.getByTestId("platform-group-by")).toBeTruthy());
+    fireEvent.change(screen.getByTestId("platform-group-by"), { target: { value: "engine_version" } });
+    expect(screen.getByText(/1.4.0 \(2 results\)/)).toBeTruthy();
+    expect(screen.getByText(/1.3.2 \(1 result\)/)).toBeTruthy();
+  });
 });


### PR DESCRIPTION
- Expose Engine version (platform_version) in Home ranking selector grid when results contain engine versions
- Add Group by control and sectioned cohort grouping (groupCohortRows) to PlatformIndex and BenchmarkIndex list views
- Add unit tests for Home engine version filter and table cohort grouping
