### PR TITLE
feat(publication): implement canonical transaction state machine and journal CAS

### DIFF
--- a/scripts/publication/journal.py
+++ b/scripts/publication/journal.py
@@ -1,0 +1,253 @@
+#!/usr/bin/env python3
+"""Single state authority and Git journal CAS on the publication metadata ref.
+
+Manages reading, preparing, and fast-forward compare-and-set updates on the
+`publication` Git ref under the `publication/transaction-state/` subtree.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import tempfile
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any
+
+from scripts.publication.transaction import Transaction, canonical_json
+
+JOURNAL_OBJECT_TYPE = "publication-journal"
+JOURNAL_SCHEMA_VERSION = 1
+SUBTREE_PATH = "publication/transaction-state"
+DEFAULT_REF = "publication"
+
+
+class JournalError(Exception):
+    """Base exception for journal operations."""
+
+
+class CasConflictError(JournalError):
+    """Raised when an atomic CAS update fails due to a competing commit."""
+
+
+class CorruptJournalError(JournalError):
+    """Raised when journal state is missing or malformed."""
+
+
+@dataclass(frozen=True)
+class JournalState:
+    target: dict[str, str]
+    next_generation: int
+    active_transaction_id: str | None
+    durable_transaction_id: str | None
+    write_block: str | None
+    policy_digest: str
+    tip_commit_oid: str
+    object_type: str = JOURNAL_OBJECT_TYPE
+    journal_schema_version: int = JOURNAL_SCHEMA_VERSION
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+def _run_git(args: list[str], cwd: Path, env: dict[str, str] | None = None) -> str:
+    proc = subprocess.run(
+        ["git", *args],
+        cwd=cwd,
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if proc.returncode != 0:
+        raise JournalError(f"git {' '.join(args)} failed (rc={proc.returncode}): {proc.stderr.strip()}")
+    return proc.stdout.strip()
+
+
+def read_journal_state(repo_path: Path, ref: str = DEFAULT_REF) -> JournalState:
+    """Read the current journal state.json directly from the given Git ref."""
+    try:
+        tip_oid = _run_git(["rev-parse", f"refs/heads/{ref}"], cwd=repo_path)
+    except JournalError as e:
+        raise CorruptJournalError(f"Cannot resolve journal ref '{ref}': {e}") from e
+
+    state_path = f"{ref}:{SUBTREE_PATH}/state.json"
+    try:
+        content = _run_git(["cat-file", "-p", state_path], cwd=repo_path)
+        data = json.loads(content)
+    except Exception as e:
+        raise CorruptJournalError(f"Missing or invalid state.json at {state_path}: {e}") from e
+
+    if data.get("object_type") != JOURNAL_OBJECT_TYPE:
+        raise CorruptJournalError(
+            f"Invalid journal object_type: expected '{JOURNAL_OBJECT_TYPE}', got '{data.get('object_type')}'"
+        )
+    if data.get("journal_schema_version") != JOURNAL_SCHEMA_VERSION:
+        raise CorruptJournalError(
+            f"Unsupported journal schema version: expected {JOURNAL_SCHEMA_VERSION}, got {data.get('journal_schema_version')}"
+        )
+
+    return JournalState(
+        target=data["target"],
+        next_generation=data["next_generation"],
+        active_transaction_id=data.get("active_transaction_id"),
+        durable_transaction_id=data.get("durable_transaction_id"),
+        write_block=data.get("write_block"),
+        policy_digest=data["policy_digest"],
+        tip_commit_oid=tip_oid,
+        object_type=data["object_type"],
+        journal_schema_version=data["journal_schema_version"],
+    )
+
+
+def read_transaction(repo_path: Path, tx_id: str, ref: str = DEFAULT_REF) -> Transaction:
+    """Read a canonical transaction object directly from the journal ref."""
+    tx_path = f"{ref}:{SUBTREE_PATH}/transactions/{tx_id}.json"
+    try:
+        content = _run_git(["cat-file", "-p", tx_path], cwd=repo_path)
+        data = json.loads(content)
+        return Transaction(**data)
+    except Exception as e:
+        raise JournalError(f"Failed to read transaction '{tx_id}' at {tx_path}: {e}") from e
+
+
+def write_journal_update(
+    repo_path: Path,
+    expected_parent_oid: str,
+    new_state: JournalState,
+    transaction: Transaction | None = None,
+    ref: str = DEFAULT_REF,
+    commit_message: str | None = None,
+) -> tuple[JournalState, str]:
+    """Atomically commit and fast-forward CAS a journal state update."""
+    with tempfile.NamedTemporaryFile(delete=False) as tmp_idx:
+        index_file = tmp_idx.name
+
+    env = dict(os.environ, GIT_INDEX_FILE=index_file)
+    try:
+        # 1. Initialize temporary index from parent commit tree
+        _run_git(["read-tree", expected_parent_oid], cwd=repo_path, env=env)
+
+        # 2. Write state.json blob
+        state_data = new_state.to_dict()
+        state_data.pop("tip_commit_oid", None)
+        state_bytes = canonical_json(state_data).encode("utf-8")
+
+        p_state = subprocess.run(
+            ["git", "hash-object", "-w", "--stdin"],
+            cwd=repo_path,
+            input=state_bytes,
+            capture_output=True,
+            check=True,
+        )
+        state_blob_oid = p_state.stdout.strip().decode()
+
+        _run_git(
+            ["update-index", "--add", "--cacheinfo", "100644", state_blob_oid, f"{SUBTREE_PATH}/state.json"],
+            cwd=repo_path,
+            env=env,
+        )
+
+        # 3. Write transaction blob if provided
+        if transaction is not None:
+            tx_bytes = canonical_json(transaction.to_dict()).encode("utf-8")
+            p_tx = subprocess.run(
+                ["git", "hash-object", "-w", "--stdin"],
+                cwd=repo_path,
+                input=tx_bytes,
+                capture_output=True,
+                check=True,
+            )
+            tx_blob_oid = p_tx.stdout.strip().decode()
+            _run_git(
+                [
+                    "update-index",
+                    "--add",
+                    "--cacheinfo",
+                    "100644",
+                    tx_blob_oid,
+                    f"{SUBTREE_PATH}/transactions/{transaction.transaction_id}.json",
+                ],
+                cwd=repo_path,
+                env=env,
+            )
+
+        # 4. Write new tree
+        tree_oid = _run_git(["write-tree"], cwd=repo_path, env=env)
+
+        # 5. Create commit pointing to expected_parent_oid
+        msg = commit_message or f"journal: advance state to gen {new_state.next_generation}"
+        commit_oid = _run_git(
+            ["commit-tree", tree_oid, "-p", expected_parent_oid, "-m", msg],
+            cwd=repo_path,
+        )
+
+        # 6. Fast-forward atomic CAS update on refs/heads/{ref}
+        p_update = subprocess.run(
+            ["git", "update-ref", f"refs/heads/{ref}", commit_oid, expected_parent_oid],
+            cwd=repo_path,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        if p_update.returncode != 0:
+            raise CasConflictError(
+                f"CAS update on ref '{ref}' failed (expected {expected_parent_oid}): {p_update.stderr.strip()}"
+            )
+
+        updated_state = JournalState(
+            target=new_state.target,
+            next_generation=new_state.next_generation,
+            active_transaction_id=new_state.active_transaction_id,
+            durable_transaction_id=new_state.durable_transaction_id,
+            write_block=new_state.write_block,
+            policy_digest=new_state.policy_digest,
+            tip_commit_oid=commit_oid,
+            object_type=new_state.object_type,
+            journal_schema_version=new_state.journal_schema_version,
+        )
+        return updated_state, commit_oid
+
+    finally:
+        if os.path.exists(index_file):
+            try:
+                os.unlink(index_file)
+            except OSError:
+                pass
+
+
+def init_genesis_journal(
+    repo_path: Path,
+    target: dict[str, str],
+    genesis_transaction: Transaction,
+    base_commit_oid: str,
+    ref: str = DEFAULT_REF,
+) -> tuple[JournalState, str]:
+    """Initialize a fresh publication journal at genesis referencing an attested known-good transaction."""
+    init_state = JournalState(
+        target=target,
+        next_generation=genesis_transaction.generation + 1,
+        active_transaction_id=None,
+        durable_transaction_id=genesis_transaction.transaction_id,
+        write_block=None,
+        policy_digest="genesis",
+        tip_commit_oid=base_commit_oid,
+    )
+    return write_journal_update(
+        repo_path=repo_path,
+        expected_parent_oid=base_commit_oid,
+        new_state=init_state,
+        transaction=genesis_transaction,
+        ref=ref,
+        commit_message=f"journal: initialize genesis at generation {genesis_transaction.generation}",
+    )
+
+
+def resolve_timeout_or_recheck(repo_path: Path, proposed_commit_oid: str, ref: str = DEFAULT_REF) -> bool:
+    """Resolve an ambiguous network or API timeout by re-checking whether the proposed commit won."""
+    try:
+        current_oid = _run_git(["rev-parse", f"refs/heads/{ref}"], cwd=repo_path)
+        return current_oid == proposed_commit_oid
+    except Exception:
+        return False

--- a/scripts/publication/journal.py
+++ b/scripts/publication/journal.py
@@ -15,7 +15,7 @@ from dataclasses import asdict, dataclass
 from pathlib import Path
 from typing import Any
 
-from scripts.publication.transaction import Transaction, canonical_json
+from scripts.publication.transaction import OBJECT_TYPE, SCHEMA_VERSION, VALID_STATES, Transaction, canonical_json
 
 JOURNAL_OBJECT_TYPE = "publication-journal"
 JOURNAL_SCHEMA_VERSION = 1
@@ -107,6 +107,14 @@ def read_transaction(repo_path: Path, tx_id: str, ref: str = DEFAULT_REF) -> Tra
     try:
         content = _run_git(["cat-file", "-p", tx_path], cwd=repo_path)
         data = json.loads(content)
+        if data.get("object_type") != OBJECT_TYPE:
+            raise CorruptJournalError(f"Invalid transaction object_type: {data.get('object_type')!r}")
+        if data.get("transaction_schema_version") != SCHEMA_VERSION:
+            raise CorruptJournalError(
+                f"Unsupported transaction schema version: {data.get('transaction_schema_version')!r}"
+            )
+        if data.get("state") not in VALID_STATES:
+            raise CorruptJournalError(f"Invalid transaction state: {data.get('state')!r}")
         return Transaction(**data)
     except Exception as e:
         raise JournalError(f"Failed to read transaction '{tx_id}' at {tx_path}: {e}") from e
@@ -183,9 +191,15 @@ def write_journal_update(
             cwd=repo_path,
         )
 
-        # 6. Fast-forward atomic CAS update on refs/heads/{ref}
+        # 6. Atomically reserve the shared ref on the remote authority.
         p_update = subprocess.run(
-            ["git", "update-ref", f"refs/heads/{ref}", commit_oid, expected_parent_oid],
+            [
+                "git",
+                "push",
+                "origin",
+                f"{commit_oid}:refs/heads/{ref}",
+                f"--force-with-lease=refs/heads/{ref}:{expected_parent_oid}",
+            ],
             cwd=repo_path,
             capture_output=True,
             text=True,
@@ -193,8 +207,9 @@ def write_journal_update(
         )
         if p_update.returncode != 0:
             raise CasConflictError(
-                f"CAS update on ref '{ref}' failed (expected {expected_parent_oid}): {p_update.stderr.strip()}"
+                f"CAS update on remote ref '{ref}' failed (expected {expected_parent_oid}): {p_update.stderr.strip()}"
             )
+        _run_git(["update-ref", f"refs/heads/{ref}", commit_oid], cwd=repo_path)
 
         updated_state = JournalState(
             target=new_state.target,
@@ -247,7 +262,14 @@ def init_genesis_journal(
 def resolve_timeout_or_recheck(repo_path: Path, proposed_commit_oid: str, ref: str = DEFAULT_REF) -> bool:
     """Resolve an ambiguous network or API timeout by re-checking whether the proposed commit won."""
     try:
-        current_oid = _run_git(["rev-parse", f"refs/heads/{ref}"], cwd=repo_path)
-        return current_oid == proposed_commit_oid
+        current_oid = _run_git(["ls-remote", "origin", f"refs/heads/{ref}"], cwd=repo_path).split()[0]
+        return (
+            subprocess.run(
+                ["git", "merge-base", "--is-ancestor", proposed_commit_oid, current_oid],
+                cwd=repo_path,
+                check=False,
+            ).returncode
+            == 0
+        )
     except Exception:
         return False

--- a/scripts/publication/journal.py
+++ b/scripts/publication/journal.py
@@ -257,7 +257,13 @@ def write_journal_update(
                 raise CasConflictError(
                     f"CAS update on remote ref '{ref}' failed (expected {expected_parent_oid}): {p_update.stderr.strip()}"
                 )
-        _run_git(["update-ref", f"refs/heads/{ref}", commit_oid], cwd=repo_path)
+        elif not resolve_timeout_or_recheck(repo_path, commit_oid, ref=ref):
+            raise JournalError(f"Remote ref '{ref}' did not retain committed journal update {commit_oid}")
+
+        authoritative_tip = _run_git(["rev-parse", "FETCH_HEAD"], cwd=repo_path)
+        _run_git(["update-ref", f"refs/heads/{ref}", authoritative_tip], cwd=repo_path)
+        if authoritative_tip != commit_oid:
+            return read_journal_state(repo_path, ref=ref), authoritative_tip
 
         updated_state = JournalState(
             target=new_state.target,
@@ -266,11 +272,11 @@ def write_journal_update(
             durable_transaction_id=new_state.durable_transaction_id,
             write_block=new_state.write_block,
             policy_digest=new_state.policy_digest,
-            tip_commit_oid=commit_oid,
+            tip_commit_oid=authoritative_tip,
             object_type=new_state.object_type,
             journal_schema_version=new_state.journal_schema_version,
         )
-        return updated_state, commit_oid
+        return updated_state, authoritative_tip
 
     finally:
         if os.path.exists(index_file):
@@ -288,6 +294,12 @@ def init_genesis_journal(
     ref: str = DEFAULT_REF,
 ) -> tuple[JournalState, str]:
     """Initialize a fresh publication journal at genesis referencing an attested known-good transaction."""
+    if genesis_transaction.state not in (STATE_DURABLE, STATE_ROLLBACK_DURABLE):
+        raise CorruptJournalError("Genesis transaction must be durable")
+    if genesis_transaction.target != target:
+        raise CorruptJournalError("Genesis transaction target does not match journal target")
+    if not isinstance(genesis_transaction.attestation, dict):
+        raise CorruptJournalError("Genesis transaction must retain a valid live-receipt attestation")
     init_state = JournalState(
         target=target,
         next_generation=genesis_transaction.generation + 1,

--- a/scripts/publication/journal.py
+++ b/scripts/publication/journal.py
@@ -206,9 +206,10 @@ def write_journal_update(
             check=False,
         )
         if p_update.returncode != 0:
-            raise CasConflictError(
-                f"CAS update on remote ref '{ref}' failed (expected {expected_parent_oid}): {p_update.stderr.strip()}"
-            )
+            if not resolve_timeout_or_recheck(repo_path, commit_oid, ref=ref):
+                raise CasConflictError(
+                    f"CAS update on remote ref '{ref}' failed (expected {expected_parent_oid}): {p_update.stderr.strip()}"
+                )
         _run_git(["update-ref", f"refs/heads/{ref}", commit_oid], cwd=repo_path)
 
         updated_state = JournalState(
@@ -262,7 +263,8 @@ def init_genesis_journal(
 def resolve_timeout_or_recheck(repo_path: Path, proposed_commit_oid: str, ref: str = DEFAULT_REF) -> bool:
     """Resolve an ambiguous network or API timeout by re-checking whether the proposed commit won."""
     try:
-        current_oid = _run_git(["ls-remote", "origin", f"refs/heads/{ref}"], cwd=repo_path).split()[0]
+        _run_git(["fetch", "--no-tags", "origin", f"refs/heads/{ref}"], cwd=repo_path)
+        current_oid = _run_git(["rev-parse", "FETCH_HEAD"], cwd=repo_path)
         return (
             subprocess.run(
                 ["git", "merge-base", "--is-ancestor", proposed_commit_oid, current_oid],

--- a/scripts/publication/journal.py
+++ b/scripts/publication/journal.py
@@ -15,6 +15,7 @@ from dataclasses import asdict, dataclass
 from pathlib import Path
 from typing import Any
 
+from scripts.publication import transaction as transaction_module
 from scripts.publication.transaction import (
     KIND_LEGACY_RECOVERY,
     KIND_PROMOTION,
@@ -34,6 +35,7 @@ from scripts.publication.transaction import (
     VALID_KINDS,
     VALID_STATES,
     Transaction,
+    TransactionError,
     canonical_json,
 )
 
@@ -300,6 +302,16 @@ def init_genesis_journal(
         raise CorruptJournalError("Genesis transaction target does not match journal target")
     if not isinstance(genesis_transaction.attestation, dict):
         raise CorruptJournalError("Genesis transaction must retain a valid live-receipt attestation")
+    try:
+        transaction_module.validate_live_receipt(
+            genesis_transaction,
+            {
+                "attestation": genesis_transaction.attestation,
+                "observation_digest": genesis_transaction.attestation.get("observation_digest"),
+            },
+        )
+    except TransactionError as error:
+        raise CorruptJournalError(f"Genesis transaction attestation is invalid: {error}") from error
     init_state = JournalState(
         target=target,
         next_generation=genesis_transaction.generation + 1,

--- a/scripts/publication/journal.py
+++ b/scripts/publication/journal.py
@@ -168,7 +168,26 @@ def read_transaction(repo_path: Path, tx_id: str, ref: str = DEFAULT_REF) -> Tra
             raise CorruptJournalError(f"Invalid state {data['state']!r} for transaction kind {kind!r}")
         if kind == KIND_ROLLBACK and not isinstance(data.get("restore_source"), dict):
             raise CorruptJournalError("Rollback transaction requires restore_source data")
-        return Transaction(**data)
+        loaded = Transaction(**data)
+        if loaded.state in {
+            STATE_EXTERNALLY_VERIFIED,
+            STATE_ROLLBACK_VERIFIED,
+            STATE_DURABLE,
+            STATE_ROLLBACK_DURABLE,
+        }:
+            if not isinstance(loaded.attestation, dict):
+                raise CorruptJournalError("Verified transaction must retain a live-receipt attestation")
+            try:
+                transaction_module.validate_live_receipt(
+                    loaded,
+                    {
+                        "attestation": loaded.attestation,
+                        "observation_digest": loaded.attestation.get("observation_digest"),
+                    },
+                )
+            except TransactionError as error:
+                raise CorruptJournalError(f"Verified transaction attestation is invalid: {error}") from error
+        return loaded
     except Exception as e:
         raise JournalError(f"Failed to read transaction '{tx_id}' at {tx_path}: {e}") from e
 

--- a/scripts/publication/journal.py
+++ b/scripts/publication/journal.py
@@ -15,12 +15,52 @@ from dataclasses import asdict, dataclass
 from pathlib import Path
 from typing import Any
 
-from scripts.publication.transaction import OBJECT_TYPE, SCHEMA_VERSION, VALID_STATES, Transaction, canonical_json
+from scripts.publication.transaction import (
+    KIND_LEGACY_RECOVERY,
+    KIND_PROMOTION,
+    KIND_ROLLBACK,
+    OBJECT_TYPE,
+    SCHEMA_VERSION,
+    STATE_DURABLE,
+    STATE_EXTERNALLY_VERIFIED,
+    STATE_PREPARED,
+    STATE_RECOVERY_REQUIRED,
+    STATE_ROLLBACK_DURABLE,
+    STATE_ROLLBACK_VERIFIED,
+    STATE_ROLLBACK_WRITE_STARTED,
+    STATE_TERMINAL_FAILURE,
+    STATE_WRITE_ACKNOWLEDGED,
+    STATE_WRITE_STARTED,
+    VALID_KINDS,
+    VALID_STATES,
+    Transaction,
+    canonical_json,
+)
 
 JOURNAL_OBJECT_TYPE = "publication-journal"
 JOURNAL_SCHEMA_VERSION = 1
 SUBTREE_PATH = "publication/transaction-state"
 DEFAULT_REF = "publication"
+
+KIND_STATES = {
+    KIND_PROMOTION: {
+        STATE_PREPARED,
+        STATE_WRITE_STARTED,
+        STATE_WRITE_ACKNOWLEDGED,
+        STATE_EXTERNALLY_VERIFIED,
+        STATE_DURABLE,
+        STATE_RECOVERY_REQUIRED,
+        STATE_TERMINAL_FAILURE,
+    },
+    KIND_ROLLBACK: {
+        STATE_ROLLBACK_WRITE_STARTED,
+        STATE_WRITE_ACKNOWLEDGED,
+        STATE_ROLLBACK_VERIFIED,
+        STATE_ROLLBACK_DURABLE,
+        STATE_TERMINAL_FAILURE,
+    },
+    KIND_LEGACY_RECOVERY: {STATE_RECOVERY_REQUIRED, STATE_TERMINAL_FAILURE},
+}
 
 
 class JournalError(Exception):
@@ -115,6 +155,13 @@ def read_transaction(repo_path: Path, tx_id: str, ref: str = DEFAULT_REF) -> Tra
             )
         if data.get("state") not in VALID_STATES:
             raise CorruptJournalError(f"Invalid transaction state: {data.get('state')!r}")
+        kind = data.get("kind")
+        if kind not in VALID_KINDS:
+            raise CorruptJournalError(f"Invalid transaction kind: {kind!r}")
+        if data["state"] not in KIND_STATES[kind]:
+            raise CorruptJournalError(f"Invalid state {data['state']!r} for transaction kind {kind!r}")
+        if kind == KIND_ROLLBACK and not isinstance(data.get("restore_source"), dict):
+            raise CorruptJournalError("Rollback transaction requires restore_source data")
         return Transaction(**data)
     except Exception as e:
         raise JournalError(f"Failed to read transaction '{tx_id}' at {tx_path}: {e}") from e

--- a/scripts/publication/journal.py
+++ b/scripts/publication/journal.py
@@ -205,6 +205,10 @@ def write_journal_update(
         index_file = tmp_idx.name
 
     env = dict(os.environ, GIT_INDEX_FILE=index_file)
+    env.setdefault("GIT_AUTHOR_NAME", "BenchBox Publication Controller")
+    env.setdefault("GIT_AUTHOR_EMAIL", "publication-controller@benchbox.dev")
+    env.setdefault("GIT_COMMITTER_NAME", "BenchBox Publication Controller")
+    env.setdefault("GIT_COMMITTER_EMAIL", "publication-controller@benchbox.dev")
     try:
         # 1. Initialize temporary index from parent commit tree
         _run_git(["read-tree", expected_parent_oid], cwd=repo_path, env=env)
@@ -261,6 +265,7 @@ def write_journal_update(
         commit_oid = _run_git(
             ["commit-tree", tree_oid, "-p", expected_parent_oid, "-m", msg],
             cwd=repo_path,
+            env=env,
         )
 
         # 6. Atomically reserve the shared ref on the remote authority.

--- a/scripts/publication/reconciliation.py
+++ b/scripts/publication/reconciliation.py
@@ -848,8 +848,9 @@ def validate_live_receipt_contract(
 ) -> list[DriftFinding]:
     """Validate the complete signed live-receipt contract and freshness boundary."""
     findings = _check_receipt_contract_fields(receipt)
+    probe_findings, _ = _check_observed_probes(receipt)
     freshness, _ = _check_receipt_freshness(receipt, True, max_age_hours, now or datetime.now(timezone.utc))
-    return [*findings, *freshness]
+    return [*findings, *probe_findings, *freshness]
 
 
 def reconcile_states(

--- a/scripts/publication/reconciliation.py
+++ b/scripts/publication/reconciliation.py
@@ -843,6 +843,15 @@ def _check_receipt_freshness(
     return drifts, receipt_age_hours
 
 
+def validate_live_receipt_contract(
+    receipt: dict[str, Any], *, now: datetime | None = None, max_age_hours: float = DEFAULT_MAX_AGE_HOURS
+) -> list[DriftFinding]:
+    """Validate the complete signed live-receipt contract and freshness boundary."""
+    findings = _check_receipt_contract_fields(receipt)
+    freshness, _ = _check_receipt_freshness(receipt, True, max_age_hours, now or datetime.now(timezone.utc))
+    return [*findings, *freshness]
+
+
 def reconcile_states(
     desired: dict[str, Any],
     built: dict[str, Any] | None,

--- a/scripts/publication/transaction.py
+++ b/scripts/publication/transaction.py
@@ -88,15 +88,38 @@ def validate_live_receipt(current: Transaction, payload: dict[str, Any]) -> dict
         raise TransactionError(f"Live-receipt attestation is invalid: {contract_findings[0].description}")
 
     artifact = receipt.get("artifact") if isinstance(receipt.get("artifact"), dict) else {}
+    receipt_target = receipt.get("target")
+    expected_target = current.target
+    expected_host = str(current.target.get("base_url") or current.target.get("url") or "").rstrip("/").split("://")[-1]
+    target_matches = receipt_target == expected_target or (
+        isinstance(receipt_target, str)
+        and receipt_target.rstrip("/").split("://")[-1]
+        in {
+            expected_host,
+            str(current.target.get("environment") or ""),
+        }
+    )
+    artifact_set = receipt.get("artifacts") if isinstance(receipt.get("artifacts"), dict) else {}
+    pages_artifact = artifact_set.get("pages_assembly") if isinstance(artifact_set.get("pages_assembly"), dict) else {}
+    receipt_artifact_digest = (
+        receipt.get("artifact_digest") or artifact.get("archive_sha256") or pages_artifact.get("digest")
+    )
+    routes = receipt.get("routes") or receipt.get("probes")
+    receipt_observation_digest = receipt.get("observation_digest")
+    if receipt_observation_digest is None and isinstance(routes, list):
+        receipt_observation_digest = hashlib.sha256(canonical_json({"routes": routes}).encode("utf-8")).hexdigest()
     bindings = {
-        "target": (receipt.get("target"), current.target),
+        "target": (expected_target if target_matches else receipt_target, expected_target),
         "generation": (receipt.get("generation"), current.generation),
         "manifest_digest": (receipt.get("manifest_digest"), current.content.get("manifest_digest")),
         "artifact_digest": (
-            receipt.get("artifact_digest") or artifact.get("archive_sha256"),
+            receipt_artifact_digest,
             current.artifact.get("archive_sha256"),
         ),
-        "observation_digest": (receipt.get("observation_digest"), payload.get("observation_digest")),
+        "observation_digest": (
+            receipt_observation_digest,
+            payload.get("observation_digest") or receipt_observation_digest,
+        ),
     }
     mismatches = [name for name, (actual, expected) in bindings.items() if actual != expected or actual is None]
     if mismatches:

--- a/scripts/publication/transaction.py
+++ b/scripts/publication/transaction.py
@@ -1,0 +1,467 @@
+#!/usr/bin/env python3
+"""Canonical publication transaction schema, builder, and state machine.
+
+Implements the single state transition engine shared by promotion,
+rollback, and external recovery (Slice B).
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import uuid
+from dataclasses import asdict, dataclass, field
+from datetime import datetime, timezone
+from typing import Any
+
+SCHEMA_VERSION = 1
+OBJECT_TYPE = "publication-transaction"
+
+# Transaction kinds
+KIND_PROMOTION = "promotion"
+KIND_ROLLBACK = "rollback"
+KIND_LEGACY_RECOVERY = "legacy_recovery"
+
+# States
+STATE_PREPARED = "prepared"
+STATE_WRITE_STARTED = "write-started"
+STATE_WRITE_ACKNOWLEDGED = "write-acknowledged"
+STATE_EXTERNALLY_VERIFIED = "externally-verified"
+STATE_DURABLE = "durable"
+STATE_RECOVERY_REQUIRED = "recovery-required"
+STATE_ROLLBACK_WRITE_STARTED = "rollback-write-started"
+STATE_ROLLBACK_VERIFIED = "rollback-verified"
+STATE_ROLLBACK_DURABLE = "rollback-durable"
+STATE_TERMINAL_FAILURE = "terminal-failure"
+
+VALID_STATES = {
+    STATE_PREPARED,
+    STATE_WRITE_STARTED,
+    STATE_WRITE_ACKNOWLEDGED,
+    STATE_EXTERNALLY_VERIFIED,
+    STATE_DURABLE,
+    STATE_RECOVERY_REQUIRED,
+    STATE_ROLLBACK_WRITE_STARTED,
+    STATE_ROLLBACK_VERIFIED,
+    STATE_ROLLBACK_DURABLE,
+    STATE_TERMINAL_FAILURE,
+}
+
+# Events
+EVENT_PREPARE = "prepare"
+EVENT_START_WRITE = "start-write"
+EVENT_ACKNOWLEDGE_WRITE = "acknowledge-write"
+EVENT_VERIFY_SUCCESS = "verify-success"
+EVENT_COMMIT_DURABLE = "commit-durable"
+EVENT_FAIL_WRITE = "fail-write"
+EVENT_FAIL_VERIFICATION = "fail-verification"
+EVENT_START_ROLLBACK = "start-rollback"
+EVENT_VERIFY_ROLLBACK = "verify-rollback"
+EVENT_COMMIT_ROLLBACK = "commit-rollback"
+EVENT_MARK_TERMINAL = "mark-terminal"
+
+
+class TransactionError(Exception):
+    """Base exception for invalid transaction operations or state transitions."""
+
+
+def canonical_json(data: dict[str, Any]) -> str:
+    """Return compact, sorted UTF-8 JSON representation."""
+    return json.dumps(data, sort_keys=True, separators=(",", ":"))
+
+
+def compute_digest(data: dict[str, Any]) -> str:
+    """Compute SHA-256 digest of canonical JSON."""
+    return hashlib.sha256(canonical_json(data).encode("utf-8")).hexdigest()
+
+
+@dataclass(frozen=True)
+class Effect:
+    action: str
+    data: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class Transaction:
+    transaction_id: str
+    target: dict[str, str]
+    kind: str
+    generation: int
+    parent_transaction_id: str | None
+    recovery_of: str | None
+    restore_source: dict[str, Any] | None
+    approval: dict[str, Any]
+    controller: dict[str, Any]
+    owner: dict[str, Any]
+    content: dict[str, Any]
+    desired: dict[str, Any]
+    artifact: dict[str, Any]
+    state: str = STATE_PREPARED
+    write: dict[str, Any] | None = None
+    verification: dict[str, Any] | None = None
+    certification: dict[str, Any] | None = None
+    failure: dict[str, Any] | None = None
+    event: dict[str, Any] = field(default_factory=dict)
+    attestation: dict[str, Any] | None = None
+    object_type: str = OBJECT_TYPE
+    transaction_schema_version: int = SCHEMA_VERSION
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+    def digest(self) -> str:
+        d = self.to_dict()
+        d["attestation"] = None
+        return compute_digest(d)
+
+
+def prepare_promotion(
+    *,
+    target: dict[str, str],
+    generation: int,
+    parent_transaction_id: str | None,
+    approval: dict[str, Any],
+    controller: dict[str, Any],
+    owner: dict[str, Any],
+    content: dict[str, Any],
+    artifact: dict[str, Any],
+    transaction_id: str | None = None,
+) -> tuple[Transaction, Effect]:
+    """Prepare a new promotion transaction in PREPARED state."""
+    tx_id = transaction_id or str(uuid.uuid4())
+
+    desired_payload = {
+        "content_digest": content.get("manifest_digest"),
+        "target": target,
+        "generation": generation,
+        "parent_transaction_id": parent_transaction_id,
+    }
+    desired = {
+        "digest": compute_digest(desired_payload),
+        "payload": desired_payload,
+    }
+
+    event = {
+        "event_id": str(uuid.uuid4()),
+        "event_type": EVENT_PREPARE,
+        "actor": controller.get("workflow_path", "controller"),
+        "timestamp": datetime.now(timezone.utc).isoformat(),
+    }
+
+    tx = Transaction(
+        transaction_id=tx_id,
+        target=target,
+        kind=KIND_PROMOTION,
+        generation=generation,
+        parent_transaction_id=parent_transaction_id,
+        recovery_of=None,
+        restore_source=None,
+        approval=approval,
+        controller=controller,
+        owner=owner,
+        content=content,
+        desired=desired,
+        artifact=artifact,
+        state=STATE_PREPARED,
+        event=event,
+    )
+    return tx, Effect(action="persist_prepared", data={"transaction_id": tx.transaction_id})
+
+
+def prepare_rollback(
+    *,
+    failed_transaction: Transaction,
+    parent_durable_transaction: Transaction,
+    generation: int,
+    controller: dict[str, Any],
+    owner: dict[str, Any],
+    barrier_evidence: dict[str, Any],
+    transaction_id: str | None = None,
+) -> tuple[Transaction, Effect]:
+    """Prepare a successor rollback transaction describing restored parent bytes."""
+    if failed_transaction.state not in (STATE_RECOVERY_REQUIRED, STATE_WRITE_STARTED, STATE_WRITE_ACKNOWLEDGED):
+        raise TransactionError(f"Cannot initiate rollback from non-recoverable state: {failed_transaction.state}")
+
+    if not barrier_evidence:
+        raise TransactionError("Provider activation barrier evidence is required before preparing rollback")
+
+    tx_id = transaction_id or str(uuid.uuid4())
+
+    restore_source = {
+        "parent_transaction_id": parent_durable_transaction.transaction_id,
+        "parent_generation": parent_durable_transaction.generation,
+        "manifest_digest": parent_durable_transaction.content.get("manifest_digest"),
+        "artifact_digest": parent_durable_transaction.artifact.get("archive_sha256"),
+        "barrier_evidence": barrier_evidence,
+    }
+
+    desired_payload = {
+        "content_digest": parent_durable_transaction.content.get("manifest_digest"),
+        "target": failed_transaction.target,
+        "generation": generation,
+        "parent_transaction_id": failed_transaction.parent_transaction_id,
+        "recovery_of": failed_transaction.transaction_id,
+    }
+    desired = {
+        "digest": compute_digest(desired_payload),
+        "payload": desired_payload,
+    }
+
+    event = {
+        "event_id": str(uuid.uuid4()),
+        "event_type": EVENT_START_ROLLBACK,
+        "actor": controller.get("workflow_path", "watchdog"),
+        "timestamp": datetime.now(timezone.utc).isoformat(),
+    }
+
+    tx = Transaction(
+        transaction_id=tx_id,
+        target=failed_transaction.target,
+        kind=KIND_ROLLBACK,
+        generation=generation,
+        parent_transaction_id=failed_transaction.parent_transaction_id,
+        recovery_of=failed_transaction.transaction_id,
+        restore_source=restore_source,
+        approval=failed_transaction.approval,
+        controller=controller,
+        owner=owner,
+        content=parent_durable_transaction.content,
+        desired=desired,
+        artifact=parent_durable_transaction.artifact,
+        state=STATE_ROLLBACK_WRITE_STARTED,
+        event=event,
+    )
+    return tx, Effect(
+        action="create_deployment",
+        data={
+            "artifact_id": tx.artifact.get("artifact_id"),
+            "pages_build_version": tx.restore_source.get("manifest_digest", "")[:40],
+        },
+    )
+
+
+def _handle_prepared(
+    current: Transaction,
+    event_type: str,
+    payload: dict[str, Any],
+    ev: dict[str, Any],
+    data: dict[str, Any],
+) -> tuple[Transaction, Effect]:
+    if event_type == EVENT_START_WRITE:
+        intent_commit_oid = payload.get("intent_commit_oid")
+        if not intent_commit_oid:
+            raise TransactionError("intent_commit_oid is required to start write")
+        data["state"] = STATE_WRITE_STARTED
+        data["write"] = {
+            "write_id": payload.get("write_id", str(uuid.uuid4())),
+            "intent_commit_oid": intent_commit_oid,
+            "pages_build_version": intent_commit_oid,
+            "status": "in_flight",
+            "started_at": ev["timestamp"],
+        }
+        tx = Transaction(**data)
+        return tx, Effect(
+            action="create_deployment",
+            data={
+                "artifact_id": tx.artifact.get("artifact_id"),
+                "pages_build_version": intent_commit_oid,
+            },
+        )
+
+    if event_type == EVENT_FAIL_WRITE:
+        data["state"] = STATE_RECOVERY_REQUIRED
+        data["failure"] = {
+            "code": payload.get("code", "PRE_SEND_FAILURE"),
+            "stage": "pre_send",
+            "reason": payload.get("reason", "Write failed before provider transmission"),
+        }
+        return Transaction(**data), Effect(action="escalate_recovery", data=data["failure"])
+
+    raise TransactionError(f"Invalid transition: event '{event_type}' from state '{current.state}'")
+
+
+def _handle_write_started(
+    current: Transaction,
+    event_type: str,
+    payload: dict[str, Any],
+    ev: dict[str, Any],
+    data: dict[str, Any],
+) -> tuple[Transaction, Effect]:
+    if event_type == EVENT_ACKNOWLEDGE_WRITE:
+        provider_id = payload.get("id")
+        if not provider_id:
+            raise TransactionError("Provider deployment id is required for write acknowledgement")
+        data["state"] = STATE_WRITE_ACKNOWLEDGED
+        write_info = dict(data.get("write") or {})
+        write_info.update(
+            {
+                "id": provider_id,
+                "status_url": payload.get("status_url"),
+                "status": payload.get("status", "SUCCESS"),
+                "observed_at": ev["timestamp"],
+            }
+        )
+        data["write"] = write_info
+        tx = Transaction(**data)
+        return tx, Effect(action="probe_endpoints", data={"write_id": write_info.get("write_id")})
+
+    if event_type == EVENT_FAIL_WRITE:
+        data["state"] = STATE_RECOVERY_REQUIRED
+        data["failure"] = {
+            "code": payload.get("code", "POST_SEND_FAILURE"),
+            "stage": "post_send",
+            "reason": payload.get("reason", "Provider deployment write failed or timed out"),
+        }
+        return Transaction(**data), Effect(action="escalate_recovery", data=data["failure"])
+
+    raise TransactionError(f"Invalid transition: event '{event_type}' from state '{current.state}'")
+
+
+def _handle_write_acknowledged(
+    current: Transaction,
+    event_type: str,
+    payload: dict[str, Any],
+    ev: dict[str, Any],
+    data: dict[str, Any],
+) -> tuple[Transaction, Effect]:
+    if event_type == EVENT_VERIFY_SUCCESS:
+        obs_digest = payload.get("observation_digest")
+        if not obs_digest:
+            raise TransactionError("observation_digest is required for verification success")
+        data["state"] = STATE_ROLLBACK_VERIFIED if current.kind == KIND_ROLLBACK else STATE_EXTERNALLY_VERIFIED
+        data["verification"] = {
+            "challenge": payload.get("challenge"),
+            "verifier_sha": payload.get("verifier_sha"),
+            "observation_digest": obs_digest,
+            "verified_at": ev["timestamp"],
+        }
+        tx = Transaction(**data)
+        next_action = "commit_rollback" if current.kind == KIND_ROLLBACK else "commit_durable"
+        return tx, Effect(action=next_action, data={"transaction_id": tx.transaction_id})
+
+    if event_type == EVENT_FAIL_VERIFICATION:
+        data["state"] = STATE_TERMINAL_FAILURE if current.kind == KIND_ROLLBACK else STATE_RECOVERY_REQUIRED
+        data["failure"] = {
+            "code": payload.get("code", "VERIFICATION_FAILURE"),
+            "stage": "verification",
+            "reason": payload.get("reason", "External probe verification failed"),
+        }
+        return Transaction(**data), Effect(action="escalate_recovery", data=data["failure"])
+
+    raise TransactionError(f"Invalid transition: event '{event_type}' from state '{current.state}'")
+
+
+def _handle_externally_verified(
+    current: Transaction,
+    event_type: str,
+    payload: dict[str, Any],
+    ev: dict[str, Any],
+    data: dict[str, Any],
+) -> tuple[Transaction, Effect]:
+    if event_type == EVENT_COMMIT_DURABLE:
+        data["state"] = STATE_DURABLE
+        tx = Transaction(**data)
+        return tx, Effect(action="advance_durable_head", data={"durable_transaction_id": tx.transaction_id})
+    raise TransactionError(f"Invalid transition: event '{event_type}' from state '{current.state}'")
+
+
+def _handle_rollback_write_started(
+    current: Transaction,
+    event_type: str,
+    payload: dict[str, Any],
+    ev: dict[str, Any],
+    data: dict[str, Any],
+) -> tuple[Transaction, Effect]:
+    if event_type == EVENT_ACKNOWLEDGE_WRITE:
+        provider_id = payload.get("id")
+        if not provider_id:
+            raise TransactionError("Provider deployment id is required for rollback acknowledgement")
+        data["state"] = STATE_WRITE_ACKNOWLEDGED
+        data["write"] = {
+            "id": provider_id,
+            "status_url": payload.get("status_url"),
+            "status": payload.get("status", "SUCCESS"),
+            "observed_at": ev["timestamp"],
+        }
+        tx = Transaction(**data)
+        return tx, Effect(action="probe_endpoints", data={"transaction_id": tx.transaction_id})
+
+    if event_type == EVENT_FAIL_WRITE:
+        data["state"] = STATE_TERMINAL_FAILURE
+        data["failure"] = {
+            "code": payload.get("code", "ROLLBACK_WRITE_FAILURE"),
+            "stage": "post_send",
+            "reason": payload.get("reason", "Rollback provider write failed"),
+        }
+        return Transaction(**data), Effect(action="terminal_stop", data=data["failure"])
+
+    raise TransactionError(f"Invalid transition: event '{event_type}' from state '{current.state}'")
+
+
+def _handle_rollback_verified(
+    current: Transaction,
+    event_type: str,
+    payload: dict[str, Any],
+    ev: dict[str, Any],
+    data: dict[str, Any],
+) -> tuple[Transaction, Effect]:
+    if event_type == EVENT_COMMIT_ROLLBACK:
+        data["state"] = STATE_ROLLBACK_DURABLE
+        tx = Transaction(**data)
+        return tx, Effect(action="advance_durable_head", data={"durable_transaction_id": tx.transaction_id})
+    raise TransactionError(f"Invalid transition: event '{event_type}' from state '{current.state}'")
+
+
+def _handle_recovery_required(
+    current: Transaction,
+    event_type: str,
+    payload: dict[str, Any],
+    ev: dict[str, Any],
+    data: dict[str, Any],
+) -> tuple[Transaction, Effect]:
+    if event_type == EVENT_MARK_TERMINAL:
+        data["state"] = STATE_TERMINAL_FAILURE
+        data["failure"] = {
+            "code": payload.get("code", "MANUAL_TERMINAL_ESCALATION"),
+            "stage": "terminal",
+            "reason": payload.get("reason", "Marked terminal due to unresolvable ambiguity"),
+        }
+        return Transaction(**data), Effect(action="terminal_stop", data=data["failure"])
+    raise TransactionError(f"Invalid transition: event '{event_type}' from state '{current.state}'")
+
+
+_HANDLERS = {
+    STATE_PREPARED: _handle_prepared,
+    STATE_WRITE_STARTED: _handle_write_started,
+    STATE_WRITE_ACKNOWLEDGED: _handle_write_acknowledged,
+    STATE_EXTERNALLY_VERIFIED: _handle_externally_verified,
+    STATE_ROLLBACK_WRITE_STARTED: _handle_rollback_write_started,
+    STATE_ROLLBACK_VERIFIED: _handle_rollback_verified,
+    STATE_RECOVERY_REQUIRED: _handle_recovery_required,
+}
+
+
+def transition(
+    current: Transaction,
+    event_type: str,
+    payload: dict[str, Any] | None = None,
+) -> tuple[Transaction, Effect]:
+    """Execute a pure state transition and return (new_transaction, next_effect)."""
+    payload = payload or {}
+    ev = {
+        "event_id": str(uuid.uuid4()),
+        "event_type": event_type,
+        "actor": payload.get("actor", current.controller.get("workflow_path", "controller")),
+        "timestamp": datetime.now(timezone.utc).isoformat(),
+    }
+
+    data = current.to_dict()
+    data["event"] = ev
+
+    handler = _HANDLERS.get(current.state)
+    if not handler:
+        raise TransactionError(
+            f"Invalid transition: event '{event_type}' is not allowed from terminal or unhandled state '{current.state}'"
+        )
+
+    return handler(current, event_type, payload, ev, data)

--- a/scripts/publication/transaction.py
+++ b/scripts/publication/transaction.py
@@ -182,6 +182,13 @@ def prepare_rollback(
     if failed_transaction.state not in (STATE_RECOVERY_REQUIRED, STATE_WRITE_STARTED, STATE_WRITE_ACKNOWLEDGED):
         raise TransactionError(f"Cannot initiate rollback from non-recoverable state: {failed_transaction.state}")
 
+    if parent_durable_transaction.state not in (STATE_DURABLE, STATE_ROLLBACK_DURABLE):
+        raise TransactionError("Rollback source must be a durable transaction")
+    if failed_transaction.parent_transaction_id != parent_durable_transaction.transaction_id:
+        raise TransactionError("Rollback source must match the failed transaction parent")
+    if failed_transaction.target != parent_durable_transaction.target:
+        raise TransactionError("Rollback source target must match the failed transaction target")
+
     failed_write = failed_transaction.write or {}
     expected_deployment = failed_write.get("id") or failed_write.get("write_id")
     if (

--- a/scripts/publication/transaction.py
+++ b/scripts/publication/transaction.py
@@ -14,7 +14,7 @@ from dataclasses import asdict, dataclass, field
 from datetime import datetime, timezone
 from typing import Any
 
-from scripts.publication.reconciliation import verify_live_receipt_signature
+from scripts.publication.reconciliation import validate_live_receipt_contract
 
 SCHEMA_VERSION = 1
 OBJECT_TYPE = "publication-transaction"
@@ -83,9 +83,9 @@ def validate_live_receipt(current: Transaction, payload: dict[str, Any]) -> dict
     receipt = payload.get("attestation")
     if not isinstance(receipt, dict):
         raise TransactionError("A signed live-receipt attestation is required for verification success")
-    signature_valid, signature_error = verify_live_receipt_signature(receipt)
-    if not signature_valid:
-        raise TransactionError(f"Live-receipt attestation signature is invalid: {signature_error}")
+    contract_findings = validate_live_receipt_contract(receipt)
+    if contract_findings:
+        raise TransactionError(f"Live-receipt attestation is invalid: {contract_findings[0].description}")
 
     artifact = receipt.get("artifact") if isinstance(receipt.get("artifact"), dict) else {}
     bindings = {
@@ -210,6 +210,8 @@ def prepare_rollback(
     """Prepare a successor rollback transaction describing restored parent bytes."""
     if failed_transaction.state not in (STATE_RECOVERY_REQUIRED, STATE_WRITE_STARTED, STATE_WRITE_ACKNOWLEDGED):
         raise TransactionError(f"Cannot initiate rollback from non-recoverable state: {failed_transaction.state}")
+    if generation <= failed_transaction.generation:
+        raise TransactionError("Rollback generation must advance beyond the failed transaction generation")
 
     if parent_durable_transaction.state not in (STATE_DURABLE, STATE_ROLLBACK_DURABLE):
         raise TransactionError("Rollback source must be a durable transaction")

--- a/scripts/publication/transaction.py
+++ b/scripts/publication/transaction.py
@@ -182,8 +182,14 @@ def prepare_rollback(
     if failed_transaction.state not in (STATE_RECOVERY_REQUIRED, STATE_WRITE_STARTED, STATE_WRITE_ACKNOWLEDGED):
         raise TransactionError(f"Cannot initiate rollback from non-recoverable state: {failed_transaction.state}")
 
-    if not barrier_evidence:
-        raise TransactionError("Provider activation barrier evidence is required before preparing rollback")
+    failed_write = failed_transaction.write or {}
+    expected_deployment = failed_write.get("id") or failed_write.get("write_id")
+    if (
+        barrier_evidence.get("provider_status", "").upper() not in {"CANCELED", "FAILED", "ERROR"}
+        or barrier_evidence.get("quiescence_observed") is not True
+        or barrier_evidence.get("deployment_id") != expected_deployment
+    ):
+        raise TransactionError("Affirmative provider activation barrier evidence is required before preparing rollback")
 
     tx_id = transaction_id or str(uuid.uuid4())
 
@@ -324,7 +330,7 @@ def _handle_write_acknowledged(
     ev: dict[str, Any],
     data: dict[str, Any],
 ) -> tuple[Transaction, Effect]:
-    if event_type == EVENT_VERIFY_SUCCESS:
+    if event_type == EVENT_VERIFY_SUCCESS or (current.kind == KIND_ROLLBACK and event_type == EVENT_VERIFY_ROLLBACK):
         obs_digest = payload.get("observation_digest")
         if not obs_digest:
             raise TransactionError("observation_digest is required for verification success")

--- a/scripts/publication/transaction.py
+++ b/scripts/publication/transaction.py
@@ -14,6 +14,8 @@ from dataclasses import asdict, dataclass, field
 from datetime import datetime, timezone
 from typing import Any
 
+from scripts.publication.reconciliation import verify_live_receipt_signature
+
 SCHEMA_VERSION = 1
 OBJECT_TYPE = "publication-transaction"
 
@@ -46,6 +48,7 @@ VALID_STATES = {
     STATE_ROLLBACK_DURABLE,
     STATE_TERMINAL_FAILURE,
 }
+VALID_KINDS = {KIND_PROMOTION, KIND_ROLLBACK, KIND_LEGACY_RECOVERY}
 
 # Events
 EVENT_PREPARE = "prepare"
@@ -73,6 +76,32 @@ def canonical_json(data: dict[str, Any]) -> str:
 def compute_digest(data: dict[str, Any]) -> str:
     """Compute SHA-256 digest of canonical JSON."""
     return hashlib.sha256(canonical_json(data).encode("utf-8")).hexdigest()
+
+
+def validate_live_receipt(current: Transaction, payload: dict[str, Any]) -> dict[str, Any]:
+    """Validate signed receipt evidence and bind it to the current transaction."""
+    receipt = payload.get("attestation")
+    if not isinstance(receipt, dict):
+        raise TransactionError("A signed live-receipt attestation is required for verification success")
+    signature_valid, signature_error = verify_live_receipt_signature(receipt)
+    if not signature_valid:
+        raise TransactionError(f"Live-receipt attestation signature is invalid: {signature_error}")
+
+    artifact = receipt.get("artifact") if isinstance(receipt.get("artifact"), dict) else {}
+    bindings = {
+        "target": (receipt.get("target"), current.target),
+        "generation": (receipt.get("generation"), current.generation),
+        "manifest_digest": (receipt.get("manifest_digest"), current.content.get("manifest_digest")),
+        "artifact_digest": (
+            receipt.get("artifact_digest") or artifact.get("archive_sha256"),
+            current.artifact.get("archive_sha256"),
+        ),
+        "observation_digest": (receipt.get("observation_digest"), payload.get("observation_digest")),
+    }
+    mismatches = [name for name, (actual, expected) in bindings.items() if actual != expected or actual is None]
+    if mismatches:
+        raise TransactionError(f"Live-receipt attestation does not match transaction fields: {', '.join(mismatches)}")
+    return receipt
 
 
 @dataclass(frozen=True)
@@ -190,11 +219,20 @@ def prepare_rollback(
         raise TransactionError("Rollback source target must match the failed transaction target")
 
     failed_write = failed_transaction.write or {}
-    expected_deployment = failed_write.get("id") or failed_write.get("write_id")
+    expected_deployment = failed_write.get("id")
+    provider_identity_matches = (
+        expected_deployment is not None and barrier_evidence.get("deployment_id") == expected_deployment
+    )
+    provider_absence_matches = (
+        expected_deployment is None
+        and barrier_evidence.get("provider_deployment_absent") is True
+        and barrier_evidence.get("artifact_id") == failed_transaction.artifact.get("artifact_id")
+        and barrier_evidence.get("pages_build_version") == failed_write.get("pages_build_version")
+    )
     if (
         barrier_evidence.get("provider_status", "").upper() not in {"CANCELED", "FAILED", "ERROR"}
         or barrier_evidence.get("quiescence_observed") is not True
-        or barrier_evidence.get("deployment_id") != expected_deployment
+        or not (provider_identity_matches or provider_absence_matches)
     ):
         raise TransactionError("Affirmative provider activation barrier evidence is required before preparing rollback")
 
@@ -341,6 +379,7 @@ def _handle_write_acknowledged(
         obs_digest = payload.get("observation_digest")
         if not obs_digest:
             raise TransactionError("observation_digest is required for verification success")
+        attestation = validate_live_receipt(current, payload)
         data["state"] = STATE_ROLLBACK_VERIFIED if current.kind == KIND_ROLLBACK else STATE_EXTERNALLY_VERIFIED
         data["verification"] = {
             "challenge": payload.get("challenge"),
@@ -348,6 +387,7 @@ def _handle_write_acknowledged(
             "observation_digest": obs_digest,
             "verified_at": ev["timestamp"],
         }
+        data["attestation"] = attestation
         tx = Transaction(**data)
         next_action = "commit_rollback" if current.kind == KIND_ROLLBACK else "commit_durable"
         return tx, Effect(action=next_action, data={"transaction_id": tx.transaction_id})

--- a/tests/unit/scripts/publication/test_journal.py
+++ b/tests/unit/scripts/publication/test_journal.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 import subprocess
 from pathlib import Path
 
@@ -28,6 +29,10 @@ def git_repo(tmp_path: Path) -> Path:
 
     # Branch publication off main
     subprocess.run(["git", "branch", "publication"], cwd=repo, check=True)
+    remote = tmp_path / "remote.git"
+    subprocess.run(["git", "init", "--bare", str(remote)], check=True, capture_output=True)
+    subprocess.run(["git", "remote", "add", "origin", str(remote)], cwd=repo, check=True)
+    subprocess.run(["git", "push", "origin", "main", "publication"], cwd=repo, check=True, capture_output=True)
     return repo
 
 
@@ -192,7 +197,7 @@ def test_cas_conflict_detection(git_repo: Path, genesis_tx: tx_mod.Transaction) 
     )
 
     # Writer 2 attempts to commit using old parent -> MUST fail with CasConflictError
-    with pytest.raises(journal_mod.CasConflictError, match="CAS update on ref 'publication' failed"):
+    with pytest.raises(journal_mod.CasConflictError, match="CAS update on remote ref 'publication' failed"):
         journal_mod.write_journal_update(
             repo_path=git_repo,
             expected_parent_oid=genesis_commit_oid,
@@ -220,6 +225,33 @@ def test_timeout_resolution(git_repo: Path, genesis_tx: tx_mod.Transaction) -> N
     )
 
     assert journal_mod.resolve_timeout_or_recheck(git_repo, commit_oid, ref="publication") is True
+    tree_oid = subprocess.run(
+        ["git", "show", "-s", "--format=%T", commit_oid],
+        cwd=git_repo,
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.strip()
+    descendant_oid = subprocess.run(
+        ["git", "commit-tree", tree_oid, "-p", commit_oid, "-m", "later journal update"],
+        cwd=git_repo,
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.strip()
+    subprocess.run(
+        [
+            "git",
+            "push",
+            "origin",
+            f"{descendant_oid}:refs/heads/publication",
+            f"--force-with-lease=refs/heads/publication:{commit_oid}",
+        ],
+        cwd=git_repo,
+        check=True,
+        capture_output=True,
+    )
+    assert journal_mod.resolve_timeout_or_recheck(git_repo, commit_oid, ref="publication") is True
     assert journal_mod.resolve_timeout_or_recheck(git_repo, "nonexistent-sha", ref="publication") is False
 
 
@@ -227,3 +259,19 @@ def test_corrupt_journal_fails_closed(git_repo: Path) -> None:
     # On empty/uninitialized publication branch, read fails closed
     with pytest.raises(journal_mod.CorruptJournalError, match="Missing or invalid state.json"):
         journal_mod.read_journal_state(git_repo, ref="publication")
+
+
+@pytest.mark.parametrize(
+    "field,value",
+    [("object_type", "wrong"), ("transaction_schema_version", 99), ("state", "invented")],
+)
+def test_read_transaction_rejects_invalid_contract(monkeypatch: pytest.MonkeyPatch, field: str, value: object) -> None:
+    data = {
+        "object_type": tx_mod.OBJECT_TYPE,
+        "transaction_schema_version": tx_mod.SCHEMA_VERSION,
+        "state": tx_mod.STATE_PREPARED,
+    }
+    data[field] = value
+    monkeypatch.setattr(journal_mod, "_run_git", lambda *args, **kwargs: json.dumps(data))
+    with pytest.raises(journal_mod.JournalError):
+        journal_mod.read_transaction(Path("."), "bad")

--- a/tests/unit/scripts/publication/test_journal.py
+++ b/tests/unit/scripts/publication/test_journal.py
@@ -160,6 +160,15 @@ def test_write_journal_update_happy_path(git_repo: Path, genesis_tx: tx_mod.Tran
     assert t1.transaction_id == "genesis-tx-0001"
     assert t2.transaction_id == "tx-0002"
 
+    identity = subprocess.run(
+        ["git", "show", "-s", "--format=%an <%ae>", new_commit_oid],
+        cwd=git_repo,
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.strip()
+    assert identity == "BenchBox Publication Controller <publication-controller@benchbox.dev>"
+
 
 def test_cas_conflict_detection(git_repo: Path, genesis_tx: tx_mod.Transaction) -> None:
     base_oid = subprocess.run(

--- a/tests/unit/scripts/publication/test_journal.py
+++ b/tests/unit/scripts/publication/test_journal.py
@@ -13,6 +13,11 @@ from scripts.publication import journal as journal_mod, transaction as tx_mod
 pytestmark = [pytest.mark.unit, pytest.mark.fast]
 
 
+@pytest.fixture(autouse=True)
+def valid_receipt_contract(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(tx_mod, "validate_live_receipt_contract", lambda receipt: [])
+
+
 @pytest.fixture
 def git_repo(tmp_path: Path) -> Path:
     """Create a temporary initialized Git repository with an initial commit."""
@@ -50,7 +55,14 @@ def genesis_tx() -> tx_mod.Transaction:
         transaction_id="genesis-tx-0001",
     )
     # Mark as durable genesis
-    return tx_mod.Transaction(**{**tx.to_dict(), "state": tx_mod.STATE_DURABLE})
+    attestation = {
+        "target": tx.target,
+        "generation": tx.generation,
+        "manifest_digest": tx.content["manifest_digest"],
+        "artifact_digest": tx.artifact["archive_sha256"],
+        "observation_digest": "genesis-observation",
+    }
+    return tx_mod.Transaction(**{**tx.to_dict(), "state": tx_mod.STATE_DURABLE, "attestation": attestation})
 
 
 def test_init_genesis_and_read(git_repo: Path, genesis_tx: tx_mod.Transaction) -> None:

--- a/tests/unit/scripts/publication/test_journal.py
+++ b/tests/unit/scripts/publication/test_journal.py
@@ -315,13 +315,20 @@ def test_corrupt_journal_fails_closed(git_repo: Path) -> None:
 
 @pytest.mark.parametrize(
     "field,value",
-    [("object_type", "wrong"), ("transaction_schema_version", 99), ("state", "invented")],
+    [
+        ("object_type", "wrong"),
+        ("transaction_schema_version", 99),
+        ("state", "invented"),
+        ("kind", "invented"),
+        ("kind", tx_mod.KIND_ROLLBACK),
+    ],
 )
 def test_read_transaction_rejects_invalid_contract(monkeypatch: pytest.MonkeyPatch, field: str, value: object) -> None:
     data = {
         "object_type": tx_mod.OBJECT_TYPE,
         "transaction_schema_version": tx_mod.SCHEMA_VERSION,
         "state": tx_mod.STATE_PREPARED,
+        "kind": tx_mod.KIND_PROMOTION,
     }
     data[field] = value
     monkeypatch.setattr(journal_mod, "_run_git", lambda *args, **kwargs: json.dumps(data))

--- a/tests/unit/scripts/publication/test_journal.py
+++ b/tests/unit/scripts/publication/test_journal.py
@@ -206,7 +206,47 @@ def test_cas_conflict_detection(git_repo: Path, genesis_tx: tx_mod.Transaction) 
         )
 
 
-def test_timeout_resolution(git_repo: Path, genesis_tx: tx_mod.Transaction) -> None:
+def test_ambiguous_push_failure_reconciles_remote_success(
+    git_repo: Path, genesis_tx: tx_mod.Transaction, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    base_oid = subprocess.run(
+        ["git", "rev-parse", "refs/heads/publication"],
+        cwd=git_repo,
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.strip()
+    state = journal_mod.JournalState(
+        target={"repository": "BenchBox-dev/BenchBox", "environment": "github-pages"},
+        next_generation=2,
+        active_transaction_id=genesis_tx.transaction_id,
+        durable_transaction_id=None,
+        write_block=None,
+        policy_digest="policy",
+        tip_commit_oid=base_oid,
+    )
+    original_run = subprocess.run
+
+    def lose_push_response(args, *positional, **kwargs):
+        result = original_run(args, *positional, **kwargs)
+        if args[:2] == ["git", "push"]:
+            return subprocess.CompletedProcess(args, 1, stdout="", stderr="connection closed after update")
+        return result
+
+    monkeypatch.setattr(journal_mod.subprocess, "run", lose_push_response)
+    updated, commit_oid = journal_mod.write_journal_update(
+        repo_path=git_repo,
+        expected_parent_oid=base_oid,
+        new_state=state,
+        transaction=genesis_tx,
+        ref="publication",
+    )
+
+    assert updated.tip_commit_oid == commit_oid
+    assert journal_mod.resolve_timeout_or_recheck(git_repo, commit_oid, ref="publication") is True
+
+
+def test_timeout_resolution(git_repo: Path, genesis_tx: tx_mod.Transaction, tmp_path: Path) -> None:
     base_oid = subprocess.run(
         ["git", "rev-parse", "refs/heads/publication"],
         cwd=git_repo,
@@ -225,16 +265,28 @@ def test_timeout_resolution(git_repo: Path, genesis_tx: tx_mod.Transaction) -> N
     )
 
     assert journal_mod.resolve_timeout_or_recheck(git_repo, commit_oid, ref="publication") is True
+    remote = subprocess.run(
+        ["git", "remote", "get-url", "origin"],
+        cwd=git_repo,
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.strip()
+    other_repo = tmp_path / "other"
+    subprocess.run(["git", "clone", remote, str(other_repo)], check=True, capture_output=True)
+    subprocess.run(["git", "config", "user.email", "test@example.com"], cwd=other_repo, check=True)
+    subprocess.run(["git", "config", "user.name", "Test User"], cwd=other_repo, check=True)
+    subprocess.run(["git", "checkout", "publication"], cwd=other_repo, check=True, capture_output=True)
     tree_oid = subprocess.run(
         ["git", "show", "-s", "--format=%T", commit_oid],
-        cwd=git_repo,
+        cwd=other_repo,
         check=True,
         capture_output=True,
         text=True,
     ).stdout.strip()
     descendant_oid = subprocess.run(
         ["git", "commit-tree", tree_oid, "-p", commit_oid, "-m", "later journal update"],
-        cwd=git_repo,
+        cwd=other_repo,
         check=True,
         capture_output=True,
         text=True,
@@ -247,7 +299,7 @@ def test_timeout_resolution(git_repo: Path, genesis_tx: tx_mod.Transaction) -> N
             f"{descendant_oid}:refs/heads/publication",
             f"--force-with-lease=refs/heads/publication:{commit_oid}",
         ],
-        cwd=git_repo,
+        cwd=other_repo,
         check=True,
         capture_output=True,
     )

--- a/tests/unit/scripts/publication/test_journal.py
+++ b/tests/unit/scripts/publication/test_journal.py
@@ -1,0 +1,229 @@
+"""Unit tests for publication metadata Git journal CAS module (scripts/publication/journal.py)."""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from scripts.publication import journal as journal_mod, transaction as tx_mod
+
+pytestmark = [pytest.mark.unit, pytest.mark.fast]
+
+
+@pytest.fixture
+def git_repo(tmp_path: Path) -> Path:
+    """Create a temporary initialized Git repository with an initial commit."""
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    subprocess.run(["git", "init", "-b", "main"], cwd=repo, check=True, capture_output=True)
+    subprocess.run(["git", "config", "user.name", "Test User"], cwd=repo, check=True)
+    subprocess.run(["git", "config", "user.email", "test@benchbox.dev"], cwd=repo, check=True)
+
+    # Initial commit on main
+    (repo / "README.md").write_text("# Test Repo\n", encoding="utf-8")
+    subprocess.run(["git", "add", "README.md"], cwd=repo, check=True)
+    subprocess.run(["git", "commit", "-m", "initial commit"], cwd=repo, check=True, capture_output=True)
+
+    # Branch publication off main
+    subprocess.run(["git", "branch", "publication"], cwd=repo, check=True)
+    return repo
+
+
+@pytest.fixture
+def genesis_tx() -> tx_mod.Transaction:
+    tx, _ = tx_mod.prepare_promotion(
+        target={"repository": "BenchBox-dev/BenchBox", "environment": "github-pages", "url": "https://benchbox.dev"},
+        generation=1,
+        parent_transaction_id=None,
+        approval={"permit_sha256": "genesis-permit", "approver": "maintainer"},
+        controller={"workflow_path": "release.yml", "workflow_sha": "0" * 40},
+        owner={"run_id": "1", "epoch": "0"},
+        content={"manifest_digest": "g" * 64},
+        artifact={"artifact_id": 1, "archive_sha256": "g_art" * 16},
+        transaction_id="genesis-tx-0001",
+    )
+    # Mark as durable genesis
+    return tx_mod.Transaction(**{**tx.to_dict(), "state": tx_mod.STATE_DURABLE})
+
+
+def test_init_genesis_and_read(git_repo: Path, genesis_tx: tx_mod.Transaction) -> None:
+    base_oid = subprocess.run(
+        ["git", "rev-parse", "refs/heads/publication"],
+        cwd=git_repo,
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.strip()
+
+    target = {"repository": "BenchBox-dev/BenchBox", "environment": "github-pages", "url": "https://benchbox.dev"}
+    state, commit_oid = journal_mod.init_genesis_journal(
+        repo_path=git_repo,
+        target=target,
+        genesis_transaction=genesis_tx,
+        base_commit_oid=base_oid,
+        ref="publication",
+    )
+
+    assert state.next_generation == 2
+    assert state.durable_transaction_id == "genesis-tx-0001"
+    assert state.active_transaction_id is None
+    assert state.tip_commit_oid == commit_oid
+
+    # Read state back
+    loaded_state = journal_mod.read_journal_state(git_repo, ref="publication")
+    assert loaded_state.next_generation == 2
+    assert loaded_state.durable_transaction_id == "genesis-tx-0001"
+    assert loaded_state.tip_commit_oid == commit_oid
+
+    # Read transaction back
+    loaded_tx = journal_mod.read_transaction(git_repo, "genesis-tx-0001", ref="publication")
+    assert loaded_tx.transaction_id == "genesis-tx-0001"
+    assert loaded_tx.generation == 1
+    assert loaded_tx.state == tx_mod.STATE_DURABLE
+
+
+def test_write_journal_update_happy_path(git_repo: Path, genesis_tx: tx_mod.Transaction) -> None:
+    base_oid = subprocess.run(
+        ["git", "rev-parse", "refs/heads/publication"],
+        cwd=git_repo,
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.strip()
+
+    target = {"repository": "BenchBox-dev/BenchBox", "environment": "github-pages", "url": "https://benchbox.dev"}
+    state, genesis_commit_oid = journal_mod.init_genesis_journal(
+        repo_path=git_repo,
+        target=target,
+        genesis_transaction=genesis_tx,
+        base_commit_oid=base_oid,
+        ref="publication",
+    )
+
+    # Next transaction
+    tx2, _ = tx_mod.prepare_promotion(
+        target=target,
+        generation=2,
+        parent_transaction_id=genesis_tx.transaction_id,
+        approval={"permit_sha256": "permit-2", "approver": "maintainer"},
+        controller={"workflow_path": "tx.yml", "workflow_sha": "1" * 40},
+        owner={"run_id": "2", "epoch": "1"},
+        content={"manifest_digest": "m2" * 32},
+        artifact={"artifact_id": 2, "archive_sha256": "art2" * 16},
+        transaction_id="tx-0002",
+    )
+
+    new_state = journal_mod.JournalState(
+        target=target,
+        next_generation=3,
+        active_transaction_id="tx-0002",
+        durable_transaction_id=genesis_tx.transaction_id,
+        write_block=None,
+        policy_digest="p2",
+        tip_commit_oid=genesis_commit_oid,
+    )
+
+    updated_state, new_commit_oid = journal_mod.write_journal_update(
+        repo_path=git_repo,
+        expected_parent_oid=genesis_commit_oid,
+        new_state=new_state,
+        transaction=tx2,
+        ref="publication",
+    )
+
+    assert updated_state.next_generation == 3
+    assert updated_state.active_transaction_id == "tx-0002"
+    assert updated_state.tip_commit_oid == new_commit_oid
+
+    # Verify both transactions are readable
+    t1 = journal_mod.read_transaction(git_repo, "genesis-tx-0001", ref="publication")
+    t2 = journal_mod.read_transaction(git_repo, "tx-0002", ref="publication")
+    assert t1.transaction_id == "genesis-tx-0001"
+    assert t2.transaction_id == "tx-0002"
+
+
+def test_cas_conflict_detection(git_repo: Path, genesis_tx: tx_mod.Transaction) -> None:
+    base_oid = subprocess.run(
+        ["git", "rev-parse", "refs/heads/publication"],
+        cwd=git_repo,
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.strip()
+
+    target = {"repository": "BenchBox-dev/BenchBox", "environment": "github-pages", "url": "https://benchbox.dev"}
+    state, genesis_commit_oid = journal_mod.init_genesis_journal(
+        repo_path=git_repo,
+        target=target,
+        genesis_transaction=genesis_tx,
+        base_commit_oid=base_oid,
+        ref="publication",
+    )
+
+    # Writer 1 prepares an update
+    state_writer_1 = journal_mod.JournalState(
+        target=target,
+        next_generation=3,
+        active_transaction_id="tx-w1",
+        durable_transaction_id=genesis_tx.transaction_id,
+        write_block=None,
+        policy_digest="p-w1",
+        tip_commit_oid=genesis_commit_oid,
+    )
+    # Writer 2 also prepares from the same genesis_commit_oid
+    state_writer_2 = journal_mod.JournalState(
+        target=target,
+        next_generation=3,
+        active_transaction_id="tx-w2",
+        durable_transaction_id=genesis_tx.transaction_id,
+        write_block=None,
+        policy_digest="p-w2",
+        tip_commit_oid=genesis_commit_oid,
+    )
+
+    # Writer 1 commits first
+    _, w1_commit = journal_mod.write_journal_update(
+        repo_path=git_repo,
+        expected_parent_oid=genesis_commit_oid,
+        new_state=state_writer_1,
+        ref="publication",
+    )
+
+    # Writer 2 attempts to commit using old parent -> MUST fail with CasConflictError
+    with pytest.raises(journal_mod.CasConflictError, match="CAS update on ref 'publication' failed"):
+        journal_mod.write_journal_update(
+            repo_path=git_repo,
+            expected_parent_oid=genesis_commit_oid,
+            new_state=state_writer_2,
+            ref="publication",
+        )
+
+
+def test_timeout_resolution(git_repo: Path, genesis_tx: tx_mod.Transaction) -> None:
+    base_oid = subprocess.run(
+        ["git", "rev-parse", "refs/heads/publication"],
+        cwd=git_repo,
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.strip()
+
+    target = {"repository": "BenchBox-dev/BenchBox", "environment": "github-pages", "url": "https://benchbox.dev"}
+    _, commit_oid = journal_mod.init_genesis_journal(
+        repo_path=git_repo,
+        target=target,
+        genesis_transaction=genesis_tx,
+        base_commit_oid=base_oid,
+        ref="publication",
+    )
+
+    assert journal_mod.resolve_timeout_or_recheck(git_repo, commit_oid, ref="publication") is True
+    assert journal_mod.resolve_timeout_or_recheck(git_repo, "nonexistent-sha", ref="publication") is False
+
+
+def test_corrupt_journal_fails_closed(git_repo: Path) -> None:
+    # On empty/uninitialized publication branch, read fails closed
+    with pytest.raises(journal_mod.CorruptJournalError, match="Missing or invalid state.json"):
+        journal_mod.read_journal_state(git_repo, ref="publication")

--- a/tests/unit/scripts/publication/test_transaction.py
+++ b/tests/unit/scripts/publication/test_transaction.py
@@ -11,7 +11,7 @@ pytestmark = [pytest.mark.unit, pytest.mark.fast]
 
 @pytest.fixture(autouse=True)
 def valid_receipt_signature(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setattr(tx_mod, "verify_live_receipt_signature", lambda receipt: (True, ""))
+    monkeypatch.setattr(tx_mod, "validate_live_receipt_contract", lambda receipt: [])
 
 
 def receipt_for(tx: tx_mod.Transaction, observation_digest: str) -> dict[str, object]:
@@ -228,6 +228,41 @@ def test_prepare_rollback_rejects_non_durable_source(base_context: dict[str, dic
             failed_transaction=failed_tx,
             parent_durable_transaction=parent_tx,
             generation=11,
+            controller=base_context["controller"],
+            owner=base_context["owner"],
+            barrier_evidence={},
+        )
+
+
+def test_prepare_rollback_requires_advancing_generation(base_context: dict[str, dict[str, str]]) -> None:
+    parent_tx, _ = tx_mod.prepare_promotion(
+        target=base_context["target"],
+        generation=9,
+        parent_transaction_id="g8",
+        approval=base_context["approval"],
+        controller=base_context["controller"],
+        owner=base_context["owner"],
+        content=base_context["content"],
+        artifact=base_context["artifact"],
+    )
+    parent_tx = make_durable(parent_tx)
+    failed_tx, _ = tx_mod.prepare_promotion(
+        target=base_context["target"],
+        generation=10,
+        parent_transaction_id=parent_tx.transaction_id,
+        approval=base_context["approval"],
+        controller=base_context["controller"],
+        owner=base_context["owner"],
+        content=base_context["content"],
+        artifact=base_context["artifact"],
+    )
+    failed_tx, _ = tx_mod.transition(failed_tx, tx_mod.EVENT_FAIL_WRITE, {"reason": "pre-send failure"})
+
+    with pytest.raises(tx_mod.TransactionError, match="generation must advance"):
+        tx_mod.prepare_rollback(
+            failed_transaction=failed_tx,
+            parent_durable_transaction=parent_tx,
+            generation=10,
             controller=base_context["controller"],
             owner=base_context["owner"],
             barrier_evidence={},

--- a/tests/unit/scripts/publication/test_transaction.py
+++ b/tests/unit/scripts/publication/test_transaction.py
@@ -159,7 +159,7 @@ def test_prepare_rollback_requires_activation_barrier(base_context: dict[str, di
     failed_tx, _ = tx_mod.transition(failed_tx, tx_mod.EVENT_FAIL_WRITE, {"reason": "timeout"})
 
     # Rollback without barrier evidence must fail
-    with pytest.raises(tx_mod.TransactionError, match="Provider activation barrier evidence is required"):
+    with pytest.raises(tx_mod.TransactionError, match="activation barrier evidence is required"):
         tx_mod.prepare_rollback(
             failed_transaction=failed_tx,
             parent_durable_transaction=parent_tx,
@@ -167,6 +167,43 @@ def test_prepare_rollback_requires_activation_barrier(base_context: dict[str, di
             controller=base_context["controller"],
             owner=base_context["owner"],
             barrier_evidence={},
+        )
+
+
+def test_prepare_rollback_rejects_nonterminal_provider(base_context: dict[str, dict[str, str]]) -> None:
+    parent_tx, _ = tx_mod.prepare_promotion(
+        target=base_context["target"],
+        generation=9,
+        parent_transaction_id="g8",
+        approval=base_context["approval"],
+        controller=base_context["controller"],
+        owner=base_context["owner"],
+        content=base_context["content"],
+        artifact=base_context["artifact"],
+    )
+    failed_tx, _ = tx_mod.prepare_promotion(
+        target=base_context["target"],
+        generation=10,
+        parent_transaction_id=parent_tx.transaction_id,
+        approval=base_context["approval"],
+        controller=base_context["controller"],
+        owner=base_context["owner"],
+        content=base_context["content"],
+        artifact=base_context["artifact"],
+    )
+    failed_tx, _ = tx_mod.transition(failed_tx, tx_mod.EVENT_START_WRITE, {"intent_commit_oid": "2" * 40})
+    with pytest.raises(tx_mod.TransactionError, match="Affirmative"):
+        tx_mod.prepare_rollback(
+            failed_transaction=failed_tx,
+            parent_durable_transaction=parent_tx,
+            generation=11,
+            controller=base_context["controller"],
+            owner=base_context["owner"],
+            barrier_evidence={
+                "provider_status": "in_progress",
+                "quiescence_observed": False,
+                "deployment_id": failed_tx.write["write_id"],
+            },
         )
 
 
@@ -202,7 +239,11 @@ def test_rollback_lifecycle_happy_path(base_context: dict[str, dict[str, str]]) 
         generation=11,
         controller=base_context["controller"],
         owner=base_context["owner"],
-        barrier_evidence={"provider_status": "canceled", "quiescence_observed": True},
+        barrier_evidence={
+            "provider_status": "canceled",
+            "quiescence_observed": True,
+            "deployment_id": failed_tx.write["write_id"],
+        },
     )
 
     assert rb_tx.state == tx_mod.STATE_ROLLBACK_WRITE_STARTED
@@ -221,7 +262,7 @@ def test_rollback_lifecycle_happy_path(base_context: dict[str, dict[str, str]]) 
     assert effect.action == "probe_endpoints"
 
     # Verify rollback probes
-    rb_tx, effect = tx_mod.transition(rb_tx, tx_mod.EVENT_VERIFY_SUCCESS, {"observation_digest": "rb-obs-999"})
+    rb_tx, effect = tx_mod.transition(rb_tx, tx_mod.EVENT_VERIFY_ROLLBACK, {"observation_digest": "rb-obs-999"})
     assert rb_tx.state == tx_mod.STATE_ROLLBACK_VERIFIED
     assert effect.action == "commit_rollback"
 

--- a/tests/unit/scripts/publication/test_transaction.py
+++ b/tests/unit/scripts/publication/test_transaction.py
@@ -1,0 +1,247 @@
+"""Unit tests for canonical publication transaction module (scripts/publication/transaction.py)."""
+
+from __future__ import annotations
+
+import pytest
+
+from scripts.publication import transaction as tx_mod
+
+pytestmark = [pytest.mark.unit, pytest.mark.fast]
+
+
+@pytest.fixture
+def base_context() -> dict[str, dict[str, str]]:
+    return {
+        "target": {
+            "repository": "BenchBox-dev/BenchBox",
+            "environment": "github-pages",
+            "url": "https://benchbox.dev",
+        },
+        "approval": {
+            "permit_sha256": "permit-sha-123456",
+            "approver": "joe",
+        },
+        "controller": {
+            "workflow_path": ".github/workflows/publication-transaction.yml",
+            "workflow_sha": "a" * 40,
+            "run_id": "1001",
+            "run_attempt": "1",
+        },
+        "owner": {
+            "run_id": "1001",
+            "epoch": "1",
+        },
+        "content": {
+            "manifest_digest": "m" * 64,
+            "develop_sha": "d" * 40,
+            "published_results_sha": "p" * 40,
+        },
+        "artifact": {
+            "artifact_id": 999,
+            "archive_sha256": "art" * 20,
+        },
+    }
+
+
+def test_prepare_promotion(base_context: dict[str, dict[str, str]]) -> None:
+    tx, effect = tx_mod.prepare_promotion(
+        target=base_context["target"],
+        generation=10,
+        parent_transaction_id="parent-uuid-001",
+        approval=base_context["approval"],
+        controller=base_context["controller"],
+        owner=base_context["owner"],
+        content=base_context["content"],
+        artifact=base_context["artifact"],
+    )
+
+    assert tx.state == tx_mod.STATE_PREPARED
+    assert tx.kind == tx_mod.KIND_PROMOTION
+    assert tx.generation == 10
+    assert tx.parent_transaction_id == "parent-uuid-001"
+    assert tx.recovery_of is None
+    assert effect.action == "persist_prepared"
+    assert tx.desired["payload"]["generation"] == 10
+    assert tx.desired["payload"]["content_digest"] == base_context["content"]["manifest_digest"]
+
+
+def test_promotion_lifecycle_happy_path(base_context: dict[str, dict[str, str]]) -> None:
+    tx, _ = tx_mod.prepare_promotion(
+        target=base_context["target"],
+        generation=10,
+        parent_transaction_id="parent-uuid-001",
+        approval=base_context["approval"],
+        controller=base_context["controller"],
+        owner=base_context["owner"],
+        content=base_context["content"],
+        artifact=base_context["artifact"],
+    )
+
+    # 1. Start write
+    intent_oid = "1" * 40
+    tx, effect = tx_mod.transition(tx, tx_mod.EVENT_START_WRITE, {"intent_commit_oid": intent_oid})
+    assert tx.state == tx_mod.STATE_WRITE_STARTED
+    assert effect.action == "create_deployment"
+    assert effect.data["pages_build_version"] == intent_oid
+
+    # 2. Acknowledge write
+    tx, effect = tx_mod.transition(
+        tx,
+        tx_mod.EVENT_ACKNOWLEDGE_WRITE,
+        {"id": "dep-456", "status": "SUCCESS", "status_url": "https://api.github.com/..."},
+    )
+    assert tx.state == tx_mod.STATE_WRITE_ACKNOWLEDGED
+    assert effect.action == "probe_endpoints"
+    assert tx.write["id"] == "dep-456"
+
+    # 3. Verify success
+    obs_digest = "obs" * 20
+    tx, effect = tx_mod.transition(
+        tx,
+        tx_mod.EVENT_VERIFY_SUCCESS,
+        {"observation_digest": obs_digest, "challenge": "ch-1"},
+    )
+    assert tx.state == tx_mod.STATE_EXTERNALLY_VERIFIED
+    assert effect.action == "commit_durable"
+    assert tx.verification["observation_digest"] == obs_digest
+
+    # 4. Commit durable
+    tx, effect = tx_mod.transition(tx, tx_mod.EVENT_COMMIT_DURABLE)
+    assert tx.state == tx_mod.STATE_DURABLE
+    assert effect.action == "advance_durable_head"
+
+
+def test_promotion_write_failure_requires_recovery(base_context: dict[str, dict[str, str]]) -> None:
+    tx, _ = tx_mod.prepare_promotion(
+        target=base_context["target"],
+        generation=10,
+        parent_transaction_id="parent-uuid-001",
+        approval=base_context["approval"],
+        controller=base_context["controller"],
+        owner=base_context["owner"],
+        content=base_context["content"],
+        artifact=base_context["artifact"],
+    )
+
+    intent_oid = "1" * 40
+    tx, _ = tx_mod.transition(tx, tx_mod.EVENT_START_WRITE, {"intent_commit_oid": intent_oid})
+    assert tx.state == tx_mod.STATE_WRITE_STARTED
+
+    tx, effect = tx_mod.transition(tx, tx_mod.EVENT_FAIL_WRITE, {"reason": "Provider rejected write with 503"})
+    assert tx.state == tx_mod.STATE_RECOVERY_REQUIRED
+    assert effect.action == "escalate_recovery"
+    assert tx.failure["stage"] == "post_send"
+
+
+def test_prepare_rollback_requires_activation_barrier(base_context: dict[str, dict[str, str]]) -> None:
+    parent_tx, _ = tx_mod.prepare_promotion(
+        target=base_context["target"],
+        generation=9,
+        parent_transaction_id="g8",
+        approval=base_context["approval"],
+        controller=base_context["controller"],
+        owner=base_context["owner"],
+        content={"manifest_digest": "parent-manifest"},
+        artifact={"artifact_id": 888, "archive_sha256": "parent-art"},
+    )
+
+    failed_tx, _ = tx_mod.prepare_promotion(
+        target=base_context["target"],
+        generation=10,
+        parent_transaction_id=parent_tx.transaction_id,
+        approval=base_context["approval"],
+        controller=base_context["controller"],
+        owner=base_context["owner"],
+        content=base_context["content"],
+        artifact=base_context["artifact"],
+    )
+    failed_tx, _ = tx_mod.transition(failed_tx, tx_mod.EVENT_START_WRITE, {"intent_commit_oid": "2" * 40})
+    failed_tx, _ = tx_mod.transition(failed_tx, tx_mod.EVENT_FAIL_WRITE, {"reason": "timeout"})
+
+    # Rollback without barrier evidence must fail
+    with pytest.raises(tx_mod.TransactionError, match="Provider activation barrier evidence is required"):
+        tx_mod.prepare_rollback(
+            failed_transaction=failed_tx,
+            parent_durable_transaction=parent_tx,
+            generation=11,
+            controller=base_context["controller"],
+            owner=base_context["owner"],
+            barrier_evidence={},
+        )
+
+
+def test_rollback_lifecycle_happy_path(base_context: dict[str, dict[str, str]]) -> None:
+    parent_tx, _ = tx_mod.prepare_promotion(
+        target=base_context["target"],
+        generation=9,
+        parent_transaction_id="g8",
+        approval=base_context["approval"],
+        controller=base_context["controller"],
+        owner=base_context["owner"],
+        content={"manifest_digest": "parent-manifest-123"},
+        artifact={"artifact_id": 888, "archive_sha256": "parent-art-123"},
+    )
+
+    failed_tx, _ = tx_mod.prepare_promotion(
+        target=base_context["target"],
+        generation=10,
+        parent_transaction_id=parent_tx.transaction_id,
+        approval=base_context["approval"],
+        controller=base_context["controller"],
+        owner=base_context["owner"],
+        content=base_context["content"],
+        artifact=base_context["artifact"],
+    )
+    failed_tx, _ = tx_mod.transition(failed_tx, tx_mod.EVENT_START_WRITE, {"intent_commit_oid": "3" * 40})
+    failed_tx, _ = tx_mod.transition(failed_tx, tx_mod.EVENT_FAIL_WRITE, {"reason": "timeout"})
+
+    # Prepare rollback
+    rb_tx, effect = tx_mod.prepare_rollback(
+        failed_transaction=failed_tx,
+        parent_durable_transaction=parent_tx,
+        generation=11,
+        controller=base_context["controller"],
+        owner=base_context["owner"],
+        barrier_evidence={"provider_status": "canceled", "quiescence_observed": True},
+    )
+
+    assert rb_tx.state == tx_mod.STATE_ROLLBACK_WRITE_STARTED
+    assert rb_tx.kind == tx_mod.KIND_ROLLBACK
+    assert rb_tx.generation == 11
+    assert rb_tx.recovery_of == failed_tx.transaction_id
+    assert rb_tx.restore_source["manifest_digest"] == "parent-manifest-123"
+    assert rb_tx.desired["payload"]["content_digest"] == "parent-manifest-123"
+    assert rb_tx.desired["payload"]["recovery_of"] == failed_tx.transaction_id
+    assert effect.action == "create_deployment"
+    assert effect.data["artifact_id"] == 888
+
+    # Acknowledge rollback write
+    rb_tx, effect = tx_mod.transition(rb_tx, tx_mod.EVENT_ACKNOWLEDGE_WRITE, {"id": "rb-dep-1", "status": "SUCCESS"})
+    assert rb_tx.state == tx_mod.STATE_WRITE_ACKNOWLEDGED
+    assert effect.action == "probe_endpoints"
+
+    # Verify rollback probes
+    rb_tx, effect = tx_mod.transition(rb_tx, tx_mod.EVENT_VERIFY_SUCCESS, {"observation_digest": "rb-obs-999"})
+    assert rb_tx.state == tx_mod.STATE_ROLLBACK_VERIFIED
+    assert effect.action == "commit_rollback"
+
+    # Commit rollback durable
+    rb_tx, effect = tx_mod.transition(rb_tx, tx_mod.EVENT_COMMIT_ROLLBACK)
+    assert rb_tx.state == tx_mod.STATE_ROLLBACK_DURABLE
+    assert effect.action == "advance_durable_head"
+
+
+def test_invalid_state_transition_raises_error(base_context: dict[str, dict[str, str]]) -> None:
+    tx, _ = tx_mod.prepare_promotion(
+        target=base_context["target"],
+        generation=10,
+        parent_transaction_id="parent-001",
+        approval=base_context["approval"],
+        controller=base_context["controller"],
+        owner=base_context["owner"],
+        content=base_context["content"],
+        artifact=base_context["artifact"],
+    )
+
+    with pytest.raises(tx_mod.TransactionError, match="Invalid transition"):
+        tx_mod.transition(tx, tx_mod.EVENT_COMMIT_DURABLE)

--- a/tests/unit/scripts/publication/test_transaction.py
+++ b/tests/unit/scripts/publication/test_transaction.py
@@ -9,10 +9,30 @@ from scripts.publication import transaction as tx_mod
 pytestmark = [pytest.mark.unit, pytest.mark.fast]
 
 
+@pytest.fixture(autouse=True)
+def valid_receipt_signature(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(tx_mod, "verify_live_receipt_signature", lambda receipt: (True, ""))
+
+
+def receipt_for(tx: tx_mod.Transaction, observation_digest: str) -> dict[str, object]:
+    return {
+        "signature": "test-signature",
+        "target": tx.target,
+        "generation": tx.generation,
+        "manifest_digest": tx.content.get("manifest_digest"),
+        "artifact_digest": tx.artifact.get("archive_sha256"),
+        "observation_digest": observation_digest,
+    }
+
+
 def make_durable(tx: tx_mod.Transaction) -> tx_mod.Transaction:
     tx, _ = tx_mod.transition(tx, tx_mod.EVENT_START_WRITE, {"intent_commit_oid": "a" * 40})
     tx, _ = tx_mod.transition(tx, tx_mod.EVENT_ACKNOWLEDGE_WRITE, {"id": "durable-deployment"})
-    tx, _ = tx_mod.transition(tx, tx_mod.EVENT_VERIFY_SUCCESS, {"observation_digest": "verified"})
+    tx, _ = tx_mod.transition(
+        tx,
+        tx_mod.EVENT_VERIFY_SUCCESS,
+        {"observation_digest": "verified", "attestation": receipt_for(tx, "verified")},
+    )
     tx, _ = tx_mod.transition(tx, tx_mod.EVENT_COMMIT_DURABLE)
     return tx
 
@@ -107,11 +127,12 @@ def test_promotion_lifecycle_happy_path(base_context: dict[str, dict[str, str]])
     tx, effect = tx_mod.transition(
         tx,
         tx_mod.EVENT_VERIFY_SUCCESS,
-        {"observation_digest": obs_digest, "challenge": "ch-1"},
+        {"observation_digest": obs_digest, "challenge": "ch-1", "attestation": receipt_for(tx, obs_digest)},
     )
     assert tx.state == tx_mod.STATE_EXTERNALLY_VERIFIED
     assert effect.action == "commit_durable"
     assert tx.verification["observation_digest"] == obs_digest
+    assert tx.attestation["signature"] == "test-signature"
 
     # 4. Commit durable
     tx, effect = tx_mod.transition(tx, tx_mod.EVENT_COMMIT_DURABLE)
@@ -287,7 +308,9 @@ def test_rollback_lifecycle_happy_path(base_context: dict[str, dict[str, str]]) 
         barrier_evidence={
             "provider_status": "canceled",
             "quiescence_observed": True,
-            "deployment_id": failed_tx.write["write_id"],
+            "provider_deployment_absent": True,
+            "artifact_id": failed_tx.artifact["artifact_id"],
+            "pages_build_version": failed_tx.write["pages_build_version"],
         },
     )
 
@@ -307,7 +330,11 @@ def test_rollback_lifecycle_happy_path(base_context: dict[str, dict[str, str]]) 
     assert effect.action == "probe_endpoints"
 
     # Verify rollback probes
-    rb_tx, effect = tx_mod.transition(rb_tx, tx_mod.EVENT_VERIFY_ROLLBACK, {"observation_digest": "rb-obs-999"})
+    rb_tx, effect = tx_mod.transition(
+        rb_tx,
+        tx_mod.EVENT_VERIFY_ROLLBACK,
+        {"observation_digest": "rb-obs-999", "attestation": receipt_for(rb_tx, "rb-obs-999")},
+    )
     assert rb_tx.state == tx_mod.STATE_ROLLBACK_VERIFIED
     assert effect.action == "commit_rollback"
 

--- a/tests/unit/scripts/publication/test_transaction.py
+++ b/tests/unit/scripts/publication/test_transaction.py
@@ -9,6 +9,14 @@ from scripts.publication import transaction as tx_mod
 pytestmark = [pytest.mark.unit, pytest.mark.fast]
 
 
+def make_durable(tx: tx_mod.Transaction) -> tx_mod.Transaction:
+    tx, _ = tx_mod.transition(tx, tx_mod.EVENT_START_WRITE, {"intent_commit_oid": "a" * 40})
+    tx, _ = tx_mod.transition(tx, tx_mod.EVENT_ACKNOWLEDGE_WRITE, {"id": "durable-deployment"})
+    tx, _ = tx_mod.transition(tx, tx_mod.EVENT_VERIFY_SUCCESS, {"observation_digest": "verified"})
+    tx, _ = tx_mod.transition(tx, tx_mod.EVENT_COMMIT_DURABLE)
+    return tx
+
+
 @pytest.fixture
 def base_context() -> dict[str, dict[str, str]]:
     return {
@@ -144,6 +152,7 @@ def test_prepare_rollback_requires_activation_barrier(base_context: dict[str, di
         content={"manifest_digest": "parent-manifest"},
         artifact={"artifact_id": 888, "archive_sha256": "parent-art"},
     )
+    parent_tx = make_durable(parent_tx)
 
     failed_tx, _ = tx_mod.prepare_promotion(
         target=base_context["target"],
@@ -170,6 +179,40 @@ def test_prepare_rollback_requires_activation_barrier(base_context: dict[str, di
         )
 
 
+def test_prepare_rollback_rejects_non_durable_source(base_context: dict[str, dict[str, str]]) -> None:
+    parent_tx, _ = tx_mod.prepare_promotion(
+        target=base_context["target"],
+        generation=9,
+        parent_transaction_id="g8",
+        approval=base_context["approval"],
+        controller=base_context["controller"],
+        owner=base_context["owner"],
+        content=base_context["content"],
+        artifact=base_context["artifact"],
+    )
+    failed_tx, _ = tx_mod.prepare_promotion(
+        target=base_context["target"],
+        generation=10,
+        parent_transaction_id=parent_tx.transaction_id,
+        approval=base_context["approval"],
+        controller=base_context["controller"],
+        owner=base_context["owner"],
+        content=base_context["content"],
+        artifact=base_context["artifact"],
+    )
+    failed_tx, _ = tx_mod.transition(failed_tx, tx_mod.EVENT_FAIL_WRITE, {"reason": "pre-send failure"})
+
+    with pytest.raises(tx_mod.TransactionError, match="durable transaction"):
+        tx_mod.prepare_rollback(
+            failed_transaction=failed_tx,
+            parent_durable_transaction=parent_tx,
+            generation=11,
+            controller=base_context["controller"],
+            owner=base_context["owner"],
+            barrier_evidence={},
+        )
+
+
 def test_prepare_rollback_rejects_nonterminal_provider(base_context: dict[str, dict[str, str]]) -> None:
     parent_tx, _ = tx_mod.prepare_promotion(
         target=base_context["target"],
@@ -181,6 +224,7 @@ def test_prepare_rollback_rejects_nonterminal_provider(base_context: dict[str, d
         content=base_context["content"],
         artifact=base_context["artifact"],
     )
+    parent_tx = make_durable(parent_tx)
     failed_tx, _ = tx_mod.prepare_promotion(
         target=base_context["target"],
         generation=10,
@@ -218,6 +262,7 @@ def test_rollback_lifecycle_happy_path(base_context: dict[str, dict[str, str]]) 
         content={"manifest_digest": "parent-manifest-123"},
         artifact={"artifact_id": 888, "archive_sha256": "parent-art-123"},
     )
+    parent_tx = make_durable(parent_tx)
 
     failed_tx, _ = tx_mod.prepare_promotion(
         target=base_context["target"],


### PR DESCRIPTION
## Summary

Implement the canonical publication transaction state machine and Git metadata journal compare-and-set module with comprehensive unit tests.

## Key Changes

- **Transaction State Machine (`scripts/publication/transaction.py`):** Single canonical transaction builder and transition function shared by promotion, rollback, and recovery. Models explicit states (`prepared`, `write-started`, `write-acknowledged`, `externally-verified`, `durable`, `recovery-required`, `rollback-write-started`, `rollback-verified`, `rollback-durable`, `terminal-failure`). Enforces that rollback transactions construct a self-consistent successor state referencing restored parent content with a newly reserved generation and recovery link.
- **Git Journal CAS (`scripts/publication/journal.py`):** Single state authority on the `publication` metadata ref (`publication/transaction-state/` subtree) managing `state.json` and transaction objects. Implements non-forced fast-forward compare-and-set updates via Git plumbing without touching the working tree, and handles timeout re-checks and corrupt journal fail-closed semantics.
- **Unit Tests (`tests/unit/scripts/publication/`):** Added `test_transaction.py` and `test_journal.py` covering promotion and rollback lifecycle transitions, activation barrier prerequisites, CAS conflict detection between competing writers, timeout resolution, and fail-closed corrupt state validation.
