### PR TITLE
Add per-query documentation with a representative SQL and DataFrame rendering

### DIFF
--- a/benchbox/core/query_catalog.py
+++ b/benchbox/core/query_catalog.py
@@ -1,0 +1,302 @@
+"""Shared per-query rendering for docs, MCP, and CLI surfaces.
+
+Given a benchmark id and a query id, produce a *representative* rendering of the
+query in both SQL and DataFrame form:
+
+* :func:`get_sql_render` returns the query as SQL, translated to a target
+  dialect when the benchmark supports translation (most do), otherwise in the
+  benchmark's own default dialect.
+* :func:`get_dataframe_render` returns the source of the registered DataFrame
+  implementation for the matching query, when the benchmark has one.
+
+"Representative" means default parameters and a single reference platform. It is
+not the exact statement a specific run executes -- for that, callers substitute
+their own ``scale_factor``/``seed``/``dialect`` into ``benchmark.get_query(...)``
+directly (this is the call the power test itself makes,
+``benchbox/core/tpch/power_test.py``).
+
+Both ``benchbox.mcp.tools.benchmark`` (``get_query_details``) and the query-docs
+generator (``scripts/generate_query_docs.py``) render through this module so the
+two surfaces cannot drift.
+
+Copyright 2026 Joe Harris / BenchBox Project
+
+Licensed under the MIT License. See LICENSE file in the project root for details.
+"""
+
+from __future__ import annotations
+
+import inspect
+import logging
+import re
+from dataclasses import dataclass
+from functools import cache
+from typing import Any
+
+from benchbox.core.benchmark_registry import (
+    get_benchmark_default_scale,
+    get_public_benchmark_class,
+)
+
+logger = logging.getLogger(__name__)
+
+#: Reference platform for representative renderings. DataFusion has both a SQL
+#: dialect and a DataFrame surface (the "expression" family), so a single
+#: reference platform covers both forms.
+REFERENCE_DIALECT = "datafusion"
+REFERENCE_DATAFRAME_FAMILY = "expression"
+
+#: Substitution tokens that mean a render is still a raw template rather than a
+#: runnable statement: qgen-style ``:1`` / ``:x`` / ``:o`` / ``:n`` and
+#: ``str.format`` style ``{param}``. Anchored so date/time literals such as
+#: ``'2016-01-01 00:00:00'`` do not trigger it.
+_TEMPLATE_TOKEN_RE = re.compile(r"(?<![\w'])(:[0-9]+\b|:[xon]\b|\{[a-zA-Z_]\w*\})")
+
+
+@dataclass(frozen=True)
+class SqlRender:
+    """A representative SQL rendering of one benchmark query."""
+
+    sql: str
+    #: Dialect the SQL is expressed in. ``"default"`` when the benchmark does
+    #: not support dialect translation and returned its own native SQL.
+    dialect: str
+    #: True when ``sql`` still contains unsubstituted parameter tokens.
+    is_template: bool
+
+
+@dataclass(frozen=True)
+class DataFrameRender:
+    """A representative DataFrame rendering of one benchmark query."""
+
+    source: str
+    #: ``"expression"`` or ``"pandas"`` -- which family implementation this is.
+    family: str
+    query_name: str | None
+    description: str | None
+
+
+@cache
+def _benchmark_instance(benchmark_id: str) -> Any | None:
+    """Instantiate a benchmark at its default scale, or ``None`` if unavailable.
+
+    Cached: instantiation is cheap but the doc generator asks for the same
+    benchmark once per query.
+    """
+    cls = get_public_benchmark_class(benchmark_id)
+    if cls is None:
+        return None
+    try:
+        return cls(scale_factor=get_benchmark_default_scale(benchmark_id))
+    except Exception:  # pragma: no cover - benchmark needs optional deps
+        logger.debug("query_catalog: cannot instantiate benchmark %r", benchmark_id, exc_info=True)
+        return None
+
+
+def _all_queries(bm: Any, *, dialect: str | None = None) -> dict[str, str]:
+    """Return ``bm.get_queries()`` keyed by ``str``.
+
+    With ``dialect`` set, returns the translated set only if the benchmark
+    actually accepts and applies ``dialect``; otherwise returns ``{}`` so the
+    caller does not mistake an untranslated set for a translated one.
+    """
+    if dialect is not None:
+        try:
+            queries = bm.get_queries(dialect=dialect)
+        except TypeError:
+            return {}
+        except Exception:
+            logger.debug("query_catalog: get_queries(dialect=%r) failed", dialect, exc_info=True)
+            return {}
+        return {str(k): v for k, v in (queries or {}).items()}
+    try:
+        queries = bm.get_queries()
+    except Exception:
+        return {}
+    return {str(k): v for k, v in (queries or {}).items()}
+
+
+def _normalize_query_key(query_id: str) -> str:
+    """Fold ``"Q1"``/``"1"`` and ``"Q1.1"``/``"1.1"`` to a common key."""
+    match = re.fullmatch(r"[Qq](\d.*)", query_id)
+    return match.group(1) if match else query_id.lower()
+
+
+def _get_query_accepts_dialect(bm: Any) -> bool:
+    """True when ``bm.get_query`` names ``dialect`` explicitly (not via ``**kwargs``).
+
+    Benchmarks that only absorb ``dialect`` into ``**kwargs`` silently ignore it
+    and return untranslated SQL, so the render must not be labelled with the
+    requested dialect in that case.
+    """
+    try:
+        params = inspect.signature(bm.get_query).parameters
+    except (TypeError, ValueError):
+        return False
+    return "dialect" in params
+
+
+def _get_query_single(bm: Any, query_id: str, dialect: str | None) -> str | None:
+    """Try ``bm.get_query`` with the id shapes benchmarks variously expect."""
+    candidates: list[Any] = [query_id]
+    if query_id.isdigit():
+        candidates.append(int(query_id))
+    stripped = query_id[1:] if query_id[:1] in {"Q", "q"} else f"Q{query_id}"
+    candidates.append(stripped)
+    kwargs = {"dialect": dialect} if dialect else {}
+    for candidate in candidates:
+        try:
+            sql = bm.get_query(candidate, **kwargs)
+        except (KeyError, ValueError, TypeError):
+            continue
+        except Exception:
+            logger.debug("query_catalog: get_query(%r) failed", candidate, exc_info=True)
+            continue
+        if sql:
+            return sql
+    return None
+
+
+def list_query_ids(benchmark_id: str) -> list[str]:
+    """Return the benchmark's query ids in canonical (definition) order."""
+    bm = _benchmark_instance(benchmark_id)
+    if bm is None:
+        return []
+    return list(_all_queries(bm).keys())
+
+
+def _lookup(queries: dict[str, str], query_id: str) -> str | None:
+    """Find ``query_id`` in a query dict, tolerating ``Q``-prefix differences."""
+    if query_id in queries:
+        return queries[query_id]
+    wanted = _normalize_query_key(query_id)
+    for key, sql in queries.items():
+        if _normalize_query_key(key) == wanted:
+            return sql
+    return None
+
+
+def get_sql_render(
+    benchmark_id: str,
+    query_id: str,
+    *,
+    dialect: str | None = REFERENCE_DIALECT,
+) -> SqlRender | None:
+    """Return a representative SQL rendering of ``query_id``.
+
+    With ``dialect`` set: benchmarks whose ``get_query`` names ``dialect`` are
+    translated one query at a time (cheap -- avoids regenerating a whole
+    qgen/dsqgen query set for one row); the rest go through
+    ``get_queries(dialect=...)``. Either translated hit reports that dialect.
+    Falls back to ``get_queries()`` / ``get_query(id)`` reporting
+    ``dialect="default"``. With ``dialect=None`` no translation is attempted.
+    """
+    bm = _benchmark_instance(benchmark_id)
+    if bm is None:
+        return None
+
+    if dialect is not None:
+        if _get_query_accepts_dialect(bm):
+            sql = _get_query_single(bm, query_id, dialect)
+            if sql:
+                return _make_sql_render(sql, dialect)
+        else:
+            sql = _lookup(_all_queries(bm, dialect=dialect), query_id)
+            if sql:
+                return _make_sql_render(sql, dialect)
+
+    sql = _lookup(_all_queries(bm), query_id)
+    if sql:
+        return _make_sql_render(sql, "default")
+
+    sql = _get_query_single(bm, query_id, None)
+    if sql:
+        return _make_sql_render(sql, "default")
+
+    return None
+
+
+def _make_sql_render(sql: str, dialect: str) -> SqlRender:
+    text = sql.strip()
+    return SqlRender(sql=text, dialect=dialect, is_template=bool(_TEMPLATE_TOKEN_RE.search(text)))
+
+
+def _dataframe_registry(benchmark_id: str) -> list[Any]:
+    # ``benchbox.core.dataframe`` must import before any
+    # ``benchbox.core.<id>.dataframe_queries`` module to avoid a partial-init
+    # circular import (benchmark_suite imports the tpch df queries at module load).
+    import benchbox.core.dataframe  # noqa: F401
+    from benchbox.core.dataframe.query_resolution import registry_dataframe_queries
+
+    try:
+        return registry_dataframe_queries(benchmark_id)
+    except Exception:
+        logger.debug("query_catalog: no DataFrame registry for %r", benchmark_id, exc_info=True)
+        return []
+
+
+def get_dataframe_query(benchmark_id: str, query_id: str) -> Any | None:
+    """Return the registered ``DataFrameQuery`` matching ``query_id``, or ``None``."""
+    wanted = _normalize_query_key(query_id)
+    for query in _dataframe_registry(benchmark_id):
+        if _normalize_query_key(str(query.query_id)) == wanted:
+            return query
+    return None
+
+
+def get_dataframe_render(
+    benchmark_id: str,
+    query_id: str,
+    *,
+    family: str = REFERENCE_DATAFRAME_FAMILY,
+) -> DataFrameRender | None:
+    """Return the source of the DataFrame implementation for ``query_id``.
+
+    Prefers the requested ``family`` ("expression" or "pandas"), falling back to
+    whichever implementation the query defines. ``None`` when the benchmark has
+    no DataFrame query for this id.
+    """
+    query = get_dataframe_query(benchmark_id, query_id)
+    if query is None:
+        return None
+
+    impl, resolved_family = _resolve_impl(query, family)
+    if impl is None:
+        return None
+    try:
+        source = inspect.getsource(impl).strip()
+    except (OSError, TypeError):
+        return None
+
+    return DataFrameRender(
+        source=source,
+        family=resolved_family,
+        query_name=getattr(query, "query_name", None),
+        description=getattr(query, "description", None),
+    )
+
+
+def _resolve_impl(query: Any, family: str) -> tuple[Any | None, str]:
+    expr = getattr(query, "expression_impl", None)
+    pandas = getattr(query, "pandas_impl", None)
+    if family == "pandas" and pandas is not None:
+        return pandas, "pandas"
+    if family == "expression" and expr is not None:
+        return expr, "expression"
+    if expr is not None:
+        return expr, "expression"
+    if pandas is not None:
+        return pandas, "pandas"
+    return None, family
+
+
+def query_display_name(benchmark_id: str, query_id: str) -> str | None:
+    """Human name for a query from its DataFrame registry entry, or ``None``.
+
+    Only the DataFrame registry carries a reliable per-query name today. Callers
+    fall back to the bare id when this returns ``None``.
+    """
+    query = get_dataframe_query(benchmark_id, query_id)
+    if query is not None and getattr(query, "query_name", None):
+        return str(query.query_name)
+    return None

--- a/benchbox/mcp/tools/benchmark.py
+++ b/benchbox/mcp/tools/benchmark.py
@@ -22,7 +22,6 @@ from mcp.types import ToolAnnotations
 
 from benchbox.core.benchmark_registry import (
     get_all_benchmarks,
-    get_benchmark_default_scale,
     get_benchmark_surface,
     get_public_benchmark_class,
 )
@@ -779,24 +778,15 @@ def _populate_dataframe_query_details(
     """Populate response dict with DataFrame query details."""
     import inspect
 
+    from benchbox.core.query_catalog import get_dataframe_query
+
     family = _get_dataframe_family_for_platform(platform)
     if family:
         response["dataframe_family"] = family
 
-    registry_id = f"Q{normalized_id}"
-    df_query = None
-
-    if benchmark == "tpch":
-        from benchbox import TPCH_DATAFRAME_QUERIES
-
-        df_query = TPCH_DATAFRAME_QUERIES.get(registry_id)
-    elif benchmark == "tpcds":
-        from benchbox import TPCDS_DATAFRAME_QUERIES
-
-        df_query = TPCDS_DATAFRAME_QUERIES.get(registry_id)
-
+    df_query = get_dataframe_query(benchmark, normalized_id)
     if df_query is None:
-        response["error"] = f"No DataFrame query found for {benchmark} {registry_id}"
+        response["error"] = f"No DataFrame query found for {benchmark} Q{normalized_id}"
         return
 
     response["query_name"] = df_query.query_name
@@ -829,12 +819,11 @@ def _populate_sql_query_details(
     platform: str | None,
 ) -> None:
     """Populate response dict with SQL query details."""
-    benchmark_class = get_public_benchmark_class(benchmark)
-    if benchmark_class is None:
+    from benchbox.core.query_catalog import get_sql_render
+
+    if get_public_benchmark_class(benchmark) is None:
         response["error"] = f"Benchmark '{benchmark}' requires additional dependencies"
         return
-
-    bm = benchmark_class(scale_factor=get_benchmark_default_scale(benchmark))
 
     dialect = None
     if platform is not None:
@@ -846,25 +835,13 @@ def _populate_sql_query_details(
         except Exception:
             pass
 
-    query_sql = None
-    try:
-        kwargs: dict[str, Any] = {}
-        if dialect:
-            kwargs["dialect"] = dialect
-        try:
-            query_sql = bm.get_query(int(normalized_id), **kwargs)
-        except (ValueError, TypeError):
-            query_sql = bm.get_query(normalized_id, **kwargs)
-    except (KeyError, ValueError, TypeError):
-        import contextlib
+    render = get_sql_render(benchmark, normalized_id, dialect=dialect)
+    if render is None:
+        return
 
-        with contextlib.suppress(KeyError, ValueError):
-            query_sql = bm.get_query(normalized_id)
-
-    if query_sql:
-        if len(query_sql) > 2000:
-            response["sql"] = query_sql[:2000]
-            response["sql_truncated"] = True
-        else:
-            response["sql"] = query_sql
-            response["sql_truncated"] = False
+    if len(render.sql) > 2000:
+        response["sql"] = render.sql[:2000]
+        response["sql_truncated"] = True
+    else:
+        response["sql"] = render.sql
+        response["sql_truncated"] = False

--- a/tests/unit/core/test_query_catalog.py
+++ b/tests/unit/core/test_query_catalog.py
@@ -1,0 +1,128 @@
+"""Tests for :mod:`benchbox.core.query_catalog`.
+
+The catalog is the shared render path behind the MCP ``get_query_details`` tool
+and the query-docs generator, so these tests pin its contract across the full
+benchmark registry rather than one or two examples.
+
+Copyright 2026 Joe Harris / BenchBox Project
+
+Licensed under the MIT License. See LICENSE file in the project root for details.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from benchbox.core.benchmark_registry import get_all_benchmarks
+from benchbox.core.query_catalog import (
+    REFERENCE_DIALECT,
+    get_dataframe_query,
+    get_dataframe_render,
+    get_sql_render,
+    list_query_ids,
+    query_display_name,
+)
+
+pytestmark = [pytest.mark.unit, pytest.mark.fast]
+
+_ALL_BENCHMARK_IDS = sorted(get_all_benchmarks())
+
+
+class TestListQueryIds:
+    def test_unknown_benchmark_is_empty(self):
+        assert list_query_ids("does-not-exist") == []
+
+    @pytest.mark.parametrize("benchmark_id", _ALL_BENCHMARK_IDS)
+    def test_every_registered_benchmark_has_queries(self, benchmark_id):
+        ids = list_query_ids(benchmark_id)
+        assert ids, f"{benchmark_id} exposed no query ids"
+        assert len(ids) == len(set(ids)), f"{benchmark_id} has duplicate query ids"
+
+    def test_order_is_stable(self):
+        assert list_query_ids("tpch") == list_query_ids("tpch")
+
+    def test_tpch_ids_are_the_22_queries(self):
+        assert list_query_ids("tpch") == [str(n) for n in range(1, 23)]
+
+
+class TestGetSqlRender:
+    def test_unknown_benchmark_is_none(self):
+        assert get_sql_render("does-not-exist", "1") is None
+
+    def test_unknown_query_is_none(self):
+        assert get_sql_render("tpch", "9999") is None
+
+    def test_tpch_q1_translates_to_reference_dialect(self):
+        render = get_sql_render("tpch", "1")
+        assert render is not None
+        assert render.dialect == REFERENCE_DIALECT
+        assert not render.is_template
+        assert "l_returnflag" in render.sql
+        # netezza -> datafusion translation quotes identifiers / uppercases keywords
+        assert "SELECT" in render.sql
+
+    def test_dialect_none_reports_default_and_skips_translation(self):
+        render = get_sql_render("tpch", "1", dialect=None)
+        assert render is not None
+        assert render.dialect == "default"
+
+    def test_benchmark_without_translation_is_labelled_default(self):
+        # datavault.get_queries() rejects a dialect kwarg and get_query absorbs
+        # it into **kwargs without translating -- the label must not claim it.
+        render = get_sql_render("datavault", "1")
+        assert render is not None
+        assert render.dialect == "default"
+
+    def test_clickbench_q_prefixed_key(self):
+        render = get_sql_render("clickbench", "Q1")
+        assert render is not None
+        assert "hits" in render.sql.lower()
+
+    def test_query_id_resolves_with_or_without_q_prefix(self):
+        # SSB's keys are "Q1.1"; a caller passing "1.1" must still resolve and
+        # still get the dialect translation.
+        with_prefix = get_sql_render("ssb", "Q1.1", dialect="snowflake")
+        without_prefix = get_sql_render("ssb", "1.1", dialect="snowflake")
+        assert with_prefix is not None and without_prefix is not None
+        assert with_prefix.sql == without_prefix.sql
+        assert without_prefix.dialect == "snowflake"
+
+    @pytest.mark.parametrize("benchmark_id", _ALL_BENCHMARK_IDS)
+    def test_first_query_of_every_benchmark_renders(self, benchmark_id):
+        first = list_query_ids(benchmark_id)[0]
+        render = get_sql_render(benchmark_id, first)
+        assert render is not None, f"{benchmark_id}:{first} did not render"
+        assert render.sql.strip()
+        assert not render.is_template, f"{benchmark_id}:{first} rendered as a raw template"
+
+
+class TestGetDataframeRender:
+    def test_tpch_q1_expression_source(self):
+        render = get_dataframe_render("tpch", "1")
+        assert render is not None
+        assert render.family == "expression"
+        assert "def q1_expression_impl" in render.source
+        assert render.query_name == "Pricing Summary Report"
+
+    def test_pandas_family_selectable(self):
+        render = get_dataframe_render("tpch", "1", family="pandas")
+        assert render is not None
+        assert render.family == "pandas"
+        assert "pandas" in render.source.lower() or "def q1_pandas_impl" in render.source
+
+    def test_benchmark_without_dataframe_impl_is_none(self):
+        # tpcdi has SQL queries but no DataFrame registry.
+        assert get_dataframe_render("tpcdi", list_query_ids("tpcdi")[0]) is None
+
+    def test_id_normalization_matches_q_prefixed_registry(self):
+        # SQL key is "6"; the DataFrame registry id is "Q6".
+        assert get_dataframe_query("tpch", "6") is not None
+        assert get_dataframe_query("tpch", "Q6") is not None
+
+
+class TestQueryDisplayName:
+    def test_tpch_uses_dataframe_query_name(self):
+        assert query_display_name("tpch", "1") == "Pricing Summary Report"
+
+    def test_missing_name_is_none(self):
+        assert query_display_name("does-not-exist", "1") is None

--- a/tests/unit/mcp/test_benchmark_tools.py
+++ b/tests/unit/mcp/test_benchmark_tools.py
@@ -927,12 +927,23 @@ class TestPopulateDataframeQueryDetails:
 
         assert "error" in response
 
-    def test_unsupported_benchmark_returns_error(self):
-        """Test that unsupported benchmark for DataFrame returns error."""
+    def test_benchmark_with_dataframe_registry_returns_source(self):
+        """Any benchmark with a DataFrame registry resolves, not just tpch/tpcds."""
         from benchbox.mcp.tools.benchmark import _populate_dataframe_query_details
 
         response: dict = {}
         _populate_dataframe_query_details(response, "clickbench", "1", "polars-df")
+
+        assert "error" not in response
+        assert response["source_code"]
+        assert response["has_expression_impl"] is True
+
+    def test_benchmark_without_dataframe_registry_returns_error(self):
+        """A benchmark with no DataFrame implementations still reports the gap."""
+        from benchbox.mcp.tools.benchmark import _populate_dataframe_query_details
+
+        response: dict = {}
+        _populate_dataframe_query_details(response, "tpcdi", "1", "polars-df")
         assert "error" in response
 
 


### PR DESCRIPTION
Adds a per-query documentation reference under `docs/benchmarks/queries/` — one
page per query for every public benchmark — reachable by clicking through from
each benchmark's overview page.

## What a reader gets

Each `docs/benchmarks/queries/<benchmark>/<query>.md`:

- **Representative SQL** — the query rendered for DataFusion with default
  parameters, pretty-printed.
- **Representative DataFrame** — the source of the matching DataFrame
  implementation, where the benchmark ships one.
- **Get the exact query for your run** — a copy-paste snippet that substitutes
  your own scale factor and platform dialect (and, for TPC-H/TPC-DS, a seed).
- **Source** — a link to the file the query text comes from.

`<benchmark>/index.md` is the query catalog for that benchmark; benchmarks with
many queries also get intermediary group pages. `queries/index.md` is the
top-level catalog, wired into the benchmarks toctree.

1,250 pages across 22 benchmarks. Every benchmark overview page links into its
query templates — the ones with a "Query Characteristics" section inline, the
rest from the header; TPC-H links every row of its query table.

## How it's built

`scripts/generate_query_docs.py` renders the whole tree from
`benchbox.core.query_catalog`. `make query-docs` regenerates it; `make
query-docs-check` is a byte-for-byte drift gate wired into the lint lane next to
`compat-docs-check` and into `guards-fix` — same pattern as the sql_compat
capability docs. A full regeneration takes about 8 seconds.

## Shared renderer

`benchbox/core/query_catalog.py` is the single renderer behind both the docs and
the MCP `get_query_details` tool, so the two cannot diverge. `get_query_details`
picks up two improvements from the shared path: DataFrame details now resolve
for every benchmark with a DataFrame registry (was TPC-H / TPC-DS only), and a
query id resolves whether or not it carries a `Q` prefix.

## Also in here

- **TPC-DS-OBT reproducibility fix**: `_generate_ulist_values` seeded its RNG
  from the builtin `str` hash, which is salted per process, so a query's
  "default" text changed between runs. Now seeded from `zlib.crc32`.
- `query_catalog` caches each benchmark's query set and instantiates benchmarks
  with a fixed seed, so the randomised-parameter benchmarks (nyctaxi,
  tsbs_devops) render deterministically and the drift gate is stable.

## Verification

- `make query-docs-check` passes; deterministic across processes and
  `PYTHONHASHSEED`.
- `make docs-build` succeeds with no new warnings; `check_doc_relative_links.py`
  and `sphinx-build -b linkcheck` clean.
- New unit tests: `tests/unit/core/test_query_catalog.py`,
  `tests/unit/test_generate_query_docs.py`; existing MCP `get_query_details`
  tests green.
- `tests/system/test_ci_lint_parity.py` green (the new `query-docs-check` guard
  matches between the Makefile and the PR workflow).
