### PR TITLE
feat(publication): add independent production Pages deployer

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -251,8 +251,37 @@ jobs:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
+      - name: Check for independent publication ownership
+        id: independent
+        env:
+          GH_TOKEN: ${{ github.token }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          ACTIVE=false
+          gh api --paginate "repos/${{ github.repository }}/actions/artifacts?per_page=100" \
+            --jq '.artifacts[] | select(.expired == false) | select(.name | startswith("publication-live-receipt-")) | "\(.workflow_run.id)"' \
+            | sort -ru > independent-publication-runs.txt
+          while read -r RUN_ID; do
+            [ -n "${RUN_ID:-}" ] || continue
+            RUN_META=$(gh api "repos/${{ github.repository }}/actions/runs/$RUN_ID" \
+              --jq '[.name, .status, .conclusion, .event, .head_branch] | @tsv')
+            IFS=$'\t' read -r RUN_NAME RUN_STATUS RUN_CONCLUSION RUN_EVENT RUN_BRANCH <<< "$RUN_META"
+            if [[ "$RUN_NAME" == "Publication Control Plane Deployment" && \
+                  "$RUN_STATUS" == "completed" && "$RUN_CONCLUSION" == "success" && \
+                  "$RUN_EVENT" == "workflow_dispatch" && "$RUN_BRANCH" == "develop" ]]; then
+              ACTIVE=true
+              break
+            fi
+          done < independent-publication-runs.txt
+          echo "active=$ACTIVE" >> "$GITHUB_OUTPUT"
+          if [ "$ACTIVE" = "true" ]; then
+            echo "::notice::Independent publication owns Pages; skipping the legacy release deployment"
+          fi
+
       - name: Deploy to GitHub Pages
         id: deployment
+        if: steps.independent.outputs.active != 'true'
         uses: actions/deploy-pages@v4
 
   # Validate example files and documentation references

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -244,6 +244,9 @@ jobs:
     if: github.event_name == 'push' && github.ref == 'refs/heads/release'
     needs: build
     runs-on: ubuntu-latest
+    concurrency:
+      group: pages-deploy
+      cancel-in-progress: false
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -251,6 +251,8 @@ jobs:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
+      - uses: actions/checkout@v4
+
       - name: Check for independent publication ownership
         id: independent
         env:
@@ -260,16 +262,45 @@ jobs:
           set -euo pipefail
           ACTIVE=false
           gh api --paginate "repos/${{ github.repository }}/actions/artifacts?per_page=100" \
-            --jq '.artifacts[] | select(.expired == false) | select(.name | startswith("publication-live-receipt-")) | "\(.workflow_run.id)"' \
-            | sort -ru > independent-publication-runs.txt
-          while read -r RUN_ID; do
+            --jq '.artifacts[] | select(.expired == false) | select(.name | startswith("publication-live-receipt-")) | "\(.created_at) \(.id) \(.workflow_run.id)"' \
+            | sort -r > independent-publication-runs.txt
+          while read -r _CREATED_AT ARTIFACT_ID RUN_ID; do
             [ -n "${RUN_ID:-}" ] || continue
             RUN_META=$(gh api "repos/${{ github.repository }}/actions/runs/$RUN_ID" \
               --jq '[.name, .status, .conclusion, .event, .head_branch] | @tsv')
             IFS=$'\t' read -r RUN_NAME RUN_STATUS RUN_CONCLUSION RUN_EVENT RUN_BRANCH <<< "$RUN_META"
-            if [[ "$RUN_NAME" == "Publication Control Plane Deployment" && \
-                  "$RUN_STATUS" == "completed" && "$RUN_CONCLUSION" == "success" && \
-                  "$RUN_EVENT" == "workflow_dispatch" && "$RUN_BRANCH" == "develop" ]]; then
+            if [[ "$RUN_NAME" != "Publication Control Plane Deployment" || "$RUN_STATUS" != "completed" || \
+                  "$RUN_EVENT" != "workflow_dispatch" || "$RUN_BRANCH" != "develop" ]]; then
+              continue
+            fi
+            rm -rf independent-receipt && mkdir independent-receipt
+            gh api "repos/${{ github.repository }}/actions/artifacts/$ARTIFACT_ID/zip" > independent-receipt.zip
+            unzip -q independent-receipt.zip -d independent-receipt
+            if EXPECTED_RUN_ID="$RUN_ID" RUN_CONCLUSION="$RUN_CONCLUSION" python3 - <<'PY'
+          import json
+          import os
+          import re
+          from pathlib import Path
+          from scripts.publication.reconciliation import verify_live_receipt_signature
+
+          path = Path("independent-receipt/live-receipt.json")
+          if not path.is_file():
+              raise SystemExit(1)
+          receipt = json.loads(path.read_text())
+          valid, _ = verify_live_receipt_signature(receipt)
+          if not valid or receipt.get("target") != "benchbox.dev":
+              raise SystemExit(1)
+          if str(receipt.get("receipt_run_id", receipt.get("artifact_run_id"))) != os.environ["EXPECTED_RUN_ID"]:
+              raise SystemExit(1)
+          if not re.fullmatch(r"[0-9a-f]{40}", str(receipt.get("source_commit", ""))):
+              raise SystemExit(1)
+          if os.environ["RUN_CONCLUSION"] != "success":
+              if not str(receipt.get("receipt_id", "")).startswith("rollback-"):
+                  raise SystemExit(1)
+              if not receipt.get("routes") or not all(route.get("ok") for route in receipt["routes"]):
+                  raise SystemExit(1)
+          PY
+            then
               ACTIVE=true
               break
             fi

--- a/.github/workflows/publication-deploy.yml
+++ b/.github/workflows/publication-deploy.yml
@@ -504,6 +504,8 @@ jobs:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+
       - name: Revalidate authoritative live head
         env:
           GH_TOKEN: ${{ github.token }}
@@ -511,9 +513,49 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          CURRENT=$(gh api --paginate "repos/${{ github.repository }}/actions/artifacts?per_page=100" \
-            --jq '.artifacts[] | select(.expired == false) | select(.name | startswith("publication-live-receipt-")) | "\(.created_at) \(.id)"' \
-            | sort -r | sed -n '1{s/^[^ ]* //;p;}')
+          CURRENT=""
+          gh api --paginate "repos/${{ github.repository }}/actions/artifacts?per_page=100" \
+            --jq '.artifacts[] | select(.expired == false) | select(.name | startswith("publication-live-receipt-")) | "\(.created_at) \(.id) \(.workflow_run.id)"' \
+            | sort -r > current-candidates.txt
+          while read -r _CREATED_AT ARTIFACT_ID RUN_ID; do
+            [ -n "${ARTIFACT_ID:-}" ] || continue
+            RUN_META=$(gh api "repos/${{ github.repository }}/actions/runs/$RUN_ID" --jq '[.name, .status, .conclusion, .event] | @tsv')
+            IFS=$'\t' read -r RUN_NAME RUN_STATUS RUN_CONCLUSION RUN_EVENT <<< "$RUN_META"
+            if [[ "$RUN_NAME" != "Publication Control Plane Deployment" || "$RUN_STATUS" != "completed" || "$RUN_EVENT" != "workflow_dispatch" ]]; then
+              continue
+            fi
+            rm -rf current-candidate && mkdir current-candidate
+            gh api "repos/${{ github.repository }}/actions/artifacts/$ARTIFACT_ID/zip" > current-candidate.zip
+            unzip -q current-candidate.zip -d current-candidate
+            if EXPECTED_RUN_ID="$RUN_ID" RUN_CONCLUSION="$RUN_CONCLUSION" python3 - <<'PY'
+          import json
+          import os
+          import re
+          from pathlib import Path
+          from scripts.publication.reconciliation import verify_live_receipt_signature
+
+          path = Path("current-candidate/live-receipt.json")
+          if not path.is_file():
+              raise SystemExit(1)
+          receipt = json.loads(path.read_text())
+          valid, _ = verify_live_receipt_signature(receipt)
+          if not valid or receipt.get("target") != "benchbox.dev":
+              raise SystemExit(1)
+          if os.environ["RUN_CONCLUSION"] != "success":
+              if not str(receipt.get("receipt_id", "")).startswith("rollback-"):
+                  raise SystemExit(1)
+              if not receipt.get("routes") or not all(route.get("ok") for route in receipt["routes"]):
+                  raise SystemExit(1)
+          if str(receipt.get("receipt_run_id", receipt.get("artifact_run_id"))) != os.environ["EXPECTED_RUN_ID"]:
+              raise SystemExit(1)
+          if not re.fullmatch(r"[0-9a-f]{40}", str(receipt.get("source_commit", ""))):
+              raise SystemExit(1)
+          PY
+            then
+              CURRENT="$ARTIFACT_ID"
+              break
+            fi
+          done < current-candidates.txt
           [ "$CURRENT" = "$EXPECTED_PARENT_ARTIFACT_ID" ] || {
             echo "::error::publication live head changed after build; refusing stale deployment"
             exit 1

--- a/.github/workflows/publication-deploy.yml
+++ b/.github/workflows/publication-deploy.yml
@@ -35,6 +35,10 @@ name: Publication Control Plane Deployment
         description: "Rehearse against the baseline without a Pages write"
         type: boolean
         default: false
+      candidate_only:
+        description: "Build reviewable candidate bytes without a Pages write or baseline no-op assertion"
+        type: boolean
+        default: false
       force_rollback:
         description: "Exercise rollback using a prior attested artifact"
         type: boolean
@@ -91,8 +95,10 @@ jobs:
             echo "::error::publication deployment must be dispatched from develop"
             exit 1
           fi
-          if [ "$EXPECT_NOOP" = "true" ] && [ "$FORCE_ROLLBACK" = "true" ]; then
-            echo "::error::expect_noop and force_rollback are mutually exclusive"
+          if { [ "$EXPECT_NOOP" = "true" ] && [ "$FORCE_ROLLBACK" = "true" ]; } || \
+             { [ "$EXPECT_NOOP" = "true" ] && [ "$CANDIDATE_ONLY" = "true" ]; } || \
+             { [ "$FORCE_ROLLBACK" = "true" ] && [ "$CANDIDATE_ONLY" = "true" ]; }; then
+            echo "::error::expect_noop, candidate_only, and force_rollback are mutually exclusive"
             exit 1
           fi
           for value in "$DEVELOP_SHA" "$PUBLISHED_RESULTS_SHA"; do
@@ -131,7 +137,7 @@ jobs:
           elif [ -n "$APPROVED_CANDIDATE_RUN_ID" ]; then
             echo "::error::approved_candidate_run_id requires approved_manifest_digest"
             exit 1
-          elif [ "$EXPECT_NOOP" != "true" ] && [ "$FORCE_ROLLBACK" != "true" ]; then
+          elif [ "$EXPECT_NOOP" != "true" ] && [ "$CANDIDATE_ONLY" != "true" ] && [ "$FORCE_ROLLBACK" != "true" ]; then
             echo "::error::production deployment requires an independently reviewed approved_manifest_digest"
             exit 1
           fi
@@ -148,6 +154,7 @@ jobs:
           INPUT_APPROVED_MANIFEST_DIGEST: ${{ inputs.approved_manifest_digest }}
           INPUT_APPROVED_CANDIDATE_RUN_ID: ${{ inputs.approved_candidate_run_id }}
           EXPECT_NOOP: ${{ inputs.expect_noop }}
+          CANDIDATE_ONLY: ${{ inputs.candidate_only }}
           FORCE_ROLLBACK: ${{ inputs.force_rollback }}
 
       - name: Materialize pinned control plane and corpus
@@ -313,7 +320,7 @@ jobs:
               raise SystemExit(f"approved candidate manifest binding mismatch: expected={expected} actual={actual}")
           if desired.get("build_closure", {}).get("workflow_sha") != os.environ["EXPECTED_WORKFLOW_SHA"]:
               raise SystemExit("approved candidate was built by different workflow code")
-          if assembly.get("candidate_mode") != "no-write":
+          if assembly.get("candidate_mode") not in {"no-op-rehearsal", "candidate-only"}:
               raise SystemExit("approved candidate was not produced by a no-write rehearsal")
           if str(assembly.get("artifact_run_id")) != os.environ["CANDIDATE_RUN_ID"]:
               raise SystemExit("approved candidate receipt is not bound to its workflow run")
@@ -434,6 +441,7 @@ jobs:
           PAGES_ARTIFACT: publication-pages-${{ steps.inputs.outputs.generation }}
           GITHUB_RUN_ID: ${{ github.run_id }}
           EXPECT_NOOP: ${{ inputs.expect_noop }}
+          CANDIDATE_ONLY: ${{ inputs.candidate_only }}
         if: inputs.approved_manifest_digest == ''
         shell: bash
         run: |
@@ -477,7 +485,7 @@ jobs:
           export ROOT_ENDPOINT_DIGEST DOCS_ENDPOINT_DIGEST API_DOCS_ENDPOINT_DIGEST EXPLORER_ENDPOINT_DIGEST
           export NODE_VERSION UV_VERSION IMAGE_OS SITE_ARTIFACT PAGES_ARTIFACT GITHUB_RUN_ID TIMESTAMP GITHUB_OUTPUT
           export PARENT_SHA PARENT_GENERATION WORKFLOW_SHA APPROVED_MANIFEST_DIGEST
-          export PARENT_ARTIFACT_ID EXPECT_NOOP
+          export PARENT_ARTIFACT_ID EXPECT_NOOP CANDIDATE_ONLY
           python3 - <<'PY'
           import hashlib
           import json
@@ -586,7 +594,13 @@ jobs:
               "rollback_artifact_name": os.environ["SITE_ARTIFACT"],
               "rollback_artifact_run_id": os.environ["GITHUB_RUN_ID"],
               "parent_artifact_id": os.environ.get("PARENT_ARTIFACT_ID") or None,
-              "candidate_mode": "no-write" if os.environ["EXPECT_NOOP"] == "true" else "rollback-preparation",
+              "candidate_mode": (
+                  "no-op-rehearsal"
+                  if os.environ["EXPECT_NOOP"] == "true"
+                  else "candidate-only"
+                  if os.environ["CANDIDATE_ONLY"] == "true"
+                  else "rollback-preparation"
+              ),
               "timestamp": os.environ["TIMESTAMP"],
               "status": "BUILT",
           })
@@ -663,7 +677,7 @@ jobs:
   deploy:
     name: Deploy atomic artifact to GitHub Pages
     needs: build
-    if: inputs.expect_noop != true && inputs.force_rollback != true
+    if: inputs.expect_noop != true && inputs.candidate_only != true && inputs.force_rollback != true
     runs-on: ubuntu-latest
     permissions:
       actions: read

--- a/.github/workflows/publication-deploy.yml
+++ b/.github/workflows/publication-deploy.yml
@@ -530,6 +530,8 @@ jobs:
     needs: [build, deploy]
     if: needs.deploy.result == 'success'
     runs-on: ubuntu-latest
+    environment:
+      name: publication-attestation
     permissions:
       contents: read
     steps:

--- a/.github/workflows/publication-deploy.yml
+++ b/.github/workflows/publication-deploy.yml
@@ -244,6 +244,19 @@ jobs:
         run: npm ci
         working-directory: results-explorer
 
+      - name: Build lane-equivalent Explorer artifact
+        run: |
+          test ! -e results-explorer/public/data/results.duckdb || {
+            echo "::error::Explorer lane artifact must not contain the corpus database"
+            exit 1
+          }
+          npm run build --prefix results-explorer
+          uv run python scripts/publication/check_explorer_compat.py \
+            --artifact results-explorer/dist --generate-manifest
+          uv run python scripts/publication/check_explorer_compat.py \
+            --artifact results-explorer/dist --require-manifest
+          mv results-explorer/dist explorer-app
+
       - name: Build Explorer corpus database
         run: |
           uv run python _project/scripts/explorer_publish.py build \
@@ -270,6 +283,14 @@ jobs:
           mkdir -p api-docs
           test -f docs/_build/html/api.html && cp docs/_build/html/api.html api-docs/
           test -d docs/_build/html/_modules && cp -r docs/_build/html/_modules api-docs/
+          if [ -d docs/_build/html/_static ]; then
+            mkdir -p api-docs/_static
+            cp -r docs/_build/html/_static/* api-docs/_static/
+          fi
+          if [ -d docs/_build/html/reference/python-api ]; then
+            mkdir -p api-docs/reference/python-api
+            cp -r docs/_build/html/reference/python-api api-docs/reference/
+          fi
           uv run python scripts/assemble_public_site.py --site-dir site
           test -s site/results/data/results.duckdb || {
             echo "::error::atomic site artifact is missing results.duckdb"
@@ -303,7 +324,7 @@ jobs:
           SITE_DIGEST=$(sha256sum receipt-dist/site-file-digests.txt | cut -d ' ' -f 1)
           (cd prose-site && find . -type f -exec sha256sum {} + | sort) > receipt-dist/prose-file-digests.txt
           PROSE_DIGEST=$(sha256sum receipt-dist/prose-file-digests.txt | cut -d ' ' -f 1)
-          (cd results-explorer/dist && find . -type f -exec sha256sum {} + | sort) > receipt-dist/explorer-file-digests.txt
+          (cd explorer-app && find . -type f -exec sha256sum {} + | sort) > receipt-dist/explorer-file-digests.txt
           EXPLORER_DIGEST=$(sha256sum receipt-dist/explorer-file-digests.txt | cut -d ' ' -f 1)
           (cd api-docs && find . -type f -exec sha256sum {} + | sort) > receipt-dist/docs-file-digests.txt
           DOCS_DIGEST=$(sha256sum receipt-dist/docs-file-digests.txt | cut -d ' ' -f 1)
@@ -391,7 +412,7 @@ jobs:
                   "explorer_app": {
                       "digest": os.environ["EXPLORER_DIGEST"],
                       "endpoint_sha256": os.environ["EXPLORER_ENDPOINT_DIGEST"],
-                      "size": tree_size("results-explorer/dist"),
+                      "size": tree_size("explorer-app"),
                       "path": "/results/",
                   },
                   "publisher_bundle": {

--- a/.github/workflows/publication-deploy.yml
+++ b/.github/workflows/publication-deploy.yml
@@ -21,6 +21,11 @@ name: Publication Control Plane Deployment
         required: false
         default: ""
         type: string
+      approved_candidate_run_id:
+        description: "Workflow run containing the reviewed candidate bytes; required with approved_manifest_digest"
+        required: false
+        default: ""
+        type: string
       prior_live_receipt_id:
         description: "Prior attested live receipt ID, if this supersedes one"
         required: false
@@ -57,15 +62,15 @@ jobs:
       generation: ${{ steps.inputs.outputs.generation }}
       develop_sha: ${{ steps.inputs.outputs.develop_sha }}
       published_results_sha: ${{ steps.inputs.outputs.published_results_sha }}
-      manifest_digest: ${{ steps.receipt.outputs.manifest_digest }}
-      assembly_digest: ${{ steps.receipt.outputs.assembly_digest }}
-      database_digest: ${{ steps.receipt.outputs.database_digest }}
-      explorer_digest: ${{ steps.receipt.outputs.explorer_digest }}
-      docs_digest: ${{ steps.receipt.outputs.docs_digest }}
+      manifest_digest: ${{ steps.receipt.outputs.manifest_digest || steps.approved.outputs.manifest_digest }}
+      assembly_digest: ${{ steps.receipt.outputs.assembly_digest || steps.approved.outputs.assembly_digest }}
+      database_digest: ${{ steps.receipt.outputs.database_digest || steps.approved.outputs.database_digest }}
+      explorer_digest: ${{ steps.receipt.outputs.explorer_digest || steps.approved.outputs.explorer_digest }}
+      docs_digest: ${{ steps.receipt.outputs.docs_digest || steps.approved.outputs.docs_digest }}
       site_artifact: ${{ steps.inputs.outputs.site_artifact }}
-      parent_sha: ${{ steps.lineage.outputs.parent_sha }}
-      parent_generation: ${{ steps.lineage.outputs.parent_generation }}
-      parent_artifact_id: ${{ steps.lineage.outputs.parent_artifact_id }}
+      parent_sha: ${{ steps.lineage.outputs.parent_sha || steps.approved.outputs.parent_sha }}
+      parent_generation: ${{ steps.lineage.outputs.parent_generation || steps.approved.outputs.parent_generation }}
+      parent_artifact_id: ${{ steps.lineage.outputs.parent_artifact_id || steps.approved.outputs.parent_artifact_id }}
     steps:
       - name: Checkout control-plane source
         uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
@@ -81,6 +86,7 @@ jobs:
           PUBLISHED_RESULTS_SHA="$INPUT_PUBLISHED_RESULTS_SHA"
           GENERATION="$INPUT_GENERATION"
           APPROVED_MANIFEST_DIGEST="$INPUT_APPROVED_MANIFEST_DIGEST"
+          APPROVED_CANDIDATE_RUN_ID="$INPUT_APPROVED_CANDIDATE_RUN_ID"
           if [ "$GITHUB_REF" != "refs/heads/develop" ]; then
             echo "::error::publication deployment must be dispatched from develop"
             exit 1
@@ -118,6 +124,13 @@ jobs:
               echo "::error::approved_manifest_digest must be a lowercase SHA-256 digest"
               exit 1
             }
+            printf '%s' "$APPROVED_CANDIDATE_RUN_ID" | grep -qE '^[1-9][0-9]*$' || {
+              echo "::error::approved_candidate_run_id is required with approved_manifest_digest"
+              exit 1
+            }
+          elif [ -n "$APPROVED_CANDIDATE_RUN_ID" ]; then
+            echo "::error::approved_candidate_run_id requires approved_manifest_digest"
+            exit 1
           elif [ "$EXPECT_NOOP" != "true" ] && [ "$FORCE_ROLLBACK" != "true" ]; then
             echo "::error::production deployment requires an independently reviewed approved_manifest_digest"
             exit 1
@@ -133,10 +146,12 @@ jobs:
           INPUT_PUBLISHED_RESULTS_SHA: ${{ inputs.published_results_sha }}
           INPUT_GENERATION: ${{ inputs.generation }}
           INPUT_APPROVED_MANIFEST_DIGEST: ${{ inputs.approved_manifest_digest }}
+          INPUT_APPROVED_CANDIDATE_RUN_ID: ${{ inputs.approved_candidate_run_id }}
           EXPECT_NOOP: ${{ inputs.expect_noop }}
           FORCE_ROLLBACK: ${{ inputs.force_rollback }}
 
       - name: Materialize pinned control plane and corpus
+        if: inputs.approved_manifest_digest == ''
         shell: bash
         run: |
           set -euo pipefail
@@ -156,9 +171,11 @@ jobs:
         uses: astral-sh/setup-uv@38f3f104447c67c051c4a08e39b64a148898af3a # v4
 
       - name: Install Python dependencies
+        if: inputs.approved_manifest_digest == ''
         run: uv sync --group dev
 
       - name: Resolve attested publication lineage
+        if: inputs.approved_manifest_digest == ''
         id: lineage
         env:
           GH_TOKEN: ${{ github.token }}
@@ -241,7 +258,96 @@ jobs:
           echo "::error::no authoritative attested live head is available for generation $GENERATION"
           exit 1
 
+      - name: Restore independently approved candidate bytes
+        if: inputs.approved_manifest_digest != ''
+        id: approved
+        env:
+          GH_TOKEN: ${{ github.token }}
+          APPROVED_DIGEST: ${{ inputs.approved_manifest_digest }}
+          CANDIDATE_RUN_ID: ${{ inputs.approved_candidate_run_id }}
+          EXPECTED_DEVELOP_SHA: ${{ steps.inputs.outputs.develop_sha }}
+          EXPECTED_PUBLISHED_RESULTS_SHA: ${{ steps.inputs.outputs.published_results_sha }}
+          EXPECTED_GENERATION: ${{ steps.inputs.outputs.generation }}
+          EXPECTED_WORKFLOW_SHA: ${{ github.sha }}
+          EXPECTED_PRIOR_LIVE_RECEIPT_ID: ${{ inputs.prior_live_receipt_id }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          RUN_META=$(gh api "repos/${{ github.repository }}/actions/runs/$CANDIDATE_RUN_ID" \
+            --jq '[.name, .status, .conclusion, .event, .head_branch, .head_sha] | @tsv')
+          IFS=$'\t' read -r RUN_NAME RUN_STATUS RUN_CONCLUSION RUN_EVENT RUN_BRANCH RUN_HEAD_SHA <<< "$RUN_META"
+          if [[ "$RUN_NAME" != "Publication Control Plane Deployment" || "$RUN_STATUS" != "completed" || \
+                "$RUN_CONCLUSION" != "success" || "$RUN_EVENT" != "workflow_dispatch" || \
+                "$RUN_BRANCH" != "develop" || "$RUN_HEAD_SHA" != "$EXPECTED_WORKFLOW_SHA" ]]; then
+            echo "::error::approved candidate run is not a successful develop publication rehearsal"
+            exit 1
+          fi
+          mkdir -p receipt-dist site
+          gh run download "$CANDIDATE_RUN_ID" \
+            --name "publication-candidate-receipts-$EXPECTED_GENERATION-$CANDIDATE_RUN_ID" --dir receipt-dist
+          gh run download "$CANDIDATE_RUN_ID" \
+            --name "publication-site-$EXPECTED_GENERATION" --dir site
+          CURRENT_RUN_ID="$GITHUB_RUN_ID" python3 - <<'PY'
+          import hashlib
+          import json
+          import os
+          from pathlib import Path
+
+          desired_path = Path("receipt-dist/desired-manifest.json")
+          assembly_path = Path("receipt-dist/assembly-receipt.json")
+          desired = json.loads(desired_path.read_text())
+          assembly = json.loads(assembly_path.read_text())
+          claimed = desired.pop("manifest_digest", None)
+          canonical = json.dumps(desired, sort_keys=True, separators=(",", ":")).encode()
+          recomputed = hashlib.sha256(canonical).hexdigest()
+          desired["manifest_digest"] = claimed
+          expected = {
+              "manifest_digest": os.environ["APPROVED_DIGEST"],
+              "develop_sha": os.environ["EXPECTED_DEVELOP_SHA"],
+              "published_results_sha": os.environ["EXPECTED_PUBLISHED_RESULTS_SHA"],
+              "generation": int(os.environ["EXPECTED_GENERATION"]),
+              "prior_live_receipt_id": os.environ.get("EXPECTED_PRIOR_LIVE_RECEIPT_ID") or None,
+          }
+          actual = {key: desired.get(key) for key in expected}
+          if claimed != recomputed or actual != expected:
+              raise SystemExit(f"approved candidate manifest binding mismatch: expected={expected} actual={actual}")
+          if desired.get("build_closure", {}).get("workflow_sha") != os.environ["EXPECTED_WORKFLOW_SHA"]:
+              raise SystemExit("approved candidate was built by different workflow code")
+          if assembly.get("candidate_mode") != "no-write":
+              raise SystemExit("approved candidate was not produced by a no-write rehearsal")
+          if str(assembly.get("artifact_run_id")) != os.environ["CANDIDATE_RUN_ID"]:
+              raise SystemExit("approved candidate receipt is not bound to its workflow run")
+          digest_lines = []
+          for path in sorted(item for item in Path("site").rglob("*") if item.is_file()):
+              rel = path.relative_to("site").as_posix()
+              digest_lines.append(f"{hashlib.sha256(path.read_bytes()).hexdigest()}  ./{rel}\n")
+          digest_lines.sort()
+          site_digest = hashlib.sha256("".join(digest_lines).encode()).hexdigest()
+          expected_site_digest = desired.get("artifacts", {}).get("pages_assembly", {}).get("digest")
+          if site_digest != expected_site_digest:
+              raise SystemExit(
+                  f"approved candidate site digest mismatch: expected={expected_site_digest} actual={site_digest}"
+              )
+          assembly.update({
+              "approved_candidate_run_id": os.environ["CANDIDATE_RUN_ID"],
+              "artifact_run_id": os.environ["CURRENT_RUN_ID"],
+              "rollback_artifact_run_id": os.environ["CURRENT_RUN_ID"],
+          })
+          assembly_path.write_text(json.dumps(assembly, sort_keys=True) + "\n")
+          Path("receipt-dist/publication-receipt.json").write_text(json.dumps(assembly, sort_keys=True) + "\n")
+          with open(os.environ["GITHUB_OUTPUT"], "a") as output:
+              output.write(f"manifest_digest={claimed}\n")
+              output.write(f"assembly_digest={site_digest}\n")
+              output.write(f"database_digest={desired['artifacts']['corpus_database']['digest']}\n")
+              output.write(f"explorer_digest={desired['artifacts']['explorer_app']['digest']}\n")
+              output.write(f"docs_digest={desired['artifacts']['api_docs']['digest']}\n")
+              output.write(f"parent_sha={desired.get('parent_sha') or ''}\n")
+              output.write(f"parent_generation={desired.get('parent_generation') or ''}\n")
+              output.write(f"parent_artifact_id={assembly.get('parent_artifact_id') or ''}\n")
+          PY
+
       - name: Set up Node.js
+        if: inputs.approved_manifest_digest == ''
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: "20"
@@ -249,10 +355,12 @@ jobs:
           cache-dependency-path: results-explorer/package-lock.json
 
       - name: Install Explorer dependencies
+        if: inputs.approved_manifest_digest == ''
         run: npm ci
         working-directory: results-explorer
 
       - name: Build lane-equivalent Explorer artifact
+        if: inputs.approved_manifest_digest == ''
         run: |
           test ! -e results-explorer/public/data/results.duckdb || {
             echo "::error::Explorer lane artifact must not contain the corpus database"
@@ -266,6 +374,7 @@ jobs:
           mv results-explorer/dist explorer-app
 
       - name: Build Explorer corpus database
+        if: inputs.approved_manifest_digest == ''
         run: |
           uv run python _project/scripts/explorer_publish.py build \
             --data-dir results-data --output results-explorer/public/data
@@ -277,15 +386,18 @@ jobs:
             results-explorer/public/data/results.duckdb
 
       - name: Build Explorer application
+        if: inputs.approved_manifest_digest == ''
         run: npm run build
         working-directory: results-explorer
 
       - name: Build documentation
+        if: inputs.approved_manifest_digest == ''
         run: |
           cd docs
           uv run sphinx-build -b html --keep-going . _build/html
 
       - name: Assemble and validate whole-site artifact
+        if: inputs.approved_manifest_digest == ''
         run: |
           uv run python scripts/assemble_public_site.py --site-dir prose-site --prose-only
           mkdir -p api-docs
@@ -316,10 +428,13 @@ jobs:
           APPROVED_MANIFEST_DIGEST: ${{ inputs.approved_manifest_digest }}
           PARENT_SHA: ${{ steps.lineage.outputs.parent_sha }}
           PARENT_GENERATION: ${{ steps.lineage.outputs.parent_generation }}
+          PARENT_ARTIFACT_ID: ${{ steps.lineage.outputs.parent_artifact_id }}
           WORKFLOW_SHA: ${{ github.sha }}
           SITE_ARTIFACT: ${{ steps.inputs.outputs.site_artifact }}
           PAGES_ARTIFACT: publication-pages-${{ steps.inputs.outputs.generation }}
           GITHUB_RUN_ID: ${{ github.run_id }}
+          EXPECT_NOOP: ${{ inputs.expect_noop }}
+        if: inputs.approved_manifest_digest == ''
         shell: bash
         run: |
           set -euo pipefail
@@ -362,6 +477,7 @@ jobs:
           export ROOT_ENDPOINT_DIGEST DOCS_ENDPOINT_DIGEST API_DOCS_ENDPOINT_DIGEST EXPLORER_ENDPOINT_DIGEST
           export NODE_VERSION UV_VERSION IMAGE_OS SITE_ARTIFACT PAGES_ARTIFACT GITHUB_RUN_ID TIMESTAMP GITHUB_OUTPUT
           export PARENT_SHA PARENT_GENERATION WORKFLOW_SHA APPROVED_MANIFEST_DIGEST
+          export PARENT_ARTIFACT_ID EXPECT_NOOP
           python3 - <<'PY'
           import hashlib
           import json
@@ -469,6 +585,8 @@ jobs:
               "artifact_run_id": os.environ["GITHUB_RUN_ID"],
               "rollback_artifact_name": os.environ["SITE_ARTIFACT"],
               "rollback_artifact_run_id": os.environ["GITHUB_RUN_ID"],
+              "parent_artifact_id": os.environ.get("PARENT_ARTIFACT_ID") or None,
+              "candidate_mode": "no-write" if os.environ["EXPECT_NOOP"] == "true" else "rollback-preparation",
               "timestamp": os.environ["TIMESTAMP"],
               "status": "BUILT",
           })
@@ -488,7 +606,7 @@ jobs:
           cp receipt-dist/assembly-receipt.json receipt-dist/publication-receipt.json
 
       - name: Upload candidate receipts for independent review
-        if: always() && steps.receipt.outcome == 'success'
+        if: inputs.approved_manifest_digest == '' && always() && steps.receipt.outcome == 'success'
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: publication-candidate-receipts-${{ steps.inputs.outputs.generation }}-${{ github.run_id }}
@@ -496,6 +614,7 @@ jobs:
           retention-days: 90
 
       - name: Pre-deploy candidate verification
+        if: inputs.approved_manifest_digest == ''
         env:
           EXPECT_NOOP: ${{ inputs.expect_noop }}
         shell: bash

--- a/.github/workflows/publication-deploy.yml
+++ b/.github/workflows/publication-deploy.yml
@@ -81,6 +81,10 @@ jobs:
           PUBLISHED_RESULTS_SHA="$INPUT_PUBLISHED_RESULTS_SHA"
           GENERATION="$INPUT_GENERATION"
           APPROVED_MANIFEST_DIGEST="$INPUT_APPROVED_MANIFEST_DIGEST"
+          if [ "$EXPECT_NOOP" = "true" ] && [ "$FORCE_ROLLBACK" = "true" ]; then
+            echo "::error::expect_noop and force_rollback are mutually exclusive"
+            exit 1
+          fi
           for value in "$DEVELOP_SHA" "$PUBLISHED_RESULTS_SHA"; do
             printf '%s' "$value" | grep -qE '^[0-9a-f]{40}$' || {
               echo "::error::dispatch SHAs must be lowercase 40-hex commits"
@@ -330,6 +334,7 @@ jobs:
           DOCS_DIGEST=$(sha256sum receipt-dist/docs-file-digests.txt | cut -d ' ' -f 1)
           (cd results-data/bundles && find . -type f -exec sha256sum {} + | sort) > receipt-dist/corpus-file-digests.txt
           CORPUS_DIGEST=$(sha256sum receipt-dist/corpus-file-digests.txt | cut -d ' ' -f 1)
+          INVENTORY_DIGEST=$(sha256sum results-data/corpus-inventory.json | cut -d ' ' -f 1)
           DATABASE_DIGEST=$(sha256sum site/results/data/results.duckdb | cut -d ' ' -f 1)
           ROOT_ENDPOINT_DIGEST=$(sha256sum site/index.html | cut -d ' ' -f 1)
           DOCS_ENDPOINT_DIGEST=$(sha256sum site/docs/index.html | cut -d ' ' -f 1)
@@ -349,7 +354,7 @@ jobs:
           UV_VERSION=$(uv --version | awk '{print $2}')
           IMAGE_OS="${ImageOS:-ubuntu-latest}"
           export GENERATION DEVELOP_SHA PUBLISHED_RESULTS_SHA PRIOR_LIVE_RECEIPT_ID SITE_DIGEST PROSE_DIGEST DOCS_DIGEST
-          export EXPLORER_DIGEST DATABASE_DIGEST CORPUS_DIGEST LOCKFILE_DIGEST BUNDLE_COUNT PYTHON_VERSION
+          export EXPLORER_DIGEST DATABASE_DIGEST CORPUS_DIGEST INVENTORY_DIGEST LOCKFILE_DIGEST BUNDLE_COUNT PYTHON_VERSION
           export ROOT_ENDPOINT_DIGEST DOCS_ENDPOINT_DIGEST API_DOCS_ENDPOINT_DIGEST EXPLORER_ENDPOINT_DIGEST
           export NODE_VERSION UV_VERSION IMAGE_OS SITE_ARTIFACT PAGES_ARTIFACT GITHUB_RUN_ID TIMESTAMP GITHUB_OUTPUT
           export PARENT_SHA PARENT_GENERATION WORKFLOW_SHA APPROVED_MANIFEST_DIGEST
@@ -393,7 +398,8 @@ jobs:
               },
               "corpus": {
                   "bundle_count": int(os.environ["BUNDLE_COUNT"]),
-                  "inventory_sha256": os.environ["CORPUS_DIGEST"],
+                  "inventory_sha256": os.environ["INVENTORY_DIGEST"],
+                  "bundle_tree_sha256": os.environ["CORPUS_DIGEST"],
                   "read_model_sha256": os.environ["DATABASE_DIGEST"],
               },
               "artifacts": {
@@ -536,6 +542,7 @@ jobs:
       id-token: write
     outputs:
       page_url: ${{ steps.deployment.outputs.page_url }}
+      pages_write_outcome: ${{ steps.deployment.outcome }}
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
@@ -744,7 +751,7 @@ jobs:
     needs: [build, deploy, verify]
     if: >-
       always() && needs.build.result == 'success' && (
-        needs.deploy.result == 'failure' || needs.verify.result == 'failure' ||
+        needs.deploy.outputs.pages_write_outcome == 'failure' || needs.verify.result == 'failure' ||
         (github.event_name == 'workflow_dispatch' && inputs.force_rollback == true)
       )
     runs-on: ubuntu-latest

--- a/.github/workflows/publication-deploy.yml
+++ b/.github/workflows/publication-deploy.yml
@@ -285,6 +285,7 @@ jobs:
           PARENT_GENERATION: ${{ steps.lineage.outputs.parent_generation }}
           WORKFLOW_SHA: ${{ github.sha }}
           SITE_ARTIFACT: ${{ steps.inputs.outputs.site_artifact }}
+          PAGES_ARTIFACT: publication-pages-${{ steps.inputs.outputs.generation }}
           GITHUB_RUN_ID: ${{ github.run_id }}
         shell: bash
         run: |
@@ -315,7 +316,7 @@ jobs:
           export GENERATION DEVELOP_SHA PUBLISHED_RESULTS_SHA PRIOR_LIVE_RECEIPT_ID SITE_DIGEST DOCS_DIGEST
           export EXPLORER_DIGEST DATABASE_DIGEST CORPUS_DIGEST LOCKFILE_DIGEST BUNDLE_COUNT PYTHON_VERSION
           export ROOT_ENDPOINT_DIGEST DOCS_ENDPOINT_DIGEST EXPLORER_ENDPOINT_DIGEST
-          export NODE_VERSION UV_VERSION IMAGE_OS SITE_ARTIFACT GITHUB_RUN_ID TIMESTAMP GITHUB_OUTPUT
+          export NODE_VERSION UV_VERSION IMAGE_OS SITE_ARTIFACT PAGES_ARTIFACT GITHUB_RUN_ID TIMESTAMP GITHUB_OUTPUT
           export PARENT_SHA PARENT_GENERATION WORKFLOW_SHA APPROVED_MANIFEST_DIGEST
           python3 - <<'PY'
           import hashlib
@@ -418,8 +419,10 @@ jobs:
               )
           assembly = dict(manifest)
           assembly.update({
-              "artifact_name": os.environ["SITE_ARTIFACT"],
+              "artifact_name": os.environ["PAGES_ARTIFACT"],
               "artifact_run_id": os.environ["GITHUB_RUN_ID"],
+              "rollback_artifact_name": os.environ["SITE_ARTIFACT"],
+              "rollback_artifact_run_id": os.environ["GITHUB_RUN_ID"],
               "timestamp": os.environ["TIMESTAMP"],
               "status": "BUILT",
           })
@@ -718,11 +721,12 @@ jobs:
           if prior_id and receipt.get('receipt_id') != prior_id: raise SystemExit(1)
           if current_gen and str(receipt.get('generation')) == current_gen: raise SystemExit(1)
           if str(receipt.get('receipt_run_id', receipt.get('artifact_run_id'))) != os.environ.get('RUN_ID'): raise SystemExit(1)
-          if not receipt.get('artifact_name') or not receipt.get('artifacts', {}).get('pages_assembly', {}).get('digest'): raise SystemExit(1)
+          if not receipt.get('artifact_name') or not receipt.get('rollback_artifact_name'): raise SystemExit(1)
+          if not receipt.get('artifacts', {}).get('pages_assembly', {}).get('digest'): raise SystemExit(1)
           PY
             then
-              ARTIFACT_NAME=$(uv run python -c "import json; print(json.load(open('candidate/live-receipt.json'))['artifact_name'])")
-              ARTIFACT_RUN_ID="$RUN_ID"
+              ARTIFACT_NAME=$(uv run python -c "import json; print(json.load(open('candidate/live-receipt.json'))['rollback_artifact_name'])")
+              ARTIFACT_RUN_ID=$(uv run python -c "import json; print(json.load(open('candidate/live-receipt.json')).get('rollback_artifact_run_id', '$RUN_ID'))")
               cp -R candidate/. known-good-receipt/
               echo "artifact_name=$ARTIFACT_NAME" >> "$GITHUB_OUTPUT"
               echo "artifact_run_id=$ARTIFACT_RUN_ID" >> "$GITHUB_OUTPUT"
@@ -782,6 +786,7 @@ jobs:
           PARENT_GENERATION: ${{ needs.build.outputs.parent_generation }}
           PRIOR_LIVE_RECEIPT_ID: ${{ inputs.prior_live_receipt_id }}
           SITE_ARTIFACT: publication-site-${{ needs.build.outputs.generation }}-rollback
+          PAGES_ARTIFACT: publication-rollback-pages-${{ github.run_id }}-${{ github.run_attempt }}
           GITHUB_RUN_ID: ${{ github.run_id }}
           GITHUB_RUN_ATTEMPT: ${{ github.run_attempt }}
         shell: bash
@@ -804,8 +809,10 @@ jobs:
               'parent_generation': int(os.environ['PARENT_GENERATION']),
               'receipt_id': f"rollback-{os.environ['GITHUB_RUN_ID']}-{os.environ['GITHUB_RUN_ATTEMPT']}",
               'receipt_run_id': os.environ['GITHUB_RUN_ID'],
-              'artifact_name': os.environ['SITE_ARTIFACT'],
+              'artifact_name': os.environ['PAGES_ARTIFACT'],
               'artifact_run_id': os.environ['GITHUB_RUN_ID'],
+              'rollback_artifact_name': os.environ['SITE_ARTIFACT'],
+              'rollback_artifact_run_id': os.environ['GITHUB_RUN_ID'],
               'timestamp': datetime.now(timezone.utc).isoformat().replace('+00:00', 'Z'),
               'routes': probes,
               'nonce': f"{os.environ['GITHUB_RUN_ID']}-{os.environ['GITHUB_RUN_ATTEMPT']}",

--- a/.github/workflows/publication-deploy.yml
+++ b/.github/workflows/publication-deploy.yml
@@ -81,6 +81,10 @@ jobs:
           PUBLISHED_RESULTS_SHA="$INPUT_PUBLISHED_RESULTS_SHA"
           GENERATION="$INPUT_GENERATION"
           APPROVED_MANIFEST_DIGEST="$INPUT_APPROVED_MANIFEST_DIGEST"
+          if [ "$GITHUB_REF" != "refs/heads/develop" ]; then
+            echo "::error::publication deployment must be dispatched from develop"
+            exit 1
+          fi
           if [ "$EXPECT_NOOP" = "true" ] && [ "$FORCE_ROLLBACK" = "true" ]; then
             echo "::error::expect_noop and force_rollback are mutually exclusive"
             exit 1

--- a/.github/workflows/publication-deploy.yml
+++ b/.github/workflows/publication-deploy.yml
@@ -266,6 +266,10 @@ jobs:
 
       - name: Assemble and validate whole-site artifact
         run: |
+          uv run python scripts/assemble_public_site.py --site-dir prose-site --prose-only
+          mkdir -p api-docs
+          test -f docs/_build/html/api.html && cp docs/_build/html/api.html api-docs/
+          test -d docs/_build/html/_modules && cp -r docs/_build/html/_modules api-docs/
           uv run python scripts/assemble_public_site.py --site-dir site
           test -s site/results/data/results.duckdb || {
             echo "::error::atomic site artifact is missing results.duckdb"
@@ -297,15 +301,18 @@ jobs:
           TIMESTAMP=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
           (cd site && find . -type f -exec sha256sum {} + | sort) > receipt-dist/site-file-digests.txt
           SITE_DIGEST=$(sha256sum receipt-dist/site-file-digests.txt | cut -d ' ' -f 1)
+          (cd prose-site && find . -type f -exec sha256sum {} + | sort) > receipt-dist/prose-file-digests.txt
+          PROSE_DIGEST=$(sha256sum receipt-dist/prose-file-digests.txt | cut -d ' ' -f 1)
           (cd results-explorer/dist && find . -type f -exec sha256sum {} + | sort) > receipt-dist/explorer-file-digests.txt
           EXPLORER_DIGEST=$(sha256sum receipt-dist/explorer-file-digests.txt | cut -d ' ' -f 1)
-          (cd docs/_build/html && find . -type f -exec sha256sum {} + | sort) > receipt-dist/docs-file-digests.txt
+          (cd api-docs && find . -type f -exec sha256sum {} + | sort) > receipt-dist/docs-file-digests.txt
           DOCS_DIGEST=$(sha256sum receipt-dist/docs-file-digests.txt | cut -d ' ' -f 1)
           (cd results-data/bundles && find . -type f -exec sha256sum {} + | sort) > receipt-dist/corpus-file-digests.txt
           CORPUS_DIGEST=$(sha256sum receipt-dist/corpus-file-digests.txt | cut -d ' ' -f 1)
           DATABASE_DIGEST=$(sha256sum site/results/data/results.duckdb | cut -d ' ' -f 1)
           ROOT_ENDPOINT_DIGEST=$(sha256sum site/index.html | cut -d ' ' -f 1)
           DOCS_ENDPOINT_DIGEST=$(sha256sum site/docs/index.html | cut -d ' ' -f 1)
+          API_DOCS_ENDPOINT_DIGEST=$(sha256sum site/docs/api.html | cut -d ' ' -f 1)
           EXPLORER_ENDPOINT_DIGEST=$(sha256sum site/results/index.html | cut -d ' ' -f 1)
           LOCKFILE_DIGEST=$(sha256sum uv.lock | cut -d ' ' -f 1)
           BUNDLE_COUNT=$(find results-data/bundles -type f -name '*.json' \
@@ -320,9 +327,9 @@ jobs:
           NODE_VERSION=$(node --version | sed 's/^v//')
           UV_VERSION=$(uv --version | awk '{print $2}')
           IMAGE_OS="${ImageOS:-ubuntu-latest}"
-          export GENERATION DEVELOP_SHA PUBLISHED_RESULTS_SHA PRIOR_LIVE_RECEIPT_ID SITE_DIGEST DOCS_DIGEST
+          export GENERATION DEVELOP_SHA PUBLISHED_RESULTS_SHA PRIOR_LIVE_RECEIPT_ID SITE_DIGEST PROSE_DIGEST DOCS_DIGEST
           export EXPLORER_DIGEST DATABASE_DIGEST CORPUS_DIGEST LOCKFILE_DIGEST BUNDLE_COUNT PYTHON_VERSION
-          export ROOT_ENDPOINT_DIGEST DOCS_ENDPOINT_DIGEST EXPLORER_ENDPOINT_DIGEST
+          export ROOT_ENDPOINT_DIGEST DOCS_ENDPOINT_DIGEST API_DOCS_ENDPOINT_DIGEST EXPLORER_ENDPOINT_DIGEST
           export NODE_VERSION UV_VERSION IMAGE_OS SITE_ARTIFACT PAGES_ARTIFACT GITHUB_RUN_ID TIMESTAMP GITHUB_OUTPUT
           export PARENT_SHA PARENT_GENERATION WORKFLOW_SHA APPROVED_MANIFEST_DIGEST
           python3 - <<'PY'
@@ -370,16 +377,16 @@ jobs:
               },
               "artifacts": {
                   "prose_site": {
-                      "digest": os.environ["SITE_DIGEST"],
+                      "digest": os.environ["PROSE_DIGEST"],
                       "endpoint_sha256": os.environ["ROOT_ENDPOINT_DIGEST"],
-                      "size": tree_size("site"),
+                      "size": tree_size("prose-site"),
                       "path": "/",
                   },
                   "api_docs": {
                       "digest": os.environ["DOCS_DIGEST"],
-                      "endpoint_sha256": os.environ["DOCS_ENDPOINT_DIGEST"],
-                      "size": tree_size("docs/_build/html"),
-                      "path": "/docs/",
+                      "endpoint_sha256": os.environ["API_DOCS_ENDPOINT_DIGEST"],
+                      "size": tree_size("api-docs"),
+                      "path": "/docs/api.html",
                   },
                   "explorer_app": {
                       "digest": os.environ["EXPLORER_DIGEST"],
@@ -406,6 +413,7 @@ jobs:
               "checksums": {
                   "/": os.environ["ROOT_ENDPOINT_DIGEST"],
                   "/docs/": os.environ["DOCS_ENDPOINT_DIGEST"],
+                  "/docs/api.html": os.environ["API_DOCS_ENDPOINT_DIGEST"],
                   "/results/": os.environ["EXPLORER_ENDPOINT_DIGEST"],
                   "/results/data/results.duckdb": os.environ["DATABASE_DIGEST"],
               },
@@ -635,6 +643,7 @@ jobs:
           uv run python scripts/publication/verify_live.py \
             --base-url "$TARGET_URL" \
             --manifest receipt-dist/publication-receipt.json \
+            --observation-origin github-actions:publication-verify \
             --require-receipt --timeout 60 --json > receipt-dist/live-probe-report.json
 
       - name: Create and sign live receipt
@@ -655,7 +664,10 @@ jobs:
           import json, os
           from datetime import datetime, timezone
           assembly = json.load(open('receipt-dist/assembly-receipt.json'))
-          probes = json.load(open('receipt-dist/live-probe-report.json'))['probes']
+          probe_report = json.load(open('receipt-dist/live-probe-report.json'))
+          if probe_report.get('observation_origin') != 'github-actions:publication-verify':
+              raise SystemExit('live receipt requires the external GitHub Actions observation origin')
+          probes = probe_report['probes']
           prior_live_receipt_id = os.environ.get('PRIOR_LIVE_RECEIPT_ID') or None
           receipt = dict(assembly)
           receipt.update({
@@ -663,6 +675,7 @@ jobs:
               'receipt_run_id': os.environ['GITHUB_RUN_ID'],
               'timestamp': datetime.now(timezone.utc).isoformat().replace('+00:00', 'Z'),
               'routes': probes,
+              'observation_origin': probe_report['observation_origin'],
               'nonce': f"{os.environ['GITHUB_RUN_ID']}-{os.environ['GITHUB_RUN_ATTEMPT']}",
               'freshness_window': '24h',
               'attestor': 'github-actions:publication-deploy',
@@ -862,7 +875,7 @@ jobs:
         run: |
           set -euo pipefail
           TARGET_URL="${{ steps.deployment.outputs.page_url }}"
-          uv run python scripts/publication/verify_live.py --base-url "$TARGET_URL" --manifest known-good-receipt/live-receipt.json --require-receipt --timeout 60 --json > known-good-receipt/rollback-probe-report.json
+          uv run python scripts/publication/verify_live.py --base-url "$TARGET_URL" --manifest known-good-receipt/live-receipt.json --observation-origin github-actions:publication-rollback-verify --require-receipt --timeout 60 --json > known-good-receipt/rollback-probe-report.json
 
       - name: Create and sign rollback live receipt
         env:
@@ -887,7 +900,10 @@ jobs:
           from datetime import datetime, timezone
           from scripts.publication.manifest import validate_manifest_dict
           prior = json.load(open('known-good-receipt/live-receipt.json'))
-          probes = json.load(open('known-good-receipt/rollback-probe-report.json'))['probes']
+          probe_report = json.load(open('known-good-receipt/rollback-probe-report.json'))
+          if probe_report.get('observation_origin') != 'github-actions:publication-rollback-verify':
+              raise SystemExit('rollback receipt requires the external GitHub Actions observation origin')
+          probes = probe_report['probes']
           receipt = dict(prior)
           receipt.update({
               'generation': int(os.environ['BUILD_GENERATION']),
@@ -901,6 +917,7 @@ jobs:
               'rollback_artifact_run_id': os.environ['GITHUB_RUN_ID'],
               'timestamp': datetime.now(timezone.utc).isoformat().replace('+00:00', 'Z'),
               'routes': probes,
+              'observation_origin': probe_report['observation_origin'],
               'nonce': f"{os.environ['GITHUB_RUN_ID']}-{os.environ['GITHUB_RUN_ATTEMPT']}",
               'prior_live_receipt_id': os.environ['PRIOR_LIVE_RECEIPT_ID'],
               'rollback_source_receipt_id': prior['receipt_id'],

--- a/.github/workflows/publication-deploy.yml
+++ b/.github/workflows/publication-deploy.yml
@@ -308,7 +308,14 @@ jobs:
           DOCS_ENDPOINT_DIGEST=$(sha256sum site/docs/index.html | cut -d ' ' -f 1)
           EXPLORER_ENDPOINT_DIGEST=$(sha256sum site/results/index.html | cut -d ' ' -f 1)
           LOCKFILE_DIGEST=$(sha256sum uv.lock | cut -d ' ' -f 1)
-          BUNDLE_COUNT=$(find results-data/bundles -type f -name '*.json' | wc -l | tr -d ' ')
+          BUNDLE_COUNT=$(find results-data/bundles -type f -name '*.json' \
+            ! -name '*.manifest.json' ! -name '*.applied.json' \
+            ! -name '*.plans.json' ! -name '*.tuning.json' | wc -l | tr -d ' ')
+          INVENTORY_COUNT=$(python3 -c "import json; print(json.load(open('results-data/corpus-inventory.json'))['summary']['total_bundles'])")
+          [ "$BUNDLE_COUNT" = "$INVENTORY_COUNT" ] || {
+            echo "::error::primary bundle count $BUNDLE_COUNT differs from validated inventory count $INVENTORY_COUNT"
+            exit 1
+          }
           PYTHON_VERSION=$(python3 -c 'import platform; print(platform.python_version())')
           NODE_VERSION=$(node --version | sed 's/^v//')
           UV_VERSION=$(uv --version | awk '{print $2}')
@@ -814,6 +821,41 @@ jobs:
         uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4
         with:
           artifact_name: publication-rollback-pages-${{ github.run_id }}-${{ github.run_attempt }}
+
+      - name: Record rollback provider acknowledgement
+        env:
+          PAGE_URL: ${{ steps.deployment.outputs.page_url }}
+          DEPLOYMENT_ID: ${{ github.run_id }}-${{ github.run_attempt }}
+          PAGES_ARTIFACT: publication-rollback-pages-${{ github.run_id }}-${{ github.run_attempt }}
+          BUILD_GENERATION: ${{ needs.build.outputs.generation }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          python3 - <<'PY'
+          import json
+          import os
+
+          receipt = {
+              'schema_version': '1.0',
+              'target': 'benchbox.dev',
+              'generation': int(os.environ['BUILD_GENERATION']),
+              'deployment_id': os.environ['DEPLOYMENT_ID'],
+              'page_url': os.environ['PAGE_URL'],
+              'artifact_name': os.environ['PAGES_ARTIFACT'],
+              'artifact_run_id': os.environ['GITHUB_RUN_ID'],
+              'status': 'DEPLOYED_ROLLBACK',
+          }
+          open('known-good-receipt/rollback-deployment-receipt.json', 'w').write(
+              json.dumps(receipt, sort_keys=True) + '\n'
+          )
+          PY
+
+      - name: Upload rollback provider acknowledgement
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: publication-rollback-deployment-receipt-${{ needs.build.outputs.generation }}
+          path: known-good-receipt/rollback-deployment-receipt.json
+          retention-days: 90
 
       - name: Probe restored required live routes
         shell: bash

--- a/.github/workflows/publication-deploy.yml
+++ b/.github/workflows/publication-deploy.yml
@@ -1,46 +1,110 @@
 name: Publication Control Plane Deployment
 
+# Dispatch-only during soak: docs.yml still owns release-push deployment.
 "on":
-  push:
-    branches: [release]
-    paths:
-      - "results-data/**"
-      - "results-explorer/**"
-      - "_project/scripts/explorer_pipeline/**"
-      - "_project/scripts/explorer_publish.py"
-      - "_project/scripts/results_explorer_snapshot_invariants.py"
-      - "scripts/publication/**"
-      - ".github/workflows/publication-deploy.yml"
-      - "docs/**"
-      - "pyproject.toml"
-      - "Makefile"
   workflow_dispatch:
     inputs:
+      develop_sha:
+        description: "Pinned develop commit SHA (40 hex)"
+        required: true
+        type: string
+      published_results_sha:
+        description: "Pinned published-results commit SHA (40 hex)"
+        required: true
+        type: string
+      generation:
+        description: "Optional immutable generation label; defaults to the run ID"
+        required: false
+        default: ""
+        type: string
+      prior_live_receipt_id:
+        description: "Prior attested live receipt ID, if this supersedes one"
+        required: false
+        default: ""
+        type: string
       expect_noop:
-        description: "Verify pre-deploy candidate against baseline (assert no unexpected mutation occurs)"
+        description: "Rehearse against the baseline without a Pages write"
         type: boolean
         default: false
       force_rollback:
-        description: "Force automated rollback drill execution"
+        description: "Exercise rollback using a prior attested artifact"
         type: boolean
         default: false
       rollback_target_sha:
-        description: "Specific target commit SHA for rollback (optional, defaults to baseline)"
+        description: "Deprecated: rollback selects an attested artifact, never a branch SHA"
         type: string
         default: ""
 
 permissions:
   contents: read
 
+concurrency:
+  group: pages-deploy
+  cancel-in-progress: false
+
 jobs:
   build:
-    name: Build Publication Artifacts & Candidate Pre-check
+    name: Build atomic publication artifact
     runs-on: ubuntu-latest
     permissions:
       contents: read
+    outputs:
+      generation: ${{ steps.inputs.outputs.generation }}
+      develop_sha: ${{ steps.inputs.outputs.develop_sha }}
+      published_results_sha: ${{ steps.inputs.outputs.published_results_sha }}
+      manifest_digest: ${{ steps.receipt.outputs.manifest_digest }}
+      assembly_digest: ${{ steps.receipt.outputs.assembly_digest }}
+      database_digest: ${{ steps.receipt.outputs.database_digest }}
+      explorer_digest: ${{ steps.receipt.outputs.explorer_digest }}
+      docs_digest: ${{ steps.receipt.outputs.docs_digest }}
+      site_artifact: ${{ steps.inputs.outputs.site_artifact }}
     steps:
-      - name: Checkout repository
+      - name: Checkout control-plane source
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Validate pinned dispatch inputs
+        id: inputs
+        shell: bash
+        run: |
+          set -euo pipefail
+          DEVELOP_SHA="${{ inputs.develop_sha }}"
+          PUBLISHED_RESULTS_SHA="${{ inputs.published_results_sha }}"
+          GENERATION="${{ inputs.generation }}"
+          for value in "$DEVELOP_SHA" "$PUBLISHED_RESULTS_SHA"; do
+            printf '%s' "$value" | grep -qE '^[0-9a-f]{40}$' || {
+              echo "::error::dispatch SHAs must be lowercase 40-hex commits"
+              exit 1
+            }
+            git cat-file -e "$value^{commit}" || {
+              echo "::error::pinned commit is not available: $value"
+              exit 1
+            }
+          done
+          if [ -z "$GENERATION" ]; then
+            GENERATION="publication-${{ github.run_id }}-${{ github.run_attempt }}"
+          fi
+          printf '%s' "$GENERATION" | grep -qE '^[a-z0-9-]{1,80}$' || {
+            echo "::error::generation must match [a-z0-9-]{1,80}"
+            exit 1
+          }
+          {
+            echo "generation=$GENERATION"
+            echo "develop_sha=$DEVELOP_SHA"
+            echo "published_results_sha=$PUBLISHED_RESULTS_SHA"
+            echo "site_artifact=publication-site-$GENERATION"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Materialize pinned control plane and corpus
+        shell: bash
+        run: |
+          set -euo pipefail
+          git checkout --detach "${{ steps.inputs.outputs.develop_sha }}"
+          rm -rf results-data
+          mkdir results-data
+          git archive "${{ steps.inputs.outputs.published_results_sha }}" results-data | tar -x
+          test -d results-data/bundles
 
       - name: Set up Python
         uses: actions/setup-python@v5
@@ -50,7 +114,7 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@v4
 
-      - name: Install dependencies
+      - name: Install Python dependencies
         run: uv sync --group dev
 
       - name: Set up Node.js
@@ -60,121 +124,133 @@ jobs:
           cache: npm
           cache-dependency-path: results-explorer/package-lock.json
 
-      - name: Install explorer dependencies
+      - name: Install Explorer dependencies
         run: npm ci
         working-directory: results-explorer
 
-      - name: Build explorer snapshot data
+      - name: Build Explorer corpus database
         run: |
-          mkdir -p results-explorer/public/data
           uv run python _project/scripts/explorer_publish.py build \
-            --data-dir results-data \
-            --output results-explorer/public/data
-
-      - name: Validate snapshot invariants
-        run: |
-          if [ ! -f "results-explorer/public/data/results.duckdb" ]; then
-            echo "::error::results-explorer/public/data/results.duckdb is missing after explorer_publish build"
+            --data-dir results-data --output results-explorer/public/data
+          test -s results-explorer/public/data/results.duckdb || {
+            echo "::error::results.duckdb is missing after explorer_publish build"
             exit 1
-          fi
+          }
           uv run python _project/scripts/results_explorer_snapshot_invariants.py \
             results-explorer/public/data/results.duckdb
 
-      - name: Build static publication site
+      - name: Build Explorer application
         run: npm run build
         working-directory: results-explorer
 
-      - name: Generate candidate publication receipt
+      - name: Build documentation
+        run: |
+          cd docs
+          uv run sphinx-build -b html --keep-going . _build/html
+
+      - name: Assemble and validate whole-site artifact
+        run: |
+          uv run python scripts/assemble_public_site.py --site-dir site
+          test -s site/results/data/results.duckdb || {
+            echo "::error::atomic site artifact is missing results.duckdb"
+            exit 1
+          }
+          uv run python scripts/publication/check_artifact_privacy.py site
+
+      - name: Write desired and assembly receipts
         id: receipt
         shell: bash
         run: |
           set -euo pipefail
-          mkdir -p site-dist receipt-dist
-          cp -r results-explorer/dist/* site-dist/
-          mkdir -p site-dist/results/data
-          if [ -d "results-explorer/public/data" ]; then
-            cp -r results-explorer/public/data/* site-dist/results/data/
-          fi
-
-          DB_SHA=""
-          if [ -f "site-dist/results/data/results.duckdb" ]; then
-            DB_SHA=$(sha256sum site-dist/results/data/results.duckdb | cut -d ' ' -f 1)
-          fi
-
+          mkdir -p receipt-dist
+          GENERATION="${{ steps.inputs.outputs.generation }}"
+          DEVELOP_SHA="${{ steps.inputs.outputs.develop_sha }}"
+          PUBLISHED_RESULTS_SHA="${{ steps.inputs.outputs.published_results_sha }}"
           TIMESTAMP=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
-          RECEIPT_FILE="receipt-dist/publication-receipt.json"
-
-          cat <<EOF > "$RECEIPT_FILE"
-          {
-            "schema_version": 1,
-            "sha": "${{ github.sha }}",
-            "ref": "${{ github.ref }}",
-            "timestamp": "$TIMESTAMP",
-            "database_sha256": "$DB_SHA",
-            "checksums": {
-              "/results/data/results.duckdb": "$DB_SHA"
-            }
-          }
+          MANIFEST_DIGEST=$(printf '%s' "develop=$DEVELOP_SHA|published-results=$PUBLISHED_RESULTS_SHA|target=benchbox.dev|generation=$GENERATION" | sha256sum | cut -d ' ' -f 1)
+          (cd site && find . -type f -exec sha256sum {} + | sort) > receipt-dist/site-file-digests.txt
+          SITE_DIGEST=$(sha256sum receipt-dist/site-file-digests.txt | cut -d ' ' -f 1)
+          (cd results-explorer/dist && find . -type f -exec sha256sum {} + | sort) > receipt-dist/explorer-file-digests.txt
+          EXPLORER_DIGEST=$(sha256sum receipt-dist/explorer-file-digests.txt | cut -d ' ' -f 1)
+          (cd docs/_build/html && find . -type f -exec sha256sum {} + | sort) > receipt-dist/docs-file-digests.txt
+          DOCS_DIGEST=$(sha256sum receipt-dist/docs-file-digests.txt | cut -d ' ' -f 1)
+          DATABASE_DIGEST=$(sha256sum site/results/data/results.duckdb | cut -d ' ' -f 1)
+          cat > receipt-dist/desired-manifest.json <<EOF
+          {"schema_version":1,"generation":"$GENERATION","target":"benchbox.dev","develop_sha":"$DEVELOP_SHA","published_results_sha":"$PUBLISHED_RESULTS_SHA","manifest_digest":"$MANIFEST_DIGEST","prior_live_receipt_id":"${{ inputs.prior_live_receipt_id }}","timestamp":"$TIMESTAMP"}
           EOF
+          cat > receipt-dist/assembly-receipt.json <<EOF
+          {"schema_version":1,"generation":"$GENERATION","target":"benchbox.dev","manifest_digest":"$MANIFEST_DIGEST","develop_sha":"$DEVELOP_SHA","published_results_sha":"$PUBLISHED_RESULTS_SHA","artifact_name":"${{ steps.inputs.outputs.site_artifact }}","artifact_run_id":"${{ github.run_id }}","artifacts":{"site":{"path":"/","digest":"$SITE_DIGEST"},"docs":{"path":"/docs/","digest":"$DOCS_DIGEST"},"explorer":{"path":"/results/","digest":"$EXPLORER_DIGEST"},"database":{"path":"/results/data/results.duckdb","digest":"$DATABASE_DIGEST"}},"checksums":{"/results/data/results.duckdb":"$DATABASE_DIGEST"},"timestamp":"$TIMESTAMP"}
+          EOF
+          cp receipt-dist/assembly-receipt.json receipt-dist/publication-receipt.json
+          {
+            echo "manifest_digest=$MANIFEST_DIGEST"
+            echo "assembly_digest=$SITE_DIGEST"
+            echo "database_digest=$DATABASE_DIGEST"
+            echo "explorer_digest=$EXPLORER_DIGEST"
+            echo "docs_digest=$DOCS_DIGEST"
+          } >> "$GITHUB_OUTPUT"
 
-          echo "Generated candidate deployment receipt:"
-          cat "$RECEIPT_FILE"
-
-      - name: Pre-deploy candidate verification and no-op check
-        env:
-          EXPECT_NOOP: ${{ inputs.expect_noop || false }}
+      - name: Pre-deploy candidate verification
         shell: bash
         run: |
-          NOOP_FLAG=""
-          if [ "$EXPECT_NOOP" = "true" ]; then
-            NOOP_FLAG="--expect-noop"
+          set -euo pipefail
+          if [ "${{ inputs.expect_noop }}" = "true" ]; then
+            uv run python scripts/publication/verify_live.py \
+              --candidate-manifest receipt-dist/publication-receipt.json \
+              --baseline-manifest docs/operations/publication-baseline-2026-08-31.json \
+              --pre-deploy --require-receipt --expect-noop
+          else
+            uv run python scripts/publication/verify_live.py \
+              --candidate-manifest receipt-dist/publication-receipt.json \
+              --baseline-manifest receipt-dist/publication-receipt.json \
+              --pre-deploy --require-receipt
           fi
 
-          echo "Executing pre-deploy candidate check (expect_noop=$EXPECT_NOOP)..."
-          uv run python scripts/publication/verify_live.py \
-            --candidate-manifest receipt-dist/publication-receipt.json \
-            --baseline-manifest docs/operations/publication-baseline-2026-08-31.json \
-            --pre-deploy \
-            --require-receipt \
-            $NOOP_FLAG
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: site
 
-      - name: Upload rehearsal site artifact
+      - name: Retain immutable site artifact for attested rollback
         uses: actions/upload-artifact@v4
         with:
-          name: publication-site-rehearsal
-          path: site-dist
-          retention-days: 7
+          name: ${{ steps.inputs.outputs.site_artifact }}
+          path: site
+          retention-days: 90
 
-      - name: Upload candidate deployment receipt
+      - name: Upload build receipts
         uses: actions/upload-artifact@v4
         with:
-          name: publication-receipt
-          path: receipt-dist/publication-receipt.json
-          retention-days: 30
+          name: publication-build-receipts-${{ steps.inputs.outputs.generation }}
+          path: receipt-dist/
+          retention-days: 90
 
   deploy:
-    name: Deploy to GitHub Pages
+    name: Deploy atomic artifact to GitHub Pages
     needs: build
-    if: github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && inputs.expect_noop != true && inputs.force_rollback != true)
+    if: inputs.expect_noop != true && inputs.force_rollback != true
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
     steps:
-      - name: Rehearsal no-op (freeze G3)
-        shell: bash
-        run: |
-          echo "Freeze G3 keeps docs.yml as the sole production Pages deployer; do not deploy."
-          echo "publication-deploy.yml is a rehearsal control-plane only until G1-G5 pass."
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4
 
   verify:
-    name: Verify Live Publication & Checksum Receipt
+    name: Probe live routes and issue attested receipt
     needs: [build, deploy]
+    if: needs.deploy.result == 'success'
     runs-on: ubuntu-latest
     permissions:
       contents: read
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
+      - uses: actions/checkout@v4
 
       - name: Set up Python
         uses: actions/setup-python@v5
@@ -184,85 +260,243 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@v4
 
-      - name: Download deployment receipt
+      - name: Download build receipts
         uses: actions/download-artifact@v4
         with:
-          name: publication-receipt
-          path: ./downloaded-receipt
+          name: publication-build-receipts-${{ needs.build.outputs.generation }}
+          path: receipt-dist
 
-      - name: Run live verification probe
-        env:
-          PAGE_URL: ${{ needs.deploy.outputs.page_url }}
-        shell: bash
-        run: |
-          RECEIPT_PATH="./downloaded-receipt/publication-receipt.json"
-          TARGET_URL="${PAGE_URL:-https://benchbox.dev}"
-
-          echo "Verifying live publication at: $TARGET_URL"
-          uv run python scripts/publication/verify_live.py \
-            --base-url "$TARGET_URL" \
-            --manifest "$RECEIPT_PATH" \
-            --require-receipt \
-            --timeout 60
-
-  rollback:
-    name: Immutable CAS Artifact Rollback Drill / Mitigation
-    needs: [build, deploy, verify]
-    if: always() && (needs.deploy.result == 'failure' || needs.verify.result == 'failure' || (github.event_name == 'workflow_dispatch' && inputs.force_rollback == true))
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-
-      - name: Log rollback trigger context
-        shell: bash
-        run: |
-          echo "::error::Publication deployment or verification failed; recording freeze-blocked rollback receipt (no Pages write)."
-          echo "Build status: ${{ needs.build.result }}"
-          echo "Deploy status: ${{ needs.deploy.result }}"
-          echo "Verify status: ${{ needs.verify.result }}"
-          echo "Force rollback requested: ${{ inputs.force_rollback || false }}"
-
-      - name: Write facts-only rollback receipt
-        id: rollback-stage
+      - name: Probe required live routes
         shell: bash
         run: |
           set -euo pipefail
-          mkdir -p rollback-receipt-dist
+          uv run python scripts/publication/verify_live.py \
+            --base-url "${{ needs.deploy.outputs.page_url }}" \
+            --manifest receipt-dist/publication-receipt.json \
+            --require-receipt --timeout 60 --json > receipt-dist/live-probe-report.json
 
-          BASELINE_FILE="docs/operations/publication-baseline-2026-08-31.json"
-          TARGET_SHA=""
-          EXPECTED_DB_SHA=""
-          if [ -f "$BASELINE_FILE" ]; then
-            TARGET_SHA=$(python3 -c "import json; data=json.load(open('$BASELINE_FILE')); print(data.get('branches', {}).get('release', {}).get('sha', ''))")
-            EXPECTED_DB_SHA=$(python3 -c "import json; data=json.load(open('$BASELINE_FILE')); print(data.get('live_database', {}).get('sha256', ''))")
-          fi
+      - name: Record provider deployment acknowledgement
+        shell: bash
+        run: |
+          set -euo pipefail
+          cp receipt-dist/assembly-receipt.json receipt-dist/deployment-receipt.json
+          python3 - <<'PY'
+          import json
+          path = 'receipt-dist/deployment-receipt.json'
+          receipt = json.load(open(path))
+          receipt.update({'deployment_id': '${{ github.run_id }}-${{ github.run_attempt }}', 'page_url': '${{ needs.deploy.outputs.page_url }}', 'status': 'DEPLOYED'})
+          open(path, 'w').write(json.dumps(receipt, sort_keys=True) + '\\n')
+          PY
 
-          TIMESTAMP=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
-          RECEIPT_FILE="rollback-receipt-dist/rollback-receipt.json"
-
-          cat <<EOF > "$RECEIPT_FILE"
-          {
-            "schema_version": 1,
-            "action": "freeze_blocked_rollback_receipt",
-            "pinned_baseline_release_sha": "$TARGET_SHA",
-            "attested_database_sha256": "$EXPECTED_DB_SHA",
-            "timestamp": "$TIMESTAMP",
-            "reason": "deploy_or_verification_failure",
-            "freeze_still_blocked": true,
-            "pages_deploy_attempted": false,
-            "sole_production_pages_deployer": "docs.yml"
+      - name: Create and sign live receipt
+        env:
+          PUBLICATION_ATTESTOR_PRIVATE_KEY: ${{ secrets.PUBLICATION_ATTESTOR_PRIVATE_KEY }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          test -n "$PUBLICATION_ATTESTOR_PRIVATE_KEY" || {
+            echo "::error::PUBLICATION_ATTESTOR_PRIVATE_KEY is required to attest a live deployment"
+            exit 1
           }
-          EOF
+          python3 - <<'PY'
+          import json
+          from datetime import datetime, timezone
+          assembly = json.load(open('receipt-dist/assembly-receipt.json'))
+          probes = json.load(open('receipt-dist/live-probe-report.json'))['probes']
+          receipt = dict(assembly)
+          receipt.update({
+              'receipt_id': 'live-${{ needs.build.outputs.generation }}-${{ github.run_id }}',
+              'timestamp': datetime.now(timezone.utc).isoformat().replace('+00:00', 'Z'),
+              'routes': probes,
+              'nonce': '${{ github.run_id }}-${{ github.run_attempt }}',
+              'freshness_window': '24h',
+              'attestor': 'github-actions:publication-deploy',
+              'attestor_key_id': 'publication-attestor-ed25519-2026-09-04',
+              'signature_algorithm': 'ed25519',
+              'prior_live_receipt_id': '${{ inputs.prior_live_receipt_id }}' or None,
+          })
+          open('receipt-dist/live-receipt.json', 'w').write(json.dumps(receipt, sort_keys=True) + '\\n')
+          PY
+          umask 077
+          printf '%s' "$PUBLICATION_ATTESTOR_PRIVATE_KEY" > /tmp/publication-attestor-private-key.pem
+          uv run python - <<'PY'
+          import json
+          from scripts.publication.reconciliation import canonical_live_receipt_payload
+          receipt = json.load(open('receipt-dist/live-receipt.json'))
+          open('/tmp/live-receipt-payload.json', 'wb').write(canonical_live_receipt_payload(receipt))
+          PY
+          openssl pkeyutl -sign -rawin -inkey /tmp/publication-attestor-private-key.pem -in /tmp/live-receipt-payload.json -out /tmp/live-receipt.sig
+          SIGNATURE=$(base64 -w 0 /tmp/live-receipt.sig)
+          rm -f /tmp/publication-attestor-private-key.pem /tmp/live-receipt-payload.json /tmp/live-receipt.sig
+          python3 - <<PY
+          import json
+          path = 'receipt-dist/live-receipt.json'
+          receipt = json.load(open(path))
+          receipt['signature'] = '$SIGNATURE'
+          open(path, 'w').write(json.dumps(receipt, sort_keys=True) + '\\n')
+          PY
+          uv run python - <<'PY'
+          import json
+          from scripts.publication.reconciliation import verify_live_receipt_signature
+          valid, reason = verify_live_receipt_signature(json.load(open('receipt-dist/live-receipt.json')))
+          assert valid, reason
+          PY
 
-          echo "Generated freeze-blocked rollback receipt:"
-          cat "$RECEIPT_FILE"
+      - name: Upload attested live receipt
+        uses: actions/upload-artifact@v4
+        with:
+          name: publication-live-receipt-${{ needs.build.outputs.generation }}
+          path: receipt-dist/
+          retention-days: 90
+
+  rollback:
+    name: Roll back to last known-good attested artifact
+    needs: [build, deploy, verify]
+    if: >-
+      always() && needs.build.result == 'success' && (
+        needs.deploy.result == 'failure' || needs.verify.result == 'failure' ||
+        (github.event_name == 'workflow_dispatch' && inputs.force_rollback == true)
+      )
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v4
+
+      - name: Resolve last known-good attested receipt
+        id: known_good
+        env:
+          GH_TOKEN: ${{ github.token }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p known-good-receipt
+          gh api --paginate "repos/${{ github.repository }}/actions/artifacts?per_page=100" --jq '.artifacts[] | select(.expired == false) | select(.name | startswith("publication-live-receipt-")) | "\(.id) \(.workflow_run.id)"' > candidates.txt
+          while read -r ARTIFACT_ID RUN_ID; do
+            [ -n "${ARTIFACT_ID:-}" ] || continue
+            rm -rf candidate && mkdir candidate
+            gh api "repos/${{ github.repository }}/actions/artifacts/$ARTIFACT_ID/zip" > candidate.zip
+            unzip -q candidate.zip -d candidate
+            if uv run python - <<'PY'
+          import json
+          from pathlib import Path
+          from scripts.publication.reconciliation import verify_live_receipt_signature
+          p = Path('candidate/live-receipt.json')
+          if not p.is_file(): raise SystemExit(1)
+          receipt = json.loads(p.read_text())
+          valid, _ = verify_live_receipt_signature(receipt)
+          if not valid or receipt.get('target') != 'benchbox.dev': raise SystemExit(1)
+          assembly = json.loads(Path('candidate/assembly-receipt.json').read_text())
+          assert assembly.get('artifact_name') and assembly.get('artifact_run_id')
+          PY
+            then
+              ARTIFACT_NAME=$(uv run python -c "import json; print(json.load(open('candidate/assembly-receipt.json'))['artifact_name'])")
+              ARTIFACT_RUN_ID=$(uv run python -c "import json; print(json.load(open('candidate/assembly-receipt.json'))['artifact_run_id'])")
+              cp -R candidate/. known-good-receipt/
+              echo "artifact_name=$ARTIFACT_NAME" >> "$GITHUB_OUTPUT"
+              echo "artifact_run_id=$ARTIFACT_RUN_ID" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
+          done < candidates.txt
+          echo "::error::no cryptographically attested, unexpired rollback artifact is available"
+          exit 1
+
+      - name: Download and verify known-good site artifact
+        env:
+          GH_TOKEN: ${{ github.token }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          gh run download "${{ steps.known_good.outputs.artifact_run_id }}" --name "${{ steps.known_good.outputs.artifact_name }}" --dir restored-site
+          EXPECTED=$(uv run python -c "import json; print(json.load(open('known-good-receipt/assembly-receipt.json'))['artifacts']['site']['digest'])")
+          (cd restored-site && find . -type f -exec sha256sum {} + | sort) > restored-site-file-digests.txt
+          ACTUAL=$(sha256sum restored-site-file-digests.txt | cut -d ' ' -f 1)
+          [ "$ACTUAL" = "$EXPECTED" ] || { echo "::error::known-good artifact digest mismatch; refusing rollback"; exit 1; }
+          test -s restored-site/results/data/results.duckdb
+
+      - name: Upload attested rollback Pages artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: restored-site
+
+      - name: Deploy attested rollback artifact to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4
+
+      - name: Probe restored required live routes
+        shell: bash
+        run: |
+          set -euo pipefail
+          uv run python scripts/publication/verify_live.py --base-url "${{ steps.deployment.outputs.page_url }}" --manifest known-good-receipt/live-receipt.json --require-receipt --timeout 60 --json > known-good-receipt/rollback-probe-report.json
+
+      - name: Create and sign rollback live receipt
+        env:
+          PUBLICATION_ATTESTOR_PRIVATE_KEY: ${{ secrets.PUBLICATION_ATTESTOR_PRIVATE_KEY }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          test -n "$PUBLICATION_ATTESTOR_PRIVATE_KEY" || {
+            echo "::error::PUBLICATION_ATTESTOR_PRIVATE_KEY is required to attest rollback"
+            exit 1
+          }
+          python3 - <<'PY'
+          import json
+          from datetime import datetime, timezone
+          prior = json.load(open('known-good-receipt/live-receipt.json'))
+          probes = json.load(open('known-good-receipt/rollback-probe-report.json'))['probes']
+          receipt = dict(prior)
+          receipt.update({
+              'receipt_id': 'rollback-${{ github.run_id }}-${{ github.run_attempt }}',
+              'timestamp': datetime.now(timezone.utc).isoformat().replace('+00:00', 'Z'),
+              'routes': probes,
+              'nonce': '${{ github.run_id }}-${{ github.run_attempt }}',
+              'prior_live_receipt_id': prior['receipt_id'],
+          })
+          receipt.pop('signature', None)
+          open('known-good-receipt/rollback-live-receipt.json', 'w').write(json.dumps(receipt, sort_keys=True) + '\\n')
+          PY
+          umask 077
+          printf '%s' "$PUBLICATION_ATTESTOR_PRIVATE_KEY" > /tmp/publication-attestor-private-key.pem
+          uv run python - <<'PY'
+          import json
+          from scripts.publication.reconciliation import canonical_live_receipt_payload
+          receipt = json.load(open('known-good-receipt/rollback-live-receipt.json'))
+          open('/tmp/rollback-live-receipt-payload.json', 'wb').write(canonical_live_receipt_payload(receipt))
+          PY
+          openssl pkeyutl -sign -rawin -inkey /tmp/publication-attestor-private-key.pem -in /tmp/rollback-live-receipt-payload.json -out /tmp/rollback-live-receipt.sig
+          SIGNATURE=$(base64 -w 0 /tmp/rollback-live-receipt.sig)
+          rm -f /tmp/publication-attestor-private-key.pem /tmp/rollback-live-receipt-payload.json /tmp/rollback-live-receipt.sig
+          python3 - <<PY
+          import json
+          path = 'known-good-receipt/rollback-live-receipt.json'
+          receipt = json.load(open(path))
+          receipt['signature'] = '$SIGNATURE'
+          open(path, 'w').write(json.dumps(receipt, sort_keys=True) + '\\n')
+          PY
+          uv run python - <<'PY'
+          import json
+          from scripts.publication.reconciliation import verify_live_receipt_signature
+          valid, reason = verify_live_receipt_signature(json.load(open('known-good-receipt/rollback-live-receipt.json')))
+          assert valid, reason
+          PY
 
       - name: Upload rollback audit receipt
         uses: actions/upload-artifact@v4
         with:
-          name: rollback-receipt
-          path: rollback-receipt-dist/rollback-receipt.json
+          name: publication-rollback-${{ github.run_id }}
+          path: known-good-receipt/
           retention-days: 90

--- a/.github/workflows/publication-deploy.yml
+++ b/.github/workflows/publication-deploy.yml
@@ -303,6 +303,9 @@ jobs:
           (cd results-data/bundles && find . -type f -exec sha256sum {} + | sort) > receipt-dist/corpus-file-digests.txt
           CORPUS_DIGEST=$(sha256sum receipt-dist/corpus-file-digests.txt | cut -d ' ' -f 1)
           DATABASE_DIGEST=$(sha256sum site/results/data/results.duckdb | cut -d ' ' -f 1)
+          ROOT_ENDPOINT_DIGEST=$(sha256sum site/index.html | cut -d ' ' -f 1)
+          DOCS_ENDPOINT_DIGEST=$(sha256sum site/docs/index.html | cut -d ' ' -f 1)
+          EXPLORER_ENDPOINT_DIGEST=$(sha256sum site/results/index.html | cut -d ' ' -f 1)
           LOCKFILE_DIGEST=$(sha256sum uv.lock | cut -d ' ' -f 1)
           BUNDLE_COUNT=$(find results-data/bundles -type f -name '*.json' | wc -l | tr -d ' ')
           PYTHON_VERSION=$(python3 -c 'import platform; print(platform.python_version())')
@@ -311,6 +314,7 @@ jobs:
           IMAGE_OS="${ImageOS:-ubuntu-latest}"
           export GENERATION DEVELOP_SHA PUBLISHED_RESULTS_SHA PRIOR_LIVE_RECEIPT_ID SITE_DIGEST DOCS_DIGEST
           export EXPLORER_DIGEST DATABASE_DIGEST CORPUS_DIGEST LOCKFILE_DIGEST BUNDLE_COUNT PYTHON_VERSION
+          export ROOT_ENDPOINT_DIGEST DOCS_ENDPOINT_DIGEST EXPLORER_ENDPOINT_DIGEST
           export NODE_VERSION UV_VERSION IMAGE_OS SITE_ARTIFACT GITHUB_RUN_ID TIMESTAMP GITHUB_OUTPUT
           export PARENT_SHA PARENT_GENERATION WORKFLOW_SHA APPROVED_MANIFEST_DIGEST
           python3 - <<'PY'
@@ -357,14 +361,21 @@ jobs:
                   "read_model_sha256": os.environ["DATABASE_DIGEST"],
               },
               "artifacts": {
-                  "prose_site": {"digest": os.environ["SITE_DIGEST"], "size": tree_size("site"), "path": "/"},
+                  "prose_site": {
+                      "digest": os.environ["SITE_DIGEST"],
+                      "endpoint_sha256": os.environ["ROOT_ENDPOINT_DIGEST"],
+                      "size": tree_size("site"),
+                      "path": "/",
+                  },
                   "api_docs": {
                       "digest": os.environ["DOCS_DIGEST"],
+                      "endpoint_sha256": os.environ["DOCS_ENDPOINT_DIGEST"],
                       "size": tree_size("docs/_build/html"),
                       "path": "/docs/",
                   },
                   "explorer_app": {
                       "digest": os.environ["EXPLORER_DIGEST"],
+                      "endpoint_sha256": os.environ["EXPLORER_ENDPOINT_DIGEST"],
                       "size": tree_size("results-explorer/dist"),
                       "path": "/results/",
                   },
@@ -384,7 +395,12 @@ jobs:
                       "path": "/",
                   },
               },
-              "checksums": {"/results/data/results.duckdb": os.environ["DATABASE_DIGEST"]},
+              "checksums": {
+                  "/": os.environ["ROOT_ENDPOINT_DIGEST"],
+                  "/docs/": os.environ["DOCS_ENDPOINT_DIGEST"],
+                  "/results/": os.environ["EXPLORER_ENDPOINT_DIGEST"],
+                  "/results/data/results.duckdb": os.environ["DATABASE_DIGEST"],
+              },
           }
           if os.environ.get("PRIOR_LIVE_RECEIPT_ID"):
               manifest["prior_live_receipt_id"] = os.environ["PRIOR_LIVE_RECEIPT_ID"]
@@ -530,16 +546,6 @@ jobs:
           name: publication-build-receipts-${{ needs.build.outputs.generation }}
           path: receipt-dist
 
-      - name: Probe required live routes
-        shell: bash
-        run: |
-          set -euo pipefail
-          TARGET_URL="${{ needs.deploy.outputs.page_url || 'https://benchbox.dev' }}"
-          uv run python scripts/publication/verify_live.py \
-            --base-url "$TARGET_URL" \
-            --manifest receipt-dist/publication-receipt.json \
-            --require-receipt --timeout 60 --json > receipt-dist/live-probe-report.json
-
       - name: Record provider deployment acknowledgement
         env:
           PAGE_URL: ${{ needs.deploy.outputs.page_url || 'https://benchbox.dev' }}
@@ -559,6 +565,23 @@ jobs:
           })
           open(path, 'w').write(json.dumps(receipt, sort_keys=True) + '\n')
           PY
+
+      - name: Upload provider deployment acknowledgement
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: publication-deployment-receipt-${{ needs.build.outputs.generation }}
+          path: receipt-dist/deployment-receipt.json
+          retention-days: 90
+
+      - name: Probe required live routes
+        shell: bash
+        run: |
+          set -euo pipefail
+          TARGET_URL="${{ needs.deploy.outputs.page_url || 'https://benchbox.dev' }}"
+          uv run python scripts/publication/verify_live.py \
+            --base-url "$TARGET_URL" \
+            --manifest receipt-dist/publication-receipt.json \
+            --require-receipt --timeout 60 --json > receipt-dist/live-probe-report.json
 
       - name: Create and sign live receipt
         env:

--- a/.github/workflows/publication-deploy.yml
+++ b/.github/workflows/publication-deploy.yml
@@ -621,10 +621,17 @@ jobs:
         run: |
           set -euo pipefail
           if [ "$EXPECT_NOOP" = "true" ]; then
-            uv run python scripts/publication/verify_live.py \
-              --candidate-manifest receipt-dist/publication-receipt.json \
-              --baseline-manifest docs/operations/publication-baseline-2026-08-31.json \
-              --pre-deploy --require-receipt --expect-noop
+            LIVE_DB_SHA=$(python3 -c \
+              "import json; print(json.load(open('docs/operations/publication-baseline-2026-08-31.json'))['live_database']['sha256'])")
+            LIVE_DB_URL=$(python3 -c \
+              "import json; print(json.load(open('docs/operations/publication-baseline-2026-08-31.json'))['live_database']['url'])")
+            curl -sSL --fail --retry 3 -o live-results.duckdb "$LIVE_DB_URL"
+            [ "$(sha256sum live-results.duckdb | cut -d ' ' -f 1)" = "$LIVE_DB_SHA" ] || {
+              echo "::error::live database no longer matches the frozen baseline; refusing rehearsal"
+              exit 1
+            }
+            uv run python scripts/publication/compare_db_digest.py compare \
+              site/results/data/results.duckdb live-results.duckdb
           else
             uv run python scripts/publication/verify_live.py \
               --candidate-manifest receipt-dist/publication-receipt.json \

--- a/.github/workflows/publication-deploy.yml
+++ b/.github/workflows/publication-deploy.yml
@@ -160,9 +160,10 @@ jobs:
         run: |
           set -euo pipefail
           mkdir -p prior-live-receipt
-          gh api "repos/${{ github.repository }}/actions/artifacts?per_page=100" \
-            --jq '.artifacts | map(select(.expired == false) | select(.name | startswith("publication-live-receipt-"))) | sort_by(.created_at) | reverse | .[] | "\(.id) \(.workflow_run.id)"' > prior-candidates.txt
-          while read -r ARTIFACT_ID RUN_ID; do
+          gh api --paginate "repos/${{ github.repository }}/actions/artifacts?per_page=100" \
+            --jq '.artifacts[] | select(.expired == false) | select(.name | startswith("publication-live-receipt-")) | "\(.created_at) \(.id) \(.workflow_run.id)"' \
+            | sort -r > prior-candidates.txt
+          while read -r _CREATED_AT ARTIFACT_ID RUN_ID; do
             [ -n "${ARTIFACT_ID:-}" ] || continue
             RUN_META=$(gh api "repos/${{ github.repository }}/actions/runs/$RUN_ID" --jq '[.name, .status, .conclusion, .event] | @tsv')
             IFS=$'\t' read -r RUN_NAME RUN_STATUS RUN_CONCLUSION RUN_EVENT <<< "$RUN_META"
@@ -491,8 +492,9 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          CURRENT=$(gh api "repos/${{ github.repository }}/actions/artifacts?per_page=100" \
-            --jq '[.artifacts | map(select(.expired == false) | select(.name | startswith("publication-live-receipt-"))) | sort_by(.created_at) | reverse | .[0].id][0] // ""')
+          CURRENT=$(gh api --paginate "repos/${{ github.repository }}/actions/artifacts?per_page=100" \
+            --jq '.artifacts[] | select(.expired == false) | select(.name | startswith("publication-live-receipt-")) | "\(.created_at) \(.id)"' \
+            | sort -r | sed -n '1{s/^[^ ]* //;p;}')
           [ "$CURRENT" = "$EXPECTED_PARENT_ARTIFACT_ID" ] || {
             echo "::error::publication live head changed after build; refusing stale deployment"
             exit 1
@@ -728,6 +730,14 @@ jobs:
           name: publication-rollback-pages-${{ github.run_id }}-${{ github.run_attempt }}
           path: restored-site
 
+      - name: Retain restored site artifact for the new rollback head
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: publication-site-${{ needs.build.outputs.generation }}-rollback
+          path: restored-site
+          include-hidden-files: true
+          retention-days: 90
+
       - name: Deploy attested rollback artifact to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4
@@ -748,6 +758,7 @@ jobs:
           PARENT_SHA: ${{ needs.build.outputs.parent_sha }}
           PARENT_GENERATION: ${{ needs.build.outputs.parent_generation }}
           PRIOR_LIVE_RECEIPT_ID: ${{ inputs.prior_live_receipt_id }}
+          SITE_ARTIFACT: publication-site-${{ needs.build.outputs.generation }}-rollback
           GITHUB_RUN_ID: ${{ github.run_id }}
           GITHUB_RUN_ATTEMPT: ${{ github.run_attempt }}
         shell: bash
@@ -770,6 +781,8 @@ jobs:
               'parent_generation': int(os.environ['PARENT_GENERATION']),
               'receipt_id': f"rollback-{os.environ['GITHUB_RUN_ID']}-{os.environ['GITHUB_RUN_ATTEMPT']}",
               'receipt_run_id': os.environ['GITHUB_RUN_ID'],
+              'artifact_name': os.environ['SITE_ARTIFACT'],
+              'artifact_run_id': os.environ['GITHUB_RUN_ID'],
               'timestamp': datetime.now(timezone.utc).isoformat().replace('+00:00', 'Z'),
               'routes': probes,
               'nonce': f"{os.environ['GITHUB_RUN_ID']}-{os.environ['GITHUB_RUN_ATTEMPT']}",

--- a/.github/workflows/publication-deploy.yml
+++ b/.github/workflows/publication-deploy.yml
@@ -13,9 +13,8 @@ name: Publication Control Plane Deployment
         required: true
         type: string
       generation:
-        description: "Optional immutable generation label; defaults to the run ID"
-        required: false
-        default: ""
+        description: "Positive decimal CAS generation (1 for the first independent deployment)"
+        required: true
         type: string
       prior_live_receipt_id:
         description: "Prior attested live receipt ID, if this supersedes one"
@@ -47,6 +46,7 @@ jobs:
     name: Build atomic publication artifact
     runs-on: ubuntu-latest
     permissions:
+      actions: read
       contents: read
     outputs:
       generation: ${{ steps.inputs.outputs.generation }}
@@ -60,7 +60,7 @@ jobs:
       site_artifact: ${{ steps.inputs.outputs.site_artifact }}
     steps:
       - name: Checkout control-plane source
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
           fetch-depth: 0
 
@@ -92,9 +92,6 @@ jobs:
           git merge-base --is-ancestor "$PUBLISHED_RESULTS_SHA" refs/remotes/origin/published-results || {
             echo "::error::published_results_sha is not reachable from the protected published-results branch"; exit 1;
           }
-          if [ -z "$GENERATION" ]; then
-            GENERATION="$GITHUB_RUN_ID"
-          fi
           printf '%s' "$GENERATION" | grep -qE '^[1-9][0-9]{0,18}$' || {
             echo "::error::generation must be a positive decimal CAS generation"
             exit 1
@@ -109,8 +106,6 @@ jobs:
           INPUT_DEVELOP_SHA: ${{ inputs.develop_sha }}
           INPUT_PUBLISHED_RESULTS_SHA: ${{ inputs.published_results_sha }}
           INPUT_GENERATION: ${{ inputs.generation }}
-          GITHUB_RUN_ID: ${{ github.run_id }}
-          GITHUB_RUN_ATTEMPT: ${{ github.run_attempt }}
 
       - name: Materialize pinned control plane and corpus
         shell: bash
@@ -124,18 +119,87 @@ jobs:
           test -d results-data/bundles
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: "3.11"
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v4
+        uses: astral-sh/setup-uv@38f3f104447c67c051c4a08e39b64a148898af3a # v4
 
       - name: Install Python dependencies
         run: uv sync --group dev
 
+      - name: Resolve attested publication lineage
+        id: lineage
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GENERATION: ${{ steps.inputs.outputs.generation }}
+          PRIOR_LIVE_RECEIPT_ID: ${{ inputs.prior_live_receipt_id }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [ "$GENERATION" = "1" ]; then
+            [ -z "$PRIOR_LIVE_RECEIPT_ID" ] || {
+              echo "::error::generation 1 is genesis and cannot name a prior live receipt"
+              exit 1
+            }
+            echo "parent_sha=" >> "$GITHUB_OUTPUT"
+            echo "parent_generation=" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          [ -n "$PRIOR_LIVE_RECEIPT_ID" ] || {
+            echo "::error::generation $GENERATION requires prior_live_receipt_id"
+            exit 1
+          }
+          mkdir -p prior-live-receipt
+          gh api --paginate "repos/${{ github.repository }}/actions/artifacts?per_page=100" \
+            --jq '.artifacts[] | select(.expired == false) | select(.name | startswith("publication-live-receipt-")) | "\(.id) \(.workflow_run.id)"' > prior-candidates.txt
+          while read -r ARTIFACT_ID RUN_ID; do
+            [ -n "${ARTIFACT_ID:-}" ] || continue
+            RUN_META=$(gh api "repos/${{ github.repository }}/actions/runs/$RUN_ID" --jq '[.name, .conclusion, .event] | @tsv')
+            IFS=$'\t' read -r RUN_NAME RUN_CONCLUSION RUN_EVENT <<< "$RUN_META"
+            if [[ "$RUN_NAME" != "Publication Control Plane Deployment" || "$RUN_CONCLUSION" != "success" || "$RUN_EVENT" != "workflow_dispatch" ]]; then
+              continue
+            fi
+            rm -rf prior-candidate && mkdir prior-candidate
+            gh api "repos/${{ github.repository }}/actions/artifacts/$ARTIFACT_ID/zip" > prior-candidate.zip
+            unzip -q prior-candidate.zip -d prior-candidate
+            if EXPECTED_RUN_ID="$RUN_ID" uv run python - <<'PY'
+          import json
+          import os
+          import re
+          from pathlib import Path
+          from scripts.publication.reconciliation import verify_live_receipt_signature
+
+          path = Path("prior-candidate/live-receipt.json")
+          if not path.is_file():
+              raise SystemExit(1)
+          receipt = json.loads(path.read_text())
+          valid, _ = verify_live_receipt_signature(receipt)
+          if not valid or receipt.get("target") != "benchbox.dev":
+              raise SystemExit(1)
+          if receipt.get("receipt_id") != os.environ["PRIOR_LIVE_RECEIPT_ID"]:
+              raise SystemExit(1)
+          if receipt.get("generation") != int(os.environ["GENERATION"]) - 1:
+              raise SystemExit(1)
+          if str(receipt.get("artifact_run_id")) != os.environ["EXPECTED_RUN_ID"]:
+              raise SystemExit(1)
+          if not re.fullmatch(r"[0-9a-f]{40}", str(receipt.get("source_commit", ""))):
+              raise SystemExit(1)
+          PY
+            then
+              cp prior-candidate/live-receipt.json prior-live-receipt/live-receipt.json
+              PARENT_SHA=$(uv run python -c "import json; print(json.load(open('prior-live-receipt/live-receipt.json'))['source_commit'])")
+              echo "parent_sha=$PARENT_SHA" >> "$GITHUB_OUTPUT"
+              echo "parent_generation=$((GENERATION - 1))" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
+          done < prior-candidates.txt
+          echo "::error::prior_live_receipt_id did not resolve to a valid attested predecessor"
+          exit 1
+
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: "20"
           cache: npm
@@ -181,6 +245,8 @@ jobs:
           BUILD_GENERATION: ${{ steps.inputs.outputs.generation }}
           BUILD_DEVELOP_SHA: ${{ steps.inputs.outputs.develop_sha }}
           BUILD_PUBLISHED_RESULTS_SHA: ${{ steps.inputs.outputs.published_results_sha }}
+          PARENT_SHA: ${{ steps.lineage.outputs.parent_sha }}
+          PARENT_GENERATION: ${{ steps.lineage.outputs.parent_generation }}
           SITE_ARTIFACT: ${{ steps.inputs.outputs.site_artifact }}
           GITHUB_RUN_ID: ${{ github.run_id }}
         shell: bash
@@ -191,31 +257,118 @@ jobs:
           DEVELOP_SHA="$BUILD_DEVELOP_SHA"
           PUBLISHED_RESULTS_SHA="$BUILD_PUBLISHED_RESULTS_SHA"
           TIMESTAMP=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
-          MANIFEST_DIGEST=$(printf '%s' "develop=$DEVELOP_SHA|published-results=$PUBLISHED_RESULTS_SHA|target=benchbox.dev|generation=$GENERATION" | sha256sum | cut -d ' ' -f 1)
           (cd site && find . -type f -exec sha256sum {} + | sort) > receipt-dist/site-file-digests.txt
           SITE_DIGEST=$(sha256sum receipt-dist/site-file-digests.txt | cut -d ' ' -f 1)
           (cd results-explorer/dist && find . -type f -exec sha256sum {} + | sort) > receipt-dist/explorer-file-digests.txt
           EXPLORER_DIGEST=$(sha256sum receipt-dist/explorer-file-digests.txt | cut -d ' ' -f 1)
           (cd docs/_build/html && find . -type f -exec sha256sum {} + | sort) > receipt-dist/docs-file-digests.txt
           DOCS_DIGEST=$(sha256sum receipt-dist/docs-file-digests.txt | cut -d ' ' -f 1)
+          (cd results-data/bundles && find . -type f -exec sha256sum {} + | sort) > receipt-dist/corpus-file-digests.txt
+          CORPUS_DIGEST=$(sha256sum receipt-dist/corpus-file-digests.txt | cut -d ' ' -f 1)
           DATABASE_DIGEST=$(sha256sum site/results/data/results.duckdb | cut -d ' ' -f 1)
-          export GENERATION DEVELOP_SHA PUBLISHED_RESULTS_SHA MANIFEST_DIGEST PRIOR_LIVE_RECEIPT_ID SITE_DIGEST DOCS_DIGEST EXPLORER_DIGEST DATABASE_DIGEST SITE_ARTIFACT GITHUB_RUN_ID TIMESTAMP
+          LOCKFILE_DIGEST=$(sha256sum uv.lock | cut -d ' ' -f 1)
+          BUNDLE_COUNT=$(find results-data/bundles -type f -name '*.json' | wc -l | tr -d ' ')
+          PYTHON_VERSION=$(python3 -c 'import platform; print(platform.python_version())')
+          NODE_VERSION=$(node --version | sed 's/^v//')
+          UV_VERSION=$(uv --version | awk '{print $2}')
+          IMAGE_OS="${ImageOS:-ubuntu-latest}"
+          export GENERATION DEVELOP_SHA PUBLISHED_RESULTS_SHA PRIOR_LIVE_RECEIPT_ID SITE_DIGEST DOCS_DIGEST
+          export EXPLORER_DIGEST DATABASE_DIGEST CORPUS_DIGEST LOCKFILE_DIGEST BUNDLE_COUNT PYTHON_VERSION
+          export NODE_VERSION UV_VERSION IMAGE_OS SITE_ARTIFACT GITHUB_RUN_ID TIMESTAMP GITHUB_OUTPUT
+          export PARENT_SHA PARENT_GENERATION
           python3 - <<'PY'
-          import hashlib, json, os
-          def d(value): return hashlib.sha256(value.encode()).hexdigest()
-          receipt = {"schema_version": 2, "generation": int(os.environ['GENERATION']), "parent_sha": None, "parent_generation": None, "source_commit": os.environ['DEVELOP_SHA'], "source_branch": "develop", "develop_sha": os.environ['DEVELOP_SHA'], "published_results_sha": os.environ['PUBLISHED_RESULTS_SHA'], "build_closure": {"os_image": "ubuntu-latest", "python_version": "3.11", "node_version": "20", "uv_version": "repository", "lockfile_sha256": d("lock"), "workflow_sha": os.environ['DEVELOP_SHA'], "action_shas": {"checkout": os.environ['DEVELOP_SHA']}, "read_model_version": "publication-v2"}, "corpus": {"bundle_count": 0, "inventory_sha256": d("corpus"), "read_model_sha256": d("read-model")}, "artifacts": {"prose_site": {"digest": os.environ['SITE_DIGEST'], "size": 0, "path": "/"}, "api_docs": {"digest": os.environ['DOCS_DIGEST'], "size": 0, "path": "/docs/"}, "explorer_app": {"digest": os.environ['EXPLORER_DIGEST'], "size": 0, "path": "/results/"}, "publisher_bundle": {"digest": os.environ['SITE_DIGEST'], "size": 0, "path": "/"}, "corpus_database": {"digest": os.environ['DATABASE_DIGEST'], "size": 0, "path": "/results/data/results.duckdb"}, "pages_assembly": {"digest": os.environ['SITE_DIGEST'], "size": 0, "path": "/"}}, "artifact_name": os.environ['SITE_ARTIFACT'], "artifact_run_id": os.environ['GITHUB_RUN_ID'], "manifest_digest": os.environ['MANIFEST_DIGEST'], "checksums": {"/results/data/results.duckdb": os.environ['DATABASE_DIGEST']}, "timestamp": os.environ['TIMESTAMP']}
+          import hashlib
+          import json
+          import os
+          from pathlib import Path
+
+          def tree_size(path: str) -> int:
+              return sum(item.stat().st_size for item in Path(path).rglob("*") if item.is_file())
+
+          receipt = {
+              "schema_version": 2,
+              "target": "benchbox.dev",
+              "generation": int(os.environ["GENERATION"]),
+              "parent_sha": os.environ.get("PARENT_SHA") or None,
+              "parent_generation": int(os.environ["PARENT_GENERATION"]) if os.environ.get("PARENT_GENERATION") else None,
+              "source_commit": os.environ["DEVELOP_SHA"],
+              "source_branch": "develop",
+              "develop_sha": os.environ["DEVELOP_SHA"],
+              "published_results_sha": os.environ["PUBLISHED_RESULTS_SHA"],
+              "build_closure": {
+                  "os_image": os.environ["IMAGE_OS"],
+                  "python_version": os.environ["PYTHON_VERSION"],
+                  "node_version": os.environ["NODE_VERSION"],
+                  "uv_version": os.environ["UV_VERSION"],
+                  "lockfile_sha256": os.environ["LOCKFILE_DIGEST"],
+                  "workflow_sha": os.environ["DEVELOP_SHA"],
+                  "action_shas": {
+                      "actions/checkout": "11d5960a326750d5838078e36cf38b85af677262",
+                      "actions/setup-python": "a26af69be951a213d495a4c3e4e4022e16d87065",
+                      "actions/setup-node": "49933ea5288caeca8642d1e84afbd3f7d6820020",
+                      "astral-sh/setup-uv": "38f3f104447c67c051c4a08e39b64a148898af3a",
+                      "actions/upload-pages-artifact": "56afc609e74202658d3ffba0e8f6dda462b719fa",
+                      "actions/upload-artifact": "ea165f8d65b6e75b540449e92b4886f43607fa02",
+                      "actions/deploy-pages": "d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e",
+                      "actions/download-artifact": "d3f86a106a0bac45b974a628896c90dbdf5c8093",
+                  },
+                  "read_model_version": "publication-v2",
+              },
+              "corpus": {
+                  "bundle_count": int(os.environ["BUNDLE_COUNT"]),
+                  "inventory_sha256": os.environ["CORPUS_DIGEST"],
+                  "read_model_sha256": os.environ["DATABASE_DIGEST"],
+              },
+              "artifacts": {
+                  "prose_site": {"digest": os.environ["SITE_DIGEST"], "size": tree_size("site"), "path": "/"},
+                  "api_docs": {
+                      "digest": os.environ["DOCS_DIGEST"],
+                      "size": tree_size("docs/_build/html"),
+                      "path": "/docs/",
+                  },
+                  "explorer_app": {
+                      "digest": os.environ["EXPLORER_DIGEST"],
+                      "size": tree_size("results-explorer/dist"),
+                      "path": "/results/",
+                  },
+                  "publisher_bundle": {
+                      "digest": os.environ["SITE_DIGEST"],
+                      "size": tree_size("site"),
+                      "path": "/",
+                  },
+                  "corpus_database": {
+                      "digest": os.environ["DATABASE_DIGEST"],
+                      "size": Path("site/results/data/results.duckdb").stat().st_size,
+                      "path": "/results/data/results.duckdb",
+                  },
+                  "pages_assembly": {
+                      "digest": os.environ["SITE_DIGEST"],
+                      "size": tree_size("site"),
+                      "path": "/",
+                  },
+              },
+              "artifact_name": os.environ["SITE_ARTIFACT"],
+              "artifact_run_id": os.environ["GITHUB_RUN_ID"],
+              "checksums": {"/results/data/results.duckdb": os.environ["DATABASE_DIGEST"]},
+              "timestamp": os.environ["TIMESTAMP"],
+          }
           if os.environ.get('PRIOR_LIVE_RECEIPT_ID'): receipt["prior_live_receipt_id"] = os.environ['PRIOR_LIVE_RECEIPT_ID']
+          from scripts.publication.manifest import validate_manifest_dict
+          errors = validate_manifest_dict(receipt)
+          if errors:
+              raise SystemExit("invalid publication manifest: " + "; ".join(errors))
+          canonical = json.dumps(receipt, sort_keys=True, separators=(",", ":")).encode()
+          receipt["manifest_digest"] = hashlib.sha256(canonical).hexdigest()
           for name in ("desired-manifest.json", "assembly-receipt.json"):
               with open("receipt-dist/" + name, "w") as f: json.dump(receipt, f, sort_keys=True); f.write("\n")
+          with open(os.environ["GITHUB_OUTPUT"], "a") as output:
+              output.write(f"manifest_digest={receipt['manifest_digest']}\n")
+              output.write(f"assembly_digest={os.environ['SITE_DIGEST']}\n")
+              output.write(f"database_digest={os.environ['DATABASE_DIGEST']}\n")
+              output.write(f"explorer_digest={os.environ['EXPLORER_DIGEST']}\n")
+              output.write(f"docs_digest={os.environ['DOCS_DIGEST']}\n")
           PY
           cp receipt-dist/assembly-receipt.json receipt-dist/publication-receipt.json
-          {
-            echo "manifest_digest=$MANIFEST_DIGEST"
-            echo "assembly_digest=$SITE_DIGEST"
-            echo "database_digest=$DATABASE_DIGEST"
-            echo "explorer_digest=$EXPLORER_DIGEST"
-            echo "docs_digest=$DOCS_DIGEST"
-          } >> "$GITHUB_OUTPUT"
       - name: Pre-deploy candidate verification
         env:
           EXPECT_NOOP: ${{ inputs.expect_noop }}
@@ -235,20 +388,21 @@ jobs:
           fi
 
       - name: Upload Pages artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa # v3
         with:
           name: publication-pages-${{ steps.inputs.outputs.generation }}
           path: site
 
       - name: Retain immutable site artifact for attested rollback
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: ${{ steps.inputs.outputs.site_artifact }}
           path: site
+          include-hidden-files: true
           retention-days: 90
 
       - name: Upload build receipts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: publication-build-receipts-${{ steps.inputs.outputs.generation }}
           path: receipt-dist/
@@ -271,7 +425,9 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4
+        with:
+          artifact_name: publication-pages-${{ needs.build.outputs.generation }}
 
   verify:
     name: Probe live routes and issue attested receipt
@@ -281,18 +437,18 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: "3.11"
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v4
+        uses: astral-sh/setup-uv@38f3f104447c67c051c4a08e39b64a148898af3a # v4
 
       - name: Download build receipts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: publication-build-receipts-${{ needs.build.outputs.generation }}
           path: receipt-dist
@@ -378,7 +534,7 @@ jobs:
           path = 'receipt-dist/live-receipt.json'
           receipt = json.load(open(path))
           receipt['signature'] = os.environ['SIGNATURE']
-          open(path, 'w').write(json.dumps(receipt, sort_keys=True) + '\\n')
+          open(path, 'w').write(json.dumps(receipt, sort_keys=True) + '\n')
           PY
           uv run python - <<'PY'
           import json
@@ -388,7 +544,7 @@ jobs:
           PY
 
       - name: Upload attested live receipt
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: publication-live-receipt-${{ needs.build.outputs.generation }}
           path: receipt-dist/
@@ -412,15 +568,15 @@ jobs:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: "3.11"
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v4
+        uses: astral-sh/setup-uv@38f3f104447c67c051c4a08e39b64a148898af3a # v4
 
       - name: Resolve last known-good attested receipt
         id: known_good
@@ -433,13 +589,17 @@ jobs:
         run: |
           set -euo pipefail
           mkdir -p known-good-receipt
-          gh api --paginate "repos/${{ github.repository }}/actions/artifacts?per_page=100" --jq '.artifacts[] | select(.expired == false) | select(.name | startswith("publication-live-receipt-")) | "\(.id) \(.workflow_run.id) \(.workflow_run.name)"' > candidates.txt
-          while read -r ARTIFACT_ID RUN_ID RUN_NAME; do
+          gh api --paginate "repos/${{ github.repository }}/actions/artifacts?per_page=100" --jq '.artifacts[] | select(.expired == false) | select(.name | startswith("publication-live-receipt-")) | "\(.id) \(.workflow_run.id)"' > candidates.txt
+          while read -r ARTIFACT_ID RUN_ID; do
             [ -n "${ARTIFACT_ID:-}" ] || continue
+            RUN_META=$(gh api "repos/${{ github.repository }}/actions/runs/$RUN_ID" --jq '[.name, .conclusion, .event] | @tsv')
+            IFS=$'\t' read -r RUN_NAME RUN_CONCLUSION RUN_EVENT <<< "$RUN_META"
+            if [[ "$RUN_NAME" != "Publication Control Plane Deployment" || "$RUN_CONCLUSION" != "success" || "$RUN_EVENT" != "workflow_dispatch" ]]; then
+              continue
+            fi
             rm -rf candidate && mkdir candidate
             gh api "repos/${{ github.repository }}/actions/artifacts/$ARTIFACT_ID/zip" > candidate.zip
             unzip -q candidate.zip -d candidate
-            if [[ "$RUN_NAME" != "Publication Control Plane Deployment" ]]; then continue; fi
             if RUN_ID="$RUN_ID" uv run python - <<'PY'
           import json, os
           from pathlib import Path
@@ -454,7 +614,7 @@ jobs:
           if prior_id and receipt.get('receipt_id') != prior_id: raise SystemExit(1)
           if current_gen and str(receipt.get('generation')) == current_gen: raise SystemExit(1)
           if str(receipt.get('artifact_run_id')) != os.environ.get('RUN_ID'): raise SystemExit(1)
-          if not receipt.get('artifact_name') or not receipt.get('artifacts', {}).get('site', {}).get('digest'): raise SystemExit(1)
+          if not receipt.get('artifact_name') or not receipt.get('artifacts', {}).get('pages_assembly', {}).get('digest'): raise SystemExit(1)
           PY
             then
               ARTIFACT_NAME=$(uv run python -c "import json; print(json.load(open('candidate/live-receipt.json'))['artifact_name'])")
@@ -469,13 +629,11 @@ jobs:
           exit 1
 
       - name: Download and verify known-good site artifact
-        env:
-          GH_TOKEN: ${{ github.token }}
         shell: bash
         run: |
           set -euo pipefail
           gh run download "$EXPECTED_RUN_ID" --name "$EXPECTED_ARTIFACT_NAME" --dir restored-site
-          EXPECTED=$(uv run python -c "import json; print(json.load(open('known-good-receipt/live-receipt.json'))['artifacts']['site']['digest'])")
+          EXPECTED=$(uv run python -c "import json; print(json.load(open('known-good-receipt/live-receipt.json'))['artifacts']['pages_assembly']['digest'])")
           (cd restored-site && find . -type f -exec sha256sum {} + | sort) > restored-site-file-digests.txt
           ACTUAL=$(sha256sum restored-site-file-digests.txt | cut -d ' ' -f 1)
           [ "$ACTUAL" = "$EXPECTED" ] || { echo "::error::known-good artifact digest mismatch; refusing rollback"; exit 1; }
@@ -486,14 +644,14 @@ jobs:
           EXPECTED_ARTIFACT_NAME: ${{ steps.known_good.outputs.artifact_name }}
 
       - name: Upload attested rollback Pages artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa # v3
         with:
           name: publication-rollback-pages-${{ github.run_id }}-${{ github.run_attempt }}
           path: restored-site
 
       - name: Deploy attested rollback artifact to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4
         with:
           artifact_name: publication-rollback-pages-${{ github.run_id }}-${{ github.run_attempt }}
 
@@ -530,7 +688,7 @@ jobs:
               'prior_live_receipt_id': prior['receipt_id'],
           })
           receipt.pop('signature', None)
-          open('known-good-receipt/rollback-live-receipt.json', 'w').write(json.dumps(receipt, sort_keys=True) + '\\n')
+          open('known-good-receipt/rollback-live-receipt.json', 'w').write(json.dumps(receipt, sort_keys=True) + '\n')
           PY
           umask 077
           printf '%s' "$PUBLICATION_ATTESTOR_PRIVATE_KEY" > /tmp/publication-attestor-private-key.pem
@@ -549,7 +707,7 @@ jobs:
           path = 'known-good-receipt/rollback-live-receipt.json'
           receipt = json.load(open(path))
           receipt['signature'] = os.environ['SIGNATURE']
-          open(path, 'w').write(json.dumps(receipt, sort_keys=True) + '\\n')
+          open(path, 'w').write(json.dumps(receipt, sort_keys=True) + '\n')
           PY
           uv run python - <<'PY'
           import json
@@ -559,7 +717,7 @@ jobs:
           PY
 
       - name: Upload rollback audit receipt
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: publication-rollback-${{ github.run_id }}
           path: known-good-receipt/

--- a/.github/workflows/publication-deploy.yml
+++ b/.github/workflows/publication-deploy.yml
@@ -69,24 +69,34 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          DEVELOP_SHA="${{ inputs.develop_sha }}"
-          PUBLISHED_RESULTS_SHA="${{ inputs.published_results_sha }}"
-          GENERATION="${{ inputs.generation }}"
+          DEVELOP_SHA="$INPUT_DEVELOP_SHA"
+          PUBLISHED_RESULTS_SHA="$INPUT_PUBLISHED_RESULTS_SHA"
+          GENERATION="$INPUT_GENERATION"
           for value in "$DEVELOP_SHA" "$PUBLISHED_RESULTS_SHA"; do
             printf '%s' "$value" | grep -qE '^[0-9a-f]{40}$' || {
               echo "::error::dispatch SHAs must be lowercase 40-hex commits"
               exit 1
             }
+          done
+          git fetch --depth=1 origin "$PUBLISHED_RESULTS_SHA" || git fetch --no-tags origin published-results:refs/remotes/origin/published-results || git fetch --no-tags origin published-results
+          git fetch --no-tags origin develop:refs/remotes/origin/develop
+          for value in "$DEVELOP_SHA" "$PUBLISHED_RESULTS_SHA"; do
             git cat-file -e "$value^{commit}" || {
               echo "::error::pinned commit is not available: $value"
               exit 1
             }
           done
+          git merge-base --is-ancestor "$DEVELOP_SHA" refs/remotes/origin/develop || {
+            echo "::error::develop_sha is not reachable from the protected develop branch"; exit 1;
+          }
+          git merge-base --is-ancestor "$PUBLISHED_RESULTS_SHA" refs/remotes/origin/published-results || {
+            echo "::error::published_results_sha is not reachable from the protected published-results branch"; exit 1;
+          }
           if [ -z "$GENERATION" ]; then
-            GENERATION="publication-${{ github.run_id }}-${{ github.run_attempt }}"
+            GENERATION="$GITHUB_RUN_ID"
           fi
-          printf '%s' "$GENERATION" | grep -qE '^[a-z0-9-]{1,80}$' || {
-            echo "::error::generation must match [a-z0-9-]{1,80}"
+          printf '%s' "$GENERATION" | grep -qE '^[1-9][0-9]{0,18}$' || {
+            echo "::error::generation must be a positive decimal CAS generation"
             exit 1
           }
           {
@@ -95,11 +105,18 @@ jobs:
             echo "published_results_sha=$PUBLISHED_RESULTS_SHA"
             echo "site_artifact=publication-site-$GENERATION"
           } >> "$GITHUB_OUTPUT"
+        env:
+          INPUT_DEVELOP_SHA: ${{ inputs.develop_sha }}
+          INPUT_PUBLISHED_RESULTS_SHA: ${{ inputs.published_results_sha }}
+          INPUT_GENERATION: ${{ inputs.generation }}
+          GITHUB_RUN_ID: ${{ github.run_id }}
+          GITHUB_RUN_ATTEMPT: ${{ github.run_attempt }}
 
       - name: Materialize pinned control plane and corpus
         shell: bash
         run: |
           set -euo pipefail
+          git fetch --depth=1 origin "${{ steps.inputs.outputs.published_results_sha }}" || git fetch --no-tags origin published-results:refs/remotes/origin/published-results || git fetch --no-tags origin published-results
           git checkout --detach "${{ steps.inputs.outputs.develop_sha }}"
           rm -rf results-data
           mkdir results-data
@@ -159,13 +176,20 @@ jobs:
 
       - name: Write desired and assembly receipts
         id: receipt
+        env:
+          PRIOR_LIVE_RECEIPT_ID: ${{ inputs.prior_live_receipt_id }}
+          BUILD_GENERATION: ${{ steps.inputs.outputs.generation }}
+          BUILD_DEVELOP_SHA: ${{ steps.inputs.outputs.develop_sha }}
+          BUILD_PUBLISHED_RESULTS_SHA: ${{ steps.inputs.outputs.published_results_sha }}
+          SITE_ARTIFACT: ${{ steps.inputs.outputs.site_artifact }}
+          GITHUB_RUN_ID: ${{ github.run_id }}
         shell: bash
         run: |
           set -euo pipefail
           mkdir -p receipt-dist
-          GENERATION="${{ steps.inputs.outputs.generation }}"
-          DEVELOP_SHA="${{ steps.inputs.outputs.develop_sha }}"
-          PUBLISHED_RESULTS_SHA="${{ steps.inputs.outputs.published_results_sha }}"
+          GENERATION="$BUILD_GENERATION"
+          DEVELOP_SHA="$BUILD_DEVELOP_SHA"
+          PUBLISHED_RESULTS_SHA="$BUILD_PUBLISHED_RESULTS_SHA"
           TIMESTAMP=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
           MANIFEST_DIGEST=$(printf '%s' "develop=$DEVELOP_SHA|published-results=$PUBLISHED_RESULTS_SHA|target=benchbox.dev|generation=$GENERATION" | sha256sum | cut -d ' ' -f 1)
           (cd site && find . -type f -exec sha256sum {} + | sort) > receipt-dist/site-file-digests.txt
@@ -175,12 +199,15 @@ jobs:
           (cd docs/_build/html && find . -type f -exec sha256sum {} + | sort) > receipt-dist/docs-file-digests.txt
           DOCS_DIGEST=$(sha256sum receipt-dist/docs-file-digests.txt | cut -d ' ' -f 1)
           DATABASE_DIGEST=$(sha256sum site/results/data/results.duckdb | cut -d ' ' -f 1)
-          cat > receipt-dist/desired-manifest.json <<EOF
-          {"schema_version":1,"generation":"$GENERATION","target":"benchbox.dev","develop_sha":"$DEVELOP_SHA","published_results_sha":"$PUBLISHED_RESULTS_SHA","manifest_digest":"$MANIFEST_DIGEST","prior_live_receipt_id":"${{ inputs.prior_live_receipt_id }}","timestamp":"$TIMESTAMP"}
-          EOF
-          cat > receipt-dist/assembly-receipt.json <<EOF
-          {"schema_version":1,"generation":"$GENERATION","target":"benchbox.dev","manifest_digest":"$MANIFEST_DIGEST","develop_sha":"$DEVELOP_SHA","published_results_sha":"$PUBLISHED_RESULTS_SHA","artifact_name":"${{ steps.inputs.outputs.site_artifact }}","artifact_run_id":"${{ github.run_id }}","artifacts":{"site":{"path":"/","digest":"$SITE_DIGEST"},"docs":{"path":"/docs/","digest":"$DOCS_DIGEST"},"explorer":{"path":"/results/","digest":"$EXPLORER_DIGEST"},"database":{"path":"/results/data/results.duckdb","digest":"$DATABASE_DIGEST"}},"checksums":{"/results/data/results.duckdb":"$DATABASE_DIGEST"},"timestamp":"$TIMESTAMP"}
-          EOF
+          export GENERATION DEVELOP_SHA PUBLISHED_RESULTS_SHA MANIFEST_DIGEST PRIOR_LIVE_RECEIPT_ID SITE_DIGEST DOCS_DIGEST EXPLORER_DIGEST DATABASE_DIGEST SITE_ARTIFACT GITHUB_RUN_ID TIMESTAMP
+          python3 - <<'PY'
+          import hashlib, json, os
+          def d(value): return hashlib.sha256(value.encode()).hexdigest()
+          receipt = {"schema_version": 2, "generation": int(os.environ['GENERATION']), "parent_sha": None, "parent_generation": None, "source_commit": os.environ['DEVELOP_SHA'], "source_branch": "develop", "develop_sha": os.environ['DEVELOP_SHA'], "published_results_sha": os.environ['PUBLISHED_RESULTS_SHA'], "build_closure": {"os_image": "ubuntu-latest", "python_version": "3.11", "node_version": "20", "uv_version": "repository", "lockfile_sha256": d("lock"), "workflow_sha": os.environ['DEVELOP_SHA'], "action_shas": {"checkout": os.environ['DEVELOP_SHA']}, "read_model_version": "publication-v2"}, "corpus": {"bundle_count": 0, "inventory_sha256": d("corpus"), "read_model_sha256": d("read-model")}, "artifacts": {"prose_site": {"digest": os.environ['SITE_DIGEST'], "size": 0, "path": "/"}, "api_docs": {"digest": os.environ['DOCS_DIGEST'], "size": 0, "path": "/docs/"}, "explorer_app": {"digest": os.environ['EXPLORER_DIGEST'], "size": 0, "path": "/results/"}, "publisher_bundle": {"digest": os.environ['SITE_DIGEST'], "size": 0, "path": "/"}, "corpus_database": {"digest": os.environ['DATABASE_DIGEST'], "size": 0, "path": "/results/data/results.duckdb"}, "pages_assembly": {"digest": os.environ['SITE_DIGEST'], "size": 0, "path": "/"}}, "artifact_name": os.environ['SITE_ARTIFACT'], "artifact_run_id": os.environ['GITHUB_RUN_ID'], "manifest_digest": os.environ['MANIFEST_DIGEST'], "checksums": {"/results/data/results.duckdb": os.environ['DATABASE_DIGEST']}, "timestamp": os.environ['TIMESTAMP']}
+          if os.environ.get('PRIOR_LIVE_RECEIPT_ID'): receipt["prior_live_receipt_id"] = os.environ['PRIOR_LIVE_RECEIPT_ID']
+          for name in ("desired-manifest.json", "assembly-receipt.json"):
+              with open("receipt-dist/" + name, "w") as f: json.dump(receipt, f, sort_keys=True); f.write("\n")
+          PY
           cp receipt-dist/assembly-receipt.json receipt-dist/publication-receipt.json
           {
             echo "manifest_digest=$MANIFEST_DIGEST"
@@ -189,12 +216,13 @@ jobs:
             echo "explorer_digest=$EXPLORER_DIGEST"
             echo "docs_digest=$DOCS_DIGEST"
           } >> "$GITHUB_OUTPUT"
-
       - name: Pre-deploy candidate verification
+        env:
+          EXPECT_NOOP: ${{ inputs.expect_noop }}
         shell: bash
         run: |
           set -euo pipefail
-          if [ "${{ inputs.expect_noop }}" = "true" ]; then
+          if [ "$EXPECT_NOOP" = "true" ]; then
             uv run python scripts/publication/verify_live.py \
               --candidate-manifest receipt-dist/publication-receipt.json \
               --baseline-manifest docs/operations/publication-baseline-2026-08-31.json \
@@ -209,6 +237,7 @@ jobs:
       - name: Upload Pages artifact
         uses: actions/upload-pages-artifact@v3
         with:
+          name: publication-pages-${{ steps.inputs.outputs.generation }}
           path: site
 
       - name: Retain immutable site artifact for attested rollback
@@ -234,6 +263,8 @@ jobs:
       contents: read
       pages: write
       id-token: write
+    outputs:
+      page_url: ${{ steps.deployment.outputs.page_url }}
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
@@ -270,27 +301,39 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
+          TARGET_URL="${{ needs.deploy.outputs.page_url || 'https://benchbox.dev' }}"
           uv run python scripts/publication/verify_live.py \
-            --base-url "${{ needs.deploy.outputs.page_url }}" \
+            --base-url "$TARGET_URL" \
             --manifest receipt-dist/publication-receipt.json \
             --require-receipt --timeout 60 --json > receipt-dist/live-probe-report.json
 
       - name: Record provider deployment acknowledgement
+        env:
+          PAGE_URL: ${{ needs.deploy.outputs.page_url || 'https://benchbox.dev' }}
+          DEPLOYMENT_ID: ${{ github.run_id }}-${{ github.run_attempt }}
         shell: bash
         run: |
           set -euo pipefail
           cp receipt-dist/assembly-receipt.json receipt-dist/deployment-receipt.json
           python3 - <<'PY'
-          import json
+          import json, os
           path = 'receipt-dist/deployment-receipt.json'
           receipt = json.load(open(path))
-          receipt.update({'deployment_id': '${{ github.run_id }}-${{ github.run_attempt }}', 'page_url': '${{ needs.deploy.outputs.page_url }}', 'status': 'DEPLOYED'})
-          open(path, 'w').write(json.dumps(receipt, sort_keys=True) + '\\n')
+          receipt.update({
+              'deployment_id': os.environ.get('DEPLOYMENT_ID', ''),
+              'page_url': os.environ.get('PAGE_URL') or 'https://benchbox.dev',
+              'status': 'DEPLOYED',
+          })
+          open(path, 'w').write(json.dumps(receipt, sort_keys=True) + '\n')
           PY
 
       - name: Create and sign live receipt
         env:
           PUBLICATION_ATTESTOR_PRIVATE_KEY: ${{ secrets.PUBLICATION_ATTESTOR_PRIVATE_KEY }}
+          PRIOR_LIVE_RECEIPT_ID: ${{ inputs.prior_live_receipt_id }}
+          BUILD_GENERATION: ${{ needs.build.outputs.generation }}
+          GITHUB_RUN_ID: ${{ github.run_id }}
+          GITHUB_RUN_ATTEMPT: ${{ github.run_attempt }}
         shell: bash
         run: |
           set -euo pipefail
@@ -299,23 +342,24 @@ jobs:
             exit 1
           }
           python3 - <<'PY'
-          import json
+          import json, os
           from datetime import datetime, timezone
           assembly = json.load(open('receipt-dist/assembly-receipt.json'))
           probes = json.load(open('receipt-dist/live-probe-report.json'))['probes']
+          prior_live_receipt_id = os.environ.get('PRIOR_LIVE_RECEIPT_ID') or None
           receipt = dict(assembly)
           receipt.update({
-              'receipt_id': 'live-${{ needs.build.outputs.generation }}-${{ github.run_id }}',
+              'receipt_id': f"live-{os.environ['BUILD_GENERATION']}-{os.environ['GITHUB_RUN_ID']}",
               'timestamp': datetime.now(timezone.utc).isoformat().replace('+00:00', 'Z'),
               'routes': probes,
-              'nonce': '${{ github.run_id }}-${{ github.run_attempt }}',
+              'nonce': f"{os.environ['GITHUB_RUN_ID']}-{os.environ['GITHUB_RUN_ATTEMPT']}",
               'freshness_window': '24h',
               'attestor': 'github-actions:publication-deploy',
               'attestor_key_id': 'publication-attestor-ed25519-2026-09-04',
               'signature_algorithm': 'ed25519',
-              'prior_live_receipt_id': '${{ inputs.prior_live_receipt_id }}' or None,
+              'prior_live_receipt_id': prior_live_receipt_id,
           })
-          open('receipt-dist/live-receipt.json', 'w').write(json.dumps(receipt, sort_keys=True) + '\\n')
+          open('receipt-dist/live-receipt.json', 'w').write(json.dumps(receipt, sort_keys=True) + '\n')
           PY
           umask 077
           printf '%s' "$PUBLICATION_ATTESTOR_PRIVATE_KEY" > /tmp/publication-attestor-private-key.pem
@@ -328,11 +372,12 @@ jobs:
           openssl pkeyutl -sign -rawin -inkey /tmp/publication-attestor-private-key.pem -in /tmp/live-receipt-payload.json -out /tmp/live-receipt.sig
           SIGNATURE=$(base64 -w 0 /tmp/live-receipt.sig)
           rm -f /tmp/publication-attestor-private-key.pem /tmp/live-receipt-payload.json /tmp/live-receipt.sig
-          python3 - <<PY
+          SIGNATURE="$SIGNATURE" python3 - <<'PY'
           import json
+          import os
           path = 'receipt-dist/live-receipt.json'
           receipt = json.load(open(path))
-          receipt['signature'] = '$SIGNATURE'
+          receipt['signature'] = os.environ['SIGNATURE']
           open(path, 'w').write(json.dumps(receipt, sort_keys=True) + '\\n')
           PY
           uv run python - <<'PY'
@@ -381,18 +426,22 @@ jobs:
         id: known_good
         env:
           GH_TOKEN: ${{ github.token }}
+          CURRENT_GENERATION: ${{ needs.build.outputs.generation }}
+          PRIOR_LIVE_RECEIPT_ID: ${{ inputs.prior_live_receipt_id }}
+          FORCE_ROLLBACK: ${{ inputs.force_rollback }}
         shell: bash
         run: |
           set -euo pipefail
           mkdir -p known-good-receipt
-          gh api --paginate "repos/${{ github.repository }}/actions/artifacts?per_page=100" --jq '.artifacts[] | select(.expired == false) | select(.name | startswith("publication-live-receipt-")) | "\(.id) \(.workflow_run.id)"' > candidates.txt
-          while read -r ARTIFACT_ID RUN_ID; do
+          gh api --paginate "repos/${{ github.repository }}/actions/artifacts?per_page=100" --jq '.artifacts[] | select(.expired == false) | select(.name | startswith("publication-live-receipt-")) | "\(.id) \(.workflow_run.id) \(.workflow_run.name)"' > candidates.txt
+          while read -r ARTIFACT_ID RUN_ID RUN_NAME; do
             [ -n "${ARTIFACT_ID:-}" ] || continue
             rm -rf candidate && mkdir candidate
             gh api "repos/${{ github.repository }}/actions/artifacts/$ARTIFACT_ID/zip" > candidate.zip
             unzip -q candidate.zip -d candidate
-            if uv run python - <<'PY'
-          import json
+            if [[ "$RUN_NAME" != "Publication Control Plane Deployment" ]]; then continue; fi
+            if RUN_ID="$RUN_ID" uv run python - <<'PY'
+          import json, os
           from pathlib import Path
           from scripts.publication.reconciliation import verify_live_receipt_signature
           p = Path('candidate/live-receipt.json')
@@ -400,18 +449,22 @@ jobs:
           receipt = json.loads(p.read_text())
           valid, _ = verify_live_receipt_signature(receipt)
           if not valid or receipt.get('target') != 'benchbox.dev': raise SystemExit(1)
-          assembly = json.loads(Path('candidate/assembly-receipt.json').read_text())
-          assert assembly.get('artifact_name') and assembly.get('artifact_run_id')
+          prior_id = os.environ.get('PRIOR_LIVE_RECEIPT_ID', '').strip()
+          current_gen = os.environ.get('CURRENT_GENERATION', '').strip()
+          if prior_id and receipt.get('receipt_id') != prior_id: raise SystemExit(1)
+          if current_gen and str(receipt.get('generation')) == current_gen: raise SystemExit(1)
+          if str(receipt.get('artifact_run_id')) != os.environ.get('RUN_ID'): raise SystemExit(1)
+          if not receipt.get('artifact_name') or not receipt.get('artifacts', {}).get('site', {}).get('digest'): raise SystemExit(1)
           PY
             then
-              ARTIFACT_NAME=$(uv run python -c "import json; print(json.load(open('candidate/assembly-receipt.json'))['artifact_name'])")
-              ARTIFACT_RUN_ID=$(uv run python -c "import json; print(json.load(open('candidate/assembly-receipt.json'))['artifact_run_id'])")
+              ARTIFACT_NAME=$(uv run python -c "import json; print(json.load(open('candidate/live-receipt.json'))['artifact_name'])")
+              ARTIFACT_RUN_ID="$RUN_ID"
               cp -R candidate/. known-good-receipt/
               echo "artifact_name=$ARTIFACT_NAME" >> "$GITHUB_OUTPUT"
               echo "artifact_run_id=$ARTIFACT_RUN_ID" >> "$GITHUB_OUTPUT"
               exit 0
             fi
-          done < candidates.txt
+            done < candidates.txt
           echo "::error::no cryptographically attested, unexpired rollback artifact is available"
           exit 1
 
@@ -421,31 +474,41 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          gh run download "${{ steps.known_good.outputs.artifact_run_id }}" --name "${{ steps.known_good.outputs.artifact_name }}" --dir restored-site
-          EXPECTED=$(uv run python -c "import json; print(json.load(open('known-good-receipt/assembly-receipt.json'))['artifacts']['site']['digest'])")
+          gh run download "$EXPECTED_RUN_ID" --name "$EXPECTED_ARTIFACT_NAME" --dir restored-site
+          EXPECTED=$(uv run python -c "import json; print(json.load(open('known-good-receipt/live-receipt.json'))['artifacts']['site']['digest'])")
           (cd restored-site && find . -type f -exec sha256sum {} + | sort) > restored-site-file-digests.txt
           ACTUAL=$(sha256sum restored-site-file-digests.txt | cut -d ' ' -f 1)
           [ "$ACTUAL" = "$EXPECTED" ] || { echo "::error::known-good artifact digest mismatch; refusing rollback"; exit 1; }
           test -s restored-site/results/data/results.duckdb
+        env:
+          GH_TOKEN: ${{ github.token }}
+          EXPECTED_RUN_ID: ${{ steps.known_good.outputs.artifact_run_id }}
+          EXPECTED_ARTIFACT_NAME: ${{ steps.known_good.outputs.artifact_name }}
 
       - name: Upload attested rollback Pages artifact
         uses: actions/upload-pages-artifact@v3
         with:
+          name: publication-rollback-pages-${{ github.run_id }}-${{ github.run_attempt }}
           path: restored-site
 
       - name: Deploy attested rollback artifact to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v4
+        with:
+          artifact_name: publication-rollback-pages-${{ github.run_id }}-${{ github.run_attempt }}
 
       - name: Probe restored required live routes
         shell: bash
         run: |
           set -euo pipefail
-          uv run python scripts/publication/verify_live.py --base-url "${{ steps.deployment.outputs.page_url }}" --manifest known-good-receipt/live-receipt.json --require-receipt --timeout 60 --json > known-good-receipt/rollback-probe-report.json
+          TARGET_URL="${{ steps.deployment.outputs.page_url }}"
+          uv run python scripts/publication/verify_live.py --base-url "$TARGET_URL" --manifest known-good-receipt/live-receipt.json --require-receipt --timeout 60 --json > known-good-receipt/rollback-probe-report.json
 
       - name: Create and sign rollback live receipt
         env:
           PUBLICATION_ATTESTOR_PRIVATE_KEY: ${{ secrets.PUBLICATION_ATTESTOR_PRIVATE_KEY }}
+          GITHUB_RUN_ID: ${{ github.run_id }}
+          GITHUB_RUN_ATTEMPT: ${{ github.run_attempt }}
         shell: bash
         run: |
           set -euo pipefail
@@ -454,16 +517,16 @@ jobs:
             exit 1
           }
           python3 - <<'PY'
-          import json
+          import json, os
           from datetime import datetime, timezone
           prior = json.load(open('known-good-receipt/live-receipt.json'))
           probes = json.load(open('known-good-receipt/rollback-probe-report.json'))['probes']
           receipt = dict(prior)
           receipt.update({
-              'receipt_id': 'rollback-${{ github.run_id }}-${{ github.run_attempt }}',
+              'receipt_id': f"rollback-{os.environ['GITHUB_RUN_ID']}-{os.environ['GITHUB_RUN_ATTEMPT']}",
               'timestamp': datetime.now(timezone.utc).isoformat().replace('+00:00', 'Z'),
               'routes': probes,
-              'nonce': '${{ github.run_id }}-${{ github.run_attempt }}',
+              'nonce': f"{os.environ['GITHUB_RUN_ID']}-{os.environ['GITHUB_RUN_ATTEMPT']}",
               'prior_live_receipt_id': prior['receipt_id'],
           })
           receipt.pop('signature', None)
@@ -480,11 +543,12 @@ jobs:
           openssl pkeyutl -sign -rawin -inkey /tmp/publication-attestor-private-key.pem -in /tmp/rollback-live-receipt-payload.json -out /tmp/rollback-live-receipt.sig
           SIGNATURE=$(base64 -w 0 /tmp/rollback-live-receipt.sig)
           rm -f /tmp/publication-attestor-private-key.pem /tmp/rollback-live-receipt-payload.json /tmp/rollback-live-receipt.sig
-          python3 - <<PY
+          SIGNATURE="$SIGNATURE" python3 - <<'PY'
           import json
+          import os
           path = 'known-good-receipt/rollback-live-receipt.json'
           receipt = json.load(open(path))
-          receipt['signature'] = '$SIGNATURE'
+          receipt['signature'] = os.environ['SIGNATURE']
           open(path, 'w').write(json.dumps(receipt, sort_keys=True) + '\\n')
           PY
           uv run python - <<'PY'

--- a/.github/workflows/publication-deploy.yml
+++ b/.github/workflows/publication-deploy.yml
@@ -16,6 +16,11 @@ name: Publication Control Plane Deployment
         description: "Positive decimal CAS generation (1 for the first independent deployment)"
         required: true
         type: string
+      approved_manifest_digest:
+        description: "Reviewed candidate manifest SHA-256; required for a production deployment"
+        required: false
+        default: ""
+        type: string
       prior_live_receipt_id:
         description: "Prior attested live receipt ID, if this supersedes one"
         required: false
@@ -58,6 +63,9 @@ jobs:
       explorer_digest: ${{ steps.receipt.outputs.explorer_digest }}
       docs_digest: ${{ steps.receipt.outputs.docs_digest }}
       site_artifact: ${{ steps.inputs.outputs.site_artifact }}
+      parent_sha: ${{ steps.lineage.outputs.parent_sha }}
+      parent_generation: ${{ steps.lineage.outputs.parent_generation }}
+      parent_artifact_id: ${{ steps.lineage.outputs.parent_artifact_id }}
     steps:
       - name: Checkout control-plane source
         uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
@@ -72,6 +80,7 @@ jobs:
           DEVELOP_SHA="$INPUT_DEVELOP_SHA"
           PUBLISHED_RESULTS_SHA="$INPUT_PUBLISHED_RESULTS_SHA"
           GENERATION="$INPUT_GENERATION"
+          APPROVED_MANIFEST_DIGEST="$INPUT_APPROVED_MANIFEST_DIGEST"
           for value in "$DEVELOP_SHA" "$PUBLISHED_RESULTS_SHA"; do
             printf '%s' "$value" | grep -qE '^[0-9a-f]{40}$' || {
               echo "::error::dispatch SHAs must be lowercase 40-hex commits"
@@ -96,6 +105,15 @@ jobs:
             echo "::error::generation must be a positive decimal CAS generation"
             exit 1
           }
+          if [ -n "$APPROVED_MANIFEST_DIGEST" ]; then
+            printf '%s' "$APPROVED_MANIFEST_DIGEST" | grep -qE '^[0-9a-f]{64}$' || {
+              echo "::error::approved_manifest_digest must be a lowercase SHA-256 digest"
+              exit 1
+            }
+          elif [ "$EXPECT_NOOP" != "true" ] && [ "$FORCE_ROLLBACK" != "true" ]; then
+            echo "::error::production deployment requires an independently reviewed approved_manifest_digest"
+            exit 1
+          fi
           {
             echo "generation=$GENERATION"
             echo "develop_sha=$DEVELOP_SHA"
@@ -106,6 +124,9 @@ jobs:
           INPUT_DEVELOP_SHA: ${{ inputs.develop_sha }}
           INPUT_PUBLISHED_RESULTS_SHA: ${{ inputs.published_results_sha }}
           INPUT_GENERATION: ${{ inputs.generation }}
+          INPUT_APPROVED_MANIFEST_DIGEST: ${{ inputs.approved_manifest_digest }}
+          EXPECT_NOOP: ${{ inputs.expect_noop }}
+          FORCE_ROLLBACK: ${{ inputs.force_rollback }}
 
       - name: Materialize pinned control plane and corpus
         shell: bash
@@ -138,33 +159,20 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          if [ "$GENERATION" = "1" ]; then
-            [ -z "$PRIOR_LIVE_RECEIPT_ID" ] || {
-              echo "::error::generation 1 is genesis and cannot name a prior live receipt"
-              exit 1
-            }
-            echo "parent_sha=" >> "$GITHUB_OUTPUT"
-            echo "parent_generation=" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-          [ -n "$PRIOR_LIVE_RECEIPT_ID" ] || {
-            echo "::error::generation $GENERATION requires prior_live_receipt_id"
-            exit 1
-          }
           mkdir -p prior-live-receipt
-          gh api --paginate "repos/${{ github.repository }}/actions/artifacts?per_page=100" \
-            --jq '.artifacts[] | select(.expired == false) | select(.name | startswith("publication-live-receipt-")) | "\(.id) \(.workflow_run.id)"' > prior-candidates.txt
+          gh api "repos/${{ github.repository }}/actions/artifacts?per_page=100" \
+            --jq '.artifacts | map(select(.expired == false) | select(.name | startswith("publication-live-receipt-"))) | sort_by(.created_at) | reverse | .[] | "\(.id) \(.workflow_run.id)"' > prior-candidates.txt
           while read -r ARTIFACT_ID RUN_ID; do
             [ -n "${ARTIFACT_ID:-}" ] || continue
-            RUN_META=$(gh api "repos/${{ github.repository }}/actions/runs/$RUN_ID" --jq '[.name, .conclusion, .event] | @tsv')
-            IFS=$'\t' read -r RUN_NAME RUN_CONCLUSION RUN_EVENT <<< "$RUN_META"
-            if [[ "$RUN_NAME" != "Publication Control Plane Deployment" || "$RUN_CONCLUSION" != "success" || "$RUN_EVENT" != "workflow_dispatch" ]]; then
+            RUN_META=$(gh api "repos/${{ github.repository }}/actions/runs/$RUN_ID" --jq '[.name, .status, .conclusion, .event] | @tsv')
+            IFS=$'\t' read -r RUN_NAME RUN_STATUS RUN_CONCLUSION RUN_EVENT <<< "$RUN_META"
+            if [[ "$RUN_NAME" != "Publication Control Plane Deployment" || "$RUN_STATUS" != "completed" || "$RUN_EVENT" != "workflow_dispatch" ]]; then
               continue
             fi
             rm -rf prior-candidate && mkdir prior-candidate
             gh api "repos/${{ github.repository }}/actions/artifacts/$ARTIFACT_ID/zip" > prior-candidate.zip
             unzip -q prior-candidate.zip -d prior-candidate
-            if EXPECTED_RUN_ID="$RUN_ID" uv run python - <<'PY'
+            if EXPECTED_RUN_ID="$RUN_ID" RUN_CONCLUSION="$RUN_CONCLUSION" uv run python - <<'PY'
           import json
           import os
           import re
@@ -178,24 +186,50 @@ jobs:
           valid, _ = verify_live_receipt_signature(receipt)
           if not valid or receipt.get("target") != "benchbox.dev":
               raise SystemExit(1)
-          if receipt.get("receipt_id") != os.environ["PRIOR_LIVE_RECEIPT_ID"]:
-              raise SystemExit(1)
-          if receipt.get("generation") != int(os.environ["GENERATION"]) - 1:
-              raise SystemExit(1)
-          if str(receipt.get("artifact_run_id")) != os.environ["EXPECTED_RUN_ID"]:
+          if os.environ["RUN_CONCLUSION"] != "success":
+              if not str(receipt.get("receipt_id", "")).startswith("rollback-"):
+                  raise SystemExit(1)
+              if not receipt.get("routes") or not all(route.get("ok") for route in receipt["routes"]):
+                  raise SystemExit(1)
+          if str(receipt.get("receipt_run_id", receipt.get("artifact_run_id"))) != os.environ["EXPECTED_RUN_ID"]:
               raise SystemExit(1)
           if not re.fullmatch(r"[0-9a-f]{40}", str(receipt.get("source_commit", ""))):
               raise SystemExit(1)
           PY
             then
+              RECEIPT_ID=$(uv run python -c "import json; print(json.load(open('prior-candidate/live-receipt.json'))['receipt_id'])")
+              RECEIPT_GENERATION=$(uv run python -c "import json; print(json.load(open('prior-candidate/live-receipt.json'))['generation'])")
+              if [ "$GENERATION" = "1" ]; then
+                echo "::error::generation 1 cannot replace current live receipt $RECEIPT_ID"
+                exit 1
+              fi
+              [ -n "$PRIOR_LIVE_RECEIPT_ID" ] || {
+                echo "::error::generation $GENERATION requires prior_live_receipt_id"
+                exit 1
+              }
+              [ "$RECEIPT_ID" = "$PRIOR_LIVE_RECEIPT_ID" ] || {
+                echo "::error::prior_live_receipt_id is stale; current live head is $RECEIPT_ID"
+                exit 1
+              }
+              [ "$RECEIPT_GENERATION" = "$((GENERATION - 1))" ] || {
+                echo "::error::generation $GENERATION is not the successor of live generation $RECEIPT_GENERATION"
+                exit 1
+              }
               cp prior-candidate/live-receipt.json prior-live-receipt/live-receipt.json
               PARENT_SHA=$(uv run python -c "import json; print(json.load(open('prior-live-receipt/live-receipt.json'))['source_commit'])")
               echo "parent_sha=$PARENT_SHA" >> "$GITHUB_OUTPUT"
               echo "parent_generation=$((GENERATION - 1))" >> "$GITHUB_OUTPUT"
+              echo "parent_artifact_id=$ARTIFACT_ID" >> "$GITHUB_OUTPUT"
               exit 0
             fi
           done < prior-candidates.txt
-          echo "::error::prior_live_receipt_id did not resolve to a valid attested predecessor"
+          if [ "$GENERATION" = "1" ] && [ -z "$PRIOR_LIVE_RECEIPT_ID" ]; then
+            echo "parent_sha=" >> "$GITHUB_OUTPUT"
+            echo "parent_generation=" >> "$GITHUB_OUTPUT"
+            echo "parent_artifact_id=" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          echo "::error::no authoritative attested live head is available for generation $GENERATION"
           exit 1
 
       - name: Set up Node.js
@@ -245,8 +279,10 @@ jobs:
           BUILD_GENERATION: ${{ steps.inputs.outputs.generation }}
           BUILD_DEVELOP_SHA: ${{ steps.inputs.outputs.develop_sha }}
           BUILD_PUBLISHED_RESULTS_SHA: ${{ steps.inputs.outputs.published_results_sha }}
+          APPROVED_MANIFEST_DIGEST: ${{ inputs.approved_manifest_digest }}
           PARENT_SHA: ${{ steps.lineage.outputs.parent_sha }}
           PARENT_GENERATION: ${{ steps.lineage.outputs.parent_generation }}
+          WORKFLOW_SHA: ${{ github.sha }}
           SITE_ARTIFACT: ${{ steps.inputs.outputs.site_artifact }}
           GITHUB_RUN_ID: ${{ github.run_id }}
         shell: bash
@@ -275,7 +311,7 @@ jobs:
           export GENERATION DEVELOP_SHA PUBLISHED_RESULTS_SHA PRIOR_LIVE_RECEIPT_ID SITE_DIGEST DOCS_DIGEST
           export EXPLORER_DIGEST DATABASE_DIGEST CORPUS_DIGEST LOCKFILE_DIGEST BUNDLE_COUNT PYTHON_VERSION
           export NODE_VERSION UV_VERSION IMAGE_OS SITE_ARTIFACT GITHUB_RUN_ID TIMESTAMP GITHUB_OUTPUT
-          export PARENT_SHA PARENT_GENERATION
+          export PARENT_SHA PARENT_GENERATION WORKFLOW_SHA APPROVED_MANIFEST_DIGEST
           python3 - <<'PY'
           import hashlib
           import json
@@ -285,7 +321,7 @@ jobs:
           def tree_size(path: str) -> int:
               return sum(item.stat().st_size for item in Path(path).rglob("*") if item.is_file())
 
-          receipt = {
+          manifest = {
               "schema_version": 2,
               "target": "benchbox.dev",
               "generation": int(os.environ["GENERATION"]),
@@ -301,7 +337,7 @@ jobs:
                   "node_version": os.environ["NODE_VERSION"],
                   "uv_version": os.environ["UV_VERSION"],
                   "lockfile_sha256": os.environ["LOCKFILE_DIGEST"],
-                  "workflow_sha": os.environ["DEVELOP_SHA"],
+                  "workflow_sha": os.environ["WORKFLOW_SHA"],
                   "action_shas": {
                       "actions/checkout": "11d5960a326750d5838078e36cf38b85af677262",
                       "actions/setup-python": "a26af69be951a213d495a4c3e4e4022e16d87065",
@@ -347,28 +383,52 @@ jobs:
                       "path": "/",
                   },
               },
-              "artifact_name": os.environ["SITE_ARTIFACT"],
-              "artifact_run_id": os.environ["GITHUB_RUN_ID"],
               "checksums": {"/results/data/results.duckdb": os.environ["DATABASE_DIGEST"]},
-              "timestamp": os.environ["TIMESTAMP"],
           }
-          if os.environ.get('PRIOR_LIVE_RECEIPT_ID'): receipt["prior_live_receipt_id"] = os.environ['PRIOR_LIVE_RECEIPT_ID']
+          if os.environ.get("PRIOR_LIVE_RECEIPT_ID"):
+              manifest["prior_live_receipt_id"] = os.environ["PRIOR_LIVE_RECEIPT_ID"]
           from scripts.publication.manifest import validate_manifest_dict
-          errors = validate_manifest_dict(receipt)
+          errors = validate_manifest_dict(manifest)
           if errors:
               raise SystemExit("invalid publication manifest: " + "; ".join(errors))
-          canonical = json.dumps(receipt, sort_keys=True, separators=(",", ":")).encode()
-          receipt["manifest_digest"] = hashlib.sha256(canonical).hexdigest()
-          for name in ("desired-manifest.json", "assembly-receipt.json"):
-              with open("receipt-dist/" + name, "w") as f: json.dump(receipt, f, sort_keys=True); f.write("\n")
+          canonical = json.dumps(manifest, sort_keys=True, separators=(",", ":")).encode()
+          manifest["manifest_digest"] = hashlib.sha256(canonical).hexdigest()
+          approved = os.environ.get("APPROVED_MANIFEST_DIGEST")
+          if approved and approved != manifest["manifest_digest"]:
+              raise SystemExit(
+                  "built manifest does not match approved_manifest_digest: "
+                  f"approved={approved} built={manifest['manifest_digest']}"
+              )
+          assembly = dict(manifest)
+          assembly.update({
+              "artifact_name": os.environ["SITE_ARTIFACT"],
+              "artifact_run_id": os.environ["GITHUB_RUN_ID"],
+              "timestamp": os.environ["TIMESTAMP"],
+              "status": "BUILT",
+          })
+          with open("receipt-dist/desired-manifest.json", "w") as f:
+              json.dump(manifest, f, sort_keys=True)
+              f.write("\n")
+          with open("receipt-dist/assembly-receipt.json", "w") as f:
+              json.dump(assembly, f, sort_keys=True)
+              f.write("\n")
           with open(os.environ["GITHUB_OUTPUT"], "a") as output:
-              output.write(f"manifest_digest={receipt['manifest_digest']}\n")
+              output.write(f"manifest_digest={manifest['manifest_digest']}\n")
               output.write(f"assembly_digest={os.environ['SITE_DIGEST']}\n")
               output.write(f"database_digest={os.environ['DATABASE_DIGEST']}\n")
               output.write(f"explorer_digest={os.environ['EXPLORER_DIGEST']}\n")
               output.write(f"docs_digest={os.environ['DOCS_DIGEST']}\n")
           PY
           cp receipt-dist/assembly-receipt.json receipt-dist/publication-receipt.json
+
+      - name: Upload candidate receipts for independent review
+        if: always() && steps.receipt.outcome == 'success'
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: publication-candidate-receipts-${{ steps.inputs.outputs.generation }}-${{ github.run_id }}
+          path: receipt-dist/
+          retention-days: 90
+
       - name: Pre-deploy candidate verification
         env:
           EXPECT_NOOP: ${{ inputs.expect_noop }}
@@ -383,7 +443,7 @@ jobs:
           else
             uv run python scripts/publication/verify_live.py \
               --candidate-manifest receipt-dist/publication-receipt.json \
-              --baseline-manifest receipt-dist/publication-receipt.json \
+              --baseline-manifest receipt-dist/desired-manifest.json \
               --pre-deploy --require-receipt
           fi
 
@@ -414,6 +474,7 @@ jobs:
     if: inputs.expect_noop != true && inputs.force_rollback != true
     runs-on: ubuntu-latest
     permissions:
+      actions: read
       contents: read
       pages: write
       id-token: write
@@ -423,6 +484,20 @@ jobs:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
+      - name: Revalidate authoritative live head
+        env:
+          GH_TOKEN: ${{ github.token }}
+          EXPECTED_PARENT_ARTIFACT_ID: ${{ needs.build.outputs.parent_artifact_id }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          CURRENT=$(gh api "repos/${{ github.repository }}/actions/artifacts?per_page=100" \
+            --jq '[.artifacts | map(select(.expired == false) | select(.name | startswith("publication-live-receipt-"))) | sort_by(.created_at) | reverse | .[0].id][0] // ""')
+          [ "$CURRENT" = "$EXPECTED_PARENT_ARTIFACT_ID" ] || {
+            echo "::error::publication live head changed after build; refusing stale deployment"
+            exit 1
+          }
+
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4
@@ -506,6 +581,7 @@ jobs:
           receipt = dict(assembly)
           receipt.update({
               'receipt_id': f"live-{os.environ['BUILD_GENERATION']}-{os.environ['GITHUB_RUN_ID']}",
+              'receipt_run_id': os.environ['GITHUB_RUN_ID'],
               'timestamp': datetime.now(timezone.utc).isoformat().replace('+00:00', 'Z'),
               'routes': probes,
               'nonce': f"{os.environ['GITHUB_RUN_ID']}-{os.environ['GITHUB_RUN_ATTEMPT']}",
@@ -592,15 +668,15 @@ jobs:
           gh api --paginate "repos/${{ github.repository }}/actions/artifacts?per_page=100" --jq '.artifacts[] | select(.expired == false) | select(.name | startswith("publication-live-receipt-")) | "\(.id) \(.workflow_run.id)"' > candidates.txt
           while read -r ARTIFACT_ID RUN_ID; do
             [ -n "${ARTIFACT_ID:-}" ] || continue
-            RUN_META=$(gh api "repos/${{ github.repository }}/actions/runs/$RUN_ID" --jq '[.name, .conclusion, .event] | @tsv')
-            IFS=$'\t' read -r RUN_NAME RUN_CONCLUSION RUN_EVENT <<< "$RUN_META"
-            if [[ "$RUN_NAME" != "Publication Control Plane Deployment" || "$RUN_CONCLUSION" != "success" || "$RUN_EVENT" != "workflow_dispatch" ]]; then
+            RUN_META=$(gh api "repos/${{ github.repository }}/actions/runs/$RUN_ID" --jq '[.name, .status, .conclusion, .event] | @tsv')
+            IFS=$'\t' read -r RUN_NAME RUN_STATUS RUN_CONCLUSION RUN_EVENT <<< "$RUN_META"
+            if [[ "$RUN_NAME" != "Publication Control Plane Deployment" || "$RUN_STATUS" != "completed" || "$RUN_EVENT" != "workflow_dispatch" ]]; then
               continue
             fi
             rm -rf candidate && mkdir candidate
             gh api "repos/${{ github.repository }}/actions/artifacts/$ARTIFACT_ID/zip" > candidate.zip
             unzip -q candidate.zip -d candidate
-            if RUN_ID="$RUN_ID" uv run python - <<'PY'
+            if RUN_ID="$RUN_ID" RUN_CONCLUSION="$RUN_CONCLUSION" uv run python - <<'PY'
           import json, os
           from pathlib import Path
           from scripts.publication.reconciliation import verify_live_receipt_signature
@@ -609,11 +685,14 @@ jobs:
           receipt = json.loads(p.read_text())
           valid, _ = verify_live_receipt_signature(receipt)
           if not valid or receipt.get('target') != 'benchbox.dev': raise SystemExit(1)
+          if os.environ['RUN_CONCLUSION'] != 'success':
+              if not str(receipt.get('receipt_id', '')).startswith('rollback-'): raise SystemExit(1)
+              if not receipt.get('routes') or not all(route.get('ok') for route in receipt['routes']): raise SystemExit(1)
           prior_id = os.environ.get('PRIOR_LIVE_RECEIPT_ID', '').strip()
           current_gen = os.environ.get('CURRENT_GENERATION', '').strip()
           if prior_id and receipt.get('receipt_id') != prior_id: raise SystemExit(1)
           if current_gen and str(receipt.get('generation')) == current_gen: raise SystemExit(1)
-          if str(receipt.get('artifact_run_id')) != os.environ.get('RUN_ID'): raise SystemExit(1)
+          if str(receipt.get('receipt_run_id', receipt.get('artifact_run_id'))) != os.environ.get('RUN_ID'): raise SystemExit(1)
           if not receipt.get('artifact_name') or not receipt.get('artifacts', {}).get('pages_assembly', {}).get('digest'): raise SystemExit(1)
           PY
             then
@@ -665,6 +744,10 @@ jobs:
       - name: Create and sign rollback live receipt
         env:
           PUBLICATION_ATTESTOR_PRIVATE_KEY: ${{ secrets.PUBLICATION_ATTESTOR_PRIVATE_KEY }}
+          BUILD_GENERATION: ${{ needs.build.outputs.generation }}
+          PARENT_SHA: ${{ needs.build.outputs.parent_sha }}
+          PARENT_GENERATION: ${{ needs.build.outputs.parent_generation }}
+          PRIOR_LIVE_RECEIPT_ID: ${{ inputs.prior_live_receipt_id }}
           GITHUB_RUN_ID: ${{ github.run_id }}
           GITHUB_RUN_ATTEMPT: ${{ github.run_attempt }}
         shell: bash
@@ -675,19 +758,37 @@ jobs:
             exit 1
           }
           python3 - <<'PY'
-          import json, os
+          import hashlib, json, os
           from datetime import datetime, timezone
+          from scripts.publication.manifest import validate_manifest_dict
           prior = json.load(open('known-good-receipt/live-receipt.json'))
           probes = json.load(open('known-good-receipt/rollback-probe-report.json'))['probes']
           receipt = dict(prior)
           receipt.update({
+              'generation': int(os.environ['BUILD_GENERATION']),
+              'parent_sha': os.environ['PARENT_SHA'],
+              'parent_generation': int(os.environ['PARENT_GENERATION']),
               'receipt_id': f"rollback-{os.environ['GITHUB_RUN_ID']}-{os.environ['GITHUB_RUN_ATTEMPT']}",
+              'receipt_run_id': os.environ['GITHUB_RUN_ID'],
               'timestamp': datetime.now(timezone.utc).isoformat().replace('+00:00', 'Z'),
               'routes': probes,
               'nonce': f"{os.environ['GITHUB_RUN_ID']}-{os.environ['GITHUB_RUN_ATTEMPT']}",
-              'prior_live_receipt_id': prior['receipt_id'],
+              'prior_live_receipt_id': os.environ['PRIOR_LIVE_RECEIPT_ID'],
+              'rollback_source_receipt_id': prior['receipt_id'],
           })
           receipt.pop('signature', None)
+          manifest_keys = (
+              'schema_version', 'target', 'generation', 'parent_sha', 'parent_generation',
+              'source_commit', 'source_branch', 'develop_sha', 'published_results_sha',
+              'build_closure', 'corpus', 'artifacts', 'checksums', 'prior_live_receipt_id',
+          )
+          manifest = {key: receipt[key] for key in manifest_keys}
+          errors = validate_manifest_dict(manifest)
+          if errors:
+              raise SystemExit('invalid rollback manifest: ' + '; '.join(errors))
+          receipt['manifest_digest'] = hashlib.sha256(
+              json.dumps(manifest, sort_keys=True, separators=(',', ':')).encode()
+          ).hexdigest()
           open('known-good-receipt/rollback-live-receipt.json', 'w').write(json.dumps(receipt, sort_keys=True) + '\n')
           PY
           umask 077
@@ -715,6 +816,15 @@ jobs:
           valid, reason = verify_live_receipt_signature(json.load(open('known-good-receipt/rollback-live-receipt.json')))
           assert valid, reason
           PY
+          mkdir -p successor-live-receipt
+          cp known-good-receipt/rollback-live-receipt.json successor-live-receipt/live-receipt.json
+
+      - name: Publish rollback as the new attested live head
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: publication-live-receipt-${{ needs.build.outputs.generation }}
+          path: successor-live-receipt/
+          retention-days: 90
 
       - name: Upload rollback audit receipt
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4

--- a/.github/workflows/publication-preview-deploy.yml
+++ b/.github/workflows/publication-preview-deploy.yml
@@ -313,6 +313,7 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     permissions:
+      actions: read
       contents: read
       pages: write
       id-token: write
@@ -320,8 +321,68 @@ jobs:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
+      - uses: actions/checkout@v4
+
+      - name: Check for independent publication ownership
+        id: independent
+        env:
+          GH_TOKEN: ${{ github.token }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          ACTIVE=false
+          gh api --paginate "repos/${{ github.repository }}/actions/artifacts?per_page=100" \
+            --jq '.artifacts[] | select(.expired == false) | select(.name | startswith("publication-live-receipt-")) | "\(.created_at) \(.id) \(.workflow_run.id)"' \
+            | sort -r > independent-publication-runs.txt
+          while read -r _CREATED_AT ARTIFACT_ID RUN_ID; do
+            [ -n "${RUN_ID:-}" ] || continue
+            RUN_META=$(gh api "repos/${{ github.repository }}/actions/runs/$RUN_ID" \
+              --jq '[.name, .status, .conclusion, .event, .head_branch] | @tsv')
+            IFS=$'\t' read -r RUN_NAME RUN_STATUS RUN_CONCLUSION RUN_EVENT RUN_BRANCH <<< "$RUN_META"
+            if [[ "$RUN_NAME" != "Publication Control Plane Deployment" || "$RUN_STATUS" != "completed" || \
+                  "$RUN_EVENT" != "workflow_dispatch" || "$RUN_BRANCH" != "develop" ]]; then
+              continue
+            fi
+            rm -rf independent-receipt && mkdir independent-receipt
+            gh api "repos/${{ github.repository }}/actions/artifacts/$ARTIFACT_ID/zip" > independent-receipt.zip
+            unzip -q independent-receipt.zip -d independent-receipt
+            if EXPECTED_RUN_ID="$RUN_ID" RUN_CONCLUSION="$RUN_CONCLUSION" python3 - <<'PY'
+          import json
+          import os
+          import re
+          from pathlib import Path
+          from scripts.publication.reconciliation import verify_live_receipt_signature
+
+          path = Path("independent-receipt/live-receipt.json")
+          if not path.is_file():
+              raise SystemExit(1)
+          receipt = json.loads(path.read_text())
+          valid, _ = verify_live_receipt_signature(receipt)
+          if not valid or receipt.get("target") != "benchbox.dev":
+              raise SystemExit(1)
+          if str(receipt.get("receipt_run_id", receipt.get("artifact_run_id"))) != os.environ["EXPECTED_RUN_ID"]:
+              raise SystemExit(1)
+          if not re.fullmatch(r"[0-9a-f]{40}", str(receipt.get("source_commit", ""))):
+              raise SystemExit(1)
+          if os.environ["RUN_CONCLUSION"] != "success":
+              if not str(receipt.get("receipt_id", "")).startswith("rollback-"):
+                  raise SystemExit(1)
+              if not receipt.get("routes") or not all(route.get("ok") for route in receipt["routes"]):
+                  raise SystemExit(1)
+          PY
+            then
+              ACTIVE=true
+              break
+            fi
+          done < independent-publication-runs.txt
+          echo "active=$ACTIVE" >> "$GITHUB_OUTPUT"
+          if [ "$ACTIVE" = "true" ]; then
+            echo "::notice::Independent publication owns Pages; skipping the preview deployment"
+          fi
+
       - name: Deploy to GitHub Pages
         id: deployment
+        if: steps.independent.outputs.active != 'true'
         uses: actions/deploy-pages@v4
 
   record:

--- a/.github/workflows/publication-preview-deploy.yml
+++ b/.github/workflows/publication-preview-deploy.yml
@@ -81,6 +81,10 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
+          if [ "$GITHUB_REF" != "refs/heads/develop" ]; then
+            echo "::error::preview publication must be dispatched from develop"
+            exit 1
+          fi
           DEVELOP_SHA="${{ inputs.develop_sha }}"
           PUBLISHED_SHA="${{ inputs.published_results_sha }}"
           RELEASE_SHA="${{ inputs.release_sha }}"
@@ -320,6 +324,8 @@ jobs:
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
+    outputs:
+      pages_write_outcome: ${{ steps.deployment.outcome }}
     steps:
       - uses: actions/checkout@v4
 
@@ -388,6 +394,7 @@ jobs:
   record:
     name: Record deployment receipt + soak state
     needs: [build, deploy]
+    if: needs.deploy.outputs.pages_write_outcome == 'success'
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/docs/operations/independent-publication-contract.md
+++ b/docs/operations/independent-publication-contract.md
@@ -76,9 +76,16 @@ fabricate a state; a missing or malformed input fails closed.
   `retention-policy.json` (which must cite its `source`), and either a
   `capacity-audit.json` or a `--pages-dir` to measure.
 
-Signature verification against an attestor key is not yet implemented; the
-canary currently requires only that the signature field is present and
-non-empty. Closing that gap is tracked with the w3-w5 live-evidence work.
+`scripts/publication/reconciliation.py` verifies every live receipt signature
+against the repository public key at
+`docs/operations/publication-attestor-public-key.pem`. It signs canonical JSON
+(sorted keys, compact separators, UTF-8) with `signature` and
+`attestor_signature` excluded. Receipts must declare
+`signature_algorithm: ed25519`; missing, empty, malformed, or non-verifying
+signatures fail closed. The matching private key is never stored in the
+repository. Before dispatching the production deployer, a maintainer must set
+the `PUBLICATION_ATTESTOR_PRIVATE_KEY` GitHub Actions secret to the matching
+Ed25519 PEM private key.
 
 ## Rollback
 

--- a/docs/operations/independent-publication-contract.md
+++ b/docs/operations/independent-publication-contract.md
@@ -84,8 +84,9 @@ against the repository public key at
 `signature_algorithm: ed25519`; missing, empty, malformed, or non-verifying
 signatures fail closed. The matching private key is never stored in the
 repository. Before dispatching the production deployer, a maintainer must set
-the `PUBLICATION_ATTESTOR_PRIVATE_KEY` GitHub Actions secret to the matching
-Ed25519 PEM private key.
+the `PUBLICATION_ATTESTOR_PRIVATE_KEY` environment secret to the matching
+Ed25519 PEM private key in the protected `publication-attestation` and
+`github-pages` environments. There must be no repository-level copy.
 
 ## Rollback
 

--- a/docs/operations/publication-attestor-public-key.pem
+++ b/docs/operations/publication-attestor-public-key.pem
@@ -1,0 +1,3 @@
+-----BEGIN PUBLIC KEY-----
+MCowBQYDK2VwAyEA1i+4ZKsf0Qjos80CLUwv4h/biQVoi+tDy1aa1IvsZds=
+-----END PUBLIC KEY-----

--- a/docs/operations/publication-deployer-soak-and-retirement.md
+++ b/docs/operations/publication-deployer-soak-and-retirement.md
@@ -8,8 +8,12 @@ automatic Pages writer while `docs.yml` continues to deploy release pushes.
 
 ## Prerequisites
 
-Before the first dispatch, configure the repository Actions secret
-`PUBLICATION_ATTESTOR_PRIVATE_KEY`. It must be the PEM Ed25519 private key
+Before the first dispatch, configure the `PUBLICATION_ATTESTOR_PRIVATE_KEY`
+environment secret in both `publication-attestation` and `github-pages`. The
+former must allow only `develop`; the latter must retain its protected-branch
+policy for deployment and rollback. Do not configure a repository-level copy,
+because unmerged branch workflow code could request it. The secret must be the
+PEM Ed25519 private key
 whose public half is committed at
 [`publication-attestor-public-key.pem`](publication-attestor-public-key.pem).
 Do not place the private key in a workflow input, artifact, commit, issue, or

--- a/docs/operations/publication-deployer-soak-and-retirement.md
+++ b/docs/operations/publication-deployer-soak-and-retirement.md
@@ -12,8 +12,10 @@ overwriting an attested deployment during the soak.
 
 Before the first dispatch, configure the `PUBLICATION_ATTESTOR_PRIVATE_KEY`
 environment secret in both `publication-attestation` and `github-pages`. The
-former must allow only `develop`; the latter must retain its protected-branch
-policy for deployment and rollback. Do not configure a repository-level copy,
+former must allow only `develop`; the latter must also allow only `develop` and
+must disable administrator bypass before activation. This retires stale
+`release` copies of the legacy and preview Pages writers while preserving
+deployment and rollback from the independent workflow. Do not configure a repository-level copy,
 because unmerged branch workflow code could request it. The secret must be the
 PEM Ed25519 private key
 whose public half is committed at

--- a/docs/operations/publication-deployer-soak-and-retirement.md
+++ b/docs/operations/publication-deployer-soak-and-retirement.md
@@ -16,10 +16,18 @@ Do not place the private key in a workflow input, artifact, commit, issue, or
 receipt. A missing secret makes the live-receipt stage fail closed.
 
 Choose exact 40-character lowercase commit SHAs for `develop_sha` and
-`published_results_sha`. Choose a unique, lowercase `generation`, and record
-the prior live receipt ID when the run replaces an earlier generation. Dispatch
-from the Actions page with `expect_noop=false` and `force_rollback=false`.
-This is an authorized production action; this runbook does not authorize it.
+`published_results_sha`. Generations are positive decimal CAS values: use `1`
+for the first independent deployment, then increment by one. Record the current
+attested live receipt ID when the run replaces an earlier generation.
+
+First dispatch the exact inputs with `expect_noop=true` and no
+`approved_manifest_digest`. Download `desired-manifest.json` from the candidate
+receipt artifact, inspect its pins and measured artifact closure, and record its
+`manifest_digest`. Dispatch the production run with the same inputs,
+`expect_noop=false`, `force_rollback=false`, and that reviewed digest as
+`approved_manifest_digest`. The workflow rebuilds and refuses deployment unless
+the complete candidate manifest matches the approved digest. This is an
+authorized production action; this runbook does not authorize it.
 
 For a no-write rehearsal, set `expect_noop=true`. That compares the candidate
 database with the freeze baseline and skips the deploy job. A rehearsal is not

--- a/docs/operations/publication-deployer-soak-and-retirement.md
+++ b/docs/operations/publication-deployer-soak-and-retirement.md
@@ -29,11 +29,14 @@ attested live receipt ID when the run replaces an earlier generation.
 First dispatch the exact inputs with `expect_noop=true` and no
 `approved_manifest_digest`. Download `desired-manifest.json` from the candidate
 receipt artifact, inspect its pins and measured artifact closure, and record its
-`manifest_digest`. Dispatch the production run with the same inputs,
+`manifest_digest` and workflow run ID. Dispatch the production run with the same inputs,
 `expect_noop=false`, `force_rollback=false`, and that reviewed digest as
-`approved_manifest_digest`. The workflow rebuilds and refuses deployment unless
-the complete candidate manifest matches the approved digest. This is an
-authorized production action; this runbook does not authorize it.
+`approved_manifest_digest`; pass the recorded run ID as
+`approved_candidate_run_id`. The workflow authenticates the successful no-write
+run, rechecks its pins and manifest digest, downloads its retained site, and
+refuses deployment unless the site's exact byte digest matches the reviewed
+manifest. It promotes those reviewed bytes without rebuilding the DuckDB file.
+This is an authorized production action; this runbook does not authorize it.
 
 For a no-write rehearsal, set `expect_noop=true`. That compares the candidate
 database with the freeze baseline and skips the deploy job. A rehearsal is not

--- a/docs/operations/publication-deployer-soak-and-retirement.md
+++ b/docs/operations/publication-deployer-soak-and-retirement.md
@@ -28,7 +28,8 @@ Choose exact 40-character lowercase commit SHAs for `develop_sha` and
 for the first independent deployment, then increment by one. Record the current
 attested live receipt ID when the run replaces an earlier generation.
 
-First dispatch the exact inputs with `expect_noop=true` and no
+For a publication that changes corpus content, first dispatch the exact inputs
+with `candidate_only=true`, `expect_noop=false`, and no
 `approved_manifest_digest`. Download `desired-manifest.json` from the candidate
 receipt artifact, inspect its pins and measured artifact closure, and record its
 `manifest_digest` and workflow run ID. Dispatch the production run with the same inputs,
@@ -40,7 +41,7 @@ refuses deployment unless the site's exact byte digest matches the reviewed
 manifest. It promotes those reviewed bytes without rebuilding the DuckDB file.
 This is an authorized production action; this runbook does not authorize it.
 
-For a no-write rehearsal, set `expect_noop=true`. That compares the candidate
+For a no-op rehearsal, set `expect_noop=true` and `candidate_only=false`. That compares the candidate
 database with the freeze baseline and skips the deploy job. A rehearsal is not
 a live receipt and cannot count toward soak.
 

--- a/docs/operations/publication-deployer-soak-and-retirement.md
+++ b/docs/operations/publication-deployer-soak-and-retirement.md
@@ -3,8 +3,10 @@
 `publication-deploy.yml` is an armed, dispatch-only Pages deployer. It builds
 one complete site from an exact `develop` SHA and an exact
 `published-results` SHA, then deploys that immutable artifact only after its
-pre-deploy checks pass. It does not run on a push. This avoids a second
-automatic Pages writer while `docs.yml` continues to deploy release pushes.
+pre-deploy checks pass. It does not run on a push. The `docs.yml` release job
+shares its deployment lock and stops writing Pages after the first successful
+independent live-receipt run, preventing a queued legacy artifact from
+overwriting an attested deployment during the soak.
 
 ## Prerequisites
 
@@ -47,7 +49,7 @@ The run is a successful production observation only when all are present:
   digests; the retained site artifact has the same site digest.
 - `deployment-receipt.json` is provider acknowledgement, not proof of live
   service.
-- `live-receipt.json` follows external probes of `/`, `/results/`, and
+- `live-receipt.json` follows external probes of `/`, `/docs/`, `/results/`, and
   `/results/data/results.duckdb`, has a fresh nonce and timestamp, includes the
   source SHAs, digest set, prior receipt ID where applicable, and verifies with
   `scripts/publication/reconciliation.py` against the repository public key.

--- a/docs/operations/publication-deployer-soak-and-retirement.md
+++ b/docs/operations/publication-deployer-soak-and-retirement.md
@@ -1,0 +1,83 @@
+# Publication deployer soak and retirement
+
+`publication-deploy.yml` is an armed, dispatch-only Pages deployer. It builds
+one complete site from an exact `develop` SHA and an exact
+`published-results` SHA, then deploys that immutable artifact only after its
+pre-deploy checks pass. It does not run on a push. This avoids a second
+automatic Pages writer while `docs.yml` continues to deploy release pushes.
+
+## Prerequisites
+
+Before the first dispatch, configure the repository Actions secret
+`PUBLICATION_ATTESTOR_PRIVATE_KEY`. It must be the PEM Ed25519 private key
+whose public half is committed at
+[`publication-attestor-public-key.pem`](publication-attestor-public-key.pem).
+Do not place the private key in a workflow input, artifact, commit, issue, or
+receipt. A missing secret makes the live-receipt stage fail closed.
+
+Choose exact 40-character lowercase commit SHAs for `develop_sha` and
+`published_results_sha`. Choose a unique, lowercase `generation`, and record
+the prior live receipt ID when the run replaces an earlier generation. Dispatch
+from the Actions page with `expect_noop=false` and `force_rollback=false`.
+This is an authorized production action; this runbook does not authorize it.
+
+For a no-write rehearsal, set `expect_noop=true`. That compares the candidate
+database with the freeze baseline and skips the deploy job. A rehearsal is not
+a live receipt and cannot count toward soak.
+
+## Evidence for each soak run
+
+Collect the build, deployment, and live-receipt artifacts from the same run.
+The run is a successful production observation only when all are present:
+
+- `desired-manifest.json` identifies the pinned inputs and generation.
+- `assembly-receipt.json` records distinct site, docs, Explorer, and DuckDB
+  digests; the retained site artifact has the same site digest.
+- `deployment-receipt.json` is provider acknowledgement, not proof of live
+  service.
+- `live-receipt.json` follows external probes of `/`, `/results/`, and
+  `/results/data/results.duckdb`, has a fresh nonce and timestamp, includes the
+  source SHAs, digest set, prior receipt ID where applicable, and verifies with
+  `scripts/publication/reconciliation.py` against the repository public key.
+
+Digest equivalence means that the whole-site digest and its component docs,
+Explorer, and DuckDB digests from the new lane are compared with the equivalent
+artifact produced by the current `docs.yml` release lane for the same pinned
+inputs. Compare like with like: a deployment acknowledgement is not a digest,
+and a live route hash is not a substitute for the retained artifact digest.
+The required DuckDB route must also equal the assembly receipt checksum. Any
+mismatch, stale receipt, signature failure, or partial route success fails the
+soak run.
+
+Run the bounded soak for the approved window and preserve each attested receipt
+and comparison record. A `docs.yml` release deployment during a run changes
+the observed target; mark that sample inconclusive and start a fresh comparison
+for the new release generation. Do not call an artifact live before its
+external probes and signature have completed.
+
+## Rollback boundary
+
+On a deployment or probe failure, the workflow searches retained
+`publication-live-receipt-*` artifacts, verifies the newest eligible receipt
+with the public key, downloads its named site artifact, recomputes its digest,
+and only then permits the rollback Pages write. It never rebuilds a site from a
+branch name or uses `rollback_target_sha` as bytes. If no unexpired attested
+artifact exists, rollback fails closed.
+
+## Retirement decision
+
+The freeze closure at
+[`publication-freeze-closure-2026-09-04.json`](publication-freeze-closure-2026-09-04.json)
+records that G1–G5 passed but that retirement was deferred because there was no
+independent production deployer. This workflow supplies the replacement; it
+does not itself prove retirement.
+
+Do not remove the `docs.yml` release Pages deploy, retire or disable
+`sync-results-data-to-published.yml`, or remove `develop` from the GitHub Pages
+branch policy (policy id 59059907) until the bounded soak has preserved the
+digest-equivalence and attested-live evidence above and an authorized follow-up
+approves the retirement change.
+
+Corpus mirror pull requests are reconciled by the exact `results-data` path set
+and content digests against the target branch. Recency, title, and a newer open
+mirror PR are not grounds to close an older mirror PR.

--- a/docs/operations/publication-deployer-soak-and-retirement.md
+++ b/docs/operations/publication-deployer-soak-and-retirement.md
@@ -12,10 +12,12 @@ overwriting an attested deployment during the soak.
 
 Before the first dispatch, configure the `PUBLICATION_ATTESTOR_PRIVATE_KEY`
 environment secret in both `publication-attestation` and `github-pages`. The
-former must allow only `develop`; the latter must also allow only `develop` and
-must disable administrator bypass before activation. This retires stale
-`release` copies of the legacy and preview Pages writers while preserving
-deployment and rollback from the independent workflow. Do not configure a repository-level copy,
+former must allow only `develop`; the latter must continue to allow `develop`
+and `release` during the bounded soak so the legacy release deploy remains
+available until its retirement is approved. Disable the obsolete
+`publication-preview-deploy.yml` workflow at repository level before activation;
+its in-file ownership guard remains defense in depth if it is later re-enabled.
+Do not configure a repository-level copy,
 because unmerged branch workflow code could request it. The secret must be the
 PEM Ed25519 private key
 whose public half is committed at

--- a/scripts/publication/audit_mirror_prs.py
+++ b/scripts/publication/audit_mirror_prs.py
@@ -120,7 +120,7 @@ def _list_open_prs(repo: str, base: str) -> list[dict[str, Any]]:
             "--state",
             "open",
             "--limit",
-            "200",
+            "100000",
             "--json",
             "number,title,headRefName",
         ],
@@ -191,6 +191,14 @@ def _audit_pr(pr: dict[str, Any], base_shas: dict[str, str], repo: str) -> Mirro
         head_ref=pr.get("headRefName", ""),
         mirrored_file_count=0,
     )
+
+    # Only the synchronizer's machine-owned head namespace is authoritative
+    # mirror provenance.  Unrelated PRs must never become retire-able EMPTY
+    # records merely because they target the same base branch.
+    if not audit.head_ref.startswith("auto/results-mirror-"):
+        audit.verdict = "UNRELATED"
+        audit.error = "PR has no authoritative results-mirror head provenance"
+        return audit
 
     try:
         files = _list_pr_files(repo, number)

--- a/scripts/publication/audit_mirror_prs.py
+++ b/scripts/publication/audit_mirror_prs.py
@@ -122,7 +122,7 @@ def _list_open_prs(repo: str, base: str) -> list[dict[str, Any]]:
             "--limit",
             "100000",
             "--json",
-            "number,title,headRefName",
+            "number,title,headRefName,headRepository,headRepositoryOwner",
         ],
         "gh pr list",
     )
@@ -195,9 +195,26 @@ def _audit_pr(pr: dict[str, Any], base_shas: dict[str, str], repo: str) -> Mirro
     # Only the synchronizer's machine-owned head namespace is authoritative
     # mirror provenance.  Unrelated PRs must never become retire-able EMPTY
     # records merely because they target the same base branch.
-    if not audit.head_ref.startswith("auto/results-mirror-"):
+    try:
+        expected_owner, expected_repo = repo.split("/", 1)
+    except ValueError:
+        audit.verdict = "ERROR"
+        audit.error = f"invalid repository identifier: {repo!r}"
+        return audit
+    head_repository = pr.get("headRepository")
+    head_owner = pr.get("headRepositoryOwner")
+    actual_repo = head_repository.get("name") if isinstance(head_repository, dict) else None
+    actual_owner = head_owner.get("login") if isinstance(head_owner, dict) else None
+    authoritative_head = (
+        audit.head_ref.startswith("auto/results-mirror-")
+        and isinstance(actual_repo, str)
+        and actual_repo.casefold() == expected_repo.casefold()
+        and isinstance(actual_owner, str)
+        and actual_owner.casefold() == expected_owner.casefold()
+    )
+    if not authoritative_head:
         audit.verdict = "UNRELATED"
-        audit.error = "PR has no authoritative results-mirror head provenance"
+        audit.error = "PR has no authoritative same-repository results-mirror head provenance"
         return audit
 
     try:

--- a/scripts/publication/audit_mirror_prs.py
+++ b/scripts/publication/audit_mirror_prs.py
@@ -122,7 +122,7 @@ def _list_open_prs(repo: str, base: str) -> list[dict[str, Any]]:
             "--limit",
             "100000",
             "--json",
-            "number,title,headRefName,headRepository,headRepositoryOwner",
+            "number,title,author,headRefName,headRepository,headRepositoryOwner",
         ],
         "gh pr list",
     )
@@ -203,14 +203,17 @@ def _audit_pr(pr: dict[str, Any], base_shas: dict[str, str], repo: str) -> Mirro
         return audit
     head_repository = pr.get("headRepository")
     head_owner = pr.get("headRepositoryOwner")
+    author = pr.get("author")
     actual_repo = head_repository.get("name") if isinstance(head_repository, dict) else None
     actual_owner = head_owner.get("login") if isinstance(head_owner, dict) else None
+    actual_author = author.get("login") if isinstance(author, dict) else None
     authoritative_head = (
         audit.head_ref.startswith("auto/results-mirror-")
         and isinstance(actual_repo, str)
         and actual_repo.casefold() == expected_repo.casefold()
         and isinstance(actual_owner, str)
         and actual_owner.casefold() == expected_owner.casefold()
+        and actual_author == "github-actions[bot]"
     )
     if not authoritative_head:
         audit.verdict = "UNRELATED"

--- a/scripts/publication/check_operational_receipts.py
+++ b/scripts/publication/check_operational_receipts.py
@@ -464,11 +464,14 @@ def audit_operational_receipts(
             largest_file_bytes = int(cap_data.get("largest_file_bytes", 0))
         except (KeyError, TypeError, ValueError) as e:
             raise ReceiptsConfigError(f"{CAPACITY_FILE} is missing/invalid total_size_bytes: {e}") from e
+        measured = cap_data.get("measured", False)
+        if not isinstance(measured, bool):
+            raise ReceiptsConfigError(f"{CAPACITY_FILE} measured must be a boolean")
         capacity_audit = audit_capacity(
             total_bytes,
             largest_file_bytes,
             str(cap_data.get("largest_file_path", "")),
-            measured=bool(cap_data.get("measured", False)),
+            measured=measured,
         )
     else:
         capacity_audit = CapacityAudit(total_size_bytes=0, passed=False)

--- a/scripts/publication/check_operational_receipts.py
+++ b/scripts/publication/check_operational_receipts.py
@@ -175,6 +175,10 @@ def audit_capacity(
     violations: list[str] = []
     passed = True
 
+    if not measured:
+        passed = False
+        violations.append("Capacity evidence is a declaration; measured=true or --pages-dir is required")
+
     if total_bytes >= MAX_TOTAL_PAGES_BYTES:
         passed = False
         violations.append(
@@ -349,6 +353,32 @@ def audit_drill_receipt(
             max_age_days=max_age_days,
             passed=False,
             error=f"Drill receipt is expired: age {age_days} days exceeds maximum threshold of {max_age_days} days",
+        )
+
+    evidence = receipt_data.get("evidence")
+    if not isinstance(evidence, dict):
+        return DrillReceiptStatus(
+            drill_type=drill_type,
+            status="INVALID",
+            receipt_id=receipt_id,
+            executed_at=str(executed_at),
+            age_days=age_days,
+            max_age_days=max_age_days,
+            passed=False,
+            error="Successful drill receipt lacks bound workflow/artifact evidence",
+        )
+    required_evidence = ("workflow_run_id", "event_id", "artifact_name", "artifact_digest")
+    missing = [key for key in required_evidence if not evidence.get(key)]
+    if missing:
+        return DrillReceiptStatus(
+            drill_type=drill_type,
+            status="INVALID",
+            receipt_id=receipt_id,
+            executed_at=str(executed_at),
+            age_days=age_days,
+            max_age_days=max_age_days,
+            passed=False,
+            error=f"Drill evidence missing required bindings: {', '.join(missing)}",
         )
 
     return DrillReceiptStatus(

--- a/scripts/publication/check_operational_receipts.py
+++ b/scripts/publication/check_operational_receipts.py
@@ -33,6 +33,7 @@ from __future__ import annotations
 import argparse
 import json
 import os
+import re
 import sys
 from collections.abc import Sequence
 from dataclasses import asdict, dataclass, field
@@ -41,6 +42,7 @@ from pathlib import Path
 from typing import Any
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
+HEX_64_RE = re.compile(r"^(sha256:)?[0-9a-f]{64}$", re.IGNORECASE)
 
 MAX_TOTAL_PAGES_BYTES = 1024 * 1024 * 1024  # 1 GiB
 WARNING_TOTAL_PAGES_BYTES = 800 * 1024 * 1024  # 800 MiB
@@ -62,6 +64,27 @@ RETENTION_FILE = "retention-policy.json"
 
 class ReceiptsConfigError(ValueError):
     """Raised for a configuration or parse error in operational inputs."""
+
+
+def _validate_artifact_evidence(evidence: Any) -> list[str]:
+    """Validate immutable workflow-artifact provenance carried by a receipt."""
+    if not isinstance(evidence, dict):
+        return ["evidence must be an object"]
+    errors: list[str] = []
+    run_id = evidence.get("workflow_run_id")
+    valid_run_id = (isinstance(run_id, int) and not isinstance(run_id, bool) and run_id > 0) or (
+        isinstance(run_id, str) and run_id.isdecimal() and int(run_id) > 0
+    )
+    if not valid_run_id:
+        errors.append("workflow_run_id must be a positive integer")
+    for key in ("event_id", "artifact_name"):
+        value = evidence.get(key)
+        if not isinstance(value, str) or not value.strip():
+            errors.append(f"{key} must be a non-empty string")
+    digest = evidence.get("artifact_digest")
+    if not isinstance(digest, str) or HEX_64_RE.fullmatch(digest.strip()) is None:
+        errors.append("artifact_digest must be a SHA-256 digest")
+    return errors
 
 
 @dataclass
@@ -355,8 +378,8 @@ def audit_drill_receipt(
             error=f"Drill receipt is expired: age {age_days} days exceeds maximum threshold of {max_age_days} days",
         )
 
-    evidence = receipt_data.get("evidence")
-    if not isinstance(evidence, dict):
+    evidence_errors = _validate_artifact_evidence(receipt_data.get("evidence"))
+    if evidence_errors:
         return DrillReceiptStatus(
             drill_type=drill_type,
             status="INVALID",
@@ -365,20 +388,7 @@ def audit_drill_receipt(
             age_days=age_days,
             max_age_days=max_age_days,
             passed=False,
-            error="Successful drill receipt lacks bound workflow/artifact evidence",
-        )
-    required_evidence = ("workflow_run_id", "event_id", "artifact_name", "artifact_digest")
-    missing = [key for key in required_evidence if not evidence.get(key)]
-    if missing:
-        return DrillReceiptStatus(
-            drill_type=drill_type,
-            status="INVALID",
-            receipt_id=receipt_id,
-            executed_at=str(executed_at),
-            age_days=age_days,
-            max_age_days=max_age_days,
-            passed=False,
-            error=f"Drill evidence missing required bindings: {', '.join(missing)}",
+            error="Invalid bound workflow/artifact evidence: " + "; ".join(evidence_errors),
         )
 
     return DrillReceiptStatus(

--- a/scripts/publication/check_plan_reconciliation.py
+++ b/scripts/publication/check_plan_reconciliation.py
@@ -79,6 +79,13 @@ EXPECTED_DEPS: dict[str, list[str]] = {
         "independent-publication-a10-release-and-mirror-retirement"
     ],
 }
+# Freeze closure deferred A10 retirement onto an independent production deployer.
+# That one external predecessor is pinned here; arbitrary external deps still fail.
+EXPECTED_EXTERNAL_DEPS: dict[str, frozenset[str]] = {
+    "independent-publication-a10-release-and-mirror-retirement": frozenset(
+        {"independent-production-deployer-and-retirement"}
+    ),
+}
 # Tracker identity -- must match .todo-db/config.json (project_id / repository).
 TRACKER_PROJECT_ID = "benchbox"
 TRACKER_REPOSITORY = "https://github.com/joeharris76/BenchBox"
@@ -154,9 +161,10 @@ def dependency_violations(plan_order: list[str], deps: dict[str, list[str]]) -> 
     violation, as is an unexpected in-set edge. This closes the "last prior
     edge" gap where only orphan detection would fire.
 
-    Dependencies outside the A0-A11 set are also validated: any live edge to
-    an item not in the plan's ordered set is an unexpected external
-    dependency, because readiness requires every predecessor to be done.
+    Dependencies outside the A0-A11 set are also validated: only edges listed
+    in ``EXPECTED_EXTERNAL_DEPS`` are allowed, and each pinned external
+    predecessor must be present. Arbitrary external deps still fail, because
+    readiness would otherwise require an unplanned predecessor.
 
     ``deps`` maps each plan item to its live dependency ids (all deps are
     validated; only in-set edges are checked for order/missing/unexpected).
@@ -166,12 +174,12 @@ def dependency_violations(plan_order: list[str], deps: dict[str, list[str]]) -> 
     violations: list[str] = []
     for item_id in plan_order:
         live_all = deps.get(item_id, []) or []
-        # External dependencies (outside A0-A11) must be explicitly pinned;
-        # any such edge is drift because the plan's total order cannot
-        # justify it and readiness would require the external predecessor.
-        for dep in live_all:
-            if dep not in order_set:
-                violations.append(f"{item_id} has unexpected external dependency on {dep}")
+        allowed_external = EXPECTED_EXTERNAL_DEPS.get(item_id, frozenset())
+        live_external = {dep for dep in live_all if dep not in order_set}
+        for dep in sorted(live_external - allowed_external):
+            violations.append(f"{item_id} has unexpected external dependency on {dep}")
+        for dep in sorted(allowed_external - live_external):
+            violations.append(f"{item_id} is missing expected external dependency on {dep}")
         item_deps = [dep for dep in live_all if dep in order_set]
         for dep in item_deps:
             if rank[dep] >= rank[item_id]:

--- a/scripts/publication/check_workflow_permissions.py
+++ b/scripts/publication/check_workflow_permissions.py
@@ -136,7 +136,7 @@ def _check_deploy_job_perms(file_path: Path, jobs: dict[str, Any]) -> list[str]:
     errors: list[str] = []
     deploy_job = jobs.get("deploy", {})
     deploy_perm = _normalize_permissions(deploy_job.get("permissions"))
-    expected = {"contents": "read", "pages": "write", "id-token": "write"}
+    expected = {"actions": "read", "contents": "read", "pages": "write", "id-token": "write"}
     if deploy_perm != expected:
         errors.append(
             f"{file_path.name} (job 'deploy'): must declare exactly {expected}; "

--- a/scripts/publication/check_workflow_permissions.py
+++ b/scripts/publication/check_workflow_permissions.py
@@ -5,11 +5,12 @@ This script inspects `.github/workflows/*.yml` files to verify that:
 1. No workflow uses wildcard or unconstrained permissions (`write-all` or `read-all`).
 2. Dangerous write permissions are scoped to the specific jobs requiring them.
 3. The independent publication deployment workflow (`publication-deploy.yml`)
-   strictly follows the principle of least privilege under freeze G3:
+   strictly follows the armed production-deployer least-privilege contract:
    - `build` job has only `contents: read` (no write permissions).
-   - `deploy` job is rehearsal-only: `contents: read` only (no Pages write).
+   - `deploy` job alone receives the Pages deployment write capabilities.
    - `verify` job has only `contents: read` (read-only probes).
-   - `rollback` job is facts-only receipt: `contents: read` only (no Pages write).
+   - `rollback` has only the bounded Pages deployment capabilities needed to
+     restore a cryptographically attested artifact plus `actions: read`.
 
 Usage:
   uv run -- python scripts/publication/check_workflow_permissions.py
@@ -135,20 +136,11 @@ def _check_deploy_job_perms(file_path: Path, jobs: dict[str, Any]) -> list[str]:
     errors: list[str] = []
     deploy_job = jobs.get("deploy", {})
     deploy_perm = _normalize_permissions(deploy_job.get("permissions"))
-    if isinstance(deploy_perm, dict):
-        write_scopes = [k for k, v in deploy_perm.items() if v == "write"]
-        if write_scopes:
-            errors.append(
-                f"{file_path.name} (job 'deploy'): declared write permissions: {write_scopes}. "
-                f"Freeze G3 rehearsal deploy must be read-only (no pages/id-token write)."
-            )
-        if deploy_perm.get("pages") == "write":
-            errors.append(f"{file_path.name} (job 'deploy'): pages: write is forbidden under freeze G3")
-        if deploy_perm.get("id-token") == "write":
-            errors.append(f"{file_path.name} (job 'deploy'): id-token: write is forbidden under freeze G3")
-    else:
+    expected = {"contents": "read", "pages": "write", "id-token": "write"}
+    if deploy_perm != expected:
         errors.append(
-            f"{file_path.name} (job 'deploy'): must declare explicit per-job read-only permissions (contents: read)"
+            f"{file_path.name} (job 'deploy'): must declare exactly {expected}; "
+            "only the deploy job may receive Pages write capabilities."
         )
     return errors
 
@@ -178,19 +170,12 @@ def _check_rollback_job_perms(file_path: Path, jobs: dict[str, Any]) -> list[str
     errors: list[str] = []
     rollback_job = jobs.get("rollback", {})
     rollback_perm = _normalize_permissions(rollback_job.get("permissions"))
-    if isinstance(rollback_perm, dict):
-        write_scopes = [k for k, v in rollback_perm.items() if v == "write"]
-        if write_scopes:
-            errors.append(
-                f"{file_path.name} (job 'rollback'): declared write permissions: {write_scopes}. "
-                f"Freeze G3 facts-only rollback must be read-only (no pages/id-token write)."
-            )
-        if rollback_perm.get("pages") == "write":
-            errors.append(f"{file_path.name} (job 'rollback'): pages: write is forbidden under freeze G3")
-        if rollback_perm.get("id-token") == "write":
-            errors.append(f"{file_path.name} (job 'rollback'): id-token: write is forbidden under freeze G3")
-    elif rollback_perm is None:
-        errors.append(f"{file_path.name} (job 'rollback'): must declare explicit per-job read-only permissions")
+    expected = {"actions": "read", "contents": "read", "pages": "write", "id-token": "write"}
+    if rollback_perm != expected:
+        errors.append(
+            f"{file_path.name} (job 'rollback'): must declare exactly {expected}; "
+            "rollback may restore only an attested artifact and may not gain unbounded write."
+        )
     return errors
 
 

--- a/scripts/publication/reconciliation.py
+++ b/scripts/publication/reconciliation.py
@@ -37,9 +37,12 @@ Exit codes:
 from __future__ import annotations
 
 import argparse
+import base64
 import hashlib
 import json
+import subprocess
 import sys
+import tempfile
 import time
 import urllib.error
 import urllib.parse
@@ -68,6 +71,11 @@ DEFAULT_PROBE_PATHS = (
 ASSEMBLY_RECEIPT_NAME = "assembly-receipt.json"
 DEPLOYMENT_RECEIPT_NAME = "deployment-receipt.json"
 LIVE_RECEIPT_NAME = "live-receipt.json"
+
+# This is a public verification key. The corresponding private key is held
+# only by the GitHub Actions secret documented in the operations contract.
+DEFAULT_ATTESTOR_PUBLIC_KEY = REPO_ROOT / "docs/operations/publication-attestor-public-key.pem"
+ATTESTOR_SIGNATURE_ALGORITHM = "ed25519"
 
 # Fields the contract (independent-publication-contract.md, "Required live
 # receipt fields") mandates on an attested live-observation receipt.
@@ -196,6 +204,68 @@ def _first_present(data: dict[str, Any], keys: tuple[str, ...]) -> Any:
         if key in data and data[key] not in (None, "", [], {}):
             return data[key]
     return None
+
+
+def canonical_live_receipt_payload(receipt: dict[str, Any]) -> bytes:
+    """Return the deterministic byte payload an attestor signs for a receipt.
+
+    Signatures never sign themselves. Both accepted signature field spellings
+    are excluded so aliases cannot change the verified payload.
+    """
+    payload = dict(receipt)
+    payload.pop("signature", None)
+    payload.pop("attestor_signature", None)
+    return json.dumps(payload, sort_keys=True, separators=(",", ":"), ensure_ascii=True).encode("utf-8")
+
+
+def verify_live_receipt_signature(receipt: dict[str, Any], public_key_path: Path | None = None) -> tuple[bool, str]:
+    """Verify an Ed25519 receipt signature with the repository public key.
+
+    ``openssl pkeyutl`` is available on GitHub-hosted runners and avoids adding
+    a cryptography dependency solely for this verification boundary.
+    """
+    public_key_path = public_key_path or DEFAULT_ATTESTOR_PUBLIC_KEY
+    signature = _first_present(receipt, ("signature", "attestor_signature"))
+    if not isinstance(signature, str) or not signature.strip():
+        return False, "receipt signature is missing or empty"
+    if receipt.get("signature_algorithm") != ATTESTOR_SIGNATURE_ALGORITHM:
+        return False, f"receipt signature algorithm must be {ATTESTOR_SIGNATURE_ALGORITHM!r}"
+    if not public_key_path.is_file():
+        return False, f"attestor public key is unavailable: {public_key_path}"
+    try:
+        signature_bytes = base64.b64decode(signature, validate=True)
+    except (ValueError, TypeError) as exc:
+        return False, f"receipt signature is not valid base64: {exc}"
+    if not signature_bytes:
+        return False, "receipt signature is empty"
+
+    with tempfile.TemporaryDirectory(prefix="benchbox-receipt-") as temp_dir:
+        temp = Path(temp_dir)
+        payload_path = temp / "receipt-payload.json"
+        signature_path = temp / "receipt.sig"
+        payload_path.write_bytes(canonical_live_receipt_payload(receipt))
+        signature_path.write_bytes(signature_bytes)
+        completed = subprocess.run(
+            [
+                "openssl",
+                "pkeyutl",
+                "-verify",
+                "-pubin",
+                "-inkey",
+                str(public_key_path),
+                "-rawin",
+                "-in",
+                str(payload_path),
+                "-sigfile",
+                str(signature_path),
+            ],
+            capture_output=True,
+            check=False,
+            text=True,
+        )
+    if completed.returncode != 0:
+        return False, "receipt signature does not verify against the configured attestor public key"
+    return True, ""
 
 
 def probe_live_endpoint(
@@ -576,16 +646,14 @@ def _check_receipt_contract_fields(observed: dict[str, Any] | None) -> list[Drif
                 )
                 break
 
-    # Signature verification against a key is out of scope here; the contract
-    # gap is that we can only require presence and non-emptiness of the field.
-    sig = _first_present(observed, ("signature", "attestor_signature"))
-    if sig is not None and not str(sig).strip():
+    signature_valid, signature_error = verify_live_receipt_signature(observed)
+    if not signature_valid:
         drifts.append(
             DriftFinding(
-                drift_type="RECEIPT_INCOMPLETE",
-                description="Live receipt attestor signature field is present but empty",
-                expected="non-empty signature",
-                actual="empty string",
+                drift_type="RECEIPT_SIGNATURE_INVALID",
+                description=f"Live receipt attestor signature verification failed: {signature_error}",
+                expected="valid Ed25519 signature from the configured attestor key",
+                actual="missing, malformed, or unverifiable signature",
             )
         )
     return drifts

--- a/scripts/publication/reconciliation.py
+++ b/scripts/publication/reconciliation.py
@@ -91,6 +91,7 @@ REQUIRED_RECEIPT_FIELDS: tuple[tuple[str, tuple[str, ...]], ...] = (
     ("published-results SHA", ("published_results_sha", "published_results_commit")),
     ("artifact identity", ("artifacts", "artifact")),
     ("required route set", ("routes", "probes")),
+    ("observation origin", ("observation_origin",)),
     ("nonce", ("nonce",)),
     ("freshness window", ("freshness_window", "freshness_window_hours", "max_age_hours")),
     ("attestor identity", ("attestor", "attestor_identity", "attested_by")),
@@ -683,6 +684,21 @@ def _check_receipt_contract_fields(observed: dict[str, Any] | None) -> list[Drif
                     actual="absent or empty",
                 )
             )
+
+    observation_origin = observed.get("observation_origin")
+    if observation_origin is not None and not (
+        isinstance(observation_origin, str)
+        and observation_origin.startswith("github-actions:")
+        and len(observation_origin) > len("github-actions:")
+    ):
+        drifts.append(
+            DriftFinding(
+                drift_type="RECEIPT_INCOMPLETE",
+                description="Live receipt observation origin is not an approved external observer",
+                expected="github-actions:<workflow-observer>",
+                actual=str(observation_origin),
+            )
+        )
 
     # Route-set completeness with per-route status.
     routes = observed.get("routes") or observed.get("probes")

--- a/scripts/publication/reconciliation.py
+++ b/scripts/publication/reconciliation.py
@@ -183,7 +183,7 @@ def parse_iso_timestamp(ts_str: str) -> datetime | None:
         return None
 
 
-def _normalize_generation(value: Any) -> int | None:
+def _normalize_generation(value: Any) -> int | str | None:
     """Coerce a generation value to int, tolerating string encodings."""
     if value is None:
         return None
@@ -195,7 +195,10 @@ def _normalize_generation(value: Any) -> int | None:
         try:
             return int(value.strip())
         except ValueError:
-            return None
+            # Workflow receipts deliberately use an opaque, validated label
+            # (for example publication-123-1).  Treat it as a real value, not
+            # as an absent generation that can silently evade comparison.
+            return value.strip()
     return None
 
 
@@ -245,24 +248,27 @@ def verify_live_receipt_signature(receipt: dict[str, Any], public_key_path: Path
         signature_path = temp / "receipt.sig"
         payload_path.write_bytes(canonical_live_receipt_payload(receipt))
         signature_path.write_bytes(signature_bytes)
-        completed = subprocess.run(
-            [
-                "openssl",
-                "pkeyutl",
-                "-verify",
-                "-pubin",
-                "-inkey",
-                str(public_key_path),
-                "-rawin",
-                "-in",
-                str(payload_path),
-                "-sigfile",
-                str(signature_path),
-            ],
-            capture_output=True,
-            check=False,
-            text=True,
-        )
+        try:
+            completed = subprocess.run(
+                [
+                    "openssl",
+                    "pkeyutl",
+                    "-verify",
+                    "-pubin",
+                    "-inkey",
+                    str(public_key_path),
+                    "-rawin",
+                    "-in",
+                    str(payload_path),
+                    "-sigfile",
+                    str(signature_path),
+                ],
+                capture_output=True,
+                check=False,
+                text=True,
+            )
+        except (FileNotFoundError, PermissionError, OSError) as exc:
+            return False, f"openssl binary execution failed: {exc}"
     if completed.returncode != 0:
         return False, "receipt signature does not verify against the configured attestor public key"
     return True, ""
@@ -386,6 +392,51 @@ def _check_manifest_drift(
 ) -> list[DriftFinding]:
     """Detect commit or build closure drift across desired, built, and deployed."""
     drifts: list[DriftFinding] = []
+    binding_fields = (
+        ("target", ("target",)),
+        ("develop SHA", ("develop_sha", "source_commit", "develop_commit")),
+        ("published-results SHA", ("published_results_sha", "published_results_commit")),
+        ("manifest digest", ("manifest_digest", "manifest_sha256")),
+    )
+    states = (("desired", desired), ("built", built), ("deployed", deployed))
+    for label, keys in binding_fields:
+        values = [(name, _first_present(state, keys)) for name, state in states]
+        present = [(name, value) for name, value in values if value is not None]
+        if len(present) >= 2:
+            first_name, first_value = present[0]
+            for name, value in present[1:]:
+                if value != first_value:
+                    drifts.append(
+                        DriftFinding(
+                            drift_type="MANIFEST_DRIFT",
+                            description=f"{label} mismatch between {first_name} and {name}",
+                            expected=first_value,
+                            actual=value,
+                        )
+                    )
+
+    # Artifact identity is part of the binding, not merely descriptive
+    # assembly metadata.  Compare the complete identity wherever a state
+    # supplies it so crossed receipts cannot reconcile successfully.
+    identity_fields = (
+        ("artifact_name", "artifact identity name"),
+        ("artifact_run_id", "artifact workflow run"),
+    )
+    for key, label in identity_fields:
+        values = [(name, state.get(key)) for name, state in states if state.get(key) not in (None, "")]
+        if len(values) >= 2:
+            first_name, first_value = values[0]
+            for name, value in values[1:]:
+                if value != first_value:
+                    drifts.append(
+                        DriftFinding(
+                            drift_type="ARTIFACT_DRIFT",
+                            description=f"{label} mismatch between {first_name} and {name}",
+                            expected=first_value,
+                            actual=value,
+                        )
+                    )
+
     des_commit = _first_present(desired, ("develop_sha", "source_commit", "develop_commit"))
     dep_commit = _first_present(deployed, ("develop_sha", "source_commit", "commit_sha"))
 

--- a/scripts/publication/reconciliation.py
+++ b/scripts/publication/reconciliation.py
@@ -324,7 +324,7 @@ def probe_live_endpoint(
 
 
 def extract_artifact_digests(manifest_or_receipt: dict[str, Any]) -> dict[str, str]:
-    """Extract path -> sha256 mapping from various manifest/receipt schemas."""
+    """Extract identity-scoped artifact and endpoint digest mappings."""
     digests: dict[str, str] = {}
 
     artifacts = manifest_or_receipt.get("artifacts")
@@ -332,24 +332,25 @@ def extract_artifact_digests(manifest_or_receipt: dict[str, Any]) -> dict[str, s
         for name, entry in artifacts.items():
             if isinstance(entry, dict) and "digest" in entry:
                 p = entry.get("path", name)
-                digests[p] = str(entry["digest"]).lower().removeprefix("sha256:")
+                digests[f"artifact:{name}:{p}"] = str(entry["digest"]).lower().removeprefix("sha256:")
     elif isinstance(artifacts, list):
         for item in artifacts:
             if isinstance(item, dict) and "sha256" in item:
                 p = item.get("path", "")
-                digests[p] = str(item["sha256"]).lower().removeprefix("sha256:")
+                name = item.get("name") or item.get("artifact_name") or p
+                digests[f"artifact:{name}:{p}"] = str(item["sha256"]).lower().removeprefix("sha256:")
 
     checksums = manifest_or_receipt.get("checksums")
     if isinstance(checksums, dict):
         for p, h in checksums.items():
-            digests[p] = str(h).lower().removeprefix("sha256:")
+            digests[f"endpoint:{p}"] = str(h).lower().removeprefix("sha256:")
 
     live_db = manifest_or_receipt.get("live_database")
     if isinstance(live_db, dict) and "sha256" in live_db:
-        digests["/results/data/results.duckdb"] = str(live_db["sha256"]).lower().removeprefix("sha256:")
+        digests["endpoint:/results/data/results.duckdb"] = str(live_db["sha256"]).lower().removeprefix("sha256:")
 
     if "database_sha256" in manifest_or_receipt:
-        digests["/results/data/results.duckdb"] = (
+        digests["endpoint:/results/data/results.duckdb"] = (
             str(manifest_or_receipt["database_sha256"]).lower().removeprefix("sha256:")
         )
 
@@ -525,7 +526,8 @@ def _run_live_probes(
                 )
             )
         elif probe.sha256:
-            expected_sha = desired_digests.get(p) or built_digests.get(p)
+            endpoint_key = f"endpoint:{p}"
+            expected_sha = desired_digests.get(endpoint_key) or built_digests.get(endpoint_key)
             if expected_sha and probe.sha256.lower() != expected_sha.lower():
                 drifts.append(
                     DriftFinding(

--- a/scripts/publication/reconciliation.py
+++ b/scripts/publication/reconciliation.py
@@ -472,6 +472,48 @@ def _check_manifest_drift(
     return drifts
 
 
+def _check_state_binding_completeness(
+    desired: dict[str, Any],
+    built: dict[str, Any],
+    deployed: dict[str, Any],
+    observed: dict[str, Any],
+) -> list[DriftFinding]:
+    """Require every publication state to identify the manifest and artifact it represents."""
+    shared = (
+        ("target", ("target",), "MANIFEST_DRIFT"),
+        ("manifest digest", ("manifest_digest", "manifest_sha256"), "MANIFEST_DRIFT"),
+        ("develop SHA", ("develop_sha", "source_commit", "develop_commit"), "MANIFEST_DRIFT"),
+        (
+            "published-results SHA",
+            ("published_results_sha", "published_results_commit"),
+            "MANIFEST_DRIFT",
+        ),
+        ("artifact digest set", ("artifacts", "artifact"), "ARTIFACT_DRIFT"),
+    )
+    artifact_identity = (
+        ("artifact identity name", ("artifact_name",), "ARTIFACT_DRIFT"),
+        ("artifact workflow run", ("artifact_run_id",), "ARTIFACT_DRIFT"),
+    )
+    drifts: list[DriftFinding] = []
+    for state_name, state, requirements in (
+        ("desired", desired, shared),
+        ("built", built, shared + artifact_identity),
+        ("deployed", deployed, shared + artifact_identity),
+        ("observed", observed, shared + artifact_identity),
+    ):
+        for label, keys, drift_type in requirements:
+            if _first_present(state, keys) is None:
+                drifts.append(
+                    DriftFinding(
+                        drift_type=drift_type,
+                        description=f"{state_name.capitalize()} state is missing required {label}",
+                        expected=f"one of {keys}",
+                        actual="absent or empty",
+                    )
+                )
+    return drifts
+
+
 def _check_built_vs_desired(desired_digests: dict[str, str], built_digests: dict[str, str]) -> list[DriftFinding]:
     """Full set comparison of manifest vs build artifact digests (not the intersection)."""
     if not desired_digests:
@@ -874,6 +916,7 @@ def reconcile_states(
         )
 
     drifts.extend(_check_generation_drift(des_gen, dep_gen, obs_gen))
+    drifts.extend(_check_state_binding_completeness(desired, built or {}, deployed or {}, observed or {}))
     drifts.extend(_check_manifest_drift(desired, built or {}, deployed or {}, observed or {}))
 
     desired_digests = extract_artifact_digests(desired)

--- a/scripts/publication/reconciliation.py
+++ b/scripts/publication/reconciliation.py
@@ -389,8 +389,9 @@ def _check_manifest_drift(
     desired: dict[str, Any],
     built: dict[str, Any],
     deployed: dict[str, Any],
+    observed: dict[str, Any],
 ) -> list[DriftFinding]:
-    """Detect commit or build closure drift across desired, built, and deployed."""
+    """Detect commit or build closure drift across all publication states."""
     drifts: list[DriftFinding] = []
     binding_fields = (
         ("target", ("target",)),
@@ -398,7 +399,7 @@ def _check_manifest_drift(
         ("published-results SHA", ("published_results_sha", "published_results_commit")),
         ("manifest digest", ("manifest_digest", "manifest_sha256")),
     )
-    states = (("desired", desired), ("built", built), ("deployed", deployed))
+    states = (("desired", desired), ("built", built), ("deployed", deployed), ("observed", observed))
     for label, keys in binding_fields:
         values = [(name, _first_present(state, keys)) for name, state in states]
         present = [(name, value) for name, value in values if value is not None]
@@ -854,7 +855,7 @@ def reconcile_states(
         )
 
     drifts.extend(_check_generation_drift(des_gen, dep_gen, obs_gen))
-    drifts.extend(_check_manifest_drift(desired, built or {}, deployed or {}))
+    drifts.extend(_check_manifest_drift(desired, built or {}, deployed or {}, observed or {}))
 
     desired_digests = extract_artifact_digests(desired)
     built_digests = extract_artifact_digests(built or {})

--- a/scripts/publication/reconciliation.py
+++ b/scripts/publication/reconciliation.py
@@ -62,6 +62,7 @@ FUTURE_SKEW_SECONDS = 300.0
 
 DEFAULT_PROBE_PATHS = (
     "/",
+    "/docs/",
     "/results/",
     "/results/data/results.duckdb",
 )

--- a/scripts/publication/reconciliation.py
+++ b/scripts/publication/reconciliation.py
@@ -514,37 +514,39 @@ def _check_state_binding_completeness(
     return drifts
 
 
-def _check_built_vs_desired(desired_digests: dict[str, str], built_digests: dict[str, str]) -> list[DriftFinding]:
-    """Full set comparison of manifest vs build artifact digests (not the intersection)."""
+def _check_state_vs_desired(
+    desired_digests: dict[str, str], state_digests: dict[str, str], state_name: str
+) -> list[DriftFinding]:
+    """Full set comparison of manifest vs one publication state's digests."""
     if not desired_digests:
         return []
     drifts: list[DriftFinding] = []
-    for path in sorted(set(desired_digests) - set(built_digests)):
+    for path in sorted(set(desired_digests) - set(state_digests)):
         drifts.append(
             DriftFinding(
                 drift_type="ARTIFACT_DRIFT",
-                description=f"Manifest-required artifact '{path}' is absent from the build",
+                description=f"Manifest-required artifact '{path}' is absent from the {state_name} state",
                 expected=desired_digests[path],
                 actual=None,
             )
         )
-    for path in sorted(set(built_digests) - set(desired_digests)):
+    for path in sorted(set(state_digests) - set(desired_digests)):
         drifts.append(
             DriftFinding(
                 drift_type="ARTIFACT_DRIFT",
-                description=f"Built artifact '{path}' is not present in the desired manifest",
+                description=f"{state_name.capitalize()} artifact '{path}' is not present in the desired manifest",
                 expected=None,
-                actual=built_digests[path],
+                actual=state_digests[path],
             )
         )
-    for path in sorted(set(desired_digests) & set(built_digests)):
-        if desired_digests[path] != built_digests[path]:
+    for path in sorted(set(desired_digests) & set(state_digests)):
+        if desired_digests[path] != state_digests[path]:
             drifts.append(
                 DriftFinding(
                     drift_type="ARTIFACT_DRIFT",
-                    description=f"Built artifact digest for '{path}' differs from desired manifest",
+                    description=f"{state_name.capitalize()} artifact digest for '{path}' differs from desired manifest",
                     expected=desired_digests[path],
-                    actual=built_digests[path],
+                    actual=state_digests[path],
                 )
             )
     return drifts
@@ -674,13 +676,17 @@ def _check_observed_probes(
 def _check_artifact_drift(
     desired_digests: dict[str, str],
     built_digests: dict[str, str],
+    deployed_digests: dict[str, str],
     observed_digests: dict[str, str],
     base_url: str,
     live: bool,
     observed: dict[str, Any] | None,
 ) -> tuple[list[DriftFinding], list[EndpointObservation]]:
     """Detect checksum and endpoint response drift across built and observed targets."""
-    drifts = _check_built_vs_desired(desired_digests, built_digests)
+    drifts = _check_state_vs_desired(desired_digests, built_digests, "built")
+    drifts.extend(_check_state_vs_desired(desired_digests, deployed_digests, "deployed"))
+    if observed is not None:
+        drifts.extend(_check_state_vs_desired(desired_digests, observed_digests, "observed"))
 
     if live:
         live_drifts, probes = _run_live_probes(base_url, desired_digests, built_digests)
@@ -688,18 +694,6 @@ def _check_artifact_drift(
 
     obs_drifts, probes = _check_observed_probes(observed)
     drifts.extend(obs_drifts)
-
-    for path, obs_hash in observed_digests.items():
-        exp_hash = desired_digests.get(path) or built_digests.get(path)
-        if exp_hash and obs_hash.lower() != exp_hash.lower():
-            drifts.append(
-                DriftFinding(
-                    drift_type="ARTIFACT_DRIFT",
-                    description=f"Observed receipt digest for '{path}' differs from desired state",
-                    expected=exp_hash,
-                    actual=obs_hash,
-                )
-            )
 
     return drifts, probes
 
@@ -921,9 +915,10 @@ def reconcile_states(
 
     desired_digests = extract_artifact_digests(desired)
     built_digests = extract_artifact_digests(built or {})
+    deployed_digests = extract_artifact_digests(deployed or {})
     observed_digests = extract_artifact_digests(observed or {})
     art_drifts, probes = _check_artifact_drift(
-        desired_digests, built_digests, observed_digests, base_url, live, observed
+        desired_digests, built_digests, deployed_digests, observed_digests, base_url, live, observed
     )
     drifts.extend(art_drifts)
 

--- a/scripts/publication/verify_independence_matrix.py
+++ b/scripts/publication/verify_independence_matrix.py
@@ -26,6 +26,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import re
 import sys
 from collections.abc import Sequence
 from dataclasses import asdict, dataclass, field
@@ -38,10 +39,32 @@ LANES = ("package", "site", "explorer", "corpus")
 
 MATRIX_FILE_NAME = "independence-matrix.json"
 LANE_TRANSITIONS_FILE_NAME = "lane-transitions.json"
+HEX_64_RE = re.compile(r"^(sha256:)?[0-9a-f]{64}$", re.IGNORECASE)
 
 
 class MatrixInputError(ValueError):
     """Raised when no real transition record is available."""
+
+
+def _validate_artifact_evidence(evidence: Any) -> list[str]:
+    """Validate immutable workflow-artifact provenance carried by a transition."""
+    if not isinstance(evidence, dict):
+        return ["evidence must be an object"]
+    errors: list[str] = []
+    run_id = evidence.get("workflow_run_id")
+    valid_run_id = (isinstance(run_id, int) and not isinstance(run_id, bool) and run_id > 0) or (
+        isinstance(run_id, str) and run_id.isdecimal() and int(run_id) > 0
+    )
+    if not valid_run_id:
+        errors.append("workflow_run_id must be a positive integer")
+    for key in ("event_id", "artifact_name"):
+        value = evidence.get(key)
+        if not isinstance(value, str) or not value.strip():
+            errors.append(f"{key} must be a non-empty string")
+    digest = evidence.get("artifact_digest")
+    if not isinstance(digest, str) or HEX_64_RE.fullmatch(digest.strip()) is None:
+        errors.append("artifact_digest must be a SHA-256 digest")
+    return errors
 
 
 @dataclass
@@ -135,11 +158,12 @@ def _parse_transition_records(raw_transitions: Any) -> list[LaneTransition]:
     for r in raw_transitions:
         if not isinstance(r, dict):
             raise MatrixInputError(f"transition entry is not an object: {type(r).__name__}")
-        evidence = r.get("evidence")
-        if not isinstance(evidence, dict) or any(
-            not evidence.get(key) for key in ("workflow_run_id", "event_id", "artifact_name", "artifact_digest")
-        ):
-            raise MatrixInputError("transition entry lacks provenance bound to a workflow event and immutable artifact")
+        evidence_errors = _validate_artifact_evidence(r.get("evidence"))
+        if evidence_errors:
+            raise MatrixInputError(
+                "transition entry lacks valid provenance bound to a workflow event and immutable artifact: "
+                + "; ".join(evidence_errors)
+            )
         parsed.append(
             verify_transition_independence(
                 transition_id=str(r.get("transition_id", "unknown")),

--- a/scripts/publication/verify_independence_matrix.py
+++ b/scripts/publication/verify_independence_matrix.py
@@ -135,6 +135,11 @@ def _parse_transition_records(raw_transitions: Any) -> list[LaneTransition]:
     for r in raw_transitions:
         if not isinstance(r, dict):
             raise MatrixInputError(f"transition entry is not an object: {type(r).__name__}")
+        evidence = r.get("evidence")
+        if not isinstance(evidence, dict) or any(
+            not evidence.get(key) for key in ("workflow_run_id", "event_id", "artifact_name", "artifact_digest")
+        ):
+            raise MatrixInputError("transition entry lacks provenance bound to a workflow event and immutable artifact")
         parsed.append(
             verify_transition_independence(
                 transition_id=str(r.get("transition_id", "unknown")),

--- a/scripts/publication/verify_lane_isolation.py
+++ b/scripts/publication/verify_lane_isolation.py
@@ -106,6 +106,7 @@ LANE_PREFIXES: dict[str, tuple[str, ...]] = {
     ),
     "explorer": (
         "results-explorer/",
+        "scripts/publication/check_explorer_compat.py",
         "_project/scripts/explorer_pipeline/",
         "_project/scripts/explorer_publish.py",
         "_project/scripts/results_explorer_snapshot_invariants.py",

--- a/scripts/publication/verify_lane_isolation.py
+++ b/scripts/publication/verify_lane_isolation.py
@@ -116,6 +116,8 @@ LANE_PREFIXES: dict[str, tuple[str, ...]] = {
     "corpus": (
         "results-data/",
         "scripts/validate_submission.py",
+        "scripts/publication/create_ledger_seed.py",
+        "scripts/publication/assembler.py",
         "scripts/publication/validator_parity.py",
         ".github/workflows/validate-submission.yml",
         ".github/workflows/sync-results-data-to-published.yml",

--- a/scripts/publication/verify_lane_isolation.py
+++ b/scripts/publication/verify_lane_isolation.py
@@ -67,6 +67,10 @@ SHARED_BUILD_INPUTS: tuple[str, ...] = (
 NON_LANE_INPUTS: tuple[str, ...] = (
     # Test suites: exercised by code CI, never read by lane builds.
     "tests/",
+    # Publication control-plane checks and receipt tooling do not contribute
+    # bytes to any lane artifact. Lane-owned scripts below this prefix are
+    # still classified first by ``verify_lane_isolation``.
+    "scripts/publication/",
     # Agent skill mirrors: consumed by coding agents, not lane builds.
     ".claude/skills/",
     # CI definitions and repo orchestration.

--- a/scripts/publication/verify_live.py
+++ b/scripts/publication/verify_live.py
@@ -145,12 +145,18 @@ def compare_candidate_against_baseline(
     mismatched: dict[str, dict[str, str]] = {}
     errors: list[str] = []
 
-    for path, cand_sha in candidate_checksums.items():
+    # A frozen baseline defines the scope of a no-op assertion. Newer
+    # manifests may carry additional endpoint checksums; compare every path
+    # the baseline attests without treating those stronger claims as drift.
+    comparison_paths = baseline_checksums if expect_noop else candidate_checksums
+    for path in comparison_paths:
+        cand_sha = candidate_checksums.get(path)
         base_sha = baseline_checksums.get(path)
+        if cand_sha is None:
+            mismatched[path] = {"expected": str(base_sha), "actual": "(missing)"}
+            errors.append(f"Pre-deploy no-op check cannot verify baseline path '{path}': candidate checksum is missing")
+            continue
         if base_sha is None:
-            if expect_noop:
-                errors.append(f"Pre-deploy no-op violation: candidate contains unexpected new path '{path}'")
-                mismatched[path] = {"expected": "(none)", "actual": cand_sha}
             continue
 
         if cand_sha.lower() == base_sha.lower():

--- a/scripts/publication/verify_live.py
+++ b/scripts/publication/verify_live.py
@@ -114,6 +114,17 @@ def extract_expected_checksums(manifest_data: dict[str, Any]) -> dict[str, str]:
                 norm_p = p if p.startswith("/") else f"/{p}"
                 expected[norm_p] = str(artifact["sha256"]).strip()
 
+    # Publication receipts use the canonical manifest's mapping form.  Keep
+    # route checks and byte checks separate: only entries with an explicit
+    # checksum are byte-equivalence claims.
+    if "artifacts" in manifest_data and isinstance(manifest_data["artifacts"], dict):
+        for artifact in manifest_data["artifacts"].values():
+            if not isinstance(artifact, dict) or not artifact.get("path"):
+                continue
+            if artifact.get("endpoint_sha256"):
+                path = str(artifact["path"])
+                expected[path if path.startswith("/") else f"/{path}"] = str(artifact["endpoint_sha256"]).strip()
+
     return expected
 
 

--- a/scripts/publication/verify_live.py
+++ b/scripts/publication/verify_live.py
@@ -64,6 +64,7 @@ class EndpointProbeResult:
 @dataclass
 class VerificationReport:
     base_url: str | None = None
+    observation_origin: str | None = None
     ok: bool = True
     expect_noop: bool = False
     require_receipt: bool = False
@@ -77,6 +78,7 @@ class VerificationReport:
     def to_dict(self) -> dict[str, Any]:
         return {
             "base_url": self.base_url,
+            "observation_origin": self.observation_origin,
             "ok": self.ok,
             "expect_noop": self.expect_noop,
             "require_receipt": self.require_receipt,
@@ -365,10 +367,12 @@ def verify_live(
     endpoints: list[str] | None = None,
     skip_live_probes: bool = False,
     pre_deploy: bool = False,
+    observation_origin: str | None = None,
 ) -> VerificationReport:
     """Perform comprehensive pre-deploy candidate and/or live verification."""
     report = VerificationReport(
         base_url=base_url,
+        observation_origin=observation_origin,
         expect_noop=expect_noop,
         require_receipt=require_receipt,
     )
@@ -408,6 +412,11 @@ def build_parser() -> argparse.ArgumentParser:
         "--base-url",
         default=DEFAULT_BASE_URL,
         help=f"Base URL of publication target (default: {DEFAULT_BASE_URL})",
+    )
+    parser.add_argument(
+        "--observation-origin",
+        default=None,
+        help="External origin that performed live observations",
     )
     parser.add_argument(
         "--manifest",
@@ -491,6 +500,7 @@ def main(argv: list[str] | None = None) -> int:
         endpoints=args.endpoints,
         skip_live_probes=args.pre_deploy,
         pre_deploy=args.pre_deploy,
+        observation_origin=args.observation_origin,
     )
 
     if args.json:

--- a/scripts/publication/verify_live.py
+++ b/scripts/publication/verify_live.py
@@ -40,6 +40,7 @@ DEFAULT_BASE_URL = "https://benchbox.dev"
 DEFAULT_TIMEOUT = 30.0
 DEFAULT_ENDPOINTS = (
     "/",
+    "/docs/",
     "/results/",
     "/results/data/results.duckdb",
 )

--- a/scripts/publication/verify_release_isolation.py
+++ b/scripts/publication/verify_release_isolation.py
@@ -222,9 +222,15 @@ def _analyze(
         except RuntimeError as exc:
             errors.append(str(exc))
             continue
-        except yaml.YAMLError:
+        except yaml.YAMLError as exc:
+            errors.append(f"workflow '{wf_name}' has malformed YAML: {exc}")
             continue
         if not isinstance(data, dict):
+            errors.append(f"workflow '{wf_name}' must have a mapping root")
+            continue
+
+        if not isinstance(data.get("jobs"), dict):
+            errors.append(f"workflow '{wf_name}' has invalid jobs mapping")
             continue
 
         scan = _scan_workflow(data)

--- a/tests/unit/scripts/publication/test_audit_mirror_prs.py
+++ b/tests/unit/scripts/publication/test_audit_mirror_prs.py
@@ -87,7 +87,24 @@ def _run_main(argv: list[str], fake: _FakeRunner) -> int:
 
 
 def _pr(number: int, title: str = "mirror") -> dict:
-    return {"number": number, "title": title, "headRefName": f"auto/results-mirror-{number:08d}"}
+    return {
+        "number": number,
+        "title": title,
+        "headRefName": f"auto/results-mirror-{number:08d}",
+        "headRepository": {"name": "BenchBox"},
+        "headRepositoryOwner": {"login": "benchbox-dev"},
+    }
+
+
+def test_fork_with_machine_named_branch_is_unrelated(capsys):
+    pr = _pr(11)
+    pr["headRepositoryOwner"] = {"login": "untrusted-contributor"}
+    fake = _FakeRunner(prs=[pr], tree=BASE_TREE)
+
+    assert _run_main(["--repo", CID, "--base", BASE, "--json"], fake) == 0
+    (result,) = json.loads(capsys.readouterr().out)["prs"]
+    assert result["verdict"] == "UNRELATED"
+    assert result["retire_able"] is False
 
 
 def test_no_open_prs(capsys):

--- a/tests/unit/scripts/publication/test_audit_mirror_prs.py
+++ b/tests/unit/scripts/publication/test_audit_mirror_prs.py
@@ -90,6 +90,7 @@ def _pr(number: int, title: str = "mirror") -> dict:
     return {
         "number": number,
         "title": title,
+        "author": {"login": "github-actions[bot]"},
         "headRefName": f"auto/results-mirror-{number:08d}",
         "headRepository": {"name": "BenchBox"},
         "headRepositoryOwner": {"login": "benchbox-dev"},
@@ -99,6 +100,17 @@ def _pr(number: int, title: str = "mirror") -> dict:
 def test_fork_with_machine_named_branch_is_unrelated(capsys):
     pr = _pr(11)
     pr["headRepositoryOwner"] = {"login": "untrusted-contributor"}
+    fake = _FakeRunner(prs=[pr], tree=BASE_TREE)
+
+    assert _run_main(["--repo", CID, "--base", BASE, "--json"], fake) == 0
+    (result,) = json.loads(capsys.readouterr().out)["prs"]
+    assert result["verdict"] == "UNRELATED"
+    assert result["retire_able"] is False
+
+
+def test_human_authored_same_repo_machine_branch_is_unrelated(capsys):
+    pr = _pr(10)
+    pr["author"] = {"login": "human-collaborator"}
     fake = _FakeRunner(prs=[pr], tree=BASE_TREE)
 
     assert _run_main(["--repo", CID, "--base", BASE, "--json"], fake) == 0

--- a/tests/unit/scripts/publication/test_check_workflow_permissions.py
+++ b/tests/unit/scripts/publication/test_check_workflow_permissions.py
@@ -82,7 +82,7 @@ def test_publication_deploy_permissions_valid_structure(tmp_path: Path) -> None:
                 "steps": [],
             },
             "deploy": {
-                "permissions": {"contents": "read", "pages": "write", "id-token": "write"},
+                "permissions": {"actions": "read", "contents": "read", "pages": "write", "id-token": "write"},
                 "runs-on": "ubuntu-latest",
                 "steps": [],
             },
@@ -148,7 +148,7 @@ def test_publication_deploy_permissions_detects_rollback_pages_write(tmp_path: P
         "name": "Forbidden Rollback Pages Write",
         "jobs": {
             "build": {"permissions": {"contents": "read"}},
-            "deploy": {"permissions": {"contents": "read", "pages": "write", "id-token": "write"}},
+            "deploy": {"permissions": {"actions": "read", "contents": "read", "pages": "write", "id-token": "write"}},
             "verify": {"permissions": {"contents": "read"}},
             "rollback": {"permissions": {"actions": "write", "pages": "write", "id-token": "write"}},
         },

--- a/tests/unit/scripts/publication/test_check_workflow_permissions.py
+++ b/tests/unit/scripts/publication/test_check_workflow_permissions.py
@@ -82,7 +82,7 @@ def test_publication_deploy_permissions_valid_structure(tmp_path: Path) -> None:
                 "steps": [],
             },
             "deploy": {
-                "permissions": {"contents": "read"},
+                "permissions": {"contents": "read", "pages": "write", "id-token": "write"},
                 "runs-on": "ubuntu-latest",
                 "steps": [],
             },
@@ -92,7 +92,7 @@ def test_publication_deploy_permissions_valid_structure(tmp_path: Path) -> None:
                 "steps": [],
             },
             "rollback": {
-                "permissions": {"contents": "read"},
+                "permissions": {"actions": "read", "contents": "read", "pages": "write", "id-token": "write"},
                 "runs-on": "ubuntu-latest",
                 "steps": [],
             },
@@ -127,20 +127,19 @@ def test_publication_deploy_permissions_detects_build_write(tmp_path: Path) -> N
     assert any("declared write permissions" in err and "build" in err for err in errors)
 
 
-def test_publication_deploy_permissions_detects_deploy_pages_write(tmp_path: Path) -> None:
+def test_publication_deploy_permissions_requires_deploy_pages_write(tmp_path: Path) -> None:
     wf = tmp_path / "publication-deploy.yml"
     data = {
-        "name": "Forbidden Pages Write",
+        "name": "Missing Pages Write",
         "jobs": {
             "build": {"permissions": {"contents": "read"}},
-            "deploy": {"permissions": {"contents": "read", "pages": "write", "id-token": "write"}},
+            "deploy": {"permissions": {"contents": "read"}},
             "verify": {"permissions": {"contents": "read"}},
             "rollback": {"permissions": {"contents": "read"}},
         },
     }
     errors = checker.check_publication_deploy_permissions(wf, data)
-    assert any("pages: write is forbidden" in err for err in errors)
-    assert any("id-token: write is forbidden" in err for err in errors)
+    assert any("only the deploy job may receive Pages write" in err for err in errors)
 
 
 def test_publication_deploy_permissions_detects_rollback_pages_write(tmp_path: Path) -> None:
@@ -149,24 +148,21 @@ def test_publication_deploy_permissions_detects_rollback_pages_write(tmp_path: P
         "name": "Forbidden Rollback Pages Write",
         "jobs": {
             "build": {"permissions": {"contents": "read"}},
-            "deploy": {"permissions": {"contents": "read"}},
+            "deploy": {"permissions": {"contents": "read", "pages": "write", "id-token": "write"}},
             "verify": {"permissions": {"contents": "read"}},
             "rollback": {"permissions": {"actions": "write", "pages": "write", "id-token": "write"}},
         },
     }
     errors = checker.check_publication_deploy_permissions(wf, data)
-    assert any("pages: write is forbidden" in err and "rollback" in err for err in errors)
-    assert any("declared write permissions" in err and "rollback" in err for err in errors)
+    assert any("rollback may restore only an attested artifact" in err for err in errors)
 
 
 def test_repo_publication_deploy_passes_audit() -> None:
     real_wf = Path(__file__).parents[4] / ".github" / "workflows" / "publication-deploy.yml"
     assert real_wf.is_file()
     text = real_wf.read_text(encoding="utf-8")
-    assert "pages: write" not in text
-    assert "id-token: write" not in text
-    assert "actions/deploy-pages" not in text
-    assert "actions/upload-pages-artifact" not in text
+    assert "actions/deploy-pages@v4" in text
+    assert "actions/upload-pages-artifact@v3" in text
     errors = checker.audit_workflow_file(real_wf, strict=True)
     assert errors == [], f"Errors found in real publication-deploy.yml: {errors}"
 

--- a/tests/unit/scripts/publication/test_check_workflow_permissions.py
+++ b/tests/unit/scripts/publication/test_check_workflow_permissions.py
@@ -161,8 +161,8 @@ def test_repo_publication_deploy_passes_audit() -> None:
     real_wf = Path(__file__).parents[4] / ".github" / "workflows" / "publication-deploy.yml"
     assert real_wf.is_file()
     text = real_wf.read_text(encoding="utf-8")
-    assert "actions/deploy-pages@v4" in text
-    assert "actions/upload-pages-artifact@v3" in text
+    assert "actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e" in text
+    assert "actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa" in text
     errors = checker.audit_workflow_file(real_wf, strict=True)
     assert errors == [], f"Errors found in real publication-deploy.yml: {errors}"
 

--- a/tests/unit/scripts/publication/test_plan_reconciliation.py
+++ b/tests/unit/scripts/publication/test_plan_reconciliation.py
@@ -69,11 +69,23 @@ REAL_DEPS = {
 }
 
 
+def _with_expected_externals(deps: dict[str, list[str]]) -> dict[str, list[str]]:
+    """Merge pinned freeze-transferred external predecessors into in-set deps."""
+    out = {item_id: list(values) for item_id, values in deps.items()}
+    for item_id, externals in reconciliation.EXPECTED_EXTERNAL_DEPS.items():
+        merged = list(out.get(item_id, []))
+        for dep in sorted(externals):
+            if dep not in merged:
+                merged.append(dep)
+        out[item_id] = merged
+    return out
+
+
 def _snapshot(states: dict[str, str] | None = None, deps: dict[str, list[str]] | None = None) -> dict:
     if states is None:
         states = dict.fromkeys(LIVE_A0_A11, "active")
     if deps is None:
-        deps = {item_id: list(REAL_DEPS.get(item_id, [])) for item_id in states}
+        deps = _with_expected_externals({item_id: list(REAL_DEPS.get(item_id, [])) for item_id in states})
     return {"states": states, "deps": deps}
 
 
@@ -322,11 +334,33 @@ def test_main_fails_when_pinned_phase_missing_from_live(monkeypatch) -> None:
 
 
 def test_dependency_violations_passes_for_real_dag() -> None:
-    assert reconciliation.dependency_violations(LIVE_A0_A11, REAL_DEPS) == []
+    assert reconciliation.dependency_violations(LIVE_A0_A11, _with_expected_externals(REAL_DEPS)) == []
+
+
+def test_dependency_violations_accepts_pinned_a10_external_predecessor() -> None:
+    deps = _with_expected_externals(REAL_DEPS)
+
+    assert (
+        "independent-production-deployer-and-retirement"
+        in deps["independent-publication-a10-release-and-mirror-retirement"]
+    )
+    assert reconciliation.dependency_violations(LIVE_A0_A11, deps) == []
+
+
+def test_dependency_violations_fails_when_pinned_a10_external_missing() -> None:
+    # In-set REAL_DEPS alone omit the freeze-transferred deployer predecessor.
+    violations = reconciliation.dependency_violations(LIVE_A0_A11, REAL_DEPS)
+
+    assert any(
+        "is missing expected external dependency" in v
+        and "independent-publication-a10-release-and-mirror-retirement" in v
+        and "independent-production-deployer-and-retirement" in v
+        for v in violations
+    )
 
 
 def test_dependency_violations_fails_on_removed_chain() -> None:
-    drifted = dict(REAL_DEPS)
+    drifted = _with_expected_externals(REAL_DEPS)
     drifted["independent-publication-a1-authority-and-threat-contract"] = []
 
     violations = reconciliation.dependency_violations(LIVE_A0_A11, drifted)
@@ -335,7 +369,7 @@ def test_dependency_violations_fails_on_removed_chain() -> None:
 
 
 def test_dependency_violations_fails_on_backward_edge() -> None:
-    drifted = dict(REAL_DEPS)
+    drifted = _with_expected_externals(REAL_DEPS)
     drifted["independent-publication-a1-authority-and-threat-contract"] = [
         "independent-publication-a2-corpus-trust-isolation"
     ]
@@ -346,7 +380,7 @@ def test_dependency_violations_fails_on_backward_edge() -> None:
 
 
 def test_dependency_violations_surfaces_cycle_as_backward_edge() -> None:
-    drifted = dict(REAL_DEPS)
+    drifted = _with_expected_externals(REAL_DEPS)
     drifted["independent-publication-a0-baseline-and-freeze"] = [
         "independent-publication-a1-authority-and-threat-contract"
     ]
@@ -357,7 +391,7 @@ def test_dependency_violations_surfaces_cycle_as_backward_edge() -> None:
 
 
 def test_dependency_violations_fails_on_partial_edge_removal() -> None:
-    drifted = dict(REAL_DEPS)
+    drifted = _with_expected_externals(REAL_DEPS)
     drifted["independent-publication-a8-published-results-gate-and-shadow-promotion"] = [
         "independent-publication-a2-corpus-trust-isolation",
         "independent-publication-a4-hermetic-build-and-shadow-assembly",
@@ -369,7 +403,7 @@ def test_dependency_violations_fails_on_partial_edge_removal() -> None:
 
 
 def test_dependency_violations_fails_on_unexpected_edge() -> None:
-    drifted = dict(REAL_DEPS)
+    drifted = _with_expected_externals(REAL_DEPS)
     drifted["independent-publication-a3-control-plane-and-artifact-contract"] = [
         "independent-publication-a1-authority-and-threat-contract",
         "independent-publication-a2-corpus-trust-isolation",
@@ -382,7 +416,7 @@ def test_dependency_violations_fails_on_unexpected_edge() -> None:
 
 
 def test_dependency_violations_fails_on_external_dependency() -> None:
-    drifted = dict(REAL_DEPS)
+    drifted = _with_expected_externals(REAL_DEPS)
     drifted["independent-publication-a3-control-plane-and-artifact-contract"] = [
         "independent-publication-a1-authority-and-threat-contract",
         "independent-publication-a2-corpus-trust-isolation",
@@ -392,11 +426,12 @@ def test_dependency_violations_fails_on_external_dependency() -> None:
     violations = reconciliation.dependency_violations(LIVE_A0_A11, drifted)
 
     assert any("has unexpected external dependency" in v and "external-tracker-item" in v for v in violations)
+    assert not any("independent-production-deployer-and-retirement" in v and "unexpected" in v for v in violations)
 
 
 def test_dependency_violations_fails_on_unpinned_phase() -> None:
     plan = LIVE_A0_A11 + ["independent-publication-a12-new-phase"]
-    drifted = dict(REAL_DEPS)
+    drifted = _with_expected_externals(REAL_DEPS)
     drifted["independent-publication-a12-new-phase"] = ["independent-publication-a11-operations-canaries-and-closeout"]
 
     violations = reconciliation.dependency_violations(plan, drifted)
@@ -406,3 +441,11 @@ def test_dependency_violations_fails_on_unpinned_phase() -> None:
 
 def test_expected_deps_matches_real_deps() -> None:
     assert reconciliation.EXPECTED_DEPS == REAL_DEPS
+
+
+def test_expected_external_deps_pins_only_a10_deployer_predecessor() -> None:
+    assert {
+        "independent-publication-a10-release-and-mirror-retirement": frozenset(
+            {"independent-production-deployer-and-retirement"}
+        ),
+    } == reconciliation.EXPECTED_EXTERNAL_DEPS

--- a/tests/unit/scripts/publication/test_reconciliation.py
+++ b/tests/unit/scripts/publication/test_reconciliation.py
@@ -59,6 +59,7 @@ def _full_live_receipt(generation: int = 5, timestamp: str | None = None) -> dic
         "signature": "BASE64SIG==",
         "routes": [
             {"path": "/", "status_code": 200, "ok": True},
+            {"path": "/docs/", "status_code": 200, "ok": True},
             {"path": "/results/", "status_code": 200, "ok": True},
             {"path": "/results/data/results.duckdb", "status_code": 200, "ok": True},
         ],
@@ -322,7 +323,12 @@ def test_reconcile_live_probe_execution(monkeypatch: pytest.MonkeyPatch) -> None
     report = recon_mod.reconcile_states(
         desired=desired, built=built, deployed=deployed, observed=None, live=True, now_dt=NOW
     )
-    assert len(report.probes) == 3
+    assert {probe.path for probe in report.probes} == {
+        "/",
+        "/docs/",
+        "/results/",
+        "/results/data/results.duckdb",
+    }
     assert all(p.ok for p in report.probes)
 
 

--- a/tests/unit/scripts/publication/test_reconciliation.py
+++ b/tests/unit/scripts/publication/test_reconciliation.py
@@ -57,6 +57,7 @@ def _full_live_receipt(generation: int = 5, timestamp: str | None = None) -> dic
         "attestor": "maintainer:joe",
         "signature_algorithm": "ed25519",
         "signature": "BASE64SIG==",
+        "observation_origin": "github-actions:publication-verify",
         "routes": [
             {"path": "/", "status_code": 200, "ok": True},
             {"path": "/docs/", "status_code": 200, "ok": True},
@@ -64,6 +65,18 @@ def _full_live_receipt(generation: int = 5, timestamp: str | None = None) -> dic
             {"path": "/results/data/results.duckdb", "status_code": 200, "ok": True},
         ],
     }
+
+
+def test_reconciliation_rejects_internal_observation_origin() -> None:
+    receipt = _full_live_receipt()
+    receipt["observation_origin"] = "internal:deployment-runner"
+
+    findings = recon_mod._check_receipt_contract_fields(receipt)
+
+    assert any(
+        finding.drift_type == "RECEIPT_INCOMPLETE" and "approved external observer" in finding.description
+        for finding in findings
+    )
 
 
 def _sign_receipt(receipt: dict, private_key: Path) -> None:

--- a/tests/unit/scripts/publication/test_reconciliation.py
+++ b/tests/unit/scripts/publication/test_reconciliation.py
@@ -481,6 +481,25 @@ def test_matrix_malformed_record_is_config_error(tmp_path: Path) -> None:
         matrix_mod.verify_independence(receipts_dir=tmp_path)
 
 
+@pytest.mark.parametrize(
+    ("key", "value"),
+    (
+        ("workflow_run_id", True),
+        ("workflow_run_id", "not-a-run"),
+        ("event_id", 123),
+        ("artifact_name", ""),
+        ("artifact_digest", "not-a-digest"),
+    ),
+)
+def test_matrix_rejects_malformed_artifact_evidence(tmp_path: Path, key: str, value: object) -> None:
+    transitions = _single_lane_transitions()
+    transitions[0]["evidence"][key] = value
+    (tmp_path / matrix_mod.MATRIX_FILE_NAME).write_text(json.dumps({"transitions": transitions}), encoding="utf-8")
+
+    with pytest.raises(matrix_mod.MatrixInputError, match="valid provenance"):
+        matrix_mod.verify_independence(receipts_dir=tmp_path)
+
+
 def test_matrix_cli(tmp_path: Path) -> None:
     with pytest.raises(SystemExit) as exc:
         matrix_mod.main(["--help"])
@@ -559,6 +578,29 @@ def test_operational_missing_drill_is_missing_violation(tmp_path: Path) -> None:
     assert report.valid is False
     assert report.drills["rollback"].status == "MISSING"
     assert report.drills["rollback"].passed is False
+
+
+@pytest.mark.parametrize(
+    ("key", "value"),
+    (
+        ("workflow_run_id", True),
+        ("workflow_run_id", "not-a-run"),
+        ("event_id", 123),
+        ("artifact_name", ""),
+        ("artifact_digest", "not-a-digest"),
+    ),
+)
+def test_operational_rejects_malformed_artifact_evidence(tmp_path: Path, key: str, value: object) -> None:
+    d = _valid_operational_dir(tmp_path)
+    receipt_path = d / receipts_mod.ROLLBACK_DRILL_FILE
+    receipt = json.loads(receipt_path.read_text(encoding="utf-8"))
+    receipt["evidence"][key] = value
+    receipt_path.write_text(json.dumps(receipt), encoding="utf-8")
+
+    report = receipts_mod.audit_operational_receipts(receipts_dir=d, now_dt=NOW)
+    assert report.valid is False
+    assert report.drills["rollback"].status == "INVALID"
+    assert "artifact evidence" in (report.drills["rollback"].error or "")
 
 
 def test_operational_missing_capacity_and_retention_fail_closed(tmp_path: Path) -> None:

--- a/tests/unit/scripts/publication/test_reconciliation.py
+++ b/tests/unit/scripts/publication/test_reconciliation.py
@@ -57,6 +57,8 @@ def _full_live_receipt(generation: int = 5, timestamp: str | None = None) -> dic
         "attestor": "maintainer:joe",
         "signature_algorithm": "ed25519",
         "signature": "BASE64SIG==",
+        "artifact_name": "publication-pages-5",
+        "artifact_run_id": "12345",
         "observation_origin": "github-actions:publication-verify",
         "routes": [
             {"path": "/", "status_code": 200, "ok": True},
@@ -112,19 +114,29 @@ def attestor_keypair(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
 
 
 def _distinct_states(generation: int = 5):
-    desired = {
+    common = {
         "generation": generation,
+        "target": "benchbox.dev",
+        "manifest_digest": "sha256:" + "a" * 64,
         "develop_sha": "1111111111111111111111111111111111111111",
+        "published_results_sha": "2222222222222222222222222222222222222222",
+        "artifacts": {"site": {"digest": "d" * 64, "path": "/"}},
+    }
+    desired = {
+        **common,
         "build_closure": {"lockfile_sha256": "lock", "workflow_sha": "wf"},
     }
     built = {
-        "generation": generation,
-        "develop_sha": "1111111111111111111111111111111111111111",
+        **common,
+        "artifact_name": "publication-pages-5",
+        "artifact_run_id": "12345",
         "build_closure": {"lockfile_sha256": "lock", "workflow_sha": "wf"},
     }
     deployed = {
-        "generation": generation,
+        **common,
         "source_commit": "1111111111111111111111111111111111111111",
+        "artifact_name": "publication-pages-5",
+        "artifact_run_id": "12345",
         "status": "DEPLOYED",
     }
     observed = _full_live_receipt(generation=generation)
@@ -221,6 +233,17 @@ def test_reconcile_missing_built_and_deployed_fails_closed() -> None:
     assert report.reconciled is False
     assert any("assembly (built) receipt" in d.description for d in report.drifts)
     assert any("deployment receipt" in d.description for d in report.drifts)
+
+
+@pytest.mark.parametrize("field", ("manifest_digest", "artifact_name", "artifact_run_id"))
+def test_reconcile_rejects_deployed_state_missing_required_binding(field: str) -> None:
+    desired, built, deployed, observed = _distinct_states()
+    del deployed[field]
+
+    report = recon_mod.reconcile_states(desired=desired, built=built, deployed=deployed, observed=observed, now_dt=NOW)
+
+    assert report.reconciled is False
+    assert any("Deployed state is missing required" in finding.description for finding in report.drifts)
 
 
 def test_reconcile_generation_drift_desired_vs_observed_when_deployed_missing() -> None:

--- a/tests/unit/scripts/publication/test_reconciliation.py
+++ b/tests/unit/scripts/publication/test_reconciliation.py
@@ -252,6 +252,24 @@ def test_reconcile_missing_required_artifact_is_drift() -> None:
     assert any(d.drift_type == "ARTIFACT_DRIFT" and "/results/" in d.description for d in report.drifts)
 
 
+def test_artifact_digests_preserve_identity_when_paths_overlap() -> None:
+    receipt = {
+        "artifacts": {
+            "prose_site": {"path": "/", "digest": "a" * 64},
+            "pages_assembly": {"path": "/", "digest": "b" * 64},
+        },
+        "checksums": {"/": "c" * 64},
+    }
+
+    digests = recon_mod.extract_artifact_digests(receipt)
+
+    assert digests == {
+        "artifact:prose_site:/": "a" * 64,
+        "artifact:pages_assembly:/": "b" * 64,
+        "endpoint:/": "c" * 64,
+    }
+
+
 def test_reconcile_incomplete_receipt_fields() -> None:
     desired, built, deployed, observed = _distinct_states()
     del observed["nonce"]

--- a/tests/unit/scripts/publication/test_reconciliation.py
+++ b/tests/unit/scripts/publication/test_reconciliation.py
@@ -7,8 +7,10 @@ that real matching evidence reconciles.
 
 from __future__ import annotations
 
+import base64
 import importlib.util
 import json
+import subprocess
 import sys
 import urllib.request
 from datetime import datetime, timedelta, timezone
@@ -53,6 +55,7 @@ def _full_live_receipt(generation: int = 5, timestamp: str | None = None) -> dic
         "nonce": "nonce-xyz",
         "freshness_window": "24h",
         "attestor": "maintainer:joe",
+        "signature_algorithm": "ed25519",
         "signature": "BASE64SIG==",
         "routes": [
             {"path": "/", "status_code": 200, "ok": True},
@@ -60,6 +63,38 @@ def _full_live_receipt(generation: int = 5, timestamp: str | None = None) -> dic
             {"path": "/results/data/results.duckdb", "status_code": 200, "ok": True},
         ],
     }
+
+
+def _sign_receipt(receipt: dict, private_key: Path) -> None:
+    payload = private_key.parent / "receipt-payload.json"
+    signature = private_key.parent / "receipt.sig"
+    payload.write_bytes(recon_mod.canonical_live_receipt_payload(receipt))
+    subprocess.run(
+        [
+            "openssl",
+            "pkeyutl",
+            "-sign",
+            "-rawin",
+            "-inkey",
+            str(private_key),
+            "-in",
+            str(payload),
+            "-out",
+            str(signature),
+        ],
+        check=True,
+    )
+    receipt["signature"] = base64.b64encode(signature.read_bytes()).decode("ascii")
+
+
+@pytest.fixture
+def attestor_keypair(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    private_key = tmp_path / "attestor-private.pem"
+    public_key = tmp_path / "attestor-public.pem"
+    subprocess.run(["openssl", "genpkey", "-algorithm", "ED25519", "-out", str(private_key)], check=True)
+    subprocess.run(["openssl", "pkey", "-in", str(private_key), "-pubout", "-out", str(public_key)], check=True)
+    monkeypatch.setattr(recon_mod, "DEFAULT_ATTESTOR_PUBLIC_KEY", public_key)
+    return private_key
 
 
 def _distinct_states(generation: int = 5):
@@ -118,8 +153,9 @@ def test_reconcile_live_incomplete_observed_receipt_fails(monkeypatch: pytest.Mo
     assert any(d.drift_type == "RECEIPT_INCOMPLETE" for d in report.drifts)
 
 
-def test_reconcile_happy_path_distinct_matching_states() -> None:
+def test_reconcile_happy_path_distinct_matching_states(attestor_keypair: Path) -> None:
     desired, built, deployed, observed = _distinct_states()
+    _sign_receipt(observed, attestor_keypair)
     report = recon_mod.reconcile_states(desired=desired, built=built, deployed=deployed, observed=observed, now_dt=NOW)
     assert report.reconciled is True, [d.description for d in report.drifts]
     assert report.drift_count == 0
@@ -278,8 +314,9 @@ def test_reconciliation_cli_requires_inputs(tmp_path: Path) -> None:
     assert recon_mod.main(["--manifest", str(manifest), "--receipts-dir", str(rdir)]) == 2
 
 
-def test_reconciliation_cli_full_evidence_reconciles(tmp_path: Path) -> None:
+def test_reconciliation_cli_full_evidence_reconciles(tmp_path: Path, attestor_keypair: Path) -> None:
     desired, built, deployed, observed = _distinct_states()
+    _sign_receipt(observed, attestor_keypair)
     manifest = tmp_path / "desired-manifest.json"
     manifest.write_text(json.dumps(desired), encoding="utf-8")
     rdir = tmp_path / "reconciliation"
@@ -289,6 +326,29 @@ def test_reconciliation_cli_full_evidence_reconciles(tmp_path: Path) -> None:
     (rdir / recon_mod.LIVE_RECEIPT_NAME).write_text(json.dumps(observed), encoding="utf-8")
 
     assert recon_mod.main(["--manifest", str(manifest), "--receipts-dir", str(rdir), "--json"]) == 0
+
+
+def test_reconcile_receipt_signature_fails_closed_for_missing_empty_or_wrong_signature(
+    attestor_keypair: Path,
+) -> None:
+    for signature in (None, "", "Zm9yZ2Vk"):
+        desired, built, deployed, observed = _distinct_states()
+        if signature is None:
+            del observed["signature"]
+        else:
+            observed["signature"] = signature
+        report = recon_mod.reconcile_states(
+            desired=desired, built=built, deployed=deployed, observed=observed, now_dt=NOW
+        )
+        assert report.reconciled is False
+        assert any(d.drift_type == "RECEIPT_SIGNATURE_INVALID" for d in report.drifts)
+
+
+def test_reconcile_receipt_signature_accepts_valid_attestor_signature(attestor_keypair: Path) -> None:
+    desired, built, deployed, observed = _distinct_states()
+    _sign_receipt(observed, attestor_keypair)
+    report = recon_mod.reconcile_states(desired=desired, built=built, deployed=deployed, observed=observed, now_dt=NOW)
+    assert report.reconciled is True, [d.description for d in report.drifts]
 
 
 # ======================================================================

--- a/tests/unit/scripts/publication/test_reconciliation.py
+++ b/tests/unit/scripts/publication/test_reconciliation.py
@@ -8,6 +8,7 @@ that real matching evidence reconciles.
 from __future__ import annotations
 
 import base64
+import copy
 import importlib.util
 import json
 import subprocess
@@ -123,17 +124,17 @@ def _distinct_states(generation: int = 5):
         "artifacts": {"site": {"digest": "d" * 64, "path": "/"}},
     }
     desired = {
-        **common,
+        **copy.deepcopy(common),
         "build_closure": {"lockfile_sha256": "lock", "workflow_sha": "wf"},
     }
     built = {
-        **common,
+        **copy.deepcopy(common),
         "artifact_name": "publication-pages-5",
         "artifact_run_id": "12345",
         "build_closure": {"lockfile_sha256": "lock", "workflow_sha": "wf"},
     }
     deployed = {
-        **common,
+        **copy.deepcopy(common),
         "source_commit": "1111111111111111111111111111111111111111",
         "artifact_name": "publication-pages-5",
         "artifact_run_id": "12345",
@@ -291,6 +292,25 @@ def test_artifact_digests_preserve_identity_when_paths_overlap() -> None:
         "artifact:pages_assembly:/": "b" * 64,
         "endpoint:/": "c" * 64,
     }
+
+
+@pytest.mark.parametrize("state_name", ("deployed", "observed"))
+def test_reconcile_requires_complete_artifact_set_in_every_state(state_name: str) -> None:
+    desired, built, deployed, observed = _distinct_states()
+    for state in (desired, built, deployed, observed):
+        state["artifacts"]["explorer"] = {"path": "/results/", "digest": "e" * 64}
+    target = deployed if state_name == "deployed" else observed
+    del target["artifacts"]["explorer"]
+
+    report = recon_mod.reconcile_states(desired=desired, built=built, deployed=deployed, observed=observed, now_dt=NOW)
+
+    assert report.reconciled is False
+    assert any(
+        finding.drift_type == "ARTIFACT_DRIFT"
+        and state_name in finding.description.lower()
+        and "artifact:explorer:/results/" in finding.description
+        for finding in report.drifts
+    )
 
 
 def test_reconcile_incomplete_receipt_fields() -> None:

--- a/tests/unit/scripts/publication/test_reconciliation.py
+++ b/tests/unit/scripts/publication/test_reconciliation.py
@@ -351,6 +351,29 @@ def test_reconcile_receipt_signature_accepts_valid_attestor_signature(attestor_k
     assert report.reconciled is True, [d.description for d in report.drifts]
 
 
+def test_verify_live_receipt_signature_handles_missing_openssl(
+    attestor_keypair: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    desired, built, deployed, observed = _distinct_states()
+    _sign_receipt(observed, attestor_keypair)
+
+    def _mock_subprocess_run(*args, **kwargs):
+        raise FileNotFoundError("No such file or directory: 'openssl'")
+
+    monkeypatch.setattr(subprocess, "run", _mock_subprocess_run)
+    valid, reason = recon_mod.verify_live_receipt_signature(observed)
+    assert valid is False
+    assert "openssl binary execution failed" in reason
+    assert "No such file or directory: 'openssl'" in reason
+
+    report = recon_mod.reconcile_states(desired=desired, built=built, deployed=deployed, observed=observed, now_dt=NOW)
+    assert report.reconciled is False
+    assert any(
+        d.drift_type == "RECEIPT_SIGNATURE_INVALID" and "openssl binary execution failed" in d.description
+        for d in report.drifts
+    )
+
+
 # ======================================================================
 # INDEPENDENCE MATRIX (w2)
 # ======================================================================
@@ -370,6 +393,12 @@ def _single_lane_transitions() -> list[dict]:
                 "target_lane": lane,
                 "before_hashes": dict(_BASE),
                 "after_hashes": after,
+                "evidence": {
+                    "workflow_run_id": "123",
+                    "event_id": f"event-{lane}",
+                    "artifact_name": f"lane-{lane}",
+                    "artifact_digest": "a" * 64,
+                },
             }
         )
     return out
@@ -446,7 +475,20 @@ def _valid_operational_dir(tmp_path: Path) -> Path:
         (receipts_mod.INCIDENT_DRILL_FILE, "i1"),
     ):
         (d / name).write_text(
-            json.dumps({"receipt_id": rid, "status": "SUCCESS", "executed_at": NOW_ISO}), encoding="utf-8"
+            json.dumps(
+                {
+                    "receipt_id": rid,
+                    "status": "SUCCESS",
+                    "executed_at": NOW_ISO,
+                    "evidence": {
+                        "workflow_run_id": "123",
+                        "event_id": rid,
+                        "artifact_name": "pages",
+                        "artifact_digest": "a" * 64,
+                    },
+                }
+            ),
+            encoding="utf-8",
         )
     (d / receipts_mod.CAPACITY_FILE).write_text(
         json.dumps({"total_size_bytes": 50_000_000, "largest_file_bytes": 10_000_000, "measured": True}),

--- a/tests/unit/scripts/publication/test_reconciliation.py
+++ b/tests/unit/scripts/publication/test_reconciliation.py
@@ -161,6 +161,39 @@ def test_reconcile_happy_path_distinct_matching_states(attestor_keypair: Path) -
     assert report.drift_count == 0
 
 
+@pytest.mark.parametrize(
+    ("field", "drift_type"),
+    (
+        ("develop_sha", "MANIFEST_DRIFT"),
+        ("manifest_digest", "MANIFEST_DRIFT"),
+        ("artifact_name", "ARTIFACT_DRIFT"),
+        ("artifact_run_id", "ARTIFACT_DRIFT"),
+    ),
+)
+def test_reconcile_rejects_crossed_observed_binding(field: str, drift_type: str) -> None:
+    desired, built, deployed, observed = _distinct_states()
+    matching_values = {
+        "develop_sha": "1111111111111111111111111111111111111111",
+        "manifest_digest": "sha256:" + "a" * 64,
+        "artifact_name": "publication-site-5",
+        "artifact_run_id": "12345",
+    }
+    for state in (desired, built, deployed):
+        state[field] = matching_values[field]
+    observed[field] = "crossed-receipt-value"
+
+    report = recon_mod.reconcile_states(
+        desired=desired,
+        built=built,
+        deployed=deployed,
+        observed=observed,
+        now_dt=NOW,
+    )
+
+    assert report.reconciled is False
+    assert any(d.drift_type == drift_type and d.actual == "crossed-receipt-value" for d in report.drifts)
+
+
 def test_reconcile_missing_observation_fails_closed() -> None:
     desired, built, deployed, _ = _distinct_states()
     report = recon_mod.reconcile_states(desired=desired, built=built, deployed=deployed, observed=None, now_dt=NOW)
@@ -546,6 +579,18 @@ def test_operational_capacity_at_limit_rejected() -> None:
     assert audit.passed is False
     audit2 = receipts_mod.audit_capacity(total_bytes=1, largest_file_bytes=receipts_mod.MAX_INDIVIDUAL_FILE_BYTES)
     assert audit2.passed is False
+
+
+@pytest.mark.parametrize("measured", ["false", "true", 0, 1, None])
+def test_operational_capacity_rejects_non_boolean_measured(tmp_path: Path, measured: object) -> None:
+    d = _valid_operational_dir(tmp_path)
+    capacity_path = d / receipts_mod.CAPACITY_FILE
+    capacity = json.loads(capacity_path.read_text(encoding="utf-8"))
+    capacity["measured"] = measured
+    capacity_path.write_text(json.dumps(capacity), encoding="utf-8")
+
+    with pytest.raises(receipts_mod.ReceiptsConfigError, match="measured must be a boolean"):
+        receipts_mod.audit_operational_receipts(receipts_dir=d, now_dt=NOW)
 
 
 def test_operational_status_missing_is_invalid() -> None:

--- a/tests/unit/scripts/publication/test_verify_lane_isolation.py
+++ b/tests/unit/scripts/publication/test_verify_lane_isolation.py
@@ -138,6 +138,8 @@ def test_non_lane_inputs_skipped_in_changed_paths() -> None:
     mixed_paths = [
         "docs/index.rst",
         "tests/unit/test_example.py",
+        "scripts/publication/reconciliation.py",
+        "scripts/publication/check_operational_receipts.py",
         ".claude/skills/todo-db/SKILL.md",
         ".github/workflows/pr.yml",
         "Makefile",
@@ -174,6 +176,14 @@ def test_lane_owned_paths_still_contaminate_despite_non_lane_allowlist() -> None
     )
     assert report.success is False
     assert any("changed paths violate lane 'site' isolation" in err for err in report.errors)
+
+    corpus_report = verify_lane_isolation(
+        "site",
+        repo_root=REPO_ROOT,
+        changed_paths=["docs/index.rst", "scripts/publication/validator_parity.py"],
+    )
+    assert corpus_report.success is False
+    assert any("changed paths violate lane 'site' isolation" in err for err in corpus_report.errors)
 
 
 def test_non_lane_inputs_excluded_from_digests() -> None:

--- a/tests/unit/scripts/publication/test_verify_lane_isolation.py
+++ b/tests/unit/scripts/publication/test_verify_lane_isolation.py
@@ -193,6 +193,18 @@ def test_lane_owned_paths_still_contaminate_despite_non_lane_allowlist() -> None
     assert explorer_report.success is False
     assert any("changed paths violate lane 'site' isolation" in err for err in explorer_report.errors)
 
+    for corpus_generator in (
+        "scripts/publication/create_ledger_seed.py",
+        "scripts/publication/assembler.py",
+    ):
+        generator_report = verify_lane_isolation(
+            "site",
+            repo_root=REPO_ROOT,
+            changed_paths=["docs/index.rst", corpus_generator],
+        )
+        assert generator_report.success is False
+        assert any("changed paths violate lane 'site' isolation" in err for err in generator_report.errors)
+
 
 def test_non_lane_inputs_excluded_from_digests() -> None:
     # Unlike shared inputs, non-lane inputs must never fold into lane

--- a/tests/unit/scripts/publication/test_verify_lane_isolation.py
+++ b/tests/unit/scripts/publication/test_verify_lane_isolation.py
@@ -185,6 +185,14 @@ def test_lane_owned_paths_still_contaminate_despite_non_lane_allowlist() -> None
     assert corpus_report.success is False
     assert any("changed paths violate lane 'site' isolation" in err for err in corpus_report.errors)
 
+    explorer_report = verify_lane_isolation(
+        "site",
+        repo_root=REPO_ROOT,
+        changed_paths=["docs/index.rst", "scripts/publication/check_explorer_compat.py"],
+    )
+    assert explorer_report.success is False
+    assert any("changed paths violate lane 'site' isolation" in err for err in explorer_report.errors)
+
 
 def test_non_lane_inputs_excluded_from_digests() -> None:
     # Unlike shared inputs, non-lane inputs must never fold into lane

--- a/tests/unit/scripts/publication/test_verify_live.py
+++ b/tests/unit/scripts/publication/test_verify_live.py
@@ -206,6 +206,23 @@ def test_verify_live_expect_noop_fails_on_mutation(tmp_path: Path, monkeypatch: 
     assert any("Unexpected mutation detected during no-op verification" in err for err in report.errors)
 
 
+def test_noop_comparison_uses_frozen_baseline_scope() -> None:
+    candidate = {
+        "/": "newly-attested-root",
+        "/results/": "newly-attested-explorer",
+        "/results/data/results.duckdb": "stable-database",
+    }
+    baseline = {"/results/data/results.duckdb": "stable-database"}
+
+    matched, mismatched, errors = verify_live_mod.compare_candidate_against_baseline(
+        candidate, baseline, expect_noop=True
+    )
+
+    assert matched == baseline
+    assert mismatched == {}
+    assert errors == []
+
+
 def test_verify_live_missing_manifest_when_required() -> None:
     report = verify_live_mod.verify_live(
         base_url="https://benchbox.dev",

--- a/tests/unit/workflows/test_publication_preview.py
+++ b/tests/unit/workflows/test_publication_preview.py
@@ -89,6 +89,7 @@ def test_deploy_requires_pinned_shas_and_approver() -> None:
     text = DEPLOY_PATH.read_text(encoding="utf-8")
     assert "40" in text and "hex" in text, "SHAs must be validated as 40-hex"
     assert "cat-file -e" in text, "pinned SHAs must be proven present"
+    assert 'if [ "$GITHUB_REF" != "refs/heads/develop" ]' in text
 
 
 def test_deploy_writes_receipts_with_both_shas() -> None:
@@ -137,6 +138,8 @@ def test_preview_deploy_stops_after_independent_publication_takes_ownership() ->
     assert 'RUN_BRANCH" != "develop"' in guard
     assert "verify_live_receipt_signature" in guard
     assert 'startswith("rollback-")' in guard
+    assert deploy["outputs"]["pages_write_outcome"] == "${{ steps.deployment.outcome }}"
+    assert _load(DEPLOY_PATH)["jobs"]["record"]["if"] == "needs.deploy.outputs.pages_write_outcome == 'success'"
 
 
 def test_soak_never_writes_pages() -> None:

--- a/tests/unit/workflows/test_publication_preview.py
+++ b/tests/unit/workflows/test_publication_preview.py
@@ -121,6 +121,24 @@ def test_deploy_serializes_dispatches() -> None:
     assert "concurrency" in data, "concurrent dispatches must serialize (Pages is last-writer-wins)"
 
 
+def test_preview_deploy_stops_after_independent_publication_takes_ownership() -> None:
+    deploy = _load(DEPLOY_PATH)["jobs"]["deploy"]
+    steps = deploy["steps"]
+    guard_index = next(
+        index for index, step in enumerate(steps) if step.get("name") == "Check for independent publication ownership"
+    )
+    deploy_index = next(index for index, step in enumerate(steps) if step.get("uses") == "actions/deploy-pages@v4")
+
+    assert deploy["permissions"]["actions"] == "read"
+    assert guard_index < deploy_index
+    assert steps[deploy_index]["if"] == "steps.independent.outputs.active != 'true'"
+    guard = steps[guard_index]["run"]
+    assert "Publication Control Plane Deployment" in guard
+    assert 'RUN_BRANCH" != "develop"' in guard
+    assert "verify_live_receipt_signature" in guard
+    assert 'startswith("rollback-")' in guard
+
+
 def test_soak_never_writes_pages() -> None:
     data = _load(SOAK_PATH)
     text = SOAK_PATH.read_text(encoding="utf-8")

--- a/tests/unit/workflows/test_publication_rollback.py
+++ b/tests/unit/workflows/test_publication_rollback.py
@@ -144,6 +144,9 @@ def test_receipts_use_measured_provenance_and_valid_json_newlines() -> None:
     assert "! -name '*.plans.json' ! -name '*.tuning.json'" in text
     assert "['summary']['total_bundles']" in text
     assert 'tree_size("site")' in text
+    assert '"digest": os.environ["PROSE_DIGEST"]' in text
+    assert 'tree_size("prose-site")' in text
+    assert 'tree_size("api-docs")' in text
     assert " + '\\\\n'" not in text
     assert '"artifact_name": os.environ["PAGES_ARTIFACT"]' in text
     assert '"rollback_artifact_name": os.environ["SITE_ARTIFACT"]' in text
@@ -187,6 +190,7 @@ def test_verify_step_invokes_verify_live_with_receipt() -> None:
     assert "--require-receipt" in run_cmd
     assert "--manifest" in run_cmd
     assert "--base-url" in run_cmd
+    assert "--observation-origin github-actions:publication-verify" in run_cmd
 
 
 def test_live_receipt_binds_html_endpoints_and_acknowledges_before_probing() -> None:
@@ -199,6 +203,8 @@ def test_live_receipt_binds_html_endpoints_and_acknowledges_before_probing() -> 
     assert '"/docs/": os.environ["DOCS_ENDPOINT_DIGEST"]' in text
     assert '"/results/": os.environ["EXPLORER_ENDPOINT_DIGEST"]' in text
     assert names.index("Upload provider deployment acknowledgement") < names.index("Probe required live routes")
+    assert "probe_report.get('observation_origin') != 'github-actions:publication-verify'" in text
+    assert "probe_report.get('observation_origin') != 'github-actions:publication-rollback-verify'" in text
 
 
 def test_rollback_restores_only_a_cryptographically_attested_artifact() -> None:

--- a/tests/unit/workflows/test_publication_rollback.py
+++ b/tests/unit/workflows/test_publication_rollback.py
@@ -157,6 +157,8 @@ def test_build_receipt_enforces_attested_cas_lineage() -> None:
     assert '"\\(.created_at) \\(.id) \\(.workflow_run.id)"' in text
     assert "Revalidate authoritative live head" in text
     assert "publication live head changed after build" in text
+    assert "current-candidate/live-receipt.json" in text
+    assert text.count("verify_live_receipt_signature") >= 3
     assert '"parent_sha": os.environ.get("PARENT_SHA") or None' in text
     assert "validate_manifest_dict(manifest)" in text
 

--- a/tests/unit/workflows/test_publication_rollback.py
+++ b/tests/unit/workflows/test_publication_rollback.py
@@ -140,6 +140,8 @@ def test_receipts_use_measured_provenance_and_valid_json_newlines() -> None:
     assert "CORPUS_DIGEST=$(sha256sum receipt-dist/corpus-file-digests.txt" in text
     assert 'tree_size("site")' in text
     assert " + '\\\\n'" not in text
+    assert '"artifact_name": os.environ["PAGES_ARTIFACT"]' in text
+    assert '"rollback_artifact_name": os.environ["SITE_ARTIFACT"]' in text
 
 
 def test_build_receipt_enforces_attested_cas_lineage() -> None:
@@ -214,8 +216,10 @@ def test_rollback_restores_only_a_cryptographically_attested_artifact() -> None:
     assert "['artifacts']['pages_assembly']['digest']" in run_bodies
     assert "'generation': int(os.environ['BUILD_GENERATION'])" in run_bodies
     assert "successor-live-receipt/live-receipt.json" in run_bodies
-    assert "'artifact_name': os.environ['SITE_ARTIFACT']" in run_bodies
+    assert "'artifact_name': os.environ['PAGES_ARTIFACT']" in run_bodies
     assert "'artifact_run_id': os.environ['GITHUB_RUN_ID']" in run_bodies
+    assert "'rollback_artifact_name': os.environ['SITE_ARTIFACT']" in run_bodies
+    assert "['rollback_artifact_name']" in run_bodies
 
     assert any(step.get("uses") == DEPLOY_PAGES_ACTION for step in steps)
     assert any(step.get("uses") == UPLOAD_PAGES_ACTION for step in steps)

--- a/tests/unit/workflows/test_publication_rollback.py
+++ b/tests/unit/workflows/test_publication_rollback.py
@@ -41,6 +41,8 @@ def test_workflow_is_dispatch_only_with_required_inputs() -> None:
     assert "rollback_target_sha" in dispatch_inputs
     assert dispatch_inputs["develop_sha"]["required"] is True
     assert dispatch_inputs["published_results_sha"]["required"] is True
+    assert dispatch_inputs["generation"]["required"] is True
+    assert "approved_manifest_digest" in dispatch_inputs
 
 
 def test_workflow_permissions_follow_least_privilege() -> None:
@@ -52,7 +54,12 @@ def test_workflow_permissions_follow_least_privilege() -> None:
 
     assert jobs["build"]["permissions"] == {"actions": "read", "contents": "read"}
     assert jobs["verify"]["permissions"] == {"contents": "read"}
-    assert jobs["deploy"]["permissions"] == {"contents": "read", "pages": "write", "id-token": "write"}
+    assert jobs["deploy"]["permissions"] == {
+        "actions": "read",
+        "contents": "read",
+        "pages": "write",
+        "id-token": "write",
+    }
     assert jobs["rollback"]["permissions"] == {
         "actions": "read",
         "contents": "read",
@@ -138,12 +145,26 @@ def test_receipts_use_measured_provenance_and_valid_json_newlines() -> None:
 def test_build_receipt_enforces_attested_cas_lineage() -> None:
     text = _workflow_text()
 
-    assert "generation 1 is genesis and cannot name a prior live receipt" in text
+    assert "generation 1 cannot replace current live receipt" in text
     assert "requires prior_live_receipt_id" in text
     assert "verify_live_receipt_signature" in text
-    assert 'receipt.get("generation") != int(os.environ["GENERATION"]) - 1' in text
+    assert "prior_live_receipt_id is stale; current live head is" in text
+    assert "Revalidate authoritative live head" in text
+    assert "publication live head changed after build" in text
     assert '"parent_sha": os.environ.get("PARENT_SHA") or None' in text
-    assert "validate_manifest_dict(receipt)" in text
+    assert "validate_manifest_dict(manifest)" in text
+
+
+def test_production_requires_an_independently_approved_manifest() -> None:
+    text = _workflow_text()
+
+    assert "production deployment requires an independently reviewed approved_manifest_digest" in text
+    assert 'approved != manifest["manifest_digest"]' in text
+    assert 'open("receipt-dist/desired-manifest.json", "w")' in text
+    assert 'open("receipt-dist/assembly-receipt.json", "w")' in text
+    assert "--baseline-manifest receipt-dist/desired-manifest.json" in text
+    assert "WORKFLOW_SHA: ${{ github.sha }}" in text
+    assert '"workflow_sha": os.environ["WORKFLOW_SHA"]' in text
 
 
 def test_verify_step_invokes_verify_live_with_receipt() -> None:
@@ -165,6 +186,7 @@ def test_rollback_restores_only_a_cryptographically_attested_artifact() -> None:
     assert "Resolve last known-good attested receipt" in step_names
     assert "Download and verify known-good site artifact" in step_names
     assert "Create and sign rollback live receipt" in step_names
+    assert "Publish rollback as the new attested live head" in step_names
     assert "Upload rollback audit receipt" in step_names
     assert "Deploy attested rollback artifact to GitHub Pages" in step_names
     assert "Upload attested rollback Pages artifact" in step_names
@@ -175,6 +197,8 @@ def test_rollback_restores_only_a_cryptographically_attested_artifact() -> None:
     assert ".workflow_run.name" not in run_bodies
     assert "actions/runs/$RUN_ID" in run_bodies
     assert "['artifacts']['pages_assembly']['digest']" in run_bodies
+    assert "'generation': int(os.environ['BUILD_GENERATION'])" in run_bodies
+    assert "successor-live-receipt/live-receipt.json" in run_bodies
 
     assert any(step.get("uses") == DEPLOY_PAGES_ACTION for step in steps)
     assert any(step.get("uses") == UPLOAD_PAGES_ACTION for step in steps)

--- a/tests/unit/workflows/test_publication_rollback.py
+++ b/tests/unit/workflows/test_publication_rollback.py
@@ -149,6 +149,8 @@ def test_build_receipt_enforces_attested_cas_lineage() -> None:
     assert "requires prior_live_receipt_id" in text
     assert "verify_live_receipt_signature" in text
     assert "prior_live_receipt_id is stale; current live head is" in text
+    assert 'gh api --paginate "repos/${{ github.repository }}/actions/artifacts?per_page=100"' in text
+    assert '"\\(.created_at) \\(.id) \\(.workflow_run.id)"' in text
     assert "Revalidate authoritative live head" in text
     assert "publication live head changed after build" in text
     assert '"parent_sha": os.environ.get("PARENT_SHA") or None' in text
@@ -187,6 +189,7 @@ def test_rollback_restores_only_a_cryptographically_attested_artifact() -> None:
     assert "Download and verify known-good site artifact" in step_names
     assert "Create and sign rollback live receipt" in step_names
     assert "Publish rollback as the new attested live head" in step_names
+    assert "Retain restored site artifact for the new rollback head" in step_names
     assert "Upload rollback audit receipt" in step_names
     assert "Deploy attested rollback artifact to GitHub Pages" in step_names
     assert "Upload attested rollback Pages artifact" in step_names
@@ -199,6 +202,8 @@ def test_rollback_restores_only_a_cryptographically_attested_artifact() -> None:
     assert "['artifacts']['pages_assembly']['digest']" in run_bodies
     assert "'generation': int(os.environ['BUILD_GENERATION'])" in run_bodies
     assert "successor-live-receipt/live-receipt.json" in run_bodies
+    assert "'artifact_name': os.environ['SITE_ARTIFACT']" in run_bodies
+    assert "'artifact_run_id': os.environ['GITHUB_RUN_ID']" in run_bodies
 
     assert any(step.get("uses") == DEPLOY_PAGES_ACTION for step in steps)
     assert any(step.get("uses") == UPLOAD_PAGES_ACTION for step in steps)

--- a/tests/unit/workflows/test_publication_rollback.py
+++ b/tests/unit/workflows/test_publication_rollback.py
@@ -43,6 +43,7 @@ def test_workflow_is_dispatch_only_with_required_inputs() -> None:
     assert dispatch_inputs["published_results_sha"]["required"] is True
     assert dispatch_inputs["generation"]["required"] is True
     assert "approved_manifest_digest" in dispatch_inputs
+    assert "approved_candidate_run_id" in dispatch_inputs
 
 
 def test_workflow_permissions_follow_least_privilege() -> None:
@@ -186,6 +187,29 @@ def test_production_requires_an_independently_approved_manifest() -> None:
     assert "--baseline-manifest receipt-dist/desired-manifest.json" in text
     assert "WORKFLOW_SHA: ${{ github.sha }}" in text
     assert '"workflow_sha": os.environ["WORKFLOW_SHA"]' in text
+
+
+def test_production_promotes_exact_approved_candidate_bytes() -> None:
+    steps = _workflow()["jobs"]["build"]["steps"]
+    restore = next(step for step in steps if step.get("name") == "Restore independently approved candidate bytes")
+    run = restore["run"]
+
+    assert restore["if"] == "inputs.approved_manifest_digest != ''"
+    assert "publication-candidate-receipts-$EXPECTED_GENERATION-$CANDIDATE_RUN_ID" in run
+    assert 'gh run download "$CANDIDATE_RUN_ID"' in run
+    assert 'assembly.get("candidate_mode") != "no-write"' in run
+    assert 'RUN_HEAD_SHA" != "$EXPECTED_WORKFLOW_SHA"' in run
+    assert '"prior_live_receipt_id": os.environ.get("EXPECTED_PRIOR_LIVE_RECEIPT_ID") or None' in run
+    assert "approved candidate site digest mismatch" in run
+    assert "digest_lines.sort()" in run
+    for name in (
+        "Materialize pinned control plane and corpus",
+        "Build Explorer corpus database",
+        "Build Explorer application",
+        "Build documentation",
+    ):
+        step = next(item for item in steps if item.get("name") == name)
+        assert step["if"] == "inputs.approved_manifest_digest == ''"
 
 
 def test_verify_step_invokes_verify_live_with_receipt() -> None:

--- a/tests/unit/workflows/test_publication_rollback.py
+++ b/tests/unit/workflows/test_publication_rollback.py
@@ -25,18 +25,11 @@ def _workflow_text() -> str:
     return WORKFLOW_PATH.read_text(encoding="utf-8")
 
 
-def test_workflow_has_required_triggers() -> None:
+def test_workflow_is_dispatch_only_with_required_inputs() -> None:
     wf = _workflow()
     triggers = wf.get("on") or wf.get(True) or {}
 
-    # push trigger on release branch
-    assert "push" in triggers
-    push = triggers["push"]
-    assert "release" in push.get("branches", [])
-    assert any("results-data/**" in p for p in push.get("paths", []))
-    assert any("scripts/publication/**" in p for p in push.get("paths", []))
-
-    # workflow_dispatch with required drill inputs
+    assert "push" not in triggers
     assert "workflow_dispatch" in triggers
     dispatch_inputs = triggers["workflow_dispatch"].get("inputs", {})
     assert "expect_noop" in dispatch_inputs
@@ -44,6 +37,8 @@ def test_workflow_has_required_triggers() -> None:
     assert "force_rollback" in dispatch_inputs
     assert dispatch_inputs["force_rollback"]["type"] == "boolean"
     assert "rollback_target_sha" in dispatch_inputs
+    assert dispatch_inputs["develop_sha"]["required"] is True
+    assert dispatch_inputs["published_results_sha"]["required"] is True
 
 
 def test_workflow_permissions_follow_least_privilege() -> None:
@@ -53,20 +48,23 @@ def test_workflow_permissions_follow_least_privilege() -> None:
     # Top-level permissions should be read-only
     assert wf.get("permissions") == {"contents": "read"}
 
-    # Freeze G3: every job is contents: read only (docs.yml is sole Pages deployer)
-    for job_name in ("build", "deploy", "verify", "rollback"):
-        assert jobs[job_name]["permissions"] == {"contents": "read"}, job_name
-        perms = jobs[job_name]["permissions"]
-        assert perms.get("pages") != "write", job_name
-        assert perms.get("id-token") != "write", job_name
+    assert jobs["build"]["permissions"] == {"contents": "read"}
+    assert jobs["verify"]["permissions"] == {"contents": "read"}
+    assert jobs["deploy"]["permissions"] == {"contents": "read", "pages": "write", "id-token": "write"}
+    assert jobs["rollback"]["permissions"] == {
+        "actions": "read",
+        "contents": "read",
+        "pages": "write",
+        "id-token": "write",
+    }
 
 
-def test_workflow_has_no_pages_deploy_actions() -> None:
+def test_workflow_uses_pages_deploy_actions_only_in_write_jobs() -> None:
     text = _workflow_text()
-    assert "actions/deploy-pages" not in text
-    assert "actions/upload-pages-artifact" not in text
-    assert "pages: write" not in text
-    assert "id-token: write" not in text
+    assert "actions/deploy-pages@v4" in text
+    assert "actions/upload-pages-artifact@v3" in text
+    assert "group: pages-deploy" in text
+    assert "cancel-in-progress: false" in text
 
 
 def test_workflow_job_dependencies_and_ordering() -> None:
@@ -94,12 +92,15 @@ def test_build_uses_correct_cli_flags() -> None:
     assert "--data-dir results-explorer/public/data" not in text
     assert "2>/dev/null || true" not in text
     assert 'if [ -f "results-explorer/public/data/results.duckdb" ]' not in text
-    assert 'if [ ! -f "results-explorer/public/data/results.duckdb" ]' in text
+    assert "test -s results-explorer/public/data/results.duckdb" in text
+    assert "test -s site/results/data/results.duckdb" in text
+    assert "scripts/assemble_public_site.py --site-dir site" in text
+    assert "sphinx-build -b html" in text
 
 
 def test_build_step_includes_pre_deploy_candidate_and_noop_check() -> None:
     steps = _workflow()["jobs"]["build"]["steps"]
-    precheck_step = next(s for s in steps if s.get("name") == "Pre-deploy candidate verification and no-op check")
+    precheck_step = next(s for s in steps if s.get("name") == "Pre-deploy candidate verification")
     run_cmd = precheck_step["run"]
 
     assert "scripts/publication/verify_live.py" in run_cmd
@@ -109,21 +110,15 @@ def test_build_step_includes_pre_deploy_candidate_and_noop_check() -> None:
     assert "--require-receipt" in run_cmd
 
 
-def test_deploy_is_rehearsal_noop() -> None:
+def test_deploy_uses_real_pages_deployment() -> None:
     steps = _workflow()["jobs"]["deploy"]["steps"]
-    assert len(steps) >= 1
-    run_bodies = "\n".join(s.get("run", "") for s in steps if isinstance(s.get("run"), str))
-    assert "docs.yml as the sole production Pages deployer" in run_bodies
-    assert "do not deploy" in run_bodies.lower()
-    for step in steps:
-        uses = step.get("uses", "")
-        assert "deploy-pages" not in uses
-        assert "upload-pages-artifact" not in uses
+    assert any(step.get("uses") == "actions/deploy-pages@v4" for step in steps)
+    assert _workflow()["jobs"]["deploy"]["environment"]["name"] == "github-pages"
 
 
 def test_verify_step_invokes_verify_live_with_receipt() -> None:
     steps = _workflow()["jobs"]["verify"]["steps"]
-    verify_step = next(s for s in steps if s.get("name") == "Run live verification probe")
+    verify_step = next(s for s in steps if s.get("name") == "Probe required live routes")
     run_cmd = verify_step["run"]
 
     assert "scripts/publication/verify_live.py" in run_cmd
@@ -132,26 +127,24 @@ def test_verify_step_invokes_verify_live_with_receipt() -> None:
     assert "--base-url" in run_cmd
 
 
-def test_rollback_writes_facts_only_receipt_without_pages_deploy() -> None:
+def test_rollback_restores_only_a_cryptographically_attested_artifact() -> None:
     steps = _workflow()["jobs"]["rollback"]["steps"]
     step_names = [s.get("name") for s in steps]
     run_bodies = "\n".join(s.get("run", "") for s in steps if isinstance(s.get("run"), str))
 
-    assert "Write facts-only rollback receipt" in step_names
+    assert "Resolve last known-good attested receipt" in step_names
+    assert "Download and verify known-good site artifact" in step_names
+    assert "Create and sign rollback live receipt" in step_names
     assert "Upload rollback audit receipt" in step_names
-    assert "Deploy attested rollback artifact to GitHub Pages" not in step_names
-    assert "Upload immutable rollback Pages artifact" not in step_names
+    assert "Deploy attested rollback artifact to GitHub Pages" in step_names
+    assert "Upload attested rollback Pages artifact" in step_names
 
-    assert "<html" not in run_bodies.lower()
-    assert "index.html" not in run_bodies
-    assert "pinned_baseline_release_sha" in run_bodies
-    assert "freeze_still_blocked" in run_bodies
-    assert "pages_deploy_attempted" in run_bodies
+    assert "verify_live_receipt_signature" in run_bodies
+    assert "known-good artifact digest mismatch" in run_bodies
+    assert "rollback_target_sha" not in run_bodies
 
-    for step in steps:
-        uses = step.get("uses", "")
-        assert "deploy-pages" not in uses
-        assert "upload-pages-artifact" not in uses
+    assert any(step.get("uses") == "actions/deploy-pages@v4" for step in steps)
+    assert any(step.get("uses") == "actions/upload-pages-artifact@v3" for step in steps)
 
 
 def test_rollback_condition_covers_all_failure_modes_and_drills() -> None:
@@ -188,11 +181,12 @@ def test_simulated_rollback_trigger_logic(
     assert should_rollback is expected_rollback
 
 
-def test_rollback_resolves_baseline_target_sha() -> None:
+def test_rollback_does_not_rebuild_from_a_baseline_branch_sha() -> None:
     assert BASELINE_PATH.is_file(), f"Baseline file missing at {BASELINE_PATH}"
     baseline_data = json.loads(BASELINE_PATH.read_text(encoding="utf-8"))
-    release_sha = baseline_data.get("branches", {}).get("release", {}).get("sha")
-
-    assert release_sha, "Baseline must contain pinned release SHA"
-    assert len(release_sha) == 40
-    assert all(c in "0123456789abcdef" for c in release_sha.lower())
+    assert baseline_data.get("branches", {}).get("release", {}).get("sha")
+    rollback_text = "\n".join(
+        step.get("run", "") for step in _workflow()["jobs"]["rollback"]["steps"] if isinstance(step.get("run"), str)
+    )
+    assert "git worktree add" not in rollback_text
+    assert "git checkout" not in rollback_text

--- a/tests/unit/workflows/test_publication_rollback.py
+++ b/tests/unit/workflows/test_publication_rollback.py
@@ -140,6 +140,9 @@ def test_receipts_use_measured_provenance_and_valid_json_newlines() -> None:
     assert '"size": 0' not in text
     assert "LOCKFILE_DIGEST=$(sha256sum uv.lock" in text
     assert "CORPUS_DIGEST=$(sha256sum receipt-dist/corpus-file-digests.txt" in text
+    assert "INVENTORY_DIGEST=$(sha256sum results-data/corpus-inventory.json" in text
+    assert '"inventory_sha256": os.environ["INVENTORY_DIGEST"]' in text
+    assert '"bundle_tree_sha256": os.environ["CORPUS_DIGEST"]' in text
     assert "! -name '*.manifest.json' ! -name '*.applied.json'" in text
     assert "! -name '*.plans.json' ! -name '*.tuning.json'" in text
     assert "['summary']['total_bundles']" in text
@@ -261,29 +264,45 @@ def test_rollback_condition_covers_all_failure_modes_and_drills() -> None:
     if_cond = rollback_job.get("if", "")
 
     assert "always()" in if_cond
-    assert "needs.deploy.result == 'failure'" in if_cond
+    assert "needs.deploy.outputs.pages_write_outcome == 'failure'" in if_cond
     assert "needs.verify.result == 'failure'" in if_cond
     assert "force_rollback == true" in if_cond
 
 
+def test_noop_and_forced_rollback_are_mutually_exclusive() -> None:
+    validation = next(
+        step for step in _workflow()["jobs"]["build"]["steps"] if step.get("name") == "Validate pinned dispatch inputs"
+    )
+
+    assert 'if [ "$EXPECT_NOOP" = "true" ] && [ "$FORCE_ROLLBACK" = "true" ]' in validation["run"]
+
+
+def test_pre_write_cas_rejection_does_not_trigger_rollback() -> None:
+    deploy = _workflow()["jobs"]["deploy"]
+
+    assert deploy["outputs"]["pages_write_outcome"] == "${{ steps.deployment.outcome }}"
+    assert "needs.deploy.result == 'failure'" not in _workflow()["jobs"]["rollback"]["if"]
+
+
 @pytest.mark.parametrize(
-    ("deploy_result", "verify_result", "force_rollback", "expected_rollback"),
+    ("pages_write_outcome", "verify_result", "force_rollback", "expected_rollback"),
     [
         ("success", "success", False, False),  # Normal successful deployment -> no rollback
-        ("failure", "skipped", False, True),  # Deploy failed -> rollback
+        ("", "skipped", False, False),  # Pre-write CAS rejection -> no rollback
+        ("failure", "skipped", False, True),  # Pages write failed -> rollback
         ("success", "failure", False, True),  # Healthcheck/checksum verification failed -> rollback
         ("success", "success", True, True),  # Forced drill -> rollback
         ("failure", "failure", True, True),  # Multiple failures + force -> rollback
     ],
 )
 def test_simulated_rollback_trigger_logic(
-    deploy_result: str,
+    pages_write_outcome: str,
     verify_result: str,
     force_rollback: bool,
     expected_rollback: bool,
 ) -> None:
     """Simulate GitHub Actions expression evaluation for the rollback conditional."""
-    deploy_failed = deploy_result == "failure"
+    deploy_failed = pages_write_outcome == "failure"
     verify_failed = verify_result == "failure"
     should_rollback = deploy_failed or verify_failed or force_rollback
 

--- a/tests/unit/workflows/test_publication_rollback.py
+++ b/tests/unit/workflows/test_publication_rollback.py
@@ -66,6 +66,8 @@ def test_workflow_permissions_follow_least_privilege() -> None:
         "pages": "write",
         "id-token": "write",
     }
+    assert jobs["verify"]["environment"] == {"name": "publication-attestation"}
+    assert jobs["rollback"]["environment"]["name"] == "github-pages"
 
 
 def test_workflow_uses_pages_deploy_actions_only_in_write_jobs() -> None:

--- a/tests/unit/workflows/test_publication_rollback.py
+++ b/tests/unit/workflows/test_publication_rollback.py
@@ -140,6 +140,9 @@ def test_receipts_use_measured_provenance_and_valid_json_newlines() -> None:
     assert '"size": 0' not in text
     assert "LOCKFILE_DIGEST=$(sha256sum uv.lock" in text
     assert "CORPUS_DIGEST=$(sha256sum receipt-dist/corpus-file-digests.txt" in text
+    assert "! -name '*.manifest.json' ! -name '*.applied.json'" in text
+    assert "! -name '*.plans.json' ! -name '*.tuning.json'" in text
+    assert "['summary']['total_bundles']" in text
     assert 'tree_size("site")' in text
     assert " + '\\\\n'" not in text
     assert '"artifact_name": os.environ["PAGES_ARTIFACT"]' in text
@@ -211,6 +214,11 @@ def test_rollback_restores_only_a_cryptographically_attested_artifact() -> None:
     assert "Upload rollback audit receipt" in step_names
     assert "Deploy attested rollback artifact to GitHub Pages" in step_names
     assert "Upload attested rollback Pages artifact" in step_names
+    assert "Record rollback provider acknowledgement" in step_names
+    assert "Upload rollback provider acknowledgement" in step_names
+    assert step_names.index("Upload rollback provider acknowledgement") < step_names.index(
+        "Probe restored required live routes"
+    )
 
     assert "verify_live_receipt_signature" in run_bodies
     assert "known-good artifact digest mismatch" in run_bodies

--- a/tests/unit/workflows/test_publication_rollback.py
+++ b/tests/unit/workflows/test_publication_rollback.py
@@ -277,6 +277,14 @@ def test_noop_and_forced_rollback_are_mutually_exclusive() -> None:
     assert 'if [ "$EXPECT_NOOP" = "true" ] && [ "$FORCE_ROLLBACK" = "true" ]' in validation["run"]
 
 
+def test_dispatch_ref_must_be_develop() -> None:
+    validation = next(
+        step for step in _workflow()["jobs"]["build"]["steps"] if step.get("name") == "Validate pinned dispatch inputs"
+    )
+
+    assert 'if [ "$GITHUB_REF" != "refs/heads/develop" ]' in validation["run"]
+
+
 def test_pre_write_cas_rejection_does_not_trigger_rollback() -> None:
     deploy = _workflow()["jobs"]["deploy"]
 

--- a/tests/unit/workflows/test_publication_rollback.py
+++ b/tests/unit/workflows/test_publication_rollback.py
@@ -180,6 +180,18 @@ def test_verify_step_invokes_verify_live_with_receipt() -> None:
     assert "--base-url" in run_cmd
 
 
+def test_live_receipt_binds_html_endpoints_and_acknowledges_before_probing() -> None:
+    workflow = _workflow()
+    text = _workflow_text()
+    steps = workflow["jobs"]["verify"]["steps"]
+    names = [step.get("name") for step in steps]
+
+    assert '"/": os.environ["ROOT_ENDPOINT_DIGEST"]' in text
+    assert '"/docs/": os.environ["DOCS_ENDPOINT_DIGEST"]' in text
+    assert '"/results/": os.environ["EXPLORER_ENDPOINT_DIGEST"]' in text
+    assert names.index("Upload provider deployment acknowledgement") < names.index("Probe required live routes")
+
+
 def test_rollback_restores_only_a_cryptographically_attested_artifact() -> None:
     steps = _workflow()["jobs"]["rollback"]["steps"]
     step_names = [s.get("name") for s in steps]

--- a/tests/unit/workflows/test_publication_rollback.py
+++ b/tests/unit/workflows/test_publication_rollback.py
@@ -147,6 +147,10 @@ def test_receipts_use_measured_provenance_and_valid_json_newlines() -> None:
     assert '"digest": os.environ["PROSE_DIGEST"]' in text
     assert 'tree_size("prose-site")' in text
     assert 'tree_size("api-docs")' in text
+    assert 'tree_size("explorer-app")' in text
+    assert "(cd explorer-app && find . -type f" in text
+    assert "docs/_build/html/_static/* api-docs/_static/" in text
+    assert "docs/_build/html/reference/python-api api-docs/reference/" in text
     assert " + '\\\\n'" not in text
     assert '"artifact_name": os.environ["PAGES_ARTIFACT"]' in text
     assert '"rollback_artifact_name": os.environ["SITE_ARTIFACT"]' in text

--- a/tests/unit/workflows/test_publication_rollback.py
+++ b/tests/unit/workflows/test_publication_rollback.py
@@ -36,6 +36,7 @@ def test_workflow_is_dispatch_only_with_required_inputs() -> None:
     dispatch_inputs = triggers["workflow_dispatch"].get("inputs", {})
     assert "expect_noop" in dispatch_inputs
     assert dispatch_inputs["expect_noop"]["type"] == "boolean"
+    assert dispatch_inputs["candidate_only"]["type"] == "boolean"
     assert "force_rollback" in dispatch_inputs
     assert dispatch_inputs["force_rollback"]["type"] == "boolean"
     assert "rollback_target_sha" in dispatch_inputs
@@ -199,7 +200,7 @@ def test_production_promotes_exact_approved_candidate_bytes() -> None:
     assert restore["if"] == "inputs.approved_manifest_digest != ''"
     assert "publication-candidate-receipts-$EXPECTED_GENERATION-$CANDIDATE_RUN_ID" in run
     assert 'gh run download "$CANDIDATE_RUN_ID"' in run
-    assert 'assembly.get("candidate_mode") != "no-write"' in run
+    assert 'assembly.get("candidate_mode") not in {"no-op-rehearsal", "candidate-only"}' in run
     assert 'RUN_HEAD_SHA" != "$EXPECTED_WORKFLOW_SHA"' in run
     assert '"prior_live_receipt_id": os.environ.get("EXPECTED_PRIOR_LIVE_RECEIPT_ID") or None' in run
     assert "approved candidate site digest mismatch" in run
@@ -295,12 +296,20 @@ def test_rollback_condition_covers_all_failure_modes_and_drills() -> None:
     assert "force_rollback == true" in if_cond
 
 
-def test_noop_and_forced_rollback_are_mutually_exclusive() -> None:
+def test_no_write_modes_and_forced_rollback_are_mutually_exclusive() -> None:
     validation = next(
         step for step in _workflow()["jobs"]["build"]["steps"] if step.get("name") == "Validate pinned dispatch inputs"
     )
 
-    assert 'if [ "$EXPECT_NOOP" = "true" ] && [ "$FORCE_ROLLBACK" = "true" ]' in validation["run"]
+    assert "expect_noop, candidate_only, and force_rollback are mutually exclusive" in validation["run"]
+
+
+def test_changed_candidate_mode_builds_without_deploying() -> None:
+    workflow = _workflow()
+
+    assert "inputs.candidate_only != true" in workflow["jobs"]["deploy"]["if"]
+    assert '"candidate-only"' in _workflow_text()
+    assert "CANDIDATE_ONLY: ${{ inputs.candidate_only }}" in _workflow_text()
 
 
 def test_dispatch_ref_must_be_develop() -> None:

--- a/tests/unit/workflows/test_publication_rollback.py
+++ b/tests/unit/workflows/test_publication_rollback.py
@@ -187,6 +187,8 @@ def test_production_requires_an_independently_approved_manifest() -> None:
     assert "--baseline-manifest receipt-dist/desired-manifest.json" in text
     assert "WORKFLOW_SHA: ${{ github.sha }}" in text
     assert '"workflow_sha": os.environ["WORKFLOW_SHA"]' in text
+    assert "scripts/publication/compare_db_digest.py compare" in text
+    assert "live database no longer matches the frozen baseline" in text
 
 
 def test_production_promotes_exact_approved_candidate_bytes() -> None:

--- a/tests/unit/workflows/test_publication_rollback.py
+++ b/tests/unit/workflows/test_publication_rollback.py
@@ -14,6 +14,8 @@ pytestmark = [pytest.mark.unit, pytest.mark.fast]
 ROOT = Path(__file__).resolve().parents[3]
 WORKFLOW_PATH = ROOT / ".github" / "workflows" / "publication-deploy.yml"
 BASELINE_PATH = ROOT / "docs" / "operations" / "publication-baseline-2026-08-31.json"
+DEPLOY_PAGES_ACTION = "actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e"
+UPLOAD_PAGES_ACTION = "actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa"
 
 
 def _workflow() -> dict[str, Any]:
@@ -48,7 +50,7 @@ def test_workflow_permissions_follow_least_privilege() -> None:
     # Top-level permissions should be read-only
     assert wf.get("permissions") == {"contents": "read"}
 
-    assert jobs["build"]["permissions"] == {"contents": "read"}
+    assert jobs["build"]["permissions"] == {"actions": "read", "contents": "read"}
     assert jobs["verify"]["permissions"] == {"contents": "read"}
     assert jobs["deploy"]["permissions"] == {"contents": "read", "pages": "write", "id-token": "write"}
     assert jobs["rollback"]["permissions"] == {
@@ -61,8 +63,8 @@ def test_workflow_permissions_follow_least_privilege() -> None:
 
 def test_workflow_uses_pages_deploy_actions_only_in_write_jobs() -> None:
     text = _workflow_text()
-    assert "actions/deploy-pages@v4" in text
-    assert "actions/upload-pages-artifact@v3" in text
+    assert DEPLOY_PAGES_ACTION in text
+    assert UPLOAD_PAGES_ACTION in text
     assert "group: pages-deploy" in text
     assert "cancel-in-progress: false" in text
 
@@ -111,9 +113,37 @@ def test_build_step_includes_pre_deploy_candidate_and_noop_check() -> None:
 
 
 def test_deploy_uses_real_pages_deployment() -> None:
-    steps = _workflow()["jobs"]["deploy"]["steps"]
-    assert any(step.get("uses") == "actions/deploy-pages@v4" for step in steps)
-    assert _workflow()["jobs"]["deploy"]["environment"]["name"] == "github-pages"
+    workflow = _workflow()
+    steps = workflow["jobs"]["deploy"]["steps"]
+    deployment = next(step for step in steps if step.get("uses") == DEPLOY_PAGES_ACTION)
+    assert deployment["with"]["artifact_name"] == "publication-pages-${{ needs.build.outputs.generation }}"
+    assert workflow["jobs"]["deploy"]["environment"]["name"] == "github-pages"
+
+
+def test_receipts_use_measured_provenance_and_valid_json_newlines() -> None:
+    text = _workflow_text()
+
+    assert '"target": "benchbox.dev"' in text
+    assert 'd("lock")' not in text
+    assert 'd("corpus")' not in text
+    assert 'd("read-model")' not in text
+    assert '"bundle_count": 0' not in text
+    assert '"size": 0' not in text
+    assert "LOCKFILE_DIGEST=$(sha256sum uv.lock" in text
+    assert "CORPUS_DIGEST=$(sha256sum receipt-dist/corpus-file-digests.txt" in text
+    assert 'tree_size("site")' in text
+    assert " + '\\\\n'" not in text
+
+
+def test_build_receipt_enforces_attested_cas_lineage() -> None:
+    text = _workflow_text()
+
+    assert "generation 1 is genesis and cannot name a prior live receipt" in text
+    assert "requires prior_live_receipt_id" in text
+    assert "verify_live_receipt_signature" in text
+    assert 'receipt.get("generation") != int(os.environ["GENERATION"]) - 1' in text
+    assert '"parent_sha": os.environ.get("PARENT_SHA") or None' in text
+    assert "validate_manifest_dict(receipt)" in text
 
 
 def test_verify_step_invokes_verify_live_with_receipt() -> None:
@@ -142,9 +172,21 @@ def test_rollback_restores_only_a_cryptographically_attested_artifact() -> None:
     assert "verify_live_receipt_signature" in run_bodies
     assert "known-good artifact digest mismatch" in run_bodies
     assert "rollback_target_sha" not in run_bodies
+    assert ".workflow_run.name" not in run_bodies
+    assert "actions/runs/$RUN_ID" in run_bodies
+    assert "['artifacts']['pages_assembly']['digest']" in run_bodies
 
-    assert any(step.get("uses") == "actions/deploy-pages@v4" for step in steps)
-    assert any(step.get("uses") == "actions/upload-pages-artifact@v3" for step in steps)
+    assert any(step.get("uses") == DEPLOY_PAGES_ACTION for step in steps)
+    assert any(step.get("uses") == UPLOAD_PAGES_ACTION for step in steps)
+
+
+def test_retained_site_artifact_includes_hidden_files() -> None:
+    steps = _workflow()["jobs"]["build"]["steps"]
+    retained = next(
+        step for step in steps if step.get("name") == "Retain immutable site artifact for attested rollback"
+    )
+
+    assert retained["with"]["include-hidden-files"] is True
 
 
 def test_rollback_condition_covers_all_failure_modes_and_drills() -> None:

--- a/tests/unit/workflows/test_results_explorer_publication.py
+++ b/tests/unit/workflows/test_results_explorer_publication.py
@@ -49,5 +49,8 @@ def test_release_docs_workflow_deploys_only_from_protected_release_push() -> Non
     assert steps[deploy_index]["if"] == "steps.independent.outputs.active != 'true'"
     guard_run = steps[guard_index]["run"]
     assert "Publication Control Plane Deployment" in guard_run
-    assert 'RUN_BRANCH" == "develop"' in guard_run
-    assert 'RUN_CONCLUSION" == "success"' in guard_run
+    assert 'RUN_BRANCH" != "develop"' in guard_run
+    assert "verify_live_receipt_signature" in guard_run
+    assert 'RUN_CONCLUSION"] != "success"' in guard_run
+    assert 'startswith("rollback-")' in guard_run
+    assert 'all(route.get("ok")' in guard_run

--- a/tests/unit/workflows/test_results_explorer_publication.py
+++ b/tests/unit/workflows/test_results_explorer_publication.py
@@ -39,3 +39,15 @@ def test_release_docs_workflow_deploys_only_from_protected_release_push() -> Non
     assert deploy["needs"] == "build"
     assert deploy["environment"]["name"] == "github-pages"
     assert deploy["concurrency"] == {"group": "pages-deploy", "cancel-in-progress": False}
+
+    steps = deploy["steps"]
+    guard_index = next(
+        i for i, step in enumerate(steps) if step.get("name") == "Check for independent publication ownership"
+    )
+    deploy_index = next(i for i, step in enumerate(steps) if step.get("uses") == "actions/deploy-pages@v4")
+    assert guard_index < deploy_index
+    assert steps[deploy_index]["if"] == "steps.independent.outputs.active != 'true'"
+    guard_run = steps[guard_index]["run"]
+    assert "Publication Control Plane Deployment" in guard_run
+    assert 'RUN_BRANCH" == "develop"' in guard_run
+    assert 'RUN_CONCLUSION" == "success"' in guard_run

--- a/tests/unit/workflows/test_results_explorer_publication.py
+++ b/tests/unit/workflows/test_results_explorer_publication.py
@@ -38,3 +38,4 @@ def test_release_docs_workflow_deploys_only_from_protected_release_push() -> Non
     assert deploy["if"] == "github.event_name == 'push' && github.ref == 'refs/heads/release'"
     assert deploy["needs"] == "build"
     assert deploy["environment"]["name"] == "github-pages"
+    assert deploy["concurrency"] == {"group": "pages-deploy", "cancel-in-progress": False}


### PR DESCRIPTION
## Summary

- build one immutable site artifact from pinned `develop` and `published-results` commits
- deploy only through an explicit publication dispatch, independent of package release
- issue Ed25519-signed live receipts and verify retained bytes before rollback
- keep the existing release deploy in place until the replacement lane completes its soak and retirement decision

## Why

This lets site and Results Explorer updates reach benchbox.dev without cutting a package release, while preserving the existing production fallback during migration.

## Validation

- `uv run pytest -q tests/unit/scripts/publication tests/unit/workflows/test_publication_rollback.py tests/unit/workflows/test_release_isolation.py tests/unit/docs/test_publication_architecture.py`
- `make pr-preflight`