### PR TITLE
fix(explorer): show validation badge for non-clean unranked results

### DIFF
--- a/results-explorer/package-lock.json
+++ b/results-explorer/package-lock.json
@@ -2383,9 +2383,9 @@
       }
     },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.10.13",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.13.tgz",
-      "integrity": "sha512-BL2sTuHOdy0YT1lYieUxTw/QMtPBC3pmlJC6xk8BBYVv6vcw3SGdKemQ+Xsx9ik2F/lYDO9tqsFQH1r9PFuHKw==",
+      "version": "2.11.20",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.11.20.tgz",
+      "integrity": "sha512-H0ulySigv6icDJ1F7SjtdCD6PrhTpdYCmP0CactWy1+ekh0AFd0o1Wn5T8b+hnTmdBx19u9yhL6wvCylXMY7zw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -2439,9 +2439,9 @@
       }
     },
     "node_modules/browserslist": {
-      "version": "4.28.2",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.2.tgz",
-      "integrity": "sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==",
+      "version": "4.28.8",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.8.tgz",
+      "integrity": "sha512-V2NpofLblG64mfOtSgDhOJESZEGogzDMBv/q+W6oc4LXWP/q75eOXoOaaOu1EOadB9U4Bwx/e0yzbvwKH8zalA==",
       "dev": true,
       "funding": [
         {
@@ -2459,11 +2459,11 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "baseline-browser-mapping": "^2.10.12",
-        "caniuse-lite": "^1.0.30001782",
-        "electron-to-chromium": "^1.5.328",
-        "node-releases": "^2.0.36",
-        "update-browserslist-db": "^1.2.3"
+        "baseline-browser-mapping": "^2.11.12",
+        "caniuse-lite": "^1.0.30001809",
+        "electron-to-chromium": "^1.5.402",
+        "node-releases": "^2.0.53",
+        "update-browserslist-db": "^1.3.0"
       },
       "bin": {
         "browserslist": "cli.js"
@@ -2533,9 +2533,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001784",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001784.tgz",
-      "integrity": "sha512-WU346nBTklUV9YfUl60fqRbU5ZqyXlqvo1SgigE1OAXK5bFL8LL9q1K7aap3N739l4BvNqnkm3YrGHiY9sfUQw==",
+      "version": "1.0.30001810",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001810.tgz",
+      "integrity": "sha512-TITQPUkaz+aVk5GL6NhOdwk1aEaNTSDPsGFWrTuhKGtjTF70jL/Oht2W4c6rXUe5fu7Ie19VIahAXHIIiWWNeg==",
       "dev": true,
       "funding": [
         {
@@ -3009,9 +3009,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.331",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.331.tgz",
-      "integrity": "sha512-IbxXrsTlD3hRodkLnbxAPP4OuJYdWCeM3IOdT+CpcMoIwIoDfCmRpEtSPfwBXxVkg9xmBeY7Lz2Eo2TDn/HC3Q==",
+      "version": "1.5.419",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.419.tgz",
+      "integrity": "sha512-nHMPn8x4yCxCI0iSnL+LlHL5sUoUfjLXkcRIagZ4GBdrfFLFaiLNvzJWbJqZhFT9IAhw5tUSNlhggWN+otvp/A==",
       "dev": true,
       "license": "ISC"
     },
@@ -4464,11 +4464,14 @@
       }
     },
     "node_modules/node-releases": {
-      "version": "2.0.37",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.37.tgz",
-      "integrity": "sha512-1h5gKZCF+pO/o3Iqt5Jp7wc9rH3eJJ0+nh/CIoiRwjRxde/hAHyLPXYN4V3CqKAbiZPSeJFSWHmJsbkicta0Eg==",
+      "version": "2.0.54",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.54.tgz",
+      "integrity": "sha512-YHs7BmmcsdAI5Ozuf8JZo6PT0mv2GIWC9vMfvUC3dp65M8hn7Ux8CPL+2oBI7juNuj9d0ndhTcznq2ODBps9cQ==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/normalize-path": {
       "version": "3.0.0",
@@ -4865,9 +4868,9 @@
       }
     },
     "node_modules/postcss-selector-parser": {
-      "version": "6.1.2",
-      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.1.2.tgz",
-      "integrity": "sha512-Q8qQfPiZ+THO/3ZrOrO0cJJKfpYCagtMUkXbnEfmgUjwXg6z/WBeOyS9APBBPCTSiDV+s4SwQGu8yFsiMRIudg==",
+      "version": "6.1.4",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.1.4.tgz",
+      "integrity": "sha512-bIoJLOmjCO1S9XdY/DcnR5hJxvrDir1PbGChrzXG3vw0/FOliy/fA3dmdhQ441kah4gKv+TwckGzex6wNS5cnQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5708,9 +5711,9 @@
       "license": "MIT"
     },
     "node_modules/update-browserslist-db": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
-      "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.3.2.tgz",
+      "integrity": "sha512-UQ+MSxlhRm1bzjhU+DcuXfjFO1FzNtqhK5+9Yvlp90ItDLk5vT932A0rFu619nf7RVS+Y/VeaUW1jaRDqZ8VJw==",
       "dev": true,
       "funding": [
         {

--- a/results-explorer/src/components/MetaLeaderboard.tsx
+++ b/results-explorer/src/components/MetaLeaderboard.tsx
@@ -441,10 +441,14 @@ export function MetaLeaderboard({
                         ) : (
                           renderCellValue(cellState, cohort, mode)
                         )}
-                        {metadata && cellState.kind === "ranked" && (
+                        {metadata && cellState.kind !== "missing" && (
                           <div class="mt-0.5 flex flex-wrap justify-center gap-1">
-                            <TrustBadge trustLabel={metadata.trust_label} compact />
-                            <FundingChip funding={metadata.funding} compact />
+                            {cellState.kind === "ranked" && (
+                              <>
+                                <TrustBadge trustLabel={metadata.trust_label} compact />
+                                <FundingChip funding={metadata.funding} compact />
+                              </>
+                            )}
                             {metadata.validation_status?.trim().toLowerCase() !== "passed" && (
                               <ValidationBadge validationStatus={metadata.validation_status} showMissing />
                             )}

--- a/results-explorer/src/components/TrustBadge.tsx
+++ b/results-explorer/src/components/TrustBadge.tsx
@@ -137,6 +137,10 @@ function validationTone(status: string): StatusTone {
     return "info";
   }
   if (status === "loose" || status === "range") return "warning";
+  // Validation never executed for this result (e.g. DataFrame-mode "not_run").
+  // That is not a pass, so it must not read as the least-alarming ("neutral")
+  // tone - treat it the same as other incomplete-validation statuses above.
+  if (status === "not_run") return "warning";
   return "neutral";
 }
 

--- a/results-explorer/src/components/__tests__/MetaLeaderboard.test.tsx
+++ b/results-explorer/src/components/__tests__/MetaLeaderboard.test.tsx
@@ -708,6 +708,70 @@ describe("MetaLeaderboard", () => {
     expect(passedCell.textContent).toContain("Community");
   });
 
+  it("shows a validation badge for an unranked not_run result (non-clean status excluded from ranking)", () => {
+    const data: MetaLeaderboardData = {
+      ...DATA,
+      cohorts: [
+        {
+          ...DATA.cohorts[0]!,
+          key: "tpch-sf0.1-power",
+          benchmark: "tpch",
+          label: "TPC-H SF0.1",
+          href: "/results/tpch/",
+          primary_metric: "power_score",
+          primary_order: "desc" as const,
+          platforms: [
+            {
+              platform_id: "polars",
+              platform: "Polars",
+              result_id: "polars-tpch-r1",
+              rank: null,
+              metric_value: null,
+              speedup_vs_best: null,
+              primary_metric: "power_score",
+              primary_order: "desc" as const,
+              ...META_TIMING_ELIGIBLE,
+              ranking_exclusion_reason: "validation_not_clean",
+            },
+          ],
+        },
+      ],
+      platforms: [
+        {
+          platform_id: "polars",
+          platform: "Polars",
+          ranks: {},
+          avg_rank: null,
+          n_cohorts: 0,
+        },
+      ],
+    };
+    render(
+      <MetaLeaderboard
+        data={data}
+        mode="times"
+        onModeChange={vi.fn()}
+        resultMetadataById={new Map([
+          ["polars-tpch-r1", { trust_label: "community-submission", validation_status: "not_run" }],
+        ])}
+      />,
+    );
+
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: "1 more platform has published results but nothing ranked — Show them",
+      }),
+    );
+    const cell = screen.getByRole("gridcell", { name: /Polars has published evidence for TPC-H SF0\.1/ });
+    // Unranked (never a "ranked" cellState), so trust/funding stay hidden here -
+    // but the validation badge, the one signal that flags a non-clean result,
+    // must still surface.
+    expect(cell.querySelector('[data-role="trust"]')).toBeNull();
+    const badge = cell.querySelector('[data-role="validation"]');
+    expect(badge?.textContent).toBe("not_run");
+    expect(badge?.getAttribute("data-tone")).toBe("warning");
+  });
+
   it("explains an all-excluded ranking and preserves distinct exclusion reasons", () => {
     const excludedPlatforms = [
       {

--- a/results-explorer/src/components/__tests__/TrustBadge.test.tsx
+++ b/results-explorer/src/components/__tests__/TrustBadge.test.tsx
@@ -194,4 +194,12 @@ describe("ValidationBadge", () => {
     const shown = render(<ValidationBadge validationStatus={null} showMissing />);
     expect(shown.getByText("validation n/a")).toBeTruthy();
   });
+
+  it("renders not_run with a warning tone, not the neutral fallback", () => {
+    const { container } = render(<ValidationBadge validationStatus="not_run" />);
+    const badge = container.querySelector(".badge");
+    expect(badge?.getAttribute("data-tone")).toBe("warning");
+    expect(badge?.textContent).toBe("not_run");
+    expect(badge?.getAttribute("title")).toContain("Validation status: not_run");
+  });
 });


### PR DESCRIPTION
The MetaLeaderboard cell badges (Trust/Funding/Validation) were gated on
cellState.kind === "ranked". Non-clean validation statuses are never
ranked (is_ranking_eligible / ranking_exclusion_reason ==
validation_not_clean), so the ValidationBadge could never fire for the
exact results it exists to flag - including the corpus's 41 not_run
DataFrame-mode bundles (Pandas/Polars/PySpark).

Extend the validation badge to unranked cells with published evidence,
keeping Trust/Funding scoped to ranked cells as before. Also give
"not_run" a warning tone instead of falling through validationTone()'s
neutral default, since "never validated" should not read as the least
alarming status.
