### PR TITLE
fix(publication): let lineage follow the durable head across retired generations

### DIFF
--- a/.github/workflows/publication-deploy.yml
+++ b/.github/workflows/publication-deploy.yml
@@ -205,9 +205,8 @@ jobs:
             DURABLE_ID=$(printf '%s' "$STATE_JSON" | jq -r '.durable_transaction_id // empty')
             if [ -n "$DURABLE_ID" ]; then
               git show "refs/heads/publication:publication/transaction-state/transactions/$DURABLE_ID.json" > durable-parent.json
-              if EXPECTED_PARENT_GENERATION="$((GENERATION - 1))" uv run python - <<'PY'
+              if uv run python - <<'PY'
           import json
-          import os
           from pathlib import Path
           from scripts.publication.reconciliation import verify_live_receipt_signature
 
@@ -218,8 +217,6 @@ jobs:
           valid, _ = verify_live_receipt_signature(receipt)
           if not valid or receipt.get("target") != "benchbox.dev":
               raise SystemExit(1)
-          if receipt.get("generation") != int(os.environ["EXPECTED_PARENT_GENERATION"]):
-              raise SystemExit(1)
           PY
               then
                 PRIOR_LIVE_RECEIPT_ID=$(jq -r '.attestation.receipt_id // empty' durable-parent.json)
@@ -228,6 +225,13 @@ jobs:
                 PARENT_ARTIFACT_ID=$(jq -r '.artifact.artifact_id // empty' durable-parent.json)
                 [ -n "$PRIOR_LIVE_RECEIPT_ID" ] && [ -n "$PARENT_SHA" ] && [ -n "$PARENT_ARTIFACT_ID" ] || {
                   echo "::error::durable publication head lacks a complete attested parent binding"
+                  exit 1
+                }
+                # Generations are monotonic but not dense: a voided pre-send
+                # reservation retires its number, so the durable head may
+                # precede this generation by more than one.
+                [ "$PARENT_GENERATION" -lt "$GENERATION" ] || {
+                  echo "::error::durable generation $PARENT_GENERATION does not precede generation $GENERATION"
                   exit 1
                 }
                 printf '%s\n' "$PARENT_SHA" > prior-live-receipt/parent-sha
@@ -292,14 +296,17 @@ jobs:
                 echo "::error::prior_live_receipt_id is stale; current live head is $RECEIPT_ID"
                 exit 1
               }
-              [ "$RECEIPT_GENERATION" = "$((GENERATION - 1))" ] || {
-                echo "::error::generation $GENERATION is not the successor of live generation $RECEIPT_GENERATION"
+              # Same density rule as the durable branch above: the new
+              # generation must strictly advance beyond the attested live
+              # head, which need not be its immediate predecessor.
+              [ "$RECEIPT_GENERATION" -lt "$GENERATION" ] || {
+                echo "::error::generation $GENERATION does not advance beyond live generation $RECEIPT_GENERATION"
                 exit 1
               }
               cp prior-candidate/live-receipt.json prior-live-receipt/live-receipt.json
               PARENT_SHA=$(uv run python -c "import json; print(json.load(open('prior-live-receipt/live-receipt.json'))['source_commit'])")
               echo "parent_sha=$PARENT_SHA" >> "$GITHUB_OUTPUT"
-              echo "parent_generation=$((GENERATION - 1))" >> "$GITHUB_OUTPUT"
+              echo "parent_generation=$RECEIPT_GENERATION" >> "$GITHUB_OUTPUT"
               echo "parent_artifact_id=$ARTIFACT_ID" >> "$GITHUB_OUTPUT"
               exit 0
             fi

--- a/scripts/publication/manifest.py
+++ b/scripts/publication/manifest.py
@@ -152,8 +152,13 @@ def _validate_generation_and_parent(data: dict[str, Any], errors: list[str]) -> 
     else:
         if not _is_valid_sha40(parent_sha):
             errors.append(f"parent_sha must be a 40-char hex string for generation {gen}, got {parent_sha}")
-        if not isinstance(parent_gen, int) or parent_gen != gen - 1:
-            errors.append(f"parent_generation must be {gen - 1} for generation {gen}, got {parent_gen}")
+        # Generations are monotonic but not dense: a voided pre-send
+        # reservation retires its number, so the parent is the attested live
+        # head strictly before this generation, not necessarily gen - 1. The
+        # journal (not the manifest) is the authority that the named parent
+        # is the actual durable head; prepare validates that equality.
+        if not isinstance(parent_gen, int) or not 1 <= parent_gen < gen:
+            errors.append(f"parent_generation must precede generation {gen}, got {parent_gen}")
 
 
 def _validate_source(data: dict[str, Any], errors: list[str]) -> None:

--- a/tests/unit/scripts/publication/test_manifest.py
+++ b/tests/unit/scripts/publication/test_manifest.py
@@ -147,7 +147,42 @@ def test_reject_invalid_generation_and_parent():
         corpus=sample_corpus(),
     )
     errors = validate_manifest_dict(m2_bad_parent_gen.to_dict())
-    assert any("parent_generation must be 1" in e for e in errors)
+    assert any("parent_generation must precede generation 2" in e for e in errors)
+
+
+def test_accept_retired_generation_gap_parent():
+    # A voided pre-send reservation retires its number: generation 5 may
+    # follow durable generation 3 directly.
+    m5_gap = PublicationManifest(
+        generation=5,
+        parent_sha="0" * 40,
+        parent_generation=3,
+        source_commit="f" * 40,
+        source_branch="develop",
+        develop_sha="d" * 40,
+        published_results_sha="c" * 40,
+        build_closure=sample_closure(),
+        artifacts=sample_artifacts(),
+        corpus=sample_corpus(),
+    )
+    errors = validate_manifest_dict(m5_gap.to_dict())
+    assert not any("parent_generation" in e for e in errors)
+
+    # A parent at or beyond the generation is still rejected.
+    m5_bad_parent = PublicationManifest(
+        generation=5,
+        parent_sha="0" * 40,
+        parent_generation=5,
+        source_commit="f" * 40,
+        source_branch="develop",
+        develop_sha="d" * 40,
+        published_results_sha="c" * 40,
+        build_closure=sample_closure(),
+        artifacts=sample_artifacts(),
+        corpus=sample_corpus(),
+    )
+    errors = validate_manifest_dict(m5_bad_parent.to_dict())
+    assert any("parent_generation must precede generation 5" in e for e in errors)
 
 
 def test_reject_incomplete_build_closure():


### PR DESCRIPTION
Fixes the candidate builder's lineage lookup for retired generations.

Voiding the proven pre-send generation-4 reservation retired its number,
so generation 5 must build against the durable generation 3 head. Three
spots still demanded parent == generation - 1 and failed the build:

- durable-parent branch: accept any attested durable head strictly
  before the new generation (signature, target, and completeness checks
  unchanged);
- live-receipt fallback: require strict advance and report the receipt's
  actual generation;
- manifest validation: require 1 <= parent_generation < generation.

Parent authority is unchanged: promotion prepare still validates the
candidate parent against the live durable head for equality.
