### PR TITLE
feat(publication): implement A10 mirror PR audit and release isolation rehearsal tooling

### DIFF
--- a/.github/workflows/rehearse-release-isolation.yml
+++ b/.github/workflows/rehearse-release-isolation.yml
@@ -1,0 +1,53 @@
+name: Rehearse Release Isolation
+
+# The v0.4.0+ release tree keeps one Pages deploy source
+# (scripts/publication/verify_release_isolation.py `publication-deploy.yml`) and
+# requires that no other workflow couples a build with a Pages deploy. This
+# workflow is a read-only rehearsal: it inspects the workflows at a ref with
+# git ls-tree/show and fails loud if hidden coupling is reintroduced, without
+# ever deploying or writing GitHub state.
+
+"on":
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: "Git ref to inspect (e.g. origin/release, origin/develop, HEAD)"
+        type: string
+        default: "HEAD"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: rehearse-release-isolation-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  rehearse:
+    name: Rehearse release isolation
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v4
+
+      - name: Install dependencies
+        run: uv sync --group dev
+
+      - name: Rehearse release isolation (read-only)
+        env:
+          REF_TO_INSPECT: ${{ inputs.ref }}
+        run: |
+          uv run python scripts/publication/verify_release_isolation.py \
+            --ref "$REF_TO_INSPECT" \
+            --mode rehearsal

--- a/.github/workflows/rehearse-release-isolation.yml
+++ b/.github/workflows/rehearse-release-isolation.yml
@@ -1,11 +1,13 @@
 name: Rehearse Release Isolation
 
-# The v0.4.0+ release tree keeps one Pages deploy source
-# (scripts/publication/verify_release_isolation.py `publication-deploy.yml`) and
-# requires that no other workflow couples a build with a Pages deploy. This
-# workflow is a read-only rehearsal: it inspects the workflows at a ref with
-# git ls-tree/show and fails loud if hidden coupling is reintroduced, without
-# ever deploying or writing GitHub state.
+# The v0.4.0+ release tree must keep exactly one GitHub Pages deploy source
+# (publication-deploy.yml) with no other workflow coupling a build step to a
+# Pages deploy. scripts/publication/verify_release_isolation.py checks that.
+# This workflow is a read-only rehearsal: it inspects the workflows at a ref
+# with git ls-tree/show and fails loud if a second deploy source or hidden
+# build+deploy coupling is present, without ever deploying or writing GitHub
+# state. It is expected to FAIL while docs.yml still carries its release-driven
+# `deploy` job (the G3 surface that A10 has not yet retired).
 
 "on":
   workflow_dispatch:
@@ -13,7 +15,9 @@ name: Rehearse Release Isolation
       ref:
         description: "Git ref to inspect (e.g. origin/release, origin/develop, HEAD)"
         type: string
-        default: "HEAD"
+        # Default to the release branch: the isolation guarantee is about the
+        # release deploy surface, not whatever branch dispatched this run.
+        default: "origin/release"
 
 permissions:
   contents: read
@@ -32,6 +36,21 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          persist-credentials: false
+
+      - name: Fetch ref to inspect
+        env:
+          REF_TO_INSPECT: ${{ inputs.ref }}
+        run: |
+          # actions/checkout fetches only the dispatched branch. Make the
+          # remote-tracking ref the verifier inspects (default origin/release)
+          # available before it runs `git ls-tree <ref>`.
+          case "$REF_TO_INSPECT" in
+            origin/*)
+              branch="${REF_TO_INSPECT#origin/}"
+              git fetch --no-tags origin "+refs/heads/${branch}:refs/remotes/origin/${branch}"
+              ;;
+          esac
 
       - name: Set up Python
         uses: actions/setup-python@v5

--- a/scripts/publication/audit_mirror_prs.py
+++ b/scripts/publication/audit_mirror_prs.py
@@ -1,17 +1,21 @@
 #!/usr/bin/env python3
-"""Audit open corpus-mirror PRs for set-equivalence against the protected base.
+"""Audit open corpus-mirror PRs for content-equivalence against the protected base.
 
-For each open mirror PR targeting the protected publication branch, compute
-whether the PR adds any corpus path that is new to the base branch's union:
+For each open mirror PR targeting the protected publication branch, this tool
+compares the *blob content* (git blob SHA) of every mirrored path the PR
+touches against the base branch tree, and classifies the PR:
 
-    ADDITIVE  - the PR adds at least one corpus path not already on base
-    NOOP      - every added corpus path already exists on base (pure subset)
-    EMPTY     - the PR adds no corpus paths at all
+    ADDITIVE  - adds at least one mirrored path that is new to the base
+    MUTATING  - adds no new path, but changes the content of, or removes, an
+                existing mirrored path (a genuine refresh — NOT retire-able)
+    NOOP      - every mirrored path it touches already exists on base with
+                byte-identical content (pure redundant re-mirror)
+    EMPTY     - touches no mirrored path at all
     ERROR     - the PR could not be audited (operational failure)
 
-This is a reporting tool, not a gate: by default it exits 0 even when it finds
-NOOP/EMPTY (retire-able) PRs. Pass ``--strict-union`` to exit 3 when any
-NOOP/EMPTY PR is present.
+Only NOOP and EMPTY are retire-able. This is a reporting tool, not a gate: by
+default it exits 0 even when it finds retire-able PRs. Pass ``--strict-union``
+to exit 3 when any NOOP/EMPTY PR is present.
 
 Runs read-only against GitHub; requires a ``gh`` CLI on PATH.
 """
@@ -29,11 +33,25 @@ from typing import Any
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 
-CORPUS_PREFIXES = (
-    "results-data/",
+# Every path that .github/workflows/sync-results-data-to-published.yml mirrors
+# from develop onto published-results (drift-detection + build-overlay lists).
+# A mirror PR that only touches paths outside this set is EMPTY, not
+# retire-able-because-empty in a way that discards corpus content.
+MIRRORED_PREFIXES: tuple[str, ...] = (
+    "results-data/bundles/",
     "results-data/corpus-inventory.json",
     "results-data/CORPUS_NOTES.md",
+    "results-data/SEED_CORPUS_SPEC.md",
+    "results-data/README.md",
+    "results-data/validate_corpus.py",
+    "results-data/generate_corpus_inventory.py",
+    "benchbox/validation/bundle.py",
+    "benchbox/core/results/query_status.py",
+    "scripts/validate_submission.py",
+    "scripts/generate_corpus_inventory.py",
 )
+
+_RETIRE_ABLE = ("NOOP", "EMPTY")
 
 
 @dataclass
@@ -41,16 +59,21 @@ class MirrorPRAudit:
     number: int
     title: str
     head_ref: str
-    added_path_count: int
-    new_to_union: bool
-    duplicate_count: int
-    verdict: str
-    added_paths: list[str] = field(default_factory=list)
+    mirrored_file_count: int
     new_paths: list[str] = field(default_factory=list)
+    changed_paths: list[str] = field(default_factory=list)
+    removed_paths: list[str] = field(default_factory=list)
+    noop_paths: list[str] = field(default_factory=list)
+    verdict: str = "ERROR"
+    error: str | None = None
+
+    @property
+    def retire_able(self) -> bool:
+        return self.verdict in _RETIRE_ABLE
 
 
 def _run(args: list[str], env: dict[str, str] | None = None) -> subprocess.CompletedProcess[str]:
-    """Run a subprocess against REPO_ROOT with text output, raising on failure."""
+    """Run a subprocess against REPO_ROOT with text output (no raise-on-failure)."""
     merged_env = dict(os.environ)
     if env:
         merged_env.update(env)
@@ -60,22 +83,32 @@ def _run(args: list[str], env: dict[str, str] | None = None) -> subprocess.Compl
         capture_output=True,
         text=True,
         env=merged_env,
-        check=True,
+        check=False,
     )
 
 
-def _is_corpus_path(rel_path: str) -> bool:
-    normalized = rel_path.replace("\\", "/")
+def _run_checked(args: list[str], what: str) -> str:
+    result = _run(args)
+    if result.returncode != 0:
+        raise RuntimeError(f"{what} failed (exit {result.returncode}): {result.stderr.strip()}")
+    return result.stdout
+
+
+def _is_mirrored_path(rel_path: str) -> bool:
+    normalized = (rel_path or "").replace("\\", "/")
     if not normalized:
         return False
-    for prefix in CORPUS_PREFIXES:
-        if normalized == prefix.rstrip("/") or normalized.startswith(prefix):
+    for prefix in MIRRORED_PREFIXES:
+        if prefix.endswith("/"):
+            if normalized == prefix.rstrip("/") or normalized.startswith(prefix):
+                return True
+        elif normalized == prefix:
             return True
     return False
 
 
 def _list_open_prs(repo: str, base: str) -> list[dict[str, Any]]:
-    result = _run(
+    out = _run_checked(
         [
             "gh",
             "pr",
@@ -86,79 +119,127 @@ def _list_open_prs(repo: str, base: str) -> list[dict[str, Any]]:
             base,
             "--state",
             "open",
+            "--limit",
+            "200",
             "--json",
-            "number,title,headRefName,files",
-        ]
+            "number,title,headRefName",
+        ],
+        "gh pr list",
     )
-    if result.returncode != 0:
-        raise RuntimeError(f"gh pr list failed: {result.stderr.strip()}")
-    return json.loads(result.stdout)
+    return json.loads(out)
 
 
-def _list_base_corpus_paths(repo: str, base: str) -> set[str]:
-    """Return the set of corpus paths present on the base branch tree."""
+def _list_pr_files(repo: str, number: int) -> list[dict[str, Any]]:
+    """Return every changed file for a PR, following pagination fully.
+
+    ``gh pr list --json files`` silently caps at 100 files; the REST
+    ``pulls/{n}/files`` endpoint with ``--paginate`` does not.
+    """
+    out = _run_checked(
+        [
+            "gh",
+            "api",
+            "--paginate",
+            "--slurp",
+            f"repos/{repo}/pulls/{number}/files?per_page=100",
+        ],
+        f"gh api pulls/{number}/files",
+    )
+    pages = json.loads(out)
+    files: list[dict[str, Any]] = []
+    for page in pages:
+        if isinstance(page, list):
+            files.extend(page)
+    return files
+
+
+def _base_blob_shas(repo: str, base: str) -> dict[str, str]:
+    """Map mirrored path -> git blob SHA on the base branch tree."""
     if not base:
-        raise RuntimeError("empty base ref provided; cannot compute the protected union")
-    result = _run(
+        raise RuntimeError("empty base ref provided; cannot compute the protected base")
+    out = _run_checked(
         ["gh", "api", f"repos/{repo}/git/trees/{base}?recursive=1"],
+        f"gh api git/trees for base '{base}'",
     )
-    if result.returncode != 0:
-        raise RuntimeError(f"gh api git/trees failed for base '{base}': {result.stderr.strip()}")
     try:
-        payload = json.loads(result.stdout)
-    except json.JSONDecodeError as exc:  # pragma: no cover - defensive
+        payload = json.loads(out)
+    except json.JSONDecodeError as exc:
         raise RuntimeError(f"gh api returned non-JSON for base '{base}': {exc}") from exc
+    if payload.get("truncated"):
+        raise RuntimeError(
+            f"base tree for '{base}' is truncated; cannot compute a complete "
+            "content baseline (refusing to classify against a partial tree)"
+        )
     tree = payload.get("tree", [])
     if not isinstance(tree, list):
         raise RuntimeError(f"gh api tree for base '{base}' is not a list")
-    return {entry["path"] for entry in tree if _is_corpus_path(entry.get("path", ""))}
+    shas: dict[str, str] = {}
+    for entry in tree:
+        if not isinstance(entry, dict) or entry.get("type") != "blob":
+            continue
+        path = entry.get("path", "")
+        if _is_mirrored_path(path):
+            shas[path] = str(entry.get("sha", ""))
+    return shas
 
 
-def _audit_pr(pr: dict[str, Any], base_paths: set[str]) -> MirrorPRAudit:
+def _audit_pr(pr: dict[str, Any], base_shas: dict[str, str], repo: str) -> MirrorPRAudit:
     number = int(pr.get("number", 0))
-    head_ref = pr.get("headRefName", "")
-
-    files = pr.get("files") or []
-    added_paths = sorted({f.get("path") for f in files if isinstance(f, dict) and _is_corpus_path(f.get("path", ""))})
-    if not added_paths:
-        return MirrorPRAudit(
-            number=number,
-            title=pr.get("title", ""),
-            head_ref=head_ref,
-            added_path_count=0,
-            new_to_union=False,
-            duplicate_count=0,
-            verdict="EMPTY",
-        )
-
-    new_paths = sorted(path for path in added_paths if path not in base_paths)
-    duplicate_count = sum(1 for path in added_paths if path in base_paths)
-    if new_paths:
-        verdict = "ADDITIVE"
-    else:
-        verdict = "NOOP"
-    return MirrorPRAudit(
+    audit = MirrorPRAudit(
         number=number,
         title=pr.get("title", ""),
-        head_ref=head_ref,
-        added_path_count=len(added_paths),
-        new_to_union=bool(new_paths),
-        duplicate_count=duplicate_count,
-        verdict=verdict,
-        added_paths=added_paths,
-        new_paths=new_paths,
+        head_ref=pr.get("headRefName", ""),
+        mirrored_file_count=0,
     )
+
+    try:
+        files = _list_pr_files(repo, number)
+    except RuntimeError as exc:
+        audit.verdict = "ERROR"
+        audit.error = str(exc)
+        return audit
+
+    mirrored = [f for f in files if isinstance(f, dict) and _is_mirrored_path(f.get("filename", ""))]
+    audit.mirrored_file_count = len(mirrored)
+
+    if not mirrored:
+        audit.verdict = "EMPTY"
+        return audit
+
+    for f in mirrored:
+        path = f.get("filename", "")
+        status = f.get("status", "")
+        head_sha = str(f.get("sha", ""))
+        if status == "removed":
+            audit.removed_paths.append(path)
+        elif path not in base_shas:
+            audit.new_paths.append(path)
+        elif head_sha and head_sha == base_shas[path]:
+            audit.noop_paths.append(path)
+        else:
+            audit.changed_paths.append(path)
+
+    for bucket in (audit.new_paths, audit.changed_paths, audit.removed_paths, audit.noop_paths):
+        bucket.sort()
+
+    if audit.new_paths:
+        audit.verdict = "ADDITIVE"
+    elif audit.changed_paths or audit.removed_paths:
+        audit.verdict = "MUTATING"
+    else:
+        audit.verdict = "NOOP"
+    return audit
 
 
 def audit_mirror_prs(repo: str, base: str) -> list[MirrorPRAudit]:
-    """Audit every open mirror PR against the base branch's corpus union."""
-    base_paths = _list_base_corpus_paths(repo, base)
+    """Audit every open mirror PR against the base branch's mirrored content."""
+    base_shas = _base_blob_shas(repo, base)
     prs = _list_open_prs(repo, base)
-    return [_audit_pr(pr, base_paths) for pr in prs]
+    return [_audit_pr(pr, base_shas, repo) for pr in prs]
 
 
 def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
-    parser = argparse.ArgumentParser(description="Audit corpus mirror PRs for set-equivalence.")
+    parser = argparse.ArgumentParser(description="Audit corpus mirror PRs for content-equivalence.")
     parser.add_argument("--repo", required=True, help="GitHub repository (owner/repo).")
     parser.add_argument("--base", required=True, help="Protected base branch (e.g. published-results).")
     parser.add_argument("--json", action="store_true", help="Emit structured JSON output.")
@@ -170,44 +251,59 @@ def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     return parser.parse_args(argv)
 
 
+def _audit_to_dict(a: MirrorPRAudit) -> dict[str, Any]:
+    d = asdict(a)
+    d["retire_able"] = a.retire_able
+    return d
+
+
 def main(argv: list[str] | None = None) -> int:
     args = _parse_args(argv)
 
     try:
         audits = audit_mirror_prs(args.repo, args.base)
-    except (RuntimeError, subprocess.CalledProcessError) as exc:
+    except (RuntimeError, subprocess.CalledProcessError, json.JSONDecodeError) as exc:
         print(f"error: {exc}", file=sys.stderr)
         return 1
 
-    retire_able = [a for a in audits if a.verdict in ("NOOP", "EMPTY")]
+    retire_able = [a for a in audits if a.retire_able]
+    errored = [a for a in audits if a.verdict == "ERROR"]
 
     if args.json:
         payload = {
-            "mode": "set-equivalence",
+            "mode": "content-equivalence",
             "base": args.base,
             "count": len(audits),
-            "prs": [asdict(a) for a in audits],
+            "retire_able": [a.number for a in retire_able],
+            "errored": [a.number for a in errored],
+            "prs": [_audit_to_dict(a) for a in audits],
         }
         print(json.dumps(payload, indent=2))
+    elif not audits:
+        print(f"[audit ok] 0 mirror PRs open against '{args.base}'")
     else:
-        if not audits:
-            print(f"[audit ok] 0 mirror PRs open against '{args.base}'")
-        else:
-            for audit in audits:
-                print(
-                    f"PR #{audit.number} ({audit.head_ref}): "
-                    f"added_path_count={audit.added_path_count} "
-                    f"new_to_union={audit.new_to_union!s} "
-                    f"duplicate_count={audit.duplicate_count} "
-                    f"verdict={audit.verdict}"
-                )
+        for audit in audits:
+            print(
+                f"PR #{audit.number} ({audit.head_ref}): "
+                f"mirrored_files={audit.mirrored_file_count} "
+                f"new={len(audit.new_paths)} changed={len(audit.changed_paths)} "
+                f"removed={len(audit.removed_paths)} noop={len(audit.noop_paths)} "
+                f"verdict={audit.verdict}" + (f" error={audit.error}" if audit.error else "")
+            )
 
+    if errored:
+        print(
+            f"warning: {len(errored)} PR(s) could not be audited ({[a.number for a in errored]}).",
+            file=sys.stderr,
+        )
     if args.strict_union and retire_able:
         print(
             f"strict-union: {len(retire_able)} retire-able PR(s) found ({[a.number for a in retire_able]}).",
             file=sys.stderr,
         )
         return 3
+    if errored:
+        return 1
     return 0
 
 

--- a/scripts/publication/audit_mirror_prs.py
+++ b/scripts/publication/audit_mirror_prs.py
@@ -1,0 +1,215 @@
+#!/usr/bin/env python3
+"""Audit open corpus-mirror PRs for set-equivalence against the protected base.
+
+For each open mirror PR targeting the protected publication branch, compute
+whether the PR adds any corpus path that is new to the base branch's union:
+
+    ADDITIVE  - the PR adds at least one corpus path not already on base
+    NOOP      - every added corpus path already exists on base (pure subset)
+    EMPTY     - the PR adds no corpus paths at all
+    ERROR     - the PR could not be audited (operational failure)
+
+This is a reporting tool, not a gate: by default it exits 0 even when it finds
+NOOP/EMPTY (retire-able) PRs. Pass ``--strict-union`` to exit 3 when any
+NOOP/EMPTY PR is present.
+
+Runs read-only against GitHub; requires a ``gh`` CLI on PATH.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+CORPUS_PREFIXES = (
+    "results-data/",
+    "results-data/corpus-inventory.json",
+    "results-data/CORPUS_NOTES.md",
+)
+
+
+@dataclass
+class MirrorPRAudit:
+    number: int
+    title: str
+    head_ref: str
+    added_path_count: int
+    new_to_union: bool
+    duplicate_count: int
+    verdict: str
+    added_paths: list[str] = field(default_factory=list)
+    new_paths: list[str] = field(default_factory=list)
+
+
+def _run(args: list[str], env: dict[str, str] | None = None) -> subprocess.CompletedProcess[str]:
+    """Run a subprocess against REPO_ROOT with text output, raising on failure."""
+    merged_env = dict(os.environ)
+    if env:
+        merged_env.update(env)
+    return subprocess.run(
+        args,
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        env=merged_env,
+        check=True,
+    )
+
+
+def _is_corpus_path(rel_path: str) -> bool:
+    normalized = rel_path.replace("\\", "/")
+    if not normalized:
+        return False
+    for prefix in CORPUS_PREFIXES:
+        if normalized == prefix.rstrip("/") or normalized.startswith(prefix):
+            return True
+    return False
+
+
+def _list_open_prs(repo: str, base: str) -> list[dict[str, Any]]:
+    result = _run(
+        [
+            "gh",
+            "pr",
+            "list",
+            "--repo",
+            repo,
+            "--base",
+            base,
+            "--state",
+            "open",
+            "--json",
+            "number,title,headRefName,files",
+        ]
+    )
+    if result.returncode != 0:
+        raise RuntimeError(f"gh pr list failed: {result.stderr.strip()}")
+    return json.loads(result.stdout)
+
+
+def _list_base_corpus_paths(repo: str, base: str) -> set[str]:
+    """Return the set of corpus paths present on the base branch tree."""
+    if not base:
+        raise RuntimeError("empty base ref provided; cannot compute the protected union")
+    result = _run(
+        ["gh", "api", f"repos/{repo}/git/trees/{base}?recursive=1"],
+    )
+    if result.returncode != 0:
+        raise RuntimeError(f"gh api git/trees failed for base '{base}': {result.stderr.strip()}")
+    try:
+        payload = json.loads(result.stdout)
+    except json.JSONDecodeError as exc:  # pragma: no cover - defensive
+        raise RuntimeError(f"gh api returned non-JSON for base '{base}': {exc}") from exc
+    tree = payload.get("tree", [])
+    if not isinstance(tree, list):
+        raise RuntimeError(f"gh api tree for base '{base}' is not a list")
+    return {entry["path"] for entry in tree if _is_corpus_path(entry.get("path", ""))}
+
+
+def _audit_pr(pr: dict[str, Any], base_paths: set[str]) -> MirrorPRAudit:
+    number = int(pr.get("number", 0))
+    head_ref = pr.get("headRefName", "")
+
+    files = pr.get("files") or []
+    added_paths = sorted({f.get("path") for f in files if isinstance(f, dict) and _is_corpus_path(f.get("path", ""))})
+    if not added_paths:
+        return MirrorPRAudit(
+            number=number,
+            title=pr.get("title", ""),
+            head_ref=head_ref,
+            added_path_count=0,
+            new_to_union=False,
+            duplicate_count=0,
+            verdict="EMPTY",
+        )
+
+    new_paths = sorted(path for path in added_paths if path not in base_paths)
+    duplicate_count = sum(1 for path in added_paths if path in base_paths)
+    if new_paths:
+        verdict = "ADDITIVE"
+    else:
+        verdict = "NOOP"
+    return MirrorPRAudit(
+        number=number,
+        title=pr.get("title", ""),
+        head_ref=head_ref,
+        added_path_count=len(added_paths),
+        new_to_union=bool(new_paths),
+        duplicate_count=duplicate_count,
+        verdict=verdict,
+        added_paths=added_paths,
+        new_paths=new_paths,
+    )
+
+
+def audit_mirror_prs(repo: str, base: str) -> list[MirrorPRAudit]:
+    """Audit every open mirror PR against the base branch's corpus union."""
+    base_paths = _list_base_corpus_paths(repo, base)
+    prs = _list_open_prs(repo, base)
+    return [_audit_pr(pr, base_paths) for pr in prs]
+
+
+def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Audit corpus mirror PRs for set-equivalence.")
+    parser.add_argument("--repo", required=True, help="GitHub repository (owner/repo).")
+    parser.add_argument("--base", required=True, help="Protected base branch (e.g. published-results).")
+    parser.add_argument("--json", action="store_true", help="Emit structured JSON output.")
+    parser.add_argument(
+        "--strict-union",
+        action="store_true",
+        help="Exit 3 if any NOOP/EMPTY (retire-able) PR is found.",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parse_args(argv)
+
+    try:
+        audits = audit_mirror_prs(args.repo, args.base)
+    except (RuntimeError, subprocess.CalledProcessError) as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 1
+
+    retire_able = [a for a in audits if a.verdict in ("NOOP", "EMPTY")]
+
+    if args.json:
+        payload = {
+            "mode": "set-equivalence",
+            "base": args.base,
+            "count": len(audits),
+            "prs": [asdict(a) for a in audits],
+        }
+        print(json.dumps(payload, indent=2))
+    else:
+        if not audits:
+            print(f"[audit ok] 0 mirror PRs open against '{args.base}'")
+        else:
+            for audit in audits:
+                print(
+                    f"PR #{audit.number} ({audit.head_ref}): "
+                    f"added_path_count={audit.added_path_count} "
+                    f"new_to_union={audit.new_to_union!s} "
+                    f"duplicate_count={audit.duplicate_count} "
+                    f"verdict={audit.verdict}"
+                )
+
+    if args.strict_union and retire_able:
+        print(
+            f"strict-union: {len(retire_able)} retire-able PR(s) found ({[a.number for a in retire_able]}).",
+            file=sys.stderr,
+        )
+        return 3
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/publication/verify_release_isolation.py
+++ b/scripts/publication/verify_release_isolation.py
@@ -1,19 +1,33 @@
 #!/usr/bin/env python3
 """Rehearsal-only release isolation verifier.
 
-Proves a release fully self-hosts its site — the full-site deployment source
-is the single source of truth with no hidden coupling to a legacy Pages deploy
-that would create collateral when the site is later self-hosted.
+Proves a release fully self-hosts its site from a *single* GitHub Pages
+deployment source, with no second deploy source and no hidden coupling of a
+build step to a Pages deploy. This is the evidence tool for the A10 "single
+deployment source" gate (G3 release-deploy removal): while the legacy
+release-driven Pages deploy (``docs.yml``) still contains a ``deploy`` job,
+isolation is NOT proven and this script fails.
 
 This script MUST NOT deploy; it is a read-only verification tool.
+
+What it checks, at the requested git ref:
+  1. Count every workflow that contains a Pages deploy step (official
+     ``actions/deploy-pages`` at any version/pin, known third-party deployers,
+     or a raw ``gh-pages`` push). Isolation requires exactly one, and it must
+     be the intended ``publication-deploy.yml``.
+  2. The legacy ``docs.yml`` workflow must contain no Pages deploy step.
+  3. No single job anywhere both builds the site AND deploys it (hidden
+     coupling). A separate build job feeding a separate deploy job is fine.
+  4. Any job that delegates to a reusable workflow (``jobs.<id>.uses``) is
+     reported as un-analyzable rather than assumed clean.
 
 Usage:
   uv run -- python scripts/publication/verify_release_isolation.py --ref origin/release --mode rehearsal
   uv run -- python scripts/publication/verify_release_isolation.py --ref origin/release --mode rehearsal --json
 
 Exit codes:
-  0 - Isolation proven (no hidden coupling found).
-  1 - Hidden coupling detected or operational error.
+  0 - Isolation proven (single deploy source, no hidden coupling).
+  1 - Isolation not proven or operational error.
   2 - ``--mode prod`` is rejected (must use rehearsal mode).
 """
 
@@ -21,6 +35,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import re
 import subprocess
 import sys
 from dataclasses import asdict, dataclass, field
@@ -35,18 +50,49 @@ WORKFLOWS_DIR = REPO_ROOT / ".github" / "workflows"
 INTENDED_DEPLOY_WORKFLOW = "publication-deploy.yml"
 LEGACY_DEPLOY_WORKFLOW = "docs.yml"
 
-PAGES_DEPLOY_PATTERNS = ("deploy-pages@v4", "actions/deploy-pages@v4")
+# Known GitHub Pages deployer actions, matched on the version-independent
+# ``owner/repo`` prefix so ``@v4``, ``@v5``, ``@main`` and 40-hex SHA pins are
+# all caught. ``actions/deploy-pages`` is matched by suffix as well to cover a
+# vendored fork path.
+KNOWN_PAGES_DEPLOYERS = (
+    "actions/deploy-pages",
+    "peaceiris/actions-gh-pages",
+    "JamesIves/github-pages-deploy-action",
+    "crazy-max/ghaction-github-pages",
+    "cloudflare/pages-action",
+    "cloudflare/wrangler-action",
+)
 
-BUILD_PATTERNS = ("api_docs", "prose_site", "uv run python scripts/", "npm run build")
+# ``run:`` script fragments that indicate a raw push to a Pages branch.
+RAW_PAGES_PUSH_RE = re.compile(
+    r"(git\s+push[^\n]*\bgh-pages\b)"
+    r"|(\bnpx\s+gh-pages\b)"
+    r"|(\bgh-pages\b[^\n]*--dist)"
+    r"|(peaceiris/actions-gh-pages)",
+    re.IGNORECASE,
+)
+
+BUILD_PATTERNS = (
+    "api_docs",
+    "prose_site",
+    "assemble_public_site",
+    "uv run python scripts/",
+    "uv run -- python scripts/",
+    "npm run build",
+    "sphinx-build",
+)
 
 
 @dataclass
 class ReleaseIsolationReport:
     mode: str
     ref: str
-    deploy_source_present: bool
-    deploy_source_workflow: str | None
+    deploy_sources: list[dict[str, Any]]
+    deploy_source_count: int
+    intended_deploy_workflow_present: bool
+    legacy_deploy_workflow_deploys: bool
     hidden_couplings: list[dict[str, Any]]
+    unanalyzable_jobs: list[dict[str, Any]]
     isolation_proven: bool
     errors: list[str] = field(default_factory=list)
 
@@ -65,12 +111,7 @@ def _run_git(args: list[str]) -> subprocess.CompletedProcess[str]:
 
 
 def _get_workflow_files_at_ref(ref: str) -> list[str]:
-    """List workflow YAML filenames (bare names) reachable from ref.
-
-    `git ls-tree --name-only` returns full paths like
-    `.github/workflows/docs.yml`; we strip the workflows-directory prefix so
-    downstream code compares against bare filenames.
-    """
+    """List workflow YAML filenames (bare names) reachable from ref."""
     result = _run_git(["ls-tree", ref, "--name-only", ".github/workflows/"])
     if result.returncode != 0:
         raise RuntimeError(f"git ls-tree failed for ref '{ref}': {result.stderr.strip()}")
@@ -92,116 +133,146 @@ def _read_workflow_at_ref(ref: str, workflow_path: str) -> str:
     return result.stdout
 
 
-def _has_pages_deploy(workflow_data: dict[str, Any]) -> bool:
-    """Check if any job in the workflow does a Pages deploy."""
-    jobs = workflow_data.get("jobs", {})
-    if not isinstance(jobs, dict):
+def _uses_is_pages_deployer(uses: str) -> bool:
+    action = uses.split("@", 1)[0].strip().lower()
+    if not action:
         return False
-    for job_def in jobs.values():
-        if not isinstance(job_def, dict):
-            continue
-        steps = job_def.get("steps", [])
-        if not isinstance(steps, list):
-            continue
-        for step in steps:
-            if not isinstance(step, dict):
-                continue
-            uses = step.get("uses", "")
-            if isinstance(uses, str) and any(p in uses for p in PAGES_DEPLOY_PATTERNS):
-                return True
-    return False
-
-
-def _has_build_job(workflow_data: dict[str, Any]) -> bool:
-    """Check if any job looks like an API-doc or site build job."""
-    jobs = workflow_data.get("jobs", {})
-    if not isinstance(jobs, dict):
-        return False
-    for job_def in jobs.values():
-        if not isinstance(job_def, dict):
-            continue
-        job_name = job_def.get("name", "")
-        steps = job_def.get("steps", [])
-        if not isinstance(steps, list):
-            continue
-        step_runs = "\n".join(str(step.get("run", "")) for step in steps if isinstance(step, dict))
-        if any(p in step_runs or p in str(job_name) for p in BUILD_PATTERNS):
+    for known in KNOWN_PAGES_DEPLOYERS:
+        if action == known or action.startswith(f"{known}/"):
             return True
-    return False
+    # Bare / vendored deploy-pages (``./.github/actions/deploy-pages``, forks).
+    return action.endswith("/deploy-pages") or action == "deploy-pages"
 
 
-def _detect_hidden_coupling(
-    ref: str,
-    workflow_files: list[str],
-) -> list[dict[str, Any]]:
-    """Detect workflows where a single job both builds AND deploys to Pages (hidden coupling).
-
-    A separate build job + deploy job is the CORRECT pattern (e.g. publication-deploy.yml
-    with a build job that produces artifacts and a deploy job that deploys them). The
-    hidden coupling is a single job that does both building and deploying as a side effect.
-    """
-    couplings: list[dict[str, Any]] = []
-    for wf_name in workflow_files:
-        if wf_name == INTENDED_DEPLOY_WORKFLOW:
+def _job_pages_deployers(job_def: dict[str, Any]) -> list[str]:
+    """Return the deploy markers found inside a single job's steps."""
+    deployers: list[str] = []
+    steps = job_def.get("steps", [])
+    if not isinstance(steps, list):
+        return deployers
+    for step in steps:
+        if not isinstance(step, dict):
             continue
+        uses = step.get("uses", "")
+        if isinstance(uses, str) and _uses_is_pages_deployer(uses):
+            deployers.append(uses.strip())
+        run = step.get("run", "")
+        if isinstance(run, str) and RAW_PAGES_PUSH_RE.search(run):
+            deployers.append("raw-run:gh-pages-push")
+    return deployers
+
+
+def _job_builds(job_def: dict[str, Any]) -> bool:
+    steps = job_def.get("steps", [])
+    if not isinstance(steps, list):
+        return False
+    step_runs = "\n".join(str(step.get("run", "")) for step in steps if isinstance(step, dict))
+    job_name = str(job_def.get("name", ""))
+    return any(p in step_runs or p in job_name for p in BUILD_PATTERNS)
+
+
+@dataclass
+class _WorkflowScan:
+    deploy_jobs: dict[str, list[str]]
+    coupled_jobs: list[str]
+    unanalyzable_jobs: list[str]
+
+
+def _scan_workflow(data: dict[str, Any]) -> _WorkflowScan:
+    deploy_jobs: dict[str, list[str]] = {}
+    coupled_jobs: list[str] = []
+    unanalyzable_jobs: list[str] = []
+
+    jobs = data.get("jobs", {})
+    if not isinstance(jobs, dict):
+        return _WorkflowScan(deploy_jobs, coupled_jobs, unanalyzable_jobs)
+
+    for job_name, job_def in jobs.items():
+        if not isinstance(job_def, dict):
+            continue
+        # A job that calls a reusable workflow has no inspectable steps.
+        if isinstance(job_def.get("uses"), str) and job_def["uses"].strip():
+            unanalyzable_jobs.append(str(job_name))
+            continue
+        deployers = _job_pages_deployers(job_def)
+        if deployers:
+            deploy_jobs[str(job_name)] = deployers
+            if _job_builds(job_def):
+                coupled_jobs.append(str(job_name))
+    return _WorkflowScan(deploy_jobs, coupled_jobs, unanalyzable_jobs)
+
+
+def _analyze(
+    ref: str, workflow_files: list[str]
+) -> tuple[
+    list[dict[str, Any]],
+    list[dict[str, Any]],
+    list[dict[str, Any]],
+    list[str],
+]:
+    """Return (deploy_sources, hidden_couplings, unanalyzable_jobs, errors)."""
+    deploy_sources: list[dict[str, Any]] = []
+    hidden_couplings: list[dict[str, Any]] = []
+    unanalyzable: list[dict[str, Any]] = []
+    errors: list[str] = []
+
+    for wf_name in sorted(workflow_files):
         try:
-            text = _read_workflow_at_ref(ref, wf_name)
-            data = yaml.safe_load(text)
-        except (RuntimeError, yaml.YAMLError):
+            data = yaml.safe_load(_read_workflow_at_ref(ref, wf_name))
+        except RuntimeError as exc:
+            errors.append(str(exc))
+            continue
+        except yaml.YAMLError:
             continue
         if not isinstance(data, dict):
             continue
 
-        jobs = data.get("jobs", {})
-        if not isinstance(jobs, dict):
-            continue
-        for job_name, job_def in jobs.items():
-            if not isinstance(job_def, dict):
-                continue
-            steps = job_def.get("steps", [])
-            if not isinstance(steps, list):
-                continue
-            step_runs = "\n".join(str(step.get("run", "")) for step in steps if isinstance(step, dict))
-            step_uses = [
-                str(step.get("uses", ""))
-                for step in steps
-                if isinstance(step, dict) and isinstance(step.get("uses"), str)
-            ]
-            builds = any(p in step_runs for p in BUILD_PATTERNS)
-            deploys = any(any(p in u for p in PAGES_DEPLOY_PATTERNS) for u in step_uses)
-            if builds and deploys:
-                couplings.append(
-                    {
-                        "workflow": wf_name,
-                        "coupled_jobs": [job_name],
-                        "description": (
-                            f"Workflow '{wf_name}' job '{job_name}' both builds and deploys to Pages — "
-                            "hidden coupling that must be eliminated before self-hosted deployment."
-                        ),
-                    }
-                )
-    return couplings
-
-
-def _check_deploy_source(workflow_files: list[str]) -> tuple[bool, str | None]:
-    """Check that the intended deploy source workflow exists."""
-    for name in (INTENDED_DEPLOY_WORKFLOW, LEGACY_DEPLOY_WORKFLOW):
-        if name in workflow_files:
-            return True, name
-    return False, None
+        scan = _scan_workflow(data)
+        if scan.deploy_jobs:
+            deploy_sources.append(
+                {
+                    "workflow": wf_name,
+                    "jobs": sorted(scan.deploy_jobs),
+                    "deployers": sorted({d for ds in scan.deploy_jobs.values() for d in ds}),
+                }
+            )
+        for job_name in scan.coupled_jobs:
+            hidden_couplings.append(
+                {
+                    "workflow": wf_name,
+                    "coupled_jobs": [job_name],
+                    "description": (
+                        f"Workflow '{wf_name}' job '{job_name}' both builds the site and "
+                        "deploys it to Pages — hidden coupling that must be eliminated "
+                        "before the release self-hosts its deployment."
+                    ),
+                }
+            )
+        for job_name in scan.unanalyzable_jobs:
+            unanalyzable.append(
+                {
+                    "workflow": wf_name,
+                    "job": job_name,
+                    "description": (
+                        f"Workflow '{wf_name}' job '{job_name}' delegates to a reusable "
+                        "workflow; its steps cannot be inspected for a hidden Pages deploy."
+                    ),
+                }
+            )
+    return deploy_sources, hidden_couplings, unanalyzable, errors
 
 
 def verify_release_isolation(ref: str, mode: str = "rehearsal") -> ReleaseIsolationReport:
-    errors: list[str] = []
-    hidden_couplings: list[dict[str, Any]] = []
-
     if mode == "prod":
         return ReleaseIsolationReport(
             mode=mode,
             ref=ref,
-            deploy_source_present=False,
-            deploy_source_workflow=None,
+            deploy_sources=[],
+            deploy_source_count=0,
+            intended_deploy_workflow_present=False,
+            legacy_deploy_workflow_deploys=False,
             hidden_couplings=[],
+            unanalyzable_jobs=[],
             isolation_proven=False,
             errors=["--mode prod is rejected; must use --mode rehearsal for read-only verification"],
         )
@@ -212,29 +283,59 @@ def verify_release_isolation(ref: str, mode: str = "rehearsal") -> ReleaseIsolat
         return ReleaseIsolationReport(
             mode=mode,
             ref=ref,
-            deploy_source_present=False,
-            deploy_source_workflow=None,
+            deploy_sources=[],
+            deploy_source_count=0,
+            intended_deploy_workflow_present=False,
+            legacy_deploy_workflow_deploys=False,
             hidden_couplings=[],
+            unanalyzable_jobs=[],
             isolation_proven=False,
             errors=[str(exc)],
         )
 
-    deploy_present, deploy_name = _check_deploy_source(workflow_files)
-    if not deploy_present:
+    deploy_sources, hidden_couplings, unanalyzable, errors = _analyze(ref, workflow_files)
+
+    source_names = {s["workflow"] for s in deploy_sources}
+    deploy_source_count = len(deploy_sources)
+    intended_present = INTENDED_DEPLOY_WORKFLOW in source_names
+    legacy_deploys = LEGACY_DEPLOY_WORKFLOW in source_names
+
+    if deploy_source_count == 0:
+        errors.append(f"No Pages deploy source found in {ref}; expected exactly one ('{INTENDED_DEPLOY_WORKFLOW}').")
+    if deploy_source_count > 1:
         errors.append(
-            f"No deploy source workflow found in {ref}; expected '{INTENDED_DEPLOY_WORKFLOW}' "
-            f"or '{LEGACY_DEPLOY_WORKFLOW}'"
+            f"{deploy_source_count} Pages deploy sources found in {ref} "
+            f"({sorted(source_names)}); isolation requires exactly one."
+        )
+    if legacy_deploys:
+        errors.append(
+            f"Legacy workflow '{LEGACY_DEPLOY_WORKFLOW}' still contains a Pages deploy step "
+            "(the G3 release-deploy surface); isolation is not proven until it is removed."
+        )
+    if deploy_source_count >= 1 and not intended_present:
+        errors.append(
+            f"Intended deploy workflow '{INTENDED_DEPLOY_WORKFLOW}' does not contain a "
+            f"Pages deploy step; deploy sources present: {sorted(source_names)}."
         )
 
-    hidden_couplings = _detect_hidden_coupling(ref, workflow_files)
+    isolation_proven = (
+        deploy_source_count == 1
+        and intended_present
+        and not legacy_deploys
+        and not hidden_couplings
+        and not unanalyzable
+        and not errors
+    )
 
-    isolation_proven = deploy_present and len(hidden_couplings) == 0 and not errors
     return ReleaseIsolationReport(
         mode=mode,
         ref=ref,
-        deploy_source_present=deploy_present,
-        deploy_source_workflow=deploy_name,
+        deploy_sources=deploy_sources,
+        deploy_source_count=deploy_source_count,
+        intended_deploy_workflow_present=intended_present,
+        legacy_deploy_workflow_deploys=legacy_deploys,
         hidden_couplings=hidden_couplings,
+        unanalyzable_jobs=unanalyzable,
         isolation_proven=isolation_proven,
         errors=errors,
     )
@@ -277,24 +378,21 @@ def main(argv: list[str] | None = None) -> int:
     if args.json:
         print(json.dumps(report.to_dict(), indent=2))
     else:
-        if report.errors:
-            for err in report.errors:
-                print(f"ERROR: {err}", file=sys.stderr)
-        if report.hidden_couplings:
-            for coupling in report.hidden_couplings:
-                print(f"HIDDEN COUPLING: {coupling['description']}", file=sys.stderr)
+        for err in report.errors:
+            print(f"ERROR: {err}", file=sys.stderr)
+        for coupling in report.hidden_couplings:
+            print(f"HIDDEN COUPLING: {coupling['description']}", file=sys.stderr)
+        for job in report.unanalyzable_jobs:
+            print(f"UNANALYZABLE: {job['description']}", file=sys.stderr)
         if report.isolation_proven:
             print(f"[OK] Release isolation proven for {report.ref} (mode={report.mode})")
-            print(f"  deploy source: {report.deploy_source_workflow}")
+            print(f"  single deploy source: {report.deploy_sources[0]['workflow']}")
         else:
             print(f"[FAIL] Release isolation NOT proven for {report.ref} (mode={report.mode})")
+            print(f"  deploy sources ({report.deploy_source_count}): {[s['workflow'] for s in report.deploy_sources]}")
 
     if args.mode == "prod":
         return 2
-    if report.errors:
-        return 1
-    if report.hidden_couplings:
-        return 1
     return 0 if report.isolation_proven else 1
 
 

--- a/scripts/publication/verify_release_isolation.py
+++ b/scripts/publication/verify_release_isolation.py
@@ -1,0 +1,302 @@
+#!/usr/bin/env python3
+"""Rehearsal-only release isolation verifier.
+
+Proves a release fully self-hosts its site — the full-site deployment source
+is the single source of truth with no hidden coupling to a legacy Pages deploy
+that would create collateral when the site is later self-hosted.
+
+This script MUST NOT deploy; it is a read-only verification tool.
+
+Usage:
+  uv run -- python scripts/publication/verify_release_isolation.py --ref origin/release --mode rehearsal
+  uv run -- python scripts/publication/verify_release_isolation.py --ref origin/release --mode rehearsal --json
+
+Exit codes:
+  0 - Isolation proven (no hidden coupling found).
+  1 - Hidden coupling detected or operational error.
+  2 - ``--mode prod`` is rejected (must use rehearsal mode).
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+WORKFLOWS_DIR = REPO_ROOT / ".github" / "workflows"
+
+INTENDED_DEPLOY_WORKFLOW = "publication-deploy.yml"
+LEGACY_DEPLOY_WORKFLOW = "docs.yml"
+
+PAGES_DEPLOY_PATTERNS = ("deploy-pages@v4", "actions/deploy-pages@v4")
+
+BUILD_PATTERNS = ("api_docs", "prose_site", "uv run python scripts/", "npm run build")
+
+
+@dataclass
+class ReleaseIsolationReport:
+    mode: str
+    ref: str
+    deploy_source_present: bool
+    deploy_source_workflow: str | None
+    hidden_couplings: list[dict[str, Any]]
+    isolation_proven: bool
+    errors: list[str] = field(default_factory=list)
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+def _run_git(args: list[str]) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["git", *args],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+def _get_workflow_files_at_ref(ref: str) -> list[str]:
+    """List workflow YAML filenames (bare names) reachable from ref.
+
+    `git ls-tree --name-only` returns full paths like
+    `.github/workflows/docs.yml`; we strip the workflows-directory prefix so
+    downstream code compares against bare filenames.
+    """
+    result = _run_git(["ls-tree", ref, "--name-only", ".github/workflows/"])
+    if result.returncode != 0:
+        raise RuntimeError(f"git ls-tree failed for ref '{ref}': {result.stderr.strip()}")
+    files: list[str] = []
+    for line in result.stdout.splitlines():
+        stripped = line.strip()
+        if not stripped.endswith((".yml", ".yaml")):
+            continue
+        files.append(Path(stripped).name)
+    return files
+
+
+def _read_workflow_at_ref(ref: str, workflow_path: str) -> str:
+    """Read a single workflow file's contents at ref."""
+    full_path = f".github/workflows/{Path(workflow_path).name}"
+    result = _run_git(["show", f"{ref}:{full_path}"])
+    if result.returncode != 0:
+        raise RuntimeError(f"git show failed for '{ref}:{workflow_path}': {result.stderr.strip()}")
+    return result.stdout
+
+
+def _has_pages_deploy(workflow_data: dict[str, Any]) -> bool:
+    """Check if any job in the workflow does a Pages deploy."""
+    jobs = workflow_data.get("jobs", {})
+    if not isinstance(jobs, dict):
+        return False
+    for job_def in jobs.values():
+        if not isinstance(job_def, dict):
+            continue
+        steps = job_def.get("steps", [])
+        if not isinstance(steps, list):
+            continue
+        for step in steps:
+            if not isinstance(step, dict):
+                continue
+            uses = step.get("uses", "")
+            if isinstance(uses, str) and any(p in uses for p in PAGES_DEPLOY_PATTERNS):
+                return True
+    return False
+
+
+def _has_build_job(workflow_data: dict[str, Any]) -> bool:
+    """Check if any job looks like an API-doc or site build job."""
+    jobs = workflow_data.get("jobs", {})
+    if not isinstance(jobs, dict):
+        return False
+    for job_def in jobs.values():
+        if not isinstance(job_def, dict):
+            continue
+        job_name = job_def.get("name", "")
+        steps = job_def.get("steps", [])
+        if not isinstance(steps, list):
+            continue
+        step_runs = "\n".join(str(step.get("run", "")) for step in steps if isinstance(step, dict))
+        if any(p in step_runs or p in str(job_name) for p in BUILD_PATTERNS):
+            return True
+    return False
+
+
+def _detect_hidden_coupling(
+    ref: str,
+    workflow_files: list[str],
+) -> list[dict[str, Any]]:
+    """Detect workflows where a single job both builds AND deploys to Pages (hidden coupling).
+
+    A separate build job + deploy job is the CORRECT pattern (e.g. publication-deploy.yml
+    with a build job that produces artifacts and a deploy job that deploys them). The
+    hidden coupling is a single job that does both building and deploying as a side effect.
+    """
+    couplings: list[dict[str, Any]] = []
+    for wf_name in workflow_files:
+        if wf_name == INTENDED_DEPLOY_WORKFLOW:
+            continue
+        try:
+            text = _read_workflow_at_ref(ref, wf_name)
+            data = yaml.safe_load(text)
+        except (RuntimeError, yaml.YAMLError):
+            continue
+        if not isinstance(data, dict):
+            continue
+
+        jobs = data.get("jobs", {})
+        if not isinstance(jobs, dict):
+            continue
+        for job_name, job_def in jobs.items():
+            if not isinstance(job_def, dict):
+                continue
+            steps = job_def.get("steps", [])
+            if not isinstance(steps, list):
+                continue
+            step_runs = "\n".join(str(step.get("run", "")) for step in steps if isinstance(step, dict))
+            step_uses = [
+                str(step.get("uses", ""))
+                for step in steps
+                if isinstance(step, dict) and isinstance(step.get("uses"), str)
+            ]
+            builds = any(p in step_runs for p in BUILD_PATTERNS)
+            deploys = any(any(p in u for p in PAGES_DEPLOY_PATTERNS) for u in step_uses)
+            if builds and deploys:
+                couplings.append(
+                    {
+                        "workflow": wf_name,
+                        "coupled_jobs": [job_name],
+                        "description": (
+                            f"Workflow '{wf_name}' job '{job_name}' both builds and deploys to Pages — "
+                            "hidden coupling that must be eliminated before self-hosted deployment."
+                        ),
+                    }
+                )
+    return couplings
+
+
+def _check_deploy_source(workflow_files: list[str]) -> tuple[bool, str | None]:
+    """Check that the intended deploy source workflow exists."""
+    for name in (INTENDED_DEPLOY_WORKFLOW, LEGACY_DEPLOY_WORKFLOW):
+        if name in workflow_files:
+            return True, name
+    return False, None
+
+
+def verify_release_isolation(ref: str, mode: str = "rehearsal") -> ReleaseIsolationReport:
+    errors: list[str] = []
+    hidden_couplings: list[dict[str, Any]] = []
+
+    if mode == "prod":
+        return ReleaseIsolationReport(
+            mode=mode,
+            ref=ref,
+            deploy_source_present=False,
+            deploy_source_workflow=None,
+            hidden_couplings=[],
+            isolation_proven=False,
+            errors=["--mode prod is rejected; must use --mode rehearsal for read-only verification"],
+        )
+
+    try:
+        workflow_files = _get_workflow_files_at_ref(ref)
+    except RuntimeError as exc:
+        return ReleaseIsolationReport(
+            mode=mode,
+            ref=ref,
+            deploy_source_present=False,
+            deploy_source_workflow=None,
+            hidden_couplings=[],
+            isolation_proven=False,
+            errors=[str(exc)],
+        )
+
+    deploy_present, deploy_name = _check_deploy_source(workflow_files)
+    if not deploy_present:
+        errors.append(
+            f"No deploy source workflow found in {ref}; expected '{INTENDED_DEPLOY_WORKFLOW}' "
+            f"or '{LEGACY_DEPLOY_WORKFLOW}'"
+        )
+
+    hidden_couplings = _detect_hidden_coupling(ref, workflow_files)
+
+    isolation_proven = deploy_present and len(hidden_couplings) == 0 and not errors
+    return ReleaseIsolationReport(
+        mode=mode,
+        ref=ref,
+        deploy_source_present=deploy_present,
+        deploy_source_workflow=deploy_name,
+        hidden_couplings=hidden_couplings,
+        isolation_proven=isolation_proven,
+        errors=errors,
+    )
+
+
+def _resolve_ref(explicit: str | None) -> str:
+    """Default to the release branch ref, falling back to HEAD when unavailable."""
+    if explicit:
+        return explicit
+    probe = _run_git(["rev-parse", "--verify", "--quiet", "origin/release"])
+    if probe.returncode == 0:
+        return "origin/release"
+    return "HEAD"
+
+
+def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Rehearsal-only release isolation verifier.")
+    parser.add_argument(
+        "--ref",
+        default=None,
+        help="Git ref to inspect (default: origin/release, or HEAD if absent).",
+    )
+    parser.add_argument(
+        "--mode",
+        choices=["rehearsal", "prod"],
+        default="rehearsal",
+        help="Verification mode: rehearsal (read-only, default) or prod (rejected).",
+    )
+    parser.add_argument("--json", action="store_true", help="Structured JSON output.")
+    args = parser.parse_args(argv)
+    args.ref = _resolve_ref(args.ref)
+    return args
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parse_args(argv)
+
+    report = verify_release_isolation(ref=args.ref, mode=args.mode)
+
+    if args.json:
+        print(json.dumps(report.to_dict(), indent=2))
+    else:
+        if report.errors:
+            for err in report.errors:
+                print(f"ERROR: {err}", file=sys.stderr)
+        if report.hidden_couplings:
+            for coupling in report.hidden_couplings:
+                print(f"HIDDEN COUPLING: {coupling['description']}", file=sys.stderr)
+        if report.isolation_proven:
+            print(f"[OK] Release isolation proven for {report.ref} (mode={report.mode})")
+            print(f"  deploy source: {report.deploy_source_workflow}")
+        else:
+            print(f"[FAIL] Release isolation NOT proven for {report.ref} (mode={report.mode})")
+
+    if args.mode == "prod":
+        return 2
+    if report.errors:
+        return 1
+    if report.hidden_couplings:
+        return 1
+    return 0 if report.isolation_proven else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/unit/scripts/publication/test_audit_mirror_prs.py
+++ b/tests/unit/scripts/publication/test_audit_mirror_prs.py
@@ -1,4 +1,4 @@
-"""Tests for the corpus-mirror PR set-equivalence auditor."""
+"""Tests for the corpus-mirror PR content-equivalence auditor."""
 
 from __future__ import annotations
 
@@ -25,37 +25,59 @@ spec.loader.exec_module(audit_mirror_prs)
 CID = "benchbox-dev/BenchBox"
 BASE = "published-results"
 
-BASE_CORPUS = ["results-data/bundles/existing.json", "results-data/corpus-inventory.json"]
+# path -> blob sha on the base branch tree
+BASE_TREE = {
+    "results-data/bundles/existing.json": "aaaa1111",
+    "results-data/corpus-inventory.json": "bbbb2222",
+    "scripts/validate_submission.py": "cccc3333",
+}
 
 
 def _completed(stdout: str = "", stderr: str = "", code: int = 0) -> subprocess.CompletedProcess[str]:
     return subprocess.CompletedProcess(args=[], returncode=code, stdout=stdout, stderr=stderr)
 
 
-def _tree_payload(paths: list[str]) -> str:
-    return json.dumps({"tree": [{"path": p} for p in paths]})
+def _tree_payload(tree: dict[str, str], truncated: bool = False) -> str:
+    return json.dumps(
+        {"truncated": truncated, "tree": [{"path": p, "type": "blob", "sha": s} for p, s in tree.items()]}
+    )
 
 
-def _pr_payload(prs: list[dict]) -> str:
-    return json.dumps(prs)
-
-
-def _pr_file(path: str) -> dict:
-    return {"path": path, "additions": 1, "deletions": 0, "status": "added", "additions/2": 0}
+def _pr_file(path: str, sha: str, status: str = "modified") -> dict:
+    return {"filename": path, "sha": sha, "status": status, "additions": 1, "deletions": 0}
 
 
 class _FakeRunner:
-    def __init__(self, pr_payload: str, tree_payload: str, tree_code: int = 0, pr_code: int = 0):
-        self.pr_payload = pr_payload
-        self.tree_payload = tree_payload
+    """Dispatches gh calls: pr list, git trees, and per-PR pulls/N/files."""
+
+    def __init__(
+        self,
+        prs: list[dict],
+        tree: dict[str, str],
+        pr_files: dict[int, list[dict]] | None = None,
+        tree_code: int = 0,
+        pr_list_code: int = 0,
+        files_code: int = 0,
+        truncated: bool = False,
+    ):
+        self.prs = prs
+        self.tree = tree
+        self.pr_files = pr_files or {}
         self.tree_code = tree_code
-        self.pr_code = pr_code
+        self.pr_list_code = pr_list_code
+        self.files_code = files_code
+        self.truncated = truncated
 
     def __call__(self, args: list[str], **kwargs):
-        if args[:2] == ["gh", "pr"]:
-            return _completed(stdout=self.pr_payload, code=self.pr_code)
+        if args[:3] == ["gh", "pr", "list"]:
+            return _completed(stdout=json.dumps(self.prs), code=self.pr_list_code)
         if args[:2] == ["gh", "api"]:
-            return _completed(stdout=self.tree_payload, code=self.tree_code)
+            target = args[-1]
+            if "git/trees" in target:
+                return _completed(stdout=_tree_payload(self.tree, self.truncated), code=self.tree_code)
+            if "/pulls/" in target and target.endswith("files?per_page=100"):
+                number = int(target.split("/pulls/")[1].split("/")[0])
+                return _completed(stdout=json.dumps([self.pr_files.get(number, [])]), code=self.files_code)
         raise AssertionError(f"unexpected args: {args}")
 
 
@@ -64,151 +86,188 @@ def _run_main(argv: list[str], fake: _FakeRunner) -> int:
         return audit_mirror_prs.main(argv)
 
 
-def test_no_open_prs_json_count_zero(capsys):
-    fake = _FakeRunner(pr_payload=_pr_payload([]), tree_payload=_tree_payload(BASE_CORPUS))
-    exit_code = _run_main(["--repo", CID, "--base", BASE, "--json"], fake)
-    assert exit_code == 0
+def _pr(number: int, title: str = "mirror") -> dict:
+    return {"number": number, "title": title, "headRefName": f"auto/results-mirror-{number:08d}"}
+
+
+def test_no_open_prs(capsys):
+    fake = _FakeRunner(prs=[], tree=BASE_TREE)
+    assert _run_main(["--repo", CID, "--base", BASE, "--json"], fake) == 0
     payload = json.loads(capsys.readouterr().out)
-    assert payload["mode"] == "set-equivalence"
     assert payload["count"] == 0
     assert payload["prs"] == []
 
 
-def test_no_open_prs_text_output(capsys):
-    fake = _FakeRunner(pr_payload=_pr_payload([]), tree_payload=_tree_payload(BASE_CORPUS))
-    exit_code = _run_main(["--repo", CID, "--base", BASE], fake)
-    assert exit_code == 0
-    assert "[audit ok] 0 mirror PRs open" in capsys.readouterr().out
+def test_additive_pr(capsys):
+    fake = _FakeRunner(
+        prs=[_pr(12)],
+        tree=BASE_TREE,
+        pr_files={12: [_pr_file("results-data/bundles/new.json", "deadbeef", status="added")]},
+    )
+    assert _run_main(["--repo", CID, "--base", BASE, "--json"], fake) == 0
+    (p,) = json.loads(capsys.readouterr().out)["prs"]
+    assert p["verdict"] == "ADDITIVE"
+    assert p["new_paths"] == ["results-data/bundles/new.json"]
+    assert p["retire_able"] is False
 
 
-def test_additive_pr_is_additive(capsys):
-    prs = [
-        {
-            "number": 12,
-            "title": "mirror new bundle",
-            "headRefName": "auto/results-mirror-abcdef12",
-            "files": [_pr_file("results-data/bundles/new.json")],
-        }
-    ]
-    fake = _FakeRunner(pr_payload=_pr_payload(prs), tree_payload=_tree_payload(BASE_CORPUS))
-    exit_code = _run_main(["--repo", CID, "--base", BASE, "--json"], fake)
-    assert exit_code == 0
-    payload = json.loads(capsys.readouterr().out)
-    (pr,) = payload["prs"]
-    assert pr["number"] == 12
-    assert pr["verdict"] == "ADDITIVE"
-    assert pr["new_to_union"] is True
-    assert pr["added_path_count"] == 1
-    assert pr["duplicate_count"] == 0
+def test_noop_pr_identical_blob(capsys):
+    fake = _FakeRunner(
+        prs=[_pr(13)],
+        tree=BASE_TREE,
+        pr_files={13: [_pr_file("results-data/bundles/existing.json", "aaaa1111", status="modified")]},
+    )
+    assert _run_main(["--repo", CID, "--base", BASE, "--json"], fake) == 0
+    (p,) = json.loads(capsys.readouterr().out)["prs"]
+    assert p["verdict"] == "NOOP"
+    assert p["noop_paths"] == ["results-data/bundles/existing.json"]
+    assert p["retire_able"] is True
 
 
-def test_noop_pr_is_noop(capsys):
-    prs = [
-        {
-            "number": 13,
-            "title": "re-mirror existing",
-            "headRefName": "auto/results-mirror-00000013",
-            "files": [_pr_file("results-data/bundles/existing.json")],
-        }
-    ]
-    fake = _FakeRunner(pr_payload=_pr_payload(prs), tree_payload=_tree_payload(BASE_CORPUS))
-    exit_code = _run_main(["--repo", CID, "--base", BASE, "--json"], fake)
-    assert exit_code == 0
-    payload = json.loads(capsys.readouterr().out)
-    (pr,) = payload["prs"]
-    assert pr["verdict"] == "NOOP"
-    assert pr["new_to_union"] is False
-    assert pr["duplicate_count"] == 1
+def test_mutating_pr_rewrites_existing_path_content(capsys):
+    """A PR that rewrites an existing path with new bytes must NOT be retire-able."""
+    fake = _FakeRunner(
+        prs=[_pr(14)],
+        tree=BASE_TREE,
+        pr_files={14: [_pr_file("results-data/corpus-inventory.json", "9999ffff", status="modified")]},
+    )
+    assert _run_main(["--repo", CID, "--base", BASE, "--json"], fake) == 0
+    (p,) = json.loads(capsys.readouterr().out)["prs"]
+    assert p["verdict"] == "MUTATING"
+    assert p["changed_paths"] == ["results-data/corpus-inventory.json"]
+    assert p["retire_able"] is False
 
 
-def test_empty_pr_is_empty(capsys):
-    prs = [
-        {
-            "number": 14,
-            "title": "docs-only mirror",
-            "headRefName": "auto/results-mirror-00000014",
-            "files": [_pr_file("scripts/validate_submission.py")],
-        }
-    ]
-    fake = _FakeRunner(pr_payload=_pr_payload(prs), tree_payload=_tree_payload(BASE_CORPUS))
-    exit_code = _run_main(["--repo", CID, "--base", BASE, "--json"], fake)
-    assert exit_code == 0
-    payload = json.loads(capsys.readouterr().out)
-    (pr,) = payload["prs"]
-    assert pr["verdict"] == "EMPTY"
-    assert pr["added_path_count"] == 0
+def test_validator_only_mirror_is_mutating_not_empty(capsys):
+    """Regression: a validator-only mirror PR used to classify EMPTY (retire-able)
+    because CORPUS_PREFIXES covered only results-data/. The mirror workflow also
+    mirrors scripts/validate_submission.py etc., so a content change there is a
+    real refresh."""
+    fake = _FakeRunner(
+        prs=[_pr(15)],
+        tree=BASE_TREE,
+        pr_files={15: [_pr_file("scripts/validate_submission.py", "newsha00", status="modified")]},
+    )
+    assert _run_main(["--repo", CID, "--base", BASE, "--json"], fake) == 0
+    (p,) = json.loads(capsys.readouterr().out)["prs"]
+    assert p["verdict"] == "MUTATING"
+    assert p["retire_able"] is False
+
+
+def test_bundle_impl_path_is_mirrored(capsys):
+    fake = _FakeRunner(
+        prs=[_pr(16)],
+        tree=BASE_TREE,
+        pr_files={16: [_pr_file("benchbox/validation/bundle.py", "implsha1", status="added")]},
+    )
+    assert _run_main(["--repo", CID, "--base", BASE, "--json"], fake) == 0
+    (p,) = json.loads(capsys.readouterr().out)["prs"]
+    assert p["verdict"] == "ADDITIVE"
+
+
+def test_empty_pr_touches_no_mirrored_path(capsys):
+    fake = _FakeRunner(
+        prs=[_pr(17)],
+        tree=BASE_TREE,
+        pr_files={17: [_pr_file("README.md", "xxxx", status="modified")]},
+    )
+    assert _run_main(["--repo", CID, "--base", BASE, "--json"], fake) == 0
+    (p,) = json.loads(capsys.readouterr().out)["prs"]
+    assert p["verdict"] == "EMPTY"
+    assert p["retire_able"] is True
+
+
+def test_removed_mirrored_path_is_mutating(capsys):
+    fake = _FakeRunner(
+        prs=[_pr(18)],
+        tree=BASE_TREE,
+        pr_files={18: [_pr_file("results-data/bundles/existing.json", "", status="removed")]},
+    )
+    assert _run_main(["--repo", CID, "--base", BASE, "--json"], fake) == 0
+    (p,) = json.loads(capsys.readouterr().out)["prs"]
+    assert p["verdict"] == "MUTATING"
+    assert p["removed_paths"] == ["results-data/bundles/existing.json"]
+
+
+def test_large_pr_files_are_fully_paginated(capsys):
+    """>100 mirrored files; a new bundle past file 100 must still be seen."""
+    files = [_pr_file(f"results-data/bundles/b{i:04d}.json", f"sha{i}", status="added") for i in range(150)]
+    fake = _FakeRunner(prs=[_pr(19)], tree=BASE_TREE, pr_files={19: files})
+    assert _run_main(["--repo", CID, "--base", BASE, "--json"], fake) == 0
+    (p,) = json.loads(capsys.readouterr().out)["prs"]
+    assert p["mirrored_file_count"] == 150
+    assert p["verdict"] == "ADDITIVE"
+    assert len(p["new_paths"]) == 150
 
 
 def test_strict_union_with_noop_exits_three():
-    prs = [
-        {
-            "number": 15,
-            "title": "noop",
-            "headRefName": "auto/results-mirror-00000015",
-            "files": [_pr_file("results-data/bundles/existing.json")],
-        }
-    ]
-    fake = _FakeRunner(pr_payload=_pr_payload(prs), tree_payload=_tree_payload(BASE_CORPUS))
-    exit_code = _run_main(["--repo", CID, "--base", BASE, "--strict-union"], fake)
-    assert exit_code == 3
+    fake = _FakeRunner(
+        prs=[_pr(20)],
+        tree=BASE_TREE,
+        pr_files={20: [_pr_file("results-data/bundles/existing.json", "aaaa1111")]},
+    )
+    assert _run_main(["--repo", CID, "--base", BASE, "--strict-union"], fake) == 3
 
 
-def test_strict_union_all_additive_exits_zero(capsys):
-    prs = [
-        {
-            "number": 16,
-            "title": "additive",
-            "headRefName": "auto/results-mirror-00000016",
-            "files": [_pr_file("results-data/bundles/new16.json")],
-        }
-    ]
-    fake = _FakeRunner(pr_payload=_pr_payload(prs), tree_payload=_tree_payload(BASE_CORPUS))
-    exit_code = _run_main(["--repo", CID, "--base", BASE, "--strict-union"], fake)
-    assert exit_code == 0
+def test_strict_union_all_mutating_exits_zero():
+    fake = _FakeRunner(
+        prs=[_pr(21)],
+        tree=BASE_TREE,
+        pr_files={21: [_pr_file("results-data/bundles/existing.json", "changed99")]},
+    )
+    assert _run_main(["--repo", CID, "--base", BASE, "--strict-union"], fake) == 0
 
 
-def test_json_schema_shape(capsys):
-    prs = [
-        {
-            "number": 17,
-            "title": "mixed",
-            "headRefName": "auto/results-mirror-00000017",
-            "files": [
-                _pr_file("results-data/bundles/existing.json"),
-                _pr_file("results-data/bundles/nouveau.json"),
-            ],
-        }
-    ]
-    fake = _FakeRunner(pr_payload=_pr_payload(prs), tree_payload=_tree_payload(BASE_CORPUS))
+def test_truncated_base_tree_is_operational_error(capsys):
+    fake = _FakeRunner(prs=[], tree=BASE_TREE, truncated=True)
+    assert _run_main(["--repo", CID, "--base", BASE], fake) != 0
+    assert "truncated" in capsys.readouterr().err.lower()
+
+
+def test_per_pr_files_failure_is_isolated_error_verdict(capsys):
+    fake = _FakeRunner(prs=[_pr(22), _pr(23)], tree=BASE_TREE, files_code=1)
+    fake.pr_files = {23: [_pr_file("results-data/bundles/new.json", "s", status="added")]}
     exit_code = _run_main(["--repo", CID, "--base", BASE, "--json"], fake)
-    assert exit_code == 0
     payload = json.loads(capsys.readouterr().out)
-    assert set(payload.keys()) == {"mode", "base", "count", "prs"}
-    (pr,) = payload["prs"]
-    assert set(pr.keys()) == {
-        "number",
-        "title",
-        "head_ref",
-        "added_path_count",
-        "new_to_union",
-        "duplicate_count",
-        "verdict",
-        "added_paths",
-        "new_paths",
-    }
-    assert pr["verdict"] == "ADDITIVE"
-    assert pr["duplicate_count"] == 1
-
-
-def test_gh_failure_is_operational_error(capsys):
-    fake = _FakeRunner(pr_payload="[]", tree_payload="", tree_code=1)
-    exit_code = _run_main(["--repo", CID, "--base", BASE], fake)
-    assert exit_code != 0
-    assert "error" in capsys.readouterr().err.lower()
+    verdicts = {p["number"]: p["verdict"] for p in payload["prs"]}
+    assert verdicts[22] == "ERROR"
+    # exit nonzero because a PR could not be audited
+    assert exit_code == 1
+    assert payload["errored"] == [22, 23]
 
 
 def test_pr_list_failure_is_operational_error(capsys):
-    fake = _FakeRunner(pr_payload="", tree_payload=_tree_payload(BASE_CORPUS), pr_code=1)
-    exit_code = _run_main(["--repo", CID, "--base", BASE], fake)
-    assert exit_code != 0
+    fake = _FakeRunner(prs=[], tree=BASE_TREE, pr_list_code=1)
+    assert _run_main(["--repo", CID, "--base", BASE], fake) != 0
     assert "error" in capsys.readouterr().err.lower()
+
+
+def test_base_tree_failure_is_operational_error(capsys):
+    fake = _FakeRunner(prs=[], tree=BASE_TREE, tree_code=1)
+    assert _run_main(["--repo", CID, "--base", BASE], fake) != 0
+    assert "error" in capsys.readouterr().err.lower()
+
+
+def test_json_schema_shape(capsys):
+    fake = _FakeRunner(
+        prs=[_pr(24)],
+        tree=BASE_TREE,
+        pr_files={24: [_pr_file("results-data/bundles/new.json", "s", status="added")]},
+    )
+    assert _run_main(["--repo", CID, "--base", BASE, "--json"], fake) == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert set(payload.keys()) == {"mode", "base", "count", "retire_able", "errored", "prs"}
+    (p,) = payload["prs"]
+    assert set(p.keys()) == {
+        "number",
+        "title",
+        "head_ref",
+        "mirrored_file_count",
+        "new_paths",
+        "changed_paths",
+        "removed_paths",
+        "noop_paths",
+        "verdict",
+        "error",
+        "retire_able",
+    }

--- a/tests/unit/scripts/publication/test_audit_mirror_prs.py
+++ b/tests/unit/scripts/publication/test_audit_mirror_prs.py
@@ -1,0 +1,214 @@
+"""Tests for the corpus-mirror PR set-equivalence auditor."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import subprocess
+import sys
+from pathlib import Path
+from unittest import mock
+
+import pytest
+
+pytestmark = [pytest.mark.unit, pytest.mark.fast]
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+SCRIPT_PATH = REPO_ROOT / "scripts" / "publication" / "audit_mirror_prs.py"
+
+spec = importlib.util.spec_from_file_location("audit_mirror_prs", SCRIPT_PATH)
+audit_mirror_prs = importlib.util.module_from_spec(spec)
+sys.modules["audit_mirror_prs"] = audit_mirror_prs
+assert spec.loader is not None
+spec.loader.exec_module(audit_mirror_prs)
+
+CID = "benchbox-dev/BenchBox"
+BASE = "published-results"
+
+BASE_CORPUS = ["results-data/bundles/existing.json", "results-data/corpus-inventory.json"]
+
+
+def _completed(stdout: str = "", stderr: str = "", code: int = 0) -> subprocess.CompletedProcess[str]:
+    return subprocess.CompletedProcess(args=[], returncode=code, stdout=stdout, stderr=stderr)
+
+
+def _tree_payload(paths: list[str]) -> str:
+    return json.dumps({"tree": [{"path": p} for p in paths]})
+
+
+def _pr_payload(prs: list[dict]) -> str:
+    return json.dumps(prs)
+
+
+def _pr_file(path: str) -> dict:
+    return {"path": path, "additions": 1, "deletions": 0, "status": "added", "additions/2": 0}
+
+
+class _FakeRunner:
+    def __init__(self, pr_payload: str, tree_payload: str, tree_code: int = 0, pr_code: int = 0):
+        self.pr_payload = pr_payload
+        self.tree_payload = tree_payload
+        self.tree_code = tree_code
+        self.pr_code = pr_code
+
+    def __call__(self, args: list[str], **kwargs):
+        if args[:2] == ["gh", "pr"]:
+            return _completed(stdout=self.pr_payload, code=self.pr_code)
+        if args[:2] == ["gh", "api"]:
+            return _completed(stdout=self.tree_payload, code=self.tree_code)
+        raise AssertionError(f"unexpected args: {args}")
+
+
+def _run_main(argv: list[str], fake: _FakeRunner) -> int:
+    with mock.patch("subprocess.run", side_effect=fake):
+        return audit_mirror_prs.main(argv)
+
+
+def test_no_open_prs_json_count_zero(capsys):
+    fake = _FakeRunner(pr_payload=_pr_payload([]), tree_payload=_tree_payload(BASE_CORPUS))
+    exit_code = _run_main(["--repo", CID, "--base", BASE, "--json"], fake)
+    assert exit_code == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["mode"] == "set-equivalence"
+    assert payload["count"] == 0
+    assert payload["prs"] == []
+
+
+def test_no_open_prs_text_output(capsys):
+    fake = _FakeRunner(pr_payload=_pr_payload([]), tree_payload=_tree_payload(BASE_CORPUS))
+    exit_code = _run_main(["--repo", CID, "--base", BASE], fake)
+    assert exit_code == 0
+    assert "[audit ok] 0 mirror PRs open" in capsys.readouterr().out
+
+
+def test_additive_pr_is_additive(capsys):
+    prs = [
+        {
+            "number": 12,
+            "title": "mirror new bundle",
+            "headRefName": "auto/results-mirror-abcdef12",
+            "files": [_pr_file("results-data/bundles/new.json")],
+        }
+    ]
+    fake = _FakeRunner(pr_payload=_pr_payload(prs), tree_payload=_tree_payload(BASE_CORPUS))
+    exit_code = _run_main(["--repo", CID, "--base", BASE, "--json"], fake)
+    assert exit_code == 0
+    payload = json.loads(capsys.readouterr().out)
+    (pr,) = payload["prs"]
+    assert pr["number"] == 12
+    assert pr["verdict"] == "ADDITIVE"
+    assert pr["new_to_union"] is True
+    assert pr["added_path_count"] == 1
+    assert pr["duplicate_count"] == 0
+
+
+def test_noop_pr_is_noop(capsys):
+    prs = [
+        {
+            "number": 13,
+            "title": "re-mirror existing",
+            "headRefName": "auto/results-mirror-00000013",
+            "files": [_pr_file("results-data/bundles/existing.json")],
+        }
+    ]
+    fake = _FakeRunner(pr_payload=_pr_payload(prs), tree_payload=_tree_payload(BASE_CORPUS))
+    exit_code = _run_main(["--repo", CID, "--base", BASE, "--json"], fake)
+    assert exit_code == 0
+    payload = json.loads(capsys.readouterr().out)
+    (pr,) = payload["prs"]
+    assert pr["verdict"] == "NOOP"
+    assert pr["new_to_union"] is False
+    assert pr["duplicate_count"] == 1
+
+
+def test_empty_pr_is_empty(capsys):
+    prs = [
+        {
+            "number": 14,
+            "title": "docs-only mirror",
+            "headRefName": "auto/results-mirror-00000014",
+            "files": [_pr_file("scripts/validate_submission.py")],
+        }
+    ]
+    fake = _FakeRunner(pr_payload=_pr_payload(prs), tree_payload=_tree_payload(BASE_CORPUS))
+    exit_code = _run_main(["--repo", CID, "--base", BASE, "--json"], fake)
+    assert exit_code == 0
+    payload = json.loads(capsys.readouterr().out)
+    (pr,) = payload["prs"]
+    assert pr["verdict"] == "EMPTY"
+    assert pr["added_path_count"] == 0
+
+
+def test_strict_union_with_noop_exits_three():
+    prs = [
+        {
+            "number": 15,
+            "title": "noop",
+            "headRefName": "auto/results-mirror-00000015",
+            "files": [_pr_file("results-data/bundles/existing.json")],
+        }
+    ]
+    fake = _FakeRunner(pr_payload=_pr_payload(prs), tree_payload=_tree_payload(BASE_CORPUS))
+    exit_code = _run_main(["--repo", CID, "--base", BASE, "--strict-union"], fake)
+    assert exit_code == 3
+
+
+def test_strict_union_all_additive_exits_zero(capsys):
+    prs = [
+        {
+            "number": 16,
+            "title": "additive",
+            "headRefName": "auto/results-mirror-00000016",
+            "files": [_pr_file("results-data/bundles/new16.json")],
+        }
+    ]
+    fake = _FakeRunner(pr_payload=_pr_payload(prs), tree_payload=_tree_payload(BASE_CORPUS))
+    exit_code = _run_main(["--repo", CID, "--base", BASE, "--strict-union"], fake)
+    assert exit_code == 0
+
+
+def test_json_schema_shape(capsys):
+    prs = [
+        {
+            "number": 17,
+            "title": "mixed",
+            "headRefName": "auto/results-mirror-00000017",
+            "files": [
+                _pr_file("results-data/bundles/existing.json"),
+                _pr_file("results-data/bundles/nouveau.json"),
+            ],
+        }
+    ]
+    fake = _FakeRunner(pr_payload=_pr_payload(prs), tree_payload=_tree_payload(BASE_CORPUS))
+    exit_code = _run_main(["--repo", CID, "--base", BASE, "--json"], fake)
+    assert exit_code == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert set(payload.keys()) == {"mode", "base", "count", "prs"}
+    (pr,) = payload["prs"]
+    assert set(pr.keys()) == {
+        "number",
+        "title",
+        "head_ref",
+        "added_path_count",
+        "new_to_union",
+        "duplicate_count",
+        "verdict",
+        "added_paths",
+        "new_paths",
+    }
+    assert pr["verdict"] == "ADDITIVE"
+    assert pr["duplicate_count"] == 1
+
+
+def test_gh_failure_is_operational_error(capsys):
+    fake = _FakeRunner(pr_payload="[]", tree_payload="", tree_code=1)
+    exit_code = _run_main(["--repo", CID, "--base", BASE], fake)
+    assert exit_code != 0
+    assert "error" in capsys.readouterr().err.lower()
+
+
+def test_pr_list_failure_is_operational_error(capsys):
+    fake = _FakeRunner(pr_payload="", tree_payload=_tree_payload(BASE_CORPUS), pr_code=1)
+    exit_code = _run_main(["--repo", CID, "--base", BASE], fake)
+    assert exit_code != 0
+    assert "error" in capsys.readouterr().err.lower()

--- a/tests/unit/workflows/test_release_isolation.py
+++ b/tests/unit/workflows/test_release_isolation.py
@@ -24,36 +24,27 @@ assert spec.loader is not None
 spec.loader.exec_module(verify_release_isolation)
 
 REF = "origin/release"
-ISOLATED_WORKFLOWS = [
-    "publication-deploy.yml",
-    "docs.yml",
-    "release.yml",
-]
-COUPLED_WORKFLOW_NAME = "legacy-deploy.yml"
+
+# Non-deploy peer workflows that are always present in the tree.
+PEER_WORKFLOWS = ["release.yml", "lint.yml"]
+INTENDED = "publication-deploy.yml"
+LEGACY = "docs.yml"
 
 
-def _make_workflow_yaml(
-    jobs: dict | None = None,
-    permissions: dict | None = None,
-    trigger_branches: list[str] | None = None,
-) -> str:
-    wf: dict = {"name": "Test Workflow", "jobs": jobs or {}}
-    if permissions:
-        wf["permissions"] = permissions
-    if trigger_branches:
-        wf["on"] = {"push": {"branches": trigger_branches}}
-    return yaml.dump(wf, default_flow_style=False)
+def _wf_yaml(jobs: dict, name: str = "Test Workflow") -> str:
+    return yaml.dump({"name": name, "jobs": jobs}, default_flow_style=False)
 
 
 def _isolated_deploy_workflow() -> str:
-    return _make_workflow_yaml(
-        jobs={
+    """publication-deploy.yml shape: separate build job feeds a separate deploy job."""
+    return _wf_yaml(
+        {
             "build": {
                 "runs-on": "ubuntu-latest",
                 "steps": [
-                    {"run": "uv run python scripts/assemble_public_site.py"},
+                    {"run": "uv run python scripts/assemble_public_site.py --site-dir site"},
                     {"run": "npm run build"},
-                    {"uses": "actions/upload-artifact@v4", "with": {"name": "prose_site"}},
+                    {"uses": "actions/upload-pages-artifact@v3", "with": {"path": "site"}},
                 ],
             },
             "deploy": {
@@ -65,46 +56,77 @@ def _isolated_deploy_workflow() -> str:
     )
 
 
-def _coupled_workflow() -> str:
-    return _make_workflow_yaml(
-        jobs={
-            "build-and-deploy": {
+def _legacy_two_job_deploy_workflow() -> str:
+    """Realistic docs.yml: a build job AND a separate release-only deploy job.
+
+    This is the exact shape the old detector whitelisted as 'correct' — it is
+    a *second* deploy source and must fail isolation.
+    """
+    return _wf_yaml(
+        {
+            "build": {
                 "runs-on": "ubuntu-latest",
                 "steps": [
-                    {"run": "uv run python scripts/assemble_public_site.py"},
-                    {"uses": "actions/upload-artifact@v4", "with": {"name": "api_docs"}},
-                    {"uses": "actions/deploy-pages@v4"},
+                    {"run": "cd docs && uv run sphinx-build -b html . _build/html"},
+                    {"run": "uv run -- python scripts/assemble_public_site.py --site-dir site"},
+                    {"uses": "actions/upload-pages-artifact@v3", "with": {"path": "site"}},
                 ],
+            },
+            "deploy": {
+                "if": "github.event_name == 'push' && github.ref == 'refs/heads/release'",
+                "needs": "build",
+                "runs-on": "ubuntu-latest",
+                "steps": [{"uses": "actions/deploy-pages@v4"}],
             },
         }
     )
 
 
-def _stub_git_ls_tree(workflow_files: list[str]):
-    stdout = "\n".join(f".github/workflows/{name}" for name in workflow_files)
-    return subprocess.CompletedProcess(args=[], returncode=0, stdout=stdout, stderr="")
-
-
-def _stub_git_show(content: str):
-    return subprocess.CompletedProcess(args=[], returncode=0, stdout=content, stderr="")
-
-
-def _stub_git_show_missing(path: str):
-    return subprocess.CompletedProcess(
-        args=[], returncode=128, stdout="", stderr=f"fatal: path '{path}' does not exist"
+def _coupled_workflow() -> str:
+    """A single job that both builds and deploys."""
+    return _wf_yaml(
+        {
+            "build-and-deploy": {
+                "runs-on": "ubuntu-latest",
+                "steps": [
+                    {"run": "uv run python scripts/assemble_public_site.py"},
+                    {"uses": "actions/deploy-pages@v4"},
+                ],
+            }
+        }
     )
 
 
-def _make_git_effects(workflow_files: list[str], wf_contents: dict[str, str] | None = None):
-    """Build mock _run_git side effects: one ls-tree result, then one show per
-    workflow file that will actually be read (workflows skipped by the verifier
-    are excluded so list-based consumption stays aligned)."""
-    effects = [_stub_git_ls_tree(workflow_files)]
-    for wf_name in workflow_files:
-        if wf_name == verify_release_isolation.INTENDED_DEPLOY_WORKFLOW:
-            continue
-        content = (wf_contents or {}).get(wf_name, _make_workflow_yaml(jobs={}))
-        effects.append(_stub_git_show(content))
+def _sha_pinned_deploy_workflow() -> str:
+    return _wf_yaml(
+        {
+            "deploy": {
+                "runs-on": "ubuntu-latest",
+                "steps": [{"uses": "actions/deploy-pages@" + "a" * 40}],
+            }
+        }
+    )
+
+
+def _reusable_call_workflow() -> str:
+    return _wf_yaml({"call": {"uses": "./.github/workflows/some-reusable.yml"}})
+
+
+def _ls_tree(workflow_files: list[str]) -> subprocess.CompletedProcess[str]:
+    stdout = "\n".join(f".github/workflows/{n}" for n in workflow_files)
+    return subprocess.CompletedProcess(args=[], returncode=0, stdout=stdout, stderr="")
+
+
+def _show(content: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.CompletedProcess(args=[], returncode=0, stdout=content, stderr="")
+
+
+def _git_effects(wf_contents: dict[str, str]) -> list:
+    """One ls-tree result, then one `git show` per workflow file (sorted, as the
+    verifier reads them)."""
+    effects: list = [_ls_tree(list(wf_contents))]
+    for name in sorted(wf_contents):
+        effects.append(_show(wf_contents[name]))
     return effects
 
 
@@ -113,126 +135,158 @@ def _run_main(argv: list[str], git_side_effects: list) -> int:
         return verify_release_isolation.main(argv)
 
 
-class TestRehearsalModeReadOnly:
-    def test_rehearsal_never_deploys(self, capsys):
-        git_effects = _make_git_effects(
-            ISOLATED_WORKFLOWS,
-            {"publication-deploy.yml": _isolated_deploy_workflow()},
-        )
-        exit_code = _run_main(
-            ["--ref", REF, "--mode", "rehearsal", "--json"],
-            git_side_effects=git_effects,
-        )
+def _empty_peers() -> dict[str, str]:
+    return {name: _wf_yaml({"job": {"runs-on": "ubuntu-latest", "steps": []}}) for name in PEER_WORKFLOWS}
+
+
+class TestSingleDeploySourceProven:
+    def test_single_intended_source_is_proven(self, capsys):
+        contents = {**_empty_peers(), INTENDED: _isolated_deploy_workflow()}
+        exit_code = _run_main(["--ref", REF, "--mode", "rehearsal", "--json"], _git_effects(contents))
         assert exit_code == 0
         payload = json.loads(capsys.readouterr().out)
-        assert payload["mode"] == "rehearsal"
         assert payload["isolation_proven"] is True
+        assert payload["deploy_source_count"] == 1
+        assert payload["deploy_sources"][0]["workflow"] == INTENDED
+        assert payload["intended_deploy_workflow_present"] is True
+        assert payload["legacy_deploy_workflow_deploys"] is False
 
-    def test_rehearsal_mode_explicit(self, capsys):
-        git_effects = _make_git_effects(
-            ISOLATED_WORKFLOWS,
-            {"publication-deploy.yml": _isolated_deploy_workflow()},
-        )
-        exit_code = _run_main(
-            ["--ref", REF, "--mode", "rehearsal"],
-            git_side_effects=git_effects,
-        )
+    def test_text_output_ok(self, capsys):
+        contents = {**_empty_peers(), INTENDED: _isolated_deploy_workflow()}
+        exit_code = _run_main(["--ref", REF, "--mode", "rehearsal"], _git_effects(contents))
         assert exit_code == 0
         assert "[OK] Release isolation proven" in capsys.readouterr().out
 
 
-class TestHiddenCouplingDetection:
-    def test_hidden_coupling_detected_exit_nonzero(self, capsys):
-        coupled_wfs = ISOLATED_WORKFLOWS + [COUPLED_WORKFLOW_NAME]
-        git_effects = _make_git_effects(
-            coupled_wfs,
-            {
-                "publication-deploy.yml": _isolated_deploy_workflow(),
-                COUPLED_WORKFLOW_NAME: _coupled_workflow(),
-            },
-        )
-        exit_code = _run_main(["--ref", REF, "--mode", "rehearsal"], git_side_effects=git_effects)
+class TestSecondDeploySourceFails:
+    def test_two_deploy_sources_fail(self, capsys):
+        contents = {
+            **_empty_peers(),
+            INTENDED: _isolated_deploy_workflow(),
+            LEGACY: _legacy_two_job_deploy_workflow(),
+        }
+        exit_code = _run_main(["--ref", REF, "--mode", "rehearsal", "--json"], _git_effects(contents))
         assert exit_code != 0
-        captured = capsys.readouterr()
-        assert "HIDDEN COUPLING" in captured.err or "FAIL" in captured.out
+        payload = json.loads(capsys.readouterr().out)
+        assert payload["isolation_proven"] is False
+        assert payload["deploy_source_count"] == 2
+        assert payload["legacy_deploy_workflow_deploys"] is True
+        assert any("2 Pages deploy sources" in e for e in payload["errors"])
+        assert any("docs.yml" in e and "still contains a Pages deploy" in e for e in payload["errors"])
 
-    def test_hidden_coupling_detected_json(self, capsys):
-        coupled_wfs = ISOLATED_WORKFLOWS + [COUPLED_WORKFLOW_NAME]
-        git_effects = _make_git_effects(
-            coupled_wfs,
-            {
-                "publication-deploy.yml": _isolated_deploy_workflow(),
-                COUPLED_WORKFLOW_NAME: _coupled_workflow(),
-            },
-        )
-        exit_code = _run_main(
-            ["--ref", REF, "--mode", "rehearsal", "--json"],
-            git_side_effects=git_effects,
-        )
+    def test_legacy_two_job_shape_is_not_whitelisted(self, capsys):
+        """The old detector treated a separate build-job/deploy-job docs.yml as
+        'the correct pattern'. It is a second deploy source and must fail."""
+        contents = {**_empty_peers(), LEGACY: _legacy_two_job_deploy_workflow()}
+        exit_code = _run_main(["--ref", REF, "--mode", "rehearsal", "--json"], _git_effects(contents))
+        assert exit_code != 0
+        payload = json.loads(capsys.readouterr().out)
+        assert payload["deploy_sources"][0]["workflow"] == LEGACY
+        assert payload["deploy_sources"][0]["jobs"] == ["deploy"]
+
+
+class TestHiddenCoupling:
+    def test_single_job_build_and_deploy_detected(self, capsys):
+        contents = {**_empty_peers(), "legacy-deploy.yml": _coupled_workflow()}
+        exit_code = _run_main(["--ref", REF, "--mode", "rehearsal", "--json"], _git_effects(contents))
         assert exit_code != 0
         payload = json.loads(capsys.readouterr().out)
         assert len(payload["hidden_couplings"]) == 1
-        assert payload["hidden_couplings"][0]["workflow"] == COUPLED_WORKFLOW_NAME
+        assert payload["hidden_couplings"][0]["workflow"] == "legacy-deploy.yml"
 
 
-class TestIsolatedRelease:
-    def test_isolated_deploy_source_present(self, capsys):
-        git_effects = _make_git_effects(
-            ISOLATED_WORKFLOWS,
-            {"publication-deploy.yml": _isolated_deploy_workflow()},
-        )
-        exit_code = _run_main(["--ref", REF, "--mode", "rehearsal", "--json"], git_side_effects=git_effects)
-        assert exit_code == 0
+class TestFailOpenDeployDetection:
+    def test_sha_pinned_deploy_pages_is_detected(self, capsys):
+        contents = {**_empty_peers(), INTENDED: _sha_pinned_deploy_workflow()}
+        # Only source + intended present, but this fixture has no build job, so
+        # it still counts as the single deploy source and passes.
+        exit_code = _run_main(["--ref", REF, "--mode", "rehearsal", "--json"], _git_effects(contents))
         payload = json.loads(capsys.readouterr().out)
-        assert payload["deploy_source_present"] is True
-        assert payload["deploy_source_workflow"] in ("publication-deploy.yml", "docs.yml")
+        assert payload["deploy_source_count"] == 1
+        assert exit_code == 0
+
+    def test_second_source_with_sha_pin_fails(self, capsys):
+        contents = {
+            **_empty_peers(),
+            INTENDED: _isolated_deploy_workflow(),
+            "extra-deploy.yml": _sha_pinned_deploy_workflow(),
+        }
+        exit_code = _run_main(["--ref", REF, "--mode", "rehearsal", "--json"], _git_effects(contents))
+        assert exit_code != 0
+        payload = json.loads(capsys.readouterr().out)
+        assert payload["deploy_source_count"] == 2
+
+    def test_raw_gh_pages_push_is_detected(self, capsys):
+        wf = _wf_yaml({"publish": {"runs-on": "ubuntu-latest", "steps": [{"run": "git push origin HEAD:gh-pages"}]}})
+        contents = {**_empty_peers(), INTENDED: _isolated_deploy_workflow(), "raw.yml": wf}
+        exit_code = _run_main(["--ref", REF, "--mode", "rehearsal", "--json"], _git_effects(contents))
+        assert exit_code != 0
+        payload = json.loads(capsys.readouterr().out)
+        assert payload["deploy_source_count"] == 2
+
+
+class TestReusableWorkflowUnanalyzable:
+    def test_reusable_call_job_flagged(self, capsys):
+        contents = {**_empty_peers(), INTENDED: _isolated_deploy_workflow(), "call.yml": _reusable_call_workflow()}
+        exit_code = _run_main(["--ref", REF, "--mode", "rehearsal", "--json"], _git_effects(contents))
+        assert exit_code != 0
+        payload = json.loads(capsys.readouterr().out)
+        assert len(payload["unanalyzable_jobs"]) == 1
+        assert payload["unanalyzable_jobs"][0]["workflow"] == "call.yml"
 
 
 class TestProdModeRejected:
     def test_prod_mode_exit_two(self):
-        exit_code = _run_main(["--ref", REF, "--mode", "prod"], git_side_effects=[])
-        assert exit_code == 2
+        assert _run_main(["--ref", REF, "--mode", "prod"], []) == 2
 
     def test_prod_mode_json_exit_two(self, capsys):
-        exit_code = _run_main(["--ref", REF, "--mode", "prod", "--json"], git_side_effects=[])
-        assert exit_code == 2
+        assert _run_main(["--ref", REF, "--mode", "prod", "--json"], []) == 2
         payload = json.loads(capsys.readouterr().out)
         assert any("rejected" in e.lower() for e in payload["errors"])
 
 
 class TestJsonSchemaShape:
     def test_json_has_required_fields(self, capsys):
-        git_effects = _make_git_effects(
-            ISOLATED_WORKFLOWS,
-            {"publication-deploy.yml": _isolated_deploy_workflow()},
-        )
-        _run_main(["--ref", REF, "--mode", "rehearsal", "--json"], git_side_effects=git_effects)
+        contents = {**_empty_peers(), INTENDED: _isolated_deploy_workflow()}
+        _run_main(["--ref", REF, "--mode", "rehearsal", "--json"], _git_effects(contents))
         payload = json.loads(capsys.readouterr().out)
         assert set(payload.keys()) == {
             "mode",
             "ref",
-            "deploy_source_present",
-            "deploy_source_workflow",
+            "deploy_sources",
+            "deploy_source_count",
+            "intended_deploy_workflow_present",
+            "legacy_deploy_workflow_deploys",
             "hidden_couplings",
+            "unanalyzable_jobs",
             "isolation_proven",
             "errors",
         }
 
 
 class TestGitFetchFailure:
-    def test_git_ls_tree_failure_is_operational_error(self, capsys):
-        git_effects = [
-            subprocess.CompletedProcess(args=[], returncode=128, stdout="", stderr="fatal: Not a valid object name")
-        ]
-        exit_code = _run_main(["--ref", REF, "--mode", "rehearsal"], git_side_effects=git_effects)
-        assert exit_code != 0
+    def test_git_ls_tree_failure_is_operational_error(self):
+        effects = [subprocess.CompletedProcess(args=[], returncode=128, stdout="", stderr="fatal: bad object")]
+        assert _run_main(["--ref", REF, "--mode", "rehearsal"], effects) != 0
 
 
 class TestNoDeploySource:
     def test_no_deploy_source_detected(self, capsys):
-        git_effects = _make_git_effects(["release.yml", "lint.yml"])
-        exit_code = _run_main(["--ref", REF, "--mode", "rehearsal", "--json"], git_side_effects=git_effects)
+        exit_code = _run_main(["--ref", REF, "--mode", "rehearsal", "--json"], _git_effects(_empty_peers()))
         assert exit_code != 0
         payload = json.loads(capsys.readouterr().out)
-        assert payload["deploy_source_present"] is False
-        assert any("deploy source" in e.lower() for e in payload["errors"])
+        assert payload["deploy_source_count"] == 0
+        assert any("no pages deploy source" in e.lower() for e in payload["errors"])
+
+
+class TestLiveTreeIntegration:
+    """Run the verifier against the real .github/workflows tree at HEAD."""
+
+    def test_current_tree_is_not_isolated_while_docs_yml_deploys(self):
+        docs_yml = REPO_ROOT / ".github" / "workflows" / "docs.yml"
+        if not docs_yml.exists() or "deploy-pages" not in docs_yml.read_text():
+            pytest.skip("docs.yml no longer carries a Pages deploy step")
+        report = verify_release_isolation.verify_release_isolation(ref="HEAD", mode="rehearsal")
+        assert report.isolation_proven is False
+        assert report.legacy_deploy_workflow_deploys is True
+        assert any("docs.yml" in e for e in report.errors)

--- a/tests/unit/workflows/test_release_isolation.py
+++ b/tests/unit/workflows/test_release_isolation.py
@@ -1,0 +1,238 @@
+"""Contract tests for the release isolation rehearsal verifier."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import subprocess
+import sys
+from pathlib import Path
+from unittest import mock
+
+import pytest
+import yaml
+
+pytestmark = [pytest.mark.unit, pytest.mark.fast]
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+SCRIPT_PATH = REPO_ROOT / "scripts" / "publication" / "verify_release_isolation.py"
+
+spec = importlib.util.spec_from_file_location("verify_release_isolation", SCRIPT_PATH)
+verify_release_isolation = importlib.util.module_from_spec(spec)
+sys.modules["verify_release_isolation"] = verify_release_isolation
+assert spec.loader is not None
+spec.loader.exec_module(verify_release_isolation)
+
+REF = "origin/release"
+ISOLATED_WORKFLOWS = [
+    "publication-deploy.yml",
+    "docs.yml",
+    "release.yml",
+]
+COUPLED_WORKFLOW_NAME = "legacy-deploy.yml"
+
+
+def _make_workflow_yaml(
+    jobs: dict | None = None,
+    permissions: dict | None = None,
+    trigger_branches: list[str] | None = None,
+) -> str:
+    wf: dict = {"name": "Test Workflow", "jobs": jobs or {}}
+    if permissions:
+        wf["permissions"] = permissions
+    if trigger_branches:
+        wf["on"] = {"push": {"branches": trigger_branches}}
+    return yaml.dump(wf, default_flow_style=False)
+
+
+def _isolated_deploy_workflow() -> str:
+    return _make_workflow_yaml(
+        jobs={
+            "build": {
+                "runs-on": "ubuntu-latest",
+                "steps": [
+                    {"run": "uv run python scripts/assemble_public_site.py"},
+                    {"run": "npm run build"},
+                    {"uses": "actions/upload-artifact@v4", "with": {"name": "prose_site"}},
+                ],
+            },
+            "deploy": {
+                "needs": "build",
+                "runs-on": "ubuntu-latest",
+                "steps": [{"uses": "actions/deploy-pages@v4"}],
+            },
+        }
+    )
+
+
+def _coupled_workflow() -> str:
+    return _make_workflow_yaml(
+        jobs={
+            "build-and-deploy": {
+                "runs-on": "ubuntu-latest",
+                "steps": [
+                    {"run": "uv run python scripts/assemble_public_site.py"},
+                    {"uses": "actions/upload-artifact@v4", "with": {"name": "api_docs"}},
+                    {"uses": "actions/deploy-pages@v4"},
+                ],
+            },
+        }
+    )
+
+
+def _stub_git_ls_tree(workflow_files: list[str]):
+    stdout = "\n".join(f".github/workflows/{name}" for name in workflow_files)
+    return subprocess.CompletedProcess(args=[], returncode=0, stdout=stdout, stderr="")
+
+
+def _stub_git_show(content: str):
+    return subprocess.CompletedProcess(args=[], returncode=0, stdout=content, stderr="")
+
+
+def _stub_git_show_missing(path: str):
+    return subprocess.CompletedProcess(
+        args=[], returncode=128, stdout="", stderr=f"fatal: path '{path}' does not exist"
+    )
+
+
+def _make_git_effects(workflow_files: list[str], wf_contents: dict[str, str] | None = None):
+    """Build mock _run_git side effects: one ls-tree result, then one show per
+    workflow file that will actually be read (workflows skipped by the verifier
+    are excluded so list-based consumption stays aligned)."""
+    effects = [_stub_git_ls_tree(workflow_files)]
+    for wf_name in workflow_files:
+        if wf_name == verify_release_isolation.INTENDED_DEPLOY_WORKFLOW:
+            continue
+        content = (wf_contents or {}).get(wf_name, _make_workflow_yaml(jobs={}))
+        effects.append(_stub_git_show(content))
+    return effects
+
+
+def _run_main(argv: list[str], git_side_effects: list) -> int:
+    with mock.patch.object(verify_release_isolation, "_run_git", side_effect=git_side_effects):
+        return verify_release_isolation.main(argv)
+
+
+class TestRehearsalModeReadOnly:
+    def test_rehearsal_never_deploys(self, capsys):
+        git_effects = _make_git_effects(
+            ISOLATED_WORKFLOWS,
+            {"publication-deploy.yml": _isolated_deploy_workflow()},
+        )
+        exit_code = _run_main(
+            ["--ref", REF, "--mode", "rehearsal", "--json"],
+            git_side_effects=git_effects,
+        )
+        assert exit_code == 0
+        payload = json.loads(capsys.readouterr().out)
+        assert payload["mode"] == "rehearsal"
+        assert payload["isolation_proven"] is True
+
+    def test_rehearsal_mode_explicit(self, capsys):
+        git_effects = _make_git_effects(
+            ISOLATED_WORKFLOWS,
+            {"publication-deploy.yml": _isolated_deploy_workflow()},
+        )
+        exit_code = _run_main(
+            ["--ref", REF, "--mode", "rehearsal"],
+            git_side_effects=git_effects,
+        )
+        assert exit_code == 0
+        assert "[OK] Release isolation proven" in capsys.readouterr().out
+
+
+class TestHiddenCouplingDetection:
+    def test_hidden_coupling_detected_exit_nonzero(self, capsys):
+        coupled_wfs = ISOLATED_WORKFLOWS + [COUPLED_WORKFLOW_NAME]
+        git_effects = _make_git_effects(
+            coupled_wfs,
+            {
+                "publication-deploy.yml": _isolated_deploy_workflow(),
+                COUPLED_WORKFLOW_NAME: _coupled_workflow(),
+            },
+        )
+        exit_code = _run_main(["--ref", REF, "--mode", "rehearsal"], git_side_effects=git_effects)
+        assert exit_code != 0
+        captured = capsys.readouterr()
+        assert "HIDDEN COUPLING" in captured.err or "FAIL" in captured.out
+
+    def test_hidden_coupling_detected_json(self, capsys):
+        coupled_wfs = ISOLATED_WORKFLOWS + [COUPLED_WORKFLOW_NAME]
+        git_effects = _make_git_effects(
+            coupled_wfs,
+            {
+                "publication-deploy.yml": _isolated_deploy_workflow(),
+                COUPLED_WORKFLOW_NAME: _coupled_workflow(),
+            },
+        )
+        exit_code = _run_main(
+            ["--ref", REF, "--mode", "rehearsal", "--json"],
+            git_side_effects=git_effects,
+        )
+        assert exit_code != 0
+        payload = json.loads(capsys.readouterr().out)
+        assert len(payload["hidden_couplings"]) == 1
+        assert payload["hidden_couplings"][0]["workflow"] == COUPLED_WORKFLOW_NAME
+
+
+class TestIsolatedRelease:
+    def test_isolated_deploy_source_present(self, capsys):
+        git_effects = _make_git_effects(
+            ISOLATED_WORKFLOWS,
+            {"publication-deploy.yml": _isolated_deploy_workflow()},
+        )
+        exit_code = _run_main(["--ref", REF, "--mode", "rehearsal", "--json"], git_side_effects=git_effects)
+        assert exit_code == 0
+        payload = json.loads(capsys.readouterr().out)
+        assert payload["deploy_source_present"] is True
+        assert payload["deploy_source_workflow"] in ("publication-deploy.yml", "docs.yml")
+
+
+class TestProdModeRejected:
+    def test_prod_mode_exit_two(self):
+        exit_code = _run_main(["--ref", REF, "--mode", "prod"], git_side_effects=[])
+        assert exit_code == 2
+
+    def test_prod_mode_json_exit_two(self, capsys):
+        exit_code = _run_main(["--ref", REF, "--mode", "prod", "--json"], git_side_effects=[])
+        assert exit_code == 2
+        payload = json.loads(capsys.readouterr().out)
+        assert any("rejected" in e.lower() for e in payload["errors"])
+
+
+class TestJsonSchemaShape:
+    def test_json_has_required_fields(self, capsys):
+        git_effects = _make_git_effects(
+            ISOLATED_WORKFLOWS,
+            {"publication-deploy.yml": _isolated_deploy_workflow()},
+        )
+        _run_main(["--ref", REF, "--mode", "rehearsal", "--json"], git_side_effects=git_effects)
+        payload = json.loads(capsys.readouterr().out)
+        assert set(payload.keys()) == {
+            "mode",
+            "ref",
+            "deploy_source_present",
+            "deploy_source_workflow",
+            "hidden_couplings",
+            "isolation_proven",
+            "errors",
+        }
+
+
+class TestGitFetchFailure:
+    def test_git_ls_tree_failure_is_operational_error(self, capsys):
+        git_effects = [
+            subprocess.CompletedProcess(args=[], returncode=128, stdout="", stderr="fatal: Not a valid object name")
+        ]
+        exit_code = _run_main(["--ref", REF, "--mode", "rehearsal"], git_side_effects=git_effects)
+        assert exit_code != 0
+
+
+class TestNoDeploySource:
+    def test_no_deploy_source_detected(self, capsys):
+        git_effects = _make_git_effects(["release.yml", "lint.yml"])
+        exit_code = _run_main(["--ref", REF, "--mode", "rehearsal", "--json"], git_side_effects=git_effects)
+        assert exit_code != 0
+        payload = json.loads(capsys.readouterr().out)
+        assert payload["deploy_source_present"] is False
+        assert any("deploy source" in e.lower() for e in payload["errors"])


### PR DESCRIPTION
## Summary

Implement non-destructive evidence tooling for A10 (release and mirror retirement):
- **w4**: mirror-PR content-equivalence auditor (`scripts/publication/audit_mirror_prs.py`)
- **w6**: release isolation rehearsal verifier (`scripts/publication/verify_release_isolation.py`) + workflow (`.github/workflows/rehearse-release-isolation.yml`)

An independent review found both tools passed vacuously. Commit `9270b580c`
is a full fix-forward (scope: `scripts/publication/`, `tests/`,
`.github/workflows/`).

## What this delivers

### w6 — Release isolation rehearsal verifier
Read-only verifier that proves a release self-hosts its site from **exactly one**
GitHub Pages deployment source. It now genuinely implements the "single
deployment source proof":

- Counts every workflow at the ref that contains a Pages deploy step and fails
  unless the count is exactly one **and** that one is `publication-deploy.yml`.
- Fails whenever the legacy `docs.yml` still carries a Pages `deploy` job — the
  exact G3 release-deploy surface. On the current tree the verifier therefore
  **fails** (`origin/release`: `docs.yml` deploys; `HEAD`: two deploy sources),
  which is the correct signal until w2 removes the legacy deploy.
- Deploy detection no longer hardcodes `@v4`: it matches `actions/deploy-pages`
  at any version or SHA pin, known third-party deployers, and raw `gh-pages`
  pushes. Jobs that delegate to a reusable workflow are reported as
  un-analyzable rather than assumed clean.
- Still refuses `--mode prod` (exit 2); still never deploys.

`rehearse-release-isolation.yml` now defaults `ref` to `origin/release`
(and fetches it), sets `persist-credentials: false`, and its header comment is
fixed.

### w4 — Mirror PR content-equivalence auditor
Audits open corpus-mirror PRs against the protected base (`published-results`).

- Enumerates PR files via `gh api --paginate .../pulls/{n}/files` instead of the
  silently 100-file-capped `gh pr list --json files`.
- Classifies on **git blob SHA (content)**, not path membership. A PR that
  rewrites or removes an existing mirrored path is `MUTATING` (not retire-able),
  not a false `NOOP`/`EMPTY`.
- Mirrored-path set expanded to everything `sync-results-data-to-published.yml`
  actually mirrors (validators + `benchbox/validation/bundle.py` +
  `query_status.py`), so a validator-only mirror PR is no longer misread as
  `EMPTY`.
- Fails closed on a truncated base tree; emits a per-PR `ERROR` verdict and
  continues instead of aborting the whole audit.

Verdicts: `ADDITIVE` / `MUTATING` / `NOOP` / `EMPTY` / `ERROR`; only `NOOP` and
`EMPTY` are retire-able. `--json` and `--strict-union` retained.

## Gated / out-of-scope (unchanged)

- **w1**: prove all lanes healthy (live-ops, production run)
- **w2**: remove release-to-Pages deploy (freeze-gated on G1–G5; the verifier is
  the evidence that this is still outstanding)
- **w5**: merge composed full site + retire legacy (live-ops)

## Verification

- [x] `uv run pytest tests/unit/scripts/publication/test_audit_mirror_prs.py tests/unit/workflows/test_release_isolation.py -q -n 0` — 31 passed
- [x] `uv run ruff check . && uv run ruff format --check .` — clean
- [x] `verify_release_isolation.py --ref origin/release --mode rehearsal` — **exit 1** (correct: `docs.yml` still deploys)
- [x] `verify_release_isolation.py --ref HEAD` — exit 1 (two deploy sources)
- [x] `audit_mirror_prs.py --repo BenchBox-dev/BenchBox --base published-results --json` — exit 0 (0 open mirror PRs)
- [ ] CI `lint` `FAST_LANE_VIOLATION` expected until #2019 raises the ceiling (29050 → 29550). Fast-lane collected on this branch: **29047**.
