### PR TITLE
fix(publication): send a resolvable commit as the Pages build version

### DIFF
--- a/.github/workflows/publication-transaction.yml
+++ b/.github/workflows/publication-transaction.yml
@@ -358,7 +358,12 @@ jobs:
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 artifact_id: deployedArtifactId,
-                pages_build_version: '${{ steps.start_write.outputs.pages_build_version }}',
+                // The provider resolves pages_build_version as a commit, so
+                // this must be a pushed commit (the run's source), never the
+                // journal's dangling write-intent OID: an unresolvable
+                // version makes the provider reject the create request.
+                // Intent correlation stays in the journal's write record.
+                pages_build_version: '${{ github.sha }}',
               }
             });
             const deploymentId = result.id || 'pages-deploy-${{ github.run_id }}';

--- a/scripts/publication/transaction_executor.py
+++ b/scripts/publication/transaction_executor.py
@@ -437,8 +437,11 @@ def cmd_start_write(args: argparse.Namespace) -> int:
     if tx.state not in (STATE_PREPARED, STATE_ROLLBACK_WRITE_STARTED):
         raise TransactionError(f"Cannot start write from state {tx.state}")
 
-    # Create a unique write-intent commit on the repository
-    # Intent commit OID is the pages_build_version passed to Pages API
+    # Create a unique write-intent commit on the repository. The intent OID
+    # stays a journal-internal correlator: the provider resolves
+    # pages_build_version as a commit, so the workflow sends the run's
+    # pushed source SHA on the wire instead (an unpushed intent OID makes
+    # the provider reject the create request).
     msg = f"write-intent: transaction {tx.transaction_id} gen {tx.generation}"
     tree_oid = subprocess.run(
         ["git", "rev-parse", f"{journal_state.tip_commit_oid}^{{tree}}"],
@@ -498,7 +501,9 @@ def cmd_start_write(args: argparse.Namespace) -> int:
     if args.output_tx:
         _write_json(args.output_tx, updated_tx.to_dict())
 
-    print(f"Started write for {tx.transaction_id}: pages_build_version={intent_commit_oid}")
+    print(
+        f"Started write for {tx.transaction_id}: intent={intent_commit_oid} (wire build version is the run source SHA)"
+    )
     return 0
 
 

--- a/tests/unit/scripts/publication/test_check_pages_artifact_wiring.py
+++ b/tests/unit/scripts/publication/test_check_pages_artifact_wiring.py
@@ -134,3 +134,13 @@ def test_matching_step_output_reference_passes(tmp_path: Path) -> None:
 def test_publication_workflow_step_outputs_resolve(workflow_path: Path) -> None:
     assert workflow_path.is_file()
     assert find_unknown_step_outputs(workflow_path) == []
+
+
+def test_deploy_script_sends_resolvable_build_version() -> None:
+    # The provider resolves pages_build_version as a commit. Sending the
+    # journal's dangling write-intent OID made it reject the create request
+    # with 404, so the wire value must be the run's pushed source SHA while
+    # intent correlation stays in the journal's write record.
+    text = (REPO_ROOT / ".github/workflows/publication-transaction.yml").read_text(encoding="utf-8")
+    assert "pages_build_version: '${{ github.sha }}'" in text
+    assert "start_write.outputs.pages_build_version" not in text


### PR DESCRIPTION
Fixes the Pages deployment create rejection (provider 404).

The deploy step sent the journal's write-intent OID as
`pages_build_version`, but that commit is dangling (created by
`commit-tree`, never pushed), so the provider could not resolve it as a
commit. The workflow now sends the run's pushed source SHA, matching the
proven official deploy flow; intent correlation stays in the journal's
write record.

Includes a wiring guard test pinning the wire value and corrects the
stale executor comment that claimed the intent OID goes to the API.
