### PR TITLE
fix(publication): compare canonical DB digest in G2 root-neutrality gate

### DIFF
--- a/.github/workflows/publication-preview-deploy.yml
+++ b/.github/workflows/publication-preview-deploy.yml
@@ -5,9 +5,10 @@
 # subtree built independently from pinned develop + published-results SHAs.
 # GitHub Pages replaces the whole site per deployment, so there is no such
 # thing as a root-independent preview deploy on one Pages site: root
-# neutrality is enforced by the pre-deploy gate (rebuilt root DB digest must
-# equal the baseline live sha256) instead of by mechanism. If the gate cannot
-# prove root neutrality, the run fails BEFORE any Pages write.
+# neutrality is enforced by the pre-deploy gate (rebuilt root DB must be
+# canonical-digest-equivalent to the live production DB, see
+# scripts/publication/compare_db_digest.py) instead of by mechanism. If the
+# gate cannot prove root neutrality, the run fails BEFORE any Pages write.
 #
 # Trigger discipline: workflow_dispatch ONLY. Dispatching with explicit SHAs
 # and an approver IS the manual maintainer approval the A1 contract requires
@@ -263,22 +264,37 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          # The rebuilt root DB must equal the live production DB pinned in the
-          # baseline. This proves the deploy cannot change production bytes at
-          # root; only /preview/<generation>/ is new. Any mismatch fails here,
-          # BEFORE any Pages write.
+          # The rebuilt root DB must be canonical-digest-equivalent to the live
+          # production DB pinned in the baseline (live_database sha256 + url).
+          # Exact bytes can never match: every build stamps a wall-clock
+          # generated_at and float aggregates drift 1 ULP across runners. The
+          # canonical digest excludes the build stamp and rounds floats, so it
+          # still fails on any added/removed table, column, row, rank, or
+          # material value change. This proves the deploy cannot change
+          # production content at root; only /preview/<generation>/ is new.
+          # Any mismatch, and any failure to fetch live for comparison, fails
+          # here BEFORE any Pages write.
           LIVE_DB_SHA=$(uv run -- python -c \
             "import json; print(json.load(open('docs/operations/publication-baseline-2026-08-31.json'))['live_database']['sha256'])")
-          ROOT_DB_SHA="${{ steps.root.outputs.root_db_sha }}"
-          if [ -z "$ROOT_DB_SHA" ]; then
+          LIVE_DB_URL=$(uv run -- python -c \
+            "import json; print(json.load(open('docs/operations/publication-baseline-2026-08-31.json'))['live_database']['url'])")
+          ROOT_DB="site/results/data/results.duckdb"
+          if [ ! -f "$ROOT_DB" ]; then
             echo "::error::rebuilt root has no results.duckdb; refusing deploy"
             exit 1
           fi
-          if [ "$ROOT_DB_SHA" != "$LIVE_DB_SHA" ]; then
-            echo "::error::root DB $ROOT_DB_SHA != live baseline $LIVE_DB_SHA; rebuild is not production-neutral"
+          curl -sSL --fail --retry 3 -o /tmp/live-results.duckdb "$LIVE_DB_URL" || {
+            echo "::error::could not download live DB from $LIVE_DB_URL; refusing deploy"
+            exit 1
+          }
+          LIVE_DL_SHA=$(sha256sum /tmp/live-results.duckdb | cut -d ' ' -f 1)
+          if [ "$LIVE_DL_SHA" != "$LIVE_DB_SHA" ]; then
+            echo "::error::live DB moved under us ($LIVE_DL_SHA != baseline $LIVE_DB_SHA); refusing deploy"
             exit 1
           fi
-          echo "root neutrality proven: $ROOT_DB_SHA"
+          uv run -- python scripts/publication/compare_db_digest.py compare \
+            "$ROOT_DB" /tmp/live-results.duckdb || exit 1
+          echo "root neutrality proven: canonical digest equivalence with live $LIVE_DB_SHA"
 
       - name: Upload Pages artifact (site + preview subtree)
         uses: actions/upload-pages-artifact@v3

--- a/scripts/publication/compare_db_digest.py
+++ b/scripts/publication/compare_db_digest.py
@@ -1,0 +1,148 @@
+#!/usr/bin/env python3
+"""Canonical content digest for explorer results.duckdb files (G2 root-neutrality gate).
+
+Exact file bytes can never match across builds: the pipeline stamps every
+build with a wall-clock ``generated_at``
+(``_project/scripts/explorer_pipeline/pipeline.py``) and float aggregates
+such as ``geomean_ms`` drift by 1 ULP across runners (libm/CPU), e.g.
+``50.5278141562074`` vs ``50.52781415620743``. Both were observed live:
+two same-input builds 60s apart hash differently while holding identical
+logical content.
+
+This script hashes canonical logical content instead: ordered tables,
+schema-ordered columns, rows sorted by full content, floats rounded to
+``--float-sig-digits`` significant digits, and ``--exclude-column``
+build-stamp columns (default: ``generated_at``) dropped. Two databases
+built from the same corpus agree on this digest even when their bytes
+differ. Any added/removed table, column, row, or material value change
+fails the comparison.
+
+Usage:
+  uv run python scripts/publication/compare_db_digest.py digest FILE
+  uv run python scripts/publication/compare_db_digest.py compare REBUILT LIVE
+
+Exit codes: 0 match; 1 content mismatch; 2 unusable input (missing file,
+unreadable database, empty table set).
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import sys
+from pathlib import Path
+
+DEFAULT_EXCLUDE_COLUMNS = ("generated_at",)
+DEFAULT_FLOAT_SIG_DIGITS = 9
+
+
+def _canonical_value(value: object, float_sig_digits: int) -> str:
+    """Render one cell deterministically with float tolerance."""
+    if isinstance(value, bool):
+        return f"bool:{value!r}"
+    if isinstance(value, int):
+        return f"int:{value}"
+    if isinstance(value, float):
+        return f"float:{format(value, f'.{float_sig_digits}g')}"
+    if value is None:
+        return "null:"
+    return f"str:{value}"
+
+
+def canonical_digest(
+    db_path: Path,
+    exclude_columns: tuple[str, ...] = DEFAULT_EXCLUDE_COLUMNS,
+    float_sig_digits: int = DEFAULT_FLOAT_SIG_DIGITS,
+) -> str:
+    """Hash canonical logical content of every table in ``db_path``."""
+    import duckdb
+
+    excluded = set(exclude_columns)
+    con = duckdb.connect(str(db_path), read_only=True)
+    try:
+        tables = [
+            row[0]
+            for row in con.execute(
+                "SELECT table_name FROM information_schema.tables WHERE table_schema = 'main' ORDER BY 1"
+            ).fetchall()
+        ]
+        if not tables:
+            raise ValueError(f"no tables in main schema of '{db_path}'")
+        digest = hashlib.sha256()
+        for table in tables:
+            columns = [row[1] for row in con.execute(f'PRAGMA table_info("{table}")').fetchall()]
+            kept = [name for name in columns if name not in excluded]
+            if not kept:
+                raise ValueError(f"table '{table}' has no comparable columns after exclusions")
+            collist = ", ".join(f'"{name}"' for name in kept)
+            rows = con.execute(f'SELECT {collist} FROM "{table}" ORDER BY {collist}').fetchall()
+            digest.update(f"table:{table}\ncolumns:{','.join(kept)}\nrows:{len(rows)}\n".encode())
+            for row in rows:
+                digest.update("|".join(_canonical_value(value, float_sig_digits) for value in row).encode())
+                digest.update(b"\n")
+        return digest.hexdigest()
+    finally:
+        con.close()
+
+
+def compare_databases(
+    rebuilt: Path,
+    live: Path,
+    exclude_columns: tuple[str, ...] = DEFAULT_EXCLUDE_COLUMNS,
+    float_sig_digits: int = DEFAULT_FLOAT_SIG_DIGITS,
+) -> list[str]:
+    """Diff two databases; empty list means digest-equivalent."""
+    for label, path in (("rebuilt", rebuilt), ("live", live)):
+        if not path.is_file():
+            return [f"{label} database missing: '{path}' (refusing comparison)"]
+    try:
+        rebuilt_digest = canonical_digest(rebuilt, exclude_columns, float_sig_digits)
+    except Exception as exc:
+        return [f"rebuilt database unreadable: {exc}"]
+    try:
+        live_digest = canonical_digest(live, exclude_columns, float_sig_digits)
+    except Exception as exc:
+        return [f"live database unreadable: {exc}"]
+    if rebuilt_digest != live_digest:
+        return [f"canonical content digests differ: rebuilt={rebuilt_digest} live={live_digest}; refusing deploy"]
+    return []
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Canonical digest comparison for results.duckdb")
+    sub = parser.add_subparsers(dest="command", required=True)
+    digest_cmd = sub.add_parser("digest", help="print the canonical digest of one database")
+    digest_cmd.add_argument("db", type=Path)
+    compare_cmd = sub.add_parser("compare", help="fail unless two databases are digest-equivalent")
+    compare_cmd.add_argument("rebuilt", type=Path)
+    compare_cmd.add_argument("live", type=Path)
+    for cmd in (digest_cmd, compare_cmd):
+        cmd.add_argument("--exclude-column", action="append", default=list(DEFAULT_EXCLUDE_COLUMNS))
+        cmd.add_argument("--float-sig-digits", type=int, default=DEFAULT_FLOAT_SIG_DIGITS)
+    args = parser.parse_args(argv)
+
+    if args.command == "digest":
+        if not args.db.is_file():
+            print(f"::error::database missing: '{args.db}'", file=sys.stderr)
+            return 2
+        try:
+            print(canonical_digest(args.db, tuple(args.exclude_column), args.float_sig_digits))
+        except Exception as exc:
+            print(f"::error::database unreadable: {exc}", file=sys.stderr)
+            return 2
+        return 0
+
+    findings = compare_databases(args.rebuilt, args.live, tuple(args.exclude_column), args.float_sig_digits)
+    if findings:
+        for finding in findings:
+            print(f"::error::{finding}")
+        return 1
+    print(
+        f"Digest-equivalent (excluding {', '.join(args.exclude_column)}; "
+        f"floats at {args.float_sig_digits} significant digits)."
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/unit/scripts/publication/test_db_digest.py
+++ b/tests/unit/scripts/publication/test_db_digest.py
@@ -1,0 +1,118 @@
+"""Unit tests for scripts/publication/compare_db_digest.py.
+
+The G2 root-neutrality gate compares a rebuilt root results.duckdb against
+the live production database. Exact bytes can never match (wall-clock
+generated_at stamp, 1-ULP float drift across runners), so the gate hashes
+canonical logical content. These tests pin that contract: build-stamp and
+float noise compare equal, real content changes do not.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+pytestmark = [pytest.mark.unit, pytest.mark.fast]
+
+duckdb = pytest.importorskip("duckdb")
+
+ROOT = Path(__file__).parents[4]
+SCRIPT = ROOT / "scripts/publication/compare_db_digest.py"
+SPEC = importlib.util.spec_from_file_location("compare_db_digest", SCRIPT)
+assert SPEC and SPEC.loader
+compare_db_digest = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(compare_db_digest)
+
+
+def _write_db(path: Path, rows: list[tuple], extra_table: bool = False) -> None:
+    con = duckdb.connect(str(path))
+    try:
+        con.execute("CREATE TABLE results (result_id VARCHAR, geomean_ms DOUBLE, rank INTEGER, generated_at VARCHAR)")
+        for row in rows:
+            con.execute("INSERT INTO results VALUES (?, ?, ?, ?)", row)
+        if extra_table:
+            con.execute("CREATE TABLE extra (id INTEGER)")
+            con.execute("INSERT INTO extra VALUES (1)")
+    finally:
+        con.close()
+
+
+BASE_ROWS = [
+    ("r1", 50.52781415620743, 1, "2026-09-03T00:00:00+00:00"),
+    ("r2", 23.624040633774726, 2, "2026-09-03T00:00:00+00:00"),
+]
+
+
+def test_same_content_different_build_stamp_is_equivalent(tmp_path: Path) -> None:
+    first = tmp_path / "a.duckdb"
+    second = tmp_path / "b.duckdb"
+    _write_db(first, BASE_ROWS)
+    _write_db(
+        second,
+        [(rid, geo, rank, "2026-09-04T12:34:56+00:00") for rid, geo, rank, _ in BASE_ROWS],
+    )
+    assert compare_db_digest.canonical_digest(first) == compare_db_digest.canonical_digest(second)
+    assert compare_db_digest.compare_databases(first, second) == []
+
+
+def test_one_ulp_float_drift_is_equivalent(tmp_path: Path) -> None:
+    first = tmp_path / "a.duckdb"
+    second = tmp_path / "b.duckdb"
+    _write_db(first, BASE_ROWS)
+    drifted = [(rid, float(f"{geo:.15g}") + 1e-15 * abs(geo), rank, ts) for rid, geo, rank, ts in BASE_ROWS]
+    _write_db(second, drifted)
+    assert compare_db_digest.compare_databases(first, second) == []
+
+
+def test_changed_rank_fails(tmp_path: Path) -> None:
+    first = tmp_path / "a.duckdb"
+    second = tmp_path / "b.duckdb"
+    _write_db(first, BASE_ROWS)
+    _write_db(second, [(rid, geo, rank + 1, ts) for rid, geo, rank, ts in BASE_ROWS])
+    findings = compare_db_digest.compare_databases(first, second)
+    assert len(findings) == 1 and "refusing deploy" in findings[0]
+
+
+def test_added_row_fails(tmp_path: Path) -> None:
+    first = tmp_path / "a.duckdb"
+    second = tmp_path / "b.duckdb"
+    _write_db(first, BASE_ROWS)
+    _write_db(second, [*BASE_ROWS, ("r3", 1.0, 3, "2026-09-03T00:00:00+00:00")])
+    assert compare_db_digest.compare_databases(first, second) != []
+
+
+def test_added_table_fails(tmp_path: Path) -> None:
+    first = tmp_path / "a.duckdb"
+    second = tmp_path / "b.duckdb"
+    _write_db(first, BASE_ROWS)
+    _write_db(second, BASE_ROWS, extra_table=True)
+    assert compare_db_digest.compare_databases(first, second) != []
+
+
+def test_material_float_change_fails(tmp_path: Path) -> None:
+    first = tmp_path / "a.duckdb"
+    second = tmp_path / "b.duckdb"
+    _write_db(first, BASE_ROWS)
+    doubled = [(rid, geo * 2.0, rank, ts) for rid, geo, rank, ts in BASE_ROWS]
+    _write_db(second, doubled)
+    assert compare_db_digest.compare_databases(first, second) != []
+
+
+def test_missing_file_is_fail_closed(tmp_path: Path) -> None:
+    first = tmp_path / "a.duckdb"
+    _write_db(first, BASE_ROWS)
+    findings = compare_db_digest.compare_databases(first, tmp_path / "absent.duckdb")
+    assert findings and "missing" in findings[0]
+    assert compare_db_digest.main(["compare", str(first), str(tmp_path / "absent.duckdb")]) == 1
+    assert compare_db_digest.main(["digest", str(tmp_path / "absent.duckdb")]) == 2
+
+
+def test_cli_compare_exit_codes(tmp_path: Path) -> None:
+    first = tmp_path / "a.duckdb"
+    second = tmp_path / "b.duckdb"
+    _write_db(first, BASE_ROWS)
+    _write_db(second, BASE_ROWS)
+    assert compare_db_digest.main(["compare", str(first), str(second)]) == 0
+    assert compare_db_digest.main(["digest", str(first)]) == 0

--- a/tests/unit/workflows/test_publication_preview.py
+++ b/tests/unit/workflows/test_publication_preview.py
@@ -72,6 +72,13 @@ def test_deploy_has_root_neutrality_gate_before_pages_write() -> None:
     assert "live_database" in text
     # Gate compares rebuilt root DB against the live baseline digest.
     assert "refusing deploy" in text or "refuses" in text or "refusing" in text
+    # Exact bytes can never match (wall-clock generated_at, 1-ULP float drift),
+    # so the gate must compare canonical digests, never raw sha256 equality.
+    assert "compare_db_digest" in text
+    assert '"$ROOT_DB_SHA" != "$LIVE_DB_SHA"' not in text
+    # Live must be fetched fail-closed and proven unmoved before comparison.
+    assert "could not download" in text
+    assert "moved under us" in text
 
 
 def test_deploy_requires_pinned_shas_and_approver() -> None:


### PR DESCRIPTION
Exact results.duckdb bytes can never match across builds: the explorer
pipeline stamps every build with a wall-clock generated_at and float
aggregates such as geomean_ms drift 1 ULP across runners (observed live:
same-input rebuilds 60s apart hash differently with identical logical
content). The gate now compares canonical content digests via
scripts/publication/compare_db_digest.py, still failing closed on
missing/unreadable input, live-download failure, live movement, or any
added/removed table, column, row, rank, or material value change.
