### PR TITLE
feat(publication): decouple publication lane isolation from whole-PR exclusivity

### DIFF
--- a/scripts/publication/verify_lane_isolation.py
+++ b/scripts/publication/verify_lane_isolation.py
@@ -95,18 +95,6 @@ NON_LANE_INPUTS: tuple[str, ...] = (
     ".todo-db/",
 )
 
-# Exact files owned by another lane but not read by this lane's artifact build.
-# Keep this map narrow: lane-owned paths remain contamination failures unless
-# they are explicitly proven irrelevant to the target lane.
-LANE_SAFE_EXTERNAL_PATHS: dict[str, frozenset[str]] = {
-    "site": frozenset(
-        {
-            ".github/workflows/validate-submission.yml",
-            "results-data/README.md",
-        }
-    ),
-}
-
 LANE_PREFIXES: dict[str, tuple[str, ...]] = {
     "site": (
         "docs/",
@@ -209,10 +197,32 @@ def _is_non_lane_input(rel_path: str) -> bool:
     return False
 
 
-def _is_safe_external_path(lane: str, rel_path: str) -> bool:
-    """Return True for an explicitly approved, other-lane non-build input."""
-    normalized = rel_path.strip().replace("\\", "/")
-    return normalized in LANE_SAFE_EXTERNAL_PATHS.get(lane, frozenset())
+def determine_affected_lanes(changed_paths: Sequence[str]) -> set[str]:
+    """Determine publication lanes affected by a set of changed paths.
+
+    Shared build inputs (``SHARED_BUILD_INPUTS``) and unknown/unclassified paths
+    conservatively affect all publication lanes. Lane-owned paths affect their
+    respective lanes. Non-lane inputs (``NON_LANE_INPUTS``) and ignored paths
+    affect no publication lanes.
+    """
+    all_lanes = set(LANE_PREFIXES.keys())
+    affected: set[str] = set()
+    for path in changed_paths:
+        normalized = path.strip().replace("\\", "/")
+        if not normalized or is_ignored(normalized):
+            continue
+        if _is_shared_input(normalized):
+            affected.update(all_lanes)
+            continue
+        path_lanes = classify_path(normalized)
+        if path_lanes:
+            affected.update(path_lanes)
+            continue
+        if _is_non_lane_input(normalized):
+            continue
+        # Unknown/unclassified paths cause conservative affected-lane coverage
+        affected.update(all_lanes)
+    return affected
 
 
 def classify_path(rel_path: str) -> set[str]:
@@ -468,7 +478,7 @@ def verify_lane_isolation(  # noqa: C901
 
     # 2. Changed paths boundary checks
     if changed_paths:
-        contaminating_paths: list[tuple[str, list[str]]] = []
+        affected_lanes = determine_affected_lanes(changed_paths)
         unclassified_paths: list[str] = []
         for path in changed_paths:
             normalized = path.strip().replace("\\", "/")
@@ -478,21 +488,10 @@ def verify_lane_isolation(  # noqa: C901
                 continue
             path_lanes = classify_path(normalized)
             if not path_lanes:
-                # Classify first so lane-owned paths still report
-                # contamination below; only genuinely unowned paths reach
-                # the non-lane allowlist.
                 if _is_non_lane_input(normalized):
                     continue
                 unclassified_paths.append(normalized)
-            elif lane not in path_lanes:
-                if _is_safe_external_path(lane, normalized):
-                    continue
-                contaminating_paths.append((normalized, sorted(path_lanes)))
-        if contaminating_paths:
-            errors.append(
-                f"changed paths violate lane '{lane}' isolation: "
-                f"{[p for p, _ in contaminating_paths]} belong to other lanes"
-            )
+
         if unclassified_paths:
             errors.append(
                 f"changed paths contain unclassified inputs not owned by any lane: "
@@ -500,7 +499,7 @@ def verify_lane_isolation(  # noqa: C901
                 f"NON_LANE_INPUTS, or assigned to a lane)"
             )
         details["changed_paths_checked"] = len(changed_paths)
-        details["contaminating_paths"] = contaminating_paths
+        details["affected_lanes"] = sorted(affected_lanes)
         details["unclassified_paths"] = unclassified_paths
 
     # 3. Lane ownership consistency check (static, not a mathematical proof of artifact isolation)
@@ -671,6 +670,11 @@ def _parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
         help="File containing newline-delimited changed paths",
     )
     parser.add_argument(
+        "--determine-affected-lanes",
+        action="store_true",
+        help="Output affected publication lanes for changed paths and exit",
+    )
+    parser.add_argument(
         "--json",
         action="store_true",
         help="Output structured JSON report",
@@ -684,7 +688,7 @@ def main(argv: Sequence[str] | None = None) -> int:
 
     # Fail closed: if --changed-paths or --changed-paths-file was supplied, the
     # combined path list must contain at least one non-empty entry. Otherwise
-    # contamination checks would be silently skipped.
+    # boundary checks would be silently skipped.
     changed_paths: list[str] = []
     paths_requested = False
     if args.changed_paths is not None:
@@ -706,6 +710,20 @@ def main(argv: Sequence[str] | None = None) -> int:
             )
             return 1
         changed_paths = non_empty
+
+    if args.determine_affected_lanes:
+        if not paths_requested:
+            print(
+                "error: --determine-affected-lanes requires --changed-paths or --changed-paths-file",
+                file=sys.stderr,
+            )
+            return 1
+        affected = sorted(determine_affected_lanes(changed_paths))
+        if args.json:
+            print(json.dumps({"affected_lanes": affected}))
+        else:
+            print(" ".join(affected))
+        return 0
 
     lanes_to_verify = ["site", "explorer", "corpus"] if args.lane == "all" else [args.lane]
     reports: list[LaneIsolationReport] = []
@@ -737,6 +755,8 @@ def main(argv: Sequence[str] | None = None) -> int:
             print(f"  - Files in lane: {report.file_count}")
             print(f"  - Artifacts: {', '.join(report.artifacts)}")
             print(f"  - Lane ownership consistency: {'OK' if report.mutation_isolation_verified else 'FAILED'}")
+            if "affected_lanes" in report.details:
+                print(f"  - Affected lanes: {', '.join(report.details['affected_lanes'])}")
             if report.errors:
                 print("  - Errors:")
                 for err in report.errors:

--- a/scripts/publication/verify_lane_isolation.py
+++ b/scripts/publication/verify_lane_isolation.py
@@ -122,6 +122,7 @@ LANE_PREFIXES: dict[str, tuple[str, ...]] = {
         ".github/workflows/validate-submission.yml",
         ".github/workflows/sync-results-data-to-published.yml",
         ".github/workflows/corpus-drift-check.yml",
+        ".github/workflows/publication-corpus-cutover.yml",
     ),
 }
 

--- a/scripts/publication/verify_lane_isolation.py
+++ b/scripts/publication/verify_lane_isolation.py
@@ -52,6 +52,7 @@ SHARED_BUILD_INPUTS: tuple[str, ...] = (
     "benchbox/",
     "pyproject.toml",
     "uv.lock",
+    "scripts/publication/verify_lane_isolation.py",
 )
 
 # Tracked repo inputs that belong to no publication lane and are never read
@@ -101,7 +102,6 @@ LANE_PREFIXES: dict[str, tuple[str, ...]] = {
         "landing/",
         "_blog/",
         "scripts/assemble_public_site.py",
-        "scripts/publication/verify_lane_isolation.py",
         ".github/workflows/publication-lane-docs.yml",
     ),
     "explorer": (

--- a/tests/unit/scripts/publication/test_verify_lane_isolation.py
+++ b/tests/unit/scripts/publication/test_verify_lane_isolation.py
@@ -43,6 +43,7 @@ def test_classify_path_identifies_correct_lanes() -> None:
     assert classify_path("results-data/bundles/bundle_123.json") == {"corpus"}
     assert classify_path("scripts/validate_submission.py") == {"corpus"}
     assert classify_path(".github/workflows/validate-submission.yml") == {"corpus"}
+    assert classify_path(".github/workflows/publication-corpus-cutover.yml") == {"corpus"}
 
     # Unclassified / root paths
     assert classify_path("README.md") == set()
@@ -175,6 +176,7 @@ def test_determine_affected_lanes() -> None:
     assert determine_affected_lanes(["docs/index.rst"]) == {"site"}
     assert determine_affected_lanes(["results-explorer/src/App.tsx"]) == {"explorer"}
     assert determine_affected_lanes(["results-data/bundles/bundle.json"]) == {"corpus"}
+    assert determine_affected_lanes([".github/workflows/publication-corpus-cutover.yml"]) == {"corpus"}
 
     # Mixed lanes
     assert determine_affected_lanes(["docs/index.rst", "results-explorer/src/App.tsx"]) == {"site", "explorer"}

--- a/tests/unit/scripts/publication/test_verify_lane_isolation.py
+++ b/tests/unit/scripts/publication/test_verify_lane_isolation.py
@@ -10,11 +10,11 @@ from pathlib import Path
 import pytest
 
 from scripts.publication.verify_lane_isolation import (
-    LANE_SAFE_EXTERNAL_PATHS,
     REPO_ROOT,
     classify_path,
     compute_all_lane_digests,
     compute_lane_digest,
+    determine_affected_lanes,
     is_ignored,
     main,
     scan_lane_files,
@@ -115,21 +115,25 @@ def test_verify_lane_isolation_current_repo() -> None:
     assert not report.errors
 
 
-def test_verify_lane_isolation_detects_contaminating_changed_paths() -> None:
+def test_verify_lane_isolation_mixed_paths_succeed_for_all_affected_lanes() -> None:
     # Clean paths for site
     clean_paths = ["docs/index.rst", "landing/index.html"]
     clean_report = verify_lane_isolation("site", repo_root=REPO_ROOT, changed_paths=clean_paths)
     assert clean_report.success is True
+    assert clean_report.details["affected_lanes"] == ["site"]
 
-    # Contaminated paths with explorer and corpus changes
-    dirty_paths = [
+    # Mixed paths spanning site, explorer, and corpus
+    mixed_paths = [
         "docs/index.rst",
         "results-explorer/package.json",
         "results-data/bundles/test.json",
     ]
-    dirty_report = verify_lane_isolation("site", repo_root=REPO_ROOT, changed_paths=dirty_paths)
-    assert dirty_report.success is False
-    assert any("changed paths violate lane 'site' isolation" in err for err in dirty_report.errors)
+    # D7: Changed paths determine affected lanes; mixed PRs succeed for all affected lanes
+    for lane in ("site", "explorer", "corpus"):
+        report = verify_lane_isolation(lane, repo_root=REPO_ROOT, changed_paths=mixed_paths)
+        assert report.success is True
+        assert not report.errors
+        assert report.details["affected_lanes"] == ["corpus", "explorer", "site"]
 
 
 def test_non_lane_inputs_skipped_in_changed_paths() -> None:
@@ -166,92 +170,81 @@ def test_unclassified_changed_paths_still_fail() -> None:
     assert any("unclassified inputs" in err for err in report.errors)
 
 
-def test_lane_owned_paths_still_contaminate_despite_non_lane_allowlist() -> None:
-    # Classification runs before the non-lane allowlist: an explorer-owned
-    # file under a non-lane parent (_project/) must still report
-    # contamination when the site lane builds.
-    report = verify_lane_isolation(
-        "site",
-        repo_root=REPO_ROOT,
-        changed_paths=["docs/index.rst", "_project/scripts/explorer_pipeline/contract.py"],
-    )
-    assert report.success is False
-    assert any("changed paths violate lane 'site' isolation" in err for err in report.errors)
+def test_determine_affected_lanes() -> None:
+    # Single lane
+    assert determine_affected_lanes(["docs/index.rst"]) == {"site"}
+    assert determine_affected_lanes(["results-explorer/src/App.tsx"]) == {"explorer"}
+    assert determine_affected_lanes(["results-data/bundles/bundle.json"]) == {"corpus"}
 
-    corpus_report = verify_lane_isolation(
-        "site",
-        repo_root=REPO_ROOT,
-        changed_paths=["docs/index.rst", "scripts/publication/validator_parity.py"],
-    )
-    assert corpus_report.success is False
-    assert any("changed paths violate lane 'site' isolation" in err for err in corpus_report.errors)
+    # Mixed lanes
+    assert determine_affected_lanes(["docs/index.rst", "results-explorer/src/App.tsx"]) == {"site", "explorer"}
+    assert determine_affected_lanes(["results-explorer/src/App.tsx", "results-data/README.md"]) == {
+        "explorer",
+        "corpus",
+    }
+
+    # Shared build inputs affect all lanes
+    assert determine_affected_lanes(["benchbox/core/runner.py"]) == {"site", "explorer", "corpus"}
+    assert determine_affected_lanes(["pyproject.toml"]) == {"site", "explorer", "corpus"}
+    assert determine_affected_lanes(["uv.lock"]) == {"site", "explorer", "corpus"}
+
+    # Non-lane inputs affect no lanes
+    assert determine_affected_lanes(["tests/unit/test_example.py", "Makefile", "AGENTS.md"]) == set()
+
+    # Ignored paths affect no lanes
+    assert determine_affected_lanes([".venv/bin/python", ".DS_Store", "tmp/scratch.txt"]) == set()
+
+    # Unclassified paths conservatively affect all lanes
+    assert determine_affected_lanes(["brand-new-area/file.txt"]) == {"site", "explorer", "corpus"}
+
+
+def test_mixed_pr_2051_corpus_and_explorer_and_tests() -> None:
+    """Verified mixed PR #2051 path set passes isolation for all affected lanes."""
+    pr_2051_paths = [
+        "results-data/bundles/nyctaxi_sf1_duckdb_sql_20260826_163349_6c37cd51.json",
+        "results-data/corpus-inventory.json",
+        "results-data/validate_corpus.py",
+        "results-explorer/src/components/ChartPanel.tsx",
+        "results-explorer/src/lib/compareCohort.ts",
+        "tests/unit/scripts/explorer_pipeline/test_pipeline.py",
+    ]
+    affected = determine_affected_lanes(pr_2051_paths)
+    assert affected == {"corpus", "explorer"}
+
+    corpus_report = verify_lane_isolation("corpus", repo_root=REPO_ROOT, changed_paths=pr_2051_paths)
+    assert corpus_report.success is True
+    assert not corpus_report.errors
 
     explorer_report = verify_lane_isolation(
-        "site",
-        repo_root=REPO_ROOT,
-        changed_paths=["docs/index.rst", "scripts/publication/check_explorer_compat.py"],
+        "explorer", repo_root=REPO_ROOT, changed_paths=pr_2051_paths, check_mutations=False
     )
-    assert explorer_report.success is False
-    assert any("changed paths violate lane 'site' isolation" in err for err in explorer_report.errors)
-
-    for corpus_generator in (
-        "scripts/publication/create_ledger_seed.py",
-        "scripts/publication/assembler.py",
-    ):
-        generator_report = verify_lane_isolation(
-            "site",
-            repo_root=REPO_ROOT,
-            changed_paths=["docs/index.rst", corpus_generator],
-        )
-        assert generator_report.success is False
-        assert any("changed paths violate lane 'site' isolation" in err for err in generator_report.errors)
+    assert explorer_report.success is True
+    assert not explorer_report.errors
 
 
-def test_site_allows_only_explicit_non_build_corpus_paths() -> None:
-    """Site docs may accompany corpus policy edits, but corpus payloads remain forbidden."""
-    assert LANE_SAFE_EXTERNAL_PATHS["site"] == frozenset(
-        {
-            ".github/workflows/validate-submission.yml",
-            "results-data/README.md",
-        }
+def test_mixed_pr_2052_shared_benchbox_and_explorer_and_tests() -> None:
+    """Verified mixed PR #2052 path set passes isolation for all affected lanes."""
+    pr_2052_paths = [
+        "benchbox/cli/commands/tuning_group.py",
+        "benchbox/core/dataframe/tuning/defaults.py",
+        "benchbox/platforms/dataframe/dask_df.py",
+        "results-explorer/scripts/generate-browser-fixtures.mjs",
+        "results-explorer/test-fixtures/source/README.md",
+        "tests/unit/cli/commands/test_tuning_group_cli.py",
+    ]
+    affected = determine_affected_lanes(pr_2052_paths)
+    assert affected == {"site", "explorer", "corpus"}
+
+    for lane in ("site", "corpus"):
+        report = verify_lane_isolation(lane, repo_root=REPO_ROOT, changed_paths=pr_2052_paths)
+        assert report.success is True
+        assert not report.errors
+
+    explorer_report = verify_lane_isolation(
+        "explorer", repo_root=REPO_ROOT, changed_paths=pr_2052_paths, check_mutations=False
     )
-
-    report = verify_lane_isolation(
-        "site",
-        repo_root=REPO_ROOT,
-        changed_paths=[
-            "docs/index.rst",
-            ".github/workflows/validate-submission.yml",
-            "results-data/README.md",
-        ],
-    )
-    assert report.success is True
-
-    contaminated = verify_lane_isolation(
-        "site",
-        repo_root=REPO_ROOT,
-        changed_paths=["docs/index.rst", "results-data/bundles/new-bundle.json"],
-    )
-    assert contaminated.success is False
-    assert any("changed paths violate lane 'site' isolation" in err for err in contaminated.errors)
-
-
-@pytest.mark.parametrize(
-    "rejected_path",
-    [
-        "results-data/CORPUS_NOTES.md",
-        ".github/workflows/sync-results-data-to-published.yml",
-        "results-explorer/src/App.tsx",
-        "results-data/bundles/amplab_sf001_clickhouse_local_sql_20260825_175441_e89a4de7.json",
-    ],
-)
-def test_site_rejects_each_non_exception_external_path(rejected_path: str) -> None:
-    report = verify_lane_isolation("site", repo_root=REPO_ROOT, changed_paths=[rejected_path])
-
-    assert report.success is False
-    assert any(
-        "changed paths violate lane 'site' isolation" in error and rejected_path in error for error in report.errors
-    )
+    assert explorer_report.success is True
+    assert not explorer_report.errors
 
 
 def test_non_lane_inputs_excluded_from_digests() -> None:
@@ -352,15 +345,44 @@ def test_cli_lane_all_json() -> None:
 
 def test_cli_changed_paths_file(tmp_path: Path) -> None:
     paths_file = tmp_path / "changed.txt"
-    paths_file.write_text("docs/overview.md\nlanding/index.html\n", encoding="utf-8")
-
+    # Mixed paths spanning site and explorer pass
+    paths_file.write_text("docs/overview.md\nresults-explorer/package.json\n", encoding="utf-8")
     exit_code = main(["--lane", "site", "--changed-paths-file", str(paths_file)])
     assert exit_code == 0
 
-    # Test failure on cross-lane path in file
-    paths_file.write_text("results-data/bundles/bundle_evil.json\n", encoding="utf-8")
+    # Unclassified paths outside any lane fail closed
+    paths_file.write_text("unclassified-dir/bundle_evil.json\n", encoding="utf-8")
     exit_code = main(["--lane", "site", "--changed-paths-file", str(paths_file)])
     assert exit_code == 1
+
+
+def test_cli_determine_affected_lanes(capsys: pytest.CaptureFixture[str]) -> None:
+    exit_code = main(
+        [
+            "--changed-paths",
+            "docs/index.rst",
+            "results-explorer/src/App.tsx",
+            "--determine-affected-lanes",
+        ]
+    )
+    assert exit_code == 0
+    captured = capsys.readouterr()
+    assert "explorer site" in captured.out or "site explorer" in captured.out
+
+    # JSON output
+    exit_code = main(
+        [
+            "--changed-paths",
+            "docs/index.rst",
+            "results-explorer/src/App.tsx",
+            "--determine-affected-lanes",
+            "--json",
+        ]
+    )
+    assert exit_code == 0
+    captured = capsys.readouterr()
+    data = json.loads(captured.out)
+    assert data == {"affected_lanes": ["explorer", "site"]}
 
 
 def test_classify_path_shared_inputs_are_exempt() -> None:

--- a/tests/unit/scripts/publication/test_verify_lane_isolation.py
+++ b/tests/unit/scripts/publication/test_verify_lane_isolation.py
@@ -31,6 +31,7 @@ def test_classify_path_identifies_correct_lanes() -> None:
     assert classify_path("landing/index.html") == {"site"}
     assert classify_path("_blog/post.md") == {"site"}
     assert classify_path("scripts/assemble_public_site.py") == {"site"}
+    assert classify_path("scripts/publication/verify_lane_isolation.py") == set()
     assert classify_path(".github/workflows/publication-lane-docs.yml") == {"site"}
 
     # Explorer lane
@@ -189,6 +190,11 @@ def test_determine_affected_lanes() -> None:
     assert determine_affected_lanes(["benchbox/core/runner.py"]) == {"site", "explorer", "corpus"}
     assert determine_affected_lanes(["pyproject.toml"]) == {"site", "explorer", "corpus"}
     assert determine_affected_lanes(["uv.lock"]) == {"site", "explorer", "corpus"}
+    assert determine_affected_lanes(["scripts/publication/verify_lane_isolation.py"]) == {
+        "site",
+        "explorer",
+        "corpus",
+    }
 
     # Non-lane inputs affect no lanes
     assert determine_affected_lanes(["tests/unit/test_example.py", "Makefile", "AGENTS.md"]) == set()


### PR DESCRIPTION
Supersede the rule that all changed files in a PR must belong to a single lane.
Use changed paths only to determine affected publication lanes and flag
unclassified repository inputs. Delete the lane-safe external allowlist and
verify each affected lane independently so legitimate multi-lane changes
pass isolation.
