### PR TITLE
feat(results): preview local run bundles in Results Explorer

### DIFF
--- a/results-explorer/e2e/routes/local-result-preview.spec.ts
+++ b/results-explorer/e2e/routes/local-result-preview.spec.ts
@@ -39,6 +39,15 @@ test.describe("local result preview", () => {
     expect(requests.some((request) => request.body?.includes("database_path") ?? false)).toBe(false);
     expect(requests.some((request) => request.url.includes(localBundle.run.id))).toBe(false);
     expect(requests.some((request) => request.url.includes(localBundleName))).toBe(false);
+
+    const persistentState = await page.evaluate(async () => ({
+      localStorage: Object.entries(localStorage),
+      sessionStorage: Object.entries(sessionStorage),
+      indexedDatabases: typeof indexedDB.databases === "function"
+        ? (await indexedDB.databases()).map((database) => database.name)
+        : [],
+    }));
+    expect(persistentState).toEqual({ localStorage: [], sessionStorage: [], indexedDatabases: [] });
   });
 
   test("explains that memory-only state is gone after a reload", async ({ page }) => {
@@ -51,5 +60,15 @@ test.describe("local result preview", () => {
     await page.reload();
     await expect(page.getByRole("alert")).toContainText("no longer available");
     await expect(page.getByRole("button", { name: "Open result file again" })).toBeVisible();
+
+    await page.getByRole("main").getByTestId("local-result-file-input").setInputFiles(LOCAL_BUNDLE);
+    await expect(page.getByTestId("local-result-banner")).toBeVisible();
+  });
+
+  test("uses the local recovery view for the bare local route", async ({ page }) => {
+    await page.goto("/results/local/");
+    await expect(page.getByRole("alert")).toContainText("No result ID provided");
+    await expect(page.getByRole("button", { name: "Open result file again" })).toBeVisible();
+    await expect(page.getByRole("heading", { name: /local results/i })).toHaveCount(0);
   });
 });

--- a/results-explorer/e2e/routes/local-result-preview.spec.ts
+++ b/results-explorer/e2e/routes/local-result-preview.spec.ts
@@ -1,0 +1,55 @@
+import { readFileSync, readdirSync } from "node:fs";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { expect, test } from "@playwright/test";
+import { waitForShell } from "../support/fixtures";
+
+const SOURCE_BUNDLES_DIR = fileURLToPath(new URL("../../test-fixtures/source/bundles/", import.meta.url));
+const localBundleName = readdirSync(SOURCE_BUNDLES_DIR).find((name) => name.startsWith("tpch-duckdb-sf0.01-"));
+if (!localBundleName) throw new Error("TPC-H DuckDB source bundle not found");
+const LOCAL_BUNDLE = join(SOURCE_BUNDLES_DIR, localBundleName);
+const localBundle = JSON.parse(readFileSync(LOCAL_BUNDLE, "utf8")) as { run: { id: string } };
+
+test.describe("local result preview", () => {
+  test("opens a local bundle in the existing detail UI without uploading it", async ({ page }) => {
+    const requests: Array<{ method: string; url: string; body: string | null }> = [];
+    page.on("request", (request) => {
+      requests.push({ method: request.method(), url: request.url(), body: request.postData() });
+    });
+
+    await page.goto("/results/");
+    await waitForShell(page);
+    await page.getByTestId("local-result-file-input").setInputFiles(LOCAL_BUNDLE);
+
+    await expect(page).toHaveURL(/\/results\/local\/local-[0-9a-f]{12}$/);
+    const main = page.getByRole("main");
+    await expect(main.getByTestId("local-result-banner")).toContainText("has not been uploaded");
+    await expect(main.getByRole("heading", { name: /TPC-H - DuckDB/ })).toBeVisible();
+    await expect(main.locator('[data-role="trust"]')).toContainText("Local");
+    await expect(main.getByText(/Local preview ID/)).toBeVisible();
+    await expect(main.getByRole("link", { name: "Submit for public review" })).toHaveAttribute(
+      "href",
+      "/docs/contributing-results.html",
+    );
+    await expect(main.getByRole("link", { name: "Compare this result" })).toHaveCount(0);
+    await expect(main.getByRole("link", { name: "Download bundle" })).toHaveCount(0);
+
+    expect(requests.filter((request) => ["POST", "PUT", "PATCH"].includes(request.method))).toEqual([]);
+    expect(requests.some((request) => request.body?.includes(localBundle.run.id) ?? false)).toBe(false);
+    expect(requests.some((request) => request.body?.includes("database_path") ?? false)).toBe(false);
+    expect(requests.some((request) => request.url.includes(localBundle.run.id))).toBe(false);
+    expect(requests.some((request) => request.url.includes(localBundleName))).toBe(false);
+  });
+
+  test("explains that memory-only state is gone after a reload", async ({ page }) => {
+    await page.goto("/results/");
+    await waitForShell(page);
+    await page.getByTestId("local-result-file-input").setInputFiles(LOCAL_BUNDLE);
+    await expect(page).toHaveURL(/\/results\/local\/local-[0-9a-f]{12}$/);
+    await expect(page.getByTestId("local-result-banner")).toBeVisible();
+
+    await page.reload();
+    await expect(page.getByRole("alert")).toContainText("no longer available");
+    await expect(page.getByRole("button", { name: "Open result file again" })).toBeVisible();
+  });
+});

--- a/results-explorer/e2e/routes/local-result-preview.spec.ts
+++ b/results-explorer/e2e/routes/local-result-preview.spec.ts
@@ -24,7 +24,7 @@ test.describe("local result preview", () => {
     await expect(page).toHaveURL(/\/results\/local\/local-[0-9a-f]{12}$/);
     const main = page.getByRole("main");
     await expect(main.getByTestId("local-result-banner")).toContainText("has not been uploaded");
-    await expect(main.getByRole("heading", { name: /TPC-H - DuckDB/ })).toBeVisible();
+    await expect(main.getByRole("heading", { name: /TPC-H result: DuckDB/ })).toBeVisible();
     await expect(main.locator('[data-role="trust"]')).toContainText("Local");
     await expect(main.getByText(/Local preview ID/)).toBeVisible();
     await expect(main.getByRole("link", { name: "Submit for public review" })).toHaveAttribute(

--- a/results-explorer/e2e/routes/pages-artifact.spec.ts
+++ b/results-explorer/e2e/routes/pages-artifact.spec.ts
@@ -26,12 +26,14 @@ test.describe("assembled GitHub Pages artifact", () => {
     const directRouteStatuses: number[] = [];
     const benchmarkIndexStatuses: number[] = [];
     const platformIndexStatuses: number[] = [];
+    const localPreviewStatuses: number[] = [];
     const docsStatuses: number[] = [];
     page.on("response", (response) => {
       const pathname = new URL(response.url()).pathname;
       if (pathname === "/results/p/polars/") directRouteStatuses.push(response.status());
       if (pathname === "/results/benchmarks/") benchmarkIndexStatuses.push(response.status());
       if (pathname === "/results/platforms/") platformIndexStatuses.push(response.status());
+      if (pathname === "/results/local/local-aabbccddeeff") localPreviewStatuses.push(response.status());
       if (pathname === "/docs/usage/installation.html") docsStatuses.push(response.status());
     });
 
@@ -60,6 +62,13 @@ test.describe("assembled GitHub Pages artifact", () => {
     await expect(page.getByRole("heading", { name: "Platforms" })).toBeVisible();
     await expect(page).toHaveURL(/\/results\/platforms\/$/);
     expect(platformIndexStatuses).toContain(404);
+
+    await page.goto("/results/local/local-aabbccddeeff");
+    await waitForShell(page);
+    await expect(page).toHaveURL(/\/results\/local\/local-aabbccddeeff$/);
+    await expect(page.getByRole("alert")).toContainText("no longer available");
+    await expect(page.getByRole("button", { name: "Open result file again" })).toBeVisible();
+    expect(localPreviewStatuses).toContain(404);
 
     await page.goto("/results/");
     await waitForDataLoaded(page, /Recent Results/i);

--- a/results-explorer/src/App.tsx
+++ b/results-explorer/src/App.tsx
@@ -31,6 +31,8 @@ export function App() {
             <PlatformIndex path="/results/p/:platform/" />
             <CompareWithinRun path="/results/r/:resultId/passes" />
             <ResultDetail path="/results/r/:resultId" />
+            <ResultDetail path="/results/local" source="local" />
+            <ResultDetail path="/results/local/" source="local" />
             <ResultDetail path="/results/local/:resultId" source="local" />
             <BenchmarkIndex path="/results/:benchmark/" />
             <NotFound default />

--- a/results-explorer/src/App.tsx
+++ b/results-explorer/src/App.tsx
@@ -11,28 +11,32 @@ import { CompareWithinRun } from "./pages/CompareWithinRun";
 import { Query } from "./pages/Query";
 import { NotFound } from "./pages/NotFound";
 import { PickingStateProvider } from "./lib/pickingState";
+import { LocalResultProvider } from "./lib/localResultState";
 
 export function App() {
   return (
-    <PickingStateProvider>
-      <Layout>
-        <Router>
-          <Home path="/results/" />
-          <Compare path="/results/compare" />
-          <Compare path="/results/compare/" />
-          <Query path="/results/query" />
-          <Query path="/results/query/" />
-          <BenchmarksIndex path="/results/benchmarks" />
-          <BenchmarksIndex path="/results/benchmarks/" />
-          <PlatformsIndex path="/results/platforms" />
-          <PlatformsIndex path="/results/platforms/" />
-          <PlatformIndex path="/results/p/:platform/" />
-          <CompareWithinRun path="/results/r/:resultId/passes" />
-          <ResultDetail path="/results/r/:resultId" />
-          <BenchmarkIndex path="/results/:benchmark/" />
-          <NotFound default />
-        </Router>
-      </Layout>
-    </PickingStateProvider>
+    <LocalResultProvider>
+      <PickingStateProvider>
+        <Layout>
+          <Router>
+            <Home path="/results/" />
+            <Compare path="/results/compare" />
+            <Compare path="/results/compare/" />
+            <Query path="/results/query" />
+            <Query path="/results/query/" />
+            <BenchmarksIndex path="/results/benchmarks" />
+            <BenchmarksIndex path="/results/benchmarks/" />
+            <PlatformsIndex path="/results/platforms" />
+            <PlatformsIndex path="/results/platforms/" />
+            <PlatformIndex path="/results/p/:platform/" />
+            <CompareWithinRun path="/results/r/:resultId/passes" />
+            <ResultDetail path="/results/r/:resultId" />
+            <ResultDetail path="/results/local/:resultId" source="local" />
+            <BenchmarkIndex path="/results/:benchmark/" />
+            <NotFound default />
+          </Router>
+        </Layout>
+      </PickingStateProvider>
+    </LocalResultProvider>
   );
 }

--- a/results-explorer/src/__tests__/userFacingStringHygiene.test.ts
+++ b/results-explorer/src/__tests__/userFacingStringHygiene.test.ts
@@ -43,6 +43,7 @@ const ALLOWED_INTERNAL_FRAGMENTS = new Map<string, ReadonlySet<string>>([
     ]),
   ],
   ["lib/duckdbQueries.ts", new Set(['"/results/data/results.duckdb"'])],
+  ["lib/localResult.ts", new Set(['"benchbox.core.cost.pricing"'])],
 ]);
 
 interface Finding {

--- a/results-explorer/src/components/Layout.tsx
+++ b/results-explorer/src/components/Layout.tsx
@@ -9,6 +9,7 @@ import {
   HEADER_NAV_ARIA_LABEL,
   HEADER_TOGGLE_ARIA_LABEL,
 } from "@/components/headerContract";
+import { LocalResultPicker } from "@/components/LocalResultPicker";
 
 interface LayoutProps {
   children: ComponentChildren;
@@ -129,6 +130,13 @@ function Header() {
             <ExplorerNavLink href="/results/query" active={currentPath.startsWith("/results/query")}>
               Find runs
             </ExplorerNavLink>
+            <LocalResultPicker
+              className={`whitespace-nowrap rounded-sm border-b-2 bg-transparent py-3 font-medium focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--bb-focus-ring-on-dark)] ${
+                currentPath.startsWith("/results/local/")
+                  ? "border-[var(--bb-accent)] text-[var(--bb-fg-primary)]"
+                  : "border-transparent text-[var(--bb-fg-muted)] hover:border-[var(--bb-border-default)] hover:text-[var(--bb-fg-primary)]"
+              }`}
+            />
           </nav>
         </div>
       </div>
@@ -187,7 +195,7 @@ function ExplorerNavLink({
 }
 
 function isBenchmarkPath(path: string): boolean {
-  return /^\/results\/(?!compare\/?$|query\/?$|platforms\/?$|p\/|r\/)[^/]+\/?$/.test(path);
+  return /^\/results\/(?!compare\/?$|query\/?$|platforms\/?$|p\/|r\/|local\/)[^/]+\/?$/.test(path);
 }
 
 function themeLabel(choice: string): string {

--- a/results-explorer/src/components/LocalResultPicker.tsx
+++ b/results-explorer/src/components/LocalResultPicker.tsx
@@ -1,0 +1,55 @@
+import { useRef, useState } from "preact/hooks";
+import { route } from "preact-router";
+import { useLocalResultState } from "@/lib/localResultState";
+import { errMsg } from "@/utils";
+
+interface LocalResultPickerProps {
+  label?: string;
+  className?: string;
+}
+
+export function LocalResultPicker({ label = "Open local result", className = "btn btn-secondary" }: LocalResultPickerProps) {
+  const inputRef = useRef<HTMLInputElement>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+  const { importFile } = useLocalResultState();
+
+  async function handleFile(file: File | undefined) {
+    if (!file) return;
+    setError(null);
+    setLoading(true);
+    try {
+      const preview = await importFile(file);
+      route(`/results/local/${encodeURIComponent(preview.detail.result_id)}`);
+    } catch (reason: unknown) {
+      setError(errMsg(reason));
+    } finally {
+      setLoading(false);
+      if (inputRef.current) inputRef.current.value = "";
+    }
+  }
+
+  return (
+    <span class="inline-flex flex-col items-start gap-1">
+      <input
+        ref={inputRef}
+        type="file"
+        accept=".json,application/json"
+        aria-label="BenchBox result JSON file"
+        class="sr-only"
+        data-testid="local-result-file-input"
+        onChange={(event) => void handleFile(event.currentTarget.files?.[0])}
+      />
+      <button
+        type="button"
+        class={className}
+        disabled={loading}
+        aria-busy={loading}
+        onClick={() => inputRef.current?.click()}
+      >
+        {loading ? "Opening…" : label}
+      </button>
+      {error && <span role="alert" class="max-w-xs text-xs text-[var(--bb-tone-danger-fg)]">{error}</span>}
+    </span>
+  );
+}

--- a/results-explorer/src/components/LocalResultPicker.tsx
+++ b/results-explorer/src/components/LocalResultPicker.tsx
@@ -36,6 +36,8 @@ export function LocalResultPicker({ label = "Open local result", className = "bt
         type="file"
         accept=".json,application/json"
         aria-label="BenchBox result JSON file"
+        aria-hidden="true"
+        tabIndex={-1}
         class="sr-only"
         data-testid="local-result-file-input"
         onChange={(event) => void handleFile(event.currentTarget.files?.[0])}

--- a/results-explorer/src/components/LocalResultPicker.tsx
+++ b/results-explorer/src/components/LocalResultPicker.tsx
@@ -30,7 +30,7 @@ export function LocalResultPicker({ label = "Open local result", className = "bt
   }
 
   return (
-    <span class="inline-flex flex-col items-start gap-1">
+    <span class="relative inline-flex flex-col items-start gap-1">
       <input
         ref={inputRef}
         type="file"

--- a/results-explorer/src/components/__tests__/Layout.test.tsx
+++ b/results-explorer/src/components/__tests__/Layout.test.tsx
@@ -124,6 +124,8 @@ describe("Layout", () => {
     }
     expect(within(explorerNav).getByRole("link", { name: "Find runs" })).toHaveAttribute("aria-current", "page");
     expect(within(explorerNav).getByRole("button", { name: "Open local result" })).toBeTruthy();
+    expect(within(explorerNav).getByTestId("local-result-file-input")).toHaveAttribute("aria-hidden", "true");
+    expect(within(explorerNav).getByTestId("local-result-file-input")).toHaveAttribute("tabindex", "-1");
     expect(within(explorerNav).getByRole("link", { name: "Leaderboards" })).not.toHaveAttribute("aria-current");
   });
 

--- a/results-explorer/src/components/__tests__/Layout.test.tsx
+++ b/results-explorer/src/components/__tests__/Layout.test.tsx
@@ -123,6 +123,7 @@ describe("Layout", () => {
       expect(within(explorerNav).getByRole("link", { name: label })).toBeTruthy();
     }
     expect(within(explorerNav).getByRole("link", { name: "Find runs" })).toHaveAttribute("aria-current", "page");
+    expect(within(explorerNav).getByRole("button", { name: "Open local result" })).toBeTruthy();
     expect(within(explorerNav).getByRole("link", { name: "Leaderboards" })).not.toHaveAttribute("aria-current");
   });
 

--- a/results-explorer/src/lib/__tests__/localResult.test.ts
+++ b/results-explorer/src/lib/__tests__/localResult.test.ts
@@ -209,6 +209,27 @@ describe("local result import", () => {
     });
   });
 
+  it("marks missing normalized cost as unavailable", async () => {
+    const preview = await parseLocalResultText(JSON.stringify(bundle()));
+
+    expect(preview.detail).toMatchObject({
+      normalized_cost_usd: null,
+      cost_model_version: "2025.11",
+      cost_model_source: "benchbox.core.cost.pricing",
+      cost_scope: "compute_only",
+      cost_status: "unavailable",
+      billing_unit: "unknown",
+      pricing_region: "unknown",
+    });
+  });
+
+  it("derives the CPU family from a recorded CPU model", async () => {
+    const preview = await parseLocalResultText(JSON.stringify(bundle()));
+
+    expect(preview.detail.environment.cpu_model).toBe("Apple M4");
+    expect(preview.detail.environment.cpu_family).toBe("apple_silicon");
+  });
+
   it("matches publication fallbacks for optional display fields", async () => {
     const value = bundle({
       benchmark: { id: "tpch", name: "TPC-H", scale_factor: 1 },

--- a/results-explorer/src/lib/__tests__/localResult.test.ts
+++ b/results-explorer/src/lib/__tests__/localResult.test.ts
@@ -131,6 +131,16 @@ describe("local result import", () => {
     expect(JSON.stringify(preview.detail)).not.toContain("/private/customer.duckdb");
   });
 
+  it("uses an opaque per-import ID rather than a bundle fingerprint", async () => {
+    const text = JSON.stringify(bundle());
+    const first = await parseLocalResultText(text);
+    const second = await parseLocalResultText(text);
+
+    expect(first.detail.result_id).toMatch(/^local-[0-9a-f]{12}$/);
+    expect(second.detail.result_id).toMatch(/^local-[0-9a-f]{12}$/);
+    expect(second.detail.result_id).not.toBe(first.detail.result_id);
+  });
+
   it("marks an otherwise passing summary partial when queries failed", async () => {
     const value = bundle({
       summary: {
@@ -140,6 +150,53 @@ describe("local result import", () => {
     });
     const preview = await parseLocalResultText(JSON.stringify(value));
     expect(preview.detail.validation_status).toBe("partial");
+  });
+
+  it("uses publication fallbacks when summary.queries.failed is absent", async () => {
+    const fromSummary = bundle({
+      summary: {
+        queries: { total: 2, passed: 1, skipped: 0 },
+        validation: "passed",
+      },
+    });
+    const fromRows = bundle({
+      summary: {
+        queries: {},
+        validation: "passed",
+      },
+      queries: [{ id: "1", ms: 10, run_type: "measurement", status: "ERROR" }],
+    });
+
+    await expect(parseLocalResultText(JSON.stringify(fromSummary))).resolves.toMatchObject({
+      detail: { validation_status: "partial" },
+    });
+    await expect(parseLocalResultText(JSON.stringify(fromRows))).resolves.toMatchObject({
+      detail: { validation_status: "partial" },
+    });
+  });
+
+  it("marks translation fallback as uncertain like the publication transform", async () => {
+    const value = bundle({
+      execution: { translation: { status: "fallback" } },
+    });
+    const preview = await parseLocalResultText(JSON.stringify(value));
+    expect(preview.detail.validation_status).toBe("uncertain");
+  });
+
+  it("matches publication fallbacks for optional display fields", async () => {
+    const value = bundle({
+      benchmark: { id: "tpch", name: "TPC-H", scale_factor: 1 },
+      platform: { name: "Example  Engine", driver_resolved_version: "platform-only" },
+      execution: {},
+      phases: { power_test: { duration_ms: 1 } },
+      cost: { total_usd: 99 },
+    });
+    const preview = await parseLocalResultText(JSON.stringify(value));
+
+    expect(preview.detail.platform_id).toBe("example--engine");
+    expect(preview.detail.driver_version).toBeNull();
+    expect(preview.detail.test_type).toBe("power");
+    expect(preview.detail.cost_usd).toBeNull();
   });
 
   it.each(["2.0", "2.1", "2.2"])("accepts supported schema %s", async (version) => {
@@ -169,6 +226,6 @@ describe("local result import", () => {
       size: MAX_LOCAL_RESULT_BYTES + 1,
       text: () => Promise.resolve("unused"),
     } as File;
-    await expect(importLocalResultFile(file)).rejects.toThrow("larger than the 50 MiB");
+    await expect(importLocalResultFile(file)).rejects.toThrow("larger than the 10 MiB");
   });
 });

--- a/results-explorer/src/lib/__tests__/localResult.test.ts
+++ b/results-explorer/src/lib/__tests__/localResult.test.ts
@@ -183,6 +183,32 @@ describe("local result import", () => {
     expect(preview.detail.validation_status).toBe("uncertain");
   });
 
+  it("projects canonical normalized cost metadata", async () => {
+    const value = bundle({
+      normalized_cost: {
+        normalized_cost_usd: 1.25,
+        cost_model_version: "2026-08",
+        cost_model_source: "benchbox",
+        cost_scope: "compute_only",
+        cost_status: "normalized",
+        billing_unit: "hour",
+        pricing_region: "us-east-1",
+      },
+    });
+    const preview = await parseLocalResultText(JSON.stringify(value));
+
+    expect(preview.detail).toMatchObject({
+      cost_usd: 1.25,
+      normalized_cost_usd: 1.25,
+      cost_model_version: "2026-08",
+      cost_model_source: "benchbox",
+      cost_scope: "compute_only",
+      cost_status: "normalized",
+      billing_unit: "hour",
+      pricing_region: "us-east-1",
+    });
+  });
+
   it("matches publication fallbacks for optional display fields", async () => {
     const value = bundle({
       benchmark: { id: "tpch", name: "TPC-H", scale_factor: 1 },

--- a/results-explorer/src/lib/__tests__/localResult.test.ts
+++ b/results-explorer/src/lib/__tests__/localResult.test.ts
@@ -1,0 +1,174 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+import {
+  importLocalResultFile,
+  LocalResultImportError,
+  MAX_LOCAL_RESULT_BYTES,
+  parseLocalResultText,
+} from "@/lib/localResult";
+
+function bundle(overrides: Record<string, unknown> = {}) {
+  return {
+    version: "2.1",
+    run: {
+      id: "private-run-id",
+      timestamp: "2026-09-05T12:34:56Z",
+      total_duration_ms: 4_000,
+    },
+    benchmark: { id: "tpch", name: "TPC-H", scale_factor: 1, test_type: "power" },
+    platform: {
+      name: "DuckDB",
+      version: "1.4.3",
+      config: { execution_mode: "sql", database_path: "/private/customer.duckdb" },
+    },
+    config: { mode: "sql" },
+    summary: {
+      queries: { total: 44, passed: 44, failed: 0 },
+      validation: "passed",
+      tpc_metrics: { power_at_size: 1234.5 },
+    },
+    environment: {
+      os: "macOS",
+      arch: "arm64",
+      cpu_count: 10,
+      cpu_model: "Apple M4",
+      machine_id: "secret-machine-id",
+      database_path: "/private/customer.duckdb",
+      client_link: {
+        client_region: "us-east",
+        client_cloud: "local",
+        collection_status: "recorded",
+        statement_overhead_ms: { min: 0.1, median: 0.2 },
+      },
+    },
+    queries: [
+      { id: "1", ms: 10, iter: 1, run_type: "measurement", status: "SUCCESS" },
+      { id: "1", ms: 30, iter: 2, run_type: "measurement", status: "SUCCESS" },
+      { id: "1", ms: 999, iter: 0, run_type: "warmup", status: "SUCCESS" },
+      { id: "2", ms: 40, iter: 1, run_type: "measurement", status: "SUCCESS" },
+      { id: "summary", ms: 0, run_type: "summary", status: "SKIPPED" },
+    ],
+    ...overrides,
+  };
+}
+
+describe("local result import", () => {
+  it("matches the publication transform for the canonical browser fixture", async () => {
+    const fixturePath = resolve(
+      import.meta.dirname,
+      "../../../test-fixtures/source/bundles/tpch-duckdb-sf0.01-20260403-7fe93365.json",
+    );
+    const preview = await parseLocalResultText(readFileSync(fixturePath, "utf8"), "fixture.json");
+
+    expect(preview.detail).toMatchObject({
+      benchmark: "tpch",
+      scale_factor: 0.01,
+      platform: "DuckDB",
+      platform_id: "duckdb",
+      driver_version: "1.4.3",
+      run_date: "2026-04-03",
+      total_duration_s: 2.815,
+      power_score: 3184.897098661065,
+      logical_query_count: 22,
+      valid_query_count: 22,
+      missing_query_count: 0,
+      zero_timing_count: 0,
+      display_exclusion_reason: null,
+      comparison_exclusion_reason: null,
+      execution_mode: "sql",
+      validation_status: "passed",
+    });
+    expect(preview.detail.geomean_ms).toBeCloseTo(11.516422021051456);
+    expect(preview.detail.display_geomean_ms).toBeCloseTo(11.335852721901425);
+    expect(preview.detail.display_timings.find((timing) => timing.query_id === "14")).toMatchObject({
+      display_ms: 12,
+      sample_count: 4,
+    });
+    expect(preview.detail.display_timings).toHaveLength(22);
+    expect(preview.detail.queries).toHaveLength(88);
+  });
+
+  it("projects a schema-v2 bundle into a private detail result", async () => {
+    const text = JSON.stringify(bundle());
+    const preview = await parseLocalResultText(text, "my-run.json");
+
+    expect(preview.fileName).toBe("my-run.json");
+    expect(preview.detail.result_id).toMatch(/^local-[0-9a-f]{12}$/);
+    expect(preview.detail.result_id).not.toContain("private-run-id");
+    expect(preview.detail.trust_label).toBe("local-run");
+    expect(preview.detail.visibility).toBe("local-preview");
+    expect(preview.detail.ranking_exclusion_reason).toBe("local_result");
+    expect(preview.detail.display_timings).toEqual([
+      {
+        query_id: "1",
+        display_ms: 20,
+        sample_count: 2,
+        is_valid_display_timing: true,
+        timing_exclusion_reason: null,
+      },
+      {
+        query_id: "2",
+        display_ms: 40,
+        sample_count: 1,
+        is_valid_display_timing: true,
+        timing_exclusion_reason: null,
+      },
+    ]);
+    expect(preview.detail.logical_query_count).toBe(22);
+    expect(preview.detail.missing_query_count).toBe(20);
+    expect(preview.primaryMetric).toBe("power_score");
+    expect(preview.detail.environment).toMatchObject({
+      os: "macOS",
+      arch: "arm64",
+      cpu_count: 10,
+      cpu_model: "Apple M4",
+      client_region: "us-east",
+      statement_overhead_median_ms: 0.2,
+    });
+    expect(preview.detail.environment).not.toHaveProperty("machine_id");
+    expect(preview.detail.environment).not.toHaveProperty("database_path");
+    expect(JSON.stringify(preview.detail)).not.toContain("/private/customer.duckdb");
+  });
+
+  it("marks an otherwise passing summary partial when queries failed", async () => {
+    const value = bundle({
+      summary: {
+        queries: { total: 2, passed: 1, failed: 1 },
+        validation: { status: "passed" },
+      },
+    });
+    const preview = await parseLocalResultText(JSON.stringify(value));
+    expect(preview.detail.validation_status).toBe("partial");
+  });
+
+  it.each(["2.0", "2.1", "2.2"])("accepts supported schema %s", async (version) => {
+    await expect(parseLocalResultText(JSON.stringify(bundle({ version })))).resolves.toBeTruthy();
+  });
+
+  it("rejects malformed and unsupported input with actionable errors", async () => {
+    await expect(parseLocalResultText("not json")).rejects.toThrow("not valid JSON");
+    await expect(parseLocalResultText(JSON.stringify(bundle({ version: "3.0" })))).rejects.toThrow(
+      "Schema 3.0 is not supported",
+    );
+    await expect(parseLocalResultText(JSON.stringify(bundle({ queries: null })))).rejects.toThrow(
+      "missing its query list",
+    );
+  });
+
+  it("rejects a non-JSON file before reading it", async () => {
+    const file = new File(["unused"], "result.txt", { type: "text/plain" });
+    await expect(importLocalResultFile(file)).rejects.toEqual(
+      expect.objectContaining<Partial<LocalResultImportError>>({ name: "LocalResultImportError" }),
+    );
+  });
+
+  it("rejects an oversized file before reading it", async () => {
+    const file = {
+      name: "result.json",
+      size: MAX_LOCAL_RESULT_BYTES + 1,
+      text: () => Promise.resolve("unused"),
+    } as File;
+    await expect(importLocalResultFile(file)).rejects.toThrow("larger than the 50 MiB");
+  });
+});

--- a/results-explorer/src/lib/displayLabels.ts
+++ b/results-explorer/src/lib/displayLabels.ts
@@ -12,6 +12,7 @@ import { humanizeBenchmark } from "@/utils";
 const TRUST_LABEL_LABELS: Record<string, string> = {
   "maintainer-run": "Maintainer run",
   "community-submission": "Community submission",
+  "local-run": "Local run",
 };
 
 const VALIDATION_STATUS_LABELS: Record<string, string> = {
@@ -129,6 +130,7 @@ export function describeValidationStatus(raw: string | null | undefined): Valida
 const VISIBILITY_LABELS: Record<string, string> = {
   "public-curated": "Published, maintainer reviewed",
   "public-community": "Published, community submitted",
+  "local-preview": "Local preview",
   internal: "Not public",
 };
 

--- a/results-explorer/src/lib/localResult.ts
+++ b/results-explorer/src/lib/localResult.ts
@@ -106,7 +106,7 @@ export async function parseLocalResultText(text: string, fileName = "local-resul
   const tuning = objectValue(platform, "tuning");
   const logicalProfile = objectValue(tuning, "logical_profile");
   const funding = fundingSource(bundle.provenance);
-  const costUsd = normalizedCostUsd(bundle);
+  const normalizedCost = normalizedCostFields(bundle);
 
   const detail: DetailResult = {
     result_id: resultId,
@@ -151,7 +151,8 @@ export async function parseLocalResultText(text: string, fileName = "local-resul
     tuning_policy_generation: stringOrNull(tuning.tuning_policy_generation),
     test_type: testType(bundle, benchmark),
     validation_status: validationStatus,
-    cost_usd: costUsd,
+    cost_usd: normalizedCost.normalized_cost_usd,
+    ...normalizedCost,
     compliance_class: stringOrNull(benchmark.compliance_class),
     physical_mechanisms: Array.isArray(logicalProfile.physical_mechanisms)
       ? logicalProfile.physical_mechanisms.map(String)
@@ -375,19 +376,32 @@ function translationIsNonClean(bundle: JsonObject): boolean {
   return status === "fallback" || status === "failed";
 }
 
-function normalizedCostUsd(bundle: JsonObject): number | null {
+function normalizedCostFields(bundle: JsonObject) {
   const root = objectValue(bundle, "normalized_cost");
-  if (Object.keys(root).length > 0) return finiteNumberOrNull(root.normalized_cost_usd);
-
   const cost = objectValue(bundle, "cost");
-  for (const key of ["normalized_cost", "normalized"]) {
-    const nested = objectValue(cost, key);
-    if (Object.keys(nested).length > 0) return finiteNumberOrNull(nested.normalized_cost_usd);
-  }
+  const nestedNormalizedCost = objectValue(cost, "normalized_cost");
+  const nestedNormalized = objectValue(cost, "normalized");
   const hasNormalizedCostShape = [
     "normalized_cost_usd", "cost_model_version", "cost_model_source", "cost_scope", "cost_status",
   ].some((key) => Object.prototype.hasOwnProperty.call(cost, key));
-  return hasNormalizedCostShape ? finiteNumberOrNull(cost.normalized_cost_usd) : null;
+  const normalized = Object.keys(root).length > 0
+    ? root
+    : Object.keys(nestedNormalizedCost).length > 0
+      ? nestedNormalizedCost
+      : Object.keys(nestedNormalized).length > 0
+        ? nestedNormalized
+        : hasNormalizedCostShape
+          ? cost
+          : {};
+  return {
+    normalized_cost_usd: finiteNumberOrNull(normalized.normalized_cost_usd),
+    cost_model_version: stringOrNull(normalized.cost_model_version),
+    cost_model_source: stringOrNull(normalized.cost_model_source),
+    cost_scope: stringOrNull(normalized.cost_scope),
+    cost_status: stringOrNull(normalized.cost_status),
+    billing_unit: stringOrNull(normalized.billing_unit),
+    pricing_region: stringOrNull(normalized.pricing_region),
+  };
 }
 
 function testType(bundle: JsonObject, benchmark: JsonObject): string | null {

--- a/results-explorer/src/lib/localResult.ts
+++ b/results-explorer/src/lib/localResult.ts
@@ -9,6 +9,18 @@ const EXECUTION_RUN_TYPES = new Set(["measurement", "warmup"]);
 const EXECUTION_MODES = new Set(["sql", "dataframe"]);
 const TUNING_MODES = new Set(["tuned", "tuned-fallback", "notuning", "auto", "custom"]);
 const FUNDING_SOURCES = new Set(["employer", "personal", "free-trial", "vendor-sponsored", "grant", "unspecified"]);
+const LOCAL_COST_MODEL_VERSION = "2025.11";
+const LOCAL_COST_MODEL_SOURCE = "benchbox.core.cost.pricing";
+const CPU_FAMILY_PATTERNS: ReadonlyArray<readonly [RegExp, string]> = [
+  [/\bapple\s+(?:m\d|a\d)/i, "apple_silicon"],
+  [/\bgraviton/i, "graviton"],
+  [/\bxeon\b/i, "intel_xeon"],
+  [/\b(?:intel.*core|core\(tm\))\b/i, "intel_core"],
+  [/\bepyc\b/i, "amd_epyc"],
+  [/\b(?:ryzen|threadripper)\b/i, "amd_ryzen"],
+  [/\b(?:ampere|altra)\b/i, "ampere_altra"],
+  [/\bneoverse\b/i, "arm_neoverse"],
+];
 const KNOWN_LOGICAL_QUERY_COUNTS: Record<string, number> = {
   tpch: 22,
   tpch_skew: 22,
@@ -284,6 +296,9 @@ function safeEnvironment(raw: unknown): Environment {
     const value = finiteNumberOrNull(source[key]);
     if (value !== null) environment[key] = value;
   }
+  if (environment.cpu_model && !environment.cpu_family) {
+    environment.cpu_family = normalizeCpuFamily(environment.cpu_model);
+  }
   const provenance = stringOrNull(source.cpu_identity_provenance);
   if (provenance === "measured" || provenance === "user_attested" || provenance === "inferred") {
     environment.cpu_identity_provenance = provenance;
@@ -296,6 +311,11 @@ function safeEnvironment(raw: unknown): Environment {
   environment.statement_overhead_min_ms = finiteNumberOrNull(overhead.min);
   environment.statement_overhead_median_ms = finiteNumberOrNull(overhead.median);
   return environment;
+}
+
+function normalizeCpuFamily(rawModel: string): string {
+  const match = CPU_FAMILY_PATTERNS.find(([pattern]) => pattern.test(rawModel));
+  return match?.[1] ?? "unknown";
 }
 
 function executionMode(bundle: JsonObject): string | null {
@@ -392,7 +412,18 @@ function normalizedCostFields(bundle: JsonObject) {
         ? nestedNormalized
         : hasNormalizedCostShape
           ? cost
-          : {};
+          : null;
+  if (normalized === null) {
+    return {
+      normalized_cost_usd: null,
+      cost_model_version: LOCAL_COST_MODEL_VERSION,
+      cost_model_source: LOCAL_COST_MODEL_SOURCE,
+      cost_scope: "compute_only",
+      cost_status: "unavailable",
+      billing_unit: "unknown",
+      pricing_region: "unknown",
+    };
+  }
   return {
     normalized_cost_usd: finiteNumberOrNull(normalized.normalized_cost_usd),
     cost_model_version: stringOrNull(normalized.cost_model_version),

--- a/results-explorer/src/lib/localResult.ts
+++ b/results-explorer/src/lib/localResult.ts
@@ -1,9 +1,10 @@
 import type { DetailResult, Environment, QueryDisplayTiming, QueryTiming } from "@/types";
 
-export const MAX_LOCAL_RESULT_BYTES = 50 * 1024 * 1024;
+export const MAX_LOCAL_RESULT_BYTES = 10 * 1024 * 1024;
 
 const SUPPORTED_SCHEMA_VERSIONS = new Set(["2.0", "2.1", "2.2"]);
 const PASS_STATUSES = new Set(["SUCCESS", "PASS", "pass", "success"]);
+const NON_FAILED_QUERY_ROW_STATUSES = new Set(["SUCCESS", "SKIPPED"]);
 const EXECUTION_RUN_TYPES = new Set(["measurement", "warmup"]);
 const EXECUTION_MODES = new Set(["sql", "dataframe"]);
 const TUNING_MODES = new Set(["tuned", "tuned-fallback", "notuning", "auto", "custom"]);
@@ -39,7 +40,7 @@ export async function importLocalResultFile(file: File): Promise<LocalResultPrev
     throw new LocalResultImportError("Choose a BenchBox result bundle in JSON format.");
   }
   if (file.size > MAX_LOCAL_RESULT_BYTES) {
-    throw new LocalResultImportError("This result is larger than the 50 MiB local preview limit.");
+    throw new LocalResultImportError("This result is larger than the 10 MiB local preview limit.");
   }
   let text: string;
   try {
@@ -92,8 +93,8 @@ export async function parseLocalResultText(text: string, fileName = "local-resul
     "qphh_at_size",
     "qphds_at_size",
   ]);
-  const resultId = await localResultId(text);
-  const validationStatus = validationStatusFor(summary, failedQueryCount(summary));
+  const resultId = localResultId();
+  const validationStatus = validationStatusFor(bundle, failedQueryCount(bundle));
   const environment = safeEnvironment(bundle.environment);
   const clientFields = {
     client_region: stringOrNull(environment.client_region),
@@ -105,8 +106,7 @@ export async function parseLocalResultText(text: string, fileName = "local-resul
   const tuning = objectValue(platform, "tuning");
   const logicalProfile = objectValue(tuning, "logical_profile");
   const funding = fundingSource(bundle.provenance);
-  const rawCost = objectValue(bundle, "cost");
-  const costUsd = firstFiniteNumber(rawCost, ["total_usd", "cost_usd"]);
+  const costUsd = normalizedCostUsd(bundle);
 
   const detail: DetailResult = {
     result_id: resultId,
@@ -149,7 +149,7 @@ export async function parseLocalResultText(text: string, fileName = "local-resul
     tuning_validation_status: stringOrNull(tuning.validation_status),
     applied_receipt: null,
     tuning_policy_generation: stringOrNull(tuning.tuning_policy_generation),
-    test_type: stringOrNull(benchmark.test_type),
+    test_type: testType(bundle, benchmark),
     validation_status: validationStatus,
     cost_usd: costUsd,
     compliance_class: stringOrNull(benchmark.compliance_class),
@@ -182,10 +182,11 @@ function queryTimings(rawQueries: unknown[]): QueryTiming[] {
     if (runType !== null && !EXECUTION_RUN_TYPES.has(runType)) continue;
     const queryId = raw.id || raw.query_id || "";
     const duration = finiteNumberOrNull(raw.ms ?? raw.execution_time_ms) ?? 0;
+    const rawStatus = Object.prototype.hasOwnProperty.call(raw, "status") ? raw.status : "pass";
     timings.push({
       query_id: String(queryId),
       duration_ms: duration,
-      status: PASS_STATUSES.has(String(raw.status ?? "pass")) ? "pass" : "fail",
+      status: PASS_STATUSES.has(String(rawStatus)) ? "pass" : "fail",
       run_type: runType,
       iter: integerOrNull(raw.iter),
       stream: integerOrNull(raw.stream),
@@ -332,19 +333,70 @@ function driverVersion(bundle: JsonObject, platform: JsonObject): string | null 
   return firstString(execution, [
     "driver_version_actual", "driver_version_resolved", "driver_version_requested",
     "driver_actual_version", "driver_resolved_version", "driver_requested_version",
-  ]) ?? firstString(platform, ["driver_actual_version", "driver_resolved_version"]);
+  ]);
 }
 
-function validationStatusFor(summary: JsonObject, failedCount: number): string | null {
+function validationStatusFor(bundle: JsonObject, failedCount: number): string | null {
+  const summary = objectValue(bundle, "summary");
   const raw = summary.validation;
   const value = typeof raw === "string" ? raw : isObject(raw) ? raw.status : null;
   const normalized = stringOrNull(value)?.toLowerCase() ?? null;
-  if (failedCount > 0 && (normalized === null || normalized === "passed" || normalized === "pass")) return "partial";
+  if (failedCount > 0 && (normalized === null || normalized === "passed")) return "partial";
+  if ((normalized === null || normalized === "passed") && translationIsNonClean(bundle)) {
+    return "uncertain";
+  }
   return normalized;
 }
 
-function failedQueryCount(summary: JsonObject): number {
-  return integerOrNull(objectValue(summary, "queries").failed) ?? 0;
+function failedQueryCount(bundle: JsonObject): number {
+  const querySummary = objectValue(objectValue(bundle, "summary"), "queries");
+  const explicitFailed = exactIntegerOrNull(querySummary.failed);
+  if (explicitFailed !== null && explicitFailed > 0) return explicitFailed;
+
+  const total = exactIntegerOrNull(querySummary.total);
+  const passed = exactIntegerOrNull(querySummary.passed);
+  const skipped = exactIntegerOrNull(querySummary.skipped) ?? 0;
+  if (total !== null && passed !== null && total > passed + skipped) {
+    return Math.max(total - passed - skipped, 0);
+  }
+
+  if (!Array.isArray(bundle.queries)) return 0;
+  return bundle.queries.filter((query) => {
+    if (!isObject(query)) return false;
+    const runType = String(query.run_type || "measurement").toLowerCase();
+    if (runType !== "measurement" || query.status === null || query.status === undefined) return false;
+    return !NON_FAILED_QUERY_ROW_STATUSES.has(String(query.status).toUpperCase());
+  }).length;
+}
+
+function translationIsNonClean(bundle: JsonObject): boolean {
+  const raw = objectValue(bundle, "execution").translation;
+  const status = stringOrNull(isObject(raw) ? raw.status : raw)?.toLowerCase() ?? null;
+  return status === "fallback" || status === "failed";
+}
+
+function normalizedCostUsd(bundle: JsonObject): number | null {
+  const root = objectValue(bundle, "normalized_cost");
+  if (Object.keys(root).length > 0) return finiteNumberOrNull(root.normalized_cost_usd);
+
+  const cost = objectValue(bundle, "cost");
+  for (const key of ["normalized_cost", "normalized"]) {
+    const nested = objectValue(cost, key);
+    if (Object.keys(nested).length > 0) return finiteNumberOrNull(nested.normalized_cost_usd);
+  }
+  const hasNormalizedCostShape = [
+    "normalized_cost_usd", "cost_model_version", "cost_model_source", "cost_scope", "cost_status",
+  ].some((key) => Object.prototype.hasOwnProperty.call(cost, key));
+  return hasNormalizedCostShape ? finiteNumberOrNull(cost.normalized_cost_usd) : null;
+}
+
+function testType(bundle: JsonObject, benchmark: JsonObject): string | null {
+  const explicit = stringOrNull(benchmark.test_type);
+  if (explicit !== null) return explicit;
+  const phases = objectValue(bundle, "phases");
+  if (phases.power_test) return "power";
+  if (phases.throughput_test) return "throughput";
+  return null;
 }
 
 function rawMeasurementDurations(queries: QueryTiming[]): number[] {
@@ -364,16 +416,16 @@ function platformId(platformName: string): string {
     .replace(/[-_]trust[-_](ci|community|local|unknown)/gi, "")
     .trim()
     .toLowerCase()
-    .replace(/\s+/g, "-");
+    .replace(/ /g, "-");
 }
 
-async function localResultId(text: string): Promise<string> {
-  if (!globalThis.crypto?.subtle) {
+function localResultId(): string {
+  if (!globalThis.crypto?.getRandomValues) {
     throw new LocalResultImportError("This browser cannot create a private local preview ID.");
   }
-  const digest = await globalThis.crypto.subtle.digest("SHA-256", new TextEncoder().encode(text));
-  const hex = [...new Uint8Array(digest)].map((byte) => byte.toString(16).padStart(2, "0")).join("");
-  return `local-${hex.slice(0, 12)}`;
+  const bytes = globalThis.crypto.getRandomValues(new Uint8Array(6));
+  const token = [...bytes].map((byte) => byte.toString(16).padStart(2, "0")).join("");
+  return `local-${token}`;
 }
 
 function objectOrError(raw: unknown, message: string): JsonObject {
@@ -433,6 +485,14 @@ function finiteNumberOrNull(raw: unknown): number | null {
 function integerOrNull(raw: unknown): number | null {
   const value = finiteNumberOrNull(raw);
   return value === null ? null : Math.trunc(value);
+}
+
+function exactIntegerOrNull(raw: unknown): number | null {
+  if (typeof raw === "boolean") return Number(raw);
+  if (typeof raw === "number") return Number.isInteger(raw) ? raw : null;
+  if (typeof raw !== "string" || !/^[+-]?\d+$/.test(raw)) return null;
+  const value = Number(raw);
+  return Number.isSafeInteger(value) ? value : null;
 }
 
 function median(values: number[]): number | null {

--- a/results-explorer/src/lib/localResult.ts
+++ b/results-explorer/src/lib/localResult.ts
@@ -1,0 +1,461 @@
+import type { DetailResult, Environment, QueryDisplayTiming, QueryTiming } from "@/types";
+
+export const MAX_LOCAL_RESULT_BYTES = 50 * 1024 * 1024;
+
+const SUPPORTED_SCHEMA_VERSIONS = new Set(["2.0", "2.1", "2.2"]);
+const PASS_STATUSES = new Set(["SUCCESS", "PASS", "pass", "success"]);
+const EXECUTION_RUN_TYPES = new Set(["measurement", "warmup"]);
+const EXECUTION_MODES = new Set(["sql", "dataframe"]);
+const TUNING_MODES = new Set(["tuned", "tuned-fallback", "notuning", "auto", "custom"]);
+const FUNDING_SOURCES = new Set(["employer", "personal", "free-trial", "vendor-sponsored", "grant", "unspecified"]);
+const KNOWN_LOGICAL_QUERY_COUNTS: Record<string, number> = {
+  tpch: 22,
+  tpch_skew: 22,
+  tpchavoc: 22,
+  tpcds: 99,
+  ssb: 13,
+  star_schema: 13,
+  clickbench: 43,
+};
+
+type JsonObject = Record<string, unknown>;
+export type LocalPrimaryMetric = "power_score" | "display_geomean_ms";
+
+export interface LocalResultPreview {
+  detail: DetailResult;
+  fileName: string;
+  primaryMetric: LocalPrimaryMetric;
+}
+
+export class LocalResultImportError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "LocalResultImportError";
+  }
+}
+
+export async function importLocalResultFile(file: File): Promise<LocalResultPreview> {
+  if (!file.name.toLowerCase().endsWith(".json")) {
+    throw new LocalResultImportError("Choose a BenchBox result bundle in JSON format.");
+  }
+  if (file.size > MAX_LOCAL_RESULT_BYTES) {
+    throw new LocalResultImportError("This result is larger than the 50 MiB local preview limit.");
+  }
+  let text: string;
+  try {
+    text = await file.text();
+  } catch {
+    throw new LocalResultImportError("The selected file could not be read.");
+  }
+  return parseLocalResultText(text, file.name);
+}
+
+export async function parseLocalResultText(text: string, fileName = "local-result.json"): Promise<LocalResultPreview> {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(text);
+  } catch {
+    throw new LocalResultImportError("This file is not valid JSON.");
+  }
+  const bundle = objectOrError(parsed, "The JSON root must be an object.");
+  const version = requiredString(bundle.version, "version");
+  if (!SUPPORTED_SCHEMA_VERSIONS.has(version)) {
+    throw new LocalResultImportError(
+      `Schema ${version} is not supported. Local preview accepts BenchBox result schemas 2.0, 2.1, and 2.2.`,
+    );
+  }
+
+  const run = objectOrError(bundle.run, "The result is missing its run metadata.");
+  const benchmark = objectOrError(bundle.benchmark, "The result is missing its benchmark metadata.");
+  const platform = objectOrError(bundle.platform, "The result is missing its platform metadata.");
+  const summary = objectOrError(bundle.summary, "The result is missing its summary.");
+  if (!Array.isArray(bundle.queries)) {
+    throw new LocalResultImportError("The result is missing its query list.");
+  }
+
+  requiredString(run.id, "run.id");
+  const timestamp = requiredString(run.timestamp, "run.timestamp");
+  const benchmarkId = requiredString(benchmark.id, "benchmark.id");
+  const scaleFactor = requiredFiniteNumber(benchmark.scale_factor, "benchmark.scale_factor");
+  const platformName = requiredString(platform.name, "platform.name");
+  const totalDurationMs = requiredFiniteNumber(run.total_duration_ms, "run.total_duration_ms");
+  if (!isObject(summary.queries)) {
+    throw new LocalResultImportError("The result is missing summary.queries metadata.");
+  }
+
+  const queries = queryTimings(bundle.queries);
+  const displayTimings = buildDisplayTimings(queries);
+  const logicalQueryCount = inferLogicalQueryCount(bundle, benchmarkId, displayTimings);
+  const eligibility = timingEligibility(displayTimings, logicalQueryCount);
+  const powerScore = firstFiniteNumber(objectValue(summary, "tpc_metrics"), [
+    "power_at_size",
+    "qphh_at_size",
+    "qphds_at_size",
+  ]);
+  const resultId = await localResultId(text);
+  const validationStatus = validationStatusFor(summary, failedQueryCount(summary));
+  const environment = safeEnvironment(bundle.environment);
+  const clientFields = {
+    client_region: stringOrNull(environment.client_region),
+    client_cloud: stringOrNull(environment.client_cloud),
+    statement_overhead_min_ms: finiteNumberOrNull(environment.statement_overhead_min_ms),
+    statement_overhead_median_ms: finiteNumberOrNull(environment.statement_overhead_median_ms),
+    link_status: stringOrNull(environment.link_status),
+  };
+  const tuning = objectValue(platform, "tuning");
+  const logicalProfile = objectValue(tuning, "logical_profile");
+  const funding = fundingSource(bundle.provenance);
+  const rawCost = objectValue(bundle, "cost");
+  const costUsd = firstFiniteNumber(rawCost, ["total_usd", "cost_usd"]);
+
+  const detail: DetailResult = {
+    result_id: resultId,
+    benchmark: benchmarkId,
+    scale_factor: scaleFactor,
+    platform: platformName,
+    platform_id: platformId(platformName),
+    driver_version: driverVersion(bundle, platform),
+    run_date: timestamp.slice(0, 10),
+    total_duration_s: totalDurationMs / 1000,
+    geomean_ms: geometricMean(rawMeasurementDurations(queries)),
+    display_geomean_ms: geometricMean(
+      displayTimings.flatMap((timing) => timing.display_ms !== null && timing.display_ms > 0 ? [timing.display_ms] : []),
+    ),
+    power_score: powerScore,
+    has_display_timing: eligibility.validQueryCount > 0,
+    logical_query_count: logicalQueryCount,
+    valid_query_count: eligibility.validQueryCount,
+    missing_query_count: eligibility.missingQueryCount,
+    zero_timing_count: eligibility.zeroTimingCount,
+    display_exclusion_reason: eligibility.displayExclusionReason,
+    comparison_exclusion_reason: eligibility.comparisonExclusionReason,
+    ranking_exclusion_reason: "local_result",
+    environment,
+    queries,
+    display_timings: displayTimings,
+    has_plans: false,
+    plans_published: false,
+    has_tuning: false,
+    bundle_download_url: "",
+    trust_label: "local-run",
+    visibility: "local-preview",
+    funding,
+    platform_version: nonUnknownString(platform.version),
+    execution_mode: executionMode(bundle),
+    tuning_mode: tuningMode(bundle),
+    tuning_hash: null,
+    requested_config_hash: stringOrNull(tuning.requested_config_hash),
+    applied_ledger_hash: stringOrNull(tuning.applied_ledger_hash),
+    tuning_validation_status: stringOrNull(tuning.validation_status),
+    applied_receipt: null,
+    tuning_policy_generation: stringOrNull(tuning.tuning_policy_generation),
+    test_type: stringOrNull(benchmark.test_type),
+    validation_status: validationStatus,
+    cost_usd: costUsd,
+    compliance_class: stringOrNull(benchmark.compliance_class),
+    physical_mechanisms: Array.isArray(logicalProfile.physical_mechanisms)
+      ? logicalProfile.physical_mechanisms.map(String)
+      : undefined,
+    physical_rendering_id: stringOrNull(logicalProfile.physical_rendering_id),
+    ...clientFields,
+  };
+
+  return {
+    detail,
+    fileName,
+    primaryMetric: (benchmarkId === "tpch" || benchmarkId === "tpcds") && powerScore !== null
+      ? "power_score"
+      : "display_geomean_ms",
+  };
+}
+
+function queryTimings(rawQueries: unknown[]): QueryTiming[] {
+  const timings: QueryTiming[] = [];
+  for (const raw of rawQueries) {
+    if (!isObject(raw)) continue;
+    const rawRunType = raw.run_type;
+    const runType = rawRunType === null || rawRunType === undefined
+      ? null
+      : typeof rawRunType === "string"
+        ? rawRunType
+        : "invalid";
+    if (runType !== null && !EXECUTION_RUN_TYPES.has(runType)) continue;
+    const queryId = raw.id || raw.query_id || "";
+    const duration = finiteNumberOrNull(raw.ms ?? raw.execution_time_ms) ?? 0;
+    timings.push({
+      query_id: String(queryId),
+      duration_ms: duration,
+      status: PASS_STATUSES.has(String(raw.status ?? "pass")) ? "pass" : "fail",
+      run_type: runType,
+      iter: integerOrNull(raw.iter),
+      stream: integerOrNull(raw.stream),
+    });
+  }
+  return timings;
+}
+
+function buildDisplayTimings(timings: QueryTiming[]): QueryDisplayTiming[] {
+  const grouped = new Map<string, QueryTiming[]>();
+  for (const timing of timings) {
+    const current = grouped.get(timing.query_id) ?? [];
+    current.push(timing);
+    grouped.set(timing.query_id, current);
+  }
+  return [...grouped.entries()].map(([queryId, group]) => {
+    const passing = group.filter((timing) => timing.status === "pass");
+    const measurements = passing.filter((timing) => timing.run_type === "measurement");
+    const legacy = passing.filter((timing) => timing.run_type === null);
+    const candidates = measurements.length > 0 ? measurements : legacy;
+    const durations = candidates.map((timing) => timing.duration_ms).sort((a, b) => a - b);
+    const displayMs = median(durations);
+    return {
+      query_id: queryId,
+      display_ms: displayMs,
+      sample_count: candidates.length,
+      is_valid_display_timing: displayMs !== null && Number.isFinite(displayMs) && displayMs > 0,
+      timing_exclusion_reason: timingExclusionReason(displayMs),
+    };
+  });
+}
+
+function inferLogicalQueryCount(bundle: JsonObject, benchmarkId: string, timings: QueryDisplayTiming[]): number {
+  const rawQueries = Array.isArray(bundle.queries) ? bundle.queries : [];
+  let dataframeSkipTotal: number | null = null;
+  for (const raw of rawQueries) {
+    if (!isObject(raw) || !isObject(raw.dataframe_skip_summary)) continue;
+    const executed = integerOrNull(raw.dataframe_skip_summary.executed_total);
+    const skipped = integerOrNull(raw.dataframe_skip_summary.skipped_total);
+    if (executed !== null && skipped !== null && executed + skipped > (dataframeSkipTotal ?? 0)) {
+      dataframeSkipTotal = executed + skipped;
+    }
+  }
+  if (dataframeSkipTotal !== null) return dataframeSkipTotal;
+
+  const summary = objectValue(bundle, "summary");
+  const querySummary = objectValue(summary, "queries");
+  const rawCount = integerOrNull(querySummary.total) ?? 0;
+  const observedCount = new Set(timings.map((timing) => timing.query_id).filter(Boolean)).size;
+  if (observedCount <= 0) return rawCount;
+  if (rawCount <= observedCount) return rawCount || observedCount;
+  const knownCount = KNOWN_LOGICAL_QUERY_COUNTS[benchmarkId];
+  if (knownCount && observedCount <= knownCount && rawCount % knownCount === 0) return knownCount;
+  if (rawCount % observedCount === 0 && timings.some((timing) => timing.sample_count > 1)) return observedCount;
+  return rawCount;
+}
+
+function timingEligibility(timings: QueryDisplayTiming[], logicalCount: number) {
+  let validQueryCount = 0;
+  let missingQueryCount = 0;
+  let zeroTimingCount = 0;
+  const seen = new Set<string>();
+  for (const timing of timings) {
+    seen.add(timing.query_id);
+    const reason = timingExclusionReason(timing.display_ms);
+    if (reason === null) validQueryCount += 1;
+    else if (reason === "zero_timing") zeroTimingCount += 1;
+    else missingQueryCount += 1;
+  }
+  missingQueryCount += Math.max(logicalCount - seen.size, 0);
+  let displayExclusionReason: string | null = null;
+  if (validQueryCount === 0) {
+    if (logicalCount <= 0) displayExclusionReason = "no_queries";
+    else if (zeroTimingCount > 0 && missingQueryCount === 0) displayExclusionReason = "zero_timings_only";
+    else if (missingQueryCount > 0 && zeroTimingCount === 0) displayExclusionReason = "missing_timings";
+    else displayExclusionReason = "no_valid_display_timing";
+  }
+  let comparisonExclusionReason = displayExclusionReason;
+  if (comparisonExclusionReason === null && validQueryCount < 2) comparisonExclusionReason = "insufficient_valid_queries";
+  if (comparisonExclusionReason === null && logicalCount > 0 && validQueryCount * 2 < logicalCount) {
+    comparisonExclusionReason = "insufficient_query_coverage";
+  }
+  return { validQueryCount, missingQueryCount, zeroTimingCount, displayExclusionReason, comparisonExclusionReason };
+}
+
+function safeEnvironment(raw: unknown): Environment {
+  const source = isObject(raw) ? raw : {};
+  const environment: Environment = {};
+  for (const key of ["os", "arch", "python", "cpu_model", "cpu_family"] as const) {
+    const value = stringOrNull(source[key]);
+    if (value !== null) environment[key] = value;
+  }
+  for (const key of ["cpu_count", "memory_gb"] as const) {
+    const value = finiteNumberOrNull(source[key]);
+    if (value !== null) environment[key] = value;
+  }
+  const provenance = stringOrNull(source.cpu_identity_provenance);
+  if (provenance === "measured" || provenance === "user_attested" || provenance === "inferred") {
+    environment.cpu_identity_provenance = provenance;
+  }
+  const clientLink = objectValue(source, "client_link");
+  const overhead = objectValue(clientLink, "statement_overhead_ms");
+  environment.client_region = stringOrNull(clientLink.client_region);
+  environment.client_cloud = stringOrNull(clientLink.client_cloud);
+  environment.link_status = stringOrNull(clientLink.collection_status);
+  environment.statement_overhead_min_ms = finiteNumberOrNull(overhead.min);
+  environment.statement_overhead_median_ms = finiteNumberOrNull(overhead.median);
+  return environment;
+}
+
+function executionMode(bundle: JsonObject): string | null {
+  const candidates = [
+    objectValue(bundle, "config").execution_mode,
+    objectValue(objectValue(bundle, "platform"), "config").execution_mode,
+    objectValue(bundle, "config").mode,
+    objectValue(bundle, "execution").execution_mode,
+  ];
+  for (const raw of candidates) {
+    const value = stringOrNull(raw)?.toLowerCase() ?? null;
+    if (value !== null && EXECUTION_MODES.has(value)) return value;
+  }
+  return null;
+}
+
+function tuningMode(bundle: JsonObject): string | null {
+  for (const raw of [objectValue(bundle, "config").tuning_mode, objectValue(bundle, "execution").tuning_mode]) {
+    const value = stringOrNull(raw);
+    if (value !== null && TUNING_MODES.has(value)) return value;
+  }
+  return null;
+}
+
+function driverVersion(bundle: JsonObject, platform: JsonObject): string | null {
+  const execution = objectValue(bundle, "execution");
+  const isDuckDb = stringOrNull(platform.name)?.toLowerCase() === "duckdb";
+  if (isDuckDb) {
+    const resolved = firstString(execution, [
+      "driver_version_resolved", "driver_version_requested", "driver_resolved_version", "driver_requested_version",
+    ]);
+    if (resolved !== null) return resolved;
+    const clientVersion = nonUnknownString(platform.client_version);
+    if (clientVersion !== null) return clientVersion;
+  }
+  return firstString(execution, [
+    "driver_version_actual", "driver_version_resolved", "driver_version_requested",
+    "driver_actual_version", "driver_resolved_version", "driver_requested_version",
+  ]) ?? firstString(platform, ["driver_actual_version", "driver_resolved_version"]);
+}
+
+function validationStatusFor(summary: JsonObject, failedCount: number): string | null {
+  const raw = summary.validation;
+  const value = typeof raw === "string" ? raw : isObject(raw) ? raw.status : null;
+  const normalized = stringOrNull(value)?.toLowerCase() ?? null;
+  if (failedCount > 0 && (normalized === null || normalized === "passed" || normalized === "pass")) return "partial";
+  return normalized;
+}
+
+function failedQueryCount(summary: JsonObject): number {
+  return integerOrNull(objectValue(summary, "queries").failed) ?? 0;
+}
+
+function rawMeasurementDurations(queries: QueryTiming[]): number[] {
+  return queries
+    .filter((query) => query.run_type !== "warmup" && query.duration_ms > 0)
+    .map((query) => query.duration_ms);
+}
+
+function fundingSource(raw: unknown): string {
+  const provenance = isObject(raw) ? raw : {};
+  const token = stringOrNull(provenance.funding)?.toLowerCase() ?? "unspecified";
+  return FUNDING_SOURCES.has(token) ? token : "unspecified";
+}
+
+function platformId(platformName: string): string {
+  return platformName
+    .replace(/[-_]trust[-_](ci|community|local|unknown)/gi, "")
+    .trim()
+    .toLowerCase()
+    .replace(/\s+/g, "-");
+}
+
+async function localResultId(text: string): Promise<string> {
+  if (!globalThis.crypto?.subtle) {
+    throw new LocalResultImportError("This browser cannot create a private local preview ID.");
+  }
+  const digest = await globalThis.crypto.subtle.digest("SHA-256", new TextEncoder().encode(text));
+  const hex = [...new Uint8Array(digest)].map((byte) => byte.toString(16).padStart(2, "0")).join("");
+  return `local-${hex.slice(0, 12)}`;
+}
+
+function objectOrError(raw: unknown, message: string): JsonObject {
+  if (!isObject(raw)) throw new LocalResultImportError(message);
+  return raw;
+}
+
+function requiredString(raw: unknown, field: string): string {
+  const value = stringOrNull(raw);
+  if (value === null) throw new LocalResultImportError(`The result is missing ${field}.`);
+  return value;
+}
+
+function requiredFiniteNumber(raw: unknown, field: string): number {
+  const value = finiteNumberOrNull(raw);
+  if (value === null) throw new LocalResultImportError(`The result has an invalid ${field}.`);
+  return value;
+}
+
+function objectValue(raw: JsonObject, key: string): JsonObject {
+  return isObject(raw[key]) ? raw[key] : {};
+}
+
+function firstFiniteNumber(raw: JsonObject, keys: string[]): number | null {
+  for (const key of keys) {
+    const value = finiteNumberOrNull(raw[key]);
+    if (value !== null) return value;
+  }
+  return null;
+}
+
+function firstString(raw: JsonObject, keys: string[]): string | null {
+  for (const key of keys) {
+    const value = stringOrNull(raw[key]);
+    if (value !== null) return value;
+  }
+  return null;
+}
+
+function nonUnknownString(raw: unknown): string | null {
+  const value = stringOrNull(raw);
+  return value !== null && value.toLowerCase() !== "unknown" ? value : null;
+}
+
+function stringOrNull(raw: unknown): string | null {
+  if (raw === null || raw === undefined) return null;
+  const value = String(raw).trim();
+  return value || null;
+}
+
+function finiteNumberOrNull(raw: unknown): number | null {
+  if (raw === null || raw === undefined || raw === "") return null;
+  const value = typeof raw === "number" ? raw : Number(raw);
+  return Number.isFinite(value) ? value : null;
+}
+
+function integerOrNull(raw: unknown): number | null {
+  const value = finiteNumberOrNull(raw);
+  return value === null ? null : Math.trunc(value);
+}
+
+function median(values: number[]): number | null {
+  if (values.length === 0) return null;
+  const middle = Math.floor(values.length / 2);
+  if (values.length % 2 === 1) return values[middle] ?? null;
+  return ((values[middle - 1] ?? 0) + (values[middle] ?? 0)) / 2;
+}
+
+function geometricMean(values: number[]): number | null {
+  const positive = values.filter((value) => Number.isFinite(value) && value > 0);
+  if (positive.length === 0) return null;
+  return Math.exp(positive.reduce((sum, value) => sum + Math.log(value), 0) / positive.length);
+}
+
+function timingExclusionReason(value: number | null): string | null {
+  if (value === null) return "missing_timing";
+  if (!Number.isFinite(value)) return "invalid_timing";
+  if (value === 0) return "zero_timing";
+  if (value < 0) return "non_positive_timing";
+  return null;
+}
+
+function isObject(raw: unknown): raw is JsonObject {
+  return typeof raw === "object" && raw !== null && !Array.isArray(raw);
+}

--- a/results-explorer/src/lib/localResultState.ts
+++ b/results-explorer/src/lib/localResultState.ts
@@ -1,0 +1,37 @@
+import { createContext, createElement, type ComponentChildren } from "preact";
+import { useContext, useMemo, useState } from "preact/hooks";
+import { importLocalResultFile, type LocalResultPreview } from "@/lib/localResult";
+
+export interface LocalResultStateValue {
+  preview: LocalResultPreview | null;
+  importFile: (file: File) => Promise<LocalResultPreview>;
+  clear: () => void;
+}
+
+const MISSING_PROVIDER_STATE: LocalResultStateValue = {
+  preview: null,
+  importFile: async () => {
+    throw new Error("Local result import is unavailable outside LocalResultProvider");
+  },
+  clear: () => undefined,
+};
+
+const LocalResultContext = createContext<LocalResultStateValue>(MISSING_PROVIDER_STATE);
+
+export function LocalResultProvider({ children }: { children: ComponentChildren }) {
+  const [preview, setPreview] = useState<LocalResultPreview | null>(null);
+  const value = useMemo<LocalResultStateValue>(() => ({
+    preview,
+    importFile: async (file) => {
+      const nextPreview = await importLocalResultFile(file);
+      setPreview(nextPreview);
+      return nextPreview;
+    },
+    clear: () => setPreview(null),
+  }), [preview]);
+  return createElement(LocalResultContext.Provider, { value }, children);
+}
+
+export function useLocalResultState(): LocalResultStateValue {
+  return useContext(LocalResultContext);
+}

--- a/results-explorer/src/pages/ResultDetail.tsx
+++ b/results-explorer/src/pages/ResultDetail.tsx
@@ -60,6 +60,12 @@ export function ResultDetail({ resultId = "", source = "public" }: ResultDetailP
   const [tuningError, setTuningError] = useState<string | null>(null);
   const tuningAbortRef = useRef<AbortController | null>(null);
   const localResultState = useLocalResultState();
+  let picking: ReturnType<typeof usePickingState> | null = null;
+  try {
+    picking = usePickingState();
+  } catch {
+    // Unit tests may not wrap with provider.
+  }
   const isLocal = source === "local";
   const detail = detailState?.detail ?? null;
   const primaryMetric = detailState?.primaryMetric ?? "display_geomean_ms";

--- a/results-explorer/src/pages/ResultDetail.tsx
+++ b/results-explorer/src/pages/ResultDetail.tsx
@@ -60,12 +60,6 @@ export function ResultDetail({ resultId = "", source = "public" }: ResultDetailP
   const [tuningError, setTuningError] = useState<string | null>(null);
   const tuningAbortRef = useRef<AbortController | null>(null);
   const localResultState = useLocalResultState();
-  let picking: ReturnType<typeof usePickingState> | null = null;
-  try {
-    picking = usePickingState();
-  } catch {
-    // Unit tests may not wrap with provider.
-  }
   const isLocal = source === "local";
   const detail = detailState?.detail ?? null;
   const primaryMetric = detailState?.primaryMetric ?? "display_geomean_ms";

--- a/results-explorer/src/pages/ResultDetail.tsx
+++ b/results-explorer/src/pages/ResultDetail.tsx
@@ -23,9 +23,12 @@ import { useDocumentTitle } from "@/lib/useDocumentTitle";
 import { formatEnumLabel, formatTrustLabel, formatValidationStatus } from "@/lib/displayLabels";
 import { formatDurationSeconds, formatLatencyMs } from "@/lib/metricFormatters";
 import { visibleResultIdForRow } from "@/lib/resultLinks";
+import { useLocalResultState } from "@/lib/localResultState";
+import { LocalResultPicker } from "@/components/LocalResultPicker";
 
 interface ResultDetailProps extends RoutableProps {
   resultId?: string;
+  source?: "public" | "local";
 }
 
 type MedianSortKey = "query_id" | "display_ms" | "sample_count";
@@ -37,7 +40,7 @@ interface DetailState {
   primaryMetric: PrimaryMetric;
 }
 
-export function ResultDetail({ resultId = "" }: ResultDetailProps) {
+export function ResultDetail({ resultId = "", source = "public" }: ResultDetailProps) {
   const timingsScrollerRef = useRef<HTMLDivElement>(null);
   const samplesScrollerRef = useRef<HTMLDivElement>(null);
   const [detailState, setDetailState] = useState<DetailState | null>(null);
@@ -56,6 +59,8 @@ export function ResultDetail({ resultId = "" }: ResultDetailProps) {
   const [tuningLoading, setTuningLoading] = useState(false);
   const [tuningError, setTuningError] = useState<string | null>(null);
   const tuningAbortRef = useRef<AbortController | null>(null);
+  const localResultState = useLocalResultState();
+  const isLocal = source === "local";
   const detail = detailState?.detail ?? null;
   const primaryMetric = detailState?.primaryMetric ?? "display_geomean_ms";
   const documentTitle = detail
@@ -77,6 +82,19 @@ export function ResultDetail({ resultId = "" }: ResultDetailProps) {
     tuningAbortRef.current?.abort();
     tuningAbortRef.current = null;
     let cancelled = false;
+    if (isLocal) {
+      const preview = localResultState.preview;
+      if (preview?.detail.result_id !== resultId) {
+        setError("This local preview is no longer available. Open the result file again to restore it.");
+      } else {
+        setDetailState({ detail: preview.detail, primaryMetric: preview.primaryMetric });
+      }
+      return () => {
+        cancelled = true;
+        tuningAbortRef.current?.abort();
+        tuningAbortRef.current = null;
+      };
+    }
     resolveShortId(resultId)
       .then(async (resolvedId) => {
         if (cancelled) return null;
@@ -101,7 +119,7 @@ export function ResultDetail({ resultId = "" }: ResultDetailProps) {
       tuningAbortRef.current?.abort();
       tuningAbortRef.current = null;
     };
-  }, [resultId]);
+  }, [isLocal, localResultState.preview, resultId]);
 
   // Hooks must run in the same order on every render - compute memos before
   // any conditional return, guarding inside the factory for the null case.
@@ -145,10 +163,11 @@ export function ResultDetail({ resultId = "" }: ResultDetailProps) {
   if (error) {
     return (
       <div class="mx-auto max-w-7xl px-4 py-8 sm:px-6 lg:px-8">
-        <Breadcrumb crumbs={[{ label: "Results", href: "/results/" }, { label: "Result detail" }]} />
+        <Breadcrumb crumbs={[{ label: "Results", href: "/results/" }, { label: isLocal ? "Local preview" : "Result detail" }]} />
         <div class="mt-8">
           <ErrorMessage message={error} />
           <div class="mt-4 flex flex-wrap gap-2">
+            {isLocal && <LocalResultPicker label="Open result file again" />}
             <a href="/results/query" class="btn btn-primary no-underline">Find runs</a>
             <a href="/results/benchmarks/" class="btn btn-secondary no-underline">Browse benchmarks</a>
           </div>
@@ -241,12 +260,29 @@ export function ResultDetail({ resultId = "" }: ResultDetailProps) {
   return (
     <div class="mx-auto max-w-7xl px-4 py-8 sm:px-6 lg:px-8">
       <Breadcrumb
-        crumbs={[
-          { label: "Results", href: "/results/" },
-          { label: benchmarkLabel, href: `/results/${detail.benchmark}/` },
-          { label: detail.platform },
-        ]}
+        crumbs={isLocal
+          ? [{ label: "Results", href: "/results/" }, { label: "Local preview" }, { label: detail.platform }]
+          : [
+              { label: "Results", href: "/results/" },
+              { label: benchmarkLabel, href: `/results/${detail.benchmark}/` },
+              { label: detail.platform },
+            ]}
       />
+
+      {isLocal && (
+        <aside
+          role="status"
+          class="mt-6 rounded-lg border border-[var(--bb-data-border-strong)] bg-[var(--bb-tone-info-bg)] p-4 text-sm text-[var(--bb-tone-info-fg)]"
+          data-testid="local-result-banner"
+          aria-label="Local result preview"
+        >
+          <p class="font-semibold">Local preview</p>
+          <p class="mt-1">
+            Viewing <span class="font-medium">{localResultState.preview?.fileName}</span> in this browser tab. This result
+            has not been uploaded, reviewed, or added to the public rankings.
+          </p>
+        </aside>
+      )}
 
       <section aria-label="Result summary" class="mt-6 mb-8 panel-elevated p-5">
         <div class="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
@@ -272,21 +308,36 @@ export function ResultDetail({ resultId = "" }: ResultDetailProps) {
             </div>
             <p class="text-sm text-[var(--bb-data-fg-muted)]">
               This {benchmarkLabel} run used scale factor {detail.scale_factor} for the {detail.test_type ? formatEnumLabel(detail.test_type) : "standard"} phase on{" "}
-              {detail.run_date.slice(0, 10)} · Public ID{" "}
+              {detail.run_date.slice(0, 10)} · {isLocal ? "Local preview ID" : "Public ID"}{" "}
               <code class="font-mono text-[var(--bb-data-fg-primary)]">{visibleResultIdForRow(detail)}</code>
             </p>
           </div>
           <div class="flex flex-wrap gap-2">
-            <a href={`/results/query?pick=${encodeURIComponent(detail.result_id)}`} class="btn btn-primary" data-testid="result-detail-compare-link">
-              Find a run to compare
-            </a>
-            <a href={detail.bundle_download_url} class="btn btn-secondary" download>
-              Download bundle
-            </a>
-            {detail.has_plans && plansUrl && (
-              <a href={plansUrl} class="btn btn-secondary" download>
-                Download plans
-              </a>
+            {isLocal ? (
+              <>
+                <LocalResultPicker label="Open another result" />
+                <a
+                  href="/docs/contributing-results.html"
+                  referrerPolicy="no-referrer"
+                  class="btn btn-primary no-underline"
+                >
+                  Submit for public review
+                </a>
+              </>
+            ) : (
+              <>
+                <a href={`/results/query?pick=${encodeURIComponent(detail.result_id)}`} class="btn btn-primary" data-testid="result-detail-compare-link">
+                  Find a run to compare
+                </a>
+                <a href={detail.bundle_download_url} class="btn btn-secondary" download>
+                  Download bundle
+                </a>
+                {detail.has_plans && plansUrl && (
+                  <a href={plansUrl} class="btn btn-secondary" download>
+                    Download plans
+                  </a>
+                )}
+              </>
             )}
           </div>
         </div>
@@ -380,7 +431,11 @@ export function ResultDetail({ resultId = "" }: ResultDetailProps) {
             <ChartPanel context={chartContext} />
           )}
 
-          <RunReceipt detail={detail} />
+          <RunReceipt
+            detail={detail}
+            isRankingEligible={isLocal ? false : null}
+            reproduceCommand={isLocal ? null : undefined}
+          />
 
           {hasTimings && (
             <section class="card">
@@ -431,7 +486,7 @@ export function ResultDetail({ resultId = "" }: ResultDetailProps) {
             {detail.queries.length > 0 && (
               <>
               <PassStrip queries={detail.queries} />
-              {withinRunBases !== null && (
+              {!isLocal && withinRunBases !== null && (
                 <p class="mb-6 text-sm">
                   <a
                     class="link"

--- a/results-explorer/src/pages/__tests__/LocalResultDetail.test.tsx
+++ b/results-explorer/src/pages/__tests__/LocalResultDetail.test.tsx
@@ -89,6 +89,10 @@ describe("local ResultDetail", () => {
       "href",
       "/docs/contributing-results.html",
     );
+    expect(screen.getByRole("link", { name: "Submit for public review" })).toHaveAttribute(
+      "referrerpolicy",
+      "no-referrer",
+    );
     expect(screen.getByRole("button", { name: "Open another result" })).toBeTruthy();
     expect(screen.queryByText("Compare this result")).toBeNull();
     expect(screen.queryByText("Add to comparison")).toBeNull();

--- a/results-explorer/src/pages/__tests__/LocalResultDetail.test.tsx
+++ b/results-explorer/src/pages/__tests__/LocalResultDetail.test.tsx
@@ -1,0 +1,108 @@
+import { render, screen, waitFor } from "@testing-library/preact";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { DetailResult } from "@/types";
+
+const localState = vi.hoisted(() => ({ preview: null as null | { detail: DetailResult; fileName: string; primaryMetric: "power_score" } }));
+
+vi.mock("@/lib/localResultState", () => ({
+  useLocalResultState: () => ({
+    preview: localState.preview,
+    importFile: vi.fn(),
+    clear: vi.fn(),
+  }),
+}));
+
+vi.mock("@/lib/duckdbQueries", async () => {
+  const actual = await vi.importActual<typeof import("@/lib/duckdbQueries")>("@/lib/duckdbQueries");
+  return {
+    ...actual,
+    getDetailResult: vi.fn(),
+    getPrimaryMetricForBenchmark: vi.fn(),
+  };
+});
+
+import { getDetailResult, getPrimaryMetricForBenchmark } from "@/lib/duckdbQueries";
+import { ResultDetail } from "@/pages/ResultDetail";
+
+function localDetail(): DetailResult {
+  return {
+    result_id: "local-aabbccddeeff",
+    benchmark: "tpch",
+    scale_factor: 1,
+    platform: "DuckDB",
+    platform_id: "duckdb",
+    driver_version: "1.4.3",
+    run_date: "2026-09-05",
+    total_duration_s: 4,
+    geomean_ms: 20,
+    display_geomean_ms: 20,
+    power_score: 1234,
+    has_display_timing: true,
+    logical_query_count: 2,
+    valid_query_count: 2,
+    missing_query_count: 0,
+    zero_timing_count: 0,
+    display_exclusion_reason: null,
+    comparison_exclusion_reason: null,
+    ranking_exclusion_reason: "local_result",
+    environment: { os: "macOS" },
+    queries: [
+      { query_id: "1", duration_ms: 10, status: "pass", run_type: "measurement", iter: 1, stream: null },
+      { query_id: "2", duration_ms: 40, status: "pass", run_type: "measurement", iter: 1, stream: null },
+    ],
+    display_timings: [
+      { query_id: "1", display_ms: 10, sample_count: 1, is_valid_display_timing: true, timing_exclusion_reason: null },
+      { query_id: "2", display_ms: 40, sample_count: 1, is_valid_display_timing: true, timing_exclusion_reason: null },
+    ],
+    has_plans: false,
+    plans_published: false,
+    has_tuning: false,
+    bundle_download_url: "",
+    trust_label: "local-run",
+    visibility: "local-preview",
+    funding: "unspecified",
+    platform_version: "1.4.3",
+    execution_mode: "sql",
+    tuning_mode: null,
+    tuning_hash: null,
+    test_type: "power",
+    validation_status: "passed",
+    cost_usd: null,
+    compliance_class: null,
+  };
+}
+
+describe("local ResultDetail", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    localState.preview = { detail: localDetail(), fileName: "run.json", primaryMetric: "power_score" };
+  });
+
+  it("reuses detail rendering with local provenance and submission actions", async () => {
+    render(<ResultDetail resultId="local-aabbccddeeff" source="local" />);
+    await waitFor(() => expect(screen.queryByText("Loading result...")).toBeNull());
+
+    expect(screen.getByTestId("local-result-banner")).toHaveTextContent("has not been uploaded");
+    expect(screen.getByText("Local", { selector: "span" })).toBeTruthy();
+    expect(screen.getByText(/Local preview ID/)).toBeTruthy();
+    expect(screen.getByRole("link", { name: "Submit for public review" })).toHaveAttribute(
+      "href",
+      "/docs/contributing-results.html",
+    );
+    expect(screen.getByRole("button", { name: "Open another result" })).toBeTruthy();
+    expect(screen.queryByText("Compare this result")).toBeNull();
+    expect(screen.queryByText("Add to comparison")).toBeNull();
+    expect(screen.queryByText("Download bundle")).toBeNull();
+    expect(screen.queryByTestId("within-run-compare-link")).toBeNull();
+    expect(getDetailResult).not.toHaveBeenCalled();
+    expect(getPrimaryMetricForBenchmark).not.toHaveBeenCalled();
+  });
+
+  it("asks for the file again after a reload loses memory state", async () => {
+    localState.preview = null;
+    render(<ResultDetail resultId="local-aabbccddeeff" source="local" />);
+
+    expect(await screen.findByRole("alert")).toHaveTextContent("no longer available");
+    expect(screen.getByRole("button", { name: "Open result file again" })).toBeTruthy();
+  });
+});


### PR DESCRIPTION
## Summary

- add an **Open local result** control to the existing Results Explorer navigation
- adapt BenchBox schema 2.0-2.2 result bundles into the Explorer detail read model entirely in the browser
- reuse the existing result-detail renderer at a local-only route, with clear local, unreviewed, and unranked indicators
- link local previews to the existing public-submission guide

The bundle and its raw metadata remain in the browser tab. Local previews are not uploaded, persisted, added to public rankings, exposed to comparison tools, or offered as downloadable public artifacts. Only an allowlist of environment fields reaches the rendered model.

## Verification

- `npm run typecheck`
- `npm run typecheck:e2e`
- `npm test`
- `npx playwright test --project=chromium --workers=1 e2e/routes/local-result-preview.spec.ts e2e/routes/result-detail.spec.ts`
- `uv run -- python -m pytest tests/unit/scripts/test_e2e_specs_have_no_hardcoded_ids.py -q`
