### PR TITLE
docs(agent): state the disclosure condition in plain language

### DIFF
--- a/docs/agent/attribution-surfaces.md
+++ b/docs/agent/attribution-surfaces.md
@@ -50,9 +50,10 @@ agent-authored comment from a human one on an OWNER-attributed post. That cost
 is accepted deliberately, on two grounds: a footer on every post is noise that
 readers stop seeing, and a blanket machine marker under the maintainer's account
 is itself misleading about who is speaking. The rule therefore asks for
-disclosure **in the text, where it is load-bearing** — for example when a
-comment reports what an agent verified, or when a reviewer would act differently
-knowing the analysis was automated — instead of an unconditional footer.
+disclosure **in the text, where it changes what a reader would do** — for
+example when a comment reports what an agent verified, or when a reviewer
+would act differently knowing the analysis was automated — instead of an
+unconditional footer.
 
 Two alternatives were considered and not chosen:
 


### PR DESCRIPTION
`docs/agent/attribution-surfaces.md` described when an agent should disclose in
the text by calling that condition "load-bearing". The metaphor names no
condition, and the two examples that follow it already state one.

This replaces the phrase with the condition itself — whether the disclosure
changes what a reader would do — and rewraps the paragraph to the file's
80-column width. Wording only; the rule's meaning is unchanged.
