### PR TITLE
fix(publication): build Sphinx docs before preview root assembly

### DIFF
--- a/.github/workflows/publication-preview-deploy.yml
+++ b/.github/workflows/publication-preview-deploy.yml
@@ -129,6 +129,11 @@ jobs:
           git worktree add --detach "$WORK" "$RELEASE_SHA"
           trap 'git worktree remove --force "$WORK"' EXIT
           mkdir -p site
+          # Mirror docs.yml: the Sphinx HTML build must exist before assembly.
+          (
+            cd "$WORK/docs"
+            uv run sphinx-build -b html --keep-going . _build/html
+          )
           (
             cd "$WORK"
             uv run -- python scripts/assemble_public_site.py --site-dir "$OLDPWD/site-tmp-root"

--- a/tests/unit/workflows/test_publication_preview.py
+++ b/tests/unit/workflows/test_publication_preview.py
@@ -93,6 +93,17 @@ def test_deploy_writes_receipts_with_both_shas() -> None:
     assert "soak-state.json" in text
 
 
+def test_deploy_builds_docs_before_assembly() -> None:
+    """Root rebuild mirrors docs.yml: Sphinx HTML must exist before assemble.
+
+    Missing docs/_build/html fails assembly with FileNotFoundError (first
+    gen1 deploy red). The sphinx-build step must precede assemble_public_site.
+    """
+    text = DEPLOY_PATH.read_text(encoding="utf-8")
+    assert "sphinx-build -b html" in text
+    assert text.index("sphinx-build -b html") < text.index("assemble_public_site.py")
+
+
 def test_deploy_serializes_dispatches() -> None:
     data = _load(DEPLOY_PATH)
     assert "concurrency" in data, "concurrent dispatches must serialize (Pages is last-writer-wins)"


### PR DESCRIPTION
First gen1 preview deploy went red before any Pages write: the release-worktree root rebuild ran assemble_public_site.py without the Sphinx HTML build docs.yml performs first (FileNotFoundError docs/_build/html). This mirrors the docs.yml sphinx-build step into the release worktree. Structural test pins the ordering. Production untouched (deploy job skipped).