### PR TITLE
Repoint publication reconciliation to the floor-CLI export envelope

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1282,6 +1282,9 @@ jobs:
         env:
           TODO_DB_URL: ${{ secrets.TODO_DB_URL }}
           TODO_DB_RO_AUTH_TOKEN: ${{ secrets.TODO_DB_RO_AUTH_TOKEN }}
+          # Required by the 0.6.0 floor CLI; a hosted call without it returns a
+          # legacy-safe exit 2 and the reconciliation gate then fails closed.
+          TODO_DB_AUTH_CONTRACT: v2
         run: |
           if [ -z "${TODO_DB_URL:-}" ] || [ -z "${TODO_DB_RO_AUTH_TOKEN:-}" ]; then
             echo "::error::Missing tracker credentials (TODO_DB_URL/RO_AUTH_TOKEN); cannot verify live publication reconciliation without live evidence."

--- a/scripts/publication/check_plan_reconciliation.py
+++ b/scripts/publication/check_plan_reconciliation.py
@@ -1,21 +1,23 @@
 #!/usr/bin/env python3
 """Check that publication migration plans cite all controlling surfaces.
 
-The A0-A11 tracker sequence is sourced from the live tracker (the todo CLI)
-rather than a hard-coded list, so the check cannot silently pass on a stale
-expected sequence. The check fails closed: if the live tracker cannot be
-reached (no credential or offline), reconciliation is a hard failure rather
-than an advisory pass, because without live evidence the gate cannot prove
-the plan matches the currently pending migration order.
+The A0-A11 tracker sequence is sourced from the live tracker (a single lossless
+``todo-db export`` envelope) rather than a hard-coded list, so the check cannot
+silently pass on a stale expected sequence. The check fails closed: if the live
+tracker cannot be reached (no credential or offline), reconciliation is a hard
+failure rather than an advisory pass, because without live evidence the gate
+cannot prove the plan matches the currently pending migration order.
 """
 
 from __future__ import annotations
 
 import argparse
 import json
+import os
 import re
 import subprocess
 import sys
+import tempfile
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[2]
@@ -77,7 +79,13 @@ EXPECTED_DEPS: dict[str, list[str]] = {
         "independent-publication-a10-release-and-mirror-retirement"
     ],
 }
-TODO_SHIM = ROOT / "_project/scripts/todo"
+# Tracker identity -- must match .todo-db/config.json (project_id / repository).
+TRACKER_PROJECT_ID = "benchbox"
+TRACKER_REPOSITORY = "https://github.com/joeharris76/BenchBox"
+# Environment variables forwarded to the floor CLI for a hosted read. The
+# credentialed CI step supplies them; without TODO_DB_AUTH_CONTRACT=v2 a hosted
+# call returns a legacy-safe exit 2, which this gate then treats as fail-closed.
+_EXPORT_ENV_KEYS = ("TODO_DB_URL", "TODO_DB_RO_AUTH_TOKEN", "TODO_DB_AUTH_CONTRACT")
 
 
 def planned_tracker_ids(text: str, prefix: str) -> list[str]:
@@ -183,48 +191,105 @@ def dependency_violations(plan_order: list[str], deps: dict[str, list[str]]) -> 
     return violations
 
 
-def load_live_deps(item_ids: list[str], todo_cmd: list[str] | None = None) -> dict[str, list[str]] | None:
-    """Return ``{item_id: deps}`` for each id, or ``None`` if any read is unavailable.
+def _export_command(output_path: Path) -> list[str]:
+    return [
+        "uv",
+        "run",
+        "--project",
+        "_project/scripts",
+        "--locked",
+        "--",
+        "todo-db",
+        "--project-id",
+        TRACKER_PROJECT_ID,
+        "--repository",
+        TRACKER_REPOSITORY,
+        "export",
+        "--output",
+        str(output_path),
+    ]
 
-    ``todo list`` does not expose dependencies, so each item is read with
-    ``show <id> --json``. Deps come from the tracker's authoritative graph; an
-    unavailable read is treated as a failure so the gate cannot pass without it.
 
-    The lifecycle state is also re-checked from the ``show`` response: if a
-    required phase flipped to ``dropped`` after the initial ``list`` call,
-    the ``show`` payload carries the fresher state and the gate must fail
-    rather than using the stale non-dropped state from the list.
+def _run_export(output_path: Path) -> bool:
+    """Run the floor-CLI export, writing the lossless envelope to ``output_path``.
+
+    Returns ``False`` on any failure so the caller fails closed. The hosted-read
+    credentials are forwarded from the process environment (the credentialed CI
+    step sets them); they are never hard-coded here.
     """
-    shim_cmd = todo_cmd if todo_cmd is not None else [str(TODO_SHIM)]
-    deps: dict[str, list[str]] = {}
-    for item_id in item_ids:
-        try:
-            result = subprocess.run(
-                [*shim_cmd, "show", item_id, "--json"], capture_output=True, text=True, check=True, timeout=60
-            )
-            item = json.loads(result.stdout)
-        except (OSError, subprocess.CalledProcessError, subprocess.TimeoutExpired, json.JSONDecodeError):
-            return None
-        if str(item.get("state", "")).lower() == "dropped":
-            return None
-        deps[item_id] = item.get("deps") or []
-    return deps
-
-
-def load_live_items(todo_cmd: list[str] | None = None) -> list[dict] | None:
-    """Return parsed ``todo list --json`` items, or ``None`` if the tracker is unreachable."""
-    cmd = todo_cmd if todo_cmd is not None else [str(TODO_SHIM), "list", "--json"]
+    env = dict(os.environ)
+    for key in _EXPORT_ENV_KEYS:
+        value = os.environ.get(key)
+        if value is not None:
+            env[key] = value
     try:
-        result = subprocess.run(cmd, capture_output=True, text=True, check=True, timeout=60)
+        subprocess.run(
+            _export_command(output_path),
+            capture_output=True,
+            text=True,
+            check=True,
+            timeout=120,
+            cwd=ROOT,
+            env=env,
+        )
     except (OSError, subprocess.CalledProcessError, subprocess.TimeoutExpired):
-        return None
+        return False
+    return True
+
+
+def parse_envelope(raw: str) -> dict | None:
+    """Shape a ``todo-db export`` envelope into the maps reconciliation needs.
+
+    Returns ``{"states": {item_id: state}, "deps": {item_id: [needs_item, ...]}}``
+    built from the top-level ``tables.items`` and ``tables.item_deps`` rows, or
+    ``None`` when the envelope is malformed or missing a required table so the
+    caller fails closed.
+    """
     try:
-        payload = json.loads(result.stdout)
+        envelope = json.loads(raw)
     except json.JSONDecodeError:
         return None
-    if not isinstance(payload, list):
+    if not isinstance(envelope, dict):
         return None
-    return payload
+    tables = envelope.get("tables")
+    if not isinstance(tables, dict):
+        return None
+    items = tables.get("items")
+    item_deps = tables.get("item_deps")
+    if not isinstance(items, list) or not isinstance(item_deps, list):
+        return None
+    states: dict[str, str] = {}
+    for row in items:
+        if not isinstance(row, dict) or "id" not in row:
+            return None
+        states[str(row["id"])] = str(row.get("state", ""))
+    deps: dict[str, list[str]] = {item_id: [] for item_id in states}
+    for row in item_deps:
+        if not isinstance(row, dict) or "item_id" not in row or "needs_item" not in row:
+            return None
+        deps.setdefault(str(row["item_id"]), []).append(str(row["needs_item"]))
+    return {"states": states, "deps": {item_id: sorted(values) for item_id, values in deps.items()}}
+
+
+def load_tracker_snapshot() -> dict | None:
+    """Export the live tracker once and shape it, or ``None`` if unavailable.
+
+    A single ``todo-db export`` is an atomic snapshot of the whole tracker, so
+    the item states and the dependency graph it returns are mutually consistent
+    with no re-read needed (the retired ``todo list``/``todo show`` path had to
+    re-read to detect concurrent edits). Any failure -- the export command, an
+    unreadable file, or a malformed envelope -- returns ``None`` and the gate
+    fails closed.
+    """
+    with tempfile.TemporaryDirectory() as tmp:
+        output_path = Path(tmp) / "tracker-export.json"
+        if not _run_export(output_path):
+            return None
+        try:
+            raw = output_path.read_text(encoding="utf-8")
+        except OSError:
+            return None
+    return parse_envelope(raw)
 
 
 def main() -> int:
@@ -235,46 +300,50 @@ def main() -> int:
     missing = [surface for surface in REQUIRED_SURFACES if surface not in text]
     missing.extend(gate for gate in REQUIRED_GATES if gate not in text)
     tracker_ids = planned_tracker_ids(text, args.todo_prefix)
-    live_items = load_live_items()
+    snapshot = load_tracker_snapshot()
 
-    if live_items is None:
+    if snapshot is None:
         print(
             "ERROR: live tracker unavailable; cannot reconcile the A0-A11 sequence (fail closed)",
             file=sys.stderr,
         )
         missing.append("exact ordered A0-A11 tracker sequence (live tracker unavailable)")
     else:
+        states: dict[str, str] = snapshot["states"]
+        dep_graph: dict[str, list[str]] = snapshot["deps"]
+        prefix_ids = [item_id for item_id in states if item_id.startswith(args.todo_prefix)]
+
         # Retain dropped rows for explicit drift failure. Filtering dropped
         # before comparison would hide a dropped required phase when the
         # decision is edited to omit that phase (11 vs 11 would match).
-        # Check against EXPECTED_DEPS so the gate fails even if the plan
-        # text was changed to match the filtered live set.
-        prefix_all = [item for item in live_items if str(item.get("id", "")).startswith(args.todo_prefix)]
-        dropped_required = [
-            item["id"]
-            for item in prefix_all
-            if str(item.get("state", "")).lower() == "dropped" and item["id"] in EXPECTED_DEPS
-        ]
-        # Also catch dropped items that appear in the plan but are not in
-        # EXPECTED_DEPS yet (forward-compat if the freeze set grows).
-        for item in prefix_all:
-            if (
-                str(item.get("state", "")).lower() == "dropped"
-                and str(item.get("id", "")) in tracker_ids
-                and item["id"] not in dropped_required
-            ):
-                dropped_required.append(item["id"])
-        for did in sorted(dropped_required, key=lambda item_id: _phase_key(item_id, args.todo_prefix)):
+        # Check against EXPECTED_DEPS and the plan text so the gate fails even
+        # if the plan text was changed to match the filtered live set.
+        dropped_required = sorted(
+            (
+                item_id
+                for item_id in prefix_ids
+                if states[item_id].lower() == "dropped" and (item_id in EXPECTED_DEPS or item_id in tracker_ids)
+            ),
+            key=lambda item_id: _phase_key(item_id, args.todo_prefix),
+        )
+        for did in dropped_required:
             missing.append(f"dropped required phase is dropped: {did}")
-        live_scope = [
-            item
-            for item in live_items
-            if str(item.get("id", "")).startswith(args.todo_prefix)
-            and str(item.get("state", "")).lower() != "dropped"
-            and item.get("id") in EXPECTED_DEPS
-        ]
-        live_ids = [item["id"] for item in live_scope]
-        live_deps = load_live_deps(live_ids)
+
+        live_item_ids = sorted(
+            (item_id for item_id in prefix_ids if states[item_id].lower() != "dropped" and item_id in EXPECTED_DEPS),
+            key=lambda item_id: _phase_key(item_id, args.todo_prefix),
+        )
+
+        # Every pinned phase must carry its dependency rows in the same atomic
+        # export snapshot; an absent id means the envelope is incomplete, so
+        # fail closed rather than treating it as having no dependencies.
+        live_deps: dict[str, list[str]] | None = {}
+        for item_id in live_item_ids:
+            if item_id not in dep_graph:
+                live_deps = None
+                break
+            live_deps[item_id] = dep_graph[item_id]
+
         if live_deps is None:
             print(
                 "ERROR: could not read the tracker dependency graph; cannot reconcile A0-A11 order (fail closed)",
@@ -282,52 +351,6 @@ def main() -> int:
             )
             missing.append("exact ordered A0-A11 tracker sequence (dependency graph unavailable)")
         else:
-            # Verify stable snapshot: the tracker must not have changed
-            # between the initial list and the per-item show reads. A concurrent
-            # change (e.g., A0's deps modified after its show, or a new A12
-            # added after the list) could otherwise assemble a mixed snapshot
-            # that still matches EXPECTED_DEPS. Use a trailing revision check
-            # via re-reading the list and deps after the second sweep so the
-            # window ends with an atomic list comparison, not with per-item reads.
-            live_items_after = load_live_items()
-            if live_items_after is None:
-                missing.append("exact ordered A0-A11 tracker sequence (live tracker unavailable on re-read)")
-            else:
-                prefix_after = [
-                    item for item in live_items_after if str(item.get("id", "")).startswith(args.todo_prefix)
-                ]
-                before_map = {item["id"]: str(item.get("state", "")).lower() for item in prefix_all}
-                after_map = {item["id"]: str(item.get("state", "")).lower() for item in prefix_after}
-                if before_map != after_map:
-                    missing.append("exact ordered A0-A11 tracker sequence (live tracker changed during check)")
-                else:
-                    live_deps_after = load_live_deps(live_ids)
-                    if live_deps_after is None:
-                        missing.append("exact ordered A0-A11 tracker sequence (dependency graph changed during check)")
-                    elif live_deps_after != live_deps:
-                        missing.append(
-                            "exact ordered A0-A11 tracker sequence (live dependency graph changed during check)"
-                        )
-                    else:
-                        # Final revision check after the second sweep: ensures no
-                        # new phase or state change slipped in after the last show.
-                        live_items_final = load_live_items()
-                        if live_items_final is None:
-                            missing.append(
-                                "exact ordered A0-A11 tracker sequence (live tracker unavailable on final re-read)"
-                            )
-                        else:
-                            prefix_final = [
-                                item
-                                for item in live_items_final
-                                if str(item.get("id", "")).startswith(args.todo_prefix)
-                            ]
-                            final_map = {item["id"]: str(item.get("state", "")).lower() for item in prefix_final}
-                            if final_map != before_map:
-                                missing.append(
-                                    "exact ordered A0-A11 tracker sequence (live tracker changed after dependency reads)"
-                                )
-            live_item_ids = sorted(live_ids, key=lambda item_id: _phase_key(item_id, args.todo_prefix))
             expected_sorted = sorted(EXPECTED_DEPS.keys(), key=lambda item_id: _phase_key(item_id, args.todo_prefix))
             # Require every pinned phase to be present in both sequences.
             # Without this, both the plan and live could omit a terminal phase

--- a/tests/unit/scripts/publication/test_plan_reconciliation.py
+++ b/tests/unit/scripts/publication/test_plan_reconciliation.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import importlib.util
+import json
 from pathlib import Path
 
 import pytest
@@ -68,6 +69,27 @@ REAL_DEPS = {
 }
 
 
+def _snapshot(states: dict[str, str] | None = None, deps: dict[str, list[str]] | None = None) -> dict:
+    if states is None:
+        states = dict.fromkeys(LIVE_A0_A11, "active")
+    if deps is None:
+        deps = {item_id: list(REAL_DEPS.get(item_id, [])) for item_id in states}
+    return {"states": states, "deps": deps}
+
+
+def _envelope(items: list[dict], item_deps: list[dict]) -> str:
+    return json.dumps({"tables": {"items": items, "item_deps": item_deps}})
+
+
+def _prefixed_argv(monkeypatch) -> None:
+    import sys
+
+    monkeypatch.setattr(sys, "argv", ["check_plan_reconciliation", "--todo-prefix", PREFIX])
+
+
+# --- planned/live ordering helpers (unchanged surface) -----------------------
+
+
 def test_all_controlling_surfaces_and_gates_are_named() -> None:
     text = reconciliation.DECISION.read_text()
 
@@ -101,15 +123,6 @@ def test_live_tracker_ids_orders_by_a_phase_not_hardcoded_order() -> None:
     ]
 
 
-def test_live_tracker_ids_ignores_items_outside_prefix() -> None:
-    payload = [
-        {"id": "independent-publication-a0-baseline-and-freeze"},
-        {"id": "some-other-item"},
-    ]
-
-    assert reconciliation.live_tracker_ids(payload, PREFIX) == ["independent-publication-a0-baseline-and-freeze"]
-
-
 def test_live_tracker_ids_excludes_dropped_items() -> None:
     payload = [
         {"id": "independent-publication-a0-baseline-and-freeze", "state": "done"},
@@ -131,133 +144,181 @@ def test_decision_names_exact_live_ordered_tracker_sequence() -> None:
     assert reconciliation.planned_tracker_ids(text, PREFIX) == LIVE_A0_A11
 
 
-def test_live_tracker_ids_orders_by_dependency_graph_not_id_number() -> None:
-    payload = [
-        {
-            "id": "independent-publication-a0-baseline-and-freeze",
-            "deps": ["independent-publication-a2-corpus-trust-isolation"],
-        },
-        {
-            "id": "independent-publication-a1-authority-and-threat-contract",
-            "deps": ["independent-publication-a0-baseline-and-freeze"],
-        },
-        {"id": "independent-publication-a2-corpus-trust-isolation", "deps": []},
-    ]
-
-    assert reconciliation.live_tracker_ids(payload, PREFIX) == [
-        "independent-publication-a2-corpus-trust-isolation",
-        "independent-publication-a0-baseline-and-freeze",
-        "independent-publication-a1-authority-and-threat-contract",
-    ]
-
-
-def test_live_tracker_ids_detects_dependency_cycle() -> None:
-    payload = [
-        {
-            "id": "independent-publication-a0-baseline-and-freeze",
-            "deps": ["independent-publication-a1-authority-and-threat-contract"],
-        },
-        {
-            "id": "independent-publication-a1-authority-and-threat-contract",
-            "deps": ["independent-publication-a0-baseline-and-freeze"],
-        },
-    ]
-
-    with pytest.raises(ValueError):
-        reconciliation.live_tracker_ids(payload, PREFIX)
-
-
 def test_authority_is_not_a_hardcoded_tracker_list() -> None:
     assert not hasattr(reconciliation, "REQUIRED_TRACKER_IDS")
 
 
-def test_load_live_items_returns_none_when_todo_cmd_fails() -> None:
-    import sys
-
-    assert reconciliation.load_live_items([sys.executable, "-c", "raise SystemExit(1)"]) is None
+# --- export envelope parsing ------------------------------------------------
 
 
-def test_load_live_items_parses_json_list() -> None:
-    import json
-    import sys
+def test_parse_envelope_builds_state_and_dep_maps() -> None:
+    raw = _envelope(
+        items=[
+            {"id": "independent-publication-a0-baseline-and-freeze", "state": "done"},
+            {"id": "independent-publication-a1-authority-and-threat-contract", "state": "active"},
+        ],
+        item_deps=[
+            {
+                "item_id": "independent-publication-a1-authority-and-threat-contract",
+                "needs_item": "independent-publication-a0-baseline-and-freeze",
+            },
+        ],
+    )
 
-    payload = [{"id": "independent-publication-a0-baseline-and-freeze"}]
-    cmd = [sys.executable, "-c", f"import json,sys; print(json.dumps({json.dumps(payload)}))"]
+    snapshot = reconciliation.parse_envelope(raw)
 
-    assert reconciliation.load_live_items(cmd) == payload
-
-
-def test_load_live_items_returns_none_on_non_list_json() -> None:
-    import sys
-
-    cmd = [sys.executable, "-c", "print('{}')"]
-
-    assert reconciliation.load_live_items(cmd) is None
-
-
-def test_load_live_items_returns_none_on_invalid_json() -> None:
-    import sys
-
-    cmd = [sys.executable, "-c", "print('not json')"]
-
-    assert reconciliation.load_live_items(cmd) is None
-
-
-def test_load_live_deps_returns_deps_for_each_item() -> None:
-    import json
-    import sys
-
-    payload = {
-        "id": "independent-publication-a1-authority-and-threat-contract",
-        "deps": ["independent-publication-a0-baseline-and-freeze"],
-    }
-    cmd = [sys.executable, "-c", f"import sys,json; print(json.dumps({json.dumps(payload)}))"]
-
-    assert reconciliation.load_live_deps(["independent-publication-a1-authority-and-threat-contract"], cmd) == {
-        "independent-publication-a1-authority-and-threat-contract": ["independent-publication-a0-baseline-and-freeze"]
+    assert snapshot == {
+        "states": {
+            "independent-publication-a0-baseline-and-freeze": "done",
+            "independent-publication-a1-authority-and-threat-contract": "active",
+        },
+        "deps": {
+            "independent-publication-a0-baseline-and-freeze": [],
+            "independent-publication-a1-authority-and-threat-contract": [
+                "independent-publication-a0-baseline-and-freeze"
+            ],
+        },
     }
 
 
-def test_load_live_deps_returns_none_when_show_fails() -> None:
-    import sys
-
-    cmd = [sys.executable, "-c", "raise SystemExit(1)"]
-
-    assert reconciliation.load_live_deps(["independent-publication-a1-authority-and-threat-contract"], cmd) is None
+def test_parse_envelope_returns_none_on_malformed_json() -> None:
+    assert reconciliation.parse_envelope("not json") is None
 
 
-def test_main_fails_closed_when_live_tracker_unavailable(monkeypatch) -> None:
-    import sys
+def test_parse_envelope_returns_none_on_truncated_envelope() -> None:
+    raw = _envelope(items=[{"id": "x", "state": "active"}], item_deps=[])
+    assert reconciliation.parse_envelope(raw[: len(raw) // 2]) is None
 
-    monkeypatch.setattr(sys, "argv", ["check_plan_reconciliation", "--todo-prefix", "independent-publication-"])
-    monkeypatch.setattr(reconciliation, "load_live_items", lambda: None)
+
+def test_parse_envelope_returns_none_on_missing_tables() -> None:
+    assert reconciliation.parse_envelope(json.dumps({"events": []})) is None
+    assert reconciliation.parse_envelope(json.dumps({"tables": {"items": []}})) is None
+
+
+def test_parse_envelope_returns_none_when_item_row_lacks_id() -> None:
+    assert (
+        reconciliation.parse_envelope(json.dumps({"tables": {"items": [{"state": "active"}], "item_deps": []}})) is None
+    )
+
+
+def test_load_tracker_snapshot_returns_none_when_export_fails(monkeypatch) -> None:
+    monkeypatch.setattr(reconciliation, "_run_export", lambda output_path: False)
+
+    assert reconciliation.load_tracker_snapshot() is None
+
+
+def test_load_tracker_snapshot_parses_written_envelope(monkeypatch) -> None:
+    raw = _envelope(items=[{"id": "x", "state": "active"}], item_deps=[{"item_id": "x", "needs_item": "y"}])
+
+    def fake_run_export(output_path: Path) -> bool:
+        output_path.write_text(raw, encoding="utf-8")
+        return True
+
+    monkeypatch.setattr(reconciliation, "_run_export", fake_run_export)
+
+    assert reconciliation.load_tracker_snapshot() == {
+        "states": {"x": "active"},
+        "deps": {"x": ["y"]},
+    }
+
+
+# --- main() fail-closed / success behaviour --------------------------------
+
+
+def test_main_fails_closed_when_snapshot_unavailable(monkeypatch) -> None:
+    _prefixed_argv(monkeypatch)
+    monkeypatch.setattr(reconciliation, "load_tracker_snapshot", lambda: None)
 
     assert reconciliation.main() == 1
 
 
-def test_main_fails_closed_when_dependency_graph_unavailable(monkeypatch) -> None:
-    import sys
-
-    monkeypatch.setattr(sys, "argv", ["check_plan_reconciliation", "--todo-prefix", "independent-publication-"])
-    live_items = [{"id": item_id} for item_id in LIVE_A0_A11]
-    monkeypatch.setattr(reconciliation, "load_live_items", lambda: live_items)
-    monkeypatch.setattr(reconciliation, "load_live_deps", lambda ids: None)
+def test_main_fails_closed_when_dependency_row_absent(monkeypatch) -> None:
+    _prefixed_argv(monkeypatch)
+    states = dict.fromkeys(LIVE_A0_A11, "active")
+    deps = {item_id: list(REAL_DEPS.get(item_id, [])) for item_id in LIVE_A0_A11}
+    deps.pop("independent-publication-a5-noop-deploy-and-automatic-rollback")
+    monkeypatch.setattr(reconciliation, "load_tracker_snapshot", lambda: _snapshot(states, deps))
 
     assert reconciliation.main() == 1
+
+
+def test_main_succeeds_when_live_sequence_matches_decision(monkeypatch) -> None:
+    _prefixed_argv(monkeypatch)
+    monkeypatch.setattr(reconciliation, "load_tracker_snapshot", lambda: _snapshot())
+
+    assert reconciliation.main() == 0
 
 
 def test_main_fails_when_live_sequence_does_not_match(monkeypatch) -> None:
-    import sys
-
-    monkeypatch.setattr(sys, "argv", ["check_plan_reconciliation", "--todo-prefix", "independent-publication-"])
-    live_items = [
-        {"id": "independent-publication-a0-baseline-and-freeze"},
-        {"id": "independent-publication-a1-authority-and-threat-contract"},
-    ]
-    monkeypatch.setattr(reconciliation, "load_live_items", lambda: live_items)
-    monkeypatch.setattr(reconciliation, "load_live_deps", lambda ids: {iid: [] for iid in ids})
+    _prefixed_argv(monkeypatch)
+    states = {
+        "independent-publication-a0-baseline-and-freeze": "active",
+        "independent-publication-a1-authority-and-threat-contract": "active",
+    }
+    monkeypatch.setattr(reconciliation, "load_tracker_snapshot", lambda: _snapshot(states))
 
     assert reconciliation.main() == 1
+
+
+def test_main_fails_on_dependency_edge_drift(monkeypatch) -> None:
+    _prefixed_argv(monkeypatch)
+    deps = {item_id: list(REAL_DEPS.get(item_id, [])) for item_id in LIVE_A0_A11}
+    deps["independent-publication-a1-authority-and-threat-contract"] = []
+    monkeypatch.setattr(reconciliation, "load_tracker_snapshot", lambda: _snapshot(deps=deps))
+
+    assert reconciliation.main() == 1
+
+
+def test_main_fails_on_partial_edge_removal(monkeypatch) -> None:
+    _prefixed_argv(monkeypatch)
+    deps = {item_id: list(REAL_DEPS.get(item_id, [])) for item_id in LIVE_A0_A11}
+    deps["independent-publication-a8-published-results-gate-and-shadow-promotion"] = [
+        "independent-publication-a2-corpus-trust-isolation",
+        "independent-publication-a4-hermetic-build-and-shadow-assembly",
+    ]
+    monkeypatch.setattr(reconciliation, "load_tracker_snapshot", lambda: _snapshot(deps=deps))
+
+    assert reconciliation.main() == 1
+
+
+def test_main_fails_when_required_phase_is_dropped(monkeypatch) -> None:
+    _prefixed_argv(monkeypatch)
+    states = dict.fromkeys(LIVE_A0_A11, "done")
+    states["independent-publication-a5-noop-deploy-and-automatic-rollback"] = "dropped"
+    monkeypatch.setattr(reconciliation, "load_tracker_snapshot", lambda: _snapshot(states))
+
+    assert reconciliation.main() == 1
+
+
+def test_main_fails_when_dropped_phase_omitted_from_decision(monkeypatch) -> None:
+    _prefixed_argv(monkeypatch)
+    states = dict.fromkeys(LIVE_A0_A11, "done")
+    states["independent-publication-a5-noop-deploy-and-automatic-rollback"] = "dropped"
+    omitted = [item_id for item_id in LIVE_A0_A11 if item_id != LIVE_A0_A11[5]]
+    monkeypatch.setattr(reconciliation, "load_tracker_snapshot", lambda: _snapshot(states))
+    monkeypatch.setattr(reconciliation, "planned_tracker_ids", lambda text, prefix: omitted)
+
+    assert reconciliation.main() == 1
+
+
+def test_main_fails_when_pinned_phase_missing_from_plan(monkeypatch) -> None:
+    _prefixed_argv(monkeypatch)
+    omitted = LIVE_A0_A11[:-1]
+    monkeypatch.setattr(reconciliation, "load_tracker_snapshot", lambda: _snapshot())
+    monkeypatch.setattr(reconciliation, "planned_tracker_ids", lambda text, prefix: omitted)
+
+    assert reconciliation.main() == 1
+
+
+def test_main_fails_when_pinned_phase_missing_from_live(monkeypatch) -> None:
+    _prefixed_argv(monkeypatch)
+    states = dict.fromkeys(LIVE_A0_A11[:-1], "done")
+    monkeypatch.setattr(reconciliation, "load_tracker_snapshot", lambda: _snapshot(states))
+
+    assert reconciliation.main() == 1
+
+
+# --- dependency_violations (pure) ------------------------------------------
 
 
 def test_dependency_violations_passes_for_real_dag() -> None:
@@ -295,42 +356,7 @@ def test_dependency_violations_surfaces_cycle_as_backward_edge() -> None:
     assert any("depends on" in v for v in violations)
 
 
-def test_main_succeeds_when_live_sequence_matches_decision(monkeypatch) -> None:
-    import sys
-
-    monkeypatch.setattr(sys, "argv", ["check_plan_reconciliation", "--todo-prefix", "independent-publication-"])
-    live_items = [{"id": item_id} for item_id in LIVE_A0_A11]
-    monkeypatch.setattr(reconciliation, "load_live_items", lambda: live_items)
-    monkeypatch.setattr(
-        reconciliation,
-        "load_live_deps",
-        lambda ids: {iid: REAL_DEPS.get(iid, []) for iid in ids},
-    )
-
-    assert reconciliation.main() == 0
-
-
-def test_main_fails_on_dependency_edge_drift(monkeypatch) -> None:
-    import sys
-
-    monkeypatch.setattr(sys, "argv", ["check_plan_reconciliation", "--todo-prefix", "independent-publication-"])
-    live_items = [{"id": item_id} for item_id in LIVE_A0_A11]
-    drifted = dict(REAL_DEPS)
-    drifted["independent-publication-a1-authority-and-threat-contract"] = []
-    monkeypatch.setattr(reconciliation, "load_live_items", lambda: live_items)
-    monkeypatch.setattr(reconciliation, "load_live_deps", lambda ids: {iid: drifted.get(iid, []) for iid in ids})
-
-    assert reconciliation.main() == 1
-
-
-def test_expected_deps_matches_real_deps() -> None:
-    assert reconciliation.EXPECTED_DEPS == REAL_DEPS
-
-
 def test_dependency_violations_fails_on_partial_edge_removal() -> None:
-    # A8 originally depends on a2,a4,a7; removing a7 while keeping a2,a4
-    # still leaves a valid topological order (orphan check would pass) but
-    # must be flagged as missing expected edge.
     drifted = dict(REAL_DEPS)
     drifted["independent-publication-a8-published-results-gate-and-shadow-promotion"] = [
         "independent-publication-a2-corpus-trust-isolation",
@@ -355,57 +381,6 @@ def test_dependency_violations_fails_on_unexpected_edge() -> None:
     assert any("has unexpected dependency" in v and "a3-control" in v for v in violations)
 
 
-def test_main_fails_on_partial_edge_removal(monkeypatch) -> None:
-    import sys
-
-    monkeypatch.setattr(sys, "argv", ["check_plan_reconciliation", "--todo-prefix", "independent-publication-"])
-    live_items = [{"id": item_id} for item_id in LIVE_A0_A11]
-    drifted = dict(REAL_DEPS)
-    drifted["independent-publication-a8-published-results-gate-and-shadow-promotion"] = [
-        "independent-publication-a2-corpus-trust-isolation",
-        "independent-publication-a4-hermetic-build-and-shadow-assembly",
-    ]
-    monkeypatch.setattr(reconciliation, "load_live_items", lambda: live_items)
-    monkeypatch.setattr(reconciliation, "load_live_deps", lambda ids: {iid: drifted.get(iid, []) for iid in ids})
-
-    assert reconciliation.main() == 1
-
-
-def test_main_fails_when_required_phase_is_dropped(monkeypatch) -> None:
-    import sys
-
-    monkeypatch.setattr(sys, "argv", ["check_plan_reconciliation", "--todo-prefix", "independent-publication-"])
-    live_items = [{"id": item_id, "state": "done"} for item_id in LIVE_A0_A11]
-    # Mark a5 as dropped but keep it in live set; main must retain it to fail.
-    for item in live_items:
-        if item["id"] == "independent-publication-a5-noop-deploy-and-automatic-rollback":
-            item["state"] = "dropped"
-    monkeypatch.setattr(reconciliation, "load_live_items", lambda: live_items)
-    monkeypatch.setattr(
-        reconciliation,
-        "load_live_deps",
-        lambda ids: {iid: REAL_DEPS.get(iid, []) for iid in ids},
-    )
-
-    assert reconciliation.main() == 1
-
-
-def test_main_fails_when_dropped_phase_omitted_from_decision(monkeypatch) -> None:
-    import sys
-
-    # Live: a5 is dropped, plus 11 other actives. Decision is edited to omit a5 (11 ids).
-    live_items = [{"id": item_id, "state": "done"} for item_id in LIVE_A0_A11 if item_id != LIVE_A0_A11[5]]
-    live_items.append({"id": LIVE_A0_A11[5], "state": "dropped"})
-    omitted_tracker = [iid for iid in LIVE_A0_A11 if iid != LIVE_A0_A11[5]]
-
-    monkeypatch.setattr(sys, "argv", ["check_plan_reconciliation", "--todo-prefix", "independent-publication-"])
-    monkeypatch.setattr(reconciliation, "load_live_items", lambda: live_items)
-    monkeypatch.setattr(reconciliation, "load_live_deps", lambda ids: {iid: REAL_DEPS.get(iid, []) for iid in ids})
-    monkeypatch.setattr(reconciliation, "planned_tracker_ids", lambda text, prefix: omitted_tracker)
-
-    assert reconciliation.main() == 1
-
-
 def test_dependency_violations_fails_on_external_dependency() -> None:
     drifted = dict(REAL_DEPS)
     drifted["independent-publication-a3-control-plane-and-artifact-contract"] = [
@@ -419,39 +394,6 @@ def test_dependency_violations_fails_on_external_dependency() -> None:
     assert any("has unexpected external dependency" in v and "external-tracker-item" in v for v in violations)
 
 
-def test_load_live_deps_returns_none_when_show_is_dropped() -> None:
-    import json
-    import sys
-
-    payload = {
-        "id": "independent-publication-a5-noop-deploy-and-automatic-rollback",
-        "state": "dropped",
-        "deps": [],
-    }
-    cmd = [sys.executable, "-c", f"import sys,json; print(json.dumps({json.dumps(payload)}))"]
-
-    assert reconciliation.load_live_deps(["independent-publication-a5-noop-deploy-and-automatic-rollback"], cmd) is None
-
-
-def test_main_fails_when_dependency_show_reports_dropped(monkeypatch) -> None:
-    import sys
-
-    monkeypatch.setattr(sys, "argv", ["check_plan_reconciliation", "--todo-prefix", "independent-publication-"])
-    live_items = [{"id": item_id, "state": "done"} for item_id in LIVE_A0_A11]
-
-    def fake_load_deps(ids):
-        # Simulate race: show for a5 reports dropped
-        for iid in ids:
-            if iid == "independent-publication-a5-noop-deploy-and-automatic-rollback":
-                return None
-        return {iid: REAL_DEPS.get(iid, []) for iid in ids}
-
-    monkeypatch.setattr(reconciliation, "load_live_items", lambda: live_items)
-    monkeypatch.setattr(reconciliation, "load_live_deps", fake_load_deps)
-
-    assert reconciliation.main() == 1
-
-
 def test_dependency_violations_fails_on_unpinned_phase() -> None:
     plan = LIVE_A0_A11 + ["independent-publication-a12-new-phase"]
     drifted = dict(REAL_DEPS)
@@ -462,89 +404,5 @@ def test_dependency_violations_fails_on_unpinned_phase() -> None:
     assert any("is not pinned in EXPECTED_DEPS" in v and "a12-new-phase" in v for v in violations)
 
 
-def test_main_fails_when_pinned_phase_missing_from_both(monkeypatch) -> None:
-    import sys
-
-    omitted = LIVE_A0_A11[:-1]  # omit A11
-    live_items = [{"id": item_id, "state": "done"} for item_id in omitted]
-
-    monkeypatch.setattr(sys, "argv", ["check_plan_reconciliation", "--todo-prefix", "independent-publication-"])
-    monkeypatch.setattr(reconciliation, "load_live_items", lambda: live_items)
-    monkeypatch.setattr(reconciliation, "load_live_deps", lambda ids: {iid: REAL_DEPS.get(iid, []) for iid in ids})
-    monkeypatch.setattr(reconciliation, "planned_tracker_ids", lambda text, prefix: omitted)
-
-    assert reconciliation.main() == 1
-
-
-def test_main_fails_when_pinned_phase_missing_from_plan(monkeypatch) -> None:
-    import sys
-
-    omitted = LIVE_A0_A11[:-1]
-    live_items = [{"id": item_id} for item_id in LIVE_A0_A11]
-
-    monkeypatch.setattr(sys, "argv", ["check_plan_reconciliation", "--todo-prefix", "independent-publication-"])
-    monkeypatch.setattr(reconciliation, "load_live_items", lambda: live_items)
-    monkeypatch.setattr(reconciliation, "load_live_deps", lambda ids: {iid: REAL_DEPS.get(iid, []) for iid in ids})
-    monkeypatch.setattr(reconciliation, "planned_tracker_ids", lambda text, prefix: omitted)
-
-    assert reconciliation.main() == 1
-
-
-def test_main_fails_when_pinned_phase_missing_from_live(monkeypatch) -> None:
-    import sys
-
-    live_items = [{"id": item_id, "state": "done"} for item_id in LIVE_A0_A11[:-1]]
-
-    monkeypatch.setattr(sys, "argv", ["check_plan_reconciliation", "--todo-prefix", "independent-publication-"])
-    monkeypatch.setattr(reconciliation, "load_live_items", lambda: live_items)
-    monkeypatch.setattr(reconciliation, "load_live_deps", lambda ids: {iid: REAL_DEPS.get(iid, []) for iid in ids})
-
-    assert reconciliation.main() == 1
-
-
-def test_main_fails_when_tracker_changes_during_check(monkeypatch) -> None:
-    import sys
-
-    live_items_initial = [{"id": item_id, "state": "done"} for item_id in LIVE_A0_A11]
-    live_items_after = [{"id": item_id, "state": "done"} for item_id in LIVE_A0_A11] + [
-        {"id": "independent-publication-a12-new-phase", "state": "active"}
-    ]
-
-    call_count = {"n": 0}
-
-    def fake_load_items():
-        call_count["n"] += 1
-        return live_items_initial if call_count["n"] == 1 else live_items_after
-
-    monkeypatch.setattr(sys, "argv", ["check_plan_reconciliation", "--todo-prefix", "independent-publication-"])
-    monkeypatch.setattr(reconciliation, "load_live_items", fake_load_items)
-    monkeypatch.setattr(
-        reconciliation,
-        "load_live_deps",
-        lambda ids: {iid: REAL_DEPS.get(iid, []) for iid in ids},
-    )
-
-    assert reconciliation.main() == 1
-
-
-def test_main_fails_when_deps_change_during_check(monkeypatch) -> None:
-    import sys
-
-    live_items = [{"id": item_id, "state": "done"} for item_id in LIVE_A0_A11]
-
-    call_count = {"n": 0}
-
-    def fake_load_deps(ids):
-        call_count["n"] += 1
-        if call_count["n"] == 1:
-            return {iid: REAL_DEPS.get(iid, []) for iid in ids}
-        # Second call (stability check) returns drifted deps for a0
-        drifted = dict(REAL_DEPS)
-        drifted["independent-publication-a1-authority-and-threat-contract"] = []
-        return {iid: drifted.get(iid, []) for iid in ids}
-
-    monkeypatch.setattr(sys, "argv", ["check_plan_reconciliation", "--todo-prefix", "independent-publication-"])
-    monkeypatch.setattr(reconciliation, "load_live_items", lambda: live_items)
-    monkeypatch.setattr(reconciliation, "load_live_deps", fake_load_deps)
-
-    assert reconciliation.main() == 1
+def test_expected_deps_matches_real_deps() -> None:
+    assert reconciliation.EXPECTED_DEPS == REAL_DEPS


### PR DESCRIPTION
First half of retiring `_project/scripts/todo shim: the publication reconciliation gate reads live tracker state from one atomic `todo-db export` envelope instead of shelling the shim's removed-in-spirit `list`/`show` verbs. Fail-closed semantics unchanged.

Ordering matters: this lands while the shim still exists because the credentialed CI step runs the base-branch script whenever this file changes. Verified the new invocation (`export --output`, `--project-id`/`--repository`, `TODO_DB_RO_AUTH_TOKEN`, `TODO_DB_AUTH_CONTRACT=v2`) against the currently vendored 0.4.3 wheel's CLI, whose envelope shape matches 0.6.x. Unit tests (32) and ruff pass locally. The shim's deletion follows in #2032, which rebases onto this.