### PR TITLE
fix(tests): make nightly Windows jobs pass on windows-latest

### DIFF
--- a/benchbox/core/results/exporter.py
+++ b/benchbox/core/results/exporter.py
@@ -180,7 +180,11 @@ class ResultExporter:
 
             try:
                 existing_mode = stat.S_IMODE(destination.stat().st_mode) if destination.exists() else None
-                if existing_mode is not None:
+                # os.fchmod is POSIX-only (no Windows implementation); Windows
+                # has no equivalent notion of the POSIX permission bits this
+                # preserves, so permission preservation is simply unavailable
+                # there and the write proceeds with the new file's default mode.
+                if existing_mode is not None and hasattr(os, "fchmod"):
                     os.fchmod(file_descriptor, existing_mode)
                 with os.fdopen(file_descriptor, mode, encoding="utf-8", newline="") as handle:
                     file_descriptor = None

--- a/tests/unit/core/test_system.py
+++ b/tests/unit/core/test_system.py
@@ -49,6 +49,12 @@ class TestGetCpuModel:
         with (
             patch("benchbox.core.system.HAS_PSUTIL", False),
             patch("benchbox.core.system.platform.machine", return_value="arm64"),
+            # platform.processor() is the fallback path exercised right after
+            # detect_cpu_info() fails; on a real machine it returns a genuine
+            # (platform-dependent) CPU string, not an empty value, so it must
+            # be patched too or this test only passes by accident on
+            # platforms where the real processor() happens to be "".
+            patch("benchbox.core.system.platform.processor", return_value=""),
             patch("benchbox.core.system.detect_cpu_info", return_value=(None, None)),
         ):
             profile = SystemProfiler().get_system_profile()

--- a/tests/unit/scripts/test_worktree_audit.py
+++ b/tests/unit/scripts/test_worktree_audit.py
@@ -754,7 +754,7 @@ def test_snapshot_file_persistence(tmp_path: Path, monkeypatch: pytest.MonkeyPat
     assert first_snapshot != second_snapshot
     assert first_snapshot.is_file()
     assert second_snapshot.is_file()
-    assert "_project/reports/worktree-lifecycle" in str(first_snapshot)
+    assert "_project/reports/worktree-lifecycle" in first_snapshot.as_posix()
 
 
 def test_git_timeout_in_worktree_evaluation_resolves_unavailable(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):

--- a/tests/unit/test_results_exporter.py
+++ b/tests/unit/test_results_exporter.py
@@ -108,6 +108,24 @@ def test_write_file_preserves_existing_permissions(tmp_path):
     assert stat.S_IMODE(destination.stat().st_mode) == 0o640
 
 
+def test_write_file_skips_permission_preservation_without_fchmod(monkeypatch, tmp_path):
+    """Simulates Windows, where ``os.fchmod`` does not exist.
+
+    ``_write_file`` must not raise ``AttributeError`` when the platform has no
+    ``os.fchmod`` (e.g. Windows); it should simply skip permission
+    preservation and still complete the write.
+    """
+    destination = tmp_path / "result.json"
+    destination.write_text("old\n", encoding="utf-8")
+    destination.chmod(0o640)
+
+    monkeypatch.delattr(exporter_module.os, "fchmod", raising=False)
+
+    ResultExporter(output_dir=tmp_path, anonymize=False)._write_file(destination, "new\n")
+
+    assert destination.read_text(encoding="utf-8") == "new\n"
+
+
 def test_write_file_prefers_canonical_cloud_bytes(tmp_path):
     class CloudPath:
         content: bytes | None = None


### PR DESCRIPTION
Three independent Windows-only failures have kept Nightly Validation red on
both windows-latest/3.10 and 3.12. They are unrelated to each other and are
not regressions of the 2026-08-23..26 nightly batch.

os.fchmod is POSIX-only, so ResultExporter._write_file raised AttributeError
on Windows for every existing destination file. Guard the call and document
that Windows has no equivalent POSIX mode bits to preserve, so the write
proceeds with the new file's default mode.

test_snapshot_file_persistence compared a forward-slash literal against
str(Path), which uses backslashes on Windows; compare against as_posix()
instead of skipping, so the assertion keeps its coverage on every platform.

test_profile_never_turns_architecture_into_cpu_model_without_psutil patched
platform.machine but not platform.processor, so on a real Windows machine it
read the genuine CPU string instead of the intended empty value. It passed
only where the real processor() happened to be empty.
