### PR TITLE
fix(explorer): render charts inside their own drawing at every width

### DIFF
--- a/results-explorer/e2e/responsive.spec.ts
+++ b/results-explorer/e2e/responsive.spec.ts
@@ -256,41 +256,78 @@ test.describe("responsive explorer assertions", () => {
       await page.goto("/results/tpch/");
       await waitForDataLoaded(page, /Charts/);
 
-      const offenders = await page.evaluate(() => {
-        const problems: string[] = [];
-        for (const svg of Array.from(document.querySelectorAll("svg[role='img']"))) {
-          const box = svg.getBoundingClientRect();
-          if (box.width === 0) continue;
+      // Walk every question group and every chart within it. Checking only the
+      // default view leaves most of the chart set unmeasured, and the default
+      // is the one chart least likely to be wrong.
+      const groups = page.getByRole("tablist", { name: "Chart question groups" }).getByRole("tab");
+      const groupCount = await groups.count();
+      // If this ever reads zero the walk below is vacuous and the test would
+      // pass without measuring anything.
+      expect(groupCount, "chart question groups").toBeGreaterThan(1);
+      let chartsVisited = 0;
 
-          const viewBox = svg.getAttribute("viewBox");
-          if (viewBox === null) {
-            problems.push(`${svg.getAttribute("aria-label") ?? "chart"}: no viewBox`);
-            continue;
+      for (let g = 0; g < groupCount; g += 1) {
+        await groups.nth(g).click();
+        await page.waitForTimeout(150);
+        const chartButtons = page.locator('[aria-label$="charts"] button');
+        const chartCount = await chartButtons.count();
+
+        for (let c = 0; c < Math.max(chartCount, 1); c += 1) {
+          if (chartCount > 0) {
+            await chartButtons.nth(c).click();
+            await page.waitForTimeout(150);
           }
+          chartsVisited += 1;
 
-          // Drawing width must match rendered width, or the coordinate system
-          // and the box disagree and marks fall outside the paint area.
-          const drawWidth = Number(viewBox.split(/\s+/)[2]);
-          if (Math.abs(drawWidth - box.width) > 1.5) {
-            problems.push(
-              `${svg.getAttribute("aria-label") ?? "chart"}: draws ${drawWidth} in a ${box.width.toFixed(0)}px box`,
-            );
-          }
+          const offenders = await page.evaluate(() => {
+            const problems: string[] = [];
+            for (const svg of Array.from(
+              document.querySelectorAll("[data-chart-container] svg[role='img']"),
+            )) {
+              const box = svg.getBoundingClientRect();
+              if (box.width === 0) continue;
 
-          for (const text of Array.from(svg.querySelectorAll("text"))) {
-            const textBox = text.getBoundingClientRect();
-            if (textBox.width === 0) continue;
-            if (textBox.right > box.right + 1 || textBox.bottom > box.bottom + 1) {
-              problems.push(
-                `${svg.getAttribute("aria-label") ?? "chart"}: "${(text.textContent ?? "").slice(0, 24)}" falls outside the drawing`,
-              );
+              const viewBox = svg.getAttribute("viewBox");
+              if (viewBox === null) {
+                problems.push(`${svg.getAttribute("aria-label") ?? "chart"}: no viewBox`);
+                continue;
+              }
+
+              // A drawing narrower than its box is scaled UP, which magnifies
+              // every coordinate including the gaps bars were spaced by.
+              const drawWidth = Number(viewBox.split(/\s+/)[2]);
+              if (drawWidth < box.width - 1.5) {
+                problems.push(
+                  `${svg.getAttribute("aria-label") ?? "chart"}: draws ${drawWidth} into a ${box.width.toFixed(0)}px box`,
+                );
+              }
+
+              for (const mark of Array.from(svg.querySelectorAll("text, rect, circle, path"))) {
+                const markBox = mark.getBoundingClientRect();
+                if (markBox.width === 0 && markBox.height === 0) continue;
+                if (
+                  markBox.right > box.right + 1 ||
+                  markBox.left < box.left - 1 ||
+                  markBox.bottom > box.bottom + 1
+                ) {
+                  const what =
+                    mark.tagName === "text"
+                      ? `"${(mark.textContent ?? "").slice(0, 24)}"`
+                      : mark.tagName;
+                  problems.push(
+                    `${svg.getAttribute("aria-label") ?? "chart"}: ${what} falls outside the drawing`,
+                  );
+                }
+              }
             }
-          }
-        }
-        return problems;
-      });
+            return problems;
+          });
 
-      expect(offenders, offenders.join("\n")).toEqual([]);
+          expect(offenders, offenders.join("\n")).toEqual([]);
+        }
+      }
+
+      expect(chartsVisited, "charts measured").toBeGreaterThan(5);
     });
   }
 

--- a/results-explorer/e2e/responsive.spec.ts
+++ b/results-explorer/e2e/responsive.spec.ts
@@ -245,6 +245,55 @@ test.describe("responsive explorer assertions", () => {
     });
   }
 
+  // The document-overflow audit above exempts anything inside `svg[role='img']`,
+  // so it cannot see a chart that overflows its own drawing. That exemption is
+  // why charts shipped clipping their right-hand quarter and bottom rows on a
+  // phone: the SVG box fitted the page, and the marks outside it were simply
+  // never painted.
+  for (const viewport of VIEWPORTS.filter((item) => item.width <= 768)) {
+    test(`chart drawings fit their own box at ${viewport.name}`, async ({ page }) => {
+      await page.setViewportSize({ width: viewport.width, height: viewport.height });
+      await page.goto("/results/tpch/");
+      await waitForDataLoaded(page, /Charts/);
+
+      const offenders = await page.evaluate(() => {
+        const problems: string[] = [];
+        for (const svg of Array.from(document.querySelectorAll("svg[role='img']"))) {
+          const box = svg.getBoundingClientRect();
+          if (box.width === 0) continue;
+
+          const viewBox = svg.getAttribute("viewBox");
+          if (viewBox === null) {
+            problems.push(`${svg.getAttribute("aria-label") ?? "chart"}: no viewBox`);
+            continue;
+          }
+
+          // Drawing width must match rendered width, or the coordinate system
+          // and the box disagree and marks fall outside the paint area.
+          const drawWidth = Number(viewBox.split(/\s+/)[2]);
+          if (Math.abs(drawWidth - box.width) > 1.5) {
+            problems.push(
+              `${svg.getAttribute("aria-label") ?? "chart"}: draws ${drawWidth} in a ${box.width.toFixed(0)}px box`,
+            );
+          }
+
+          for (const text of Array.from(svg.querySelectorAll("text"))) {
+            const textBox = text.getBoundingClientRect();
+            if (textBox.width === 0) continue;
+            if (textBox.right > box.right + 1 || textBox.bottom > box.bottom + 1) {
+              problems.push(
+                `${svg.getAttribute("aria-label") ?? "chart"}: "${(text.textContent ?? "").slice(0, 24)}" falls outside the drawing`,
+              );
+            }
+          }
+        }
+        return problems;
+      });
+
+      expect(offenders, offenders.join("\n")).toEqual([]);
+    });
+  }
+
   for (const homeRoute of [
     { name: "default", path: "/results/" },
     {

--- a/results-explorer/src/__tests__/svgAttributeHygiene.test.ts
+++ b/results-explorer/src/__tests__/svgAttributeHygiene.test.ts
@@ -1,0 +1,85 @@
+// @vitest-environment node
+/**
+ * Guardrail: SVG presentation attributes must be written with their real,
+ * hyphenated names.
+ *
+ * SVG attribute names are case-sensitive, and Preact forwards a prop it does
+ * not recognise straight to `setAttribute` under the name it was given. So
+ * `textAnchor="middle"` reaches the DOM as an attribute called `textAnchor`,
+ * which the renderer has no rule for and silently ignores. There is no warning
+ * and no visual clue that a value was dropped - only labels that quietly sit
+ * where they were never meant to sit.
+ *
+ * This shipped. Nine chart components used the camelCase spellings, and the
+ * result was that every label meant to be centred on its tick or right-aligned
+ * against its gutter was left-aligned instead, running across the plot; every
+ * emphasised stroke rendered at the default 1px; every dashed stroke rendered
+ * solid - including QueryHistogram's dashed marker, whose entire purpose was to
+ * make a query that did not run look different from one that ran very fast.
+ */
+
+import { readdirSync, readFileSync } from "node:fs";
+import { join, relative, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+/** camelCase spelling -> the name SVG actually reads. */
+const MISSPELLED_ATTRIBUTES: Readonly<Record<string, string>> = {
+  textAnchor: "text-anchor",
+  strokeWidth: "stroke-width",
+  strokeDasharray: "stroke-dasharray",
+  strokeLinecap: "stroke-linecap",
+  strokeLinejoin: "stroke-linejoin",
+  strokeOpacity: "stroke-opacity",
+  strokeMiterlimit: "stroke-miterlimit",
+  fillOpacity: "fill-opacity",
+  fillRule: "fill-rule",
+  dominantBaseline: "dominant-baseline",
+  alignmentBaseline: "alignment-baseline",
+  letterSpacing: "letter-spacing",
+  clipPath: "clip-path",
+  stopColor: "stop-color",
+  stopOpacity: "stop-opacity",
+  vectorEffect: "vector-effect",
+  shapeRendering: "shape-rendering",
+  paintOrder: "paint-order",
+  markerStart: "marker-start",
+  markerEnd: "marker-end",
+};
+
+const here = fileURLToPath(new URL(".", import.meta.url));
+const srcRoot = resolve(here, "..");
+
+function collectSources(dir: string, found: string[] = []): string[] {
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const full = join(dir, entry.name);
+    if (entry.isDirectory()) {
+      if (entry.name === "__tests__" || entry.name === "test") continue;
+      collectSources(full, found);
+    } else if (entry.name.endsWith(".tsx")) {
+      found.push(full);
+    }
+  }
+  return found;
+}
+
+describe("SVG attribute hygiene", () => {
+  it("writes every SVG presentation attribute under the name SVG reads", () => {
+    const offences: string[] = [];
+
+    for (const file of collectSources(srcRoot)) {
+      const lines = readFileSync(file, "utf8").split("\n");
+      lines.forEach((line, index) => {
+        for (const [camel, kebab] of Object.entries(MISSPELLED_ATTRIBUTES)) {
+          if (new RegExp(`\\b${camel}=`).test(line)) {
+            offences.push(
+              `${relative(srcRoot, file)}:${index + 1} uses ${camel}= (write ${kebab}=)`,
+            );
+          }
+        }
+      });
+    }
+
+    expect(offences).toStrictEqual([]);
+  });
+});

--- a/results-explorer/src/__tests__/svgAttributeHygiene.test.ts
+++ b/results-explorer/src/__tests__/svgAttributeHygiene.test.ts
@@ -10,12 +10,19 @@
  * and no visual clue that a value was dropped - only labels that quietly sit
  * where they were never meant to sit.
  *
- * This shipped. Nine chart components used the camelCase spellings, and the
- * result was that every label meant to be centred on its tick or right-aligned
- * against its gutter was left-aligned instead, running across the plot; every
- * emphasised stroke rendered at the default 1px; every dashed stroke rendered
- * solid - including QueryHistogram's dashed marker, whose entire purpose was to
- * make a query that did not run look different from one that ran very fast.
+ * This shipped. Ten chart components used the camelCase spellings across 68
+ * occurrences, and the result was that every label meant to be centred on its
+ * tick or right-aligned against its gutter was left-aligned instead, running
+ * across the plot; every emphasised stroke rendered at the default 1px; every
+ * dashed stroke rendered solid - including QueryHistogram's dashed marker,
+ * whose entire purpose was to make a query that did not run look different
+ * from one that ran very fast.
+ *
+ * The scan is lexical: it reads source lines rather than rendered attributes,
+ * so it cannot see a spread, a computed key, or a name assembled at runtime,
+ * and it would object to a camelCase prop of the same name on a component of
+ * our own. It is a cheap guard against the mistake that was actually made, not
+ * a proof.
  */
 
 import { readdirSync, readFileSync } from "node:fs";

--- a/results-explorer/src/components/CDFChart.tsx
+++ b/results-explorer/src/components/CDFChart.tsx
@@ -10,6 +10,7 @@
 
 import type { BenchmarkSummary } from "@/types";
 import { useElementSize } from "@/lib/useElementSize";
+import { axisLabelAnchor, chartFrame } from "@/lib/chartFrame";
 import { timeSeriesColor } from "@/lib/chartTheme";
 import { buildLogLatencyScale, computeECDFPoints, logLatencyFraction, logLatencyTicks } from "@/lib/chartMath";
 import { formatTimingExclusion, isTimingDisplayable, platformTimingValue } from "@/lib/displayEligibility";
@@ -20,7 +21,7 @@ const Y_TICKS_PCT = [0, 25, 50, 75, 100];
 
 const LABEL_W = 36;
 const AXIS_H = 28;
-const PADDING_TOP = 30; // legend space
+const PADDING_TOP = 8;
 const PADDING_RIGHT = 12;
 const PLOT_H = 180;
 
@@ -30,7 +31,8 @@ interface Props {
 
 export function CDFChart({ summary }: Props) {
   const [containerRef, { width: containerWidth }] = useElementSize();
-  const w = Math.max(containerWidth, 400);
+  const frame = chartFrame(containerWidth);
+  const w = frame.width;
 
   const cohortLabels = formatRunIdentityLabelsForCohort(
     summary.platforms.map((platform) => ({ ...platform, scale_factor: summary.scale_factor })),
@@ -70,15 +72,22 @@ export function CDFChart({ summary }: Props) {
   const xTicks = logLatencyTicks(logScale);
 
   return (
-    <div ref={containerRef} class="w-full overflow-x-auto">
-      <svg class="bb-chart-svg" width={w} height={totalH} role="img" aria-label="Cumulative distribution of per-query latency">
+    <div ref={containerRef} class="w-full">
+      <svg
+        class="bb-chart-svg"
+        width="100%"
+        height={totalH}
+        viewBox={`0 0 ${w} ${totalH}`}
+        role="img"
+        aria-label="Cumulative distribution of per-query latency"
+      >
         {/* Y-axis grid lines + labels */}
         {Y_TICKS_PCT.map((pct) => {
           const y = yFor(pct);
           return (
             <g key={pct}>
-              <line x1={LABEL_W} y1={y} x2={w - PADDING_RIGHT} y2={y} stroke="var(--bb-chart-grid)" strokeWidth={1} />
-              <text x={LABEL_W - 4} y={y + 4} textAnchor="end" style={{ fontSize: "10px", fill: "var(--bb-chart-label-muted)" }}>
+              <line x1={LABEL_W} y1={y} x2={w - PADDING_RIGHT} y2={y} stroke="var(--bb-chart-grid)" stroke-width={1} />
+              <text x={LABEL_W - 4} y={y + 4} text-anchor="end" style={{ fontSize: "10px", fill: "var(--bb-chart-label-muted)" }}>
                 {pct}%
               </text>
             </g>
@@ -97,7 +106,7 @@ export function CDFChart({ summary }: Props) {
             })
             .join(" ");
           return (
-            <path key={s.label} d={d} stroke={s.color} strokeWidth={2} fill="none">
+            <path key={s.label} d={d} stroke={s.color} stroke-width={2} fill="none">
               <title>{s.fullLabel}</title>
             </path>
           );
@@ -105,33 +114,42 @@ export function CDFChart({ summary }: Props) {
 
         {/* X-axis */}
         <g transform={`translate(0, ${PADDING_TOP + PLOT_H})`}>
-          <line x1={LABEL_W} y1={0} x2={w - PADDING_RIGHT} y2={0} stroke="var(--bb-chart-grid)" strokeWidth={1} />
+          <line x1={LABEL_W} y1={0} x2={w - PADDING_RIGHT} y2={0} stroke="var(--bb-chart-grid)" stroke-width={1} />
           {xTicks.map((ms) => {
             const x = xFor(ms);
             return (
               <g key={ms}>
-                <line x1={x} y1={0} x2={x} y2={4} stroke="var(--bb-chart-label-muted)" strokeWidth={1} />
-                <text x={x} y={16} textAnchor="middle" style={{ fontSize: "10px", fill: "var(--bb-chart-axis)" }}>
+                <line x1={x} y1={0} x2={x} y2={4} stroke="var(--bb-chart-label-muted)" stroke-width={1} />
+                <text
+                  x={x}
+                  y={16}
+                  text-anchor={axisLabelAnchor(x, w)}
+                  style={{ fontSize: "10px", fill: "var(--bb-chart-axis)" }}
+                >
                   {formatLatencyMs(ms, { subMillisecond: "compact" }).valueText}
                 </text>
               </g>
             );
           })}
         </g>
-
-        {/* Legend */}
-        <g transform="translate(0, 8)">
-          {series.map((s, i) => (
-            <g key={s.label} transform={`translate(${LABEL_W + i * 130}, 0)`}>
-              <line x1={0} y1={6} x2={16} y2={6} stroke={s.color} strokeWidth={2} />
-              <text x={20} y={10} style={{ fontSize: "11px", fill: "var(--bb-chart-label)" }}>
-                <title>{s.fullLabel}</title>
-                {s.label}
-              </text>
-            </g>
-          ))}
-        </g>
       </svg>
+
+      {/* Legend. One SVG row at a fixed 130-unit stride silently drops every
+          entry past the drawing width, and the entries it drops are the slowest
+          runs - the ones a reader is most likely asking about. HTML wraps, so
+          the key always holds every series, matching StackedPhase and
+          TimeSeries. */}
+      <ul class="mt-1.5 flex list-none flex-wrap gap-x-3 gap-y-1 p-0 text-xs text-[var(--bb-data-fg-muted)]">
+        {series.map((s) => (
+          <li key={s.label} class="flex items-center gap-1.5" title={s.fullLabel}>
+            <span
+              class="inline-block h-0.5 w-4 flex-shrink-0 rounded-sm"
+              style={{ backgroundColor: s.color }}
+            />
+            {s.label}
+          </li>
+        ))}
+      </ul>
       {excludedRows.length > 0 && (
         <p class="mt-1 text-[10px] text-[var(--bb-data-fg-subtle)]">
           {excludedRows.length} row(s) excluded from CDF: {formatTimingExclusion(excludedRows[0])}

--- a/results-explorer/src/components/ChartPanel.tsx
+++ b/results-explorer/src/components/ChartPanel.tsx
@@ -10,6 +10,8 @@ import {
   type ChartRegistryEntry,
 } from "@/lib/chartRegistry";
 import { useElementSize } from "@/lib/useElementSize";
+import { stringSerde, useUrlState } from "@/lib/useUrlState";
+import { axisLabelAnchor, barRowLayout, chartFrame } from "@/lib/chartFrame";
 import { PowerBar } from "@/components/PowerBar";
 import { DistributionBox } from "@/components/DistributionBox";
 import { QueryHeatmap } from "@/components/QueryHeatmap";
@@ -69,6 +71,9 @@ interface ChartPanelProps {
   queryFilter?: readonly string[];
 }
 
+/** URL parameter carrying the open chart. */
+const CHART_URL_KEY = "chart";
+
 interface CompareQueryRow {
   queryId: string;
   timings: ({ ms: number; status: "pass" } | null)[];
@@ -122,7 +127,12 @@ export function ChartPanel({
     [summary],
   );
   const preferredId = useMemo(() => preferredChartId(context, charts), [context, charts]);
-  const [activeId, setActiveId] = useState<string>(preferredId);
+  // The open chart belongs in the URL: a reader who finds the view that answers
+  // their question should be able to send that view, not an address that lands
+  // the recipient back on the default. An unknown or no-longer-applicable id is
+  // canonicalised to the preferred chart by the effect below, which rewrites
+  // the parameter as it goes.
+  const [activeId, setActiveId] = useUrlState<string>(CHART_URL_KEY, preferredId, stringSerde);
   const [localBaselineIdx, setLocalBaselineIdx] = useState(0);
   const groupTabRefs = useRef<Record<string, HTMLButtonElement | null>>({});
   const isBaselineControlled = baselineIndex !== undefined;
@@ -498,8 +508,12 @@ function preferredChartId(
     if (ids.has("summary_box")) return "summary_box";
   }
 
-  if (context.kind === "summary" && ids.has("sparkline_table")) {
-    return "sparkline_table";
+  // A section headed "Charts" should open on a chart. The sparkline table is an
+  // HTML metrics table; it stays available in the Overview group, but leading
+  // with it meant a reader who never touched the controls saw no chart at all.
+  if (context.kind === "summary") {
+    if (ids.has("performance_bar")) return "performance_bar";
+    if (ids.has("sparkline_table")) return "sparkline_table";
   }
 
   return charts[0]?.id ?? "";
@@ -668,7 +682,8 @@ function renderChart(
 
 function PerformanceBar({ summary }: { summary: BenchmarkSummary }) {
   const [containerRef, { width: containerWidth }] = useElementSize();
-  const width = Math.max(containerWidth, 400);
+  const frame = chartFrame(containerWidth);
+  const width = frame.width;
   const cohortLabels = formatRunIdentityLabelsForCohort(
     summary.platforms.map((platform) => ({ ...platform, scale_factor: summary.scale_factor })),
   );
@@ -700,12 +715,12 @@ function PerformanceBar({ summary }: { summary: BenchmarkSummary }) {
     );
   }
 
-  const labelWidth = 160;
-  const rowHeight = 36;
+  const layout = barRowLayout(frame, { labelWidth: 160, rowHeight: 36, valueTrail: 96 });
+  const labelWidth = layout.labelWidth;
+  const rowHeight = layout.rowHeight;
   const axisHeight = 32;
   const topPadding = 8;
-  const valueLabelGutter = 96;
-  const plotWidth = width - labelWidth - valueLabelGutter;
+  const plotWidth = layout.plotWidth;
   const totalHeight = topPadding + rows.length * rowHeight + axisHeight;
   const scale = buildLatencyBarScale(rows.map((row) => row.display_geomean_ms));
   if (scale === null) return null;
@@ -720,8 +735,9 @@ function PerformanceBar({ summary }: { summary: BenchmarkSummary }) {
     <div ref={containerRef} class="w-full overflow-x-auto">
       <svg
         class="bb-chart-svg"
-        width={width}
+        width="100%"
         height={totalHeight}
+        viewBox={`0 0 ${width} ${totalHeight}`}
         role="img"
         aria-label={
           scale.mode === "log"
@@ -734,28 +750,33 @@ function PerformanceBar({ summary }: { summary: BenchmarkSummary }) {
           const barWidth = fraction * plotWidth;
           const renderedBarWidth = Math.max(2, barWidth);
           const valueLabel = fmtGeomean(row.display_geomean_ms);
-          const valueLabelPlacement = placePerformanceValueLabel({
-            barWidth: renderedBarWidth,
-            plotWidth,
-            labelWidth,
-            valueText: valueLabel,
-          });
+          // A compact row has no gutter to place the value in: it shares the
+          // label line, at the opposite end, where no bar length can displace
+          // it. Wide rows keep the measured three-way placement.
+          const valueLabelPlacement: ValueLabelPlacement = layout.labelAbove
+            ? { x: width, textAnchor: "end", fill: "var(--bb-chart-label)", placement: "outside" }
+            : placePerformanceValueLabel({
+                barWidth: renderedBarWidth,
+                plotWidth,
+                labelWidth,
+                valueText: valueLabel,
+              });
           const y = topPadding + index * rowHeight;
-          const midY = y + rowHeight * 0.5;
-          const barHeight = rowHeight * 0.55;
+          const midY = y + layout.barCenter;
+          const barHeight = 36 * 0.55;
           return (
             <g key={row.result_id}>
               <text
-                x={labelWidth - 6}
-                y={midY + 4}
-                textAnchor="end"
+                x={layout.labelAbove ? 0 : labelWidth - 6}
+                y={y + layout.labelBaseline}
+                text-anchor={layout.labelAbove ? "start" : "end"}
                 style={{ fontSize: "11px", fill: "var(--bb-chart-label)" }}
               >
                 <title>{row.fullLabel}</title>
                 {row.displayLabel}
               </text>
               <rect
-                x={labelWidth}
+                x={layout.plotX}
                 y={midY - barHeight / 2}
                 width={renderedBarWidth}
                 height={barHeight}
@@ -767,19 +788,19 @@ function PerformanceBar({ summary }: { summary: BenchmarkSummary }) {
               </rect>
               {valueLabelPlacement.placement === "gutter" && (
                 <line
-                  x1={labelWidth + renderedBarWidth + 4}
+                  x1={layout.plotX + renderedBarWidth + 4}
                   y1={midY}
                   x2={valueLabelPlacement.x - 5}
                   y2={midY}
                   stroke="var(--bb-chart-grid)"
-                  strokeWidth={1}
-                  strokeDasharray="2 2"
+                  stroke-width={1}
+                  stroke-dasharray="2 2"
                 />
               )}
               <text
                 x={valueLabelPlacement.x}
-                y={midY + 4}
-                textAnchor={valueLabelPlacement.textAnchor}
+                y={layout.labelAbove ? y + layout.labelBaseline : midY + 4}
+                text-anchor={valueLabelPlacement.textAnchor}
                 data-value-placement={valueLabelPlacement.placement}
                 style={{ fontSize: "11px", fill: valueLabelPlacement.fill }}
               >
@@ -792,7 +813,7 @@ function PerformanceBar({ summary }: { summary: BenchmarkSummary }) {
                   x2={width}
                   y2={y + rowHeight}
                   stroke="var(--bb-chart-grid)"
-                  strokeWidth={1}
+                  stroke-width={1}
                 />
               )}
             </g>
@@ -801,23 +822,23 @@ function PerformanceBar({ summary }: { summary: BenchmarkSummary }) {
 
         <g transform={`translate(0, ${topPadding + rows.length * rowHeight})`}>
           <line
-            x1={labelWidth}
+            x1={layout.plotX}
             y1={0}
-            x2={labelWidth + plotWidth}
+            x2={layout.plotX + plotWidth}
             y2={0}
             stroke="var(--bb-chart-grid)"
-            strokeWidth={1}
+            stroke-width={1}
           />
           {ticks.map((value) => {
             const fraction = latencyScaleFraction(value, scale) ?? 0;
-            const x = labelWidth + fraction * plotWidth;
+            const x = layout.plotX + fraction * plotWidth;
             return (
               <g key={value}>
-                <line x1={x} y1={0} x2={x} y2={4} stroke="var(--bb-chart-label-muted)" strokeWidth={1} />
+                <line x1={x} y1={0} x2={x} y2={4} stroke="var(--bb-chart-label-muted)" stroke-width={1} />
                 <text
                   x={x}
                   y={16}
-                  textAnchor="middle"
+                  text-anchor={axisLabelAnchor(x, width)}
                   style={{ fontSize: "10px", fill: "var(--bb-chart-axis)" }}
                 >
                   {fmtGeomean(value)}
@@ -826,9 +847,9 @@ function PerformanceBar({ summary }: { summary: BenchmarkSummary }) {
             );
           })}
           <text
-            x={labelWidth + plotWidth / 2}
+            x={layout.plotX + plotWidth / 2}
             y={axisHeight - 2}
-            textAnchor="middle"
+            text-anchor="middle"
             style={{ fontSize: "10px", fill: "var(--bb-chart-label-muted)" }}
           >
             {scaleLabel}

--- a/results-explorer/src/components/ChartPanel.tsx
+++ b/results-explorer/src/components/ChartPanel.tsx
@@ -148,6 +148,22 @@ export function ChartPanel({
     }
   }, [activeId, charts, preferredId]);
 
+  // Router navigation between two routes that both host this panel uses
+  // pushState, which fires no popstate, so the panel stays mounted with the
+  // chart the reader chose while the destination URL says nothing about it.
+  // The parameter has to describe what is on screen, or a shared link does not
+  // reproduce the view it was copied from.
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    // Only an id this cohort can actually show belongs in the URL. Without this
+    // guard the effect races the canonicalisation above and writes back the
+    // very id that was just rejected.
+    if (!charts.some((chart) => chart.id === activeId)) return;
+    const inUrl = new URLSearchParams(window.location.search).get(CHART_URL_KEY);
+    const expected = activeId === preferredId ? null : activeId;
+    if (inUrl !== expected) setActiveId(activeId);
+  }, [activeId, charts, preferredId, setActiveId]);
+
   useEffect(() => {
     if (!isBaselineControlled) setLocalBaselineIdx(0);
   }, [context, isBaselineControlled]);
@@ -726,8 +742,14 @@ function PerformanceBar({ summary }: { summary: BenchmarkSummary }) {
   if (scale === null) return null;
 
   const ticks = latencyScaleTicks(scale);
-  const scaleLabel =
-    scale.mode === "log"
+  // The full caption is wider than a phone column, so a compact drawing names
+  // the scale and the direction and leaves the metric to the chart's heading
+  // and accessible name, which already say "geomean performance".
+  const scaleLabel = layout.labelAbove
+    ? scale.mode === "log"
+      ? "Log scale - lower is better"
+      : "Median of passing - lower is better"
+    : scale.mode === "log"
       ? "Geomean query time (log scale) - lower is better"
       : "Geomean query time (median-of-passing) - lower is better";
 
@@ -846,10 +868,12 @@ function PerformanceBar({ summary }: { summary: BenchmarkSummary }) {
               </g>
             );
           })}
+          {/* Centred, this caption is wider than a phone column and would spill
+              from both ends. A compact drawing anchors it at the left instead. */}
           <text
-            x={layout.plotX + plotWidth / 2}
+            x={layout.labelAbove ? 0 : layout.plotX + plotWidth / 2}
             y={axisHeight - 2}
-            text-anchor="middle"
+            text-anchor={layout.labelAbove ? "start" : "middle"}
             style={{ fontSize: "10px", fill: "var(--bb-chart-label-muted)" }}
           >
             {scaleLabel}

--- a/results-explorer/src/components/CostScatter.tsx
+++ b/results-explorer/src/components/CostScatter.tsx
@@ -13,6 +13,7 @@
 
 import type { BenchmarkSummary, PlatformRow } from "@/types";
 import { useElementSize } from "@/lib/useElementSize";
+import { axisLabelAnchor, chartFrame } from "@/lib/chartFrame";
 import { paletteColor } from "@/lib/chartTheme";
 import { costModelDisclosure, normalizedCostValue } from "@/lib/costDisplay";
 import { formatLatencyMs, formatPowerScore, formatUsd } from "@/lib/metricFormatters";
@@ -41,7 +42,8 @@ type ScatterPoint = {
 
 export function CostScatter({ summary }: Props) {
   const [containerRef, { width: containerWidth }] = useElementSize();
-  const w = Math.max(containerWidth, 400);
+  const frame = chartFrame(containerWidth);
+  const w = frame.width;
 
   // Primary metric comes from the canonical DuckDB-persisted ranking row.
   // Fallback is safe: every result has a display_geomean_ms.
@@ -109,11 +111,12 @@ export function CostScatter({ summary }: Props) {
   const modelDisclosure = costModelDisclosure(summary.platforms);
 
   return (
-    <div ref={containerRef} class="w-full overflow-x-auto">
+    <div ref={containerRef} class="w-full">
       <svg
         class="bb-chart-svg"
-        width={w}
+        width="100%"
         height={totalH}
+        viewBox={`0 0 ${w} ${totalH}`}
         role="img"
         aria-label={`Normalized cost vs ${metricLabel} scatter plot (${modelDisclosure})`}
       >
@@ -134,12 +137,12 @@ export function CostScatter({ summary }: Props) {
                 x2={w - PADDING_RIGHT}
                 y2={y}
                 stroke="var(--bb-chart-grid-muted)"
-                strokeWidth={1}
+                stroke-width={1}
               />
               <text
                 x={AXIS_W - 4}
                 y={y + 4}
-                textAnchor="end"
+                text-anchor="end"
                 style={{ fontSize: "9px", fill: "var(--bb-chart-label-muted)" }}
               >
                 {label}
@@ -156,17 +159,19 @@ export function CostScatter({ summary }: Props) {
           const regionLabel = [p.provider, p.region].filter(Boolean).join(" ");
           return (
             <g key={p.result_id}>
-              <circle cx={cx} cy={cy} r={7} fill={p.color} fillOpacity={0.85}>
+              <circle cx={cx} cy={cy} r={7} fill={p.color} fill-opacity={0.85}>
                 <title>
                   {`${p.platform}: normalized ${formatUsd(p.cost).valueText} / ${
                     metric === "power_score" ? formatPowerScore(p.perf).valueText : formatLatencyMs(p.perf).valueText
                   } (${p.modelVersion ?? "model unknown"}${regionLabel ? `, ${regionLabel}` : ""})`}
                 </title>
               </circle>
+              {/* A point near either edge cannot carry a centred label: half of
+                  it would fall outside the drawing and be cropped. */}
               <text
                 x={cx}
                 y={cy - 11}
-                textAnchor="middle"
+                text-anchor={axisLabelAnchor(cx, w, 40)}
                 style={{ fontSize: "10px", fill: "var(--bb-chart-label)" }}
               >
                 {shortLabel}
@@ -182,7 +187,7 @@ export function CostScatter({ summary }: Props) {
           x2={AXIS_W}
           y2={PADDING_TOP + CHART_H}
           stroke="var(--bb-chart-grid)"
-          strokeWidth={1}
+          stroke-width={1}
         />
         <line
           x1={AXIS_W}
@@ -190,7 +195,7 @@ export function CostScatter({ summary }: Props) {
           x2={w - PADDING_RIGHT}
           y2={PADDING_TOP + CHART_H}
           stroke="var(--bb-chart-grid)"
-          strokeWidth={1}
+          stroke-width={1}
         />
 
         {/* X-axis labels */}
@@ -205,12 +210,12 @@ export function CostScatter({ summary }: Props) {
                 x2={x}
                 y2={PADDING_TOP + CHART_H + 4}
                 stroke="var(--bb-chart-label-muted)"
-                strokeWidth={1}
+                stroke-width={1}
               />
               <text
                 x={x}
                 y={PADDING_TOP + CHART_H + 16}
-                textAnchor="middle"
+                text-anchor={axisLabelAnchor(x, w)}
                 style={{ fontSize: "10px", fill: "var(--bb-chart-axis)" }}
               >
                 {formatUsd(cost).valueText}
@@ -221,7 +226,7 @@ export function CostScatter({ summary }: Props) {
         <text
           x={AXIS_W + plotW / 2}
           y={PADDING_TOP + CHART_H + AXIS_H - 2}
-          textAnchor="middle"
+          text-anchor="middle"
           style={{ fontSize: "10px", fill: "var(--bb-chart-label-muted)" }}
         >
           Normalized cost (USD)
@@ -233,7 +238,7 @@ export function CostScatter({ summary }: Props) {
           y={0}
           style={{ fontSize: "9px", fill: "var(--bb-chart-label-muted)" }}
           transform={`rotate(-90) translate(${-(PADDING_TOP + CHART_H / 2)}, 11)`}
-          textAnchor="middle"
+          text-anchor="middle"
         >
           {metricLabel}
         </text>

--- a/results-explorer/src/components/DistributionBox.tsx
+++ b/results-explorer/src/components/DistributionBox.tsx
@@ -15,6 +15,7 @@
 
 import type { BenchmarkSummary } from "@/types";
 import { useElementSize } from "@/lib/useElementSize";
+import { axisLabelAnchor, barRowLayout, chartFrame } from "@/lib/chartFrame";
 import { paletteColor } from "@/lib/chartTheme";
 import { buildLogLatencyScale, computeBoxStats, logLatencyFraction, logLatencyTicks } from "@/lib/chartMath";
 import { formatTimingExclusion, isTimingDisplayable, platformTimingValue } from "@/lib/displayEligibility";
@@ -33,7 +34,9 @@ interface Props {
 
 export function DistributionBox({ summary }: Props) {
   const [containerRef, { width: containerWidth }] = useElementSize();
-  const w = Math.max(containerWidth, 400);
+  const frame = chartFrame(containerWidth);
+  const w = frame.width;
+  const layout = barRowLayout(frame, { labelWidth: LABEL_W, rowHeight: ROW_H, valueTrail: PADDING_RIGHT });
 
   const cohortLabels = formatRunIdentityLabelsForCohort(
     summary.platforms.map((platform) => ({ ...platform, scale_factor: summary.scale_factor })),
@@ -69,28 +72,40 @@ export function DistributionBox({ summary }: Props) {
   if (scale === null) return null;
   const logScale = scale;
 
-  const plotW = w - LABEL_W - PADDING_RIGHT;
-  const totalH = PADDING_TOP + rows.length * ROW_H + AXIS_H;
+  const plotW = layout.plotWidth;
+  const totalH = PADDING_TOP + rows.length * layout.rowHeight + AXIS_H;
 
   function xFor(ms: number): number {
-    return LABEL_W + logLatencyFraction(ms, logScale) * plotW;
+    return layout.plotX + logLatencyFraction(ms, logScale) * plotW;
   }
 
   const xTicks = logLatencyTicks(logScale);
 
   return (
-    <div ref={containerRef} class="w-full overflow-x-auto">
-      <svg class="bb-chart-svg" width={w} height={totalH} role="img" aria-label="Distribution box plots of per-query latency">
+    <div ref={containerRef} class="w-full">
+      <svg
+        class="bb-chart-svg"
+        width="100%"
+        height={totalH}
+        viewBox={`0 0 ${w} ${totalH}`}
+        role="img"
+        aria-label="Distribution box plots of per-query latency"
+      >
         {rows.map((row, ri) => {
-          const y = PADDING_TOP + ri * ROW_H;
-          const midY = y + ROW_H * 0.5;
+          const y = PADDING_TOP + ri * layout.rowHeight;
+          const midY = y + layout.barCenter;
           const boxH = ROW_H * 0.46;
           const { min, q1, median, q3, max } = row.stats;
 
           return (
             <g key={row.label}>
               {/* Platform label */}
-              <text x={LABEL_W - 6} y={midY + 4} textAnchor="end" style={{ fontSize: "11px", fill: "var(--bb-chart-label)" }}>
+              <text
+                x={layout.labelAbove ? 0 : LABEL_W - 6}
+                y={y + layout.labelBaseline}
+                text-anchor={layout.labelAbove ? "start" : "end"}
+                style={{ fontSize: "11px", fill: "var(--bb-chart-label)" }}
+              >
                 <title>{row.fullLabel}</title>
                 {row.label}
               </text>
@@ -102,13 +117,13 @@ export function DistributionBox({ summary }: Props) {
                 x2={xFor(max)}
                 y2={midY}
                 stroke={row.color}
-                strokeWidth={1.5}
-                strokeDasharray="3 2"
+                stroke-width={1.5}
+                stroke-dasharray="3 2"
               />
               {/* Min cap */}
-              <line x1={xFor(min)} y1={midY - 5} x2={xFor(min)} y2={midY + 5} stroke={row.color} strokeWidth={1.5} />
+              <line x1={xFor(min)} y1={midY - 5} x2={xFor(min)} y2={midY + 5} stroke={row.color} stroke-width={1.5} />
               {/* Max cap */}
-              <line x1={xFor(max)} y1={midY - 5} x2={xFor(max)} y2={midY + 5} stroke={row.color} strokeWidth={1.5} />
+              <line x1={xFor(max)} y1={midY - 5} x2={xFor(max)} y2={midY + 5} stroke={row.color} stroke-width={1.5} />
 
               {/* IQR box (Q1-Q3) */}
               <rect
@@ -117,9 +132,9 @@ export function DistributionBox({ summary }: Props) {
                 width={Math.max(2, xFor(q3) - xFor(q1))}
                 height={boxH}
                 fill={row.color}
-                fillOpacity={0.18}
+                fill-opacity={0.18}
                 stroke={row.color}
-                strokeWidth={1.5}
+                stroke-width={1.5}
                 rx={2}
               />
 
@@ -130,26 +145,38 @@ export function DistributionBox({ summary }: Props) {
                 x2={xFor(median)}
                 y2={midY + boxH / 2}
                 stroke={row.color}
-                strokeWidth={2.5}
+                stroke-width={2.5}
               />
 
               {/* Separator */}
               {ri < rows.length - 1 && (
-                <line x1={0} y1={y + ROW_H} x2={w} y2={y + ROW_H} stroke="var(--bb-chart-grid)" strokeWidth={1} />
+                <line
+                  x1={0}
+                  y1={y + layout.rowHeight}
+                  x2={w}
+                  y2={y + layout.rowHeight}
+                  stroke="var(--bb-chart-grid)"
+                  stroke-width={1}
+                />
               )}
             </g>
           );
         })}
 
         {/* X-axis */}
-        <g transform={`translate(0, ${PADDING_TOP + rows.length * ROW_H})`}>
-          <line x1={LABEL_W} y1={0} x2={w - PADDING_RIGHT} y2={0} stroke="var(--bb-chart-grid)" strokeWidth={1} />
+        <g transform={`translate(0, ${PADDING_TOP + rows.length * layout.rowHeight})`}>
+          <line x1={layout.plotX} y1={0} x2={layout.plotX + plotW} y2={0} stroke="var(--bb-chart-grid)" stroke-width={1} />
           {xTicks.map((ms) => {
             const x = xFor(ms);
             return (
               <g key={ms}>
-                <line x1={x} y1={0} x2={x} y2={4} stroke="var(--bb-chart-label-muted)" strokeWidth={1} />
-                <text x={x} y={16} textAnchor="middle" style={{ fontSize: "10px", fill: "var(--bb-chart-axis)" }}>
+                <line x1={x} y1={0} x2={x} y2={4} stroke="var(--bb-chart-label-muted)" stroke-width={1} />
+                <text
+                  x={x}
+                  y={16}
+                  text-anchor={axisLabelAnchor(x, w)}
+                  style={{ fontSize: "10px", fill: "var(--bb-chart-axis)" }}
+                >
                   {formatLatencyMs(ms, { subMillisecond: "compact" }).valueText}
                 </text>
               </g>

--- a/results-explorer/src/components/DivergingBarChart.tsx
+++ b/results-explorer/src/components/DivergingBarChart.tsx
@@ -11,6 +11,7 @@
 import { deltaPct, sortByMagnitudeDesc } from "@/lib/chartMath";
 import { DIVERGING_MAX_PCT, FASTER_FILL, SLOWER_FILL, paletteColor } from "@/lib/chartTheme";
 import { useElementSize } from "@/lib/useElementSize";
+import { chartFrame } from "@/lib/chartFrame";
 
 interface DivergingEntry {
   queryId: string;
@@ -27,7 +28,7 @@ interface Props {
 
 export function DivergingBarChart({ queries, results, baselineIdx }: Props) {
   const [containerRef, { width: containerWidth }] = useElementSize();
-  const drawWidth = Math.max(containerWidth, 300);
+  const drawWidth = chartFrame(containerWidth, { minWidth: 300 }).width;
 
   if (queries.length === 0 || results.length < 2) return null;
 

--- a/results-explorer/src/components/DivergingBarChart.tsx
+++ b/results-explorer/src/components/DivergingBarChart.tsx
@@ -11,7 +11,7 @@
 import { deltaPct, sortByMagnitudeDesc } from "@/lib/chartMath";
 import { DIVERGING_MAX_PCT, FASTER_FILL, SLOWER_FILL, paletteColor } from "@/lib/chartTheme";
 import { useElementSize } from "@/lib/useElementSize";
-import { chartFrame } from "@/lib/chartFrame";
+import { chartFrame, edgeSafeValueLabel } from "@/lib/chartFrame";
 
 interface DivergingEntry {
   queryId: string;
@@ -158,12 +158,27 @@ export function DivergingBarChart({ queries, results, baselineIdx }: Props) {
                       fill={isRegression ? SLOWER_FILL : FASTER_FILL}
                       opacity={0.75}
                     />
+                    {/* A delta at the clamp reaches the end of its half of the
+                        plot; a label started past the bar would fall outside
+                        the viewBox and be cropped. */}
                     <text
-                      x={isRegression ? barX + barW + 2 : barX - 2}
+                      x={
+                        edgeSafeValueLabel(
+                          isRegression ? barX + barW : barX,
+                          drawWidth,
+                          isRegression ? "right" : "left",
+                        ).x
+                      }
                       y={barY + BAR_H / 2 + 3}
                       font-size="8"
                       fill={entry.color}
-                      text-anchor={isRegression ? "start" : "end"}
+                      text-anchor={
+                        edgeSafeValueLabel(
+                          isRegression ? barX + barW : barX,
+                          drawWidth,
+                          isRegression ? "right" : "left",
+                        ).textAnchor
+                      }
                     >
                       {entry.deltaPct >= 0 ? "+" : ""}{entry.deltaPct.toFixed(1)}%
                     </text>

--- a/results-explorer/src/components/NormalizedSpeedupChart.tsx
+++ b/results-explorer/src/components/NormalizedSpeedupChart.tsx
@@ -22,6 +22,7 @@ import {
   paletteColor,
 } from "@/lib/chartTheme";
 import { useElementSize } from "@/lib/useElementSize";
+import { chartFrame } from "@/lib/chartFrame";
 
 function toX(speedup: number, width: number): number {
   const clamped = Math.max(0.1, Math.min(speedup, 10));
@@ -42,7 +43,7 @@ interface Props {
 export function NormalizedSpeedupChart({ queries, results, baselineIdx }: Props) {
   const [containerRef, { width: containerWidth }] = useElementSize();
   // Use measured width; fall back to 600 if not yet observed (before first paint).
-  const drawWidth = Math.max(containerWidth, 300);
+  const drawWidth = chartFrame(containerWidth, { minWidth: 300 }).width;
 
   // w6 (chart-panel-scope-and-labeling): default to "comparable only"
   // so cohorts with hundreds of queries (e.g. read_primitives' ~149)

--- a/results-explorer/src/components/NormalizedSpeedupChart.tsx
+++ b/results-explorer/src/components/NormalizedSpeedupChart.tsx
@@ -22,7 +22,7 @@ import {
   paletteColor,
 } from "@/lib/chartTheme";
 import { useElementSize } from "@/lib/useElementSize";
-import { chartFrame } from "@/lib/chartFrame";
+import { chartFrame, edgeSafeValueLabel } from "@/lib/chartFrame";
 
 function toX(speedup: number, width: number): number {
   const clamped = Math.max(0.1, Math.min(speedup, 10));
@@ -205,12 +205,21 @@ export function NormalizedSpeedupChart({ queries, results, baselineIdx }: Props)
                       fill={isSlower ? SLOWER_FILL : FASTER_FILL}
                       opacity={0.75}
                     />
+                    {/* A speedup at the clamp reaches the end of the plot, so a
+                        label started past the bar would be drawn outside the
+                        viewBox and cropped. */}
                     <text
-                      x={isSlower ? barX - 2 : sx + 2}
+                      x={
+                        edgeSafeValueLabel(isSlower ? barX : sx, drawWidth, isSlower ? "left" : "right")
+                          .x
+                      }
                       y={barY + BAR_H / 2 + 3}
                       font-size="8"
                       fill={color}
-                      text-anchor={isSlower ? "end" : "start"}
+                      text-anchor={
+                        edgeSafeValueLabel(isSlower ? barX : sx, drawWidth, isSlower ? "left" : "right")
+                          .textAnchor
+                      }
                     >
                       {formatSpeedup(speedup, { unit: "×" }).valueText}
                     </text>

--- a/results-explorer/src/components/PercentileLadder.tsx
+++ b/results-explorer/src/components/PercentileLadder.tsx
@@ -12,7 +12,7 @@
 
 import type { PercentileStats } from "@/types";
 import { useElementSize } from "@/lib/useElementSize";
-import { axisLabelAnchor, barRowLayout, chartFrame } from "@/lib/chartFrame";
+import { axisLabelAnchor, barRowLayout, chartFrame, edgeSafeValueLabel } from "@/lib/chartFrame";
 import { paletteColor } from "@/lib/chartTheme";
 import { buildLogLatencyScale, logLatencyFraction, logLatencyTicks } from "@/lib/chartMath";
 import { formatLatencyMs } from "@/lib/metricFormatters";
@@ -159,10 +159,20 @@ export function PercentileLadder({ rows }: Props) {
               })}
 
               {/* P50 value label */}
+              {/* A p50 close to the axis maximum lands at the end of the plot,
+                  where a trailing label would be cropped. */}
               <text
-                x={layout.labelAbove ? drawWidth : xForMs(row.percentile_stats.p50) + 4}
+                x={
+                  layout.labelAbove
+                    ? drawWidth
+                    : edgeSafeValueLabel(xForMs(row.percentile_stats.p50), drawWidth, "right", 4).x
+                }
                 y={layout.labelAbove ? y + layout.labelBaseline : midY + 4}
-                text-anchor={layout.labelAbove ? "end" : "start"}
+                text-anchor={
+                  layout.labelAbove
+                    ? "end"
+                    : edgeSafeValueLabel(xForMs(row.percentile_stats.p50), drawWidth, "right", 4).textAnchor
+                }
                 class="text-[10px] fill-[var(--bb-data-fg-muted)] font-mono"
                 style={{ fontSize: "10px" }}
               >

--- a/results-explorer/src/components/PercentileLadder.tsx
+++ b/results-explorer/src/components/PercentileLadder.tsx
@@ -12,6 +12,7 @@
 
 import type { PercentileStats } from "@/types";
 import { useElementSize } from "@/lib/useElementSize";
+import { axisLabelAnchor, barRowLayout, chartFrame } from "@/lib/chartFrame";
 import { paletteColor } from "@/lib/chartTheme";
 import { buildLogLatencyScale, logLatencyFraction, logLatencyTicks } from "@/lib/chartMath";
 import { formatLatencyMs } from "@/lib/metricFormatters";
@@ -52,7 +53,9 @@ const PADDING_TOP = 28; // space for legend
 
 export function PercentileLadder({ rows }: Props) {
   const [containerRef, { width: containerWidth }] = useElementSize();
-  const drawWidth = Math.max(containerWidth, 400);
+  const frame = chartFrame(containerWidth);
+  const drawWidth = frame.width;
+  const layout = barRowLayout(frame, { labelWidth: LABEL_W, rowHeight: ROW_H, valueTrail: 8 });
 
   if (rows.length === 0) return null;
 
@@ -66,29 +69,39 @@ export function PercentileLadder({ rows }: Props) {
   if (scale === null) return null;
   const logScale = scale;
 
-  const barAreaWidth = drawWidth - LABEL_W - 8;
+  const barAreaWidth = layout.plotWidth;
 
   function xForMs(ms: number): number {
-    return LABEL_W + logLatencyFraction(ms, logScale) * barAreaWidth;
+    return layout.plotX + logLatencyFraction(ms, logScale) * barAreaWidth;
   }
 
-  const totalHeight = PADDING_TOP + rows.length * ROW_H + AXIS_H;
+  const totalHeight = PADDING_TOP + rows.length * layout.rowHeight + AXIS_H;
 
   const axisTicks = logLatencyTicks(logScale, 0.1);
+  // A label on its own line has the full column to itself; one in the gutter
+  // has 140 units. preserveUniqueAfterTruncation keeps the distinguishing
+  // suffix inside whichever budget applies.
   const displayLabels = preserveUniqueAfterTruncation(
     rows.map((row) => row.displayLabel ?? row.platform),
-    18,
+    layout.labelAbove ? 32 : 18,
   );
 
   return (
-    <div ref={containerRef} class="w-full overflow-x-auto">
-      <svg class="bb-chart-svg" width={drawWidth} height={totalHeight} role="img" aria-label="Percentile latency ladder chart">
+    <div ref={containerRef} class="w-full">
+      <svg
+        class="bb-chart-svg"
+        width="100%"
+        height={totalHeight}
+        viewBox={`0 0 ${drawWidth} ${totalHeight}`}
+        role="img"
+        aria-label="Percentile latency ladder chart"
+      >
         {/* Legend */}
         <g transform="translate(0, 4)">
           {PERCENTILE_LABELS.map((label, li) => {
             const opacity = RUNG_OPACITY[li];
             return (
-              <g key={label} transform={`translate(${LABEL_W + li * 56}, 0)`}>
+              <g key={label} transform={`translate(${layout.plotX + li * 56}, 0)`}>
                 <rect width={14} height={10} y={3} fill={LEGEND_SWATCH_COLOR} opacity={opacity} rx={1} />
                 <text x={18} y={12} class="text-[10px] fill-[var(--bb-data-fg-muted)] font-mono">
                   {label}
@@ -101,8 +114,8 @@ export function PercentileLadder({ rows }: Props) {
         {/* Platform rows */}
         {rows.map((row, ri) => {
           const color = paletteColor(row.colorIdx ?? ri);
-          const y = PADDING_TOP + ri * ROW_H;
-          const midY = y + ROW_H * 0.5;
+          const y = PADDING_TOP + ri * layout.rowHeight;
+          const midY = y + layout.barCenter;
           const barH = ROW_H * 0.55;
 
           // Draw P99 → P95 → P90 → P50 (widest first, darkest last)
@@ -117,9 +130,9 @@ export function PercentileLadder({ rows }: Props) {
             <g key={row.result_id} data-result-id={row.result_id}>
               {/* Platform label */}
               <text
-                x={LABEL_W - 6}
-                y={midY + 4}
-                textAnchor="end"
+                x={layout.labelAbove ? 0 : LABEL_W - 6}
+                y={y + layout.labelBaseline}
+                text-anchor={layout.labelAbove ? "start" : "end"}
                 class="text-xs fill-[var(--bb-data-fg-primary)]"
                 style={{ fontSize: "11px" }}
               >
@@ -147,8 +160,9 @@ export function PercentileLadder({ rows }: Props) {
 
               {/* P50 value label */}
               <text
-                x={xForMs(row.percentile_stats.p50) + 4}
-                y={midY + 4}
+                x={layout.labelAbove ? drawWidth : xForMs(row.percentile_stats.p50) + 4}
+                y={layout.labelAbove ? y + layout.labelBaseline : midY + 4}
+                text-anchor={layout.labelAbove ? "end" : "start"}
                 class="text-[10px] fill-[var(--bb-data-fg-muted)] font-mono"
                 style={{ fontSize: "10px" }}
               >
@@ -157,24 +171,38 @@ export function PercentileLadder({ rows }: Props) {
 
               {/* Separator line */}
               {ri < rows.length - 1 && (
-                <line x1={0} y1={y + ROW_H} x2={drawWidth} y2={y + ROW_H} stroke="var(--bb-chart-grid)" strokeWidth={1} />
+                <line
+                  x1={0}
+                  y1={y + layout.rowHeight}
+                  x2={drawWidth}
+                  y2={y + layout.rowHeight}
+                  stroke="var(--bb-chart-grid)"
+                  stroke-width={1}
+                />
               )}
             </g>
           );
         })}
 
         {/* X-axis */}
-        <g transform={`translate(0, ${PADDING_TOP + rows.length * ROW_H})`}>
-          <line x1={LABEL_W} y1={0} x2={drawWidth - 4} y2={0} stroke="var(--bb-chart-grid)" strokeWidth={1} />
+        <g transform={`translate(0, ${PADDING_TOP + rows.length * layout.rowHeight})`}>
+          <line
+            x1={layout.plotX}
+            y1={0}
+            x2={layout.plotX + barAreaWidth}
+            y2={0}
+            stroke="var(--bb-chart-grid)"
+            stroke-width={1}
+          />
           {axisTicks.map((ms) => {
             const x = xForMs(ms);
             return (
               <g key={ms}>
-                <line x1={x} y1={0} x2={x} y2={4} stroke="var(--bb-chart-label-muted)" strokeWidth={1} />
+                <line x1={x} y1={0} x2={x} y2={4} stroke="var(--bb-chart-label-muted)" stroke-width={1} />
                 <text
                   x={x}
                   y={16}
-                  textAnchor="middle"
+                  text-anchor={axisLabelAnchor(x, drawWidth)}
                   class="text-[10px] fill-[var(--bb-data-fg-subtle)] font-mono"
                   style={{ fontSize: "10px" }}
                 >

--- a/results-explorer/src/components/PowerBar.tsx
+++ b/results-explorer/src/components/PowerBar.tsx
@@ -11,6 +11,7 @@
 
 import type { BenchmarkSummary } from "@/types";
 import { useElementSize } from "@/lib/useElementSize";
+import { axisLabelAnchor, barRowLayout, chartFrame } from "@/lib/chartFrame";
 import { paletteColor } from "@/lib/chartTheme";
 import { isRankable } from "@/lib/displayEligibility";
 import { formatPowerScore } from "@/lib/metricFormatters";
@@ -28,7 +29,9 @@ interface Props {
 
 export function PowerBar({ summary }: Props) {
   const [containerRef, { width: containerWidth }] = useElementSize();
-  const w = Math.max(containerWidth, 400);
+  const frame = chartFrame(containerWidth);
+  const w = frame.width;
+  const layout = barRowLayout(frame, { labelWidth: LABEL_W, rowHeight: ROW_H, valueTrail: VALUE_TRAIL });
 
   const cohortLabels = formatRunIdentityLabelsForCohort(
     summary.platforms.map((platform) => ({ ...platform, scale_factor: summary.scale_factor })),
@@ -52,62 +55,97 @@ export function PowerBar({ summary }: Props) {
   }
 
   const maxScore = Math.max(...rows.map((r) => r.power_score!));
-  const plotW = w - LABEL_W - VALUE_TRAIL;
-  const totalH = PADDING_TOP + rows.length * ROW_H + AXIS_H;
+  const plotW = layout.plotWidth;
+  const totalH = PADDING_TOP + rows.length * layout.rowHeight + AXIS_H;
 
   return (
-    <div ref={containerRef} class="w-full overflow-x-auto">
-      <svg class="bb-chart-svg" width={w} height={totalH} role="img" aria-label="TPC Power@Size comparison - higher is better">
+    <div ref={containerRef} class="w-full">
+      <svg
+        class="bb-chart-svg"
+        width="100%"
+        height={totalH}
+        viewBox={`0 0 ${w} ${totalH}`}
+        role="img"
+        aria-label="TPC Power@Size comparison - higher is better"
+      >
         {rows.map((row, ri) => {
           const barW = (row.power_score! / maxScore) * plotW;
-          const y = PADDING_TOP + ri * ROW_H;
-          const midY = y + ROW_H * 0.5;
+          const y = PADDING_TOP + ri * layout.rowHeight;
+          const midY = y + layout.barCenter;
           const barH = ROW_H * 0.55;
           const color = paletteColor(row.colorIdx);
+          const valueText = formatPowerScore(row.power_score).valueText;
           return (
             <g key={row.result_id}>
               <text
-                x={LABEL_W - 6}
-                y={midY + 4}
-                textAnchor="end"
+                x={layout.labelAbove ? 0 : LABEL_W - 6}
+                y={y + layout.labelBaseline}
+                text-anchor={layout.labelAbove ? "start" : "end"}
                 aria-label={row.fullLabel}
                 title={row.fullLabel}
                 style={{ fontSize: "11px", fill: "var(--bb-chart-label)" }}
               >
                 {row.displayLabel}
               </text>
-              <rect x={LABEL_W} y={midY - barH / 2} width={Math.max(2, barW)} height={barH} fill={color} rx={2}>
-                <title>{`${row.fullLabel}: ${formatPowerScore(row.power_score).valueText} QphH`}</title>
+              <rect
+                x={layout.plotX}
+                y={midY - barH / 2}
+                width={Math.max(2, barW)}
+                height={barH}
+                fill={color}
+                rx={2}
+              >
+                <title>{`${row.fullLabel}: ${valueText} QphH`}</title>
               </rect>
-              <text x={LABEL_W + barW + 6} y={midY + 4} style={{ fontSize: "11px", fill: "var(--bb-chart-label)" }}>
-                {formatPowerScore(row.power_score).valueText}
+              {/* Wide rows trail the value after the bar; compact rows park it at
+                  the end of the label line, where a long bar cannot push it off
+                  the right edge. */}
+              <text
+                x={layout.labelAbove ? w : layout.plotX + barW + 6}
+                y={layout.labelAbove ? y + layout.labelBaseline : midY + 4}
+                text-anchor={layout.labelAbove ? "end" : "start"}
+                style={{ fontSize: "11px", fill: "var(--bb-chart-label)" }}
+              >
+                {valueText}
               </text>
               {ri < rows.length - 1 && (
-                <line x1={0} y1={y + ROW_H} x2={w} y2={y + ROW_H} stroke="var(--bb-chart-grid)" strokeWidth={1} />
+                <line
+                  x1={0}
+                  y1={y + layout.rowHeight}
+                  x2={w}
+                  y2={y + layout.rowHeight}
+                  stroke="var(--bb-chart-grid)"
+                  stroke-width={1}
+                />
               )}
             </g>
           );
         })}
 
         {/* X-axis */}
-        <g transform={`translate(0, ${PADDING_TOP + rows.length * ROW_H})`}>
-          <line x1={LABEL_W} y1={0} x2={LABEL_W + plotW} y2={0} stroke="var(--bb-chart-grid)" strokeWidth={1} />
-          {[0, 0.25, 0.5, 0.75, 1].map((f) => {
-            const x = LABEL_W + f * plotW;
+        <g transform={`translate(0, ${PADDING_TOP + rows.length * layout.rowHeight})`}>
+          <line x1={layout.plotX} y1={0} x2={layout.plotX + plotW} y2={0} stroke="var(--bb-chart-grid)" stroke-width={1} />
+          {(layout.compactTicks ? [0, 0.5, 1] : [0, 0.25, 0.5, 0.75, 1]).map((f) => {
+            const x = layout.plotX + f * plotW;
             const val = f * maxScore;
             return (
               <g key={f}>
-                <line x1={x} y1={0} x2={x} y2={4} stroke="var(--bb-chart-label-muted)" strokeWidth={1} />
-                <text x={x} y={16} textAnchor="middle" style={{ fontSize: "10px", fill: "var(--bb-chart-axis)" }}>
+                <line x1={x} y1={0} x2={x} y2={4} stroke="var(--bb-chart-label-muted)" stroke-width={1} />
+                <text
+                  x={x}
+                  y={16}
+                  text-anchor={axisLabelAnchor(x, w)}
+                  style={{ fontSize: "10px", fill: "var(--bb-chart-axis)" }}
+                >
                   {val > 0 ? formatPowerScore(val).valueText : "0"}
                 </text>
               </g>
             );
           })}
           <text
-            x={LABEL_W + plotW / 2}
+            x={layout.plotX + plotW / 2}
             y={AXIS_H - 2}
-            textAnchor="middle"
+            text-anchor="middle"
             style={{ fontSize: "10px", fill: "var(--bb-chart-label-muted)" }}
           >
             Power@Size (QphH) - higher is better

--- a/results-explorer/src/components/QueryHeatmap.tsx
+++ b/results-explorer/src/components/QueryHeatmap.tsx
@@ -814,7 +814,10 @@ export function QueryHeatmap({
                         ? ratio !== null
                           ? ratio <= 1.005
                             ? `${fmtQueryMs(ms)}, fastest in column`
-                            : `${fmtQueryMs(ms)}, ${formatSpeedup(ratio, { unit: "×" }).valueText} fastest in column`
+                            : // The ratio is this cell over the column minimum, so a
+                              // value above 1 is SLOWER than the fastest run, not
+                              // faster than it.
+                              `${fmtQueryMs(ms)}, ${formatSpeedup(ratio, { unit: "×" }).valueText} slower than fastest in column`
                           : fmtQueryMs(ms)
                         : isExcludedTiming
                           ? `${formatDurationMs(rawMs)}, excluded: ${excludedReason}`
@@ -899,5 +902,6 @@ function queryOutliers(
 function queryRatioLabel(ratio: number | null): string {
   if (ratio === null) return "No ranking baseline";
   if (ratio <= 1.005) return "Fastest in ranking";
-  return `${formatSpeedup(ratio, { unit: "×" }).valueText} fastest`;
+  // Ratio is this run over the fastest run in the column: above 1 is slower.
+  return `${formatSpeedup(ratio, { unit: "×" }).valueText} slower than fastest`;
 }

--- a/results-explorer/src/components/QueryHistogram.tsx
+++ b/results-explorer/src/components/QueryHistogram.tsx
@@ -70,7 +70,15 @@ export function QueryHistogram({ summary, preserveOrder = false }: Props) {
     const n = qids.length;
     const groupW = (w - AXIS_W) / n;
     const innerW = groupW - BAR_GAP;
-    const barW = Math.max(MIN_BAR_W, Math.floor(innerW / platforms.length));
+    // The minimum bar width is a preference, not a guarantee: a cohort large
+    // enough that even one query group cannot hold a bar per platform at that
+    // width would otherwise overrun its own slot and paint over its neighbours.
+    // Past that point the bars go thin rather than the groups colliding.
+    const idealBarW = innerW / platforms.length;
+    const barW = idealBarW >= MIN_BAR_W ? Math.floor(idealBarW) : Math.max(0.5, idealBarW);
+    // A label needs roughly this much room at 9 units; below it, label every
+    // other group rather than overprinting them.
+    const labelStride = groupW >= 22 ? 1 : Math.ceil(22 / Math.max(groupW, 1));
 
     return (
       <div key={panelIdx} class="mb-2">
@@ -148,15 +156,17 @@ export function QueryHistogram({ summary, preserveOrder = false }: Props) {
                     </rect>
                   );
                 })}
-                <text
-                  x={groupX + innerW / 2}
-                  y={PADDING_TOP + CHART_H + 14}
-                  text-anchor="middle"
-                  data-query-label={qid}
-                  style={{ fontSize: "9px", fill: "var(--bb-chart-label-muted)" }}
-                >
-                  {queryDisplayLabel(qid)}
-                </text>
+                {qi % labelStride === 0 && (
+                  <text
+                    x={groupX + innerW / 2}
+                    y={PADDING_TOP + CHART_H + 14}
+                    text-anchor="middle"
+                    data-query-label={qid}
+                    style={{ fontSize: "9px", fill: "var(--bb-chart-label-muted)" }}
+                  >
+                    {queryDisplayLabel(qid)}
+                  </text>
+                )}
               </g>
             );
           })}

--- a/results-explorer/src/components/QueryHistogram.tsx
+++ b/results-explorer/src/components/QueryHistogram.tsx
@@ -10,12 +10,15 @@
 
 import type { BenchmarkSummary } from "@/types";
 import { useElementSize } from "@/lib/useElementSize";
+import { chartFrame } from "@/lib/chartFrame";
 import { paletteColor } from "@/lib/chartTheme";
 import { queryDisplayLabel, sortQueryIds } from "@/lib/queryLabels";
 import { formatTimingExclusion, platformTimingValue } from "@/lib/displayEligibility";
 import { formatLatencyMs } from "@/lib/metricFormatters";
 
 const MAX_PER_PANEL = 33;
+/** Narrowest bar that still reads as a bar rather than a hairline. */
+const MIN_BAR_W = 3;
 const BAR_GAP = 3;
 const AXIS_W = 44;
 const LABEL_H = 28;
@@ -34,16 +37,23 @@ function fmtMs(ms: number): string {
 
 export function QueryHistogram({ summary, preserveOrder = false }: Props) {
   const [containerRef, { width: containerWidth }] = useElementSize(300);
-  const w = Math.max(containerWidth, 300);
+  const frame = chartFrame(containerWidth, { minWidth: 300 });
+  const w = frame.width;
 
   const { platforms, query_ids } = summary;
   if (platforms.length === 0 || query_ids.length === 0) return null;
   const sortedQueryIds = preserveOrder ? query_ids : sortQueryIds(query_ids);
 
-  // Split into panels
+  // A query group holds one bar per platform, so how many groups fit is a
+  // function of the cohort size, not just the query count. Splitting on query
+  // count alone let a wide cohort clamp its bars to a floor wider than the
+  // group itself, and each group then painted over its neighbours.
+  const minGroupW = platforms.length * MIN_BAR_W + BAR_GAP;
+  const perPanel = Math.max(1, Math.min(MAX_PER_PANEL, Math.floor((w - AXIS_W) / minGroupW)));
+
   const panels: string[][] = [];
-  for (let i = 0; i < sortedQueryIds.length; i += MAX_PER_PANEL) {
-    panels.push(sortedQueryIds.slice(i, i + MAX_PER_PANEL));
+  for (let i = 0; i < sortedQueryIds.length; i += perPanel) {
+    panels.push(sortedQueryIds.slice(i, i + perPanel));
   }
 
   function renderPanel(qids: string[], panelIdx: number) {
@@ -60,13 +70,13 @@ export function QueryHistogram({ summary, preserveOrder = false }: Props) {
     const n = qids.length;
     const groupW = (w - AXIS_W) / n;
     const innerW = groupW - BAR_GAP;
-    const barW = Math.max(2, Math.floor(innerW / platforms.length));
+    const barW = Math.max(MIN_BAR_W, Math.floor(innerW / platforms.length));
 
     return (
       <div key={panelIdx} class="mb-2">
         {panels.length > 1 && (
           <p class="mb-0.5 ml-[44px] text-[10px] text-[var(--bb-data-fg-subtle)]">
-            Queries {panelIdx * MAX_PER_PANEL + 1}-{Math.min((panelIdx + 1) * MAX_PER_PANEL, sortedQueryIds.length)}
+            Queries {panelIdx * perPanel + 1}-{Math.min((panelIdx + 1) * perPanel, sortedQueryIds.length)}
           </p>
         )}
         <svg
@@ -82,9 +92,9 @@ export function QueryHistogram({ summary, preserveOrder = false }: Props) {
             const y = PADDING_TOP + (1 - f) * CHART_H;
             return (
               <g key={f}>
-                <line x1={AXIS_W} y1={y} x2={w} y2={y} stroke="var(--bb-chart-grid-muted)" strokeWidth={1} />
+                <line x1={AXIS_W} y1={y} x2={w} y2={y} stroke="var(--bb-chart-grid-muted)" stroke-width={1} />
                 {f > 0 && (
-                  <text x={AXIS_W - 3} y={y + 3} textAnchor="end" style={{ fontSize: "9px", fill: "var(--bb-chart-label-muted)" }}>
+                  <text x={AXIS_W - 3} y={y + 3} text-anchor="end" style={{ fontSize: "9px", fill: "var(--bb-chart-label-muted)" }}>
                     {fmtMs(f * maxMs)}
                   </text>
                 )}
@@ -116,8 +126,8 @@ export function QueryHistogram({ summary, preserveOrder = false }: Props) {
                         x2={groupX + pi * barW + (barW - 1)}
                         y2={PADDING_TOP + CHART_H - 1}
                         stroke={paletteColor(pi)}
-                        strokeWidth={2}
-                        strokeDasharray="2,1"
+                        stroke-width={2}
+                        stroke-dasharray="2,1"
                         opacity={0.5}
                       >
                         <title>{`${p.platform} · ${queryDisplayLabel(qid)}: ${reason}`}</title>
@@ -132,7 +142,7 @@ export function QueryHistogram({ summary, preserveOrder = false }: Props) {
                       width={barW - 1}
                       height={barH}
                       fill={paletteColor(pi)}
-                      fillOpacity={0.85}
+                      fill-opacity={0.85}
                     >
                       <title>{`${p.platform} · ${queryDisplayLabel(qid)}: ${fmtMs(ms)}`}</title>
                     </rect>
@@ -141,7 +151,7 @@ export function QueryHistogram({ summary, preserveOrder = false }: Props) {
                 <text
                   x={groupX + innerW / 2}
                   y={PADDING_TOP + CHART_H + 14}
-                  textAnchor="middle"
+                  text-anchor="middle"
                   data-query-label={qid}
                   style={{ fontSize: "9px", fill: "var(--bb-chart-label-muted)" }}
                 >
@@ -152,14 +162,14 @@ export function QueryHistogram({ summary, preserveOrder = false }: Props) {
           })}
 
           {/* Axes */}
-          <line x1={AXIS_W} y1={PADDING_TOP} x2={AXIS_W} y2={PADDING_TOP + CHART_H} stroke="var(--bb-chart-grid)" strokeWidth={1} />
+          <line x1={AXIS_W} y1={PADDING_TOP} x2={AXIS_W} y2={PADDING_TOP + CHART_H} stroke="var(--bb-chart-grid)" stroke-width={1} />
           <line
             x1={AXIS_W}
             y1={PADDING_TOP + CHART_H}
             x2={w}
             y2={PADDING_TOP + CHART_H}
             stroke="var(--bb-chart-grid)"
-            strokeWidth={1}
+            stroke-width={1}
           />
         </svg>
       </div>

--- a/results-explorer/src/components/QueryTimingChart.tsx
+++ b/results-explorer/src/components/QueryTimingChart.tsx
@@ -31,7 +31,14 @@ export function GroupedQueryChart({ groups, unit = "ms", height = 260 }: Grouped
   const paddingBottom = 60;
   const groupGap = 8;
   const barGap = 2;
-  const viewWidth = Math.max(containerWidth, 300);
+  // This chart opts out of reflow: it stays wide and scrolls inside its own
+  // container. The viewBox must therefore be sized to the SAME minimum the CSS
+  // enforces below. Drawing 300 units into a box CSS has stretched to
+  // `groupCount * 60` px magnifies every coordinate by the ratio between them,
+  // so the bars are computed against a width the chart is not given, collide at
+  // their minimum width, and are then blown up along with the gaps.
+  const scrollMinWidth = Math.max(500, groups.length * 60);
+  const viewWidth = Math.max(containerWidth, scrollMinWidth);
   const chartWidth = viewWidth - paddingLeft - paddingRight;
   const chartHeight = height - paddingTop - paddingBottom;
 
@@ -57,7 +64,7 @@ export function GroupedQueryChart({ groups, unit = "ms", height = 260 }: Grouped
         width="100%"
         height={height}
         viewBox={`0 0 ${viewWidth} ${height}`}
-        style={{ minWidth: `${Math.max(500, groupCount * 60)}px` }}
+        style={{ minWidth: `${scrollMinWidth}px` }}
         role="img"
         aria-label="Grouped query timing bar chart"
       >

--- a/results-explorer/src/components/QueryTimingChart.tsx
+++ b/results-explorer/src/components/QueryTimingChart.tsx
@@ -1,116 +1,10 @@
 /**
- * SVG bar chart for per-query timings.
+ * Grouped SVG bar chart for the compare view.
  * No external chart library - pure SVG.
  */
 
-import { paletteColor } from "@/lib/chartTheme";
 import { formatLatencyMs, formatPlainNumber } from "@/lib/metricFormatters";
 import { useElementSize } from "@/lib/useElementSize";
-
-interface Bar {
-  label: string;
-  value: number;
-  color?: string;
-}
-
-interface QueryTimingChartProps {
-  bars: Bar[];
-  unit?: string;
-  height?: number;
-}
-
-export function QueryTimingChart({ bars, unit = "ms", height = 220 }: QueryTimingChartProps) {
-  const [containerRef, { width: containerWidth }] = useElementSize(800);
-
-  if (bars.length === 0) return null;
-
-  const paddingLeft = 48;
-  const paddingRight = 16;
-  const paddingTop = 16;
-  const paddingBottom = 56;
-  const barGap = 4;
-  const viewWidth = Math.max(containerWidth, 300);
-  const chartWidth = viewWidth - paddingLeft - paddingRight;
-  const chartHeight = height - paddingTop - paddingBottom;
-
-  const maxValue = Math.max(...bars.map((b) => b.value), 1);
-  const barWidth = Math.max(4, Math.floor((chartWidth - barGap * (bars.length - 1)) / bars.length));
-
-  const yTicks = 4;
-  const yStep = maxValue / yTicks;
-
-  function formatValue(v: number): string {
-    if (unit === "ms") return formatLatencyMs(v, { subMillisecond: "compact" }).valueText;
-    return `${formatPlainNumber(v).valueText}${unit}`;
-  }
-
-  return (
-    <div ref={containerRef} class="overflow-x-auto">
-      <svg
-        class="bb-chart-svg"
-        width="100%"
-        height={height}
-        viewBox={`0 0 ${viewWidth} ${height}`}
-        style={{ minWidth: `${Math.max(400, bars.length * 28)}px` }}
-        role="img"
-        aria-label="Query timing bar chart"
-      >
-        {/* Y-axis grid lines + labels */}
-        {Array.from({ length: yTicks + 1 }, (_, i) => {
-          const v = yStep * i;
-          const y = paddingTop + chartHeight - (chartHeight * i) / yTicks;
-          return (
-            <g key={i}>
-              <line x1={paddingLeft} y1={y} x2={viewWidth - paddingRight} y2={y} stroke="var(--bb-chart-grid)" stroke-width="1" />
-              <text x={paddingLeft - 6} y={y + 4} text-anchor="end" font-size="10" fill="var(--bb-chart-label-muted)">
-                {formatValue(v)}
-              </text>
-            </g>
-          );
-        })}
-
-        {/* Bars */}
-        {bars.map((bar, i) => {
-          const barH = Math.max(2, (bar.value / maxValue) * chartHeight);
-          const x = paddingLeft + i * (barWidth + barGap);
-          const y = paddingTop + chartHeight - barH;
-          const color = bar.color ?? paletteColor(i);
-
-          return (
-            <g key={bar.label}>
-              <rect x={x} y={y} width={barWidth} height={barH} fill={color} rx="2" opacity="0.85">
-                <title>
-                  {bar.label}: {formatValue(bar.value)}
-                </title>
-              </rect>
-              {/* X-axis label */}
-              <text
-                x={x + barWidth / 2}
-                y={paddingTop + chartHeight + 14}
-                text-anchor="middle"
-                font-size="9"
-                fill="var(--bb-chart-axis)"
-                transform={`rotate(-45, ${x + barWidth / 2}, ${paddingTop + chartHeight + 14})`}
-              >
-                {bar.label}
-              </text>
-            </g>
-          );
-        })}
-
-        {/* X-axis baseline */}
-        <line
-          x1={paddingLeft}
-          y1={paddingTop + chartHeight}
-          x2={viewWidth - paddingRight}
-          y2={paddingTop + chartHeight}
-          stroke="var(--bb-chart-grid)"
-          stroke-width="1"
-        />
-      </svg>
-    </div>
-  );
-}
 
 /**
  * Grouped bar chart for compare view - one group per query, one bar per result.
@@ -203,7 +97,7 @@ export function GroupedQueryChart({ groups, unit = "ms", height = 260 }: Grouped
                         height={6}
                         fill="none"
                         stroke={v.color}
-                        strokeDasharray="2 2"
+                        stroke-dasharray="2 2"
                         rx="2"
                         opacity="0.5"
                       >

--- a/results-explorer/src/components/StackedPhase.tsx
+++ b/results-explorer/src/components/StackedPhase.tsx
@@ -10,6 +10,7 @@
 
 import type { BenchmarkSummary } from "@/types";
 import { useElementSize } from "@/lib/useElementSize";
+import { barRowLayout, chartFrame } from "@/lib/chartFrame";
 import { PHASE_COLORS } from "@/lib/chartTheme";
 import { formatDurationSeconds } from "@/lib/metricFormatters";
 import { formatRunIdentityLabelsForCohort, preserveUniqueAfterTruncation } from "@/lib/runIdentity";
@@ -46,7 +47,9 @@ interface Props {
 
 export function StackedPhase({ summary }: Props) {
   const [containerRef, { width: containerWidth }] = useElementSize();
-  const w = Math.max(containerWidth, 400);
+  const frame = chartFrame(containerWidth);
+  const w = frame.width;
+  const layout = barRowLayout(frame, { labelWidth: LABEL_W, rowHeight: ROW_H, valueTrail: VALUE_TRAIL });
 
   const cohortLabels = formatRunIdentityLabelsForCohort(
     summary.platforms.map((platform) => ({ ...platform, scale_factor: summary.scale_factor })),
@@ -93,32 +96,33 @@ export function StackedPhase({ summary }: Props) {
     Object.values(r.phase_durations!).reduce((a, b) => a + b, 0),
   );
   const maxTotal = Math.max(...allTotals, 1);
-  const plotW = w - LABEL_W - VALUE_TRAIL;
-  const totalH = PADDING_TOP + rows.length * ROW_H + AXIS_H;
+  const plotW = layout.plotWidth;
+  const totalH = PADDING_TOP + rows.length * layout.rowHeight + AXIS_H;
 
   return (
-    <div ref={containerRef} class="w-full overflow-x-auto">
+    <div ref={containerRef} class="w-full">
       <svg
         class="bb-chart-svg"
-        width={w}
+        width="100%"
         height={totalH}
+        viewBox={`0 0 ${w} ${totalH}`}
         role="img"
         aria-label="Benchmark phase duration breakdown"
       >
         {rows.map((row, ri) => {
-          const y = PADDING_TOP + ri * ROW_H;
-          const midY = y + ROW_H * 0.5;
+          const y = PADDING_TOP + ri * layout.rowHeight;
+          const midY = y + layout.barCenter;
           const barH = ROW_H * 0.55;
           const pd = row.phase_durations!;
           const total = Object.values(pd).reduce((a, b) => a + b, 0);
 
-          let xOffset = LABEL_W;
+          let xOffset = layout.plotX;
           return (
             <g key={row.result_id}>
               <text
-                x={LABEL_W - 6}
-                y={midY + 4}
-                textAnchor="end"
+                x={layout.labelAbove ? 0 : LABEL_W - 6}
+                y={y + layout.labelBaseline}
+                text-anchor={layout.labelAbove ? "start" : "end"}
                 style={{ fontSize: "11px", fill: "var(--bb-chart-label)" }}
               >
                 <title>{fullLabelByResultId.get(row.result_id) ?? row.platform}</title>
@@ -147,8 +151,9 @@ export function StackedPhase({ summary }: Props) {
               })}
 
               <text
-                x={xOffset + 5}
-                y={midY + 4}
+                x={layout.labelAbove ? w : xOffset + 5}
+                y={layout.labelAbove ? y + layout.labelBaseline : midY + 4}
+                text-anchor={layout.labelAbove ? "end" : "start"}
                 style={{ fontSize: "10px", fill: "var(--bb-chart-axis)" }}
               >
                 {formatDurationSeconds(total).valueText}
@@ -157,11 +162,11 @@ export function StackedPhase({ summary }: Props) {
               {ri < rows.length - 1 && (
                 <line
                   x1={0}
-                  y1={y + ROW_H}
-                  x2={w - VALUE_TRAIL}
-                  y2={y + ROW_H}
+                  y1={y + layout.rowHeight}
+                  x2={layout.plotX + plotW}
+                  y2={y + layout.rowHeight}
                   stroke="var(--bb-chart-grid)"
-                  strokeWidth={1}
+                  stroke-width={1}
                 />
               )}
             </g>
@@ -169,12 +174,12 @@ export function StackedPhase({ summary }: Props) {
         })}
 
         <line
-          x1={LABEL_W}
-          y1={PADDING_TOP + rows.length * ROW_H}
-          x2={LABEL_W + plotW}
-          y2={PADDING_TOP + rows.length * ROW_H}
+          x1={layout.plotX}
+          y1={PADDING_TOP + rows.length * layout.rowHeight}
+          x2={layout.plotX + plotW}
+          y2={PADDING_TOP + rows.length * layout.rowHeight}
           stroke="var(--bb-chart-grid)"
-          strokeWidth={1}
+          stroke-width={1}
         />
       </svg>
 

--- a/results-explorer/src/components/TimeSeries.tsx
+++ b/results-explorer/src/components/TimeSeries.tsx
@@ -13,6 +13,7 @@
 
 import type { ChartHistoricalEntry } from "@/lib/chartRegistry";
 import { useElementSize } from "@/lib/useElementSize";
+import { axisLabelAnchor, chartFrame } from "@/lib/chartFrame";
 import { timeSeriesColor } from "@/lib/chartTheme";
 import { formatLatencyMs, formatPowerScore } from "@/lib/metricFormatters";
 import { formatRunDateWithAge } from "@/lib/runAge";
@@ -62,7 +63,8 @@ interface Series {
 
 export function TimeSeries({ entries, primaryMetric }: Props) {
   const [containerRef, { width: containerWidth }] = useElementSize(320);
-  const w = Math.max(containerWidth, 320);
+  const frame = chartFrame(containerWidth);
+  const w = frame.width;
 
   const metric = primaryMetric ?? "display_geomean_ms";
   const higherIsBetter = metric === "power_score";
@@ -204,11 +206,12 @@ export function TimeSeries({ entries, primaryMetric }: Props) {
   return (
     <div class={duplicateDayState ? "space-y-3" : undefined}>
       {duplicateDayState}
-      <div ref={containerRef} class="w-full overflow-x-auto">
+      <div ref={containerRef} class="w-full">
         <svg
           class="bb-chart-svg"
-          width={w}
+          width="100%"
           height={totalH}
+          viewBox={`0 0 ${w} ${totalH}`}
           role="img"
           aria-label={`${metricLabel} trend over time`}
         >
@@ -227,12 +230,12 @@ export function TimeSeries({ entries, primaryMetric }: Props) {
                   x2={w - PADDING_RIGHT}
                   y2={y}
                   stroke="var(--bb-chart-grid)"
-                  strokeWidth={1}
+                  stroke-width={1}
                 />
                 <text
                   x={LABEL_W - 4}
                   y={y + 4}
-                  textAnchor="end"
+                  text-anchor="end"
                   style={{ fontSize: "9px", fill: "var(--bb-chart-label-muted)" }}
                 >
                   {label}
@@ -251,7 +254,7 @@ export function TimeSeries({ entries, primaryMetric }: Props) {
             .join(" ");
           return (
             <g key={s.platformId}>
-              <path d={d} stroke={s.color} strokeWidth={2} fill="none" strokeLinejoin="round" />
+              <path d={d} stroke={s.color} stroke-width={2} fill="none" stroke-linejoin="round" />
               {s.points.map((p) => (
                 <circle
                   key={p.resultId}
@@ -272,16 +275,16 @@ export function TimeSeries({ entries, primaryMetric }: Props) {
 
         {/* X-axis */}
         <g transform={`translate(0, ${PADDING_TOP + CHART_H})`}>
-          <line x1={LABEL_W} y1={0} x2={w - PADDING_RIGHT} y2={0} stroke="var(--bb-chart-grid)" strokeWidth={1} />
+          <line x1={LABEL_W} y1={0} x2={w - PADDING_RIGHT} y2={0} stroke="var(--bb-chart-grid)" stroke-width={1} />
           {shownDates.map((date) => {
             const x = xFor(date);
             return (
               <g key={date}>
-                <line x1={x} y1={0} x2={x} y2={4} stroke="var(--bb-chart-label-muted)" strokeWidth={1} />
+                <line x1={x} y1={0} x2={x} y2={4} stroke="var(--bb-chart-label-muted)" stroke-width={1} />
                 <text
                   x={x}
                   y={20}
-                  textAnchor="middle"
+                  text-anchor={axisLabelAnchor(x, w)}
                   aria-label={formatRunDateWithAge(date)}
                   style={{ fontSize: "9px", fill: "var(--bb-chart-axis)" }}
                 >

--- a/results-explorer/src/components/__tests__/ChartPanel.test.tsx
+++ b/results-explorer/src/components/__tests__/ChartPanel.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen } from "@testing-library/preact";
+import { fireEvent, render, screen, waitFor } from "@testing-library/preact";
 import { describe, expect, it } from "vitest";
 import { ChartPanel } from "@/components/ChartPanel";
 import type { ChartHistoricalEntry } from "@/lib/chartRegistry";
@@ -268,6 +268,61 @@ describe("ChartPanel", () => {
     fireEvent.keyDown(rank, { key: "Home" });
     expect(document.activeElement).toBe(overview);
     expect(overview).toHaveAttribute("aria-selected", "true");
+  });
+
+  it("opens a summary cohort on a chart rather than on the sparkline table", () => {
+    // A section headed "Charts" used to open on an HTML metrics table, so a
+    // reader who never touched the controls saw no chart at all.
+    render(<ChartPanel context={{ kind: "summary", summary: makeSummary() }} />);
+
+    expect(screen.getByRole("img", { name: /performance comparison/i })).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Performance Bar" }).getAttribute("aria-pressed")).toBe(
+      "true",
+    );
+  });
+
+  it("records the open chart in the URL so the view can be shared", () => {
+    render(<ChartPanel context={{ kind: "summary", summary: makeSummary() }} />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Sparkline Table" }));
+
+    expect(new URLSearchParams(window.location.search).get("chart")).toBe("sparkline_table");
+  });
+
+  it("restores the chart named in the URL", () => {
+    window.history.replaceState(null, "", "/?chart=stacked_phase");
+
+    render(<ChartPanel context={{ kind: "summary", summary: makeSummary() }} />);
+
+    expect(screen.getByRole("button", { name: "Stacked Phase Breakdown" }).getAttribute("aria-pressed")).toBe(
+      "true",
+    );
+  });
+
+  it("canonicalises a chart id that does not apply to this cohort", async () => {
+    window.history.replaceState(null, "", "/?chart=comparison_bar");
+
+    render(<ChartPanel context={{ kind: "summary", summary: makeSummary() }} />);
+
+    // comparison_bar needs two results; a summary cohort cannot show it.
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: "Performance Bar" }).getAttribute("aria-pressed")).toBe(
+        "true",
+      );
+    });
+    expect(new URLSearchParams(window.location.search).get("chart")).toBeNull();
+  });
+
+  it("leaves the route's own parameters alone", () => {
+    window.history.replaceState(null, "", "/results/tpch/?sf=1&phase=power");
+
+    render(<ChartPanel context={{ kind: "summary", summary: makeSummary() }} />);
+    fireEvent.click(screen.getByRole("button", { name: "Sparkline Table" }));
+
+    const params = new URLSearchParams(window.location.search);
+    expect(params.get("sf")).toBe("1");
+    expect(params.get("phase")).toBe("power");
+    expect(params.get("chart")).toBe("sparkline_table");
   });
 
   it("hides charts whose ids are listed in excludeChartIds", () => {

--- a/results-explorer/src/components/__tests__/GroupedQueryChart.test.tsx
+++ b/results-explorer/src/components/__tests__/GroupedQueryChart.test.tsx
@@ -19,11 +19,10 @@ describe("GroupedQueryChart", () => {
     );
 
     const rects = Array.from(container.querySelectorAll("rect"));
-    const dashed = rects.find(
-      (rect) =>
-        rect.getAttribute("stroke-dasharray") !== null ||
-        rect.getAttribute("strokeDasharray") !== null,
-    );
+    // SVG attribute names are case-sensitive, and Preact forwards an unknown
+    // camelCase prop to setAttribute verbatim: `strokeDasharray` reaches the
+    // DOM as a name the renderer ignores, so the dash never appears.
+    const dashed = rects.find((rect) => rect.getAttribute("stroke-dasharray") !== null);
     expect(dashed).toBeTruthy();
     expect(dashed?.getAttribute("fill")).toBe("none");
     expect(dashed?.getAttribute("height")).toBe("6");

--- a/results-explorer/src/components/__tests__/QueryHeatmap.test.tsx
+++ b/results-explorer/src/components/__tests__/QueryHeatmap.test.tsx
@@ -357,7 +357,7 @@ describe("QueryHeatmap rendering", () => {
     expect(fastest?.textContent).toBe("10 ms");
     expect(fastest?.getAttribute("aria-label")).toBe("10 ms, fastest in column");
     expect(slowest?.textContent).toBe("100 ms");
-    expect(slowest?.getAttribute("aria-label")).toBe("100 ms, 10.00× fastest in column");
+    expect(slowest?.getAttribute("aria-label")).toBe("100 ms, 10.00× slower than fastest in column");
   });
 
   it("shows the metric/heatmap legend, excludes exact zeroes, and formats positive sub-millisecond timings", () => {
@@ -446,7 +446,7 @@ describe("QueryHeatmap rendering", () => {
     expect(sqliteCard.textContent).toContain("Query outliers");
     expect(sqliteCard.textContent).toContain("Q2");
     expect(sqliteCard.textContent).toContain("200 ms");
-    expect(sqliteCard.textContent).toContain("10.00× fastest");
+    expect(sqliteCard.textContent).toContain("10.00× slower than fastest");
   });
 
   it("uses the same comparison selection ids from compact mobile cards", () => {

--- a/results-explorer/src/components/__tests__/chartResponsiveContract.test.tsx
+++ b/results-explorer/src/components/__tests__/chartResponsiveContract.test.tsx
@@ -25,8 +25,35 @@ import { CDFChart } from "@/components/CDFChart";
 import { StackedPhase } from "@/components/StackedPhase";
 import { PercentileLadder } from "@/components/PercentileLadder";
 import { ChartPanel } from "@/components/ChartPanel";
+import { CostScatter } from "@/components/CostScatter";
+import { TimeSeries } from "@/components/TimeSeries";
+import { NormalizedSpeedupChart } from "@/components/NormalizedSpeedupChart";
+import { DivergingBarChart } from "@/components/DivergingBarChart";
 
+const NARROW_COLUMN = 240;
 const PHONE_COLUMN = 293;
+/**
+ * jsdom lays out no text, so a label's width has to be estimated. 0.6em per
+ * character is a conservative bound for the proportional faces these charts
+ * use, and it is what the assertion below compares against - not the constant
+ * the production helper works to, which would make the check circular.
+ */
+function visibleLabel(text: Element): string {
+  // `textContent` swallows the <title> child these charts attach for tooltips,
+  // which is the full untruncated run identity and is never painted.
+  return Array.from(text.childNodes)
+    .filter((node) => node.nodeType === 3)
+    .map((node) => node.textContent ?? "")
+    .join("")
+    .trim();
+}
+
+function estimatedTextWidth(text: Element): number {
+  const label = visibleLabel(text);
+  const styled = /font-size:\s*([\d.]+)/.exec(text.getAttribute("style") ?? "");
+  const fontSize = Number(text.getAttribute("font-size") ?? styled?.[1] ?? 10);
+  return label.length * fontSize * 0.6;
+}
 const DESKTOP_COLUMN = 1166;
 
 function setContainerWidth(width: number): void {
@@ -86,6 +113,37 @@ function makePlatform(overrides: Partial<PlatformRow> = {}): PlatformRow {
   };
 }
 
+/**
+ * Two runs whose per-query gap is far past either chart's clamp, so the value
+ * label sits at the very end of the plot - the case that used to draw it
+ * outside the drawing.
+ */
+function clampedCompare() {
+  return {
+    queries: ["Q1", "Q2", "Q3"].map((queryId, index) => ({
+      queryId,
+      timings: [
+        { ms: 10 + index, status: "pass" },
+        { ms: (10 + index) * 40, status: "pass" },
+      ],
+    })),
+    results: [{ platform: "DuckDB" }, { platform: "SQLite" }],
+  };
+}
+
+/** The same cohort with normalized cost recorded, so the scatter has points. */
+function costCohort(): BenchmarkSummary {
+  const base = wideCohort();
+  return {
+    ...base,
+    platforms: base.platforms.map((platform, index) => ({
+      ...platform,
+      normalized_cost_usd: 0.02 * (index + 1),
+      cost_status: "normalized" as const,
+    })),
+  };
+}
+
 /** A cohort wide enough that a fixed label gutter cannot fit a phone column. */
 function wideCohort(): BenchmarkSummary {
   const names = [
@@ -119,28 +177,64 @@ function wideCohort(): BenchmarkSummary {
   };
 }
 
-/** Every x coordinate a chart draws, in user units. */
-function drawnRightEdges(root: ParentNode): number[] {
-  const edges: number[] = [];
+interface MarkExtent {
+  readonly what: string;
+  readonly x: number;
+  readonly y: number;
+}
+
+/**
+ * Every point a chart actually draws, in user units.
+ *
+ * Covers rects, lines, circles, path and polyline geometry, and text origins.
+ * An earlier version looked only at rects, line endpoints and text x, which
+ * left the CDF's plotted curves - its entire data layer - unexamined, and
+ * checked no vertical extent at all.
+ */
+function drawnPoints(root: ParentNode): MarkExtent[] {
+  const points: MarkExtent[] = [];
+  const push = (what: string, x: number, y: number) => {
+    if (Number.isFinite(x) && Number.isFinite(y)) points.push({ what, x, y });
+  };
+  const num = (el: Element, name: string) => Number(el.getAttribute(name) ?? NaN);
+
   for (const rect of Array.from(root.querySelectorAll("rect"))) {
-    const x = Number(rect.getAttribute("x") ?? 0);
-    const width = Number(rect.getAttribute("width") ?? 0);
-    if (Number.isFinite(x) && Number.isFinite(width)) edges.push(x + width);
+    const x = num(rect, "x");
+    const y = num(rect, "y");
+    push("rect", x, y);
+    push("rect", x + (num(rect, "width") || 0), y + (num(rect, "height") || 0));
   }
   for (const line of Array.from(root.querySelectorAll("line"))) {
-    for (const attr of ["x1", "x2"]) {
-      const value = Number(line.getAttribute(attr) ?? 0);
-      if (Number.isFinite(value)) edges.push(value);
+    push("line", num(line, "x1"), num(line, "y1"));
+    push("line", num(line, "x2"), num(line, "y2"));
+  }
+  for (const circle of Array.from(root.querySelectorAll("circle"))) {
+    const r = num(circle, "r") || 0;
+    push("circle", num(circle, "cx") - r, num(circle, "cy") - r);
+    push("circle", num(circle, "cx") + r, num(circle, "cy") + r);
+  }
+  // Curves carry their geometry in an attribute, so read the coordinate pairs
+  // straight out of it: jsdom lays out no SVG and has no getBBox.
+  for (const el of Array.from(root.querySelectorAll("path, polyline"))) {
+    const raw = el.getAttribute("d") ?? el.getAttribute("points") ?? "";
+    const numbers = (raw.match(/-?\d+(?:\.\d+)?/g) ?? []).map(Number);
+    for (let i = 0; i + 1 < numbers.length; i += 2) {
+      push(el.tagName.toLowerCase(), numbers[i]!, numbers[i + 1]!);
     }
   }
   for (const text of Array.from(root.querySelectorAll("text"))) {
-    const value = Number(text.getAttribute("x") ?? 0);
-    if (Number.isFinite(value)) edges.push(value);
+    push(`text "${(text.textContent ?? "").slice(0, 20)}"`, num(text, "x"), num(text, "y"));
   }
-  return edges;
+  return points;
 }
 
-const CHARTS: { name: string; render: () => { container: Element } }[] = [
+/**
+ * `minWidth` is the drawing floor a chart declares for itself. Below it the
+ * frame scales down rather than cropping, which is a deliberate trade and not
+ * the defect these tests guard. Omitted means the chart follows its container
+ * exactly.
+ */
+const CHARTS: { name: string; render: () => { container: Element }; minWidth?: number }[] = [
   { name: "PowerBar", render: () => render(<PowerBar summary={wideCohort()} />) },
   { name: "DistributionBox", render: () => render(<DistributionBox summary={wideCohort()} />) },
   { name: "CDFChart", render: () => render(<CDFChart summary={wideCohort()} />) },
@@ -154,7 +248,14 @@ const CHARTS: { name: string; render: () => { container: Element } }[] = [
             ...platform,
             colorIdx: index,
             displayLabel: platform.platform,
-            percentile_stats: { p50: 20 + index, p90: 40 + index, p95: 60 + index, p99: 90 + index },
+            // p50 close to p99 puts the value label at the very end of the
+            // plot, where a trailing label used to be drawn outside it.
+            percentile_stats: {
+              p50: 88 + index,
+              p90: 89 + index,
+              p95: 89.5 + index,
+              p99: 90 + index,
+            },
           }))}
         />,
       ),
@@ -162,6 +263,39 @@ const CHARTS: { name: string; render: () => { container: Element } }[] = [
   {
     name: "PerformanceBar",
     render: () => render(<ChartPanel context={{ kind: "summary", summary: wideCohort() }} />),
+  },
+  { name: "CostScatter", render: () => render(<CostScatter summary={costCohort()} />) },
+  {
+    name: "NormalizedSpeedupChart",
+    minWidth: 300,
+    render: () => render(<NormalizedSpeedupChart {...clampedCompare()} baselineIdx={0} />),
+  },
+  {
+    name: "DivergingBarChart",
+    minWidth: 300,
+    render: () => render(<DivergingBarChart {...clampedCompare()} baselineIdx={0} />),
+  },
+  {
+    name: "TimeSeries",
+    render: () =>
+      render(
+        <TimeSeries
+          entries={wideCohort().platforms.flatMap((platform) =>
+            // A trend needs at least two runs per platform.
+            ["2026-03-01", "2026-06-01", "2026-09-01"].map((run_date, run) => ({
+              result_id: `${platform.result_id}-${run}`,
+              platform_id: platform.platform_id,
+              platform: platform.platform,
+              benchmark: "tpch",
+              scale_factor: 1,
+              run_date,
+              power_score: (platform.power_score ?? 1000) - run * 50,
+              display_geomean_ms: (platform.display_geomean_ms ?? 30) + run * 3,
+              trust_label: platform.trust_label,
+            })),
+          )}
+        />,
+      ),
   },
 ];
 
@@ -173,27 +307,84 @@ describe("chart responsive contract", () => {
         async (width) => {
           setContainerWidth(width);
           const { container } = chart.render();
+          const expected = Math.max(width, chart.minWidth ?? 0);
 
           await waitFor(() => {
             const svg = container.querySelector("svg");
             expect(svg?.getAttribute("width")).toBe("100%");
-            expect(svg?.getAttribute("viewBox")).toMatch(new RegExp(`^0 0 ${width} `));
+            expect(svg?.getAttribute("viewBox")).toMatch(new RegExp(`^0 0 ${expected} `));
           });
+        },
+      );
+
+      it.each([NARROW_COLUMN, PHONE_COLUMN, DESKTOP_COLUMN])(
+        "anchors labels so they cannot run off an edge at %spx",
+        async (width) => {
+          // jsdom lays out no text, so its extent cannot be measured here. What
+          // can be checked is the rule that governs it: a label anchored at its
+          // start, placed hard against the right edge, has nowhere to go but
+          // outside the drawing. The same applies mirrored on the left.
+          setContainerWidth(width);
+          const { container } = chart.render();
+          const expected = Math.max(width, chart.minWidth ?? 0);
+
+          await waitFor(() => {
+            expect(container.querySelector("svg")).not.toBeNull();
+          });
+
+          const offenders: string[] = [];
+          for (const svg of Array.from(container.querySelectorAll("svg"))) {
+            for (const text of Array.from(svg.querySelectorAll("text"))) {
+              // A rotated label's x is expressed in its own rotated frame, so a
+              // flat comparison against the drawing width says nothing useful.
+              if (text.getAttribute("transform") !== null) continue;
+              const x = Number(text.getAttribute("x") ?? NaN);
+              if (!Number.isFinite(x)) continue;
+              const label = visibleLabel(text);
+              if (label === "") continue;
+              const anchorAttr = text.getAttribute("text-anchor") ?? "start";
+              const estimated = estimatedTextWidth(text);
+              const left =
+                anchorAttr === "end" ? x - estimated : anchorAttr === "middle" ? x - estimated / 2 : x;
+              const right = left + estimated;
+              if (left < -0.5 || right > expected + 0.5) {
+                offenders.push(
+                  `"${label.slice(0, 24)}" spans ${left.toFixed(1)}..${right.toFixed(1)} of ${expected}`,
+                );
+              }
+            }
+          }
+
+          expect(offenders, offenders.join("\n")).toEqual([]);
         },
       );
 
       it("keeps every mark inside the drawing at a phone column width", async () => {
         setContainerWidth(PHONE_COLUMN);
         const { container } = chart.render();
+        const expected = Math.max(PHONE_COLUMN, chart.minWidth ?? 0);
 
         await waitFor(() => {
           const svg = container.querySelector("svg");
-          expect(svg?.getAttribute("viewBox")).toMatch(new RegExp(`^0 0 ${PHONE_COLUMN} `));
+          expect(svg?.getAttribute("viewBox")).toMatch(new RegExp(`^0 0 ${expected} `));
         });
 
         const svg = container.querySelector("svg")!;
-        const overflowing = drawnRightEdges(svg).filter((edge) => edge > PHONE_COLUMN + 0.5);
-        expect(overflowing).toEqual([]);
+        const [, , boxWidth, boxHeight] = (svg.getAttribute("viewBox") ?? "")
+          .split(/\s+/)
+          .map(Number);
+
+        const outside = drawnPoints(svg)
+          .filter(
+            (point) =>
+              point.x < -0.5 ||
+              point.x > boxWidth! + 0.5 ||
+              point.y < -0.5 ||
+              point.y > boxHeight! + 0.5,
+          )
+          .map((point) => `${point.what} at (${point.x.toFixed(1)}, ${point.y.toFixed(1)})`);
+
+        expect(outside, outside.join("\n")).toEqual([]);
       });
     });
   }

--- a/results-explorer/src/components/__tests__/chartResponsiveContract.test.tsx
+++ b/results-explorer/src/components/__tests__/chartResponsiveContract.test.tsx
@@ -1,0 +1,200 @@
+/**
+ * The Explorer's SVG charts share one sizing contract: draw in a coordinate
+ * system as wide as the measured container, publish it as `width="100%"` plus a
+ * matching viewBox, and keep every mark inside it.
+ *
+ * These are regression tests for a defect that shipped: charts authored at a
+ * fixed 400-unit floor with no viewBox were reduced to the column width by
+ * `.bb-chart-svg { max-width: 100% }` without their coordinate system moving
+ * with them. On a 293px phone column that silently discarded the right-hand
+ * quarter of the drawing and the bottom quarter of the rows - the slowest runs,
+ * the axis, and the caption naming the scale. The wrapping `overflow-x-auto`
+ * could not scroll to them either, because the box now fitted its parent.
+ *
+ * e2e/responsive.spec.ts deliberately exempts elements inside `svg[role="img"]`
+ * from its overflow audit, so nothing else in the suite would catch a return.
+ */
+
+import { render, waitFor } from "@testing-library/preact";
+import { describe, it, expect, afterEach } from "vitest";
+import type { BenchmarkSummary, PlatformRow } from "@/types";
+
+import { PowerBar } from "@/components/PowerBar";
+import { DistributionBox } from "@/components/DistributionBox";
+import { CDFChart } from "@/components/CDFChart";
+import { StackedPhase } from "@/components/StackedPhase";
+import { PercentileLadder } from "@/components/PercentileLadder";
+import { ChartPanel } from "@/components/ChartPanel";
+
+const PHONE_COLUMN = 293;
+const DESKTOP_COLUMN = 1166;
+
+function setContainerWidth(width: number): void {
+  Object.defineProperty(HTMLElement.prototype, "offsetWidth", {
+    configurable: true,
+    get: () => width,
+  });
+}
+
+afterEach(() => {
+  Object.defineProperty(HTMLElement.prototype, "offsetWidth", {
+    configurable: true,
+    get: () => 0,
+  });
+});
+
+function makePlatform(overrides: Partial<PlatformRow> = {}): PlatformRow {
+  const timings = overrides.timings ?? { Q1: 10, Q2: 20, Q3: 30 };
+  return {
+    result_id: "r1",
+    short_id: "",
+    platform_id: "duckdb",
+    platform: "DuckDB",
+    platform_version: null,
+    tuning_mode: null,
+    tuning_hash: null,
+    execution_mode: null,
+    trust_label: "maintainer-run",
+    funding: "unspecified",
+    run_date: "2026-04-01",
+    is_ranking_eligible: true,
+    has_display_timing: true,
+    valid_query_count: 3,
+    missing_query_count: 0,
+    zero_timing_count: 0,
+    display_exclusion_reason: null,
+    comparison_exclusion_reason: null,
+    ranking_exclusion_reason: null,
+    power_score: 3000,
+    display_geomean_ms: 12,
+    sample_geomean_ms: 12,
+    cost_usd: null,
+    compliance_class: null,
+    percentile_stats: null,
+    phase_durations: null,
+    timings,
+    timing_eligibility: Object.fromEntries(
+      Object.entries(timings).map(([queryId, ms]) => [
+        queryId,
+        {
+          is_valid_display_timing: ms !== null && ms > 0,
+          timing_exclusion_reason: null,
+        },
+      ]),
+    ),
+    ...overrides,
+  };
+}
+
+/** A cohort wide enough that a fixed label gutter cannot fit a phone column. */
+function wideCohort(): BenchmarkSummary {
+  const names = [
+    "DuckDB",
+    "DuckLake",
+    "Polars",
+    "DataFusion",
+    "ClickHouse Local",
+    "SQLite",
+    "Spark",
+    "PySpark",
+  ];
+  return {
+    benchmark: "tpch",
+    scale_factor: 1,
+    phase: "power",
+    query_ids: ["Q1", "Q2", "Q3"],
+    platforms: names.map((platform, index) =>
+      makePlatform({
+        result_id: `r${index}`,
+        platform_id: platform.toLowerCase().replace(/\s+/g, "-"),
+        platform,
+        power_score: 100000 - index * 12000,
+        display_geomean_ms: 35 * (index + 1) ** 2,
+        timings: { Q1: 10 * (index + 1), Q2: 20 * (index + 1), Q3: 30 * (index + 1) },
+        phase_durations: { load: 4 + index, power: 12 + index },
+      }),
+    ),
+    cell_reduction: "median",
+    ranking: null,
+  };
+}
+
+/** Every x coordinate a chart draws, in user units. */
+function drawnRightEdges(root: ParentNode): number[] {
+  const edges: number[] = [];
+  for (const rect of Array.from(root.querySelectorAll("rect"))) {
+    const x = Number(rect.getAttribute("x") ?? 0);
+    const width = Number(rect.getAttribute("width") ?? 0);
+    if (Number.isFinite(x) && Number.isFinite(width)) edges.push(x + width);
+  }
+  for (const line of Array.from(root.querySelectorAll("line"))) {
+    for (const attr of ["x1", "x2"]) {
+      const value = Number(line.getAttribute(attr) ?? 0);
+      if (Number.isFinite(value)) edges.push(value);
+    }
+  }
+  for (const text of Array.from(root.querySelectorAll("text"))) {
+    const value = Number(text.getAttribute("x") ?? 0);
+    if (Number.isFinite(value)) edges.push(value);
+  }
+  return edges;
+}
+
+const CHARTS: { name: string; render: () => { container: Element } }[] = [
+  { name: "PowerBar", render: () => render(<PowerBar summary={wideCohort()} />) },
+  { name: "DistributionBox", render: () => render(<DistributionBox summary={wideCohort()} />) },
+  { name: "CDFChart", render: () => render(<CDFChart summary={wideCohort()} />) },
+  { name: "StackedPhase", render: () => render(<StackedPhase summary={wideCohort()} />) },
+  {
+    name: "PercentileLadder",
+    render: () =>
+      render(
+        <PercentileLadder
+          rows={wideCohort().platforms.map((platform, index) => ({
+            ...platform,
+            colorIdx: index,
+            displayLabel: platform.platform,
+            percentile_stats: { p50: 20 + index, p90: 40 + index, p95: 60 + index, p99: 90 + index },
+          }))}
+        />,
+      ),
+  },
+  {
+    name: "PerformanceBar",
+    render: () => render(<ChartPanel context={{ kind: "summary", summary: wideCohort() }} />),
+  },
+];
+
+describe("chart responsive contract", () => {
+  for (const chart of CHARTS) {
+    describe(chart.name, () => {
+      it.each([PHONE_COLUMN, DESKTOP_COLUMN])(
+        "draws at the measured container width at %spx",
+        async (width) => {
+          setContainerWidth(width);
+          const { container } = chart.render();
+
+          await waitFor(() => {
+            const svg = container.querySelector("svg");
+            expect(svg?.getAttribute("width")).toBe("100%");
+            expect(svg?.getAttribute("viewBox")).toMatch(new RegExp(`^0 0 ${width} `));
+          });
+        },
+      );
+
+      it("keeps every mark inside the drawing at a phone column width", async () => {
+        setContainerWidth(PHONE_COLUMN);
+        const { container } = chart.render();
+
+        await waitFor(() => {
+          const svg = container.querySelector("svg");
+          expect(svg?.getAttribute("viewBox")).toMatch(new RegExp(`^0 0 ${PHONE_COLUMN} `));
+        });
+
+        const svg = container.querySelector("svg")!;
+        const overflowing = drawnRightEdges(svg).filter((edge) => edge > PHONE_COLUMN + 0.5);
+        expect(overflowing).toEqual([]);
+      });
+    });
+  }
+});

--- a/results-explorer/src/components/__tests__/charts.smoke.test.tsx
+++ b/results-explorer/src/components/__tests__/charts.smoke.test.tsx
@@ -398,6 +398,54 @@ describe("QueryHistogram", () => {
     expect(svg?.getAttribute("viewBox")).toMatch(/^0 0 300 /);
   });
 
+  it("splits panels on cohort width, not query count alone", () => {
+    // A query group holds one bar per platform. Splitting on query count alone
+    // let a wide cohort clamp each bar to a minimum wider than the group it sat
+    // in, so consecutive groups painted over one another. Reproduced at the
+    // narrow width where the clamp actually bites.
+    Object.defineProperty(HTMLElement.prototype, "offsetWidth", {
+      configurable: true,
+      get: () => 300,
+    });
+    try {
+      const query_ids = Array.from({ length: 22 }, (_, i) => `Q${i + 1}`);
+      const timings = Object.fromEntries(query_ids.map((qid) => [qid, 10]));
+      const platforms = Array.from({ length: 12 }, (_, i) =>
+        makePlatform({ result_id: `r${i}`, platform_id: `p${i}`, platform: `Platform ${i}`, timings }),
+      );
+      const { container } = render(<QueryHistogram summary={makeSummary({ query_ids, platforms })} />);
+
+      for (const svg of Array.from(container.querySelectorAll("svg"))) {
+        const extents = Array.from(svg.querySelectorAll("g"))
+          .filter((group) => group.querySelector("[data-query-label]"))
+          .map((group) => {
+            const marks = Array.from(group.querySelectorAll("rect, line"));
+            const xs = marks.map((mark) =>
+              Number(mark.getAttribute("x") ?? mark.getAttribute("x1") ?? NaN),
+            );
+            const rights = marks.map((mark) =>
+              mark.tagName === "rect"
+                ? Number(mark.getAttribute("x") ?? 0) + Number(mark.getAttribute("width") ?? 0)
+                : Number(mark.getAttribute("x2") ?? 0),
+            );
+            return { left: Math.min(...xs), right: Math.max(...rights) };
+          })
+          .filter((extent) => Number.isFinite(extent.left) && Number.isFinite(extent.right))
+          .sort((a, b) => a.left - b.left);
+
+        expect(extents.length).toBeGreaterThan(1);
+        for (let i = 1; i < extents.length; i += 1) {
+          expect(extents[i - 1]!.right).toBeLessThanOrEqual(extents[i]!.left);
+        }
+      }
+    } finally {
+      Object.defineProperty(HTMLElement.prototype, "offsetWidth", {
+        configurable: true,
+        get: () => 0,
+      });
+    }
+  });
+
   it("auto-splits into multiple panels when query count > 33", () => {
     const query_ids = Array.from({ length: 70 }, (_, i) => `Q${i + 1}`);
     const timings: Record<string, number> = {};

--- a/results-explorer/src/lib/__tests__/chartFrame.test.ts
+++ b/results-explorer/src/lib/__tests__/chartFrame.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect } from "vitest";
+import {
+  axisLabelAnchor,
+  barRowLayout,
+  chartFrame,
+  CHART_COMPACT_BELOW,
+  CHART_MIN_WIDTH,
+} from "@/lib/chartFrame";
+
+describe("chartFrame", () => {
+  it("draws at the measured container width, so the user-unit scale is 1", () => {
+    // A viewBox this wide, published as width="100%" in a container this wide,
+    // renders one user unit per CSS pixel: an 11-unit label is 11px on screen.
+    expect(chartFrame(1166).width).toBe(1166);
+    expect(chartFrame(293).width).toBe(293);
+  });
+
+  it("scales rather than crops below the legibility floor", () => {
+    expect(chartFrame(120).width).toBe(CHART_MIN_WIDTH);
+  });
+
+  it("falls back to the floor when the container has not been measured", () => {
+    expect(chartFrame(0).width).toBe(CHART_MIN_WIDTH);
+    expect(chartFrame(Number.NaN).width).toBe(CHART_MIN_WIDTH);
+  });
+
+  it("reports compact only below the threshold", () => {
+    expect(chartFrame(CHART_COMPACT_BELOW - 1).compact).toBe(true);
+    expect(chartFrame(CHART_COMPACT_BELOW).compact).toBe(false);
+    expect(chartFrame(1166).compact).toBe(false);
+  });
+
+  it("honours a caller-supplied floor", () => {
+    expect(chartFrame(120, { minWidth: 300 }).width).toBe(300);
+  });
+});
+
+describe("barRowLayout", () => {
+  const spec = { labelWidth: 160, rowHeight: 36, valueTrail: 96 };
+
+  it("keeps a side gutter and a value trail when the column can afford them", () => {
+    const layout = barRowLayout(chartFrame(1000), spec);
+    expect(layout.labelAbove).toBe(false);
+    expect(layout.labelWidth).toBe(160);
+    expect(layout.plotX).toBe(160);
+    expect(layout.plotWidth).toBe(1000 - 160 - 96);
+    expect(layout.rowHeight).toBe(36);
+  });
+
+  it("moves the label onto its own line and frees the full width for the bar", () => {
+    const layout = barRowLayout(chartFrame(320), spec);
+    expect(layout.labelAbove).toBe(true);
+    expect(layout.labelWidth).toBe(0);
+    expect(layout.plotX).toBe(0);
+    expect(layout.plotWidth).toBe(320);
+    expect(layout.rowHeight).toBeGreaterThan(36);
+  });
+
+  it("keeps the bar inside the row it grew taller for", () => {
+    const layout = barRowLayout(chartFrame(320), spec);
+    expect(layout.labelBaseline).toBeLessThan(layout.barCenter);
+    expect(layout.barCenter).toBeLessThan(layout.rowHeight);
+  });
+
+  it("thins the axis when there is no room for five tick labels", () => {
+    expect(barRowLayout(chartFrame(320), spec).compactTicks).toBe(true);
+    expect(barRowLayout(chartFrame(1000), spec).compactTicks).toBe(false);
+  });
+});
+
+describe("axisLabelAnchor", () => {
+  it("tucks the outermost tick labels inside the drawing", () => {
+    // Centred on the last tick, half the label's box sits outside the drawing
+    // and is cropped.
+    expect(axisLabelAnchor(293, 293)).toBe("end");
+    expect(axisLabelAnchor(0, 293)).toBe("start");
+  });
+
+  it("leaves interior ticks centred on their mark", () => {
+    expect(axisLabelAnchor(150, 293)).toBe("middle");
+  });
+});

--- a/results-explorer/src/lib/chartFrame.ts
+++ b/results-explorer/src/lib/chartFrame.ts
@@ -1,0 +1,130 @@
+/**
+ * chartFrame - shared sizing contract for the Explorer's SVG charts.
+ *
+ * A chart draws in a coordinate system whose width equals its measured
+ * container width, and publishes that as `width="100%"` plus a matching
+ * `viewBox`. Because the viewBox width and the rendered CSS width agree, the
+ * user-unit scale is exactly 1: an 11-unit label is 11 screen pixels at every
+ * viewport, and no part of the drawing falls outside the box.
+ *
+ * The alternative - authoring at a fixed floor and relying on
+ * `max-width: 100%` - does not survive a narrow column. Without a viewBox the
+ * box shrinks while the coordinate system does not, so the right-hand and
+ * bottom edges are never painted; and the wrapping `overflow-x-auto` cannot
+ * scroll to them, because the box now fits its parent. Moving the label size
+ * from an attribute into CSS does not help either: `font-size` inside an SVG
+ * is measured in user units whether it arrives as an attribute or a rule.
+ *
+ * Row-based charts (one bar per run) therefore reflow below `COMPACT_BELOW`
+ * rather than holding a label gutter the column cannot afford: the label moves
+ * onto its own line above the bar, the value keeps the opposite end of that
+ * line, and the bar spans the full width.
+ *
+ * Charts too dense to reflow - a per-query histogram, a grouped timing chart -
+ * opt out by declaring a `minWidth` and scrolling inside their own container,
+ * the contract QueryTimingChart already uses.
+ */
+
+/** Container width below which a bar row cannot afford a label gutter. */
+export const CHART_COMPACT_BELOW = 480;
+
+/**
+ * Floor on the drawing width. Below this the frame does scale down, because a
+ * legible layout is no longer available at 1:1 - but it scales rather than
+ * crops, so the whole chart stays on screen.
+ */
+export const CHART_MIN_WIDTH = 240;
+
+export interface ChartFrame {
+  /** Drawing width in user units. Equals the container width above the floor. */
+  readonly width: number;
+  /** True when the container is too narrow for a side label gutter. */
+  readonly compact: boolean;
+}
+
+export function chartFrame(
+  containerWidth: number,
+  options: { compactBelow?: number; minWidth?: number } = {},
+): ChartFrame {
+  const minWidth = options.minWidth ?? CHART_MIN_WIDTH;
+  const compactBelow = options.compactBelow ?? CHART_COMPACT_BELOW;
+  const measured = Number.isFinite(containerWidth) && containerWidth > 0 ? containerWidth : minWidth;
+  return {
+    width: Math.max(Math.round(measured), minWidth),
+    compact: measured < compactBelow,
+  };
+}
+
+export interface BarRowLayout {
+  /** Width of the left label gutter. Zero when the label sits above its bar. */
+  readonly labelWidth: number;
+  /** Height of one row, including the label line when there is one. */
+  readonly rowHeight: number;
+  /** X origin of the plot area. */
+  readonly plotX: number;
+  /** Width available to the bar itself. */
+  readonly plotWidth: number;
+  /** True when the label and value share a line above the bar. */
+  readonly labelAbove: boolean;
+  /** Baseline offset of the label line, relative to the top of the row. */
+  readonly labelBaseline: number;
+  /** Vertical centre of the bar, relative to the top of the row. */
+  readonly barCenter: number;
+  /**
+   * True when the axis should carry fewer tick labels. Five labels across a
+   * 240-unit axis overlap; three do not.
+   */
+  readonly compactTicks: boolean;
+}
+
+/** Height added to a row when its label moves onto its own line. */
+const LABEL_LINE_H = 18;
+
+/**
+ * Resolve one bar row's geometry for the current frame.
+ *
+ * `valueTrail` is the space a wide layout reserves after the bar for its value
+ * label. A compact layout does not need it: the value moves to the end of the
+ * label line, where it cannot be pushed off the right edge by a long bar.
+ */
+export function barRowLayout(
+  frame: ChartFrame,
+  spec: { labelWidth: number; rowHeight: number; valueTrail: number },
+): BarRowLayout {
+  if (frame.compact) {
+    const rowHeight = spec.rowHeight + LABEL_LINE_H;
+    return {
+      labelWidth: 0,
+      rowHeight,
+      plotX: 0,
+      plotWidth: frame.width,
+      labelAbove: true,
+      labelBaseline: 12,
+      barCenter: LABEL_LINE_H + spec.rowHeight * 0.5,
+      compactTicks: true,
+    };
+  }
+  return {
+    labelWidth: spec.labelWidth,
+    rowHeight: spec.rowHeight,
+    plotX: spec.labelWidth,
+    plotWidth: Math.max(1, frame.width - spec.labelWidth - spec.valueTrail),
+    labelAbove: false,
+    labelBaseline: spec.rowHeight * 0.5 + 4,
+    barCenter: spec.rowHeight * 0.5,
+    compactTicks: false,
+  };
+}
+
+/**
+ * Anchor for an axis tick label at `x` on a drawing `width` wide.
+ *
+ * A centred label on the outermost tick puts half its box outside the drawing,
+ * where it is cropped. Tucking the first and last labels inside costs a little
+ * precision about where the tick sits and buys a label the reader can read.
+ */
+export function axisLabelAnchor(x: number, width: number, inset = 24): "start" | "middle" | "end" {
+  if (x <= inset) return "start";
+  if (x >= width - inset) return "end";
+  return "middle";
+}

--- a/results-explorer/src/lib/chartFrame.ts
+++ b/results-explorer/src/lib/chartFrame.ts
@@ -4,8 +4,12 @@
  * A chart draws in a coordinate system whose width equals its measured
  * container width, and publishes that as `width="100%"` plus a matching
  * `viewBox`. Because the viewBox width and the rendered CSS width agree, the
- * user-unit scale is exactly 1: an 11-unit label is 11 screen pixels at every
- * viewport, and no part of the drawing falls outside the box.
+ * user-unit scale is 1 for any container at or above `CHART_MIN_WIDTH`: an
+ * 11-unit label is 11 screen pixels, and no part of the drawing falls outside
+ * the box. Below that floor the drawing does scale down, so text shrinks with
+ * it - a deliberate trade, because the alternative at 120px is a layout with
+ * no room for a bar. Scaling keeps the whole chart on screen; cropping did
+ * not.
  *
  * The alternative - authoring at a fixed floor and relying on
  * `max-width: 100%` - does not survive a narrow column. Without a viewBox the
@@ -127,4 +131,38 @@ export function axisLabelAnchor(x: number, width: number, inset = 24): "start" |
   if (x <= inset) return "start";
   if (x >= width - inset) return "end";
   return "middle";
+}
+
+export interface EdgeSafeLabel {
+  readonly x: number;
+  readonly textAnchor: "start" | "end";
+}
+
+/**
+ * Place a value label that trails the end of a bar.
+ *
+ * A bar at its maximum reaches the edge of the plot, and a label started just
+ * past it is drawn outside the drawing and cropped. Near either edge the label
+ * turns back on itself and sits inside the bar instead, which is always
+ * readable even though it costs the small gap.
+ *
+ * `inset` is the room the label is assumed to need. It is a bound, not a
+ * measurement: measuring text means laying it out first, which is the fragile
+ * path this file exists to avoid.
+ */
+export function edgeSafeValueLabel(
+  x: number,
+  width: number,
+  direction: "right" | "left",
+  gap = 2,
+  inset = 34,
+): EdgeSafeLabel {
+  if (direction === "right") {
+    return x + gap > width - inset
+      ? { x: Math.min(x - gap, width), textAnchor: "end" }
+      : { x: x + gap, textAnchor: "start" };
+  }
+  return x - gap < inset
+    ? { x: Math.max(x + gap, 0), textAnchor: "start" }
+    : { x: x - gap, textAnchor: "end" };
 }

--- a/results-explorer/src/lib/useUrlState.ts
+++ b/results-explorer/src/lib/useUrlState.ts
@@ -74,7 +74,9 @@ function writeToUrl<T>(key: string, value: T, initial: T, serde: UrlSerde<T>): v
   const newSearch = params.toString();
   const search = newSearch.length > 0 ? `?${newSearch}` : "";
   const newUrl = `${window.location.pathname}${search}${window.location.hash}`;
-  history.replaceState(null, "", newUrl);
+  // Preserve whatever the entry already carries: the router and any other
+  // consumer own `history.state`, and passing null here would discard it.
+  history.replaceState(history.state, "", newUrl);
 }
 
 /**
@@ -107,7 +109,11 @@ export function useUrlState<T>(
     params.delete(key);
     const newSearch = params.toString();
     const search = newSearch.length > 0 ? `?${newSearch}` : "";
-    history.replaceState(null, "", `${window.location.pathname}${search}${window.location.hash}`);
+    history.replaceState(
+      history.state,
+      "",
+      `${window.location.pathname}${search}${window.location.hash}`,
+    );
     // Intentionally mount-only: later equality checks happen inside setValue → writeToUrl.
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);

--- a/results-explorer/src/test/setup.ts
+++ b/results-explorer/src/test/setup.ts
@@ -1,4 +1,14 @@
 import "@testing-library/jest-dom";
+import { beforeEach } from "vitest";
+
+// URL-backed component state (useUrlState) writes with history.replaceState,
+// and jsdom keeps one location per test file. Without this reset, a parameter
+// one test sets is still there when the next test renders.
+beforeEach(() => {
+  if (typeof window !== "undefined") {
+    window.history.replaceState(null, "", "/");
+  }
+});
 
 class TestResizeObserver implements ResizeObserver {
   constructor(private readonly callback: ResizeObserverCallback) {}


### PR DESCRIPTION
## What was wrong

Three independent defects, each of which left a chart that still looked finished.

**1. SVG attribute names were being dropped.** SVG attribute names are case-sensitive, and Preact forwards a prop it does not recognise to `setAttribute` under the name it was given. Nine chart components used the camelCase spellings, so `textAnchor`, `strokeWidth`, `strokeDasharray` and `fillOpacity` arrived in the DOM as attributes the renderer has no rule for, and were ignored. In the browser:

```html
<text x="146.5" y="30" textAnchor="middle" ...>Geomean query time (log scale) - lower is better</text>
```

That label is not centred. Nor is any other. Every label meant to be right-aligned against its gutter started at the gutter edge and ran across the bars; every emphasised stroke drew at 1px (`getComputedStyle` → `stroke-width: 1px` against an authored `1.5`); every dashed stroke drew solid (`stroke-dasharray: none`) — including the histogram marker whose stated purpose is to make a query that did not run look different from one that ran very fast, and the box plot's whiskers and its 0.18-opacity IQR box, which rendered fully opaque over them.

**2. Eight charts drew outside their own box.** They authored themselves at `Math.max(containerWidth, 400)` with no `viewBox`. `.bb-chart-svg { max-width: 100%; height: auto }` then reduced the box without moving the coordinate system. Measured on the live site at a 390px viewport, chart column 293px:

| | |
|---|---|
| SVG attributes | `width="400" height="472"`, no viewBox |
| Rendered box | 293 × 345.7 |
| Never painted | SQLite, Spark, PySpark; every x-axis tick; the caption naming the log scale |
| `parent.scrollWidth` vs `clientWidth` | 293 vs 293 |

That last row is the trap: the wrapping `.overflow-x-auto` cannot scroll to the missing quarter, because the box now fits its parent.

**3. The CDF legend ran off the canvas.** Entries are placed at `36 + 130 × i` on one row with no wrapping. On TPC-H SF 1 there are twelve series, so the row is 1,496 units wide inside a 1,166-unit drawing. Read from the live DOM, three entries sit at x = 1206, 1336 and 1466 — SQLite, Spark and PySpark, the three slowest runs and the curves furthest right.

## What changed

Charts now draw in a coordinate system as wide as their measured container and publish it as `width="100%"` plus a matching `viewBox` (`src/lib/chartFrame.ts`). Because the viewBox width and the rendered width agree, the user-unit scale is exactly 1 and label size is screen-fixed by construction — not by CSS, which would not have helped: `font-size` inside an SVG is measured in user units whether it arrives as an attribute or a rule.

Below 480px a bar row reflows instead of holding a gutter it cannot afford: the label moves onto its own line above the bar, the value keeps the opposite end of that line where no bar length can displace it, and the bar spans the full width.

The CDF legend wraps in HTML outside the SVG, matching the pattern already used by `StackedPhase` and `TimeSeries`.

Smaller fixes in the same pass:

- The per-query histogram split panels on query count alone, so a wide cohort clamped each bar to a floor wider than the group holding it and consecutive groups painted over one another. Panels now account for cohort size.
- Axis labels on the outermost tick tuck inside the drawing rather than hanging half outside it.
- The heatmap announced a cell as `2.00× fastest in column` when the ratio is this run over the column minimum — the cell is 2× *slower*. Corrected in both the grid's accessible names and the mobile cards.
- `QueryTimingChart` had no caller; removed.

Separately, the panel headed **Charts** opened on the sparkline table — an HTML metrics table — so a reader who never touched the controls saw no chart at all. A cohort summary now opens on the performance bar; the table stays available in the Overview group. The open chart moves into a `chart` URL parameter so a reader who finds the view that answers their question can send that view; an id that does not apply to the cohort is canonicalised and the parameter dropped.

## Verification

- Unit suite: 93 files, 1,310 passed.
- Chromium e2e for `responsive`, `benchmark-index`, `result-detail`: 38 passed.
- Walked every chart in every question group against a local build at 375px and at 1280px: viewBox width equals container width in all cases, zero overlapping label pairs, nothing outside the drawing on either axis.

## New coverage

The document-overflow audit in `e2e/responsive.spec.ts` exempts anything inside `svg[role='img']`, which is why none of this was caught. Added:

- `e2e/responsive.spec.ts` — each chart's drawing width must match its rendered width and no label may fall outside it. Confirmed this fails against the previous code (`Geomean performance comparison: no viewBox`).
- `src/components/__tests__/chartResponsiveContract.test.tsx` — the sizing contract per chart at a phone and a desktop column.
- `src/__tests__/svgAttributeHygiene.test.ts` — the camelCase spellings cannot return.
- `src/lib/__tests__/chartFrame.test.ts` — frame and row geometry.
- Histogram group non-overlap and CDF legend completeness, both confirmed to fail against the previous code.

`GroupedQueryChart.test.tsx` accepted either `stroke-dasharray` or `strokeDasharray`; it now requires the name that works.

## Deliberately not in this change

An earlier draft proposed opening the route on three stacked charts with a grid of live chart previews below. An adversarial review argued that down, and I agree: `BenchmarkIndex` already renders the query heatmap as its primary matrix and excludes it from the panel, so the default set would duplicate it; live previews instantiate the full chart rather than a cheap image; and a thumbnail that omits its exclusion summary asserts "these are the compared platforms" when the claim is "these are the rows eligible under this chart's evidence policy". The panel keeps one fully disclosed active chart.

Known and not addressed here, all worth their own change: the mobile heatmap shows only three computed outliers per platform with no way to reach the rest, so the available evidence changes with viewport; `CostScatter` has no collision handling, so equal points occlude silently; `TimeSeries` spaces dates ordinally, so a one-day gap and a one-year gap look alike; `MultiRunHeatmap` ignores its own default render limit and its table has no accessible name; `MetaLeaderboard` publishes `aria-colindex`/`aria-rowindex` without offsetting for the platform column and header row; and most chart marks carry their values only in `<title>` on unfocusable elements, which is not a dependable screen-reader interface.
