### PR TITLE
fix(explorer): surface non-clean validation status in default matrix/index view

### DIFF
--- a/results-explorer/package-lock.json
+++ b/results-explorer/package-lock.json
@@ -2383,9 +2383,9 @@
       }
     },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.10.13",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.13.tgz",
-      "integrity": "sha512-BL2sTuHOdy0YT1lYieUxTw/QMtPBC3pmlJC6xk8BBYVv6vcw3SGdKemQ+Xsx9ik2F/lYDO9tqsFQH1r9PFuHKw==",
+      "version": "2.11.20",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.11.20.tgz",
+      "integrity": "sha512-H0ulySigv6icDJ1F7SjtdCD6PrhTpdYCmP0CactWy1+ekh0AFd0o1Wn5T8b+hnTmdBx19u9yhL6wvCylXMY7zw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -2439,9 +2439,9 @@
       }
     },
     "node_modules/browserslist": {
-      "version": "4.28.2",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.2.tgz",
-      "integrity": "sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==",
+      "version": "4.28.8",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.8.tgz",
+      "integrity": "sha512-V2NpofLblG64mfOtSgDhOJESZEGogzDMBv/q+W6oc4LXWP/q75eOXoOaaOu1EOadB9U4Bwx/e0yzbvwKH8zalA==",
       "dev": true,
       "funding": [
         {
@@ -2459,11 +2459,11 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "baseline-browser-mapping": "^2.10.12",
-        "caniuse-lite": "^1.0.30001782",
-        "electron-to-chromium": "^1.5.328",
-        "node-releases": "^2.0.36",
-        "update-browserslist-db": "^1.2.3"
+        "baseline-browser-mapping": "^2.11.12",
+        "caniuse-lite": "^1.0.30001809",
+        "electron-to-chromium": "^1.5.402",
+        "node-releases": "^2.0.53",
+        "update-browserslist-db": "^1.3.0"
       },
       "bin": {
         "browserslist": "cli.js"
@@ -2533,9 +2533,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001784",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001784.tgz",
-      "integrity": "sha512-WU346nBTklUV9YfUl60fqRbU5ZqyXlqvo1SgigE1OAXK5bFL8LL9q1K7aap3N739l4BvNqnkm3YrGHiY9sfUQw==",
+      "version": "1.0.30001810",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001810.tgz",
+      "integrity": "sha512-TITQPUkaz+aVk5GL6NhOdwk1aEaNTSDPsGFWrTuhKGtjTF70jL/Oht2W4c6rXUe5fu7Ie19VIahAXHIIiWWNeg==",
       "dev": true,
       "funding": [
         {
@@ -3009,9 +3009,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.331",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.331.tgz",
-      "integrity": "sha512-IbxXrsTlD3hRodkLnbxAPP4OuJYdWCeM3IOdT+CpcMoIwIoDfCmRpEtSPfwBXxVkg9xmBeY7Lz2Eo2TDn/HC3Q==",
+      "version": "1.5.419",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.419.tgz",
+      "integrity": "sha512-nHMPn8x4yCxCI0iSnL+LlHL5sUoUfjLXkcRIagZ4GBdrfFLFaiLNvzJWbJqZhFT9IAhw5tUSNlhggWN+otvp/A==",
       "dev": true,
       "license": "ISC"
     },
@@ -4464,11 +4464,14 @@
       }
     },
     "node_modules/node-releases": {
-      "version": "2.0.37",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.37.tgz",
-      "integrity": "sha512-1h5gKZCF+pO/o3Iqt5Jp7wc9rH3eJJ0+nh/CIoiRwjRxde/hAHyLPXYN4V3CqKAbiZPSeJFSWHmJsbkicta0Eg==",
+      "version": "2.0.54",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.54.tgz",
+      "integrity": "sha512-YHs7BmmcsdAI5Ozuf8JZo6PT0mv2GIWC9vMfvUC3dp65M8hn7Ux8CPL+2oBI7juNuj9d0ndhTcznq2ODBps9cQ==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/normalize-path": {
       "version": "3.0.0",
@@ -4865,9 +4868,9 @@
       }
     },
     "node_modules/postcss-selector-parser": {
-      "version": "6.1.2",
-      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.1.2.tgz",
-      "integrity": "sha512-Q8qQfPiZ+THO/3ZrOrO0cJJKfpYCagtMUkXbnEfmgUjwXg6z/WBeOyS9APBBPCTSiDV+s4SwQGu8yFsiMRIudg==",
+      "version": "6.1.4",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.1.4.tgz",
+      "integrity": "sha512-bIoJLOmjCO1S9XdY/DcnR5hJxvrDir1PbGChrzXG3vw0/FOliy/fA3dmdhQ441kah4gKv+TwckGzex6wNS5cnQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5708,9 +5711,9 @@
       "license": "MIT"
     },
     "node_modules/update-browserslist-db": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
-      "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.3.2.tgz",
+      "integrity": "sha512-UQ+MSxlhRm1bzjhU+DcuXfjFO1FzNtqhK5+9Yvlp90ItDLk5vT932A0rFu619nf7RVS+Y/VeaUW1jaRDqZ8VJw==",
       "dev": true,
       "funding": [
         {

--- a/results-explorer/src/components/QueryHeatmap.tsx
+++ b/results-explorer/src/components/QueryHeatmap.tsx
@@ -41,6 +41,7 @@ import {
   platformTimingValue,
   validPrimaryMetricValue,
 } from "@/lib/displayEligibility";
+import { isValidationNotClean } from "@/lib/displayLabels";
 
 // ---------------------------------------------------------------------------
 // Color math - sourced from chartMath.ts (single source of truth for parity)
@@ -473,6 +474,10 @@ export function QueryHeatmap({
           excluded from heat, ranks, and comparisons. <strong>No run</strong> means missing data. The primary score column (
           {primaryLabel}) on the left of each row uses its own metric and direction ({primaryDirectionLabel}).
         </div>
+        <div class="mt-1">
+          A validation badge next to a platform name means that result was excluded from ranking on validation
+          grounds - the query cells shown are still published evidence, not a validated, comparable score.
+        </div>
       </div>
 
       <div
@@ -657,6 +662,7 @@ export function QueryHeatmap({
                     ? selectionLimitReasonId
                     : undefined;
                 const rankingExclusion = isRankable(row) ? null : formatTimingExclusion(row.ranking_exclusion_reason);
+                const validationNotClean = isValidationNotClean(row.validation_status);
                 return (
                   <tr
                     key={row.result_id}
@@ -718,6 +724,14 @@ export function QueryHeatmap({
                         </span>
                       )}
                     </div>
+                    {validationNotClean && (
+                      <div
+                        class="mt-0.5 flex flex-wrap items-center gap-1"
+                        data-testid={`heatmap-validation-flag-${row.result_id}`}
+                      >
+                        <ValidationBadge validationStatus={row.validation_status} showMissing />
+                      </div>
+                    )}
                     <details class="mt-1 text-xs text-[var(--bb-data-fg-muted)]">
                       <summary class="cursor-pointer font-medium text-[var(--bb-accent-hover)]">
                         {BENCHMARK_MATRIX_DENSITY_CONTRACT.secondaryMetadataAffordance}
@@ -725,7 +739,9 @@ export function QueryHeatmap({
                       <div class="mt-1 flex flex-wrap items-center gap-1">
                         <TrustBadge trustLabel={row.trust_label} compact />
                         <FundingChip funding={row.funding} compact />
-                        <ValidationBadge validationStatus={row.validation_status} showMissing />
+                        {!validationNotClean && (
+                          <ValidationBadge validationStatus={row.validation_status} showMissing />
+                        )}
                         <a
                           href={`/results/r/${row.result_id}#run-receipt`}
                           class="font-medium no-underline"

--- a/results-explorer/src/components/__tests__/QueryHeatmap.test.tsx
+++ b/results-explorer/src/components/__tests__/QueryHeatmap.test.tsx
@@ -261,6 +261,50 @@ describe("QueryHeatmap rendering", () => {
     expect(screen.getAllByText("loose").length).toBeGreaterThan(0);
   });
 
+  it("surfaces a not_run validation badge next to the platform name without expanding the disclosure", () => {
+    const summary = makeSummary({
+      platforms: [
+        {
+          ...makeSummary().platforms[0]!,
+          result_id: "platform-not-run",
+          validation_status: "not_run",
+        },
+        makeSummary().platforms[1]!,
+      ],
+    });
+    render(<QueryHeatmap summary={summary} />);
+
+    // Visible without clicking any "Receipt and metadata" disclosure.
+    const flag = screen.getByTestId("heatmap-validation-flag-platform-not-run");
+    const badge = within(flag).getByText("not_run");
+    expect(badge.closest("details")).toBeNull();
+    // Tone (warning vs. neutral) for "not_run" is owned by
+    // fix/explorer-validation-badge-gating (TrustBadge.tsx validationTone());
+    // this test only asserts the badge is visible without expanding anything.
+    expect(badge.getAttribute("data-role")).toBe("validation");
+
+    // The disclosure for that row no longer duplicates the badge - it stays
+    // reserved for trust/funding/receipt, so the not_run flag has exactly one
+    // rendered instance for this row.
+    const row = flag.closest("tr");
+    expect(row).not.toBeNull();
+    expect(within(row as HTMLElement).getAllByText("not_run")).toHaveLength(1);
+  });
+
+  it("does not add a validation flag for a clean (passed) result", () => {
+    const summary = makeSummary({
+      platforms: [
+        {
+          ...makeSummary().platforms[0]!,
+          result_id: "platform-passed",
+          validation_status: "passed",
+        },
+      ],
+    });
+    render(<QueryHeatmap summary={summary} />);
+    expect(screen.queryByTestId("heatmap-validation-flag-platform-passed")).toBeNull();
+  });
+
   it("clicking a query header sorts rows by that query", () => {
     const { container } = render(<QueryHeatmap summary={makeSummary()} />);
     const rowOrder = () =>

--- a/results-explorer/src/lib/displayLabels.ts
+++ b/results-explorer/src/lib/displayLabels.ts
@@ -68,6 +68,22 @@ export function formatValidationStatus(raw: string | null | undefined): string {
   return VALIDATION_STATUS_LABELS[raw] ?? formatEnumLabel(raw);
 }
 
+/**
+ * Non-clean validation status: anything that is not the literal "passed"
+ * value, including missing/empty status. Mirrors the condition
+ * MetaLeaderboard.tsx already uses to decide whether the validation badge
+ * needs to surface outside its normal (ranked-cell) placement - kept here so
+ * every surface that needs an "is this validation status a problem" check
+ * shares one predicate rather than each re-deriving it.
+ *
+ * This is a placeholder pending the shared status->reader-facing-label
+ * mapping being introduced on fix/explorer-compare-validation-disclosure;
+ * once that lands, callers of this predicate should reconcile with it.
+ */
+export function isValidationNotClean(raw: string | null | undefined): boolean {
+  return (raw?.trim().toLowerCase() ?? "") !== "passed";
+}
+
 export function formatVisibility(raw: string | null | undefined): string {
   if (raw === null || raw === undefined || raw === "") return "unknown";
   return VISIBILITY_LABELS[raw] ?? formatEnumLabel(raw);

--- a/results-explorer/src/pages/PlatformIndex.tsx
+++ b/results-explorer/src/pages/PlatformIndex.tsx
@@ -5,7 +5,12 @@ import type { PlatformIndexRowRow } from "@/lib/duckdbQueries";
 import { getPlatformIndexRows } from "@/lib/duckdbQueries";
 import { useFacetState, type DateWindowFacet, type ExplorerFacetKey, type FacetState } from "@/lib/facetModel";
 import { hasActiveFacets, matchesFacetRow, singleFacetValue, toDateWindowFacet } from "@/lib/facetMatching";
-import { formatBenchmarkLabel, formatTrustLabel, formatValidationStatus } from "@/lib/displayLabels";
+import {
+  formatBenchmarkLabel,
+  formatTrustLabel,
+  formatValidationStatus,
+  isValidationNotClean,
+} from "@/lib/displayLabels";
 import {
   compareCohortLockReason,
   compareCohortSignatureForRow,
@@ -785,7 +790,10 @@ export function PlatformIndex({ platform = "" }: PlatformIndexProps) {
             </div>
           </div>
           <div class="flex flex-wrap items-center justify-between gap-2 border-b border-[var(--bb-data-border)] bg-[var(--bb-surface-data-muted)] px-4 py-2 text-xs text-[var(--bb-data-fg-muted)]">
-            <span>Rows are labelled by comparable ranking: benchmark, scale, phase, and primary metric.</span>
+            <span>
+              Rows are labelled by comparable ranking: benchmark, scale, phase, and primary metric. A validation
+              badge under the run label means that result was excluded from ranking on validation grounds.
+            </span>
             <TableScrollHint
               scrollerRef={resultsScrollerRef}
               testId="platform-table-scroll-hint"
@@ -1117,6 +1125,11 @@ function PlatformRow({ entry, runIdentityLabel, checked, onToggle, showMetricCon
       </td>
       <td class="table-td max-w-[24rem]" aria-colindex={platformTableColumnIndex("run", showMetricContract)}>
         <RunIdentityLabel label={runIdentityLabel} />
+        {isValidationNotClean(entry.validation_status) && (
+          <div class="mt-0.5" data-testid={`platform-validation-flag-${entry.result_id}`}>
+            <ValidationBadge validationStatus={entry.validation_status} showMissing />
+          </div>
+        )}
       </td>
       <td class="table-td font-medium" aria-colindex={platformTableColumnIndex("benchmark", showMetricContract)}>{humanizeBenchmark(entry.benchmark)}</td>
       <td class="table-td" aria-colindex={platformTableColumnIndex("scale", showMetricContract)}>SF {entry.scale_factor}</td>

--- a/results-explorer/src/pages/__tests__/PlatformIndex.test.tsx
+++ b/results-explorer/src/pages/__tests__/PlatformIndex.test.tsx
@@ -870,6 +870,29 @@ describe("PlatformIndex - sortable table headers", () => {
     expect(fundingChips[0]?.textContent).toContain("Employer");
   });
 
+  // Non-clean validation status (e.g. never-run DataFrame-mode results) must
+  // read as non-validated in the default column set - no horizontal scroll
+  // to the Source column required.
+  it("surfaces a not_run validation flag in the default (unscrolled) column set", async () => {
+    vi.mocked(getPlatformIndexRows).mockResolvedValue([
+      makeRow({ result_id: "r-not-run", short_id: "notrun01", validation_status: "not_run" }),
+      makeRow({ result_id: "r-clean", short_id: "clean001", validation_status: "passed" }),
+    ]);
+
+    const { container } = render(<PlatformIndex platform="duckdb" />);
+    await waitFor(() => expect(screen.getByText("DuckDB Results")).toBeTruthy());
+
+    const notRunFlag = screen.getByTestId("platform-validation-flag-r-not-run");
+    // The flag lives in the "Run" cell (compare, compare_state, run are the
+    // first default-visible columns) rather than the scroll-gated Source
+    // column, so it renders without scrolling the table.
+    const runCell = notRunFlag.closest("td");
+    expect(runCell?.querySelector('[data-testid="run-identity-label"]')).not.toBeNull();
+    expect(within(notRunFlag).getByText("not_run")).toBeTruthy();
+
+    expect(container.querySelector('[data-testid="platform-validation-flag-r-clean"]')).toBeNull();
+  });
+
   it("exposes the provenance legend on a page that shows the badges", async () => {
     render(<PlatformIndex platform="duckdb" />);
     await waitFor(() => expect(screen.getByText("DuckDB Results")).toBeTruthy());


### PR DESCRIPTION
The benchmark/platform matrix (QueryHeatmap) hid a non-clean validation
status (e.g. the corpus's 41 not_run DataFrame-mode bundles) behind a
collapsed "Receipt and metadata" disclosure, leaving only a tiny "*"
marker visible by default - a skimming reader saw ordinary heat-mapped
numbers indistinguishable from a validated row. The platform index
(PlatformIndex) carried no validation signal at all in its default
columns; the badge only appeared in the horizontally-scrolled "Source"
column.

Surface a ValidationBadge for any non-"passed" validation_status outside
the disclosure (matrix) and next to the run label (platform index), so
the state is visible without expanding anything or scrolling. Matrix:
move the badge out of <details> instead of duplicating it there. Index:
add it beside the existing "Run" column; the Source column keeps its
own copy as the complete provenance cluster after scroll.

The "not literally passed" predicate mirrors MetaLeaderboard.tsx's
existing gating condition (fix/explorer-validation-badge-gating,
unmerged) and now lives once in lib/displayLabels.ts as
isValidationNotClean() rather than being re-derived per surface. It is
a placeholder for the shared status->reader-facing-label mapping being
introduced on fix/explorer-compare-validation-disclosure; reconcile
once that lands.
