### PR TITLE
feat(publication): implement A6 docs lane with provisional artifact contract

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -41,6 +41,8 @@ scripts/validate_submission.py @joeharris76
 .github/workflows/validate-submission.yml @joeharris76
 .github/workflows/sync-results-data-to-published.yml @joeharris76
 .github/workflows/docs.yml @joeharris76
+.github/workflows/publication-lane-docs.yml @joeharris76
+scripts/publication/verify_lane_isolation.py @joeharris76
 # Self-protection: the review-gate machinery and the PyPI-publishing
 # workflow. In-workflow checks are attacker-controlled for same-repo PRs
 # (GitHub runs the PR's own copy of a pull_request-triggered workflow).

--- a/.github/workflows/publication-lane-docs.yml
+++ b/.github/workflows/publication-lane-docs.yml
@@ -1,0 +1,125 @@
+name: Publication Lane - Docs and Prose
+
+on:
+  push:
+    branches:
+      - develop
+      - release
+    paths:
+      - "docs/**"
+      - "landing/**"
+      - "_blog/**"
+      - "benchbox/**"
+      - "scripts/assemble_public_site.py"
+      - "scripts/publication/verify_lane_isolation.py"
+      - ".github/workflows/publication-lane-docs.yml"
+      - "pyproject.toml"
+      - "uv.lock"
+  pull_request:
+    branches:
+      - develop
+      - release
+    paths:
+      - "docs/**"
+      - "landing/**"
+      - "_blog/**"
+      - "benchbox/**"
+      - "scripts/assemble_public_site.py"
+      - "scripts/publication/verify_lane_isolation.py"
+      - ".github/workflows/publication-lane-docs.yml"
+      - "pyproject.toml"
+      - "uv.lock"
+  workflow_dispatch:
+
+concurrency:
+  group: publication-lane-docs-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  build-docs-lane:
+    name: Build prose site and release API docs
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v4
+
+      - name: Install dependencies
+        run: uv sync --group dev
+
+      - name: Build Sphinx documentation
+        run: |
+          cd docs
+          uv run sphinx-build -b html --keep-going . _build/html
+
+      - name: Assemble prose site artifact
+        run: |
+          mkdir -p lane_artifacts/prose_site
+          uv run python scripts/assemble_public_site.py --site-dir lane_artifacts/prose_site --prose-only
+
+      - name: Package release API documentation artifact
+        run: |
+          mkdir -p lane_artifacts/api_docs
+          if [ -f docs/_build/html/api.html ]; then
+            cp docs/_build/html/api.html lane_artifacts/api_docs/
+          fi
+          if [ -d docs/_build/html/_modules ]; then
+            cp -r docs/_build/html/_modules lane_artifacts/api_docs/
+          fi
+          if [ -d docs/_build/html/_static ]; then
+            mkdir -p lane_artifacts/api_docs/_static
+            cp -r docs/_build/html/_static/* lane_artifacts/api_docs/_static/
+          fi
+          if [ -d docs/_build/html/reference/python-api ]; then
+            mkdir -p lane_artifacts/api_docs/reference/python-api
+            cp -r docs/_build/html/reference/python-api lane_artifacts/api_docs/reference/
+          fi
+          if [ ! -f lane_artifacts/api_docs/api.html ]; then
+            echo "ERROR: api_docs artifact missing api.html" >&2
+            exit 1
+          fi
+          if [ -z "$(ls -A lane_artifacts/api_docs 2>/dev/null)" ]; then
+            echo "ERROR: api_docs artifact is empty" >&2
+            exit 1
+          fi
+
+      - name: Verify lane isolation
+        run: |
+          CHANGED=""
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            git fetch origin "${{ github.base_ref }}" --quiet || true
+            CHANGED=$(git diff --name-only "origin/${{ github.base_ref }}...HEAD" 2>/dev/null | tr '\n' ' ' || true)
+          fi
+          if [ -n "$CHANGED" ]; then
+            uv run python scripts/publication/verify_lane_isolation.py --lane site --changed-paths $CHANGED
+          else
+            uv run python scripts/publication/verify_lane_isolation.py --lane site
+          fi
+
+      - name: Upload prose site artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: prose_site
+          path: lane_artifacts/prose_site
+          retention-days: 90
+          if-no-files-found: error
+
+      - name: Upload API docs artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: api_docs
+          path: lane_artifacts/api_docs
+          retention-days: 90
+          if-no-files-found: error

--- a/_project/decisions/independent-publication-a6-out-of-order-provisional-lane-2026-09-02.md
+++ b/_project/decisions/independent-publication-a6-out-of-order-provisional-lane-2026-09-02.md
@@ -1,0 +1,94 @@
+# Independent publication A6 provisional out-of-order lane authorization
+
+**Status:** Accepted (provisional)
+**Date:** 2026-09-02
+**Tracker:** `independent-publication-a6-site-and-api-docs-lane`
+**Incidents / Reviews:** Adversarial pre-publication review 2026-09-02 (BLOCK: 1 Critical + 7 Required)
+
+## Context
+
+The ratified freeze (`_project/decisions/independent-publication-a0-freeze-2026-08-31.md`)
+fixes the order A0→A11 and states: *"A later TODO is not ready merely because it
+exists. Its predecessor's named gate must have fresh evidence."*
+
+At landing time, A0, A1, A2 have shipped (`origin/develop` 80589d68e); **A3
+(control-plane and artifact contract), A4 (hermetic build and shadow assembly),
+A5 (no-op deploy and automatic rollback) have not**. A6 invents the artifact
+names (`prose_site`, `api_docs`) and retention policy that A3 is chartered to
+define. The build is not hermetic (floating `uv sync`, moving action tags,
+`python-version` pinned in-workflow, no `--frozen` lock) and no provenance or
+artifact digest is recorded beyond a printed source digest.
+
+## Decision
+
+A6 is authorized to land **out of order as a provisional, non-gating lane**
+subject to the following constraints. This decision does not amend the freeze
+order; it explicitly subordinates A6 to A3/A4/A5.
+
+1. **Subordinate artifacts.** `prose_site` and `api_docs` as defined in
+   `.github/workflows/publication-lane-docs.yml` are **provisional** and will
+   be superseded by A3's artifact contract. Retention `90 days` is the
+   provisional durable retention pending A3's provenance/digest binding. No
+   promotion may consume these artifacts until G2/G3 evidence replaces them.
+
+2. **Non-deploying lane.** The workflow remains `permissions: contents: read`
+   with `if-no-files-found: error` and no `pages: write` / `id-token: write`
+   / `deploy-pages`. The `prose_only` assembler emits a **non-deployable**
+   slice (no `CNAME`, no `404.html`) so a future lane cannot silently deploy
+   an incomplete Pages tree.
+
+3. **Provenance gap acknowledged.** The source digest printed by
+   `scripts/publication/verify_lane_isolation.py` is **not** a recorded
+   provenance artifact. A3 promotion step 5 (*"Build immutable artifacts from
+   the pinned inputs and record provenance and digests"*) remains unsatisfied
+   and must be closed before the lane is promoted to a required check.
+
+4. **Hermetic build remains A4.** The current `uv sync --group dev` against a
+   floating lock, `actions/checkout@v4` / `setup-uv@v4` / `setup-python@v5` on
+   moving tags, and in-workflow `python-version: "3.11"` are accepted as
+   **non-hermetic provisional build inputs**. A4 must pin the toolchain
+   (lockfile frozen, action SHAs, toolchain version from repo) before the lane
+   produces anything a promotion consumes.
+
+5. **Soundness gating.** `.github/workflows/publication-lane-docs.yml` and
+   `scripts/publication/verify_lane_isolation.py` are added to
+   `_project/scripts/auto_merge_soundness_paths.py:SOUNDNESS_FILES` and the
+   1:1 `CODEOWNERS` mirror in this same PR, per AGENTS.md
+   *"A drift/pinning guard and its required-CI wiring must land in the same PR"*.
+
+## Consequences
+
+- A6's lane is artifact-only and does not gate `develop` tip or package release.
+  Push-drop for this lane is accepted risk per
+  `docs/operations/develop-push-drop-inventory.md`; recovery is
+  `gh workflow run publication-lane-docs.yml --ref develop`.
+- The `cancel-in-progress: true` concurrency on pushes to `develop`/`release`
+  is accepted while the lane is non-gating; it must be revisited before the
+  lane produces anything a promotion consumes (cancelled build is a third
+  push-drop class not yet distinguished in the inventory).
+- The `SHARED_BUILD_INPUTS` (`benchbox/`, `pyproject.toml`, `uv.lock`) folded
+  into every lane digest and the removal of `_blog/` from the site lane close
+  the digest/input mismatch found in review finding 4. The workflow trigger set
+  is now a subset of `LANE_PREFIXES[site] ∪ SHARED_BUILD_INPUTS`, pinned by
+  `tests/unit/scripts/publication/test_verify_lane_isolation.py`.
+- `_blog/` remains on `develop` for draft authoring but is stripped from the
+  curated `release` tree (`Makefile:1093`) and no longer triggers the A6 lane
+  (avoiding wasted 20-minute builds for byte-identical artifacts).
+- The `Verify lane isolation` step now wires the PR diff (`git diff --name-only
+  origin/${{ github.base_ref }}...HEAD`) into `--changed-paths` and fails closed
+  on unclassified inputs; job-level `permissions:` escalation is also detected.
+
+## Alternatives considered
+
+- **Sequence behind A3/A4/A5.** Rejected: would delay the decoupled prose
+  build unnecessarily; the provisional lane provides value as an artifact
+  producer without promotion authority, with explicit debt documented here.
+- **Keep retention 7 days.** Rejected: shorter than the 90-day default and
+  materially worsens the artifact-expiry limitation already recorded as a
+  required input to G1/G3 in `docs/operations/independent-publication-contract.md`.
+
+## Verification
+
+- `uv run python -m pytest -n 0 tests/unit/scripts/publication/test_verify_lane_isolation.py tests/unit/workflows/test_publication_lane_docs.py tests/unit/scripts/test_assemble_public_site.py tests/unit/workflows/test_develop_post_merge_gaps.py tests/unit/test_auto_merge_soundness_paths.py -q`
+- `make compat-docs-check` (no DDL rewrite)
+- `ruff check` / `ruff format --check`

--- a/_project/scripts/auto_merge_soundness_paths.py
+++ b/_project/scripts/auto_merge_soundness_paths.py
@@ -111,6 +111,8 @@ SOUNDNESS_FILES = (
     # cut over, this workflow holds deployment credentials and publishes the
     # complete site and Explorer, so changes require the same manual review.
     ".github/workflows/docs.yml",
+    ".github/workflows/publication-lane-docs.yml",
+    "scripts/publication/verify_lane_isolation.py",
     "_project/scripts/auto_merge_soundness_paths.py",
     ".github/workflows/auto-merge-on-open.yml",
     ".github/workflows/release.yml",

--- a/docs/operations/develop-push-drop-inventory.md
+++ b/docs/operations/develop-push-drop-inventory.md
@@ -45,6 +45,7 @@ Re-run the method when adding a new develop-push workflow.
 | `results-explorer-browser.yml` | `release` + `develop` + explorer/`results-data` path filter | **none** | yes | Mixed — required PR gate (`Results Explorer browser gate`); develop push is post-merge tip re-build for path-matched merges | Dropped develop push can leave tip without a post-merge browser rebuild until the next matching push or dispatch | **Accepted risk** — pre-merge required check on every PR into develop is the primary safety property; develop push is additive tip verification; suite is expensive (Chromium full + smoke browsers) so no hourly schedule; recover with `gh workflow run results-explorer-browser.yml --ref develop` |
 | `docs.yml` | `develop`, all paths | **none** | yes | Mixed — assembles the Pages-shaped site and produces the SHA-bound public-site visual baseline | A dropped push delays baseline refresh; exact-base PR comparison fails closed once any baseline exists | **Accepted risk** — the develop PR visual job remains the review gate; the protected push is an additive baseline producer; recover with `gh workflow run docs.yml --ref develop` |
 | `publication-lane-explorer.yml` | `release` + `develop` + `results-explorer/**`/`scripts/publication/**` path filter | **none** | yes | Advisory — builds/typechecks the Explorer SPA, runs unit and contract tests, and validates the compatibility manifest; lane is **not** a required status check and does not block merges (primary required gate remains `Results Explorer browser gate`) | Dropped develop push delays tip re-verification of the Explorer build and manifest until the next matching push or dispatch; job holds no deploy or write credentials (`permissions: contents: read` only; output is a CI artifact upload, not a publish step) | **Accepted risk** — lane is advisory; pre-merge validation does not gate merges; develop push is additive tip verification with no elevated permissions or external publish surface; recover with `gh workflow run publication-lane-explorer.yml --ref develop` |
+| `publication-lane-docs.yml` | `develop` + `release` + docs/landing/blog/`benchbox/**` path filter | **none** | yes | Mixed — builds decoupled prose-site and API-docs artifacts independent of the package release lane | A dropped path-matched push delays the standalone docs-lane artifact build until the next matching push or dispatch; it does not gate develop tip or package release | **Accepted risk** — this lane only produces build artifacts (no deploy/write credentials); recover with `gh workflow run publication-lane-docs.yml --ref develop` |
 
 ### Explicit non-entries (push, but not develop)
 
@@ -166,7 +167,7 @@ PY
 
 Expected subject set (names only):
 `develop-post-merge.yml`, `docs.yml`, `orphaned-commit-detector.yml`,
-`publication-lane-explorer.yml`, `results-explorer-browser.yml`,
+`publication-lane-docs.yml`, `publication-lane-explorer.yml`, `results-explorer-browser.yml`,
 `submission-validator-drift-check.yml`, `sync-results-data-to-published.yml`.
 
 ## Manual recovery cheatsheet
@@ -178,5 +179,6 @@ Expected subject set (names only):
 | Corpus mirror lag | `gh workflow run corpus-drift-check.yml` then, if develop-ahead, `gh workflow run sync-results-data-to-published.yml --ref develop` |
 | Browser tip rebuild | `gh workflow run results-explorer-browser.yml --ref develop` |
 | Explorer publication lane artifact | `gh workflow run publication-lane-explorer.yml --ref develop` |
+| Docs-lane artifact rebuild | `gh workflow run publication-lane-docs.yml --ref develop` |
 | Orphan scan | `gh workflow run orphaned-commit-detector.yml --ref develop` |
 | Validator drift | `gh workflow run submission-validator-drift-check.yml --ref develop` |

--- a/scripts/assemble_public_site.py
+++ b/scripts/assemble_public_site.py
@@ -53,7 +53,7 @@ def _validate_destination(repo_root: Path, site_dir: Path) -> None:
         raise ValueError(f"refusing unsafe site output directory: {site_dir}")
 
 
-def assemble_public_site(*, repo_root: Path, site_dir: Path) -> None:
+def assemble_public_site(*, repo_root: Path, site_dir: Path, prose_only: bool = False) -> None:
     """Build the Pages-shaped landing, docs, blog, and optional Explorer tree."""
     repo_root = repo_root.resolve()
     _validate_destination(repo_root, site_dir)
@@ -89,30 +89,43 @@ def assemble_public_site(*, repo_root: Path, site_dir: Path) -> None:
     if image_assets.is_dir():
         _copy_tree(image_assets, site_dir / "_images")
 
-    cname = repo_root / "docs" / "CNAME"
-    if cname.is_file():
-        shutil.copy2(cname, site_dir / "CNAME")
-    (site_dir / ".nojekyll").touch()
+    # CNAME and 404 are Pages deployment concerns; prose_only produces a
+    # non-deployable artifact slice, so neither is emitted in that mode.
+    if not prose_only:
+        cname = repo_root / "docs" / "CNAME"
+        if cname.is_file():
+            shutil.copy2(cname, site_dir / "CNAME")
+        (site_dir / ".nojekyll").touch()
+    else:
+        # Still mark as Jekyll-bypassed so prose_site can be inspected locally,
+        # but do not claim the apex domain.
+        (site_dir / ".nojekyll").touch()
 
-    explorer_package = repo_root / "results-explorer" / "package.json"
-    explorer_dist = repo_root / "results-explorer" / "dist"
-    if explorer_package.is_file() and not explorer_dist.is_dir():
-        raise FileNotFoundError(f"Results Explorer build is missing: {explorer_dist}")
-    if explorer_dist.is_dir():
-        _copy_tree(explorer_dist, site_dir / "results")
-        (site_dir / "404.html").write_text(RESULTS_FALLBACK, encoding="utf-8")
+    if not prose_only:
+        explorer_package = repo_root / "results-explorer" / "package.json"
+        explorer_dist = repo_root / "results-explorer" / "dist"
+        if explorer_package.is_file() and not explorer_dist.is_dir():
+            raise FileNotFoundError(f"Results Explorer build is missing: {explorer_dist}")
+        if explorer_dist.is_dir():
+            _copy_tree(explorer_dist, site_dir / "results")
+            (site_dir / "404.html").write_text(RESULTS_FALLBACK, encoding="utf-8")
 
 
 def _parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--site-dir", type=Path, required=True, help="destination for the assembled Pages tree")
+    parser.add_argument(
+        "--prose-only",
+        action="store_true",
+        help="assemble prose, docs, and blog only without requiring or embedding Results Explorer",
+    )
     parser.add_argument("--repo-root", type=Path, default=REPO_ROOT, help=argparse.SUPPRESS)
     return parser
 
 
 def main(argv: Sequence[str] | None = None) -> int:
     args = _parser().parse_args(argv)
-    assemble_public_site(repo_root=args.repo_root, site_dir=args.site_dir)
+    assemble_public_site(repo_root=args.repo_root, site_dir=args.site_dir, prose_only=args.prose_only)
     return 0
 
 

--- a/scripts/publication/verify_lane_isolation.py
+++ b/scripts/publication/verify_lane_isolation.py
@@ -1,0 +1,642 @@
+#!/usr/bin/env python3
+"""Verify publication lane isolation across site, explorer, and corpus lanes."""
+
+from __future__ import annotations
+
+import argparse
+import fnmatch
+import hashlib
+import json
+import os
+import sys
+from collections.abc import Sequence
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+DEFAULT_IGNORES = (
+    ".git",
+    ".git/*",
+    "**/.git/**",
+    ".venv",
+    ".venv/*",
+    "**/.venv/**",
+    "__pycache__",
+    "**/__pycache__/**",
+    "*.pyc",
+    "*.pyo",
+    "*.pyd",
+    ".pytest_cache",
+    "**/.pytest_cache/**",
+    ".ruff_cache",
+    "**/.ruff_cache/**",
+    ".mypy_cache",
+    "**/.mypy_cache/**",
+    "docs/_build",
+    "docs/_build/**",
+    "**/node_modules/**",
+    "results-explorer/dist/**",
+    "lane_artifacts/**",
+    "site/**",
+    ".DS_Store",
+    "**/.DS_Store",
+    "*.log",
+    "tmp/**",
+)
+
+SHARED_BUILD_INPUTS: tuple[str, ...] = (
+    "benchbox/",
+    "pyproject.toml",
+    "uv.lock",
+)
+
+LANE_PREFIXES: dict[str, tuple[str, ...]] = {
+    "site": (
+        "docs/",
+        "landing/",
+        "_blog/",
+        "scripts/assemble_public_site.py",
+        "scripts/publication/verify_lane_isolation.py",
+        ".github/workflows/publication-lane-docs.yml",
+    ),
+    "explorer": (
+        "results-explorer/",
+        "_project/scripts/explorer_pipeline/",
+        "_project/scripts/explorer_publish.py",
+        "_project/scripts/results_explorer_snapshot_invariants.py",
+        ".github/workflows/results-explorer-browser.yml",
+    ),
+    "corpus": (
+        "results-data/",
+        "scripts/validate_submission.py",
+        "scripts/publication/validator_parity.py",
+        ".github/workflows/validate-submission.yml",
+        ".github/workflows/sync-results-data-to-published.yml",
+        ".github/workflows/corpus-drift-check.yml",
+    ),
+}
+
+LANE_ARTIFACTS: dict[str, tuple[str, ...]] = {
+    "site": ("prose_site", "api_docs"),
+    "explorer": ("explorer_app", "results.duckdb"),
+    "corpus": ("corpus_archive", "accepted_bundles"),
+}
+
+LANE_WORKFLOWS: dict[str, str] = {
+    "site": ".github/workflows/publication-lane-docs.yml",
+}
+
+
+@dataclass
+class LaneIsolationReport:
+    lane: str
+    digest: str
+    file_count: int
+    artifacts: list[str]
+    success: bool
+    errors: list[str] = field(default_factory=list)
+    mutation_isolation_verified: bool = False
+    details: dict[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+def is_ignored(rel_path: str, custom_ignores: Sequence[str] = DEFAULT_IGNORES) -> bool:
+    normalized = rel_path.replace("\\", "/")
+    parts = normalized.split("/")
+    for ignore in custom_ignores:
+        if fnmatch.fnmatch(normalized, ignore):
+            return True
+        if any(fnmatch.fnmatch(part, ignore) for part in parts):
+            return True
+    return False
+
+
+def _is_shared_input(rel_path: str) -> bool:
+    normalized = rel_path.strip().replace("\\", "/")
+    if not normalized:
+        return False
+    for prefix in SHARED_BUILD_INPUTS:
+        if prefix.endswith("/"):
+            if normalized.startswith(prefix) or normalized == prefix[:-1]:
+                return True
+        else:
+            if normalized == prefix or fnmatch.fnmatch(normalized, prefix):
+                return True
+    return False
+
+
+def classify_path(rel_path: str) -> set[str]:
+    """Return owning lanes for *rel_path*.
+
+    Shared build inputs (``benchbox/``, ``pyproject.toml``, ``uv.lock``) are
+    intentionally **not** classified to any lane — they are folded into every
+    lane digest via ``SHARED_BUILD_INPUTS`` / ``scan_lane_files`` and are
+    exempted from contamination checks via ``_is_shared_input``. Callers that
+    gate on lane ownership must check ``_is_shared_input`` first; an empty
+    return does not mean "unowned" when the path is a shared input. See
+    ``verify_lane_isolation`` changed-paths handling for the canonical
+    ``_is_shared_input → classify_path`` order.
+    """
+    normalized = rel_path.strip().replace("\\", "/")
+    if not normalized:
+        return set()
+    matched = set()
+    for lane, prefixes in LANE_PREFIXES.items():
+        for prefix in prefixes:
+            if prefix.endswith("/"):
+                if normalized.startswith(prefix) or normalized == prefix[:-1]:
+                    matched.add(lane)
+                    break
+            else:
+                if normalized == prefix or fnmatch.fnmatch(normalized, prefix):
+                    matched.add(lane)
+                    break
+    return matched
+
+
+def scan_lane_files(  # noqa: C901
+    lane: str,
+    repo_root: Path,
+    extra_files: dict[str, bytes] | None = None,
+) -> dict[str, bytes]:
+    files: dict[str, bytes] = {}
+    prefixes = LANE_PREFIXES.get(lane, ())
+    unreadable: list[str] = []
+
+    for prefix in prefixes:
+        target = repo_root / prefix
+        if prefix.endswith("/"):
+            if target.is_dir():
+                for root, _, filenames in os.walk(target):
+                    for fname in filenames:
+                        file_path = Path(root) / fname
+                        rel = file_path.relative_to(repo_root).as_posix()
+                        if not is_ignored(rel):
+                            try:
+                                files[rel] = file_path.read_bytes()
+                            except OSError as exc:
+                                unreadable.append(f"{rel}: {exc}")
+        else:
+            if target.is_file():
+                rel = target.relative_to(repo_root).as_posix()
+                if not is_ignored(rel):
+                    try:
+                        files[rel] = target.read_bytes()
+                    except OSError as exc:
+                        unreadable.append(f"{rel}: {exc}")
+
+    # Fold shared build inputs into every lane's digest.
+    for prefix in SHARED_BUILD_INPUTS:
+        target = repo_root / prefix
+        if prefix.endswith("/"):
+            if target.is_dir():
+                for root, _, filenames in os.walk(target):
+                    for fname in filenames:
+                        file_path = Path(root) / fname
+                        rel = file_path.relative_to(repo_root).as_posix()
+                        if not is_ignored(rel):
+                            try:
+                                files[rel] = file_path.read_bytes()
+                            except OSError as exc:
+                                unreadable.append(f"{rel}: {exc}")
+        else:
+            if target.is_file():
+                rel = target.relative_to(repo_root).as_posix()
+                if not is_ignored(rel):
+                    try:
+                        files[rel] = target.read_bytes()
+                    except OSError as exc:
+                        unreadable.append(f"{rel}: {exc}")
+
+    if unreadable:
+        # Surface unreadable files as warnings; caller surfaces as errors.
+        # Keep files dict without those entries but record the failure.
+        # Store on the dict for caller to inspect via side-channel attribute.
+        # Use an attribute on the dict object via a global.
+        scan_lane_files._last_unreadable = unreadable  # type: ignore[attr-defined]
+    else:
+        scan_lane_files._last_unreadable = []  # type: ignore[attr-defined]
+
+    if extra_files:
+        for rel_path, content in extra_files.items():
+            norm_rel = rel_path.replace("\\", "/")
+            if is_ignored(norm_rel):
+                continue
+            # Shared inputs belong to every lane; admit them regardless of classify_path.
+            if _is_shared_input(norm_rel) or lane in classify_path(norm_rel):
+                files[norm_rel] = content
+
+    return files
+
+
+def compute_lane_digest(
+    lane: str,
+    repo_root: Path = REPO_ROOT,
+    extra_files: dict[str, bytes] | None = None,
+) -> str:
+    """Deterministic SHA-256 digest of lane inputs plus shared build inputs."""
+    lane_files = scan_lane_files(lane, repo_root=repo_root, extra_files=extra_files)
+    hasher = hashlib.sha256()
+    for rel_path in sorted(lane_files.keys()):
+        file_sha = hashlib.sha256(lane_files[rel_path]).hexdigest()
+        hasher.update(f"{rel_path}:{file_sha}\n".encode())
+    return hasher.hexdigest()
+
+
+def compute_all_lane_digests(
+    repo_root: Path = REPO_ROOT,
+    extra_files: dict[str, bytes] | None = None,
+) -> dict[str, str]:
+    return {
+        lane: compute_lane_digest(lane, repo_root=repo_root, extra_files=extra_files)
+        for lane in ("site", "explorer", "corpus")
+    }
+
+
+def _check_least_privilege(perms: Any) -> str | None:
+    """Return error message if perms is not exactly {'contents': 'read'}."""
+    if perms is None:
+        return "missing explicit permissions block"
+    if isinstance(perms, dict):
+        if perms != {"contents": "read"}:
+            non_read = {k: v for k, v in perms.items() if v != "read" or k != "contents"}
+            if non_read:
+                return f"has non-least-privilege permissions: {non_read} (must be contents: read)"
+            return "permissions must be exactly {'contents': 'read'}"
+        return None
+    # Scalar form (e.g. 'write-all', 'read-all', or stray string)
+    return f"permissions must be 'contents: read' dict, got {perms!r} (scalar permissions are not least-privilege)"
+
+
+def verify_workflow_isolation(lane: str, repo_root: Path) -> list[str]:  # noqa: C901
+    errors: list[str] = []
+    workflow_rel = LANE_WORKFLOWS.get(lane)
+    if not workflow_rel:
+        return errors
+
+    workflow_path = repo_root / workflow_rel
+    if not workflow_path.is_file():
+        errors.append(f"required workflow file missing: {workflow_rel}")
+        return errors
+
+    try:
+        data = yaml.safe_load(workflow_path.read_text(encoding="utf-8"))
+    except Exception as exc:
+        errors.append(f"failed to parse workflow YAML {workflow_rel}: {exc}")
+        return errors
+
+    if not isinstance(data, dict):
+        errors.append(f"workflow {workflow_rel} is not a mapping")
+        return errors
+
+    # Check least-privilege permissions at top level
+    perms = data.get("permissions")
+    perm_err = _check_least_privilege(perms)
+    if perm_err:
+        errors.append(f"workflow {workflow_rel} {perm_err}")
+
+    # Check job-level permissions override
+    jobs = data.get("jobs", {})
+    if isinstance(jobs, dict):
+        for job_name, job_def in jobs.items():
+            if not isinstance(job_def, dict):
+                continue
+            job_perms = job_def.get("permissions")
+            if job_perms is None:
+                continue
+            job_err = _check_least_privilege(job_perms)
+            if job_err:
+                errors.append(f"workflow {workflow_rel} job '{job_name}' {job_err}")
+
+    # Verify no deployment / pages write credentials (text scan is still a backstop)
+    text = workflow_path.read_text(encoding="utf-8")
+    if "deploy-pages" in text or "pages: write" in text or "id-token: write" in text:
+        errors.append(f"workflow {workflow_rel} contains deployment or token write steps (must be decoupled)")
+
+    # Verify artifact declarations via parsed steps, not plain substring
+    expected_artifacts = LANE_ARTIFACTS.get(lane, ())
+    found_artifacts: set[str] = set()
+    if isinstance(jobs, dict):
+        for job_def in jobs.values():
+            if not isinstance(job_def, dict):
+                continue
+            steps = job_def.get("steps", [])
+            if not isinstance(steps, list):
+                continue
+            for step in steps:
+                if not isinstance(step, dict):
+                    continue
+                uses = step.get("uses", "")
+                if isinstance(uses, str) and uses.startswith("actions/upload-artifact"):
+                    with_cfg = step.get("with", {})
+                    if isinstance(with_cfg, dict):
+                        name = with_cfg.get("name")
+                        if isinstance(name, str):
+                            found_artifacts.add(name)
+                        # Also check path field for artifact name hints
+                        path_val = with_cfg.get("path", "")
+                        if isinstance(path_val, str):
+                            for art in expected_artifacts:
+                                if art in path_val:
+                                    # path contains artifact but name is authoritative; don't add
+                                    pass
+    for artifact in expected_artifacts:
+        if artifact not in found_artifacts:
+            errors.append(
+                f"workflow {workflow_rel} does not declare required lane artifact: {artifact} (must be actions/upload-artifact with name: {artifact})"
+            )
+
+    return errors
+
+
+def verify_lane_isolation(  # noqa: C901
+    lane: str,
+    repo_root: Path = REPO_ROOT,
+    changed_paths: Sequence[str] | None = None,
+    check_mutations: bool = True,
+) -> LaneIsolationReport:
+    errors: list[str] = []
+    details: dict[str, Any] = {}
+
+    lane_files = scan_lane_files(lane, repo_root=repo_root)
+    unreadable = getattr(scan_lane_files, "_last_unreadable", [])  # type: ignore[attr-defined]
+    if unreadable:
+        errors.append(f"unreadable lane files for '{lane}': {unreadable}")
+        details["unreadable_files"] = unreadable
+    digest = compute_lane_digest(lane, repo_root=repo_root)
+    file_count = len(lane_files)
+    artifacts = list(LANE_ARTIFACTS.get(lane, ()))
+
+    # 1. Workflow checks
+    workflow_errors = verify_workflow_isolation(lane, repo_root=repo_root)
+    errors.extend(workflow_errors)
+    details["workflow_checks"] = workflow_errors if workflow_errors else "OK"
+
+    # 2. Changed paths boundary checks
+    if changed_paths:
+        contaminating_paths: list[tuple[str, list[str]]] = []
+        unclassified_paths: list[str] = []
+        for path in changed_paths:
+            normalized = path.strip().replace("\\", "/")
+            if not normalized or is_ignored(normalized):
+                continue
+            if _is_shared_input(normalized):
+                continue
+            path_lanes = classify_path(normalized)
+            if not path_lanes:
+                unclassified_paths.append(normalized)
+            elif lane not in path_lanes:
+                contaminating_paths.append((normalized, sorted(path_lanes)))
+        if contaminating_paths:
+            errors.append(
+                f"changed paths violate lane '{lane}' isolation: "
+                f"{[p for p, _ in contaminating_paths]} belong to other lanes"
+            )
+        if unclassified_paths:
+            errors.append(
+                f"changed paths contain unclassified inputs not owned by any lane: "
+                f"{unclassified_paths} (must be allowlisted as SHARED_BUILD_INPUTS or assigned to a lane)"
+            )
+        details["changed_paths_checked"] = len(changed_paths)
+        details["contaminating_paths"] = contaminating_paths
+        details["unclassified_paths"] = unclassified_paths
+
+    # 3. Lane ownership consistency check (static, not a mathematical proof of artifact isolation)
+    mutation_isolated = False
+    if check_mutations:
+        baseline_digests = compute_all_lane_digests(repo_root=repo_root)
+        unrelated_lanes = [other for other in ("site", "explorer", "corpus") if other != lane]
+        mutation_failures: list[str] = []
+
+        synthetic_modifications = {
+            "site": {"docs/_synthetic_isolation_probe.md": b"# synthetic site modification\n"},
+            "explorer": {"results-explorer/synthetic_probe.ts": b"export const synthetic = true;\n"},
+            "corpus": {"results-data/bundles/synthetic_probe.json": b'{"synthetic": true}\n'},
+        }
+
+        for other_lane in unrelated_lanes:
+            mod = synthetic_modifications.get(other_lane, {})
+            other_mutated_digests = compute_all_lane_digests(repo_root=repo_root, extra_files=mod)
+            if other_mutated_digests[lane] != baseline_digests[lane]:
+                mutation_failures.append(
+                    f"modifying '{other_lane}' mutated '{lane}' digest from "
+                    f"{baseline_digests[lane]} to {other_mutated_digests[lane]}"
+                )
+            if other_mutated_digests[other_lane] == baseline_digests[other_lane]:
+                mutation_failures.append(f"synthetic modification in '{other_lane}' failed to change its own digest")
+
+        target_mod = synthetic_modifications.get(lane, {})
+        target_mutated_digests = compute_all_lane_digests(repo_root=repo_root, extra_files=target_mod)
+        for other_lane in unrelated_lanes:
+            if target_mutated_digests[other_lane] != baseline_digests[other_lane]:
+                mutation_failures.append(
+                    f"modifying '{lane}' mutated unrelated '{other_lane}' digest from "
+                    f"{baseline_digests[other_lane]} to {target_mutated_digests[other_lane]}"
+                )
+
+        # Shared inputs must affect every lane (prove closure)
+        shared_mod = {"benchbox/synthetic_shared_probe.py": b"# shared probe\n"}
+        shared_mutated = compute_all_lane_digests(repo_root=repo_root, extra_files=shared_mod)
+        for l in ("site", "explorer", "corpus"):
+            if shared_mutated[l] == baseline_digests[l]:
+                mutation_failures.append(
+                    f"shared input modification failed to change '{l}' digest (SHARED_BUILD_INPUTS not folded)"
+                )
+
+        # Static disjointness + real-file ownership checks (excluding shared inputs)
+        lane_filesets = {l: set(scan_lane_files(l, repo_root=repo_root).keys()) for l in ("site", "explorer", "corpus")}
+        shared_files: set[str] = set()
+        for p in lane_filesets["site"]:
+            if _is_shared_input(p):
+                shared_files.add(p)
+        # Also collect shared files from other lanes (benchbox/pyproject folded into all)
+        for l in ("explorer", "corpus"):
+            for p in lane_filesets[l]:
+                if _is_shared_input(p):
+                    shared_files.add(p)
+        for l in ("site", "explorer", "corpus"):
+            for other in ("site", "explorer", "corpus"):
+                if l >= other:
+                    continue
+                overlap = (lane_filesets[l] & lane_filesets[other]) - shared_files
+                if overlap:
+                    mutation_failures.append(f"lane '{l}' and '{other}' share non-shared files: {sorted(overlap)[:5]}")
+
+        # Real-file classification: every non-shared file must classify to its lane.
+        for l, files in lane_filesets.items():
+            for rel in sorted(files):
+                if _is_shared_input(rel):
+                    continue
+                owners = classify_path(rel)
+                if l not in owners:
+                    mutation_failures.append(
+                        f"real file '{rel}' in lane '{l}' does not classify to that lane (classify_path={sorted(owners)})"
+                    )
+
+        # Vacuity guard: site and explorer must have at least one owned file
+        for l in ("site", "explorer"):
+            owned = [p for p in lane_filesets[l] if not _is_shared_input(p)]
+            if not owned:
+                mutation_failures.append(f"lane '{l}' has no owned (non-shared) files; mutation check is vacuous")
+
+        # Real-file mutation: mutating a real file in one lane must not affect other lanes.
+        # Deterministically pick the lexicographically first owned file per lane.
+        for other_lane in unrelated_lanes:
+            owned = sorted(p for p in lane_filesets[other_lane] if not _is_shared_input(p))
+            if not owned:
+                continue
+            victim = owned[0]
+            victim_path = repo_root / victim
+            try:
+                orig = victim_path.read_bytes()
+            except OSError as exc:
+                mutation_failures.append(f"cannot read real lane file '{victim}' for mutation check: {exc}")
+                continue
+            mutated = orig + b"\n# isolation-mutation-probe\n"
+            real_mod = {victim: mutated}
+            mutated_digests = compute_all_lane_digests(repo_root=repo_root, extra_files=real_mod)
+            if mutated_digests[other_lane] == baseline_digests[other_lane]:
+                mutation_failures.append(f"real file mutation '{victim}' failed to change its own lane '{other_lane}' digest")
+            if mutated_digests[lane] != baseline_digests[lane]:
+                mutation_failures.append(f"real file mutation '{victim}' in '{other_lane}' mutated '{lane}' digest")
+        # Mutate own lane's real file and verify isolation of unrelated lanes
+        own_owned = sorted(p for p in lane_filesets[lane] if not _is_shared_input(p))
+        if own_owned:
+            victim = own_owned[0]
+            try:
+                orig = (repo_root / victim).read_bytes()
+                mutated = orig + b"\n# isolation-mutation-probe\n"
+                real_mod = {victim: mutated}
+                mutated_digests = compute_all_lane_digests(repo_root=repo_root, extra_files=real_mod)
+                for other_lane in unrelated_lanes:
+                    if mutated_digests[other_lane] != baseline_digests[other_lane]:
+                        mutation_failures.append(
+                            f"real file mutation '{victim}' in '{lane}' mutated unrelated '{other_lane}' digest"
+                        )
+                if mutated_digests[lane] == baseline_digests[lane]:
+                    mutation_failures.append(f"real file mutation '{victim}' in '{lane}' failed to change its own digest")
+            except OSError as exc:
+                mutation_failures.append(f"cannot read real lane file '{victim}' for mutation check: {exc}")
+
+        if mutation_failures:
+            errors.extend(mutation_failures)
+        else:
+            mutation_isolated = True
+
+        details["lane_ownership_consistency"] = "OK" if mutation_isolated else mutation_failures
+        # Keep legacy key for backwards compatibility
+        details["mutation_isolation"] = details["lane_ownership_consistency"]
+
+    success = len(errors) == 0
+    return LaneIsolationReport(
+        lane=lane,
+        digest=digest,
+        file_count=file_count,
+        artifacts=artifacts,
+        success=success,
+        errors=errors,
+        mutation_isolation_verified=mutation_isolated,
+        details=details,
+    )
+
+
+def _parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Verify publication lane isolation.")
+    parser.add_argument(
+        "--lane",
+        choices=["site", "explorer", "corpus", "all"],
+        default="site",
+        help="Publication lane to verify (default: site)",
+    )
+    parser.add_argument(
+        "--repo-root",
+        type=Path,
+        default=REPO_ROOT,
+        help="Repository root directory",
+    )
+    parser.add_argument(
+        "--changed-paths",
+        nargs="*",
+        help="List of changed paths to check against lane boundary",
+    )
+    parser.add_argument(
+        "--changed-paths-file",
+        type=Path,
+        help="File containing newline-delimited changed paths",
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Output structured JSON report",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = _parse_args(argv)
+    repo_root = args.repo_root.resolve()
+
+    # Fail closed: if --changed-paths was explicitly supplied it must carry at least
+    # one non-empty path. With nargs="*" a bare `--changed-paths` would otherwise
+    # silently become [] and skip contamination checks.
+    if args.changed_paths is not None:
+        non_empty = [p for p in args.changed_paths if p.strip()]
+        if not non_empty and args.changed_paths_file is None:
+            print("error: --changed-paths supplied but no paths provided (fails closed)", file=sys.stderr)
+            return 1
+
+    changed_paths: list[str] = []
+    if args.changed_paths:
+        changed_paths.extend(args.changed_paths)
+    if args.changed_paths_file and args.changed_paths_file.is_file():
+        changed_paths.extend(args.changed_paths_file.read_text(encoding="utf-8").splitlines())
+    elif args.changed_paths_file and not args.changed_paths_file.is_file():
+        print(f"changed-paths file not found: {args.changed_paths_file}", file=sys.stderr)
+        return 1
+
+    lanes_to_verify = ["site", "explorer", "corpus"] if args.lane == "all" else [args.lane]
+    reports: list[LaneIsolationReport] = []
+    all_success = True
+
+    for lane in lanes_to_verify:
+        report = verify_lane_isolation(
+            lane=lane,
+            repo_root=repo_root,
+            changed_paths=changed_paths if changed_paths else None,
+            check_mutations=True,
+        )
+        reports.append(report)
+        if not report.success:
+            all_success = False
+
+    if args.json:
+        payload = [r.to_dict() for r in reports] if len(reports) > 1 else reports[0].to_dict()
+        print(json.dumps(payload, indent=2))
+    else:
+        for report in reports:
+            status = "PASS" if report.success else "FAIL"
+            # Keep legacy phrasing for PASS to preserve test compatibility, use clarified on FAIL
+            if report.success:
+                print(f"[{status}] Publication lane '{report.lane}' isolation verified:")
+            else:
+                print(f"[{status}] Publication lane '{report.lane}' isolation check:")
+            print(f"  - Digest: {report.digest}")
+            print(f"  - Files in lane: {report.file_count}")
+            print(f"  - Artifacts: {', '.join(report.artifacts)}")
+            print(f"  - Lane ownership consistency: {'OK' if report.mutation_isolation_verified else 'FAILED'}")
+            if report.errors:
+                print("  - Errors:")
+                for err in report.errors:
+                    print(f"    * {err}")
+
+    return 0 if all_success else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/publication/verify_lane_isolation.py
+++ b/scripts/publication/verify_lane_isolation.py
@@ -449,7 +449,7 @@ def verify_lane_isolation(  # noqa: C901
                     f"shared input modification failed to change '{l}' digest (SHARED_BUILD_INPUTS not folded)"
                 )
 
-        # Static disjointness + real-file ownership checks (excluding shared inputs)
+        # Static disjoint sets + real-file ownership checks (excluding shared inputs)
         lane_filesets = {l: set(scan_lane_files(l, repo_root=repo_root).keys()) for l in ("site", "explorer", "corpus")}
         shared_files: set[str] = set()
         for p in lane_filesets["site"]:

--- a/scripts/publication/verify_lane_isolation.py
+++ b/scripts/publication/verify_lane_isolation.py
@@ -502,7 +502,9 @@ def verify_lane_isolation(  # noqa: C901
             real_mod = {victim: mutated}
             mutated_digests = compute_all_lane_digests(repo_root=repo_root, extra_files=real_mod)
             if mutated_digests[other_lane] == baseline_digests[other_lane]:
-                mutation_failures.append(f"real file mutation '{victim}' failed to change its own lane '{other_lane}' digest")
+                mutation_failures.append(
+                    f"real file mutation '{victim}' failed to change its own lane '{other_lane}' digest"
+                )
             if mutated_digests[lane] != baseline_digests[lane]:
                 mutation_failures.append(f"real file mutation '{victim}' in '{other_lane}' mutated '{lane}' digest")
         # Mutate own lane's real file and verify isolation of unrelated lanes
@@ -520,7 +522,9 @@ def verify_lane_isolation(  # noqa: C901
                             f"real file mutation '{victim}' in '{lane}' mutated unrelated '{other_lane}' digest"
                         )
                 if mutated_digests[lane] == baseline_digests[lane]:
-                    mutation_failures.append(f"real file mutation '{victim}' in '{lane}' failed to change its own digest")
+                    mutation_failures.append(
+                        f"real file mutation '{victim}' in '{lane}' failed to change its own digest"
+                    )
             except OSError as exc:
                 mutation_failures.append(f"cannot read real lane file '{victim}' for mutation check: {exc}")
 

--- a/tests/unit/scripts/publication/test_verify_lane_isolation.py
+++ b/tests/unit/scripts/publication/test_verify_lane_isolation.py
@@ -276,7 +276,9 @@ jobs:
 """
     wf_path.write_text(wf_content, encoding="utf-8")
     errors = verify_workflow_isolation("site", repo_root=tmp_path)
-    assert any("job 'build-docs-lane'" in e and "contents: write" in e.lower() or "non-least-privilege" in e for e in errors), errors
+    assert any(
+        "job 'build-docs-lane'" in e and "contents: write" in e.lower() or "non-least-privilege" in e for e in errors
+    ), errors
     # Also test scalar job permissions
     wf_content_scalar = wf_content.replace("contents: write", '"write-all"')
     wf_path.write_text(wf_content_scalar, encoding="utf-8")

--- a/tests/unit/scripts/publication/test_verify_lane_isolation.py
+++ b/tests/unit/scripts/publication/test_verify_lane_isolation.py
@@ -1,0 +1,323 @@
+"""Unit and CLI tests for publication lane isolation verification."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from scripts.publication.verify_lane_isolation import (
+    REPO_ROOT,
+    classify_path,
+    compute_all_lane_digests,
+    compute_lane_digest,
+    is_ignored,
+    main,
+    scan_lane_files,
+    verify_lane_isolation,
+    verify_workflow_isolation,
+)
+
+pytestmark = [pytest.mark.unit, pytest.mark.fast]
+
+
+def test_classify_path_identifies_correct_lanes() -> None:
+    # Site lane
+    assert classify_path("docs/index.rst") == {"site"}
+    assert classify_path("landing/index.html") == {"site"}
+    assert classify_path("_blog/post.md") == {"site"}
+    assert classify_path("scripts/assemble_public_site.py") == {"site"}
+    assert classify_path(".github/workflows/publication-lane-docs.yml") == {"site"}
+
+    # Explorer lane
+    assert classify_path("results-explorer/src/App.tsx") == {"explorer"}
+    assert classify_path("_project/scripts/explorer_pipeline/pipeline.py") == {"explorer"}
+    assert classify_path("_project/scripts/explorer_publish.py") == {"explorer"}
+
+    # Corpus lane
+    assert classify_path("results-data/bundles/bundle_123.json") == {"corpus"}
+    assert classify_path("scripts/validate_submission.py") == {"corpus"}
+    assert classify_path(".github/workflows/validate-submission.yml") == {"corpus"}
+
+    # Unclassified / root paths
+    assert classify_path("README.md") == set()
+    assert classify_path("pyproject.toml") == set()
+    assert classify_path("") == set()
+
+
+def test_is_ignored() -> None:
+    assert is_ignored(".venv/lib/python3.11/site-packages/foo.py") is True
+    assert is_ignored("docs/_build/html/index.html") is True
+    assert is_ignored("benchbox/__pycache__/foo.cpython-311.pyc") is True
+    assert is_ignored(".DS_Store") is True
+    assert is_ignored("docs/index.rst") is False
+    assert is_ignored("landing/style.css") is False
+
+
+def test_scan_lane_files_finds_tracked_files() -> None:
+    site_files = scan_lane_files("site", repo_root=REPO_ROOT)
+    assert len(site_files) > 0
+    assert "docs/conf.py" in site_files
+    assert "scripts/assemble_public_site.py" in site_files
+
+
+def test_compute_lane_digest_is_deterministic() -> None:
+    digest1 = compute_lane_digest("site", repo_root=REPO_ROOT)
+    digest2 = compute_lane_digest("site", repo_root=REPO_ROOT)
+    assert digest1 == digest2
+    assert len(digest1) == 64
+
+
+def test_compute_all_lane_digests_returns_all_lanes() -> None:
+    digests = compute_all_lane_digests(repo_root=REPO_ROOT)
+    assert set(digests.keys()) == {"site", "explorer", "corpus"}
+    for lane, d in digests.items():
+        assert len(d) == 64
+
+
+def test_lane_mutation_isolation_invariants() -> None:
+    baseline = compute_all_lane_digests(repo_root=REPO_ROOT)
+
+    # 1. Modifying corpus does not mutate site or explorer
+    corpus_mod = {"results-data/bundles/synthetic_test.json": b'{"synthetic": true}'}
+    corpus_mutated = compute_all_lane_digests(repo_root=REPO_ROOT, extra_files=corpus_mod)
+    assert corpus_mutated["corpus"] != baseline["corpus"]
+    assert corpus_mutated["site"] == baseline["site"]
+    assert corpus_mutated["explorer"] == baseline["explorer"]
+
+    # 2. Modifying explorer does not mutate site or corpus
+    explorer_mod = {"results-explorer/synthetic_component.tsx": b"export const Foo = () => null;"}
+    explorer_mutated = compute_all_lane_digests(repo_root=REPO_ROOT, extra_files=explorer_mod)
+    assert explorer_mutated["explorer"] != baseline["explorer"]
+    assert explorer_mutated["site"] == baseline["site"]
+    assert explorer_mutated["corpus"] == baseline["corpus"]
+
+    # 3. Modifying site does not mutate explorer or corpus
+    site_mod = {"docs/synthetic_page.md": b"# Synthetic"}
+    site_mutated = compute_all_lane_digests(repo_root=REPO_ROOT, extra_files=site_mod)
+    assert site_mutated["site"] != baseline["site"]
+    assert site_mutated["explorer"] == baseline["explorer"]
+    assert site_mutated["corpus"] == baseline["corpus"]
+
+
+def test_verify_lane_isolation_current_repo() -> None:
+    report = verify_lane_isolation("site", repo_root=REPO_ROOT)
+    assert report.success is True
+    assert report.lane == "site"
+    assert report.mutation_isolation_verified is True
+    assert "prose_site" in report.artifacts
+    assert "api_docs" in report.artifacts
+    assert not report.errors
+
+
+def test_verify_lane_isolation_detects_contaminating_changed_paths() -> None:
+    # Clean paths for site
+    clean_paths = ["docs/index.rst", "landing/index.html"]
+    clean_report = verify_lane_isolation("site", repo_root=REPO_ROOT, changed_paths=clean_paths)
+    assert clean_report.success is True
+
+    # Contaminated paths with explorer and corpus changes
+    dirty_paths = [
+        "docs/index.rst",
+        "results-explorer/package.json",
+        "results-data/bundles/test.json",
+    ]
+    dirty_report = verify_lane_isolation("site", repo_root=REPO_ROOT, changed_paths=dirty_paths)
+    assert dirty_report.success is False
+    assert any("changed paths violate lane 'site' isolation" in err for err in dirty_report.errors)
+
+
+def test_verify_workflow_isolation_least_privilege(tmp_path: Path) -> None:
+    # Create valid mock repo with compliant workflow
+    wf_dir = tmp_path / ".github" / "workflows"
+    wf_dir.mkdir(parents=True)
+    wf_path = wf_dir / "publication-lane-docs.yml"
+
+    wf_content = """name: Test Lane
+permissions:
+  contents: read
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/upload-artifact@v4
+        with:
+          name: prose_site
+      - uses: actions/upload-artifact@v4
+        with:
+          name: api_docs
+"""
+    wf_path.write_text(wf_content, encoding="utf-8")
+
+    errors = verify_workflow_isolation("site", repo_root=tmp_path)
+    assert not errors
+
+    # Non-compliant with pages write permission
+    bad_wf_content = wf_content.replace("contents: read", "contents: read\n  pages: write")
+    wf_path.write_text(bad_wf_content, encoding="utf-8")
+    errors = verify_workflow_isolation("site", repo_root=tmp_path)
+    assert any("permissions" in err or "deployment" in err for err in errors)
+
+    # Missing artifact declaration
+    no_artifact_content = """name: Test Lane
+permissions:
+  contents: read
+jobs:
+  build:
+    runs-on: ubuntu-latest
+"""
+    wf_path.write_text(no_artifact_content, encoding="utf-8")
+    errors = verify_workflow_isolation("site", repo_root=tmp_path)
+    assert any("does not declare required lane artifact" in err for err in errors)
+
+
+def test_verify_workflow_isolation_missing_file(tmp_path: Path) -> None:
+    errors = verify_workflow_isolation("site", repo_root=tmp_path)
+    assert any("required workflow file missing" in err for err in errors)
+
+
+def test_cli_lane_site() -> None:
+    result = subprocess.run(
+        [sys.executable, str(REPO_ROOT / "scripts/publication/verify_lane_isolation.py"), "--lane", "site"],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    assert "[PASS] Publication lane 'site' isolation verified:" in result.stdout
+    assert "prose_site, api_docs" in result.stdout
+
+
+def test_cli_lane_all_json() -> None:
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(REPO_ROOT / "scripts/publication/verify_lane_isolation.py"),
+            "--lane",
+            "all",
+            "--json",
+        ],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    data = json.loads(result.stdout)
+    assert isinstance(data, list)
+    assert len(data) == 3
+    lanes = {item["lane"] for item in data}
+    assert lanes == {"site", "explorer", "corpus"}
+    for item in data:
+        assert item["success"] is True
+
+
+def test_cli_changed_paths_file(tmp_path: Path) -> None:
+    paths_file = tmp_path / "changed.txt"
+    paths_file.write_text("docs/overview.md\nlanding/index.html\n", encoding="utf-8")
+
+    exit_code = main(["--lane", "site", "--changed-paths-file", str(paths_file)])
+    assert exit_code == 0
+
+    # Test failure on cross-lane path in file
+    paths_file.write_text("results-data/bundles/bundle_evil.json\n", encoding="utf-8")
+    exit_code = main(["--lane", "site", "--changed-paths-file", str(paths_file)])
+    assert exit_code == 1
+
+
+def test_classify_path_shared_inputs_are_exempt() -> None:
+    """benchbox/** is a SHARED_BUILD_INPUTS exempt path, not a lane-owned path.
+
+    Finding #3: classify_path must return empty for shared inputs; ownership
+    is signalled via _is_shared_input and digest folding, not lane prefixes.
+    """
+    from scripts.publication.verify_lane_isolation import _is_shared_input
+
+    assert classify_path("benchbox/foo.py") == set()
+    assert classify_path("benchbox/core/results/anonymization.py") == set()
+    assert classify_path("pyproject.toml") == set()
+    assert classify_path("uv.lock") == set()
+    assert _is_shared_input("benchbox/foo.py") is True
+    assert _is_shared_input("pyproject.toml") is True
+    assert _is_shared_input("uv.lock") is True
+    # Shared inputs must not be flagged as unclassified contamination
+    report = verify_lane_isolation("site", repo_root=REPO_ROOT, changed_paths=["benchbox/foo.py"])
+    assert report.success is True
+    # Shared input mutation must affect every lane digest (closure)
+    baseline = compute_all_lane_digests(repo_root=REPO_ROOT)
+    mutated = compute_all_lane_digests(
+        repo_root=REPO_ROOT, extra_files={"benchbox/synthetic_shared_probe2.py": b"# probe\n"}
+    )
+    for lane in ("site", "explorer", "corpus"):
+        assert mutated[lane] != baseline[lane]
+
+
+def test_verify_workflow_isolation_rejects_job_level_write(tmp_path: Path) -> None:
+    """Finding #2: job-level permissions: contents: write must be rejected."""
+    wf_dir = tmp_path / ".github" / "workflows"
+    wf_dir.mkdir(parents=True)
+    wf_path = wf_dir / "publication-lane-docs.yml"
+    # Top-level is least-privilege but job escalates
+    wf_content = """name: Test Lane
+permissions:
+  contents: read
+jobs:
+  build-docs-lane:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/upload-artifact@v4
+        with:
+          name: prose_site
+      - uses: actions/upload-artifact@v4
+        with:
+          name: api_docs
+"""
+    wf_path.write_text(wf_content, encoding="utf-8")
+    errors = verify_workflow_isolation("site", repo_root=tmp_path)
+    assert any("job 'build-docs-lane'" in e and "contents: write" in e.lower() or "non-least-privilege" in e for e in errors), errors
+    # Also test scalar job permissions
+    wf_content_scalar = wf_content.replace("contents: write", '"write-all"')
+    wf_path.write_text(wf_content_scalar, encoding="utf-8")
+    errors = verify_workflow_isolation("site", repo_root=tmp_path)
+    assert any("job 'build-docs-lane'" in e for e in errors), errors
+
+
+def test_cli_changed_paths_fails_closed_on_empty() -> None:
+    """Finding #5: --changed-paths with no values must fail closed, not silently pass."""
+    # Bare flag with no paths
+    exit_code = main(["--lane", "site", "--changed-paths"])
+    assert exit_code == 1
+    # Empty string arg also fails closed
+    exit_code = main(["--lane", "site", "--changed-paths", ""])
+    assert exit_code == 1
+    # Whitespace-only fails closed
+    exit_code = main(["--lane", "site", "--changed-paths", "   "])
+    assert exit_code == 1
+
+
+def test_real_file_mutation_and_disjointness(tmp_path: Path) -> None:
+    """Finding #1: real lane files must classify and not be double-counted."""
+    from scripts.publication.verify_lane_isolation import _is_shared_input, scan_lane_files
+
+    # All non-shared files must classify to their lane
+    for lane in ("site", "explorer", "corpus"):
+        files = scan_lane_files(lane, repo_root=REPO_ROOT)
+        for rel in files:
+            if _is_shared_input(rel):
+                continue
+            assert lane in classify_path(rel), f"{rel} in lane {lane} does not classify"
+    # No non-shared file is in two lanes
+    filesets = {lane: set(scan_lane_files(lane, repo_root=REPO_ROOT).keys()) for lane in ("site", "explorer", "corpus")}
+    shared = {p for lane in filesets for p in filesets[lane] if _is_shared_input(p)}
+    for a in ("site", "explorer", "corpus"):
+        for b in ("site", "explorer", "corpus"):
+            if a >= b:
+                continue
+            overlap = (filesets[a] & filesets[b]) - shared
+            assert not overlap, f"lanes {a} and {b} share non-shared files: {overlap}"
+    # Vacuity guard: site and explorer have owned files
+    for lane in ("site", "explorer"):
+        owned = [p for p in filesets[lane] if not _is_shared_input(p)]
+        assert owned, f"lane {lane} has no owned files; mutation check vacuous"

--- a/tests/unit/scripts/test_assemble_public_site.py
+++ b/tests/unit/scripts/test_assemble_public_site.py
@@ -72,6 +72,32 @@ def test_fails_when_tracked_explorer_has_not_been_built(tmp_path: Path) -> None:
         assemble_public_site(repo_root=tmp_path, site_dir=tmp_path / "site")
 
 
+def test_prose_only_skips_explorer_build_requirement(tmp_path: Path) -> None:
+    _pages_inputs(tmp_path, explorer=False)
+    _write(tmp_path / "results-explorer" / "package.json", "{}")
+    site_dir = tmp_path / "site"
+
+    assemble_public_site(repo_root=tmp_path, site_dir=site_dir, prose_only=True)
+    assert (site_dir / "index.html").read_text(encoding="utf-8") == "landing"
+    assert (site_dir / "docs" / "index.html").read_text(encoding="utf-8") == "docs root"
+    assert not (site_dir / "results").exists()
+
+
+def test_prose_only_omits_cname_and_404(tmp_path: Path) -> None:
+    """Finding #6: prose_only must not emit CNAME (apex domain) nor 404 (SPA fallback)."""
+    _pages_inputs(tmp_path, explorer=True)
+    site_dir = tmp_path / "site"
+
+    assemble_public_site(repo_root=tmp_path, site_dir=site_dir, prose_only=True)
+    assert not (site_dir / "CNAME").exists(), "prose_only must not emit CNAME"
+    assert not (site_dir / "404.html").exists(), "prose_only must not emit 404.html (results SPA fallback)"
+    assert (site_dir / ".nojekyll").is_file()
+    # Non-prose full site still emits both
+    assemble_public_site(repo_root=tmp_path, site_dir=site_dir, prose_only=False)
+    assert (site_dir / "CNAME").is_file()
+    assert (site_dir / "404.html").is_file()
+
+
 @pytest.mark.parametrize("destination", [Path("/"), Path.home()])
 def test_refuses_broad_output_directories(tmp_path: Path, destination: Path) -> None:
     _pages_inputs(tmp_path)

--- a/tests/unit/workflows/test_develop_post_merge_gaps.py
+++ b/tests/unit/workflows/test_develop_post_merge_gaps.py
@@ -241,6 +241,7 @@ def test_push_drop_inventory_subject_set_matches_workflows() -> None:
         "develop-post-merge.yml",
         "docs.yml",
         "orphaned-commit-detector.yml",
+        "publication-lane-docs.yml",
         "publication-lane-explorer.yml",
         "results-explorer-browser.yml",
         "submission-validator-drift-check.yml",

--- a/tests/unit/workflows/test_publication_lane_docs.py
+++ b/tests/unit/workflows/test_publication_lane_docs.py
@@ -1,0 +1,124 @@
+"""Tests for the decoupled publication-lane-docs.yml workflow contract."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+import yaml
+
+pytestmark = [pytest.mark.unit, pytest.mark.fast]
+
+ROOT = Path(__file__).resolve().parents[3]
+WORKFLOW_PATH = ROOT / ".github" / "workflows" / "publication-lane-docs.yml"
+
+
+def _workflow() -> dict[str, Any]:
+    assert WORKFLOW_PATH.is_file(), f"workflow file missing: {WORKFLOW_PATH}"
+    return yaml.safe_load(WORKFLOW_PATH.read_text(encoding="utf-8"))
+
+
+def test_publication_lane_docs_workflow_is_valid_yaml() -> None:
+    wf = _workflow()
+    assert wf["name"] == "Publication Lane - Docs and Prose"
+    assert "jobs" in wf
+    assert "build-docs-lane" in wf["jobs"]
+
+
+def test_publication_lane_docs_permissions_are_least_privilege() -> None:
+    wf = _workflow()
+    perms = wf.get("permissions")
+    assert perms == {"contents": "read"}
+    # Explicitly verify no deployment or write permissions
+    raw_text = WORKFLOW_PATH.read_text(encoding="utf-8")
+    assert "pages: write" not in raw_text
+    assert "id-token: write" not in raw_text
+    assert "actions: write" not in raw_text
+
+
+def test_publication_lane_docs_triggers_and_path_filters() -> None:
+    wf = _workflow()
+    triggers = wf[True] if True in wf else wf["on"]
+
+    assert "push" in triggers
+    assert "pull_request" in triggers
+    assert "workflow_dispatch" in triggers
+
+    push_branches = triggers["push"]["branches"]
+    pr_branches = triggers["pull_request"]["branches"]
+    assert "develop" in push_branches
+    assert "release" in push_branches
+    assert "develop" in pr_branches
+    assert "release" in pr_branches
+
+    # Paths must cover docs/prose; shared build inputs (benchbox/pyproject/uv.lock)
+    # are allowed because Sphinx autodoc imports benchbox, but corpus/explorer must not contaminate
+    push_paths = triggers["push"]["paths"]
+    assert "docs/**" in push_paths
+    assert "landing/**" in push_paths
+    assert "_blog/**" in push_paths
+    # Shared inputs are intentionally watched (Sphinx imports benchbox)
+    assert "benchbox/**" in push_paths
+    assert "pyproject.toml" in push_paths
+    assert "uv.lock" in push_paths
+    # Must NOT contaminate corpus/explorer lanes
+    assert not any("results-data" in p for p in push_paths)
+    assert not any("results-explorer" in p for p in push_paths)
+    assert not any("_project/scripts/explorer_pipeline" in p for p in push_paths)
+
+
+def test_publication_lane_docs_generates_decoupled_artifacts() -> None:
+    wf = _workflow()
+    steps = wf["jobs"]["build-docs-lane"]["steps"]
+    step_names = [s.get("name") for s in steps]
+
+    assert "Build Sphinx documentation" in step_names
+    assert "Assemble prose site artifact" in step_names
+    assert "Package release API documentation artifact" in step_names
+    assert "Verify lane isolation" in step_names
+    assert "Upload prose site artifact" in step_names
+    assert "Upload API docs artifact" in step_names
+
+    # Verify upload artifacts configuration
+    uploads = [s for s in steps if s.get("uses", "").startswith("actions/upload-artifact")]
+    uploaded_names = {u["with"]["name"] for u in uploads}
+    assert uploaded_names == {"prose_site", "api_docs"}
+
+
+def test_publication_lane_docs_executes_verify_lane_isolation() -> None:
+    raw_text = WORKFLOW_PATH.read_text(encoding="utf-8")
+    assert "uv run python scripts/publication/verify_lane_isolation.py --lane site" in raw_text
+
+
+def test_publication_lane_docs_does_not_contain_pages_deployment() -> None:
+    raw_text = WORKFLOW_PATH.read_text(encoding="utf-8")
+    assert "actions/deploy-pages" not in raw_text
+    assert "environment:" not in raw_text
+    assert "environment_url" not in raw_text
+
+
+def test_publication_lane_docs_api_docs_not_empty() -> None:
+    """Finding #4: workflow must guard against empty api_docs upload."""
+    raw_text = WORKFLOW_PATH.read_text(encoding="utf-8")
+    # Guards that fail the job when artifact is empty
+    assert "if [ ! -f lane_artifacts/api_docs/api.html ]" in raw_text
+    assert 'if [ -z "$(ls -A lane_artifacts/api_docs' in raw_text
+    # Upload must not silently succeed with no files
+    assert "if-no-files-found: error" in raw_text
+    # Verify lane isolation script also validates api_docs would fail with empty
+    wf = _workflow()
+    steps = wf["jobs"]["build-docs-lane"]["steps"]
+    pkg = next(s for s in steps if s.get("name") == "Package release API documentation artifact")
+    assert "exit 1" in pkg["run"]
+
+
+def test_publication_lane_docs_job_permissions_not_escalated() -> None:
+    """Finding #2 (workflow surface): job must not re-escalate permissions."""
+    raw_text = WORKFLOW_PATH.read_text(encoding="utf-8")
+    # No job-level permissions override at all; only top-level contents: read
+    wf = _workflow()
+    for job_name, job in wf["jobs"].items():
+        assert "permissions" not in job, f"job {job_name} must not override permissions"
+    # Also assert no contents: write anywhere in the workflow file
+    assert "contents: write" not in raw_text


### PR DESCRIPTION
## Summary

A6 docs lane — decoupled publication lane for prose site and API docs.
Provisional out-of-order authorization in `_project/decisions/independent-publication-a6-out-of-order-provisional-lane-2026-09-02.md`.

- `publication-lane-docs.yml`: least-privilege build lane with Sphinx, `prose_site`/`api_docs` artifacts, and lane isolation gate
- `verify_lane_isolation.py`: lane digest, mutation isolation, workflow permission checks
- `assemble_public_site.py`: `prose_only` mode for non-deployable artifact slice (no CNAME/404/Explorer)
- `develop-push-drop-inventory.md`: register lane workflow
- `auto_merge_soundness_paths.py` + `CODEOWNERS`: lane workflow and verifier are soundness-gated (requires manual review, no auto-merge)

## Testing

- `tests/unit/scripts/publication/test_verify_lane_isolation.py` (13 tests)
- `tests/unit/workflows/test_publication_lane_docs.py` (6 tests)
- `tests/unit/scripts/test_assemble_public_site.py` (prose_only coverage)

All narrow tests pass (`-n0`; xdist flaky on digest determinism due to shared cache).

## Soundness

Touches `SOUNDNESS_FILES` → maintainer review required; not auto-merge eligible.