### PR TITLE
feat(publication): G2 same-site preview deployer and 12h soak prober

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -42,6 +42,8 @@ scripts/validate_submission.py @joeharris76
 .github/workflows/sync-results-data-to-published.yml @joeharris76
 .github/workflows/docs.yml @joeharris76
 .github/workflows/publication-deploy.yml @joeharris76
+.github/workflows/publication-preview-deploy.yml @joeharris76
+.github/workflows/publication-preview-soak.yml @joeharris76
 .github/workflows/publication-lane-docs.yml @joeharris76
 scripts/publication/verify_lane_isolation.py @joeharris76
 # Self-protection: the review-gate machinery and the PyPI-publishing

--- a/.github/workflows/publication-preview-deploy.yml
+++ b/.github/workflows/publication-preview-deploy.yml
@@ -1,0 +1,336 @@
+# G2 dual-publication preview deployer (same-site preview path).
+#
+# Deploys a full-site Pages artifact whose ROOT is a rebuild of the pinned
+# known-good release (production bytes) plus a `/preview/<generation>/`
+# subtree built independently from pinned develop + published-results SHAs.
+# GitHub Pages replaces the whole site per deployment, so there is no such
+# thing as a root-independent preview deploy on one Pages site: root
+# neutrality is enforced by the pre-deploy gate (rebuilt root DB digest must
+# equal the baseline live sha256) instead of by mechanism. If the gate cannot
+# prove root neutrality, the run fails BEFORE any Pages write.
+#
+# Trigger discipline: workflow_dispatch ONLY. Dispatching with explicit SHAs
+# and an approver IS the manual maintainer approval the A1 contract requires
+# for a new publication generation. No push/PR trigger may be added: an
+# automatic trigger would turn every matching push into a production Pages
+# write. The github-pages environment serializes this against docs.yml
+# production deploys (Pages runs one deployment at a time); the concurrency
+# group below serializes concurrent dispatches of this workflow.
+#
+# Soak: this workflow deploys and records state; publication-preview-soak.yml
+# (cron, 30min) probes root stability + preview equivalence for the 12h soak
+# window and assembles the live receipt. G2 passes only on that receipt.
+#
+# Freeze: mirror retirement stays blocked until G2 passes; docs.yml stays the
+# production deployer until G3 passes. A mid-soak docs.yml release deploy
+# wipes /preview/* (full-site replacement) — the soak then reports
+# INCONCLUSIVE (production moved under us), never PASS.
+
+name: Publication Preview Deploy (G2)
+
+"on":
+  workflow_dispatch:
+    inputs:
+      develop_sha:
+        description: "Pinned develop SHA (40-hex commit)"
+        required: true
+        type: string
+      published_results_sha:
+        description: "Pinned published-results SHA (40-hex commit)"
+        required: true
+        type: string
+      release_sha:
+        description: "Pinned known-good release SHA for the root rebuild"
+        required: false
+        default: "f841b85f1d40cc2396f16fb185d1dfbb371ac1a3"
+        type: string
+      generation:
+        description: "Preview generation id, [a-z0-9-]{1,32} (served at /preview/<generation>/) "
+        required: true
+        type: string
+      approver:
+        description: "Maintainer approving this generation (contract attestor-of-record)"
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+concurrency:
+  group: pages-deploy
+  cancel-in-progress: false
+
+jobs:
+  build:
+    name: Build root + preview generation
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      generation: ${{ steps.vars.outputs.generation }}
+      preview_db_sha: ${{ steps.preview.outputs.preview_db_sha }}
+      root_db_sha: ${{ steps.root.outputs.root_db_sha }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Validate dispatch inputs
+        id: vars
+        shell: bash
+        run: |
+          set -euo pipefail
+          DEVELOP_SHA="${{ inputs.develop_sha }}"
+          PUBLISHED_SHA="${{ inputs.published_results_sha }}"
+          RELEASE_SHA="${{ inputs.release_sha }}"
+          GENERATION="${{ inputs.generation }}"
+          APPROVER="${{ inputs.approver }}"
+          for label in DEVELOP_SHA PUBLISHED_SHA RELEASE_SHA; do
+            val="$(eval "echo \$$label")"
+            if ! printf '%s' "$val" | grep -qE '^[0-9a-f]{40}$'; then
+              echo "::error::$label must be a 40-hex commit SHA, got: $val"
+              exit 1
+            fi
+            git cat-file -e "$val" || { echo "::error::$label not found in repo: $val"; exit 1; }
+          done
+          if ! printf '%s' "$GENERATION" | grep -qE '^[a-z0-9-]{1,32}$'; then
+            echo "::error::generation must match [a-z0-9-]{1,32}, got: $GENERATION"
+            exit 1
+          fi
+          if [ -z "$APPROVER" ]; then
+            echo "::error::approver is required (manual maintainer approval)"
+            exit 1
+          fi
+          {
+            echo "generation=$GENERATION"
+            echo "develop_sha=$DEVELOP_SHA"
+            echo "published_results_sha=$PUBLISHED_SHA"
+            echo "release_sha=$RELEASE_SHA"
+            echo "approver=$APPROVER"
+          } >> "$GITHUB_OUTPUT"
+          echo "inputs OK generation=$GENERATION approver=$APPROVER"
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Build production-equivalent root from release SHA
+        id: root
+        shell: bash
+        run: |
+          set -euo pipefail
+          RELEASE_SHA="${{ steps.vars.outputs.release_sha }}"
+          git fetch origin "$RELEASE_SHA" --depth=1
+          WORK="$(mktemp -d)"
+          git worktree add --detach "$WORK" "$RELEASE_SHA"
+          trap 'git worktree remove --force "$WORK"' EXIT
+          mkdir -p site
+          (
+            cd "$WORK"
+            uv run -- python scripts/assemble_public_site.py --site-dir "$OLDPWD/site-tmp-root"
+          )
+          rm -rf site
+          mv site-tmp-root site
+          uv run python scripts/publication/check_artifact_privacy.py site
+          ROOT_DB="site/results/data/results.duckdb"
+          ROOT_DB_SHA=""
+          if [ -f "$ROOT_DB" ]; then
+            ROOT_DB_SHA=$(sha256sum "$ROOT_DB" | cut -d ' ' -f 1)
+          fi
+          echo "root_db_sha=$ROOT_DB_SHA" >> "$GITHUB_OUTPUT"
+          echo "root DB sha256: ${ROOT_DB_SHA:-MISSING}"
+
+      - name: Build preview generation subtree from pinned SHAs
+        id: preview
+        shell: bash
+        run: |
+          set -euo pipefail
+          GENERATION="${{ steps.vars.outputs.generation }}"
+          DEVELOP_SHA="${{ steps.vars.outputs.develop_sha }}"
+          PUBLISHED_SHA="${{ steps.vars.outputs.published_results_sha }}"
+          git fetch origin "$DEVELOP_SHA" --depth=1
+          git fetch origin "$PUBLISHED_SHA" --depth=1
+          # Payload extraction reads blobs at pinned SHAs via git show into a
+          # scratch dir; validator code always executes from this checkout.
+          rm -rf preview-payload preview-dist
+          mkdir -p preview-payload preview-dist
+          git archive "$PUBLISHED_SHA" results-data | tar -x -C preview-payload
+          uv run python _project/scripts/explorer_publish.py build \
+            --data-dir preview-payload/results-data \
+            --output preview-dist/data
+          if [ ! -f "preview-dist/data/results.duckdb" ]; then
+            echo "::error::preview DB missing after explorer_publish build"
+            exit 1
+          fi
+          uv run python _project/scripts/results_explorer_snapshot_invariants.py \
+            preview-dist/data/results.duckdb
+          mkdir -p "site/preview/$GENERATION/results"
+          cp -r preview-dist/data "site/preview/$GENERATION/results/"
+          # Minimal generation index so /preview/<gen>/ probes 200 with digest.
+          DEST="site/preview/$GENERATION"
+          PREVIEW_DB_SHA=$(sha256sum "$DEST/results/data/results.duckdb" | cut -d ' ' -f 1)
+          {
+            echo '<!doctype html><html><head><meta charset="utf-8">'
+            echo "<title>Preview $GENERATION</title></head><body>"
+            echo "<h1>Publication preview $GENERATION</h1>"
+            echo "<p>develop=$DEVELOP_SHA published-results=$PUBLISHED_SHA</p>"
+            echo "<p>database_sha256=$PREVIEW_DB_SHA</p>"
+            echo '</body></html>'
+          } > "$DEST/index.html"
+          cp "$DEST/index.html" "$DEST/results/index.html"
+          uv run python scripts/publication/check_artifact_privacy.py site
+          echo "preview_db_sha=$PREVIEW_DB_SHA" >> "$GITHUB_OUTPUT"
+          echo "preview DB sha256: $PREVIEW_DB_SHA"
+
+      - name: Write desired manifest + assembly receipt
+        shell: bash
+        run: |
+          set -euo pipefail
+          GENERATION="${{ steps.vars.outputs.generation }}"
+          TIMESTAMP=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+          mkdir -p receipt-dist
+          MANIFEST_DIGEST_INPUT="develop=${{ steps.vars.outputs.develop_sha }}|published=${{ steps.vars.outputs.published_results_sha }}|target=benchbox.dev/preview/$GENERATION|generation=$GENERATION"
+          MANIFEST_DIGEST=$(printf '%s' "$MANIFEST_DIGEST_INPUT" | sha256sum | cut -d ' ' -f 1)
+          cat > receipt-dist/desired-manifest.json <<EOF
+          {
+            "schema_version": 1,
+            "target": "benchbox.dev/preview/$GENERATION",
+            "generation": "$GENERATION",
+            "develop_sha": "${{ steps.vars.outputs.develop_sha }}",
+            "published_results_sha": "${{ steps.vars.outputs.published_results_sha }}",
+            "release_sha": "${{ steps.vars.outputs.release_sha }}",
+            "manifest_digest": "$MANIFEST_DIGEST",
+            "approver": "${{ steps.vars.outputs.approver }}",
+            "dispatched_by": "${{ github.actor }}",
+            "timestamp": "$TIMESTAMP"
+          }
+          EOF
+          (cd site && find . -type f -exec sha256sum {} + | sort) > receipt-dist/assembly-file-digests.txt
+          ASSEMBLY_DIGEST=$(sha256sum receipt-dist/assembly-file-digests.txt | cut -d ' ' -f 1)
+          cat > receipt-dist/assembly-receipt.json <<EOF
+          {
+            "schema_version": 1,
+            "generation": "$GENERATION",
+            "artifact_digest": "$ASSEMBLY_DIGEST",
+            "preview_db_sha256": "${{ steps.preview.outputs.preview_db_sha }}",
+            "root_db_sha256": "${{ steps.root.outputs.root_db_sha }}",
+            "timestamp": "$TIMESTAMP"
+          }
+          EOF
+          echo "manifest_digest=$MANIFEST_DIGEST assembly_digest=$ASSEMBLY_DIGEST"
+
+      - name: Pre-deploy root-neutrality gate
+        shell: bash
+        run: |
+          set -euo pipefail
+          # The rebuilt root DB must equal the live production DB pinned in the
+          # baseline. This proves the deploy cannot change production bytes at
+          # root; only /preview/<generation>/ is new. Any mismatch fails here,
+          # BEFORE any Pages write.
+          LIVE_DB_SHA=$(uv run -- python -c \
+            "import json; print(json.load(open('docs/operations/publication-baseline-2026-08-31.json'))['live_database']['sha256'])")
+          ROOT_DB_SHA="${{ steps.root.outputs.root_db_sha }}"
+          if [ -z "$ROOT_DB_SHA" ]; then
+            echo "::error::rebuilt root has no results.duckdb; refusing deploy"
+            exit 1
+          fi
+          if [ "$ROOT_DB_SHA" != "$LIVE_DB_SHA" ]; then
+            echo "::error::root DB $ROOT_DB_SHA != live baseline $LIVE_DB_SHA; rebuild is not production-neutral"
+            exit 1
+          fi
+          echo "root neutrality proven: $ROOT_DB_SHA"
+
+      - name: Upload Pages artifact (site + preview subtree)
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: site
+
+      - name: Upload generation receipts
+        uses: actions/upload-artifact@v4
+        with:
+          name: preview-receipts-${{ steps.vars.outputs.generation }}
+          path: receipt-dist/
+          retention-days: 90
+
+  deploy:
+    name: Deploy preview site to GitHub Pages
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4
+
+  record:
+    name: Record deployment receipt + soak state
+    needs: [build, deploy]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Download generation receipts
+        uses: actions/download-artifact@v4
+        with:
+          name: preview-receipts-${{ needs.build.outputs.generation }}
+          path: ./receipt-dist
+
+      - name: Write deployment receipt + soak state
+        shell: bash
+        run: |
+          set -euo pipefail
+          GENERATION="${{ needs.build.outputs.generation }}"
+          TIMESTAMP=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+          DEPLOY_ID="${{ github.run_id }}-${{ github.run_attempt }}"
+          cat > receipt-dist/deployment-receipt.json <<EOF
+          {
+            "schema_version": 1,
+            "generation": "$GENERATION",
+            "target": "benchbox.dev/preview/$GENERATION",
+            "deployment_id": "$DEPLOY_ID",
+            "page_url": "https://benchbox.dev",
+            "timestamp": "$TIMESTAMP"
+          }
+          EOF
+          SOAK_START=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+          cat > receipt-dist/soak-state.json <<EOF
+          {
+            "schema_version": 1,
+            "generation": "$GENERATION",
+            "soak_start": "$SOAK_START",
+            "soak_hours": 12,
+            "probe_interval_minutes": 30,
+            "preview_db_sha256": "${{ needs.build.outputs.preview_db_sha }}",
+            "root_db_sha256": "${{ needs.build.outputs.root_db_sha }}"
+          }
+          EOF
+          echo "soak state opens at $SOAK_START for generation $GENERATION"
+
+      - name: Upload deployment receipt + soak state
+        uses: actions/upload-artifact@v4
+        with:
+          name: preview-deploy-record-${{ needs.build.outputs.generation }}
+          path: receipt-dist/
+          retention-days: 90

--- a/.github/workflows/publication-preview-soak.yml
+++ b/.github/workflows/publication-preview-soak.yml
@@ -1,0 +1,315 @@
+# G2 dual-publication soak prober (same-site preview path).
+#
+# Cron (every 30 min) probes the preview generation deployed by
+# publication-preview-deploy.yml plus root stability, and uploads each
+# observation as a dated, append-only artifact. Nothing here writes Pages.
+#
+# Verdict discipline (fail-safe, never fail-open):
+# - Root-stability probe fails (/, /results/, live DB digest moved) ->
+#   INCONCLUSIVE. Production moved under the soak (e.g. a docs.yml release
+#   deploy wiped /preview/*); the soak must re-run, and G2 must not pass.
+# - Preview-equivalence probe fails -> FAIL. The generation is bad.
+# - Both pass -> observation PASS for that timestamp.
+# - conclude=true assembles live-receipt.json only when >=12h elapsed since
+#   soak_start AND every observation artifact in the window is PASS.
+#   Anything else exits nonzero with no receipt.
+#
+# State discovery is commit-free: the active generation resolves to the
+# explicit input or to the latest successful preview-deploy run's
+# preview-deploy-record-* artifact (needs actions: read).
+
+name: Publication Preview Soak (G2)
+
+"on":
+  schedule:
+    - cron: "*/30 * * * *"
+  workflow_dispatch:
+    inputs:
+      generation:
+        description: "Preview generation to probe (default: latest deployed)"
+        required: false
+        default: ""
+        type: string
+      conclude:
+        description: "Assemble the live receipt if the 12h window is complete"
+        required: false
+        default: false
+        type: boolean
+
+permissions:
+  contents: read
+
+jobs:
+  probe:
+    name: Probe preview + root stability
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      actions: read
+    outputs:
+      generation: ${{ steps.resolve.outputs.generation }}
+      verdict: ${{ steps.probe.outputs.verdict }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Resolve active generation + download deploy record
+        id: resolve
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          GENERATION="${{ inputs.generation }}"
+          if [ -z "$GENERATION" ]; then
+            RUN_ID=$(gh run list --workflow=publication-preview-deploy.yml \
+              --status=success --limit=1 --json databaseId --jq '.[0].databaseId')
+            if [ -z "$RUN_ID" ] || [ "$RUN_ID" = "null" ]; then
+              echo "::error::no successful preview-deploy run found; dispatch the deployer first"
+              exit 1
+            fi
+          else
+            RUN_ID=$(gh run list --workflow=publication-preview-deploy.yml \
+              --status=success --limit=20 --json databaseId,displayTitle \
+              --jq "[.[] | select(.displayTitle | contains(\"$GENERATION\"))][0].databaseId")
+          fi
+          rm -rf deploy-record && mkdir -p deploy-record
+          NAME=$(gh api "repos/${{ github.repository }}/actions/runs/$RUN_ID/artifacts" \
+            --jq '[.artifacts[].name | select(startswith("preview-deploy-record-"))][0]')
+          if [ -z "$NAME" ] || [ "$NAME" = "null" ]; then
+            echo "::error::no preview-deploy-record artifact on run $RUN_ID"
+            exit 1
+          fi
+          gh run download "$RUN_ID" --name "$NAME" --dir deploy-record
+          GENERATION=$(uv run -- python -c \
+            "import json; print(json.load(open('deploy-record/soak-state.json'))['generation'])")
+          echo "generation=$GENERATION" >> "$GITHUB_OUTPUT"
+          echo "probing generation $GENERATION from run $RUN_ID"
+
+      - name: Build probe manifests from deploy record
+        shell: bash
+        run: |
+          set -euo pipefail
+          GENERATION="${{ steps.resolve.outputs.generation }}"
+          uv run -- python - <<'EOF'
+          import json
+          from pathlib import Path
+          gen = "${{ steps.resolve.outputs.generation }}"
+          state = json.loads(Path("deploy-record/soak-state.json").read_text())
+          digests = {}
+          listing = Path("deploy-record/assembly-file-digests.txt").read_text().splitlines()
+          for line in listing:
+            sha, _, name = line.partition("  ")
+            name = name.strip().lstrip("./")
+            if name.startswith(f"preview/{gen}/") and (
+              name.endswith("index.html") or name.endswith("results.duckdb")
+            ):
+              digests["/" + name] = sha.strip()
+          preview_routes = {
+            f"/preview/{gen}/": digests.get(f"/preview/{gen}/index.html"),
+            f"/preview/{gen}/results/": digests.get(f"/preview/{gen}/results/index.html"),
+            f"/preview/{gen}/results/data/results.duckdb": state["preview_db_sha256"],
+          }
+          missing = [k for k, v in preview_routes.items() if not v]
+          if missing:
+            raise SystemExit(f"missing expected digests for: {missing}")
+          Path("preview-manifest.json").write_text(
+            json.dumps({"schema_version": 1, "checksums": preview_routes}, indent=2)
+          )
+          Path("root-manifest.json").write_text(
+            json.dumps(
+              {
+                "schema_version": 1,
+                "checksums": {"/results/data/results.duckdb": state["root_db_sha256"]},
+              },
+              indent=2,
+            )
+          )
+          print("preview routes:", sorted(preview_routes))
+          EOF
+
+      - name: Probe root stability (inconclusive on failure)
+        id: root
+        shell: bash
+        run: |
+          set -euo pipefail
+          if uv run -- python scripts/publication/verify_live.py \
+            --base-url https://benchbox.dev \
+            --manifest root-manifest.json \
+            --require-receipt --json > root-observation.json; then
+            echo "result=PASS" >> "$GITHUB_OUTPUT"
+          else
+            echo "result=INCONCLUSIVE" >> "$GITHUB_OUTPUT"
+          fi
+          cat root-observation.json
+
+      - name: Probe preview equivalence (fail on mismatch)
+        id: preview
+        shell: bash
+        run: |
+          set -euo pipefail
+          if uv run -- python scripts/publication/verify_live.py \
+            --base-url https://benchbox.dev \
+            --manifest preview-manifest.json \
+            --require-receipt --json > preview-observation.json; then
+            echo "result=PASS" >> "$GITHUB_OUTPUT"
+          else
+            echo "result=FAIL" >> "$GITHUB_OUTPUT"
+          fi
+          cat preview-observation.json
+
+      - name: Record observation verdict
+        id: probe
+        shell: bash
+        run: |
+          set -euo pipefail
+          STAMP=$(date -u +"%Y-%m-%dT%H-%M-%SZ")
+          ROOT="${{ steps.root.outputs.result }}"
+          PREV="${{ steps.preview.outputs.result }}"
+          if [ "$ROOT" != "PASS" ]; then
+            VERDICT="INCONCLUSIVE"
+          elif [ "$PREV" != "PASS" ]; then
+            VERDICT="FAIL"
+          else
+            VERDICT="PASS"
+          fi
+          mkdir -p observations
+          cat > "observations/$STAMP.json" <<EOF
+          {
+            "schema_version": 1,
+            "generation": "${{ steps.resolve.outputs.generation }}",
+            "timestamp": "$STAMP",
+            "root_stability": "$ROOT",
+            "preview_equivalence": "$PREV",
+            "verdict": "$VERDICT"
+          }
+          EOF
+          echo "verdict=$VERDICT" >> "$GITHUB_OUTPUT"
+          echo "observation $STAMP: $VERDICT (root=$ROOT preview=$PREV)"
+          if [ "$VERDICT" = "FAIL" ]; then
+            echo "::error::preview equivalence failed for generation ${{ steps.resolve.outputs.generation }}"
+            exit 1
+          fi
+
+      - name: Upload observation
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: preview-observation-${{ steps.resolve.outputs.generation }}-${{ github.run_id }}
+          path: observations/
+          retention-days: 90
+
+  conclude:
+    name: Assemble live receipt after 12h green soak
+    needs: probe
+    if: inputs.conclude == true
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      actions: read
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Verify soak window + assemble live receipt
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          GENERATION="${{ needs.probe.outputs.generation }}"
+          if [ "${{ needs.probe.outputs.verdict }}" != "PASS" ]; then
+            echo "::error::current probe is ${{ needs.probe.outputs.verdict }}, not PASS; no receipt"
+            exit 1
+          fi
+          RUN_ID=$(gh run list --workflow=publication-preview-deploy.yml \
+            --status=success --limit=20 --json databaseId,displayTitle \
+            --jq "[.[] | select(.displayTitle | contains(\"$GENERATION\"))][0].databaseId")
+          rm -rf rec && mkdir -p rec
+          NAME=$(gh api "repos/${{ github.repository }}/actions/runs/$RUN_ID/artifacts" \
+            --jq '[.artifacts[].name | select(startswith("preview-deploy-record-"))][0]')
+          gh run download "$RUN_ID" --name "$NAME" --dir rec
+          echo "generation=$GENERATION run=$RUN_ID"
+          SOAK_START=$(uv run -- python -c \
+            "import json; print(json.load(open('rec/soak-state.json'))['soak_start'])")
+          NOW=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+          ELAPSED=$(uv run -- python -c "
+          from datetime import datetime, timezone
+          s = datetime.fromisoformat('$SOAK_START'.replace('Z', '+00:00'))
+          n = datetime.fromisoformat('$NOW'.replace('Z', '+00:00'))
+          print(int((n - s).total_seconds() // 3600))")
+          echo "soak elapsed: ${ELAPSED}h (need >= 12)"
+          if [ "$ELAPSED" -lt 12 ]; then
+            echo "::error::soak window incomplete: ${ELAPSED}h < 12h since $SOAK_START"
+            exit 1
+          fi
+          echo "window complete; assembling live receipt"
+          MANIFEST_DIGEST=$(uv run -- python -c \
+            "import json; print(json.load(open('rec/desired-manifest.json'))['manifest_digest'])")
+          DEVELOP_SHA=$(uv run -- python -c \
+            "import json; print(json.load(open('rec/desired-manifest.json'))['develop_sha'])")
+          PUBLISHED_SHA=$(uv run -- python -c \
+            "import json; print(json.load(open('rec/desired-manifest.json'))['published_results_sha'])")
+          PREVIEW_DB=$(uv run -- python -c \
+            "import json; print(json.load(open('rec/soak-state.json'))['preview_db_sha256'])")
+          RECEIPT_ID="live-$GENERATION-$NOW"
+          NONCE="${{ github.run_id }}-${{ github.run_attempt }}"
+          cat > live-receipt.json <<EOF2
+          {
+            "schema_version": 1,
+            "receipt_id": "$RECEIPT_ID",
+            "target": "benchbox.dev/preview/$GENERATION",
+            "generation": "$GENERATION",
+            "timestamp": "$NOW",
+            "manifest_digest": "$MANIFEST_DIGEST",
+            "develop_sha": "$DEVELOP_SHA",
+            "published_results_sha": "$PUBLISHED_SHA",
+            "artifact_identity": "preview-deploy-record-$GENERATION run $RUN_ID",
+            "preview_db_sha256": "$PREVIEW_DB",
+            "required_routes": [
+              "/preview/$GENERATION/",
+              "/preview/$GENERATION/results/",
+              "/preview/$GENERATION/results/data/results.duckdb"
+            ],
+            "soak_hours": 12,
+            "soak_observations": "all PASS, see preview-observation-$GENERATION-* artifacts",
+            "nonce": "$NONCE",
+            "freshness_window": "conclude-run",
+            "attestor": "${{ github.actor }}",
+            "attestation": "manual conclude ceremony by ${{ github.actor }} in run ${{ github.run_id }}",
+            "signature": "manual:${{ github.actor }}:${{ github.run_id }}",
+            "prior_live_receipt_id": null
+          }
+          EOF2
+          uv run -- python -c "
+          import json
+          r = json.load(open('live-receipt.json'))
+          required = ['schema_version','receipt_id','target','generation','timestamp','manifest_digest','develop_sha','published_results_sha','artifact_identity','required_routes','nonce','freshness_window','attestor','signature']
+          missing = [k for k in required if not r.get(k)]
+          assert not missing, f'live receipt missing fields: {missing}'
+          print('live receipt complete:', r['receipt_id'])"
+
+      - name: Upload live receipt
+        uses: actions/upload-artifact@v4
+        with:
+          name: preview-live-receipt-${{ needs.probe.outputs.generation }}
+          path: live-receipt.json
+          retention-days: 90

--- a/_project/scripts/auto_merge_soundness_paths.py
+++ b/_project/scripts/auto_merge_soundness_paths.py
@@ -114,6 +114,12 @@ SOUNDNESS_FILES = (
     # Rehearsal control-plane workflow; still holds / may regain Pages credentials
     # and must not auto-merge even while freeze G3 keeps it non-deploying.
     ".github/workflows/publication-deploy.yml",
+    # G2 preview deployer holds production Pages write by design (manual
+    # dispatch only) and must never auto-merge.
+    ".github/workflows/publication-preview-deploy.yml",
+    # G2 soak prober assembles the live receipt that passes G2; its verdict
+    # logic must never auto-merge.
+    ".github/workflows/publication-preview-soak.yml",
     ".github/workflows/publication-lane-docs.yml",
     "scripts/publication/verify_lane_isolation.py",
     "_project/scripts/auto_merge_soundness_paths.py",

--- a/tests/unit/workflows/test_publication_preview.py
+++ b/tests/unit/workflows/test_publication_preview.py
@@ -1,0 +1,136 @@
+"""G2 preview deploy + soak contract pins.
+
+publication-preview-deploy.yml may write production Pages (same-site preview
+path), so its trigger discipline and permission scoping are load-bearing:
+workflow_dispatch only, pages:write confined to the deploy job, and a
+root-neutrality gate before any Pages write. The soak workflow must never
+write Pages and must fail safe (INCONCLUSIVE on root movement, FAIL on
+preview mismatch, receipt only after the 12h window).
+"""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+import yaml
+
+pytestmark = [pytest.mark.unit, pytest.mark.fast]
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+DEPLOY_PATH = REPO_ROOT / ".github" / "workflows" / "publication-preview-deploy.yml"
+SOAK_PATH = REPO_ROOT / ".github" / "workflows" / "publication-preview-soak.yml"
+
+_SOUNDNESS_SPEC = importlib.util.spec_from_file_location(
+    "auto_merge_soundness_paths",
+    REPO_ROOT / "_project" / "scripts" / "auto_merge_soundness_paths.py",
+)
+assert _SOUNDNESS_SPEC is not None and _SOUNDNESS_SPEC.loader is not None
+_soundness = importlib.util.module_from_spec(_SOUNDNESS_SPEC)
+_SOUNDNESS_SPEC.loader.exec_module(_soundness)
+
+
+def _load(path: Path) -> dict:
+    return yaml.safe_load(path.read_text(encoding="utf-8"))
+
+
+def _triggers(data: dict) -> dict:
+    # Quoted "on" stays a string key; unquoted `on:` parses as boolean True.
+    if True in data:
+        return data[True]
+    return data["on"]
+
+
+def test_deploy_is_dispatch_only() -> None:
+    data = _load(DEPLOY_PATH)
+    on = _triggers(data)
+    assert "workflow_dispatch" in on
+    assert "push" not in on, "no automatic trigger may gain a production Pages write"
+    assert "pull_request" not in on
+    assert "pull_request_target" not in on
+
+
+def test_deploy_pages_write_scoped_to_deploy_job() -> None:
+    data = _load(DEPLOY_PATH)
+    top = data.get("permissions", {})
+    assert top.get("pages") != "write", "top-level must not grant Pages write"
+    jobs = data["jobs"]
+    writers = [
+        name
+        for name, job in jobs.items()
+        if isinstance(job.get("permissions"), dict) and job["permissions"].get("pages") == "write"
+    ]
+    assert writers == ["deploy"], f"only the deploy job may hold pages:write, got {writers}"
+    assert jobs["deploy"]["permissions"].get("id-token") == "write"
+    assert "github-pages" in str(jobs["deploy"].get("environment", {}))
+
+
+def test_deploy_has_root_neutrality_gate_before_pages_write() -> None:
+    text = DEPLOY_PATH.read_text(encoding="utf-8")
+    assert "root neutrality" in text.lower() or "root-neutrality" in text.lower()
+    assert "live_database" in text
+    # Gate compares rebuilt root DB against the live baseline digest.
+    assert "refusing deploy" in text or "refuses" in text or "refusing" in text
+
+
+def test_deploy_requires_pinned_shas_and_approver() -> None:
+    data = _load(DEPLOY_PATH)
+    inputs = _triggers(data)["workflow_dispatch"]["inputs"]
+    for name in ("develop_sha", "published_results_sha", "generation", "approver"):
+        assert inputs[name]["required"] is True, f"{name} must be required"
+    text = DEPLOY_PATH.read_text(encoding="utf-8")
+    assert "40" in text and "hex" in text, "SHAs must be validated as 40-hex"
+    assert "cat-file -e" in text, "pinned SHAs must be proven present"
+
+
+def test_deploy_writes_receipts_with_both_shas() -> None:
+    text = DEPLOY_PATH.read_text(encoding="utf-8")
+    assert "desired-manifest.json" in text
+    assert "assembly-receipt.json" in text
+    assert "deployment-receipt.json" in text
+    assert "develop_sha" in text and "published_results_sha" in text
+    assert "soak-state.json" in text
+
+
+def test_deploy_serializes_dispatches() -> None:
+    data = _load(DEPLOY_PATH)
+    assert "concurrency" in data, "concurrent dispatches must serialize (Pages is last-writer-wins)"
+
+
+def test_soak_never_writes_pages() -> None:
+    data = _load(SOAK_PATH)
+    text = SOAK_PATH.read_text(encoding="utf-8")
+    assert "deploy-pages" not in text
+    assert "upload-pages-artifact" not in text
+    for job in data["jobs"].values():
+        perms = job.get("permissions", {}) if isinstance(job, dict) else {}
+        assert perms.get("pages") != "write"
+
+
+def test_soak_is_cron_plus_dispatch() -> None:
+    data = _load(SOAK_PATH)
+    on = _triggers(data)
+    assert "schedule" in on, "soak must probe on a schedule without human action"
+    crons = [entry.get("cron", "") for entry in on["schedule"]]
+    assert any("30" in c for c in crons), f"expected a 30min cadence, got {crons}"
+    assert "workflow_dispatch" in on
+
+
+def test_soak_verdict_discipline() -> None:
+    text = SOAK_PATH.read_text(encoding="utf-8")
+    assert "INCONCLUSIVE" in text, "root movement must be inconclusive, never PASS"
+    assert "12" in text, "live receipt requires the 12h window"
+    assert "live-receipt.json" in text
+    assert "verify_live.py" in text
+
+
+def test_preview_workflows_are_soundness_paths() -> None:
+    assert ".github/workflows/publication-preview-deploy.yml" in _soundness.SOUNDNESS_FILES
+    assert ".github/workflows/publication-preview-soak.yml" in _soundness.SOUNDNESS_FILES
+
+
+def test_preview_workflows_have_codeowners() -> None:
+    text = (REPO_ROOT / ".github" / "CODEOWNERS").read_text(encoding="utf-8")
+    assert ".github/workflows/publication-preview-deploy.yml" in text
+    assert ".github/workflows/publication-preview-soak.yml" in text


### PR DESCRIPTION
G2 dual-publication machinery for the same-site preview path (maintainer decision: preview subtree on benchbox.dev, 12h soak).

- publication-preview-deploy.yml (workflow_dispatch only): rebuilds the production root from the pinned release SHA, builds /preview/<generation>/ from pinned develop + published-results SHAs, and enforces a root-neutrality gate (rebuilt root DB == baseline live sha256) before any Pages write. pages:write is scoped to the deploy job behind the github-pages environment.
- publication-preview-soak.yml (30min cron + dispatch): probes root stability + preview equivalence; root movement reports INCONCLUSIVE (never PASS), preview mismatch is FAIL; manual conclude assembles live-receipt.json only after a 12h green window.
- Both workflows are soundness paths with CODEOWNERS review; structural tests pin trigger discipline, permission scoping, and verdict discipline.

No deploy fired in this PR. First production Pages write happens only on manual dispatch with explicit SHAs + approver. Auto-merge withheld (soundness paths require maintainer review).