### PR TITLE
chore(git): remove stale .codex/.gemini mirrors, keep .agents single mirror

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -148,13 +148,9 @@ _sources/tpc-h/dbgen/dbgen_x86_64
 .mcp.json
 
 # skill-sync mirrors (regenerate locally via `make skill-sync`). The `claude`
-# target is a TRACKED snapshot — committed for cloud/CI, managed by the
-# skill-sync block below. the shared agents mirror stays untracked locally.
-.codex/skills/
-.codex/shared-skills/
-.codex/shared-skills.lock.json
-.gemini/skills/
-.agents/
+# target is a TRACKED snapshot — committed for cloud/CI. The `.agents/skills`
+# mirror is the single untracked interoperable workspace (Codex/Gemini/
+# Antigravity) and is ignored via the skill-sync managed block below.
 .antigravitycli/
 
 # TODO system infrastructure (added for distributed TODO structure)


### PR DESCRIPTION
Follow-up to skill-sync consolidation (single untracked .agents/skills mirror for Codex/Gemini/Antigravity + tracked .claude/skills snapshot).

- Removes legacy .gitignore entries for .codex/skills, .codex/shared-skills, .gemini/skills, bare .agents/
- Keeps canonical managed block /.agents/skills/ (untracked) + /.claude/skills/.system/
- On-disk .codex/.gemini dirs already removed locally; this commit is .gitignore only (BenchBox skill-sync.yaml already canonical).
- Workflow validated: skill-sync status shows both targets clean, verify OK, diff unchanged.

Auto-validation: git diff origin/develop --stat empty after merge expected.