### PR TITLE
Bring the benchmark page closer to the long-layout artboard

### DIFF
--- a/results-explorer/src/components/SummaryChartOverview.tsx
+++ b/results-explorer/src/components/SummaryChartOverview.tsx
@@ -80,6 +80,27 @@ const CHART_DISPLAY_TITLES: Record<string, string> = {
 export function SummaryChartOverview({ context, excludeChartIds = [] }: Props) {
   const summary = buildRenderableSummary(context);
   const [openChartIds, setOpenChartIds] = useState<Set<string>>(() => new Set());
+  const [sectionLinkCopied, setSectionLinkCopied] = useState(false);
+
+  async function copySectionLink() {
+    const url = `${window.location.origin}${window.location.pathname}#cohort-charts`;
+    try {
+      if (navigator.clipboard) {
+        await navigator.clipboard.writeText(url);
+      } else {
+        throw new Error("clipboard unavailable");
+      }
+    } catch {
+      const area = document.createElement("textarea");
+      area.value = url;
+      document.body.appendChild(area);
+      area.select();
+      document.execCommand("copy");
+      area.remove();
+    }
+    setSectionLinkCopied(true);
+    window.setTimeout(() => setSectionLinkCopied(false), 1500);
+  }
 
   const charts = useMemo(() => {
     const applicableById = new Map(applicableCharts(context).map((chart) => [chart.id, chart]));
@@ -120,7 +141,34 @@ export function SummaryChartOverview({ context, excludeChartIds = [] }: Props) {
   const powerExclusions = summarizeChartDatasetExclusions(summary.platforms, "rank_safe");
 
   return (
-    <div class="space-y-6" data-testid="summary-chart-overview">
+    <div class="space-y-6" data-testid="summary-chart-overview" id="cohort-charts">
+      <div>
+        <div class="flex flex-wrap items-end justify-between gap-3">
+          <div>
+            <h2 class="text-xl font-bold text-[var(--bb-data-fg-primary)]">What does this cohort show?</h2>
+            <p class="mt-1 text-sm text-[var(--bb-data-fg-muted)]">
+              Headline metrics first, then the distribution and supporting analyses.
+            </p>
+          </div>
+          <button
+            type="button"
+            onClick={() => void copySectionLink()}
+            class="rounded-md border border-[var(--bb-data-border-strong)] bg-[var(--bb-surface-data)] px-3 py-1.5 text-sm font-medium text-[var(--bb-accent)] shadow-sm"
+          >
+            {sectionLinkCopied ? "Copied ✓" : "Copy chart-section link"}
+          </button>
+        </div>
+        <div
+          class="mt-3 rounded-md border border-[var(--bb-data-border)] border-l-4 border-l-[var(--bb-accent)] bg-[var(--bb-surface-data-muted)] px-4 py-3 text-sm text-[var(--bb-data-fg-muted)]"
+          role="note"
+        >
+          <p>
+            <strong class="font-semibold text-[var(--bb-data-fg-primary)]">Shared scope:</strong> every card
+            below names its own eligible population. Rows excluded by a chart&rsquo;s evidence policy remain
+            available in the matrix and receipts.
+          </p>
+        </div>
+      </div>
       <section class="card" aria-labelledby="summary-metric-overview-title">
         <div class="mb-4 flex flex-wrap items-start justify-between gap-3 border-b border-[var(--bb-data-border)] pb-4">
           <div>
@@ -257,6 +305,23 @@ export function SummaryChartOverview({ context, excludeChartIds = [] }: Props) {
         <div data-chart-container>
           <DistributionBox summary={summary} />
         </div>
+        <div class="mt-3 space-y-1 border-t border-[var(--bb-data-border)] pt-3 text-sm text-[var(--bb-data-fg-muted)]">
+          <p>
+            <strong class="font-semibold text-[var(--bb-data-fg-primary)]">Key:</strong> whiskers min/max ·
+            band Q1–Q3 · line median
+          </p>
+          <p>
+            <strong class="font-semibold text-[var(--bb-data-fg-primary)]">Boundary:</strong> across different
+            queries, not run-to-run variability.{" "}
+            <a class="font-medium text-[var(--bb-accent)]" href="#evidence-matrix">
+              Open per-query matrix ↗
+            </a>{" "}
+            ·{" "}
+            <a class="font-medium text-[var(--bb-accent)]" href="#provenance-legend">
+              Inspect exclusions ↗
+            </a>
+          </p>
+        </div>
       </section>
 
       {charts.length > 0 && (
@@ -265,6 +330,9 @@ export function SummaryChartOverview({ context, excludeChartIds = [] }: Props) {
             <h2 id="summary-more-views-title" class="text-lg font-semibold text-[var(--bb-data-fg-primary)]">
               More views
             </h2>
+            <p class="ml-auto text-sm font-medium text-[var(--bb-accent)]">
+              {charts.length} additional {charts.length === 1 ? "analysis" : "analyses"}
+            </p>
             <p class="text-sm text-[var(--bb-data-fg-muted)]">
               {excludeChartIds.includes("query_heatmap") ? "The full query heatmap is above. " : ""}
               Each thumbnail is drawn from this cohort. Open a card to inspect the full chart and its data scope.

--- a/results-explorer/src/components/SummaryChartOverview.tsx
+++ b/results-explorer/src/components/SummaryChartOverview.tsx
@@ -87,9 +87,8 @@ export function SummaryChartOverview({ context, excludeChartIds = [] }: Props) {
   const [copyState, setCopyState] = useState<"idle" | "copied" | "failed">("idle");
   const copyTimer = useRef<number | undefined>(undefined);
   useEffect(() => {
-    const timer = copyTimer.current;
     return () => {
-      if (timer !== undefined) window.clearTimeout(timer);
+      if (copyTimer.current !== undefined) window.clearTimeout(copyTimer.current);
     };
   }, []);
 

--- a/results-explorer/src/components/SummaryChartOverview.tsx
+++ b/results-explorer/src/components/SummaryChartOverview.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from "preact/hooks";
+import { useEffect, useMemo, useRef, useState } from "preact/hooks";
 import type { ComponentChildren } from "preact";
 import type { BenchmarkSummary } from "@/types";
 import {
@@ -77,29 +77,52 @@ const CHART_DISPLAY_TITLES: Record<string, string> = {
   rank_table: "Query ranks",
 };
 
+export function additionalAnalysesLabel(count: number): string {
+  return `${count} additional ${count === 1 ? "analysis" : "analyses"}`;
+}
+
 export function SummaryChartOverview({ context, excludeChartIds = [] }: Props) {
   const summary = buildRenderableSummary(context);
   const [openChartIds, setOpenChartIds] = useState<Set<string>>(() => new Set());
-  const [sectionLinkCopied, setSectionLinkCopied] = useState(false);
+  const [copyState, setCopyState] = useState<"idle" | "copied" | "failed">("idle");
+  const copyTimer = useRef<number | undefined>(undefined);
+  useEffect(() => {
+    const timer = copyTimer.current;
+    return () => {
+      if (timer !== undefined) window.clearTimeout(timer);
+    };
+  }, []);
 
   async function copySectionLink() {
-    const url = `${window.location.origin}${window.location.pathname}#cohort-charts`;
+    // Keep the cohort facets (scale/phase/tuning in the query string) so the
+    // pasted link resolves to the section being viewed, not the defaults.
+    const url = `${window.location.origin}${window.location.pathname}${window.location.search}#cohort-charts`;
+    let ok = false;
     try {
       if (navigator.clipboard) {
         await navigator.clipboard.writeText(url);
+        ok = true;
       } else {
         throw new Error("clipboard unavailable");
       }
     } catch {
-      const area = document.createElement("textarea");
-      area.value = url;
-      document.body.appendChild(area);
-      area.select();
-      document.execCommand("copy");
-      area.remove();
+      try {
+        const area = document.createElement("textarea");
+        area.value = url;
+        area.setAttribute("readonly", "");
+        area.style.position = "fixed";
+        area.style.opacity = "0";
+        document.body.appendChild(area);
+        area.select();
+        ok = document.execCommand("copy");
+        area.remove();
+      } catch {
+        ok = false;
+      }
     }
-    setSectionLinkCopied(true);
-    window.setTimeout(() => setSectionLinkCopied(false), 1500);
+    if (copyTimer.current !== undefined) window.clearTimeout(copyTimer.current);
+    setCopyState(ok ? "copied" : "failed");
+    copyTimer.current = window.setTimeout(() => setCopyState("idle"), 1500);
   }
 
   const charts = useMemo(() => {
@@ -141,7 +164,7 @@ export function SummaryChartOverview({ context, excludeChartIds = [] }: Props) {
   const powerExclusions = summarizeChartDatasetExclusions(summary.platforms, "rank_safe");
 
   return (
-    <div class="space-y-6" data-testid="summary-chart-overview" id="cohort-charts">
+    <div class="scroll-mt-24 space-y-6" data-testid="summary-chart-overview" id="cohort-charts">
       <div>
         <div class="flex flex-wrap items-end justify-between gap-3">
           <div>
@@ -153,21 +176,23 @@ export function SummaryChartOverview({ context, excludeChartIds = [] }: Props) {
           <button
             type="button"
             onClick={() => void copySectionLink()}
+            aria-live="polite"
             class="rounded-md border border-[var(--bb-data-border-strong)] bg-[var(--bb-surface-data)] px-3 py-1.5 text-sm font-medium text-[var(--bb-accent)] shadow-sm"
           >
-            {sectionLinkCopied ? "Copied ✓" : "Copy chart-section link"}
+            {copyState === "copied"
+              ? "Link copied ✓"
+              : copyState === "failed"
+                ? "Copy failed — copy the URL manually"
+                : "Copy chart-section link"}
           </button>
         </div>
-        <div
-          class="mt-3 rounded-md border border-[var(--bb-data-border)] border-l-4 border-l-[var(--bb-accent)] bg-[var(--bb-surface-data-muted)] px-4 py-3 text-sm text-[var(--bb-data-fg-muted)]"
-          role="note"
-        >
+        <aside class="mt-3 rounded-md border border-[var(--bb-data-border)] border-l-4 border-l-[var(--bb-accent)] bg-[var(--bb-surface-data-muted)] px-4 py-3 text-sm text-[var(--bb-data-fg-muted)]">
           <p>
             <strong class="font-semibold text-[var(--bb-data-fg-primary)]">Shared scope:</strong> every card
             below names its own eligible population. Rows excluded by a chart&rsquo;s evidence policy remain
             available in the matrix and receipts.
           </p>
-        </div>
+        </aside>
       </div>
       <section class="card" aria-labelledby="summary-metric-overview-title">
         <div class="mb-4 flex flex-wrap items-start justify-between gap-3 border-b border-[var(--bb-data-border)] pb-4">
@@ -307,10 +332,6 @@ export function SummaryChartOverview({ context, excludeChartIds = [] }: Props) {
         </div>
         <div class="mt-3 space-y-1 border-t border-[var(--bb-data-border)] pt-3 text-sm text-[var(--bb-data-fg-muted)]">
           <p>
-            <strong class="font-semibold text-[var(--bb-data-fg-primary)]">Key:</strong> whiskers min/max ·
-            band Q1–Q3 · line median
-          </p>
-          <p>
             <strong class="font-semibold text-[var(--bb-data-fg-primary)]">Boundary:</strong> across different
             queries, not run-to-run variability.{" "}
             <a class="font-medium text-[var(--bb-accent)]" href="#evidence-matrix">
@@ -331,11 +352,14 @@ export function SummaryChartOverview({ context, excludeChartIds = [] }: Props) {
               More views
             </h2>
             <p class="ml-auto text-sm font-medium text-[var(--bb-accent)]">
-              {charts.length} additional {charts.length === 1 ? "analysis" : "analyses"}
+              {additionalAnalysesLabel(charts.length)}
             </p>
             <p class="text-sm text-[var(--bb-data-fg-muted)]">
-              {excludeChartIds.includes("query_heatmap") ? "The full query heatmap is above. " : ""}
-              Each thumbnail is drawn from this cohort. Open a card to inspect the full chart and its data scope.
+              {excludeChartIds.includes("query_heatmap")
+                ? "The evidence matrix above is the query heatmap. "
+                : ""}
+              Each thumbnail is drawn from this cohort when the cohort has data for it. Open a card to
+              inspect the full chart and its data scope.
             </p>
           </div>
           <div class="grid gap-4 sm:grid-cols-2 xl:grid-cols-4">

--- a/results-explorer/src/components/__tests__/SummaryChartOverview.test.tsx
+++ b/results-explorer/src/components/__tests__/SummaryChartOverview.test.tsx
@@ -1,0 +1,134 @@
+/**
+ * Tests for the long summary overview section chrome.
+ *
+ * Covers the artboard-parity additions around the shared charts: the cohort
+ * section heading with its scope callout and section-link button, the
+ * distribution population/key/boundary footer with matrix and exclusion
+ * links, and the dynamic additional-analyses count.
+ */
+
+import { render, screen, fireEvent } from "@testing-library/preact";
+import { describe, it, expect, vi } from "vitest";
+import type { BenchmarkSummary, PlatformRow } from "@/types";
+
+import { SummaryChartOverview } from "@/components/SummaryChartOverview";
+
+function makePlatform(overrides: Partial<PlatformRow> = {}): PlatformRow {
+  const timings = overrides.timings ?? { Q1: 10, Q2: 20, Q3: 30 };
+  return {
+    result_id: "r1",
+    short_id: "",
+    platform_id: "duckdb",
+    platform: "DuckDB",
+    platform_version: null,
+    tuning_mode: null,
+    tuning_hash: null,
+    execution_mode: null,
+    trust_label: "maintainer-run",
+    funding: "unspecified",
+    run_date: "2026-04-01",
+    is_ranking_eligible: true,
+    has_display_timing: true,
+    valid_query_count: 3,
+    missing_query_count: 0,
+    zero_timing_count: 0,
+    display_exclusion_reason: null,
+    comparison_exclusion_reason: null,
+    ranking_exclusion_reason: null,
+    power_score: 3000,
+    display_geomean_ms: 12,
+    sample_geomean_ms: 12,
+    cost_usd: null,
+    compliance_class: null,
+    percentile_stats: null,
+    phase_durations: null,
+    timings,
+    timing_eligibility:
+      overrides.timing_eligibility ??
+      Object.fromEntries(
+        Object.entries(timings).map(([queryId, ms]) => [
+          queryId,
+          {
+            is_valid_display_timing: ms !== null && ms > 0,
+            timing_exclusion_reason: ms === null ? "missing_timing" : ms === 0 ? "zero_timing" : null,
+          },
+        ]),
+      ),
+    ...overrides,
+  };
+}
+
+function makeSummary(overrides: Partial<BenchmarkSummary> = {}): BenchmarkSummary {
+  return {
+    benchmark: "tpch",
+    scale_factor: 0.1,
+    phase: "standard",
+    query_ids: ["Q1", "Q2", "Q3"],
+    platforms: [
+      makePlatform({ result_id: "r1", platform_id: "duckdb", platform: "DuckDB" }),
+      makePlatform({
+        result_id: "r2",
+        platform_id: "sqlite",
+        platform: "SQLite",
+        power_score: 1500,
+        display_geomean_ms: 25,
+        timings: { Q1: 20, Q2: 40, Q3: 60 },
+      }),
+    ],
+    cell_reduction: "median",
+    ranking: null,
+    ...overrides,
+  };
+}
+
+function renderOverview(summary: BenchmarkSummary = makeSummary()) {
+  return render(<SummaryChartOverview context={{ kind: "summary", summary }} />);
+}
+
+describe("SummaryChartOverview section chrome", () => {
+  it("heads the section with the cohort question, scope callout, and link button", () => {
+    const { container } = renderOverview();
+    expect(screen.getByText("What does this cohort show?")).not.toBeNull();
+    expect(screen.getByText(/Shared scope:/)).not.toBeNull();
+    expect(
+      screen.getByRole("button", { name: "Copy chart-section link" }),
+    ).not.toBeNull();
+    const root = container.querySelector("[data-testid='summary-chart-overview']");
+    expect(root?.getAttribute("id")).toBe("cohort-charts");
+  });
+
+  it("copies the chart-section link and confirms", async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    Object.assign(navigator, { clipboard: { writeText } });
+    try {
+      renderOverview();
+      fireEvent.click(screen.getByRole("button", { name: "Copy chart-section link" }));
+      await screen.findByRole("button", { name: /Copied/ });
+      expect(writeText).toHaveBeenCalledOnce();
+      const copied = String(writeText.mock.calls[0]?.[0] ?? "");
+      expect(copied.endsWith("#cohort-charts")).toBe(true);
+    } finally {
+      // @ts-expect-error jsdom has no clipboard; restore the missing default.
+      delete navigator.clipboard;
+    }
+  });
+
+  it("footers the distribution with key, boundary, and links", () => {
+    renderOverview();
+    const paragraphs = screen
+      .getAllByText(/whiskers min\/max|across different queries, not run-to-run variability/)
+      .filter((el) => el.tagName === "P");
+    expect(paragraphs).toHaveLength(2);
+    const matrixLink = screen.getByText(/Open per-query matrix/) as HTMLAnchorElement;
+    expect(matrixLink.getAttribute("href")).toBe("#evidence-matrix");
+    const exclusionsLink = screen.getByText(/Inspect exclusions/) as HTMLAnchorElement;
+    expect(exclusionsLink.getAttribute("href")).toBe("#provenance-legend");
+  });
+
+  it("labels the more-views count from the rendered cards", () => {
+    const { container } = renderOverview();
+    const cards = container.querySelectorAll("[data-testid^='summary-chart-preview-']");
+    expect(cards.length).toBeGreaterThan(0);
+    expect(screen.getByText(`${cards.length} additional analyses`)).not.toBeNull();
+  });
+});

--- a/results-explorer/src/components/__tests__/SummaryChartOverview.test.tsx
+++ b/results-explorer/src/components/__tests__/SummaryChartOverview.test.tsx
@@ -97,28 +97,34 @@ describe("SummaryChartOverview section chrome", () => {
     expect(root?.getAttribute("id")).toBe("cohort-charts");
   });
 
-  it("copies the chart-section link and confirms", async () => {
+  it("copies the chart-section link with facets and confirms", async () => {
     const writeText = vi.fn().mockResolvedValue(undefined);
     Object.assign(navigator, { clipboard: { writeText } });
+    window.history.replaceState({}, "", "/results/tpch/?scale_factor=0.1&phase=power");
     try {
       renderOverview();
       fireEvent.click(screen.getByRole("button", { name: "Copy chart-section link" }));
-      await screen.findByRole("button", { name: /Copied/ });
+      await screen.findByRole("button", { name: /Link copied/ });
       expect(writeText).toHaveBeenCalledOnce();
       const copied = String(writeText.mock.calls[0]?.[0] ?? "");
+      expect(copied).toContain("?scale_factor=0.1&phase=power");
       expect(copied.endsWith("#cohort-charts")).toBe(true);
     } finally {
+      window.history.replaceState({}, "", "/");
       // @ts-expect-error jsdom has no clipboard; restore the missing default.
       delete navigator.clipboard;
     }
   });
 
-  it("footers the distribution with key, boundary, and links", () => {
+  it("footers the distribution with boundary and links (key lives on the chart)", () => {
     renderOverview();
+    // The whisker key belongs to DistributionBox's own footer; the overview
+    // must not restate it.
+    expect(screen.queryByText(/whiskers min\/max/)).toBeNull();
     const paragraphs = screen
-      .getAllByText(/whiskers min\/max|across different queries, not run-to-run variability/)
+      .getAllByText(/across different queries, not run-to-run variability/)
       .filter((el) => el.tagName === "P");
-    expect(paragraphs).toHaveLength(2);
+    expect(paragraphs).toHaveLength(1);
     const matrixLink = screen.getByText(/Open per-query matrix/) as HTMLAnchorElement;
     expect(matrixLink.getAttribute("href")).toBe("#evidence-matrix");
     const exclusionsLink = screen.getByText(/Inspect exclusions/) as HTMLAnchorElement;
@@ -130,5 +136,52 @@ describe("SummaryChartOverview section chrome", () => {
     const cards = container.querySelectorAll("[data-testid^='summary-chart-preview-']");
     expect(cards.length).toBeGreaterThan(0);
     expect(screen.getByText(`${cards.length} additional analyses`)).not.toBeNull();
+  });
+
+  it("omits the heatmap card when the matrix already shows it", () => {
+    const { container } = render(
+      <SummaryChartOverview context={{ kind: "summary", summary: makeSummary() }} excludeChartIds={["query_heatmap"]} />,
+    );
+    expect(container.querySelector("[data-testid='summary-chart-preview-query_heatmap']")).toBeNull();
+    const cards = container.querySelectorAll("[data-testid^='summary-chart-preview-']");
+    expect(screen.getByText(`${cards.length} additional analyses`)).not.toBeNull();
+  });
+
+  it("formats the analyses count label", async () => {
+    const { additionalAnalysesLabel } = await import("@/components/SummaryChartOverview");
+    expect(additionalAnalysesLabel(0)).toBe("0 additional analyses");
+    expect(additionalAnalysesLabel(1)).toBe("1 additional analysis");
+    expect(additionalAnalysesLabel(7)).toBe("7 additional analyses");
+  });
+
+  it("falls back to execCommand when the async clipboard is missing", async () => {
+    const execCommand = vi.fn(() => true);
+    const original = document.execCommand;
+    // @ts-expect-error jsdom has no clipboard; ensure the fallback path runs.
+    delete navigator.clipboard;
+    document.execCommand = execCommand;
+    try {
+      renderOverview();
+      fireEvent.click(screen.getByRole("button", { name: "Copy chart-section link" }));
+      await screen.findByRole("button", { name: /Link copied/ });
+      expect(execCommand).toHaveBeenCalledOnce();
+    } finally {
+      document.execCommand = original;
+    }
+  });
+
+  it("reports failure when every copy path fails", async () => {
+    const execCommand = vi.fn(() => false);
+    const original = document.execCommand;
+    // @ts-expect-error jsdom has no clipboard; ensure the fallback path runs.
+    delete navigator.clipboard;
+    document.execCommand = execCommand;
+    try {
+      renderOverview();
+      fireEvent.click(screen.getByRole("button", { name: "Copy chart-section link" }));
+      await screen.findByRole("button", { name: /Copy failed/ });
+    } finally {
+      document.execCommand = original;
+    }
   });
 });

--- a/results-explorer/src/components/__tests__/SummaryChartOverview.test.tsx
+++ b/results-explorer/src/components/__tests__/SummaryChartOverview.test.tsx
@@ -170,6 +170,31 @@ describe("SummaryChartOverview section chrome", () => {
     }
   });
 
+  it("clears the pending copy timer on unmount", async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    Object.assign(navigator, { clipboard: { writeText } });
+    const setSpy = vi.spyOn(window, "setTimeout");
+    const clearSpy = vi.spyOn(window, "clearTimeout");
+    try {
+      const { unmount } = renderOverview();
+      fireEvent.click(screen.getByRole("button", { name: "Copy chart-section link" }));
+      await screen.findByRole("button", { name: /Link copied/ });
+      // The component resets its confirmation on a 1500ms timer; locate that
+      // timer id so the assertion cannot pass on unrelated clearTimeout calls.
+      const timerCallIndex = setSpy.mock.calls.findIndex((args) => args[1] === 1500);
+      expect(timerCallIndex).toBeGreaterThanOrEqual(0);
+      const timerId = setSpy.mock.results[timerCallIndex]?.value;
+      clearSpy.mockClear();
+      unmount();
+      expect(clearSpy).toHaveBeenCalledWith(timerId);
+    } finally {
+      setSpy.mockRestore();
+      clearSpy.mockRestore();
+      // @ts-expect-error jsdom has no clipboard; restore the missing default.
+      delete navigator.clipboard;
+    }
+  });
+
   it("reports failure when every copy path fails", async () => {
     const execCommand = vi.fn(() => false);
     const original = document.execCommand;

--- a/results-explorer/src/pages/BenchmarkIndex.tsx
+++ b/results-explorer/src/pages/BenchmarkIndex.tsx
@@ -768,6 +768,40 @@ export function BenchmarkIndex({ benchmark = "" }: BenchmarkIndexProps) {
         </div>
       )}
 
+      {viewMode === "matrix" && analysisSummary && analysisSummary.platforms.length > 0 && (
+        <section class="card mb-4" data-testid="cohort-hero" aria-label="Cohort overview">
+          <div class="flex flex-wrap items-start justify-between gap-4">
+            <p class="max-w-2xl text-sm text-[var(--bb-data-fg-muted)]">
+              A readable path from the cohort&rsquo;s headline result to its distribution and execution
+              shape. The matrix remains the source for per-query evidence.
+            </p>
+            <p
+              class="rounded-lg border border-[var(--bb-data-border)] bg-[var(--bb-surface-data-muted)] px-4 py-2 text-center font-mono text-sm text-[var(--bb-data-fg-primary)]"
+              data-testid="cohort-counts"
+            >
+              {analysisSummary.platforms.length} published runs
+              <br />
+              {analysisSummary.query_ids.length} queries · SF{analysisSummary.scale_factor} ·{" "}
+              {effectivePhase}
+            </p>
+          </div>
+          <div class="mt-4 flex flex-wrap items-center justify-between gap-3 rounded-lg border border-[var(--bb-data-border)] bg-[var(--bb-surface-data-muted)] px-4 py-3">
+            <div>
+              <p class="font-semibold text-[var(--bb-data-fg-primary)]">Evidence matrix</p>
+              <p class="text-sm text-[var(--bb-data-fg-muted)]">
+                Per-query timings, validation badges, run receipts, and comparison selection stay here.
+              </p>
+            </div>
+            <a
+              class="font-medium text-[var(--bb-accent)]"
+              href="#evidence-matrix"
+            >
+              Jump to matrix ↓
+            </a>
+          </div>
+        </section>
+      )}
+
       <section
         class="mb-4 rounded-lg border border-[var(--bb-data-border)] bg-[var(--bb-surface-data)] px-4 py-3 shadow-sm"
         data-testid="benchmark-compare-guidance"
@@ -840,7 +874,7 @@ export function BenchmarkIndex({ benchmark = "" }: BenchmarkIndexProps) {
               </p>
             </div>
           ) : (
-            <>
+            <div id="evidence-matrix" class="contents" data-testid="evidence-matrix">
               {(analysisSummary ?? filteredSummary).platforms.some((row) => row.ranking_exclusion_reason !== null) && (
                 <RankingEligibilityLegend />
               )}
@@ -851,7 +885,7 @@ export function BenchmarkIndex({ benchmark = "" }: BenchmarkIndexProps) {
                 selectionLimitReasonId={selectionLimitCopy ? BENCHMARK_SELECTION_LIMIT_REASON_ID : undefined}
                 highContrast={highContrast}
               />
-            </>
+            </div>
           )}
         </>
       )}
@@ -935,7 +969,9 @@ export function BenchmarkIndex({ benchmark = "" }: BenchmarkIndexProps) {
           onClear={() => setSelectedIds(new Set())}
         />
       )}
-      <ProvenanceLegend />
+      <div id="provenance-legend">
+        <ProvenanceLegend />
+      </div>
 </div>
   );
 }

--- a/results-explorer/src/pages/BenchmarkIndex.tsx
+++ b/results-explorer/src/pages/BenchmarkIndex.tsx
@@ -768,7 +768,7 @@ export function BenchmarkIndex({ benchmark = "" }: BenchmarkIndexProps) {
         </div>
       )}
 
-      {viewMode === "matrix" && analysisSummary && analysisSummary.platforms.length > 0 && (
+      {viewMode === "matrix" && filteredSummary && filteredSummary.platforms.length > 0 && (
         <section class="card mb-4" data-testid="cohort-hero" aria-label="Cohort overview">
           <div class="flex flex-wrap items-start justify-between gap-4">
             <p class="max-w-2xl text-sm text-[var(--bb-data-fg-muted)]">
@@ -779,9 +779,9 @@ export function BenchmarkIndex({ benchmark = "" }: BenchmarkIndexProps) {
               class="rounded-lg border border-[var(--bb-data-border)] bg-[var(--bb-surface-data-muted)] px-4 py-2 text-center font-mono text-sm text-[var(--bb-data-fg-primary)]"
               data-testid="cohort-counts"
             >
-              {analysisSummary.platforms.length} published runs
+              {filteredSummary.platforms.length} published runs
               <br />
-              {analysisSummary.query_ids.length} queries · SF{analysisSummary.scale_factor} ·{" "}
+              {filteredSummary.query_ids.length} queries · SF{filteredSummary.scale_factor} ·{" "}
               {effectivePhase}
             </p>
           </div>
@@ -874,7 +874,7 @@ export function BenchmarkIndex({ benchmark = "" }: BenchmarkIndexProps) {
               </p>
             </div>
           ) : (
-            <div id="evidence-matrix" class="contents" data-testid="evidence-matrix">
+            <div id="evidence-matrix" class="scroll-mt-24" data-testid="evidence-matrix">
               {(analysisSummary ?? filteredSummary).platforms.some((row) => row.ranking_exclusion_reason !== null) && (
                 <RankingEligibilityLegend />
               )}
@@ -969,7 +969,7 @@ export function BenchmarkIndex({ benchmark = "" }: BenchmarkIndexProps) {
           onClear={() => setSelectedIds(new Set())}
         />
       )}
-      <div id="provenance-legend">
+      <div id="provenance-legend" class="scroll-mt-24">
         <ProvenanceLegend />
       </div>
 </div>

--- a/results-explorer/src/pages/__tests__/BenchmarkIndex.test.tsx
+++ b/results-explorer/src/pages/__tests__/BenchmarkIndex.test.tsx
@@ -414,6 +414,18 @@ describe("BenchmarkIndex", () => {
     });
   });
 
+  it("shows the cohort hero with live counts and anchored sections", async () => {
+    const { container } = render(<BenchmarkIndex benchmark="tpch" />);
+    await waitFor(() => expect(screen.getByTestId("cohort-hero")).toBeTruthy());
+    expect(screen.getByTestId("cohort-counts").textContent).toMatch(
+      /\d+ published runs\s*\d+ queries · SF/,
+    );
+    const jump = screen.getByText(/Jump to matrix/) as HTMLAnchorElement;
+    expect(jump.getAttribute("href")).toBe("#evidence-matrix");
+    expect(container.querySelector("#evidence-matrix")).not.toBeNull();
+    expect(container.querySelector("#provenance-legend")).not.toBeNull();
+  });
+
   it("matrix view sorts rows from query headers", async () => {
     const { container } = render(<BenchmarkIndex benchmark="tpch" />);
     await waitFor(() => expect(screen.getByRole("button", { name: /^Q1/ })).toBeTruthy());

--- a/results-explorer/src/pages/__tests__/BenchmarkIndex.test.tsx
+++ b/results-explorer/src/pages/__tests__/BenchmarkIndex.test.tsx
@@ -417,13 +417,18 @@ describe("BenchmarkIndex", () => {
   it("shows the cohort hero with live counts and anchored sections", async () => {
     const { container } = render(<BenchmarkIndex benchmark="tpch" />);
     await waitFor(() => expect(screen.getByTestId("cohort-hero")).toBeTruthy());
-    expect(screen.getByTestId("cohort-counts").textContent).toMatch(
-      /\d+ published runs\s*\d+ queries · SF/,
-    );
+    expect(screen.getByTestId("cohort-counts").textContent).toContain("2 published runs");
+    expect(screen.getByTestId("cohort-counts").textContent).toContain("2 queries");
     const jump = screen.getByText(/Jump to matrix/) as HTMLAnchorElement;
     expect(jump.getAttribute("href")).toBe("#evidence-matrix");
     expect(container.querySelector("#evidence-matrix")).not.toBeNull();
     expect(container.querySelector("#provenance-legend")).not.toBeNull();
+    // The matrix itself is the heatmap: the long layout must not render a
+    // duplicate heatmap preview card.
+    expect(
+      container.querySelector("[data-testid='summary-chart-preview-query_heatmap']"),
+    ).toBeNull();
+    expect(container.querySelector("[data-testid^='summary-chart-preview-']")).not.toBeNull();
   });
 
   it("matrix view sorts rows from query headers", async () => {


### PR DESCRIPTION
Add a cohort hero with live run counts and an evidence-matrix jump
link, a chart-section heading with scope callout and copyable section
link, distribution key/boundary footers with matrix and exclusion
links, anchored matrix and legend sections, and a dynamic
additional-analyses count.
