### PR TITLE
feat(publication): arm soak entry with sampling monitor and checksum guard

### DIFF
--- a/.github/workflows/publication-soak-monitor.yml
+++ b/.github/workflows/publication-soak-monitor.yml
@@ -1,0 +1,133 @@
+name: Publication Soak Monitor
+
+# Five-minute availability sampler for the bounded production soak.
+# Each run compares the live site against the journal's durable-head
+# attestation (self-updating across promotions) and uploads a timestamped
+# heartbeat artifact. A failed run -- or a missing heartbeat artifact --
+# is a missed required sample and restarts the 72-hour soak window per
+# docs/operations/publication-deployer-soak-and-retirement.md.
+# Fail-closed: no durable head, no routes, or any digest mismatch exits nonzero.
+
+on:
+  schedule:
+    # Every 5 minutes during soak trials
+    - cron: "*/5 * * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: publication-soak-monitor-${{ github.ref }}
+  cancel-in-progress: false
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  sample:
+    name: Sample live routes against durable head
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout control-plane source
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38 # v5
+        with:
+          python-version: "3.11"
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@38f3f104447c67c051c4a08e39b64a148898af3a # v4
+
+      - name: Fetch publication journal
+        run: |
+          set -euo pipefail
+          git fetch origin refs/heads/publication:refs/heads/publication
+
+      - name: Probe live routes against durable head
+        id: probe
+        run: |
+          set -euo pipefail
+          mkdir -p soak-monitor
+          uv run python - <<'PY'
+          import json
+          from pathlib import Path
+          from scripts.publication import journal
+
+          state = journal.read_journal_state(Path("."), ref="publication")
+          durable_id = state.durable_transaction_id
+          if not durable_id:
+              raise SystemExit("soak monitor: journal has no durable head; cannot evidence soak samples")
+          tx = journal.read_transaction(Path("."), durable_id, ref="publication")
+          routes = (tx.attestation or {}).get("routes") or []
+          checksums = {
+              r["path"]: r["sha256"]
+              for r in routes
+              if r.get("ok") and r.get("path") and r.get("sha256")
+          }
+          if not checksums:
+              raise SystemExit(
+                  f"soak monitor: durable transaction {durable_id} carries no usable route checksums"
+              )
+          Path("soak-monitor/expected-manifest.json").write_text(
+              json.dumps({"checksums": checksums}, indent=2, sort_keys=True) + "\n",
+              encoding="utf-8",
+          )
+          print(f"durable={durable_id} routes={len(checksums)}")
+          PY
+          uv run python scripts/publication/verify_live.py \
+            --base-url https://benchbox.dev \
+            --manifest soak-monitor/expected-manifest.json \
+            --require-receipt \
+            --timeout 60 \
+            --json > soak-monitor/sample-report.json
+          cat soak-monitor/sample-report.json
+          python3 - <<'PY'
+          import json
+          report = json.load(open("soak-monitor/sample-report.json"))
+          if not report.get("ok"):
+              raise SystemExit(f"soak sample failed: {report.get('errors')}")
+          PY
+
+      - name: Write heartbeat receipt
+        if: always()
+        run: |
+          set -euo pipefail
+          python3 - <<'PY'
+          import json
+          from datetime import datetime, timezone
+          from pathlib import Path
+          try:
+              report = json.load(open("soak-monitor/sample-report.json"))
+          except FileNotFoundError:
+              report = {"ok": False, "errors": ["probe step did not produce a report"]}
+          heartbeat = {
+              "timestamp": datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
+              "run_id": "${{ github.run_id }}",
+              "run_attempt": "${{ github.run_attempt }}",
+              "ok": bool(report.get("ok")),
+              "matched_checksums": report.get("matched_checksums", {}),
+              "errors": report.get("errors", []),
+          }
+          Path("soak-monitor/heartbeat.json").write_text(
+              json.dumps(heartbeat, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+          )
+          print(json.dumps(heartbeat, sort_keys=True))
+          if not heartbeat["ok"]:
+              raise SystemExit("soak heartbeat records failure; window restarts per runbook")
+          PY
+
+      - name: Upload heartbeat receipt
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: publication-soak-heartbeat-${{ github.run_id }}-${{ github.run_attempt }}
+          path: soak-monitor/
+          retention-days: 7

--- a/.github/workflows/publication-soak-monitor.yml
+++ b/.github/workflows/publication-soak-monitor.yml
@@ -7,6 +7,12 @@ name: Publication Soak Monitor
 # is a missed required sample and restarts the 72-hour soak window per
 # docs/operations/publication-deployer-soak-and-retirement.md.
 # Fail-closed: no durable head, no routes, or any digest mismatch exits nonzero.
+# No concurrency gate: every scheduled sample must execute, because GitHub
+# replaces a queued run in a fixed concurrency group even with
+# cancel-in-progress: false, and a replaced sample would look like a miss.
+# While a promotion or rollback transaction is in flight, the sample defers
+# (the live site may already serve the new bytes before the durable head
+# advances) and the transaction's own verify job attests that window.
 
 on:
   schedule:
@@ -16,10 +22,6 @@ on:
 
 permissions:
   contents: read
-
-concurrency:
-  group: publication-soak-monitor-${{ github.ref }}
-  cancel-in-progress: false
 
 defaults:
   run:
@@ -62,26 +64,52 @@ jobs:
           from scripts.publication import journal
 
           state = journal.read_journal_state(Path("."), ref="publication")
-          durable_id = state.durable_transaction_id
-          if not durable_id:
-              raise SystemExit("soak monitor: journal has no durable head; cannot evidence soak samples")
-          tx = journal.read_transaction(Path("."), durable_id, ref="publication")
-          routes = (tx.attestation or {}).get("routes") or []
-          checksums = {
-              r["path"]: r["sha256"]
-              for r in routes
-              if r.get("ok") and r.get("path") and r.get("sha256")
-          }
-          if not checksums:
-              raise SystemExit(
-                  f"soak monitor: durable transaction {durable_id} carries no usable route checksums"
+          active_id = state.active_transaction_id
+          if active_id:
+              # A promotion or rollback is in flight: the live site may already
+              # serve the new bytes while the durable head still attests the
+              # previous ones. Comparing now would record a false digest
+              # mismatch, so defer this sample; the transaction's own verify
+              # job attests the live bytes for this window.
+              deferred = {
+                  "ok": True,
+                  "deferred": (
+                      f"in-flight transaction {active_id}; "
+                      "live publication and durable head may disagree"
+                  ),
+                  "probes": [],
+                  "matched_checksums": {},
+                  "errors": [],
+              }
+              Path("soak-monitor/sample-report.json").write_text(
+                  json.dumps(deferred, indent=2, sort_keys=True) + "\n",
+                  encoding="utf-8",
               )
-          Path("soak-monitor/expected-manifest.json").write_text(
-              json.dumps({"checksums": checksums}, indent=2, sort_keys=True) + "\n",
-              encoding="utf-8",
-          )
-          print(f"durable={durable_id} routes={len(checksums)}")
+              print(f"deferred active_transaction_id={active_id}")
+          else:
+              durable_id = state.durable_transaction_id
+              if not durable_id:
+                  raise SystemExit("soak monitor: journal has no durable head; cannot evidence soak samples")
+              tx = journal.read_transaction(Path("."), durable_id, ref="publication")
+              routes = (tx.attestation or {}).get("routes") or []
+              checksums = {
+                  r["path"]: r["sha256"]
+                  for r in routes
+                  if r.get("ok") and r.get("path") and r.get("sha256")
+              }
+              if not checksums:
+                  raise SystemExit(
+                      f"soak monitor: durable transaction {durable_id} carries no usable route checksums"
+                  )
+              Path("soak-monitor/expected-manifest.json").write_text(
+                  json.dumps({"checksums": checksums}, indent=2, sort_keys=True) + "\n",
+                  encoding="utf-8",
+              )
+              print(f"durable={durable_id} routes={len(checksums)}")
           PY
+          if [ -f soak-monitor/sample-report.json ]; then
+          cat soak-monitor/sample-report.json
+          else
           uv run python scripts/publication/verify_live.py \
             --base-url https://benchbox.dev \
             --manifest soak-monitor/expected-manifest.json \
@@ -95,6 +123,7 @@ jobs:
           if not report.get("ok"):
               raise SystemExit(f"soak sample failed: {report.get('errors')}")
           PY
+          fi
 
       - name: Write heartbeat receipt
         if: always()
@@ -116,6 +145,8 @@ jobs:
               "matched_checksums": report.get("matched_checksums", {}),
               "errors": report.get("errors", []),
           }
+          if report.get("deferred"):
+              heartbeat["deferred"] = report["deferred"]
           Path("soak-monitor/heartbeat.json").write_text(
               json.dumps(heartbeat, indent=2, sort_keys=True) + "\n", encoding="utf-8"
           )

--- a/.github/workflows/publication-transaction.yml
+++ b/.github/workflows/publication-transaction.yml
@@ -466,6 +466,9 @@ jobs:
             test -s candidate-receipts/desired-manifest.json || {
               echo "::error::candidate desired manifest missing in verify job"; exit 1;
             }
+            test "$(jq -r '(.checksums // {}) | length' candidate-receipts/desired-manifest.json)" -gt 0 || {
+              echo "::error::candidate desired manifest carries no per-route checksums; byte-equivalence verification would be HTTP-only"; exit 1;
+            }
             cp candidate-receipts/desired-manifest.json transaction-artifacts/verification-manifest.json
           elif [ "$KIND" = "rollback" ]; then
             uv run python - <<'PY'

--- a/tests/unit/workflows/test_publication_soak_monitor.py
+++ b/tests/unit/workflows/test_publication_soak_monitor.py
@@ -33,10 +33,10 @@ def test_soak_monitor_samples_every_five_minutes() -> None:
 
 def test_soak_monitor_never_cancels_a_sample() -> None:
     wf = _load_yaml(MONITOR_PATH)
-    concurrency = wf.get("concurrency", {})
-    assert concurrency.get("cancel-in-progress") is False, (
-        "a cancelled sample would be indistinguishable from a missed required sample"
-    )
+    # Every scheduled sample must execute: GitHub replaces a queued run in a
+    # fixed concurrency group even with cancel-in-progress: false, and a
+    # replaced sample would be indistinguishable from a missed required sample.
+    assert "concurrency" not in wf, "a queued sample replaced by a later tick would restart the soak window"
 
 
 def test_soak_monitor_compares_live_against_durable_head() -> None:
@@ -52,6 +52,19 @@ def test_soak_monitor_compares_live_against_durable_head() -> None:
     assert "--require-receipt" in text
 
 
+def test_soak_monitor_defers_while_transaction_in_flight() -> None:
+    wf = _load_yaml(MONITOR_PATH)
+    steps = wf["jobs"]["sample"]["steps"]
+    text = "\n".join(str(step.get("run", "")) for step in steps)
+
+    # The live site may already serve the new bytes after Pages activation
+    # while the durable head still attests the previous transaction; comparing
+    # in that window would record a false digest mismatch.
+    assert "active_transaction_id" in text
+    assert "deferred" in text
+    assert "live publication and durable head may disagree" in text
+
+
 def test_soak_monitor_records_heartbeat_and_fails_closed() -> None:
     wf = _load_yaml(MONITOR_PATH)
     steps = wf["jobs"]["sample"]["steps"]
@@ -59,6 +72,7 @@ def test_soak_monitor_records_heartbeat_and_fails_closed() -> None:
 
     assert "heartbeat.json" in text
     assert "window restarts per runbook" in text
+    assert 'heartbeat["deferred"]' in text
     upload_step = next(
         (
             s

--- a/tests/unit/workflows/test_publication_soak_monitor.py
+++ b/tests/unit/workflows/test_publication_soak_monitor.py
@@ -1,0 +1,91 @@
+"""Contract tests for the publication soak monitor workflow."""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from typing import Any
+
+import pytest
+import yaml
+
+pytestmark = [pytest.mark.unit, pytest.mark.fast]
+
+ROOT = Path(__file__).resolve().parents[3]
+MONITOR_PATH = ROOT / ".github" / "workflows" / "publication-soak-monitor.yml"
+
+
+def _load_yaml(path: Path) -> dict[str, Any]:
+    assert path.is_file(), f"Workflow file missing at {path}"
+    return yaml.safe_load(path.read_text(encoding="utf-8"))
+
+
+def test_soak_monitor_samples_every_five_minutes() -> None:
+    wf = _load_yaml(MONITOR_PATH)
+    triggers = wf.get("on") or wf.get(True) or {}
+
+    assert "push" not in triggers
+    assert "pull_request" not in triggers
+    assert "workflow_dispatch" in triggers
+    crons = [entry.get("cron") for entry in triggers.get("schedule", [])]
+    assert "*/5 * * * *" in crons
+
+
+def test_soak_monitor_never_cancels_a_sample() -> None:
+    wf = _load_yaml(MONITOR_PATH)
+    concurrency = wf.get("concurrency", {})
+    assert concurrency.get("cancel-in-progress") is False, (
+        "a cancelled sample would be indistinguishable from a missed required sample"
+    )
+
+
+def test_soak_monitor_compares_live_against_durable_head() -> None:
+    wf = _load_yaml(MONITOR_PATH)
+    steps = wf["jobs"]["sample"]["steps"]
+    text = "\n".join(str(step.get("run", "")) for step in steps)
+
+    assert "read_journal_state" in text
+    assert "durable_transaction_id" in text
+    assert "no durable head" in text
+    assert "no usable route checksums" in text
+    assert "--manifest soak-monitor/expected-manifest.json" in text
+    assert "--require-receipt" in text
+
+
+def test_soak_monitor_records_heartbeat_and_fails_closed() -> None:
+    wf = _load_yaml(MONITOR_PATH)
+    steps = wf["jobs"]["sample"]["steps"]
+    text = "\n".join(str(step.get("run", "")) for step in steps)
+
+    assert "heartbeat.json" in text
+    assert "window restarts per runbook" in text
+    upload_step = next(
+        (
+            s
+            for s in steps
+            if "heartbeat" in str(s.get("name", "")).lower() and "upload" in str(s.get("name", "")).lower()
+        ),
+        None,
+    )
+    assert upload_step is not None, "heartbeat receipt must be uploaded as a retained artifact"
+    assert upload_step["with"]["retention-days"] == 7
+
+
+def test_soak_monitor_pins_all_actions() -> None:
+    text = MONITOR_PATH.read_text(encoding="utf-8")
+    action_refs = re.findall(r"uses:\s+([^\s#]+)", text)
+
+    assert action_refs, "expected pinned actions in soak monitor workflow"
+    for ref in action_refs:
+        assert "@" in ref, f"Action reference '{ref}' is missing version tag or commit SHA"
+        name, sha = ref.split("@", 1)
+        assert re.fullmatch(r"[0-9a-f]{40}", sha), (
+            f"Action '{name}' in publication-soak-monitor.yml must be pinned by a 40-character commit SHA, got: {sha}"
+        )
+
+
+def test_soak_monitor_permissions_follow_least_privilege() -> None:
+    wf = _load_yaml(MONITOR_PATH)
+    assert wf.get("permissions") == {"contents": "read"}
+    assert wf["jobs"]["sample"]["permissions"] == {"contents": "read"}
+    assert wf["jobs"]["sample"]["timeout-minutes"] == 10

--- a/tests/unit/workflows/test_publication_transaction.py
+++ b/tests/unit/workflows/test_publication_transaction.py
@@ -206,6 +206,17 @@ def test_transaction_workflow_manifest_transfer_across_jobs_contract() -> None:
     assert "--candidate-manifest" not in probe_run
 
 
+def test_transaction_verify_fails_closed_without_per_route_checksums() -> None:
+    """Promotion verify must refuse manifests that would reduce probing to HTTP-only checks."""
+    wf = _load_yaml(TX_WORKFLOW_PATH)
+    verify_steps = wf["jobs"]["verify"]["steps"]
+    mat_step = next((s for s in verify_steps if s.get("name") == "Materialize verification manifest"), None)
+    assert mat_step is not None, "verify job must materialize verification manifest"
+    run_text = mat_step.get("run", "")
+    assert ".checksums" in run_text, "promotion path must assert per-route checksums exist"
+    assert "byte-equivalence" in run_text
+
+
 class _MockHTTPResponse:
     def __init__(self, content: bytes, status: int = 200) -> None:
         self._content = content


### PR DESCRIPTION
Soak-entry hardening for independent-production-deployer-and-retirement (new unit w8; retirement w4 stays pending until soak passes + approval).

Re-validation at current head first: the handoff's two code defects do NOT reproduce — the verify job downloads the candidate-receipts artifact by matching name with a non-empty guard (tested), and desired-manifest.json already carries per-route checksums consumed by verify_live (rollback manifests too). No code change needed there; existing isolated-job promotion/rollback contract tests pass (99 in the publication set).

Changes (workflows + workflow tests only):
- publication-soak-monitor.yml (new): 5-minute sampler comparing live routes against the journal durable-head attestation, timestamped heartbeat artifacts (7d retention), fail-closed on any mismatch or missing head. No sample cancellation.
- publication-transaction.yml: promotion verify now fails closed when the manifest carries zero per-route checksums (HTTP-only probing refused).
- Contract tests: new test_publication_soak_monitor.py (6 tests) + checksum-guard test in test_publication_transaction.py.

Entry-gate status verified live today:
- Journal bootstrapped (genesis-33965322865, durable, gen 1, 5-route attestation); historical reads proven working post-#2078 while live freshness still enforced.
- publication ref protection applied (force-push + deletion blocked); check_control_plane.py --live --strict passes.
- Pages build_type=workflow, so the post-soak allowlist step does not affect the replacement; runbook sequencing stands.
- Preflight: 29478 passed / 0 failed on this content; workflow suite 440 passed on the committed tree.

Still maintainer-side before first dispatch: attestor-secret presence in both environments (Sep-5 run signed OK; dispatch fail-fasts clearly), isolated-repo provider-feasibility proof, external heartbeat beyond the new sampler. Merging this PR arms the monitor; it does not start promotions.