### PR TITLE
docs(blog): critique-followup fixes on v0.4.0 drafts

### DIFF
--- a/_blog/building-benchbox/drafts/15-v0-4-0-release-overview.md
+++ b/_blog/building-benchbox/drafts/15-v0-4-0-release-overview.md
@@ -54,7 +54,7 @@ v0.4.0 adds a canonical vocabulary for result source, trust label, and funding, 
 
 Ranked tables include maintainer-run, CI, and vendor-supplied results. Community submissions stay visible and are not ranked. The vendor label cannot be self-applied: it is derived from bundles under `results-data/bundles/vendor/`, and submission CI rejects non-maintainer PRs that touch that path. In the August 28 preview snapshot, all 138 rows are `maintainer-run` with funding `unspecified`.
 
-Accepted `--funding` values are `employer`, `personal`, `free-trial`, `vendor-sponsored`, `grant`, and `unspecified` (the default). Eligibility gates, the comparability receipt, and corpus curation belong in the companion post.
+Accepted `--funding` values are `employer`, `personal`, `free-trial`, `vendor-sponsored`, `grant`, and `unspecified` (the default). Eligibility gates, the comparability receipt, and corpus curation get a deeper treatment in a follow-up Results Explorer post.
 
 ## DuckLake beta
 

--- a/_blog/building-benchbox/drafts/16-results-explorer-preview.md
+++ b/_blog/building-benchbox/drafts/16-results-explorer-preview.md
@@ -157,7 +157,7 @@ Start a [BenchBox discussion](https://github.com/BenchBox-dev/BenchBox/discussio
 
 ## References
 
-[^release]: [BenchBox changelog: v0.4.0](https://github.com/BenchBox-dev/BenchBox/blob/develop/CHANGELOG.md#040---2026-08-27) - BenchBox, August 27, 2026
+[^release]: [BenchBox 0.4.0 release](https://github.com/BenchBox-dev/BenchBox/releases/tag/v0.4.0) - BenchBox, published August 28, 2026
 [^launch]: [BenchBox results platform strategy](https://github.com/BenchBox-dev/BenchBox/blob/develop/docs/development/benchbox-results-platform-strategy.md) - BenchBox, Phase 1 launched April 4, 2026
 [^geekbench]: [Geekbench Browser](https://browser.geekbench.com/) - Primate Labs, accessed August 31, 2026
 [^open-llm]: [Open LLM Leaderboard README](https://huggingface.co/spaces/open-llm-leaderboard/open_llm_leaderboard/blob/main/README.md) - Hugging Face, accessed August 31, 2026

--- a/_blog/building-benchbox/drafts/17-results-explorer-qualifies-comparisons.md
+++ b/_blog/building-benchbox/drafts/17-results-explorer-qualifies-comparisons.md
@@ -15,7 +15,7 @@ meta_description: "How BenchBox's Results Explorer separates display, comparison
 
 > The Results Explorer decides what may be displayed, compared, and ranked, and it leaves recorded differences visible. Two timings still have to earn a comparison.
 
-**TL;DR**: BenchBox v0.4.0's [Results Explorer](https://benchbox.dev/results/) is a curated preview that shows timings, compares runs that share enough query evidence, and puts a winner claim only when benchmark, scale factor, phase, and timing coverage line up.[^release] Other recorded differences stay on a Comparability Receipt for the reader to judge. The preview makes the public evidence inspectable.
+**TL;DR**: BenchBox v0.4.0's [Results Explorer](https://benchbox.dev/results/) is a curated preview that shows timings, compares runs that share enough query evidence, and makes a winner claim only when benchmark, scale factor, phase, and timing coverage line up.[^release] Other recorded differences stay on a Comparability Receipt for the reader to judge. The preview makes the public evidence inspectable.
 
 ---
 


### PR DESCRIPTION
Fix a grammar slip in post 17's TL;DR, reconcile the release date in
post 16's release footnote to the August 28 publication, and reword
post 15's dangling companion-post reference.
