### PR TITLE
fix(publication): mirror docs.yml explorer build in preview root rebuild

### DIFF
--- a/.github/workflows/publication-preview-deploy.yml
+++ b/.github/workflows/publication-preview-deploy.yml
@@ -118,6 +118,11 @@ jobs:
         with:
           python-version: "3.11"
 
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
       - name: Build production-equivalent root from release SHA
         id: root
         shell: bash
@@ -129,6 +134,32 @@ jobs:
           git worktree add --detach "$WORK" "$RELEASE_SHA"
           trap 'git worktree remove --force "$WORK"' EXIT
           mkdir -p site
+          # Mirror the docs.yml explorer sequence inside the release worktree:
+          # without the built app + data, assembly fails on a missing dist.
+          if [ ! -f "$WORK/results-explorer/package.json" ]; then
+            echo "::error::release worktree lacks results-explorer/package.json"
+            exit 1
+          fi
+          test -f "$WORK/results-explorer/package-lock.json" || {
+            echo "results-explorer/package-lock.json is required for npm ci" >&2
+            exit 1
+          }
+          test -d "$WORK/results-data/bundles"
+          test -d "$WORK/_project/scripts/explorer_pipeline"
+          npm ci --prefix "$WORK/results-explorer"
+          npm run --prefix "$WORK/results-explorer" typecheck
+          (
+            cd "$WORK"
+            uv run -- python _project/scripts/explorer_publish.py build \
+              --data-dir results-data/ --output results-explorer/public/data/
+          )
+          test -s "$WORK/results-explorer/public/data/results.duckdb"
+          (
+            cd "$WORK"
+            uv run -- python _project/scripts/results_explorer_snapshot_invariants.py \
+              results-explorer/public/data/results.duckdb
+          )
+          npm run --prefix "$WORK/results-explorer" build
           # Mirror docs.yml: the Sphinx HTML build must exist before assembly.
           (
             cd "$WORK/docs"

--- a/tests/unit/workflows/test_publication_preview.py
+++ b/tests/unit/workflows/test_publication_preview.py
@@ -102,6 +102,11 @@ def test_deploy_builds_docs_before_assembly() -> None:
     text = DEPLOY_PATH.read_text(encoding="utf-8")
     assert "sphinx-build -b html" in text
     assert text.index("sphinx-build -b html") < text.index("assemble_public_site.py")
+    # Explorer app + data must be built before assembly (missing dist red).
+    assert "npm ci" in text
+    assert "explorer_publish.py build" in text
+    assert "results_explorer_snapshot_invariants.py" in text
+    assert text.index("npm run --prefix") < text.index("assemble_public_site.py")
 
 
 def test_deploy_serializes_dispatches() -> None:


### PR DESCRIPTION
Follow-up to #2025 (merged with the Sphinx half only): gen1 attempt 2 passed Sphinx but failed assembly on missing results-explorer/dist. This mirrors the full docs.yml explorer sequence (npm ci, typecheck, data build + invariants, npm run build) into the release worktree before assembly. Structural test pins the ordering. Production untouched (deploy job keeps skipping until the build is green).