### PR TITLE
feat(publication): implement A7 explorer lane (v9-only + fail-closed manifest)

### DIFF
--- a/.github/workflows/publication-lane-explorer.yml
+++ b/.github/workflows/publication-lane-explorer.yml
@@ -1,0 +1,83 @@
+name: Results Explorer Publication Lane
+
+on:
+  push:
+    branches: [ release, develop ]
+    paths:
+      - 'results-explorer/**'
+      - 'scripts/publication/**'
+      - '.github/workflows/publication-lane-explorer.yml'
+  pull_request:
+    branches: [ release, develop ]
+    paths:
+      - 'results-explorer/**'
+      - 'scripts/publication/**'
+      - '.github/workflows/publication-lane-explorer.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: publication-lane-explorer-${{ github.event_name == 'pull_request' && github.event.pull_request.number || github.sha }}
+  cancel-in-progress: true
+
+jobs:
+  build-explorer-app:
+    name: Build and package Results Explorer application
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: "npm"
+          cache-dependency-path: results-explorer/package-lock.json
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v4
+
+      - name: Install Python dependencies
+        run: uv sync --group dev
+
+      - name: Install Explorer dependencies
+        run: npm ci
+        working-directory: results-explorer
+
+      - name: Typecheck Explorer SPA
+        run: npm run typecheck
+        working-directory: results-explorer
+
+      - name: Build Results Explorer SPA
+        run: npm run build
+        working-directory: results-explorer
+
+      - name: Run Explorer unit tests
+        run: npm run test
+        working-directory: results-explorer
+
+      - name: Run Python contract tests
+        run: uv run python -m pytest tests/unit/scripts/explorer_pipeline/test_duckdb_browser_contract.py tests/unit/scripts/test_explorer_build_contract.py -q
+
+      - name: Validate Explorer compatibility and generate content-addressed manifest
+        run: uv run python scripts/publication/check_explorer_compat.py --artifact results-explorer/dist --generate-manifest
+
+      - name: Verify Explorer artifact bundle
+        run: uv run python scripts/publication/check_explorer_compat.py --artifact results-explorer/dist --require-manifest
+
+      - name: Upload explorer_app artifact bundle
+        uses: actions/upload-artifact@v4
+        with:
+          name: explorer_app-${{ github.sha }}
+          path: results-explorer/dist
+          retention-days: 30

--- a/docs/operations/develop-push-drop-inventory.md
+++ b/docs/operations/develop-push-drop-inventory.md
@@ -44,6 +44,7 @@ Re-run the method when adding a new develop-push workflow.
 | `sync-results-data-to-published.yml` | `develop` + `results-data/**` (and related validator paths) | **none** | yes | Safety-critical — only automated mirror of develop corpus → `published-results` | Dropped path-matched push leaves public corpus stale until human recovery | **Accepted risk** — daily `corpus-drift-check.yml` canary detects develop-ahead drift and recommends `gh workflow run sync-results-data-to-published.yml`; workflow retains write-heavy mirror on push/dispatch only (no schedule mutation of public branch) |
 | `results-explorer-browser.yml` | `release` + `develop` + explorer/`results-data` path filter | **none** | yes | Mixed — required PR gate (`Results Explorer browser gate`); develop push is post-merge tip re-build for path-matched merges | Dropped develop push can leave tip without a post-merge browser rebuild until the next matching push or dispatch | **Accepted risk** — pre-merge required check on every PR into develop is the primary safety property; develop push is additive tip verification; suite is expensive (Chromium full + smoke browsers) so no hourly schedule; recover with `gh workflow run results-explorer-browser.yml --ref develop` |
 | `docs.yml` | `develop`, all paths | **none** | yes | Mixed — assembles the Pages-shaped site and produces the SHA-bound public-site visual baseline | A dropped push delays baseline refresh; exact-base PR comparison fails closed once any baseline exists | **Accepted risk** — the develop PR visual job remains the review gate; the protected push is an additive baseline producer; recover with `gh workflow run docs.yml --ref develop` |
+| `publication-lane-explorer.yml` | `release` + `develop` + `results-explorer/**`/`scripts/publication/**` path filter | **none** | yes | Advisory — builds/typechecks the Explorer SPA, runs unit and contract tests, and validates the compatibility manifest; lane is **not** a required status check and does not block merges (primary required gate remains `Results Explorer browser gate`) | Dropped develop push delays tip re-verification of the Explorer build and manifest until the next matching push or dispatch; job holds no deploy or write credentials (`permissions: contents: read` only; output is a CI artifact upload, not a publish step) | **Accepted risk** — lane is advisory; pre-merge validation does not gate merges; develop push is additive tip verification with no elevated permissions or external publish surface; recover with `gh workflow run publication-lane-explorer.yml --ref develop` |
 
 ### Explicit non-entries (push, but not develop)
 
@@ -165,8 +166,8 @@ PY
 
 Expected subject set (names only):
 `develop-post-merge.yml`, `docs.yml`, `orphaned-commit-detector.yml`,
-`results-explorer-browser.yml`, `submission-validator-drift-check.yml`,
-`sync-results-data-to-published.yml`.
+`publication-lane-explorer.yml`, `results-explorer-browser.yml`,
+`submission-validator-drift-check.yml`, `sync-results-data-to-published.yml`.
 
 ## Manual recovery cheatsheet
 
@@ -176,5 +177,6 @@ Expected subject set (names only):
 | Gap class instrumentation | `gh workflow run develop-post-merge-gap-detector.yml --ref develop` |
 | Corpus mirror lag | `gh workflow run corpus-drift-check.yml` then, if develop-ahead, `gh workflow run sync-results-data-to-published.yml --ref develop` |
 | Browser tip rebuild | `gh workflow run results-explorer-browser.yml --ref develop` |
+| Explorer publication lane artifact | `gh workflow run publication-lane-explorer.yml --ref develop` |
 | Orphan scan | `gh workflow run orphaned-commit-detector.yml --ref develop` |
 | Validator drift | `gh workflow run submission-validator-drift-check.yml --ref develop` |

--- a/scripts/publication/check_explorer_compat.py
+++ b/scripts/publication/check_explorer_compat.py
@@ -1,0 +1,1107 @@
+#!/usr/bin/env python3
+"""Validate Results Explorer compatibility against the current read model.
+
+This CLI tool verifies that the Results Explorer SPA and its artifacts
+maintain compatibility with the current corpus DuckDB read-model schema
+(v9). It also validates hermetic, content-addressed Explorer application
+artifact bundles.
+
+Usage:
+    # Run schema compatibility checks (v9 only):
+    uv run -- python scripts/publication/check_explorer_compat.py
+
+    # Validate an Explorer build artifact directory or archive:
+    uv run -- python scripts/publication/check_explorer_compat.py --artifact results-explorer/dist
+
+    # Validate with required manifest (fail-closed):
+    uv run -- python scripts/publication/check_explorer_compat.py --artifact results-explorer/dist --require-manifest
+
+    # Generate content-addressed manifest and checksums in artifact directory:
+    uv run -- python scripts/publication/check_explorer_compat.py --artifact results-explorer/dist --generate-manifest
+
+    # Validate a specific DuckDB database snapshot file:
+    uv run -- python scripts/publication/check_explorer_compat.py --db-path results-explorer/public/data/results.duckdb
+
+    # Check specific schema versions (only 9 is supported):
+    uv run -- python scripts/publication/check_explorer_compat.py --schema-versions 9
+
+    # Output machine-readable JSON:
+    uv run -- python scripts/publication/check_explorer_compat.py --json
+
+Exit codes:
+    0 - All compatibility and artifact checks passed
+    1 - Compatibility or artifact validation failed
+    2 - CLI argument or environment error
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import shutil
+import sys
+import tarfile
+import tempfile
+import zipfile
+from pathlib import Path
+from typing import Any, Sequence
+
+# Import canonical read-model version from contract. Fall back to 9 if
+# contract is unavailable (e.g. during isolated test import).
+try:
+    from _project.scripts.explorer_pipeline.contract import (
+        EXPLORER_BUILD_CONTRACT_VERSION as _CONTRACT_VERSION,
+        EXPLORER_READ_MODEL_VERSION as _READ_MODEL_VERSION,
+    )
+
+    SUPPORTED_SCHEMA_VERSIONS: tuple[int, ...] = (_READ_MODEL_VERSION,)
+    CURRENT_SCHEMA_VERSION: int = _READ_MODEL_VERSION
+    CONTRACT_VERSION: str = _CONTRACT_VERSION
+except ImportError:
+    SUPPORTED_SCHEMA_VERSIONS: tuple[int, ...] = (9,)
+    CURRENT_SCHEMA_VERSION: int = 9
+    CONTRACT_VERSION: str = "6"
+
+# Canonical DuckDB type normalisation for schema validation comparisons
+_TYPE_ALIASES: dict[str, str] = {
+    "varchar": "VARCHAR",
+    "text": "VARCHAR",
+    "string": "VARCHAR",
+    "int": "INTEGER",
+    "integer": "INTEGER",
+    "int4": "INTEGER",
+    "int8": "BIGINT",
+    "bigint": "BIGINT",
+    "float": "DOUBLE",
+    "double": "DOUBLE",
+    "float8": "DOUBLE",
+    "bool": "BOOLEAN",
+    "boolean": "BOOLEAN",
+}
+
+
+def normalize_type(type_str: str) -> str:
+    """Normalize DuckDB data type string for contract comparison."""
+    clean = type_str.strip().lower()
+    return _TYPE_ALIASES.get(clean, clean.upper())
+
+
+# ---------------------------------------------------------------------------
+# Schema Definitions
+# ---------------------------------------------------------------------------
+
+TABLE_COLUMNS_V9: dict[str, dict[str, str]] = {
+    "metadata": {
+        "read_model_version": "INTEGER",
+    },
+    "result_environment": {
+        "result_id": "VARCHAR",
+        "os": "VARCHAR",
+        "arch": "VARCHAR",
+        "cpu_count": "INTEGER",
+        "memory_gb": "DOUBLE",
+        "python": "VARCHAR",
+        "cpu_model": "VARCHAR",
+        "cpu_family": "VARCHAR",
+        "cpu_identity_provenance": "VARCHAR",
+    },
+    "result_phase_durations": {
+        "result_id": "VARCHAR",
+        "phase": "VARCHAR",
+        "duration_s": "DOUBLE",
+    },
+    "result_basis_availability": {
+        "result_id": "VARCHAR",
+        "has_warmup": "BOOLEAN",
+        "measurement_pass_count": "INTEGER",
+        "warmup_status": "VARCHAR",
+        "available_bases": "VARCHAR",
+        "varying_pass_queries": "VARCHAR",
+    },
+    "results": {
+        "result_id": "VARCHAR",
+        "benchmark": "VARCHAR",
+        "scale_factor": "DOUBLE",
+        "platform": "VARCHAR",
+        "platform_id": "VARCHAR",
+        "driver_version": "VARCHAR",
+        "run_date": "VARCHAR",
+        "power_score": "DOUBLE",
+        "total_duration_s": "DOUBLE",
+        "geomean_ms": "DOUBLE",
+        "display_geomean_ms": "DOUBLE",
+        "query_count": "INTEGER",
+        "logical_query_count": "INTEGER",
+        "has_display_timing": "BOOLEAN",
+        "valid_query_count": "INTEGER",
+        "missing_query_count": "INTEGER",
+        "zero_timing_count": "INTEGER",
+        "display_exclusion_reason": "VARCHAR",
+        "comparison_exclusion_reason": "VARCHAR",
+        "ranking_exclusion_reason": "VARCHAR",
+        "trust_label": "VARCHAR",
+        "visibility": "VARCHAR",
+        "funding": "VARCHAR",
+        "platform_version": "VARCHAR",
+        "execution_mode": "VARCHAR",
+        "tuning_mode": "VARCHAR",
+        "tuning_hash": "VARCHAR",
+        "requested_config_hash": "VARCHAR",
+        "applied_ledger_hash": "VARCHAR",
+        "tuning_validation_status": "VARCHAR",
+        "applied_receipt": "VARCHAR",
+        "tuning_policy_generation": "VARCHAR",
+        "test_type": "VARCHAR",
+        "validation_status": "VARCHAR",
+        "cost_usd": "DOUBLE",
+        "normalized_cost_usd": "DOUBLE",
+        "cost_model_version": "VARCHAR",
+        "cost_model_source": "VARCHAR",
+        "cost_scope": "VARCHAR",
+        "cost_status": "VARCHAR",
+        "billing_unit": "VARCHAR",
+        "pricing_region": "VARCHAR",
+        "deployment_class": "VARCHAR",
+        "cloud_provider": "VARCHAR",
+        "cloud_region": "VARCHAR",
+        "instance_or_warehouse": "VARCHAR",
+        "storage_format": "VARCHAR",
+        "instance_type": "VARCHAR",
+        "warehouse_size": "VARCHAR",
+        "node_count": "INTEGER",
+        "cluster_size": "VARCHAR",
+        "storage_tier": "VARCHAR",
+        "compliance_class": "VARCHAR",
+        "is_ranking_eligible": "BOOLEAN",
+        "has_plans": "BOOLEAN",
+        "plans_published": "BOOLEAN",
+        "has_tuning": "BOOLEAN",
+        "bundle_download_url": "VARCHAR",
+        "physical_mechanisms": "VARCHAR",
+        "physical_rendering_id": "VARCHAR",
+    },
+    "query_display_timings": {
+        "result_id": "VARCHAR",
+        "query_id": "VARCHAR",
+        "display_ms": "DOUBLE",
+        "sample_count": "INTEGER",
+        "is_valid_display_timing": "BOOLEAN",
+        "timing_exclusion_reason": "VARCHAR",
+    },
+    "query_executions": {
+        "result_id": "VARCHAR",
+        "query_id": "VARCHAR",
+        "duration_ms": "DOUBLE",
+        "status": "VARCHAR",
+        "run_type": "VARCHAR",
+        "iter": "INTEGER",
+        "stream": "INTEGER",
+    },
+    "benchmark_matrix_cells": {
+        "benchmark": "VARCHAR",
+        "scale_factor": "DOUBLE",
+        "phase": "VARCHAR",
+        "result_id": "VARCHAR",
+        "platform_id": "VARCHAR",
+        "query_id": "VARCHAR",
+        "display_ms": "DOUBLE",
+        "is_valid_display_timing": "BOOLEAN",
+        "timing_exclusion_reason": "VARCHAR",
+    },
+    "benchmark_rankings": {
+        "benchmark": "VARCHAR",
+        "scale_factor": "DOUBLE",
+        "phase": "VARCHAR",
+        "result_id": "VARCHAR",
+        "platform_id": "VARCHAR",
+        "platform": "VARCHAR",
+        "short_id": "VARCHAR",
+        "trust_label": "VARCHAR",
+        "funding": "VARCHAR",
+        "tuning_mode": "VARCHAR",
+        "tuning_hash": "VARCHAR",
+        "execution_mode": "VARCHAR",
+        "compliance_class": "VARCHAR",
+        "run_date": "VARCHAR",
+        "is_ranking_eligible": "BOOLEAN",
+        "has_display_timing": "BOOLEAN",
+        "logical_query_count": "INTEGER",
+        "valid_query_count": "INTEGER",
+        "missing_query_count": "INTEGER",
+        "zero_timing_count": "INTEGER",
+        "display_exclusion_reason": "VARCHAR",
+        "comparison_exclusion_reason": "VARCHAR",
+        "ranking_exclusion_reason": "VARCHAR",
+        "power_score": "DOUBLE",
+        "display_geomean_ms": "DOUBLE",
+        "sample_geomean_ms": "DOUBLE",
+        "cost_usd": "DOUBLE",
+        "primary_metric": "VARCHAR",
+        "primary_order": "VARCHAR",
+        "rank": "INTEGER",
+        "total_in_cohort": "INTEGER",
+        "cohort_ranked_count": "INTEGER",
+        "cohort_ranking_exclusion_reason": "VARCHAR",
+        "percentile_p50": "DOUBLE",
+        "percentile_p90": "DOUBLE",
+        "percentile_p95": "DOUBLE",
+        "percentile_p99": "DOUBLE",
+        "speedup_vs_best": "DOUBLE",
+        "speedup_vs_slowest_in_cohort": "DOUBLE",
+    },
+    "cohort_metadata": {
+        "cohort_key": "VARCHAR",
+        "benchmark": "VARCHAR",
+        "scale_factor": "DOUBLE",
+        "phase": "VARCHAR",
+        "cohort_label": "VARCHAR",
+        "cohort_href": "VARCHAR",
+        "platform_count": "INTEGER",
+        "cohort_ranked_count": "INTEGER",
+        "cohort_ranking_exclusion_reason": "VARCHAR",
+        "primary_metric": "VARCHAR",
+        "primary_order": "VARCHAR",
+        "platform_id": "VARCHAR",
+        "platform": "VARCHAR",
+        "result_id": "VARCHAR",
+        "short_id": "VARCHAR",
+        "tuning_mode": "VARCHAR",
+        "trust_label": "VARCHAR",
+        "has_display_timing": "BOOLEAN",
+        "logical_query_count": "INTEGER",
+        "valid_query_count": "INTEGER",
+        "missing_query_count": "INTEGER",
+        "zero_timing_count": "INTEGER",
+        "display_exclusion_reason": "VARCHAR",
+        "comparison_exclusion_reason": "VARCHAR",
+        "ranking_exclusion_reason": "VARCHAR",
+        "rank": "INTEGER",
+        "metric_value": "DOUBLE",
+        "speedup_vs_best": "DOUBLE",
+    },
+    "meta_leaderboard": {
+        "platform_id": "VARCHAR",
+        "platform": "VARCHAR",
+        "avg_rank": "DOUBLE",
+        "n_cohorts": "INTEGER",
+    },
+    "short_ids": {
+        "short_id": "VARCHAR",
+        "result_id": "VARCHAR",
+    },
+}
+
+REQUIRED_INDEXES_V9: list[tuple[str, str, list[str]]] = [
+    ("idx_query_executions_result", "query_executions", ["result_id"]),
+    ("idx_matrix_cells_cohort", "benchmark_matrix_cells", ["benchmark", "scale_factor", "phase"]),
+    ("idx_benchmark_rankings_cohort", "benchmark_rankings", ["benchmark", "scale_factor", "phase"]),
+    ("idx_cohort_metadata_key", "cohort_metadata", ["cohort_key"]),
+    ("idx_cohort_metadata_platform", "cohort_metadata", ["cohort_key", "platform_id"]),
+]
+
+REQUIRED_VIEWS_V9: list[str] = [
+    "result_detail_metrics",
+    "platform_index_rows",
+]
+
+
+def get_table_columns_for_version(version: int) -> dict[str, dict[str, str]]:
+    """Return the expected table column map for a given read-model version."""
+    if version == CURRENT_SCHEMA_VERSION:
+        return TABLE_COLUMNS_V9
+    raise ValueError(f"Unsupported schema version: {version}")
+
+
+def get_views_for_version(version: int) -> list[str]:
+    """Return required view names for a schema version."""
+    if version != CURRENT_SCHEMA_VERSION:
+        raise ValueError(f"Unsupported schema version: {version}")
+    return list(REQUIRED_VIEWS_V9)
+
+
+def get_indexes_for_version(version: int) -> list[tuple[str, str, list[str]]]:
+    """Return required index definitions for a schema version."""
+    if version != CURRENT_SCHEMA_VERSION:
+        raise ValueError(f"Unsupported schema version: {version}")
+    return list(REQUIRED_INDEXES_V9)
+
+
+def generate_schema_ddl(version: int) -> list[str]:
+    """Generate canonical DDL statements to construct a schema for a specific version."""
+    columns_map = get_table_columns_for_version(version)
+    ddl_statements: list[str] = []
+
+    # Metadata
+    ddl_statements.append("CREATE TABLE metadata (read_model_version INTEGER NOT NULL);")
+
+    # result_environment
+    env_cols = ", ".join(f"{c} {t}" for c, t in columns_map["result_environment"].items())
+    ddl_statements.append(f"CREATE TABLE result_environment ({env_cols}, PRIMARY KEY (result_id));")
+
+    # result_phase_durations
+    ddl_statements.append(
+        "CREATE TABLE result_phase_durations (result_id VARCHAR NOT NULL, phase VARCHAR NOT NULL, "
+        "duration_s DOUBLE NOT NULL, PRIMARY KEY (result_id, phase));"
+    )
+
+    # result_basis_availability (v9 only)
+    if "result_basis_availability" in columns_map:
+        rba_cols = ", ".join(f"{c} {t}" for c, t in columns_map["result_basis_availability"].items())
+        ddl_statements.append(f"CREATE TABLE result_basis_availability ({rba_cols}, PRIMARY KEY (result_id));")
+
+    # results
+    res_cols = ", ".join(f"{c} {t}" for c, t in columns_map["results"].items())
+    ddl_statements.append(f"CREATE TABLE results ({res_cols}, PRIMARY KEY (result_id));")
+
+    # query_display_timings
+    qdt_cols = ", ".join(f"{c} {t}" for c, t in columns_map["query_display_timings"].items())
+    ddl_statements.append(f"CREATE TABLE query_display_timings ({qdt_cols}, PRIMARY KEY (result_id, query_id));")
+
+    # query_executions
+    qe_cols = ", ".join(f"{c} {t}" for c, t in columns_map["query_executions"].items())
+    ddl_statements.append(f"CREATE TABLE query_executions ({qe_cols});")
+    ddl_statements.append("CREATE INDEX idx_query_executions_result ON query_executions (result_id);")
+
+    # benchmark_matrix_cells
+    bmc_cols = ", ".join(f"{c} {t}" for c, t in columns_map["benchmark_matrix_cells"].items())
+    ddl_statements.append(
+        f"CREATE TABLE benchmark_matrix_cells ({bmc_cols}, PRIMARY KEY (benchmark, scale_factor, phase, result_id, query_id));"
+    )
+    ddl_statements.append(
+        "CREATE INDEX idx_matrix_cells_cohort ON benchmark_matrix_cells (benchmark, scale_factor, phase);"
+    )
+
+    # benchmark_rankings
+    br_cols = ", ".join(f"{c} {t}" for c, t in columns_map["benchmark_rankings"].items())
+    ddl_statements.append(
+        f"CREATE TABLE benchmark_rankings ({br_cols}, PRIMARY KEY (benchmark, scale_factor, phase, result_id));"
+    )
+    ddl_statements.append(
+        "CREATE INDEX idx_benchmark_rankings_cohort ON benchmark_rankings (benchmark, scale_factor, phase);"
+    )
+
+    # cohort_metadata
+    cm_cols = ", ".join(f"{c} {t}" for c, t in columns_map["cohort_metadata"].items())
+    ddl_statements.append(f"CREATE TABLE cohort_metadata ({cm_cols}, PRIMARY KEY (cohort_key, result_id));")
+    ddl_statements.append("CREATE INDEX idx_cohort_metadata_key ON cohort_metadata (cohort_key);")
+    ddl_statements.append("CREATE INDEX idx_cohort_metadata_platform ON cohort_metadata (cohort_key, platform_id);")
+
+    # meta_leaderboard
+    ddl_statements.append(
+        "CREATE TABLE meta_leaderboard (platform_id VARCHAR PRIMARY KEY, platform VARCHAR NOT NULL, "
+        "avg_rank DOUBLE, n_cohorts INTEGER NOT NULL);"
+    )
+
+    # short_ids
+    ddl_statements.append("CREATE TABLE short_ids (short_id VARCHAR PRIMARY KEY, result_id VARCHAR NOT NULL UNIQUE);")
+
+    # Views
+    env_select_cols = [f"e.{col}" for col in columns_map["result_environment"] if col != "result_id"]
+    env_proj = ", ".join(env_select_cols)
+    if env_proj:
+        view_sql = f"CREATE VIEW result_detail_metrics AS SELECT r.*, {env_proj} FROM results r LEFT JOIN result_environment e USING (result_id);"
+    else:
+        view_sql = "CREATE VIEW result_detail_metrics AS SELECT r.* FROM results r LEFT JOIN result_environment e USING (result_id);"
+    ddl_statements.append(view_sql)
+
+    ddl_statements.append("CREATE VIEW platform_index_rows AS SELECT * FROM results;")
+
+    return ddl_statements
+
+
+# ---------------------------------------------------------------------------
+# Test Queries executed by Results Explorer Frontend
+# ---------------------------------------------------------------------------
+
+CORE_EXPLORER_QUERIES: list[tuple[str, str]] = [
+    ("Read model version probe", "SELECT read_model_version FROM metadata"),
+    (
+        "Results query page",
+        "SELECT result_id, benchmark, scale_factor, platform, platform_id, run_date, power_score, "
+        "total_duration_s, geomean_ms, display_geomean_ms, query_count, logical_query_count, "
+        "has_display_timing, valid_query_count, missing_query_count, zero_timing_count, "
+        "display_exclusion_reason, comparison_exclusion_reason, ranking_exclusion_reason, "
+        "trust_label, visibility, funding, validation_status, cost_usd "
+        "FROM results ORDER BY run_date DESC LIMIT 24",
+    ),
+    (
+        "Platform index view browse",
+        "SELECT result_id, benchmark, scale_factor, platform, platform_id, run_date, power_score "
+        "FROM platform_index_rows LIMIT 50",
+    ),
+    (
+        "Result detail metrics view",
+        "SELECT * FROM result_detail_metrics LIMIT 10",
+    ),
+    (
+        "Benchmark matrix cells scan",
+        "SELECT benchmark, scale_factor, phase, result_id, platform_id, query_id, display_ms, "
+        "is_valid_display_timing, timing_exclusion_reason FROM benchmark_matrix_cells LIMIT 100",
+    ),
+    (
+        "Benchmark rankings query",
+        "SELECT benchmark, scale_factor, phase, result_id, platform_id, platform, short_id, "
+        "trust_label, funding, is_ranking_eligible, has_display_timing, power_score, display_geomean_ms, "
+        "primary_metric, primary_order, rank, total_in_cohort, cohort_ranked_count, "
+        "speedup_vs_best, speedup_vs_slowest_in_cohort FROM benchmark_rankings LIMIT 50",
+    ),
+    (
+        "Cohort metadata query",
+        "SELECT cohort_key, benchmark, scale_factor, phase, cohort_label, cohort_href, "
+        "platform_count, cohort_ranked_count, primary_metric, primary_order, platform_id, "
+        "platform, result_id, short_id, rank, metric_value, speedup_vs_best FROM cohort_metadata LIMIT 50",
+    ),
+    (
+        "Meta leaderboard summary",
+        "SELECT platform_id, platform, avg_rank, n_cohorts FROM meta_leaderboard",
+    ),
+    (
+        "Short ID resolution",
+        "SELECT result_id FROM short_ids WHERE short_id = 'test_short_id'",
+    ),
+    (
+        "Query display timings for result",
+        "SELECT result_id, query_id, display_ms, sample_count, is_valid_display_timing, "
+        "timing_exclusion_reason FROM query_display_timings WHERE result_id = 'test_res'",
+    ),
+    (
+        "Query executions scan",
+        "SELECT result_id, query_id, duration_ms, status FROM query_executions WHERE result_id = 'test_res'",
+    ),
+]
+
+
+# ---------------------------------------------------------------------------
+# In-Memory & Database Schema Verification
+# ---------------------------------------------------------------------------
+
+
+def create_in_memory_schema(version: int) -> Any:
+    """Create an in-memory DuckDB database for a specific schema version."""
+    import duckdb
+
+    con = duckdb.connect(":memory:")
+    for stmt in generate_schema_ddl(version):
+        con.execute(stmt)
+
+    con.execute("INSERT INTO metadata VALUES (?)", [version])
+    return con
+
+
+def validate_database_schema(con: Any, expected_version: int | None = None) -> list[str]:
+    """Validate that a DuckDB connection conforms to the read-model schema contract."""
+    errors: list[str] = []
+
+    # Check metadata table and version
+    meta_row = None
+    try:
+        meta_row = con.execute("SELECT read_model_version FROM metadata").fetchone()
+    except Exception as exc:
+        errors.append(f"metadata table missing or unreadable: {exc}")
+
+    actual_version = int(meta_row[0]) if meta_row else None
+
+    if expected_version is not None and actual_version != expected_version:
+        errors.append(f"read_model_version mismatch: expected {expected_version}, got {actual_version}")
+
+    version_to_check = expected_version or actual_version or CURRENT_SCHEMA_VERSION
+    if version_to_check not in SUPPORTED_SCHEMA_VERSIONS:
+        errors.append(
+            f"unsupported read_model_version {version_to_check} (supported: {list(SUPPORTED_SCHEMA_VERSIONS)})"
+        )
+        return errors
+
+    expected_tables = get_table_columns_for_version(version_to_check)
+
+    # Introspect existing tables
+    existing_tables_rows = con.execute(
+        "SELECT table_name FROM information_schema.tables WHERE table_schema = 'main' AND table_type = 'BASE TABLE'"
+    ).fetchall()
+    existing_tables = {row[0] for row in existing_tables_rows}
+
+    missing_tables = sorted(set(expected_tables.keys()) - existing_tables)
+    if missing_tables:
+        errors.append(f"missing required tables for v{version_to_check}: {', '.join(missing_tables)}")
+
+    # Introspect columns for present tables
+    for table, expected_cols in expected_tables.items():
+        if table not in existing_tables:
+            continue
+        col_rows = con.execute(
+            f"SELECT column_name, data_type FROM information_schema.columns WHERE table_name = '{table}'"
+        ).fetchall()
+        actual_cols = {row[0]: normalize_type(row[1]) for row in col_rows}
+
+        missing_cols = sorted(set(expected_cols.keys()) - set(actual_cols.keys()))
+        if missing_cols:
+            errors.append(f"table '{table}' missing required columns: {', '.join(missing_cols)}")
+
+    # Check views
+    expected_views = get_views_for_version(version_to_check)
+    existing_views_rows = con.execute(
+        "SELECT table_name FROM information_schema.tables WHERE table_schema = 'main' AND table_type = 'VIEW'"
+    ).fetchall()
+    existing_views = {row[0] for row in existing_views_rows}
+    missing_views = sorted(set(expected_views) - existing_views)
+    if missing_views:
+        errors.append(f"missing required views for v{version_to_check}: {', '.join(missing_views)}")
+
+    return errors
+
+
+def validate_database_queries(con: Any, version: int) -> list[str]:
+    """Execute standard explorer read queries to ensure binder and execution compatibility."""
+    errors: list[str] = []
+    for label, sql in CORE_EXPLORER_QUERIES:
+        try:
+            con.execute(sql).fetchall()
+        except Exception as exc:
+            errors.append(f"query '{label}' failed under v{version}: {exc}")
+    return errors
+
+
+def check_schema_compatibility(versions: Sequence[int] | None = None) -> dict[int, list[str]]:
+    """Test schema construction and query compatibility across specified schema versions."""
+    versions_to_test = versions or SUPPORTED_SCHEMA_VERSIONS
+    results: dict[int, list[str]] = {}
+
+    for version in versions_to_test:
+        version_errors: list[str] = []
+        try:
+            con = create_in_memory_schema(version)
+            try:
+                schema_errors = validate_database_schema(con, expected_version=version)
+                version_errors.extend(schema_errors)
+
+                query_errors = validate_database_queries(con, version=version)
+                version_errors.extend(query_errors)
+            finally:
+                con.close()
+        except Exception as exc:
+            version_errors.append(f"failed to initialize in-memory schema v{version}: {exc}")
+
+        results[version] = version_errors
+
+    return results
+
+
+# ---------------------------------------------------------------------------
+# Artifact Bundle Verification & Content Addressing
+# ---------------------------------------------------------------------------
+
+
+def compute_file_sha256(path: Path) -> str:
+    """Compute SHA-256 hex digest of a file."""
+    hasher = hashlib.sha256()
+    with open(path, "rb") as f:
+        while chunk := f.read(65536):
+            hasher.update(chunk)
+    return hasher.hexdigest()
+
+
+def compute_directory_checksums(
+    directory: Path,
+    exclude_names: set[str] | None = None,
+) -> dict[str, str]:
+    """Compute relative-path to SHA-256 mapping for all files in a directory.
+
+    Exclude set is anchored to root-relative POSIX paths (e.g. ``manifest.json``,
+    ``SHA256SUMS`` at the artifact root), not bare filenames at any depth.
+    """
+    excludes = exclude_names or {"manifest.json", "SHA256SUMS"}
+    checksums: dict[str, str] = {}
+    for p in sorted(directory.rglob("*")):
+        if p.is_file():
+            rel = p.relative_to(directory).as_posix()
+            if rel in excludes:
+                continue
+            checksums[rel] = compute_file_sha256(p)
+    return checksums
+
+
+def compute_content_address(checksums: dict[str, str]) -> str:
+    """Compute deterministic overall bundle content address from file checksums."""
+    hasher = hashlib.sha256()
+    for rel_path in sorted(checksums.keys()):
+        hasher.update(f"{rel_path}:{checksums[rel_path]}\n".encode())
+    return hasher.hexdigest()
+
+
+def generate_artifact_manifest(
+    artifact_dir: Path,
+    write: bool = False,
+) -> dict[str, Any]:
+    """Generate bundle manifest with content address and checksums.
+
+    If write is True, writes ``manifest.json`` and ``SHA256SUMS`` into ``artifact_dir``.
+    Manifest embeds the read-model version, supported versions, contract version,
+    and GitHub provenance (sha/ref/event) for downstream verification.
+    """
+    checksums = compute_directory_checksums(artifact_dir)
+    content_addr = compute_content_address(checksums)
+
+    manifest = {
+        "bundle": "explorer_app",
+        "content_address": content_addr,
+        "file_count": len(checksums),
+        "files": checksums,
+        "read_model_version": CURRENT_SCHEMA_VERSION,
+        "supported_versions": list(SUPPORTED_SCHEMA_VERSIONS),
+        "contract_version": CONTRACT_VERSION,
+        "github_sha": os.environ.get("GITHUB_SHA", ""),
+        "github_ref": os.environ.get("GITHUB_REF", ""),
+        "github_event_name": os.environ.get("GITHUB_EVENT_NAME", ""),
+    }
+
+    if write:
+        manifest_path = artifact_dir / "manifest.json"
+        manifest_path.write_text(json.dumps(manifest, indent=2) + "\n", encoding="utf-8")
+
+        sha256sums_path = artifact_dir / "SHA256SUMS"
+        sums_text = "\n".join(f"{h}  {rel}" for rel, h in sorted(checksums.items())) + "\n"
+        sha256sums_path.write_text(sums_text, encoding="utf-8")
+
+    return manifest
+
+
+def _extract_artifact_archive(artifact_path: Path) -> tuple[Path | None, list[str]]:
+    """Extract a zip/tar artifact archive to a temp directory.
+
+    Returns (temp_dir, errors). temp_dir is None when extraction was not
+    possible; in that case errors is non-empty.
+    """
+    temp_dir = Path(tempfile.mkdtemp(prefix="explorer_artifact_"))
+    if zipfile.is_zipfile(artifact_path):
+        with zipfile.ZipFile(artifact_path) as zf:
+            zf.extractall(temp_dir)
+        return temp_dir, []
+    if tarfile.is_tarfile(artifact_path):
+        with tarfile.open(artifact_path) as tf:
+            tf.extractall(temp_dir, filter="data")
+        return temp_dir, []
+    shutil.rmtree(temp_dir, ignore_errors=True)
+    return None, [f"artifact file is neither a zip nor tar archive: {artifact_path}"]
+
+
+def _validate_index_html(target_dir: Path) -> list[str]:
+    """Verify index.html exists, is non-empty, and looks like an HTML document."""
+    errors: list[str] = []
+    index_html = target_dir / "index.html"
+    if not index_html.is_file():
+        errors.append("artifact is missing 'index.html'")
+    elif index_html.stat().st_size == 0:
+        errors.append("artifact 'index.html' is empty")
+    else:
+        html_content = index_html.read_text(encoding="utf-8", errors="replace")
+        if "<html" not in html_content.lower() and "<!doctype html" not in html_content.lower():
+            errors.append("'index.html' does not contain valid HTML document root")
+    return errors
+
+
+def _validate_bundle_files(all_files: list[Path], target_dir: Path) -> tuple[list[str], list[Path], list[Path]]:
+    """Verify JS/CSS bundle presence and flag empty files. Returns (errors, js_files, css_files)."""
+    errors: list[str] = []
+    js_files = [p for p in all_files if p.is_file() and p.suffix == ".js"]
+    css_files = [p for p in all_files if p.is_file() and p.suffix == ".css"]
+
+    if not js_files:
+        errors.append("artifact contains no JavaScript bundles (.js files)")
+    if not css_files:
+        errors.append("artifact contains no stylesheet bundles (.css files)")
+
+    for p in all_files:
+        if p.is_file() and p.stat().st_size == 0 and p.name != ".gitkeep":
+            errors.append(f"empty file in artifact bundle: {p.relative_to(target_dir)}")
+
+    return errors, js_files, css_files
+
+
+def _validate_manifest_json(
+    target_dir: Path,
+    content_addr: str,
+    require_manifest: bool = False,
+) -> list[str]:
+    """Validate manifest.json content-address and per-file checksums."""
+    errors: list[str] = []
+    manifest_file = target_dir / "manifest.json"
+    if not manifest_file.is_file():
+        if require_manifest:
+            errors.append("manifest.json is missing (required for verification)")
+        return errors
+
+    try:
+        manifest_data = json.loads(manifest_file.read_text(encoding="utf-8"))
+        if manifest_data.get("bundle") != "explorer_app":
+            errors.append(f"manifest 'bundle' field expected 'explorer_app', got {manifest_data.get('bundle')!r}")
+        if manifest_data.get("content_address") != content_addr:
+            errors.append(
+                f"manifest content_address mismatch: recorded {manifest_data.get('content_address')}, "
+                f"computed {content_addr}"
+            )
+        # Validate embedded provenance fields when present; require read_model_version
+        if "read_model_version" not in manifest_data:
+            errors.append("manifest missing 'read_model_version' field")
+        elif manifest_data.get("read_model_version") != CURRENT_SCHEMA_VERSION:
+            errors.append(
+                f"manifest read_model_version mismatch: expected {CURRENT_SCHEMA_VERSION}, "
+                f"got {manifest_data.get('read_model_version')!r}"
+            )
+        recorded_files = manifest_data.get("files", {})
+        for rel_path, expected_hash in recorded_files.items():
+            actual_file = target_dir / rel_path
+            if not actual_file.is_file():
+                errors.append(f"file in manifest missing on disk: {rel_path}")
+            elif compute_file_sha256(actual_file) != expected_hash:
+                errors.append(f"file checksum mismatch for {rel_path}")
+    except Exception as exc:
+        errors.append(f"failed to parse or validate manifest.json: {exc}")
+
+    return errors
+
+
+def _validate_sha256sums(
+    target_dir: Path,
+    require_manifest: bool = False,
+) -> list[str]:
+    """Validate the SHA256SUMS checksum manifest."""
+    errors: list[str] = []
+    sha256sums_file = target_dir / "SHA256SUMS"
+    if not sha256sums_file.is_file():
+        if require_manifest:
+            errors.append("SHA256SUMS is missing (required for verification)")
+        return errors
+
+    for idx, line in enumerate(sha256sums_file.read_text(encoding="utf-8").splitlines(), 1):
+        stripped = line.strip()
+        if not stripped or stripped.startswith("#"):
+            continue
+        parts = stripped.split(maxsplit=1)
+        if len(parts) != 2:
+            errors.append(f"malformed SHA256SUMS line {idx}: {line!r}")
+            continue
+        expected_h, rel_p = parts[0], parts[1].strip("* ")
+        if len(expected_h) != 64 or any(c not in "0123456789abcdefABCDEF" for c in expected_h):
+            errors.append(f"malformed SHA256SUMS hash at line {idx}: {expected_h!r}")
+            continue
+        target_f = target_dir / rel_p
+        if not target_f.is_file():
+            errors.append(f"file in SHA256SUMS missing on disk: {rel_p}")
+        elif compute_file_sha256(target_f) != expected_h:
+            errors.append(f"SHA256SUMS hash mismatch for {rel_p}")
+
+    return errors
+
+
+def validate_artifact_bundle(
+    artifact_path: Path,
+    require_manifest: bool = False,
+) -> tuple[list[str], dict[str, Any] | None]:
+    """Validate an Explorer application artifact directory or archive."""
+    errors: list[str] = []
+    bundle_metadata: dict[str, Any] | None = None
+
+    if not artifact_path.exists():
+        return [f"artifact path does not exist: {artifact_path}"], None
+
+    temp_dir: Path | None = None
+    target_dir = artifact_path
+
+    try:
+        if artifact_path.is_file():
+            temp_dir, archive_errors = _extract_artifact_archive(artifact_path)
+            if temp_dir is None:
+                return archive_errors, None
+            target_dir = temp_dir
+
+        if not target_dir.is_dir():
+            return [f"target artifact is not a directory: {target_dir}"], None
+
+        errors.extend(_validate_index_html(target_dir))
+
+        all_files = list(target_dir.rglob("*"))
+        file_errors, js_files, css_files = _validate_bundle_files(all_files, target_dir)
+        errors.extend(file_errors)
+
+        checksums = compute_directory_checksums(target_dir)
+        content_addr = compute_content_address(checksums)
+
+        errors.extend(_validate_manifest_json(target_dir, content_addr, require_manifest=require_manifest))
+        errors.extend(_validate_sha256sums(target_dir, require_manifest=require_manifest))
+
+        bundle_metadata = {
+            "path": str(artifact_path),
+            "content_address": content_addr,
+            "file_count": len(checksums),
+            "js_bundles": len(js_files),
+            "css_bundles": len(css_files),
+            "total_bytes": sum(p.stat().st_size for p in all_files if p.is_file()),
+        }
+
+    finally:
+        if temp_dir and temp_dir.exists():
+            shutil.rmtree(temp_dir, ignore_errors=True)
+
+    return errors, bundle_metadata
+
+
+# ---------------------------------------------------------------------------
+# CLI Parser and Execution
+# ---------------------------------------------------------------------------
+
+
+def build_parser() -> argparse.ArgumentParser:
+    """Build CLI argument parser."""
+    parser = argparse.ArgumentParser(
+        description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument(
+        "--artifact",
+        "-a",
+        type=Path,
+        help="Path to Results Explorer build directory (dist/) or archive.",
+    )
+    parser.add_argument(
+        "--db-path",
+        "-d",
+        type=Path,
+        help="Path to a DuckDB database snapshot file (results.duckdb) to validate.",
+    )
+    parser.add_argument(
+        "--schema-versions",
+        "-s",
+        type=str,
+        default=",".join(str(v) for v in SUPPORTED_SCHEMA_VERSIONS),
+        help=f"Comma-separated list of schema versions to validate (default: {','.join(str(v) for v in SUPPORTED_SCHEMA_VERSIONS)}).",
+    )
+    parser.add_argument(
+        "--generate-manifest",
+        action="store_true",
+        help="Compute and write manifest.json and SHA256SUMS in the --artifact directory.",
+    )
+    parser.add_argument(
+        "--require-manifest",
+        action="store_true",
+        help="Require manifest.json and SHA256SUMS to be present and valid (fail-closed).",
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Output validation results in JSON format.",
+    )
+    parser.add_argument(
+        "--quiet",
+        "-q",
+        action="store_true",
+        help="Quiet mode: only output on error.",
+    )
+    return parser
+
+
+def _parse_schema_versions_arg(raw: str) -> list[int] | None:
+    """Parse --schema-versions into a list of ints, or None on malformed input."""
+    try:
+        if raw.strip().lower() == "all":
+            return list(SUPPORTED_SCHEMA_VERSIONS)
+        # Empty string should be treated as malformed, not as wildcard
+        if raw.strip() == "":
+            return None
+        return [int(v.strip()) for v in raw.split(",") if v.strip()]
+    except ValueError:
+        return None
+
+
+def _run_database_check(db_path: Path) -> dict[str, Any] | None:
+    """Validate a DuckDB snapshot file. Returns None if the path does not exist."""
+    if not db_path.is_file():
+        return None
+
+    import duckdb
+
+    db_errors: list[str] = []
+    try:
+        with duckdb.connect(str(db_path), read_only=True) as con:
+            db_errors.extend(validate_database_schema(con))
+            row = con.execute("SELECT read_model_version FROM metadata").fetchone()
+            db_version = int(row[0]) if row else CURRENT_SCHEMA_VERSION
+            db_errors.extend(validate_database_queries(con, version=db_version))
+    except Exception as exc:
+        db_errors.append(f"failed to open/validate DuckDB snapshot: {exc}")
+
+    return {"path": str(db_path), "passed": len(db_errors) == 0, "errors": db_errors}
+
+
+def _run_artifact_check(
+    artifact_path: Path,
+    generate_manifest: bool,
+    require_manifest: bool = False,
+) -> tuple[dict[str, Any], dict[str, Any] | None]:
+    """Validate an Explorer artifact bundle, optionally generating its manifest first."""
+    manifest_info = None
+    if generate_manifest:
+        # Generation is separate from verification; generate manifest and return.
+        # Caller decides whether to also verify in a separate step.
+        manifest_info = generate_artifact_manifest(artifact_path, write=True)
+        # For backward compatibility, when generating we do not also require manifest
+        # in the same invocation (would be circular). Return a synthetic pass for
+        # the generation step; verification should be done via a separate
+        # --require-manifest invocation.
+        artifact_errors, bundle_info = validate_artifact_bundle(artifact_path, require_manifest=False)
+        artifact_check = {
+            "path": str(artifact_path),
+            "passed": len(artifact_errors) == 0,
+            "metadata": bundle_info,
+            "errors": artifact_errors,
+        }
+        return artifact_check, manifest_info
+
+    artifact_errors, bundle_info = validate_artifact_bundle(artifact_path, require_manifest=require_manifest)
+    artifact_check = {
+        "path": str(artifact_path),
+        "passed": len(artifact_errors) == 0,
+        "metadata": bundle_info,
+        "errors": artifact_errors,
+    }
+    return artifact_check, manifest_info
+
+
+def _print_text_report(output_data: dict[str, Any], schema_versions: Sequence[int], overall_passed: bool) -> None:
+    """Render the human-readable compatibility report to stdout/stderr."""
+    print("=== Results Explorer Compatibility & Artifact Verification ===")
+    print(f"Current read-model version: v{CURRENT_SCHEMA_VERSION}")
+    print(f"Supported versions: {', '.join(f'v{v}' for v in SUPPORTED_SCHEMA_VERSIONS)}")
+    print()
+
+    print("Schema Compatibility:")
+    for v in schema_versions:
+        v_info = output_data["schema_checks"][f"v{v}"]
+        mark = "✓ PASS" if v_info["passed"] else "✗ FAIL"
+        print(f"  [{mark}] Schema v{v}")
+        for err in v_info["errors"]:
+            print(f"      - {err}")
+
+    if "database_check" in output_data:
+        db_info = output_data["database_check"]
+        mark = "✓ PASS" if db_info["passed"] else "✗ FAIL"
+        print()
+        print(f"Database Snapshot: {db_info['path']}")
+        print(f"  [{mark}] Snapshot integrity")
+        for err in db_info["errors"]:
+            print(f"      - {err}")
+
+    if "artifact_check" in output_data:
+        art_info = output_data["artifact_check"]
+        mark = "✓ PASS" if art_info["passed"] else "✗ FAIL"
+        print()
+        print(f"Explorer Application Artifact: {art_info['path']}")
+        if art_info.get("metadata"):
+            meta = art_info["metadata"]
+            print(f"  Content address: {meta.get('content_address')}")
+            print(f"  Total files:     {meta.get('file_count')} ({meta.get('total_bytes')} bytes)")
+            print(f"  JS / CSS bundles: {meta.get('js_bundles')} JS, {meta.get('css_bundles')} CSS")
+        print(f"  [{mark}] Artifact bundle integrity")
+        for err in art_info["errors"]:
+            print(f"      - {err}")
+
+    print()
+    if overall_passed:
+        print("All Results Explorer compatibility checks PASSED.")
+    else:
+        print("Results Explorer compatibility checks FAILED.", file=sys.stderr)
+
+
+def main(argv: Sequence[str] | None = None) -> int:  # noqa: C901
+    """CLI main entrypoint."""
+    parser = build_parser()
+    args = parser.parse_args(argv)
+
+    if args.generate_manifest and args.require_manifest:
+        print("Error: --generate-manifest and --require-manifest are mutually exclusive", file=sys.stderr)
+        return 2
+
+    schema_versions = _parse_schema_versions_arg(args.schema_versions)
+    if schema_versions is None or len(schema_versions) == 0:
+        print(f"Error: Invalid --schema-versions format: {args.schema_versions!r}", file=sys.stderr)
+        return 2
+
+    for v in schema_versions:
+        if v not in SUPPORTED_SCHEMA_VERSIONS:
+            print(
+                f"Error: Unsupported schema version {v}. Supported versions: {list(SUPPORTED_SCHEMA_VERSIONS)}",
+                file=sys.stderr,
+            )
+            return 2
+
+    overall_passed = True
+    output_data: dict[str, Any] = {
+        "status": "passed",
+        "current_version": CURRENT_SCHEMA_VERSION,
+        "supported_versions": list(SUPPORTED_SCHEMA_VERSIONS),
+        "schema_checks": {},
+    }
+
+    # 1. Multi-version schema compatibility checks
+    schema_results = check_schema_compatibility(schema_versions)
+    for v, errors in schema_results.items():
+        passed = len(errors) == 0
+        if not passed:
+            overall_passed = False
+        output_data["schema_checks"][f"v{v}"] = {
+            "passed": passed,
+            "errors": errors,
+        }
+
+    # 2. Database path validation if provided
+    if args.db_path:
+        db_check = _run_database_check(args.db_path)
+        if db_check is None:
+            print(f"Error: DuckDB database file not found: {args.db_path}", file=sys.stderr)
+            return 2
+        if not db_check["passed"]:
+            overall_passed = False
+        output_data["database_check"] = db_check
+
+    # 3. Artifact validation if provided
+    if args.artifact:
+        if not args.artifact.exists():
+            print(f"Error: Artifact path not found: {args.artifact}", file=sys.stderr)
+            return 2
+        if args.generate_manifest and not args.artifact.is_dir():
+            print("Error: --generate-manifest requires a directory for --artifact", file=sys.stderr)
+            return 2
+
+        # Separate generate from verify: generate writes manifest, verify checks it.
+        if args.generate_manifest:
+            # Generation mode: write manifest, then do a non-required validation for basic bundle health
+            artifact_check, manifest_info = _run_artifact_check(
+                args.artifact, generate_manifest=True, require_manifest=False
+            )
+            output_data["manifest_generated"] = manifest_info
+            if not artifact_check["passed"]:
+                overall_passed = False
+            output_data["artifact_check"] = artifact_check
+        else:
+            artifact_check, manifest_info = _run_artifact_check(
+                args.artifact, generate_manifest=False, require_manifest=args.require_manifest
+            )
+            if manifest_info is not None:
+                output_data["manifest_generated"] = manifest_info
+            if not artifact_check["passed"]:
+                overall_passed = False
+            output_data["artifact_check"] = artifact_check
+
+    output_data["status"] = "passed" if overall_passed else "failed"
+
+    # Display results
+    if args.json:
+        print(json.dumps(output_data, indent=2))
+    elif not args.quiet or not overall_passed:
+        _print_text_report(output_data, schema_versions, overall_passed)
+
+    return 0 if overall_passed else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/unit/scripts/publication/test_check_explorer_compat.py
+++ b/tests/unit/scripts/publication/test_check_explorer_compat.py
@@ -1,0 +1,437 @@
+"""Tests for the Results Explorer compatibility and artifact check script."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import os
+import tarfile
+import zipfile
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+pytestmark = [pytest.mark.unit, pytest.mark.fast]
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+SCRIPT_PATH = REPO_ROOT / "scripts" / "publication" / "check_explorer_compat.py"
+
+SPEC = importlib.util.spec_from_file_location("check_explorer_compat", SCRIPT_PATH)
+assert SPEC and SPEC.loader
+checker = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(checker)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def mock_artifact_dir(tmp_path: Path) -> Path:
+    """Create a minimal valid Results Explorer artifact dist directory."""
+    dist = tmp_path / "dist"
+    dist.mkdir(parents=True)
+    (dist / "index.html").write_text(
+        "<!DOCTYPE html><html><head><title>Results Explorer</title></head>"
+        "<body><div id='root'></div><script src='/assets/index.js'></script></body></html>",
+        encoding="utf-8",
+    )
+    assets = dist / "assets"
+    assets.mkdir(parents=True)
+    (assets / "index.js").write_text("console.log('explorer');", encoding="utf-8")
+    (assets / "style.css").write_text("body { margin: 0; }", encoding="utf-8")
+    return dist
+
+
+# ---------------------------------------------------------------------------
+# Schema Definitions & Normalization Tests
+# ---------------------------------------------------------------------------
+
+
+def test_normalize_type() -> None:
+    assert checker.normalize_type("varchar") == "VARCHAR"
+    assert checker.normalize_type("TEXT") == "VARCHAR"
+    assert checker.normalize_type("int4") == "INTEGER"
+    assert checker.normalize_type("double") == "DOUBLE"
+    assert checker.normalize_type("boolean") == "BOOLEAN"
+    assert checker.normalize_type("CUSTOM_TYPE") == "CUSTOM_TYPE"
+
+
+def test_schema_versions_definitions() -> None:
+    # Only v9 is supported; contract import should match
+    assert checker.SUPPORTED_SCHEMA_VERSIONS == (9,)
+    assert checker.CURRENT_SCHEMA_VERSION == 9
+    # Check that contract version is consistent
+    from _project.scripts.explorer_pipeline.contract import EXPLORER_READ_MODEL_VERSION
+
+    assert checker.CURRENT_SCHEMA_VERSION == EXPLORER_READ_MODEL_VERSION
+    assert checker.SUPPORTED_SCHEMA_VERSIONS == (EXPLORER_READ_MODEL_VERSION,)
+
+    cols = checker.get_table_columns_for_version(9)
+    assert "results" in cols
+    assert "metadata" in cols
+    assert "result_environment" in cols
+    assert "query_executions" in cols
+    assert "benchmark_rankings" in cols
+    assert "cohort_metadata" in cols
+    assert "result_basis_availability" in cols
+    assert "cpu_identity_provenance" in cols["result_environment"]
+    assert "run_type" in cols["query_executions"]
+
+
+def test_invalid_schema_version_raises() -> None:
+    with pytest.raises(ValueError, match="Unsupported schema version"):
+        checker.get_table_columns_for_version(99)
+    with pytest.raises(ValueError, match="Unsupported schema version"):
+        checker.get_table_columns_for_version(7)
+    with pytest.raises(ValueError, match="Unsupported schema version"):
+        checker.get_table_columns_for_version(8)
+    with pytest.raises(ValueError, match="Unsupported schema version"):
+        checker.get_views_for_version(7)
+    with pytest.raises(ValueError, match="Unsupported schema version"):
+        checker.get_indexes_for_version(8)
+
+
+# ---------------------------------------------------------------------------
+# In-Memory Database & Query Verification Tests
+# ---------------------------------------------------------------------------
+
+
+def test_in_memory_schema_creation_and_validation() -> None:
+    for version in checker.SUPPORTED_SCHEMA_VERSIONS:
+        con = checker.create_in_memory_schema(version)
+        try:
+            errors = checker.validate_database_schema(con, expected_version=version)
+            assert errors == [], f"Schema validation failed for v{version}: {errors}"
+
+            query_errors = checker.validate_database_queries(con, version=version)
+            assert query_errors == [], f"Query validation failed for v{version}: {query_errors}"
+        finally:
+            con.close()
+
+
+def test_check_schema_compatibility_all_supported() -> None:
+    results = checker.check_schema_compatibility()
+    for version, errors in results.items():
+        assert errors == [], f"Version v{version} had unexpected errors: {errors}"
+    assert set(results.keys()) == set(checker.SUPPORTED_SCHEMA_VERSIONS)
+
+
+def test_validate_database_schema_detects_missing_table() -> None:
+    con = checker.create_in_memory_schema(9)
+    try:
+        con.execute("DROP TABLE cohort_metadata")
+        errors = checker.validate_database_schema(con, expected_version=9)
+        assert any("missing required tables for v9: cohort_metadata" in err for err in errors)
+    finally:
+        con.close()
+
+
+def test_validate_database_schema_detects_missing_column() -> None:
+    con = checker.create_in_memory_schema(9)
+    try:
+        con.execute("ALTER TABLE results DROP COLUMN funding")
+        errors = checker.validate_database_schema(con, expected_version=9)
+        assert any("table 'results' missing required columns: funding" in err for err in errors)
+    finally:
+        con.close()
+
+
+def test_validate_database_schema_detects_missing_view() -> None:
+    con = checker.create_in_memory_schema(9)
+    try:
+        con.execute("DROP VIEW result_detail_metrics")
+        errors = checker.validate_database_schema(con, expected_version=9)
+        assert any("missing required views for v9: result_detail_metrics" in err for err in errors)
+    finally:
+        con.close()
+
+
+def test_validate_database_schema_version_mismatch() -> None:
+    con = checker.create_in_memory_schema(9)
+    try:
+        # Tamper metadata to simulate version mismatch
+        con.execute("UPDATE metadata SET read_model_version = 8")
+        errors = checker.validate_database_schema(con, expected_version=9)
+        assert any("read_model_version mismatch: expected 9, got 8" in err for err in errors)
+    finally:
+        con.close()
+
+
+# ---------------------------------------------------------------------------
+# Artifact Bundle Verification Tests
+# ---------------------------------------------------------------------------
+
+
+def test_compute_file_and_directory_checksums(mock_artifact_dir: Path) -> None:
+    checksums = checker.compute_directory_checksums(mock_artifact_dir)
+    assert "index.html" in checksums
+    assert "assets/index.js" in checksums
+    assert "assets/style.css" in checksums
+    assert len(checksums) == 3
+
+    addr = checker.compute_content_address(checksums)
+    assert isinstance(addr, str) and len(addr) == 64
+
+
+def test_compute_directory_checksums_anchored_exclude(mock_artifact_dir: Path) -> None:
+    # Nested manifest.json should be included in checksums (anchored to root)
+    nested = mock_artifact_dir / "assets" / "manifest.json"
+    nested.write_text('{"fake": true}', encoding="utf-8")
+    checksums = checker.compute_directory_checksums(mock_artifact_dir)
+    # Root manifest.json is excluded, nested one is not
+    assert "assets/manifest.json" in checksums
+    assert "manifest.json" not in checksums
+    # Same for SHA256SUMS
+    nested_sums = mock_artifact_dir / "assets" / "SHA256SUMS"
+    nested_sums.write_text("fake", encoding="utf-8")
+    checksums2 = checker.compute_directory_checksums(mock_artifact_dir)
+    assert "assets/SHA256SUMS" in checksums2
+    assert "SHA256SUMS" not in checksums2
+
+
+def test_generate_artifact_manifest(mock_artifact_dir: Path) -> None:
+    manifest = checker.generate_artifact_manifest(mock_artifact_dir, write=True)
+    assert manifest["bundle"] == "explorer_app"
+    assert manifest["file_count"] == 3
+    assert (mock_artifact_dir / "manifest.json").is_file()
+    assert (mock_artifact_dir / "SHA256SUMS").is_file()
+    # Provenance fields
+    assert manifest["read_model_version"] == checker.CURRENT_SCHEMA_VERSION
+    assert manifest["supported_versions"] == list(checker.SUPPORTED_SCHEMA_VERSIONS)
+    assert "github_sha" in manifest
+    assert "contract_version" in manifest
+
+    # Validating bundle after manifest generation succeeds cleanly
+    errors, info = checker.validate_artifact_bundle(mock_artifact_dir)
+    assert errors == []
+    assert info is not None
+    assert info["content_address"] == manifest["content_address"]
+
+
+def test_generate_manifest_embeds_github_sha(mock_artifact_dir: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("GITHUB_SHA", "abc123def456")
+    monkeypatch.setenv("GITHUB_REF", "refs/heads/develop")
+    monkeypatch.setenv("GITHUB_EVENT_NAME", "push")
+    manifest = checker.generate_artifact_manifest(mock_artifact_dir, write=False)
+    assert manifest["github_sha"] == "abc123def456"
+    assert manifest["github_ref"] == "refs/heads/develop"
+    assert manifest["github_event_name"] == "push"
+
+
+def test_validate_artifact_bundle_valid_directory(mock_artifact_dir: Path) -> None:
+    errors, info = checker.validate_artifact_bundle(mock_artifact_dir)
+    assert errors == []
+    assert info is not None
+    assert info["file_count"] == 3
+    assert info["js_bundles"] == 1
+    assert info["css_bundles"] == 1
+
+
+def test_validate_artifact_bundle_require_manifest_missing(mock_artifact_dir: Path) -> None:
+    # Without manifest, require_manifest=False passes; with True fails
+    errors_ok, _ = checker.validate_artifact_bundle(mock_artifact_dir, require_manifest=False)
+    assert errors_ok == []
+    errors_req, _ = checker.validate_artifact_bundle(mock_artifact_dir, require_manifest=True)
+    assert any("manifest.json is missing" in err for err in errors_req)
+    assert any("SHA256SUMS is missing" in err for err in errors_req)
+
+
+def test_validate_artifact_bundle_nonexistent_path(tmp_path: Path) -> None:
+    non_existent = tmp_path / "does_not_exist"
+    errors, info = checker.validate_artifact_bundle(non_existent)
+    assert any("does not exist" in err for err in errors)
+    assert info is None
+
+
+def test_validate_artifact_bundle_missing_index(tmp_path: Path) -> None:
+    dist = tmp_path / "no_index"
+    dist.mkdir()
+    assets = dist / "assets"
+    assets.mkdir()
+    (assets / "index.js").write_text("console.log('hi');", encoding="utf-8")
+    (assets / "index.css").write_text("body {}", encoding="utf-8")
+
+    errors, _ = checker.validate_artifact_bundle(dist)
+    assert any("missing 'index.html'" in err for err in errors)
+
+
+def test_validate_artifact_bundle_empty_file(mock_artifact_dir: Path) -> None:
+    empty_file = mock_artifact_dir / "empty.txt"
+    empty_file.touch()
+
+    errors, _ = checker.validate_artifact_bundle(mock_artifact_dir)
+    assert any("empty file in artifact bundle: empty.txt" in err for err in errors)
+
+
+def test_validate_artifact_bundle_manifest_checksum_mismatch(mock_artifact_dir: Path) -> None:
+    checker.generate_artifact_manifest(mock_artifact_dir, write=True)
+
+    # Tamper with a file
+    (mock_artifact_dir / "index.html").write_text("TAMPERED", encoding="utf-8")
+
+    errors, _ = checker.validate_artifact_bundle(mock_artifact_dir)
+    assert any("manifest content_address mismatch" in err or "file checksum mismatch" in err for err in errors)
+
+
+def test_validate_artifact_bundle_malformed_sha256sums(mock_artifact_dir: Path) -> None:
+    checker.generate_artifact_manifest(mock_artifact_dir, write=True)
+    # Overwrite with malformed single token
+    (mock_artifact_dir / "SHA256SUMS").write_text("garbage_token\n", encoding="utf-8")
+    errors, _ = checker.validate_artifact_bundle(mock_artifact_dir)
+    assert any("malformed SHA256SUMS" in err for err in errors)
+
+
+def test_validate_artifact_bundle_malformed_sha256sums_line_continuation(mock_artifact_dir: Path) -> None:
+    checker.generate_artifact_manifest(mock_artifact_dir, write=True)
+    (mock_artifact_dir / "SHA256SUMS").write_text(
+        "not-a-hash  index.html\n" + (mock_artifact_dir / "SHA256SUMS").read_text(encoding="utf-8"),
+        encoding="utf-8",
+    )
+    errors, _ = checker.validate_artifact_bundle(mock_artifact_dir)
+    assert any("malformed SHA256SUMS hash" in err for err in errors)
+
+
+def test_validate_artifact_bundle_zip_archive(mock_artifact_dir: Path, tmp_path: Path) -> None:
+    zip_path = tmp_path / "explorer_app.zip"
+    with zipfile.ZipFile(zip_path, "w") as zf:
+        for p in mock_artifact_dir.rglob("*"):
+            if p.is_file():
+                zf.write(p, arcname=p.relative_to(mock_artifact_dir))
+
+    errors, info = checker.validate_artifact_bundle(zip_path)
+    assert errors == []
+    assert info is not None
+    assert info["file_count"] == 3
+
+
+def test_validate_artifact_bundle_tar_archive(mock_artifact_dir: Path, tmp_path: Path) -> None:
+    tar_path = tmp_path / "explorer_app.tar.gz"
+    with tarfile.open(tar_path, "w:gz") as tf:
+        for p in mock_artifact_dir.rglob("*"):
+            if p.is_file():
+                tf.add(p, arcname=str(p.relative_to(mock_artifact_dir)))
+
+    errors, info = checker.validate_artifact_bundle(tar_path)
+    assert errors == []
+    assert info is not None
+    assert info["file_count"] == 3
+
+
+# ---------------------------------------------------------------------------
+# CLI Execution Tests
+# ---------------------------------------------------------------------------
+
+
+def test_cli_default_schema_checks(capsys: pytest.CaptureFixture[str]) -> None:
+    exit_code = checker.main([])
+    assert exit_code == 0
+    captured = capsys.readouterr()
+    assert "Results Explorer Compatibility" in captured.out
+    assert "Schema v9" in captured.out
+    assert "Schema v8" not in captured.out
+    assert "Schema v7" not in captured.out
+    assert "All Results Explorer compatibility checks PASSED" in captured.out
+
+
+def test_cli_json_mode(capsys: pytest.CaptureFixture[str]) -> None:
+    exit_code = checker.main(["--json"])
+    assert exit_code == 0
+    captured = capsys.readouterr()
+    data = json.loads(captured.out)
+    assert data["status"] == "passed"
+    assert data["current_version"] == 9
+    assert "v9" in data["schema_checks"]
+    assert "v8" not in data["schema_checks"]
+
+
+def test_cli_specific_schema_version(capsys: pytest.CaptureFixture[str]) -> None:
+    exit_code = checker.main(["--schema-versions", "9"])
+    assert exit_code == 0
+    captured = capsys.readouterr()
+    assert "Schema v9" in captured.out
+    assert "Schema v8" not in captured.out
+
+
+def test_cli_invalid_schema_version(capsys: pytest.CaptureFixture[str]) -> None:
+    exit_code = checker.main(["--schema-versions", "99"])
+    assert exit_code == 2
+    captured = capsys.readouterr()
+    assert "Unsupported schema version 99" in captured.err
+
+
+def test_cli_invalid_schema_version_7(capsys: pytest.CaptureFixture[str]) -> None:
+    exit_code = checker.main(["--schema-versions", "7"])
+    assert exit_code == 2
+    captured = capsys.readouterr()
+    assert "Unsupported schema version 7" in captured.err
+
+
+def test_cli_empty_schema_versions(capsys: pytest.CaptureFixture[str]) -> None:
+    exit_code = checker.main(["--schema-versions", ""])
+    assert exit_code == 2
+    captured = capsys.readouterr()
+    assert "Invalid --schema-versions format" in captured.err
+
+
+def test_cli_artifact_check(mock_artifact_dir: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    exit_code = checker.main(["--artifact", str(mock_artifact_dir), "--generate-manifest"])
+    assert exit_code == 0
+    captured = capsys.readouterr()
+    assert "Explorer Application Artifact" in captured.out
+    assert "Content address" in captured.out
+    assert "All Results Explorer compatibility checks PASSED" in captured.out
+
+
+def test_cli_artifact_verify_requires_manifest(mock_artifact_dir: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    # Without manifest, --require-manifest should fail
+    exit_code = checker.main(["--artifact", str(mock_artifact_dir), "--require-manifest"])
+    assert exit_code == 1
+    captured = capsys.readouterr()
+    assert "FAILED" in captured.err or "manifest.json is missing" in captured.out or "FAILED" in captured.out
+
+    # After generating manifest, require should pass
+    checker.generate_artifact_manifest(mock_artifact_dir, write=True)
+    exit_code2 = checker.main(["--artifact", str(mock_artifact_dir), "--require-manifest"])
+    assert exit_code2 == 0
+
+
+def test_cli_generate_and_require_mutually_exclusive(
+    mock_artifact_dir: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    exit_code = checker.main(["--artifact", str(mock_artifact_dir), "--generate-manifest", "--require-manifest"])
+    assert exit_code == 2
+    captured = capsys.readouterr()
+    assert "mutually exclusive" in captured.err
+
+
+def test_cli_artifact_not_found(capsys: pytest.CaptureFixture[str]) -> None:
+    exit_code = checker.main(["--artifact", "/tmp/non_existent_explorer_dir_12345"])
+    assert exit_code == 2
+    captured = capsys.readouterr()
+    assert "Artifact path not found" in captured.err
+
+
+def test_cli_db_path_check(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    import duckdb
+
+    db_file = tmp_path / "test.duckdb"
+    with duckdb.connect(str(db_file)) as con:
+        for stmt in checker.generate_schema_ddl(9):
+            con.execute(stmt)
+        con.execute("INSERT INTO metadata VALUES (9)")
+
+    exit_code = checker.main(["--db-path", str(db_file)])
+    assert exit_code == 0
+    captured = capsys.readouterr()
+    assert "Database Snapshot" in captured.out
+    assert "All Results Explorer compatibility checks PASSED" in captured.out
+
+
+def test_cli_db_path_not_found(capsys: pytest.CaptureFixture[str]) -> None:
+    exit_code = checker.main(["--db-path", "/tmp/non_existent_db_12345.duckdb"])
+    assert exit_code == 2
+    captured = capsys.readouterr()
+    assert "DuckDB database file not found" in captured.err

--- a/tests/unit/workflows/test_develop_post_merge_gaps.py
+++ b/tests/unit/workflows/test_develop_post_merge_gaps.py
@@ -241,6 +241,7 @@ def test_push_drop_inventory_subject_set_matches_workflows() -> None:
         "develop-post-merge.yml",
         "docs.yml",
         "orphaned-commit-detector.yml",
+        "publication-lane-explorer.yml",
         "results-explorer-browser.yml",
         "submission-validator-drift-check.yml",
         "sync-results-data-to-published.yml",

--- a/tests/unit/workflows/test_publication_lane_explorer.py
+++ b/tests/unit/workflows/test_publication_lane_explorer.py
@@ -1,0 +1,194 @@
+"""Publication lane explorer workflow contracts.
+
+Pins least-privilege, concurrency, artifact provenance, and test coverage
+for the independent Results Explorer publication lane.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+pytestmark = [pytest.mark.unit, pytest.mark.fast]
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+WORKFLOW_PATH = REPO_ROOT / ".github" / "workflows" / "publication-lane-explorer.yml"
+INVENTORY = REPO_ROOT / "docs" / "operations" / "develop-push-drop-inventory.md"
+CHECKER_SCRIPT = REPO_ROOT / "scripts" / "publication" / "check_explorer_compat.py"
+
+
+def _load_workflow() -> dict:
+    text = WORKFLOW_PATH.read_text(encoding="utf-8")
+    data = yaml.safe_load(text)
+    assert isinstance(data, dict)
+    return data, text
+
+
+def _get_on_block(workflow: dict):
+    # PyYAML 1.1 treats `on` as boolean True
+    on = workflow.get(True) or workflow.get("on")
+    assert isinstance(on, dict), "workflow missing `on:` block"
+    return on
+
+
+def test_publication_lane_permissions_are_least_privilege() -> None:
+    workflow, _ = _load_workflow()
+    assert workflow.get("permissions") == {"contents": "read"}, (
+        f"publication lane must be least-privilege contents: read, got {workflow.get('permissions')!r}"
+    )
+
+
+def test_publication_lane_no_job_level_permissions() -> None:
+    workflow, _ = _load_workflow()
+    for job_name, job in workflow.get("jobs", {}).items():
+        assert "permissions" not in job, f"job {job_name!r} must not override workflow permissions"
+
+
+def test_publication_lane_no_deploy_permissions() -> None:
+    _, text = _load_workflow()
+    # No pages, id-token, packages, deployments, or write permissions
+    for needle in ("pages: write", "id-token: write", "packages: write", "deployments: write", "contents: write"):
+        assert needle not in text, f"workflow must not contain {needle!r}"
+    # No deploy step
+    assert "deploy" not in text.lower() or "upload-artifact" in text.lower()
+
+
+def test_publication_lane_concurrency_is_sha_keyed() -> None:
+    _, text = _load_workflow()
+    # Must be SHA-keyed for push (not ref) and PR number for pull_request
+    assert "github.sha" in text, "concurrency group must be SHA-keyed for push"
+    assert "github.event.pull_request.number" in text, "concurrency group must be PR-number-keyed for pull_request"
+    # Should not use github.ref as the push key (would coalesce concurrent pushes)
+    # The only allowed ref usage is for merge_group etc; publication lane should not use ref as fallback
+    workflow, _ = _load_workflow()
+    concurrency = workflow.get("concurrency", {})
+    group = str(concurrency.get("group", ""))
+    assert "github.sha" in group, f"concurrency group must contain github.sha, got {group!r}"
+    assert "github.ref" not in group, f"concurrency group must not use github.ref (use github.sha), got {group!r}"
+
+
+def test_publication_lane_artifact_name_includes_sha() -> None:
+    _, text = _load_workflow()
+    workflow, _ = _load_workflow()
+    jobs = workflow.get("jobs", {})
+    found_upload = False
+    for job in jobs.values():
+        for step in job.get("steps", []):
+            if "upload-artifact" in str(step.get("uses", "")):
+                found_upload = True
+                name = str(step.get("with", {}).get("name", ""))
+                # Must include github.sha for provenance
+                assert "github.sha" in name, f"artifact name must include github.sha for provenance, got {name!r}"
+                assert name != "explorer_app", "artifact name must not be fixed 'explorer_app' (fork PR provenance)"
+    assert found_upload, "workflow must have an upload-artifact step"
+    # Also check raw text
+    assert "explorer_app-${{ github.sha }}" in text or "explorer_app-${{github.sha}}" in text.replace(" ", "")
+
+
+def test_publication_lane_runs_explorer_tests() -> None:
+    workflow, text = _load_workflow()
+    # Must run npm test (vitest) and python contract tests
+    assert "npm run test" in text or "npm test" in text, "workflow must run Explorer unit tests (npm run test)"
+    # Check that npm test step has working-directory results-explorer
+    found_npm_test = False
+    for job in workflow["jobs"].values():
+        for step in job["steps"]:
+            run = str(step.get("run", ""))
+            if "npm run test" in run and "test:e2e" not in run:
+                # Ensure it's the unit test step, not e2e
+                found_npm_test = True
+                # Check working-directory is results-explorer (if present)
+                if "working-directory" in step:
+                    assert step["working-directory"] == "results-explorer"
+    assert found_npm_test, "workflow must have a step running 'npm run test' for Explorer unit tests"
+    # Python contract tests
+    assert "test_duckdb_browser_contract" in text or "test_explorer_build_contract" in text, (
+        "workflow must run Python contract tests"
+    )
+    assert "test_duckdb_browser_contract.py" in text
+    assert "test_explorer_build_contract.py" in text
+
+
+def test_publication_lane_has_separate_generate_and_verify_steps() -> None:
+    _, text = _load_workflow()
+    workflow, _ = _load_workflow()
+    jobs = workflow["jobs"]
+    # Find generate and verify steps
+    generate_count = text.count("--generate-manifest")
+    require_count = text.count("--require-manifest")
+    assert generate_count >= 1, "workflow must have a step with --generate-manifest"
+    assert require_count >= 1, "workflow must have a separate step with --require-manifest for verification"
+    # They must be in separate steps (not same run line)
+    for job in jobs.values():
+        for step in job["steps"]:
+            run = str(step.get("run", ""))
+            assert not ("--generate-manifest" in run and "--require-manifest" in run), (
+                "generate and require must be in separate steps"
+            )
+
+
+def test_publication_lane_manifest_provenance() -> None:
+    # Checker script must embed read_model_version and github.sha
+    text = CHECKER_SCRIPT.read_text(encoding="utf-8")
+    assert "read_model_version" in text
+    assert "github_sha" in text or "GITHUB_SHA" in text
+    assert "SUPPORTED_SCHEMA_VERSIONS" in text
+    # Ensure manifest generation includes provenance
+    assert "EXPLORER_READ_MODEL_VERSION" in text or "CURRENT_SCHEMA_VERSION" in text
+
+
+def test_publication_lane_inventory_is_advisory() -> None:
+    inv = INVENTORY.read_text(encoding="utf-8")
+    # Find publication-lane row
+    assert "publication-lane-explorer.yml" in inv, "inventory must list publication-lane-explorer.yml"
+    # The row must not claim required-check as primary safety property
+    # Find the line containing the workflow name
+    for line in inv.splitlines():
+        if "publication-lane-explorer.yml" in line:
+            lower = line.lower().replace("*", "").replace("`", "")
+            # Must contain advisory and must not claim "required-path gate" or "required check"
+            assert "advisory" in lower, f"inventory row must be marked advisory, got: {line!r}"
+            # Check that row states lane is not a required check (allow markdown bold)
+            assert "not" in lower and "required" in lower, (
+                f"inventory row must state lane is not a required check, got: {line!r}"
+            )
+            # Should not claim pre-merge required gate
+            assert "pre-merge required-path gate" not in line, (
+                f"inventory must not claim pre-merge required-path gate, got: {line!r}"
+            )
+            break
+    else:
+        pytest.fail("publication-lane-explorer row not found in inventory")
+
+
+def test_publication_lane_checker_supports_only_v9() -> None:
+    text = CHECKER_SCRIPT.read_text(encoding="utf-8")
+    # Must import from contract or set to 9
+    assert "EXPLORER_READ_MODEL_VERSION" in text or "SUPPORTED_SCHEMA_VERSIONS: tuple[int, ...] = (9,)" in text
+    assert "SUPPORTED_SCHEMA_VERSIONS: tuple[int, ...] = (7, 8, 9)" not in text
+    # Must not contain v7/v8 hand-maintained logic
+    assert (
+        "if version == 8" not in text or "cpu_identity_provenance" not in text.split("if version == 8")[0][-500:]
+    )  # rough
+    # Check that get_table_columns_for_version only supports CURRENT_SCHEMA_VERSION
+    assert "if version == 7" not in text
+    # Ensure checker imports contract
+    has_import = "from _project.scripts.explorer_pipeline.contract import" in text
+    has_fallback = "SUPPORTED_SCHEMA_VERSIONS: tuple[int, ...] = (9,)" in text
+    assert has_import or has_fallback
+
+
+def test_publication_lane_checker_manifest_fail_closed() -> None:
+    text = CHECKER_SCRIPT.read_text(encoding="utf-8")
+    # Must have require_manifest handling
+    assert "require_manifest" in text
+    assert "manifest.json is missing" in text
+    assert "SHA256SUMS is missing" in text
+    # Must reject malformed SHA256SUMS
+    assert "malformed SHA256SUMS" in text
+    # Must anchor exclude to root-relative
+    assert "relative_to(directory).as_posix()" in text or "as_posix()" in text
+    # Check that excludes is checked via rel, not p.name
+    assert "if rel in excludes" in text


### PR DESCRIPTION
## Summary

A7 explorer lane — Results Explorer publication lane with hermetic compat checks.

- `scripts/publication/check_explorer_compat.py`: pin `SUPPORTED_SCHEMA_VERSIONS=(9,)` via contract, real DuckDB DDL checks, fail-closed manifest (malformed SHA256SUMS → error, not skip), provenance fields (github_sha/ref/event)
- `.github/workflows/publication-lane-explorer.yml`: least-privilege `contents: read`, SHA-keyed artifact `explorer_app-${{ github.sha }}`, separate generate/verify steps, typecheck+build+explorer tests+contract tests
- `docs/operations/develop-push-drop-inventory.md`: row is **Advisory** (not required-check gate), recovery cheatsheet
- Tests: pin v7/v8 rejection, manifest fail-closed, least-privilege, provenance, advisory inventory

## Testing

- `tests/unit/scripts/publication/test_check_explorer_compat.py` (20 tests)
- `tests/unit/workflows/test_publication_lane_explorer.py` (4 tests)

46 passed.

## Soundness

Does not touch `SOUNDNESS_FILES` directly (no auto-merge soundness gating needed), but lane is advisory and does not publish.