### PR TITLE
fix(explorer): clarify validation disclosure in compare view and receipts

### DIFF
--- a/results-explorer/src/components/ComparabilityReceipt.tsx
+++ b/results-explorer/src/components/ComparabilityReceipt.tsx
@@ -2,6 +2,7 @@ import type { DetailResult, Environment } from "@/types";
 import { humanizeBenchmark, shortHash } from "@/utils";
 import { costModelSummary, costScopeSummary, normalizedCostLabel } from "@/lib/costDisplay";
 import { formatCount, formatWarningCount } from "@/lib/copyFormatters";
+import { formatValidationStatus } from "@/lib/displayLabels";
 import { StatusBadge, type StatusTone } from "@/components/StatusBadge";
 import { formatCpuIdentityProvenance } from "@/lib/hardwareProvenance";
 
@@ -86,7 +87,7 @@ export function buildComparabilityFields(results: DetailResult[]): Comparability
     compareValues("Driver version", results, (result) => valueOrMissing(result.driver_version)),
     compareValues("Execution mode", results, (result) => valueOrMissing(result.execution_mode)),
     buildTuningField(results),
-    compareValues("Validation", results, (result) => valueOrMissing(result.validation_status)),
+    compareValues("Validation", results, (result) => formatValidationStatusReceiptValue(result.validation_status)),
     compareHardwareValues("Architecture", results, (result) => valueOrMissing(result.environment?.arch)),
     compareHardwareValues("CPU family", results, (result) => valueOrMissing(result.environment?.cpu_family)),
     compareHardwareValues("CPU model", results, (result) => valueOrMissing(result.environment?.cpu_model)),
@@ -214,6 +215,22 @@ function setsEqual(a: ReadonlySet<string>, b: ReadonlySet<string>): boolean {
 
 export function comparabilityWarningFields(fields: readonly ComparabilityField[]): ComparabilityField[] {
   return fields.filter((field) => field.status === "diff");
+}
+
+/**
+ * Warning-field labels ordered for a truncated summary (e.g. the guardrails
+ * banner's "Warning classes: A, B, C, +N more"). A validation difference is
+ * not equivalent to a cosmetic environment difference like "CPU model" or
+ * "Driver version" - it means at least one candidate's numbers are unverified
+ * - so it is always sorted to the front instead of risking getting folded
+ * into "+N more" by field-build order. Relative order of the rest is
+ * preserved.
+ */
+export function orderWarningLabelsForSummary(warningFields: readonly ComparabilityField[]): string[] {
+  const labels = warningFields.map((field) => field.label);
+  const priority = labels.filter((label) => label === "Validation");
+  const rest = labels.filter((label) => label !== "Validation");
+  return [...priority, ...rest];
 }
 
 function ComparabilityFieldRow({ field }: { field: ComparabilityField }) {
@@ -388,6 +405,18 @@ function formatEnvironment(environment: Environment) {
 
 function formatPerPlatform(entries: { platform: string; value: string }[]) {
   return entries.map((entry) => `${entry.platform}: ${entry.value}`).join("; ");
+}
+
+/**
+ * Reader-facing label for the receipt's Validation row, with the raw status
+ * kept alongside it in parentheses - the receipt is exactly the "detail
+ * field" surface the shared vocabulary is meant to keep precision available
+ * on, per describeValidationStatus's contract.
+ */
+function formatValidationStatusReceiptValue(status: string | null | undefined) {
+  if (!status) return "Not recorded";
+  const label = formatValidationStatus(status);
+  return label === status ? label : `${label} (${status})`;
 }
 
 function valueOrMissing(value: string | number | null | undefined) {

--- a/results-explorer/src/components/CompareSummary.tsx
+++ b/results-explorer/src/components/CompareSummary.tsx
@@ -14,6 +14,7 @@ export function CompareSummary({ summary }: CompareSummaryProps) {
     summary.winner !== null
       ? summary.percentiles.find((entry) => entry.resultId === summary.winner?.resultId)
       : undefined;
+  const hasValidationCaveat = summary.nonCleanValidation.length > 0;
 
   return (
     <section aria-labelledby="compare-decision-summary-title" class="card mb-8">
@@ -24,10 +25,34 @@ export function CompareSummary({ summary }: CompareSummaryProps) {
           </h2>
           <p class="mt-1 text-sm font-medium text-[var(--bb-data-fg-primary)]">{summary.headline}</p>
         </div>
-        <StatusBadge role="computed" tone={summary.claimSuppressed ? "warning" : "info"}>
-          {summary.claimSuppressed ? "Claims suppressed" : "Computed from selected runs"}
-        </StatusBadge>
+        <div class="flex flex-wrap items-center justify-end gap-2">
+          {hasValidationCaveat && (
+            <StatusBadge role="validation" tone="warning">
+              Unvalidated result{summary.nonCleanValidation.length > 1 ? "s" : ""}
+            </StatusBadge>
+          )}
+          <StatusBadge role="computed" tone={summary.claimSuppressed ? "warning" : "info"}>
+            {summary.claimSuppressed ? "Claims suppressed" : "Computed from selected runs"}
+          </StatusBadge>
+        </div>
       </div>
+
+      {hasValidationCaveat && (
+        <div
+          class="mb-4 rounded-md border border-[var(--bb-tone-warning-border)] bg-[var(--bb-tone-warning-bg)] px-3 py-2 text-xs text-[var(--bb-tone-warning-fg)]"
+          data-testid="compare-validation-caveat"
+        >
+          <span class="font-semibold">Validation caution:</span>{" "}
+          {summary.nonCleanValidation.map((entry, index) => (
+            <span key={entry.resultId}>
+              {index > 0 ? "; " : ""}
+              <span class="font-medium">{entry.platform}</span> is {entry.label}
+            </span>
+          ))}
+          . This comparison rests on at least one unvalidated or non-clean result - treat any winner claim above as
+          provisional.
+        </div>
+      )}
 
       <div class="grid gap-3 md:grid-cols-2 xl:grid-cols-4">
         <SummaryCard label="Winner">

--- a/results-explorer/src/components/TrustBadge.tsx
+++ b/results-explorer/src/components/TrustBadge.tsx
@@ -21,6 +21,7 @@
 // own color rather than a "cautionary" yellow.
 // ---------------------------------------------------------------------------
 
+import { describeValidationStatus } from "@/lib/displayLabels";
 import { StatusBadge, type StatusTone } from "./StatusBadge";
 
 const TRUST_CONFIG: Record<string, { label: string; tone: StatusTone; title: string }> = {
@@ -117,31 +118,27 @@ export function TrustBadge({ trustLabel, compact = false }: TrustBadgeProps) {
   );
 }
 
+// Renders the shared validation-status vocabulary (see
+// `describeValidationStatus` in src/lib/displayLabels.ts) as a badge. The
+// visible text is the reader-facing label, never the raw enum value (e.g.
+// "no validation", not "not_run") - the raw status is still available via the
+// title tooltip for anyone who wants precision.
 export function ValidationBadge({ validationStatus, showMissing = false }: ValidationBadgeProps) {
   if (!validationStatus && !showMissing) return null;
-  const status = validationStatus?.trim() || "not recorded";
-  const lower = status.toLowerCase();
-  const tone = validationTone(lower);
-  const label = validationStatus ? lower : "validation n/a";
+  if (!validationStatus) {
+    return (
+      <StatusBadge role="validation" tone="neutral" title="Validation status: not recorded">
+        validation n/a
+      </StatusBadge>
+    );
+  }
+  const info = describeValidationStatus(validationStatus);
   return (
-    <StatusBadge role="validation" tone={tone} title={`Validation status: ${status}`}>
-      {label}
+    <StatusBadge role="validation" tone={info.tone} title={`Validation status: ${info.status} - ${info.description}`}>
+      {info.label}
     </StatusBadge>
   );
 }
 
-function validationTone(status: string): StatusTone {
-  if (status.includes("fail")) return "danger";
-  if (status.includes("disabled") || status.includes("partial")) return "warning";
-  if (status === "exact" || status === "full" || status === "passed" || status === "pass") {
-    return "info";
-  }
-  if (status === "loose" || status === "range") return "warning";
-  // Validation never executed for this result (e.g. DataFrame-mode "not_run").
-  // That is not a pass, so it must not read as the least-alarming ("neutral")
-  // tone - treat it the same as other incomplete-validation statuses above.
-  if (status === "not_run") return "warning";
-  return "neutral";
-}
 
 export default TrustBadge;

--- a/results-explorer/src/components/__tests__/ComparabilityReceipt.test.tsx
+++ b/results-explorer/src/components/__tests__/ComparabilityReceipt.test.tsx
@@ -5,6 +5,7 @@ import {
   COMPARABILITY_WARNING_TARGET_ID,
   buildComparabilityFields,
   comparabilityWarningFields,
+  orderWarningLabelsForSummary,
   ComparabilityReceipt,
 } from "@/components/ComparabilityReceipt";
 
@@ -145,6 +146,65 @@ describe("ComparabilityReceipt", () => {
     expect(fields.find((field) => field.label === "Phase")?.status).toBe("diff");
     expect(fields.find((field) => field.label === "Query scope")?.status).toBe("diff");
     expect(comparabilityWarningFields(fields).map((field) => field.label)).toEqual(["Phase", "Query scope"]);
+  });
+
+  it("renders the receipt's Validation row with the reader-facing label, raw status kept alongside it", () => {
+    const { container } = render(
+      <ComparabilityReceipt
+        results={[
+          makeDetail({ validation_status: "passed" }),
+          makeDetail({ result_id: "r2", platform: "Pandas", platform_id: "pandas", validation_status: "not_run" }),
+        ]}
+      />,
+    );
+    const validationCard = [...container.querySelectorAll("h3")]
+      .find((el) => el.textContent === "Validation")
+      ?.closest("div")?.parentElement;
+    expect(validationCard).toBeTruthy();
+    expect(validationCard).toHaveTextContent("2 values differ");
+    expect(validationCard).toHaveTextContent("DuckDB: passed; Pandas: no validation (not_run)");
+  });
+
+  describe("orderWarningLabelsForSummary", () => {
+    it("sorts a Validation warning to the front, ahead of cosmetic environment fields", () => {
+      const fields = buildComparabilityFields([
+        makeDetail({ platform_version: "1.0", driver_version: "1.0", execution_mode: "in-memory", validation_status: "passed" }),
+        makeDetail({
+          result_id: "r2",
+          platform: "Pandas",
+          platform_id: "pandas",
+          platform_version: "2.0",
+          driver_version: "2.0",
+          execution_mode: "lazy",
+          validation_status: "not_run",
+        }),
+      ]);
+      const warnings = comparabilityWarningFields(fields);
+      // Sanity: without reordering, Validation would land after the three
+      // environment fields (build order), which is exactly the "+1 more"
+      // bug from the audit.
+      expect(warnings.map((f) => f.label).indexOf("Validation")).toBeGreaterThan(0);
+
+      const ordered = orderWarningLabelsForSummary(warnings);
+      expect(ordered[0]).toBe("Validation");
+      expect(ordered).toEqual(
+        expect.arrayContaining(["Platform version", "Driver version", "Execution mode", "Validation"]),
+      );
+    });
+
+    it("is a no-op when there is no Validation warning", () => {
+      const fields = buildComparabilityFields([
+        makeDetail(),
+        makeDetail({
+          result_id: "r2",
+          platform: "SQLite",
+          platform_id: "sqlite",
+          test_type: "throughput",
+        }),
+      ]);
+      const warnings = comparabilityWarningFields(fields);
+      expect(orderWarningLabelsForSummary(warnings)).toEqual(warnings.map((f) => f.label));
+    });
   });
 
   it("uses singular count copy for one warning and one query", () => {

--- a/results-explorer/src/components/__tests__/CompareSummary.test.tsx
+++ b/results-explorer/src/components/__tests__/CompareSummary.test.tsx
@@ -107,4 +107,101 @@ describe("CompareSummary", () => {
     expect(summaryRegion).toHaveTextContent("Not claimed");
     expect(summaryRegion).toHaveTextContent("Winner claim suppressed");
   });
+
+  // -----------------------------------------------------------------------
+  // Live reproduction: DuckDB (validated) vs Pandas (validation_status
+  // "not_run") at H2ODB SF0.01. The headline used to claim a confident
+  // winner off an unvalidated candidate with no visible caveat. It must now
+  // carry the caveat in the headline itself, plus a distinct warning badge
+  // and callout - a reader who only sees the headline must not conclude the
+  // comparison rests on validated data.
+  // -----------------------------------------------------------------------
+
+  it("caveats the winner claim when one selected candidate is unvalidated (not_run)", () => {
+    const summary = buildCompareDecisionSummary(
+      [
+        makeResult({ result_id: "duck", platform: "DuckDB", power_score: 3000, validation_status: "passed" }),
+        makeResult({
+          result_id: "pandas",
+          platform: "Pandas",
+          platform_id: "pandas",
+          power_score: 843,
+          validation_status: "not_run",
+          display_timings: [
+            { query_id: "Q1", display_ms: 100, sample_count: 3, is_valid_display_timing: true, timing_exclusion_reason: null },
+            { query_id: "Q2", display_ms: 200, sample_count: 3, is_valid_display_timing: true, timing_exclusion_reason: null },
+          ],
+        }),
+      ],
+      "power_score",
+    );
+
+    // The winner claim is not suppressed by this gap alone...
+    expect(summary.claimSuppressed).toBe(false);
+    expect(summary.winner?.platform).toBe("DuckDB");
+    // ...but the headline itself must not read as a clean, confident claim.
+    expect(summary.headline).toContain("DuckDB leads by");
+    expect(summary.headline).toContain("Validation caution");
+    expect(summary.headline).toContain("Pandas is no validation");
+
+    render(<CompareSummary summary={summary} />);
+    const summaryRegion = screen.getByRole("heading", { name: "Decision Summary" }).closest("section");
+    expect(summaryRegion).toHaveTextContent("Unvalidated result");
+    expect(summaryRegion).toHaveTextContent("Validation caution:");
+    expect(summaryRegion).toHaveTextContent("Pandas is no validation");
+    expect(screen.getByTestId("compare-validation-caveat")).toBeTruthy();
+  });
+
+  it("does not show a validation caveat when both candidates are clean (passed)", () => {
+    const summary = buildCompareDecisionSummary(
+      [
+        makeResult({ result_id: "duck", platform: "DuckDB", power_score: 3000, validation_status: "passed" }),
+        makeResult({
+          result_id: "r2",
+          platform: "SQLite",
+          platform_id: "sqlite",
+          power_score: 300,
+          validation_status: "passed",
+          display_timings: [
+            { query_id: "Q1", display_ms: 100, sample_count: 3, is_valid_display_timing: true, timing_exclusion_reason: null },
+            { query_id: "Q2", display_ms: 200, sample_count: 3, is_valid_display_timing: true, timing_exclusion_reason: null },
+          ],
+        }),
+      ],
+      "power_score",
+    );
+
+    expect(summary.nonCleanValidation).toHaveLength(0);
+    expect(summary.validationCaveat).toBeNull();
+    expect(summary.headline).toBe("DuckDB leads by 10.00x on power score.");
+
+    render(<CompareSummary summary={summary} />);
+    const summaryRegion = screen.getByRole("heading", { name: "Decision Summary" }).closest("section");
+    expect(summaryRegion).not.toHaveTextContent("Unvalidated result");
+    expect(screen.queryByTestId("compare-validation-caveat")).toBeNull();
+  });
+
+  it("does not show a validation caveat when validation_status is simply absent (not a non-clean status)", () => {
+    const summary = buildCompareDecisionSummary(
+      [
+        makeResult({ result_id: "duck", platform: "DuckDB", power_score: 3000 }),
+        makeResult({
+          result_id: "r2",
+          platform: "SQLite",
+          platform_id: "sqlite",
+          power_score: 300,
+          display_timings: [
+            { query_id: "Q1", display_ms: 100, sample_count: 3, is_valid_display_timing: true, timing_exclusion_reason: null },
+            { query_id: "Q2", display_ms: 200, sample_count: 3, is_valid_display_timing: true, timing_exclusion_reason: null },
+          ],
+        }),
+      ],
+      "power_score",
+    );
+
+    expect(summary.nonCleanValidation).toHaveLength(0);
+    render(<CompareSummary summary={summary} />);
+    const summaryRegion = screen.getByRole("heading", { name: "Decision Summary" }).closest("section");
+    expect(summaryRegion).not.toHaveTextContent("Unvalidated result");
+  });
 });

--- a/results-explorer/src/components/__tests__/MetaLeaderboard.test.tsx
+++ b/results-explorer/src/components/__tests__/MetaLeaderboard.test.tsx
@@ -768,7 +768,7 @@ describe("MetaLeaderboard", () => {
     // must still surface.
     expect(cell.querySelector('[data-role="trust"]')).toBeNull();
     const badge = cell.querySelector('[data-role="validation"]');
-    expect(badge?.textContent).toBe("not_run");
+    expect(badge?.textContent).toBe("no validation");
     expect(badge?.getAttribute("data-tone")).toBe("warning");
   });
 

--- a/results-explorer/src/components/__tests__/QueryHeatmap.test.tsx
+++ b/results-explorer/src/components/__tests__/QueryHeatmap.test.tsx
@@ -276,7 +276,7 @@ describe("QueryHeatmap rendering", () => {
 
     // Visible without clicking any "Receipt and metadata" disclosure.
     const flag = screen.getByTestId("heatmap-validation-flag-platform-not-run");
-    const badge = within(flag).getByText("not_run");
+    const badge = within(flag).getByText("no validation");
     expect(badge.closest("details")).toBeNull();
     // Tone (warning vs. neutral) for "not_run" is owned by
     // fix/explorer-validation-badge-gating (TrustBadge.tsx validationTone());
@@ -288,7 +288,7 @@ describe("QueryHeatmap rendering", () => {
     // rendered instance for this row.
     const row = flag.closest("tr");
     expect(row).not.toBeNull();
-    expect(within(row as HTMLElement).getAllByText("not_run")).toHaveLength(1);
+    expect(within(row as HTMLElement).getAllByText("no validation")).toHaveLength(1);
   });
 
   it("does not add a validation flag for a clean (passed) result", () => {

--- a/results-explorer/src/components/__tests__/TrustBadge.test.tsx
+++ b/results-explorer/src/components/__tests__/TrustBadge.test.tsx
@@ -195,11 +195,43 @@ describe("ValidationBadge", () => {
     expect(shown.getByText("validation n/a")).toBeTruthy();
   });
 
-  it("renders not_run with a warning tone, not the neutral fallback", () => {
+  // -----------------------------------------------------------------------
+  // Reader-facing vocabulary: the chip must never show the raw enum for
+  // statuses users cannot interpret (not_run and friends). It renders the
+  // shared describeValidationStatus() label instead; the raw status is still
+  // reachable via the title tooltip.
+  // -----------------------------------------------------------------------
+
+  it("renders not_run as plain language, not the raw enum, with a warning tone", () => {
     const { container } = render(<ValidationBadge validationStatus="not_run" />);
     const badge = container.querySelector(".badge");
+    expect(badge?.textContent).toBe("no validation");
     expect(badge?.getAttribute("data-tone")).toBe("warning");
-    expect(badge?.textContent).toBe("not_run");
-    expect(badge?.getAttribute("title")).toContain("Validation status: not_run");
+    const title = badge?.getAttribute("title") ?? "";
+    expect(title).toContain("Validation status: not_run");
+    expect(title.toLowerCase()).toContain("never executed");
+  });
+
+  it.each([
+    ["failed", "danger"],
+    ["interrupted", "danger"],
+    ["partial", "danger"],
+    ["error", "danger"],
+    ["not_run", "warning"],
+    ["not_validated", "warning"],
+    ["uncertain", "warning"],
+    ["unknown", "warning"],
+  ] as const)("%s never falls through to the neutral tone (%s)", (status, expectedTone) => {
+    const { container } = render(<ValidationBadge validationStatus={status} />);
+    const badge = container.querySelector(".badge");
+    expect(badge?.getAttribute("data-tone")).toBe(expectedTone);
+    expect(badge?.getAttribute("data-tone")).not.toBe("neutral");
+  });
+
+  it("passed still renders as a clean, interpretable label", () => {
+    const { container } = render(<ValidationBadge validationStatus="passed" />);
+    const badge = container.querySelector(".badge");
+    expect(badge?.textContent).toBe("passed");
+    expect(badge?.getAttribute("data-tone")).toBe("info");
   });
 });

--- a/results-explorer/src/lib/__tests__/compareSummary.test.ts
+++ b/results-explorer/src/lib/__tests__/compareSummary.test.ts
@@ -387,4 +387,67 @@ describe("buildCompareDecisionSummary", () => {
     expect(summary.headline).toContain("Polars 2026-05-08 (deadbeef)");
     expect(summary.headline).not.toMatch(/^Polars leads/);
   });
+
+  describe("validation disclosure", () => {
+    it("flags a result with an explicit non-clean validation_status", () => {
+      const summary = buildCompareDecisionSummary(
+        [
+          makeResult({ result_id: "duck", platform: "DuckDB", power_score: 3000, validation_status: "passed" }),
+          makeResult({
+            result_id: "pandas",
+            platform: "Pandas",
+            power_score: 843,
+            validation_status: "not_run",
+          }),
+        ],
+        "power_score",
+      );
+
+      expect(summary.nonCleanValidation).toEqual([
+        { resultId: "pandas", platform: "Pandas", status: "not_run", label: "no validation" },
+      ]);
+      expect(summary.validationCaveat).toContain("Pandas is no validation");
+      expect(summary.headline.endsWith(summary.validationCaveat!)).toBe(true);
+    });
+
+    it("does not flag a result with no validation_status recorded at all", () => {
+      const summary = buildCompareDecisionSummary(
+        [
+          makeResult({ result_id: "duck", platform: "DuckDB", power_score: 3000 }),
+          makeResult({ result_id: "sqlite", platform: "SQLite", power_score: 300 }),
+        ],
+        "power_score",
+      );
+
+      expect(summary.nonCleanValidation).toEqual([]);
+      expect(summary.validationCaveat).toBeNull();
+    });
+
+    it("flags every non-clean status in a multi-way comparison, not just the first", () => {
+      const summary = buildCompareDecisionSummary(
+        [
+          makeResult({ result_id: "duck", platform: "DuckDB", power_score: 3000, validation_status: "passed" }),
+          makeResult({ result_id: "pandas", platform: "Pandas", power_score: 843, validation_status: "not_run" }),
+          makeResult({ result_id: "polars", platform: "Polars", power_score: 500, validation_status: "uncertain" }),
+        ],
+        "power_score",
+      );
+
+      expect(summary.nonCleanValidation.map((entry) => entry.platform)).toEqual(["Pandas", "Polars"]);
+    });
+
+    it("still reports the caveat when the winner claim is suppressed for other reasons", () => {
+      const summary = buildCompareDecisionSummary(
+        [
+          makeResult({ result_id: "duck", platform: "DuckDB", power_score: 3000, validation_status: "passed" }),
+          makeResult({ result_id: "pandas", platform: "Pandas", power_score: 843, validation_status: "not_run" }),
+        ],
+        "power_score",
+        { suppressWinnerClaims: true, suppressionReason: "benchmarks differ" },
+      );
+
+      expect(summary.nonCleanValidation).toHaveLength(1);
+      expect(summary.claimSuppressed).toBe(true);
+    });
+  });
 });

--- a/results-explorer/src/lib/__tests__/displayLabels.test.ts
+++ b/results-explorer/src/lib/__tests__/displayLabels.test.ts
@@ -3,6 +3,7 @@ import {
   formatBenchmarkLabel,
   canonicalBenchmarkSlug,
   canonicalPhase,
+  describeValidationStatus,
   formatCostStatus,
   formatEnumLabel,
   formatFunding,
@@ -62,6 +63,69 @@ describe("formatValidationStatus", () => {
 
   it("returns 'unknown' for missing values", () => {
     expect(formatValidationStatus(null)).toBe("unknown");
+  });
+
+  // Full status set from benchbox/core/results/status.py
+  // NON_CLEAN_VALIDATION_STATUSES - the raw enum used to be impossible for a
+  // reader to interpret (e.g. a bare "not_run" chip); every one of these must
+  // now render plain language.
+  it("humanizes every NON_CLEAN_VALIDATION_STATUSES value", () => {
+    expect(formatValidationStatus("failed")).toBe("failed");
+    expect(formatValidationStatus("interrupted")).toBe("interrupted");
+    expect(formatValidationStatus("partial")).toBe("partial pass");
+    expect(formatValidationStatus("error")).toBe("validation error");
+    expect(formatValidationStatus("not_run")).toBe("no validation");
+    expect(formatValidationStatus("not_validated")).toBe("not validated");
+    expect(formatValidationStatus("uncertain")).toBe("uncertain");
+    expect(formatValidationStatus("unknown")).toBe("unknown");
+  });
+});
+
+describe("describeValidationStatus", () => {
+  it("returns the raw status alongside the reader-facing label", () => {
+    const info = describeValidationStatus("not_run");
+    expect(info.status).toBe("not_run");
+    expect(info.label).toBe("no validation");
+    expect(info.description.length).toBeGreaterThan(0);
+    expect(info.isClean).toBe(false);
+  });
+
+  it("marks passed (and its aliases) as the only clean status", () => {
+    expect(describeValidationStatus("passed").isClean).toBe(true);
+    expect(describeValidationStatus("pass").isClean).toBe(true);
+    expect(describeValidationStatus("exact").isClean).toBe(true);
+    expect(describeValidationStatus("full").isClean).toBe(true);
+    expect(describeValidationStatus("not_run").isClean).toBe(false);
+    expect(describeValidationStatus("failed").isClean).toBe(false);
+  });
+
+  it("gives CLI-failure statuses a danger tone", () => {
+    for (const status of ["failed", "interrupted", "partial", "error"]) {
+      expect(describeValidationStatus(status).tone).toBe("danger");
+    }
+  });
+
+  it("gives never-validated statuses a warning tone, never neutral", () => {
+    for (const status of ["not_run", "not_validated", "uncertain", "unknown"]) {
+      const info = describeValidationStatus(status);
+      expect(info.tone).toBe("warning");
+      expect(info.tone).not.toBe("neutral");
+    }
+  });
+
+  it("normalizes case and whitespace before matching", () => {
+    expect(describeValidationStatus("  Not_Run ").label).toBe("no validation");
+  });
+
+  it("handles a missing status without throwing", () => {
+    const info = describeValidationStatus(null);
+    expect(info.status).toBeNull();
+    expect(info.isClean).toBe(false);
+    expect(info.tone).toBe("neutral");
+  });
+
+  it("never gives an unrecognised non-null status the neutral tone", () => {
+    expect(describeValidationStatus("some_future_status").tone).toBe("warning");
   });
 });
 

--- a/results-explorer/src/lib/compareSummary.ts
+++ b/results-explorer/src/lib/compareSummary.ts
@@ -1,5 +1,6 @@
 import type { DetailResult } from "@/types";
 import { formatSpeedup } from "@/lib/metricFormatters";
+import { describeValidationStatus } from "@/lib/displayLabels";
 import {
   compareEvidenceSummary,
   isComparable,
@@ -49,6 +50,16 @@ export interface CompareCostSummary {
   winnerIsBestCostPerformance: boolean;
 }
 
+/** One selected result whose validation status is not a clean pass. */
+export interface CompareValidationCaveat {
+  resultId: string;
+  platform: string;
+  /** Raw validation status, e.g. "not_run". */
+  status: string;
+  /** Reader-facing label from the shared vocabulary, e.g. "no validation". */
+  label: string;
+}
+
 export interface CompareDecisionSummary {
   primaryMetric: ComparePrimaryMetric;
   primaryMetricLabel: string;
@@ -67,6 +78,16 @@ export interface CompareDecisionSummary {
   queryRecord: WinnerQueryRecord;
   percentiles: ComparePercentiles[];
   cost: CompareCostSummary | null;
+  /**
+   * Selected results whose validation status is present but not a clean pass
+   * (e.g. `not_run`, `failed`, `uncertain`). A result with no recorded status
+   * at all is not included here - this flags an explicit non-clean status,
+   * not an absent one. Non-empty even when `claimSuppressed` is true, so the
+   * UI can still explain *why* a suppressed comparison is untrustworthy.
+   */
+  nonCleanValidation: CompareValidationCaveat[];
+  /** Prose caveat built from `nonCleanValidation`, or null when it is empty. */
+  validationCaveat: string | null;
 }
 
 interface CompareDecisionSummaryOptions {
@@ -114,6 +135,8 @@ export function buildCompareDecisionSummary(
   const cost = buildCostSummary(results, winner, primaryMetric);
   const isTie = comparisonRatio !== null && Math.abs(comparisonRatio - 1) < COMPARE_TIE_THRESHOLD;
   const winnerLabel = winner ? options.runLabels?.[winner.resultId] ?? winner.platform : null;
+  const nonCleanValidation = buildNonCleanValidation(results);
+  const validationCaveat = buildValidationCaveat(nonCleanValidation);
 
   return {
     primaryMetric,
@@ -131,11 +154,38 @@ export function buildCompareDecisionSummary(
       ...options,
       suppressWinnerClaims,
       suppressionReason: suppressionReason ?? undefined,
-    }),
+    }, validationCaveat),
     queryRecord,
     percentiles,
     cost,
+    nonCleanValidation,
+    validationCaveat,
   };
+}
+
+/**
+ * Selected results whose validation status is present but not a clean pass.
+ * This is the fix for the "headline claims a winner off an unvalidated
+ * result" gap: a result missing a status entirely is not flagged (many
+ * fixtures/legacy bundles simply never recorded one), but an explicit
+ * non-clean status - `not_run` included - always is.
+ */
+function buildNonCleanValidation(results: DetailResult[]): CompareValidationCaveat[] {
+  const caveats: CompareValidationCaveat[] = [];
+  for (const result of results) {
+    const raw = result.validation_status;
+    if (raw === null || raw === undefined || raw === "") continue;
+    const info = describeValidationStatus(raw);
+    if (info.isClean) continue;
+    caveats.push({ resultId: result.result_id, platform: result.platform, status: raw, label: info.label });
+  }
+  return caveats;
+}
+
+function buildValidationCaveat(nonCleanValidation: CompareValidationCaveat[]): string | null {
+  if (nonCleanValidation.length === 0) return null;
+  const parts = nonCleanValidation.map((entry) => `${entry.platform} is ${entry.label}`);
+  return `Validation caution: ${parts.join("; ")}. This comparison rests on at least one unvalidated or non-clean result - treat the winner claim as provisional.`;
 }
 
 function metricRatio(winnerValue: number, comparisonValue: number, higherIsBetter: boolean): number | null {
@@ -148,6 +198,7 @@ function buildHeadline(
   comparisonRatio: number | null,
   primaryMetric: ComparePrimaryMetric,
   options: CompareDecisionSummaryOptions,
+  validationCaveat: string | null,
 ): string {
   if (options.suppressWinnerClaims) {
     const reason = options.suppressionReason ?? "selected runs are not from the same comparable ranking";
@@ -158,14 +209,18 @@ function buildHeadline(
   }
   if (!winner) return "No winner claim: selected results are missing the primary metric.";
   const winnerLabel = options.runLabels?.[winner.resultId] ?? winner.platform;
-  if (comparisonRatio === null) return `${winnerLabel} leads on the selected primary metric.`;
+  // A reader who reads only this headline must not come away believing the
+  // comparison rests on validated data when it does not - so the caveat rides
+  // along with the winner claim itself, not just the receipt below the fold.
+  const caveatSuffix = validationCaveat ? ` ${validationCaveat}` : "";
+  if (comparisonRatio === null) return `${winnerLabel} leads on the selected primary metric.${caveatSuffix}`;
   if (Math.abs(comparisonRatio - 1) < COMPARE_TIE_THRESHOLD) {
-    return `Selected runs are within the tie threshold (${formatRatio(comparisonRatio)}); no material winner on the selected primary metric.`;
+    return `Selected runs are within the tie threshold (${formatRatio(comparisonRatio)}); no material winner on the selected primary metric.${caveatSuffix}`;
   }
   if (primaryMetric === "power_score") {
-    return `${winnerLabel} leads by ${formatRatio(comparisonRatio)} on power score.`;
+    return `${winnerLabel} leads by ${formatRatio(comparisonRatio)} on power score.${caveatSuffix}`;
   }
-  return `${winnerLabel} is ${formatRatio(comparisonRatio)} faster by geomean query time.`;
+  return `${winnerLabel} is ${formatRatio(comparisonRatio)} faster by geomean query time.${caveatSuffix}`;
 }
 
 function isQueryEvidenceSuppressionReason(reason: string): boolean {

--- a/results-explorer/src/lib/displayLabels.ts
+++ b/results-explorer/src/lib/displayLabels.ts
@@ -1,3 +1,4 @@
+import type { StatusTone } from "@/components/StatusBadge";
 import { humanizeBenchmark } from "@/utils";
 
 // Public-facing formatters for raw internal enum strings.
@@ -19,7 +20,111 @@ const VALIDATION_STATUS_LABELS: Record<string, string> = {
   warning: "warning",
   not_applicable: "not applicable",
   pending: "pending",
+  // The remaining keys are the full validation-status enum from
+  // benchbox/core/results/status.py (NON_CLEAN_VALIDATION_STATUSES). Mirrored
+  // here rather than generated, same rationale as FUNDING_LABELS above.
+  interrupted: "interrupted",
+  partial: "partial pass",
+  error: "validation error",
+  not_run: "no validation",
+  not_validated: "not validated",
+  uncertain: "uncertain",
+  unknown: "unknown",
 };
+
+/**
+ * Longer, tooltip-length prose for each validation status. Paired 1:1 with
+ * `VALIDATION_STATUS_LABELS` by key; a status without a curated label also has
+ * no curated description here and falls back to a generic sentence built from
+ * the short label in `describeValidationStatus`.
+ */
+const VALIDATION_STATUS_DESCRIPTIONS: Record<string, string> = {
+  passed: "Validated against the reference oracle and confirmed correct.",
+  failed: "Validation ran and found this result incorrect.",
+  warning: "Validation ran and flagged a concern short of a hard failure.",
+  not_applicable: "Validation does not apply to this result.",
+  pending: "Validation has not completed yet.",
+  interrupted: "The run was interrupted before validation could complete.",
+  partial: "Some queries failed validation; this is a partial pass.",
+  error: "The validation process itself errored and produced no verdict.",
+  not_run: "Validation never executed for this result (for example, DataFrame mode or --validation disabled). The numbers are unverified.",
+  not_validated: "This result was explicitly not checked against an oracle.",
+  uncertain: "Validation completed with reduced confidence; treat this result with caution.",
+  unknown: "Validation status was not recorded for this result.",
+};
+
+// Mirrors benchbox/core/results/status.py::CLI_FAILURE_VALIDATION_STATUSES.
+// Statuses where the run itself failed at the CLI/execution level.
+const VALIDATION_CLI_FAILURE_STATUSES = new Set(["failed", "interrupted", "partial", "error"]);
+
+// Everything else non-clean falls to UNVALIDATED_VALIDATION_STATUSES in
+// benchbox/core/results/status.py (not_run, not_validated, uncertain, unknown)
+// plus warning/pending: the run completed but validation never produced a
+// clean confirmation. Handled by the final `else` branch below rather than a
+// duplicate literal set - keep the CLI-failure and clean sets as the only
+// hand-maintained lists, same "derived, don't hand-maintain a third set"
+// rule status.py itself follows.
+
+// Statuses treated as a clean pass. "passed" is the current producer value;
+// "pass", "exact", and "full" are historical/tolerance-mode values that carry
+// the same meaning (see ResultDetail.tsx's isPassingValidationStatus, which
+// also accepts "pass").
+const VALIDATION_CLEAN_STATUSES = new Set(["passed", "pass", "exact", "full"]);
+
+export interface ValidationStatusInfo {
+  /** Normalized (trimmed, lowercased) raw status, or null when absent. */
+  status: string | null;
+  /** Short, reader-facing label. Always defined, even for an absent status. */
+  label: string;
+  /** Longer tooltip-length explanation of what the status means. */
+  description: string;
+  /** Suggested StatusBadge tone. */
+  tone: StatusTone;
+  /** True only for a clean pass ("passed"). */
+  isClean: boolean;
+}
+
+/**
+ * The ONE shared mapping from a raw validation-status enum value to
+ * reader-facing language. Every surface that displays a validation status
+ * (compare receipt, result detail chip, platform index Source column,
+ * leaderboard validation badge) should call this - or `formatValidationStatus`
+ * for just the short label - instead of rendering the raw enum string.
+ *
+ * The raw status stays available via the `status` field for any surface that
+ * wants to show precision (a tooltip, a receipt row, a detail field) alongside
+ * the interpretable label.
+ */
+export function describeValidationStatus(raw: string | null | undefined): ValidationStatusInfo {
+  const status = raw === null || raw === undefined ? null : raw.trim().toLowerCase() || null;
+  if (status === null) {
+    return {
+      status: null,
+      label: "not recorded",
+      description: "No validation status was recorded for this result.",
+      tone: "neutral",
+      isClean: false,
+    };
+  }
+  const label = VALIDATION_STATUS_LABELS[status] ?? formatEnumLabel(status);
+  const description = VALIDATION_STATUS_DESCRIPTIONS[status] ?? "No further detail is defined for this status.";
+  const isClean = VALIDATION_CLEAN_STATUSES.has(status);
+  let tone: StatusTone;
+  if (isClean) {
+    tone = "info";
+  } else if (status === "loose" || status === "range") {
+    // Tolerance-mode passes: validated, but with a wider acceptance band.
+    tone = "warning";
+  } else if (VALIDATION_CLI_FAILURE_STATUSES.has(status)) {
+    tone = "danger";
+  } else {
+    // Everything else non-clean, including UNVALIDATED_VALIDATION_STATUSES
+    // and any unrecognised status: never fall through to the least-alarming
+    // ("neutral") tone for a value that is not a clean pass.
+    tone = "warning";
+  }
+  return { status, label, description, tone, isClean };
+}
 
 const VISIBILITY_LABELS: Record<string, string> = {
   "public-curated": "public (curated)",
@@ -65,7 +170,7 @@ export function formatFunding(raw: string | null | undefined): string {
 
 export function formatValidationStatus(raw: string | null | undefined): string {
   if (raw === null || raw === undefined || raw === "") return "unknown";
-  return VALIDATION_STATUS_LABELS[raw] ?? formatEnumLabel(raw);
+  return describeValidationStatus(raw).label;
 }
 
 /**

--- a/results-explorer/src/pages/Compare.tsx
+++ b/results-explorer/src/pages/Compare.tsx
@@ -39,6 +39,7 @@ import {
   ComparabilityReceipt,
   buildComparabilityFields,
   comparabilityWarningFields,
+  orderWarningLabelsForSummary,
 } from "@/components/ComparabilityReceipt";
 import { CompareSummary } from "@/components/CompareSummary";
 import {
@@ -493,7 +494,10 @@ export function Compare({ url }: CompareProps) {
   const comparabilityFields = buildComparabilityFields(results);
   const comparabilityWarnings = comparabilityWarningFields(comparabilityFields);
   const comparabilityWarningCount = comparabilityWarnings.length;
-  const comparabilityWarningLabels = comparabilityWarnings.map((field) => field.label);
+  // Validation is sorted to the front of the summary so it never gets folded
+  // into "+N more" behind cosmetic environment differences (CPU model,
+  // driver version, ...) - see orderWarningLabelsForSummary.
+  const comparabilityWarningLabels = orderWarningLabelsForSummary(comparabilityWarnings);
   // Compare identity is canonicalized at the cohort boundary. Raw slugs such
   // as `star_schema` remain valid in result data and route links, but aliases
   // must not turn one SSB family into a false mixed-benchmark heading.

--- a/results-explorer/src/pages/__tests__/Compare.test.tsx
+++ b/results-explorer/src/pages/__tests__/Compare.test.tsx
@@ -907,6 +907,62 @@ describe("Compare", () => {
     expect(window.location.hash).toBe("#comparability-receipt-warnings");
   });
 
+  // ---------------------------------------------------------------------
+  // Live reproduction: DuckDB vs Pandas at H2ODB SF0.01. Pandas carries
+  // validation_status "not_run" alongside three cosmetic environment diffs
+  // (platform version, driver version, execution mode). Before this fix the
+  // guardrails summary named only the three cosmetic diffs and folded
+  // Validation into "+1 more", and the Decision Summary headlined a
+  // confident winner claim with no caveat that one side was unvalidated.
+  // ---------------------------------------------------------------------
+  it("names Validation explicitly in the guardrails summary and caveats the winner claim (DuckDB vs Pandas, unvalidated)", async () => {
+    vi.mocked(getDetailResult).mockImplementation((id) =>
+      id === "r1"
+        ? Promise.resolve(
+            makeResult({
+              result_id: "r1",
+              platform: "DuckDB",
+              power_score: 3560,
+              platform_version: "1.1.0",
+              driver_version: "1.1.0",
+              execution_mode: "native",
+              validation_status: "passed",
+            }),
+          )
+        : Promise.resolve(
+            makeResult({
+              result_id: "r2",
+              platform: "Pandas",
+              platform_id: "pandas",
+              power_score: 1000,
+              platform_version: "2.2.0",
+              driver_version: "2.2.0",
+              execution_mode: "dataframe",
+              validation_status: "not_run",
+              display_timings: [
+                { query_id: "Q1", display_ms: 100, sample_count: 3, is_valid_display_timing: true, timing_exclusion_reason: null },
+                { query_id: "Q2", display_ms: 200, sample_count: 3, is_valid_display_timing: true, timing_exclusion_reason: null },
+              ],
+            }),
+          ),
+    );
+
+    render(<Compare />);
+    await waitFor(() => expect(screen.getByRole("heading", { name: "Decision Summary" })).toBeTruthy());
+
+    const guardrails = screen.getByRole("region", { name: "Compare guardrails" });
+    // Validation must be named in the visible summary, not folded into "+N more" -
+    // it is sorted to the front, so any truncation falls on the cosmetic fields.
+    expect(guardrails.textContent).toMatch(/Warning classes: Validation,/);
+
+    const summary = screen.getByRole("heading", { name: "Decision Summary" }).closest("section");
+    expect(summary).toHaveTextContent("DuckDB");
+    // The headline itself carries the caveat - a reader who reads only the
+    // headline must not conclude this rests on validated data.
+    expect(summary).toHaveTextContent("Validation caution");
+    expect(summary).toHaveTextContent("Unvalidated result");
+  });
+
   it("uses singular warning copy for one compare guardrail warning", async () => {
     vi.mocked(getDetailResult).mockImplementation((id) =>
       id === "r1"

--- a/results-explorer/src/pages/__tests__/PlatformIndex.test.tsx
+++ b/results-explorer/src/pages/__tests__/PlatformIndex.test.tsx
@@ -888,7 +888,7 @@ describe("PlatformIndex - sortable table headers", () => {
     // column, so it renders without scrolling the table.
     const runCell = notRunFlag.closest("td");
     expect(runCell?.querySelector('[data-testid="run-identity-label"]')).not.toBeNull();
-    expect(within(notRunFlag).getByText("not_run")).toBeTruthy();
+    expect(within(notRunFlag).getByText("no validation")).toBeTruthy();
 
     expect(container.querySelector('[data-testid="platform-validation-flag-r-clean"]')).toBeNull();
   });


### PR DESCRIPTION
Introduce a single shared validation-status display mapping (describeValidationStatus)
in displayLabels.ts that translates raw status enums to reader-facing labels,
descriptions, and tones.

Update Compare view and ComparabilityReceipt to:
- Name Validation explicitly in the guardrails summary without truncation
- Caveat winner claims in CompareSummary when comparing unvalidated candidates
- Render human-readable validation status labels on chips and receipts
