### PR TITLE
Harden publication and submission CI pipelines

### DIFF
--- a/.github/workflows/publication-deploy.yml
+++ b/.github/workflows/publication-deploy.yml
@@ -89,9 +89,11 @@ jobs:
           git fetch origin refs/heads/publication:refs/heads/publication || true
           DEVELOP_SHA="${INPUT_DEVELOP_SHA:-$(git rev-parse refs/remotes/origin/develop)}"
           PUBLISHED_RESULTS_SHA="${INPUT_PUBLISHED_RESULTS_SHA:-$(git rev-parse refs/remotes/origin/published-results)}"
+          STATE_JSON=$(git show refs/heads/publication:publication/transaction-state/state.json 2>/dev/null || echo '{}')
+          JOURNAL_NEXT_GEN=$(printf '%s' "$STATE_JSON" | jq -r '.next_generation // empty')
           GENERATION="$INPUT_GENERATION"
           if [ -z "$GENERATION" ]; then
-            GENERATION=$(git show refs/heads/publication:publication/transaction-state/state.json 2>/dev/null | jq -r '.next_generation // 1' || echo 1)
+            GENERATION="${JOURNAL_NEXT_GEN:-1}"
           fi
           APPROVED_MANIFEST_DIGEST="$INPUT_APPROVED_MANIFEST_DIGEST"
           APPROVED_CANDIDATE_RUN_ID="$INPUT_APPROVED_CANDIDATE_RUN_ID"
@@ -133,6 +135,15 @@ jobs:
             echo "::error::generation must be a positive decimal CAS generation"
             exit 1
           }
+          if [ -n "$JOURNAL_NEXT_GEN" ]; then
+            [ "$GENERATION" -le "$JOURNAL_NEXT_GEN" ] || {
+              echo "::error::generation $GENERATION exceeds journal next_generation $JOURNAL_NEXT_GEN"
+              exit 1
+            }
+          elif [ "$GENERATION" -gt 1 ]; then
+            echo "::error::generation $GENERATION exceeds initial journal generation 1"
+            exit 1
+          fi
           if [ -n "$APPROVED_MANIFEST_DIGEST" ]; then
             printf '%s' "$APPROVED_MANIFEST_DIGEST" | grep -qE '^[0-9a-f]{64}$' || {
               echo "::error::approved_manifest_digest must be a lowercase SHA-256 digest"
@@ -234,6 +245,13 @@ jobs:
                   echo "::error::durable generation $PARENT_GENERATION does not precede generation $GENERATION"
                   exit 1
                 }
+                JOURNAL_NEXT_GEN=$(printf '%s' "$STATE_JSON" | jq -r '.next_generation // empty')
+                if [ -n "$JOURNAL_NEXT_GEN" ]; then
+                  [ "$GENERATION" -le "$JOURNAL_NEXT_GEN" ] || {
+                    echo "::error::generation $GENERATION exceeds journal next_generation $JOURNAL_NEXT_GEN"
+                    exit 1
+                  }
+                fi
                 printf '%s\n' "$PARENT_SHA" > prior-live-receipt/parent-sha
                 printf '%s\n' "$PARENT_GENERATION" > prior-live-receipt/parent-generation
                 printf '%s\n' "$PARENT_ARTIFACT_ID" > prior-live-receipt/parent-artifact-id
@@ -303,6 +321,14 @@ jobs:
                 echo "::error::generation $GENERATION does not advance beyond live generation $RECEIPT_GENERATION"
                 exit 1
               }
+              STATE_JSON=$(git show refs/heads/publication:publication/transaction-state/state.json 2>/dev/null || echo '{}')
+              JOURNAL_NEXT_GEN=$(printf '%s' "$STATE_JSON" | jq -r '.next_generation // empty')
+              if [ -n "$JOURNAL_NEXT_GEN" ]; then
+                [ "$GENERATION" -le "$JOURNAL_NEXT_GEN" ] || {
+                  echo "::error::generation $GENERATION exceeds journal next_generation $JOURNAL_NEXT_GEN"
+                  exit 1
+                }
+              fi
               cp prior-candidate/live-receipt.json prior-live-receipt/live-receipt.json
               PARENT_SHA=$(uv run python -c "import json; print(json.load(open('prior-live-receipt/live-receipt.json'))['source_commit'])")
               echo "parent_sha=$PARENT_SHA" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/publication-transaction.yml
+++ b/.github/workflows/publication-transaction.yml
@@ -341,6 +341,7 @@ jobs:
             --transaction-id "${{ needs.prepare.outputs.transaction_id }}" \
             --ref "publication" \
             --repo-path "." \
+            --pages-build-version "${{ github.sha }}" \
             --output-tx transaction-artifacts/tx_writing.json
 
       - name: Deploy to GitHub Pages via Pages adapter

--- a/.github/workflows/validate-submission.yml
+++ b/.github/workflows/validate-submission.yml
@@ -261,12 +261,25 @@ jobs:
                   | STEM="$stem" SUFFIX="$suffix" awk -v RS='\0' \
                     'length($0) == length(ENVIRON["STEM"]) + length(ENVIRON["SUFFIX"]) && \
                      substr($0, 1, length(ENVIRON["STEM"])) == ENVIRON["STEM"] && \
-                     tolower(substr($0, length(ENVIRON["STEM"]) + 1)) == tolower(ENVIRON["SUFFIX"]) { print; exit }')
+                     tolower(substr($0, length(ENVIRON["STEM"]) + 1)) == tolower(ENVIRON["SUFFIX"]) { if (!found) { print; found=1 } }')
                 if [ -n "$companion" ]; then
                   echo "::error file=${companion}::Deleting ${deleted_bundle} also requires deleting its same-stem companion"
                   exit 1
                 fi
               done
+
+              deleted_dir="${deleted_bundle%/*}"
+              deleted_name="${deleted_bundle##*/}"
+              legacy_manifest=$(git ls-tree -rz --name-only "$EFFECTIVE_MERGE" -- "$deleted_dir" \
+                | awk -v RS='\0' -v dir="$deleted_dir" \
+                  'tolower($0) == tolower(dir "/submission-manifest.json") { if (!found) { print; found=1 } }')
+              if [ -n "$legacy_manifest" ]; then
+                referenced_bundle=$(git cat-file -p "$EFFECTIVE_MERGE:${legacy_manifest}" | python3 -c "import json, sys; data = json.load(sys.stdin); print(data.get('bundle_file', '') if isinstance(data, dict) else '')" 2>/dev/null || true)
+                if [ "$referenced_bundle" = "$deleted_name" ]; then
+                  echo "::error file=${legacy_manifest}::Deleting ${deleted_bundle} also requires deleting its referencing legacy manifest"
+                  exit 1
+                fi
+              fi
           done < <(git diff --no-renames --name-only -z --diff-filter=D \
             "$BASE_SHA...$EFFECTIVE_MERGE" -- \
             ':(icase,glob)results-data/bundles/*.json' ':(icase,glob)results-data/bundles/**/*.json' \
@@ -284,7 +297,7 @@ jobs:
             while IFS= read -r manifest; do
               stem="${manifest:0:${#manifest}-14}"
               bundle=$(git ls-tree -r --name-only "$EFFECTIVE_MERGE" -- results-data/bundles \
-                | awk -v stem="$stem" 'substr($0, 1, length($0) - 5) == stem && tolower(substr($0, length($0) - 4)) == ".json" { print; exit }')
+                | awk -v stem="$stem" 'substr($0, 1, length($0) - 5) == stem && tolower(substr($0, length($0) - 4)) == ".json" { if (!found) { print; found=1 } }')
               if [ -n "$bundle" ] && git cat-file -e "$EFFECTIVE_MERGE:${bundle}" 2>/dev/null \
                   && ! printf '%s\n' "$CHANGED" | grep -qxF "$bundle"; then
                 CHANGED="${CHANGED:+${CHANGED}$'\n'}${bundle}"
@@ -301,7 +314,7 @@ jobs:
             while IFS= read -r applied; do
               stem="${applied:0:${#applied}-13}"
               bundle=$(git ls-tree -r --name-only "$EFFECTIVE_MERGE" -- results-data/bundles \
-                | awk -v stem="$stem" 'substr($0, 1, length($0) - 5) == stem && tolower(substr($0, length($0) - 4)) == ".json" { print; exit }')
+                | awk -v stem="$stem" 'substr($0, 1, length($0) - 5) == stem && tolower(substr($0, length($0) - 4)) == ".json" { if (!found) { print; found=1 } }')
               if [ -n "$bundle" ] && git cat-file -e "$EFFECTIVE_MERGE:${bundle}" 2>/dev/null \
                   && ! printf '%s\n' "$CHANGED" | grep -qxF "$bundle"; then
                 CHANGED="${CHANGED:+${CHANGED}$'\n'}${bundle}"
@@ -313,6 +326,7 @@ jobs:
             "$BASE_SHA...$EFFECTIVE_MERGE" -- \
             ':(icase,glob)results-data/bundles/*.json' ':(icase,glob)results-data/bundles/**/*.json' \
             | grep -iE '\.(plans|tuning)\.json$' \
+            | grep -ivE '(corpus-inventory|submission-manifest)\.json$' \
             || true)
           if [ -n "$CHANGED_COMPANIONS" ]; then
             while IFS= read -r companion; do
@@ -324,7 +338,7 @@ jobs:
               esac
               stem="${companion:0:$(( ${#companion} - strip ))}"
               bundle=$(git ls-tree -r --name-only "$EFFECTIVE_MERGE" -- results-data/bundles \
-                | awk -v stem="$stem" 'substr($0, 1, length($0) - 5) == stem && tolower(substr($0, length($0) - 4)) == ".json" { print; exit }')
+                | awk -v stem="$stem" 'substr($0, 1, length($0) - 5) == stem && tolower(substr($0, length($0) - 4)) == ".json" { if (!found) { print; found=1 } }')
               if [ -z "$bundle" ] && git cat-file -e "$EFFECTIVE_MERGE:${companion}" 2>/dev/null; then
                 echo "::error file=${companion}::Live companion has no primary bundle at ${stem}.json"
                 exit 1

--- a/scripts/publication/journal.py
+++ b/scripts/publication/journal.py
@@ -177,6 +177,8 @@ def read_transaction(repo_path: Path, tx_id: str, ref: str = DEFAULT_REF) -> Tra
         }:
             if not isinstance(loaded.attestation, dict):
                 raise CorruptJournalError("Verified transaction must retain a live-receipt attestation")
+            is_durable = loaded.state in {STATE_DURABLE, STATE_ROLLBACK_DURABLE}
+            kwargs = {"max_age_hours": None} if is_durable else {}
             try:
                 try:
                     transaction_module.validate_live_receipt(
@@ -185,7 +187,7 @@ def read_transaction(repo_path: Path, tx_id: str, ref: str = DEFAULT_REF) -> Tra
                             "attestation": loaded.attestation,
                             "observation_digest": loaded.attestation.get("observation_digest"),
                         },
-                        max_age_hours=None,
+                        **kwargs,
                     )
                 except TypeError:
                     transaction_module.validate_live_receipt(

--- a/scripts/publication/reconciliation.py
+++ b/scripts/publication/reconciliation.py
@@ -769,7 +769,7 @@ def _check_receipt_contract_fields(observed: dict[str, Any] | None) -> list[Drif
 def _check_receipt_freshness(
     observed: dict[str, Any] | None,
     live: bool,
-    max_age_hours: float,
+    max_age_hours: float | None,
     now: datetime,
 ) -> tuple[list[DriftFinding], float | None]:
     """Verify live observation receipt freshness and age (fails closed)."""
@@ -777,11 +777,14 @@ def _check_receipt_freshness(
     receipt_age_hours: float | None = None
 
     if observed is None:
+        expected_msg = (
+            f"receipt <= {max_age_hours}h old" if max_age_hours is not None else "valid live-observation receipt"
+        )
         drifts.append(
             DriftFinding(
                 drift_type="STALE_RECEIPT",
                 description="No live-observation receipt to age-check",
-                expected=f"receipt <= {max_age_hours}h old",
+                expected=expected_msg,
                 actual="None",
             )
         )
@@ -827,7 +830,7 @@ def _check_receipt_freshness(
         return drifts, round(age_sec / 3600.0, 2)
 
     receipt_age_hours = round(age_sec / 3600.0, 2)
-    if receipt_age_hours > max_age_hours:
+    if max_age_hours is not None and receipt_age_hours > max_age_hours:
         drifts.append(
             DriftFinding(
                 drift_type="STALE_RECEIPT",
@@ -849,9 +852,7 @@ def validate_live_receipt_contract(
     """Validate the complete signed live-receipt contract and freshness boundary."""
     findings = _check_receipt_contract_fields(receipt)
     probe_findings, _ = _check_observed_probes(receipt)
-    freshness: list[DriftFinding] = []
-    if max_age_hours is not None and max_age_hours > 0:
-        freshness, _ = _check_receipt_freshness(receipt, True, max_age_hours, now or datetime.now(timezone.utc))
+    freshness, _ = _check_receipt_freshness(receipt, True, max_age_hours, now or datetime.now(timezone.utc))
     return [*findings, *probe_findings, *freshness]
 
 

--- a/scripts/publication/transaction.py
+++ b/scripts/publication/transaction.py
@@ -339,11 +339,12 @@ def _handle_prepared(
         intent_commit_oid = payload.get("intent_commit_oid")
         if not intent_commit_oid:
             raise TransactionError("intent_commit_oid is required to start write")
+        pages_build_version = payload.get("pages_build_version") or intent_commit_oid
         data["state"] = STATE_WRITE_STARTED
         data["write"] = {
             "write_id": payload.get("write_id", str(uuid.uuid4())),
             "intent_commit_oid": intent_commit_oid,
-            "pages_build_version": intent_commit_oid,
+            "pages_build_version": pages_build_version,
             "status": "in_flight",
             "started_at": ev["timestamp"],
         }
@@ -352,7 +353,7 @@ def _handle_prepared(
             action="create_deployment",
             data={
                 "artifact_id": tx.artifact.get("artifact_id"),
-                "pages_build_version": intent_commit_oid,
+                "pages_build_version": pages_build_version,
             },
         )
 

--- a/scripts/publication/transaction_executor.py
+++ b/scripts/publication/transaction_executor.py
@@ -464,13 +464,15 @@ def cmd_start_write(args: argparse.Namespace) -> int:
         check=True,
     ).stdout.strip()
 
+    pages_build_version = getattr(args, "pages_build_version", None) or intent_commit_oid
+
     if tx.kind == KIND_ROLLBACK:
         updated_tx = replace(
             tx,
             write={
                 "write_id": tx.transaction_id,
                 "intent_commit_oid": intent_commit_oid,
-                "pages_build_version": intent_commit_oid,
+                "pages_build_version": pages_build_version,
                 "status": "in_flight",
                 "started_at": datetime.now(timezone.utc).isoformat(),
             },
@@ -479,7 +481,11 @@ def cmd_start_write(args: argparse.Namespace) -> int:
         updated_tx, _ = transaction.transition(
             tx,
             EVENT_START_WRITE,
-            payload={"intent_commit_oid": intent_commit_oid, "write_id": tx.transaction_id},
+            payload={
+                "intent_commit_oid": intent_commit_oid,
+                "pages_build_version": pages_build_version,
+                "write_id": tx.transaction_id,
+            },
         )
 
     updated_state, commit_oid = journal.write_journal_update(
@@ -495,14 +501,15 @@ def cmd_start_write(args: argparse.Namespace) -> int:
     github_output = os.environ.get("GITHUB_OUTPUT")
     if github_output:
         with open(github_output, "a", encoding="utf-8") as f:
-            f.write(f"pages_build_version={intent_commit_oid}\n")
+            f.write(f"pages_build_version={pages_build_version}\n")
+            f.write(f"intent_commit_oid={intent_commit_oid}\n")
             f.write(f"write_id={tx.transaction_id}\n")
 
     if args.output_tx:
         _write_json(args.output_tx, updated_tx.to_dict())
 
     print(
-        f"Started write for {tx.transaction_id}: intent={intent_commit_oid} (wire build version is the run source SHA)"
+        f"Started write for {tx.transaction_id}: intent={intent_commit_oid} pages_build_version={pages_build_version}"
     )
     return 0
 
@@ -869,6 +876,11 @@ def build_parser() -> argparse.ArgumentParser:
     p_start.add_argument("--transaction-id", required=True)
     p_start.add_argument("--ref", default=journal.DEFAULT_REF)
     p_start.add_argument("--repo-path", default=".")
+    p_start.add_argument(
+        "--pages-build-version",
+        default=None,
+        help="Wire pages_build_version sent to provider (defaults to intent_commit_oid)",
+    )
     p_start.add_argument("--output-tx", default=None)
     p_start.set_defaults(func=cmd_start_write)
 

--- a/tests/unit/scripts/publication/test_check_pages_artifact_wiring.py
+++ b/tests/unit/scripts/publication/test_check_pages_artifact_wiring.py
@@ -47,6 +47,11 @@ def _iter_step_strings(workflow: dict) -> tuple[str, str, str]:
     for job_name, job in jobs.items():
         if not isinstance(job, dict):
             continue
+        job_outputs = job.get("outputs") or {}
+        if isinstance(job_outputs, dict):
+            for output_name, value in job_outputs.items():
+                if isinstance(value, str):
+                    yield job_name, f"outputs.{output_name}", value
         steps = job.get("steps") or []
         for step in steps:
             if not isinstance(step, dict):
@@ -125,6 +130,40 @@ def test_matching_step_output_reference_passes(tmp_path: Path) -> None:
         "      - uses: actions/github-script@v7\n"
         "        with:\n"
         "          script: const id = ${{ steps.upload_pages.outputs.artifact_id }};\n",
+        "utf-8",
+    )
+    assert find_unknown_step_outputs(workflow) == []
+
+
+def test_unknown_job_output_reference_is_reported(tmp_path: Path) -> None:
+    workflow = tmp_path / "workflow.yml"
+    workflow.write_text(
+        "jobs:\n"
+        "  build:\n"
+        "    runs-on: ubuntu-latest\n"
+        "    outputs:\n"
+        "      candidate_id: ${{ steps.upload_candidate.outputs.artifact_id }}\n"
+        "    steps:\n"
+        "      - id: upload_candidate\n"
+        "        uses: actions/upload-artifact@v4\n",
+        "utf-8",
+    )
+    problems = find_unknown_step_outputs(workflow)
+    assert len(problems) == 1
+    assert "steps.upload_candidate.outputs.artifact_id" in problems[0]
+
+
+def test_matching_job_output_reference_passes(tmp_path: Path) -> None:
+    workflow = tmp_path / "workflow.yml"
+    workflow.write_text(
+        "jobs:\n"
+        "  build:\n"
+        "    runs-on: ubuntu-latest\n"
+        "    outputs:\n"
+        "      candidate_id: ${{ steps.upload_candidate.outputs.artifact-id }}\n"
+        "    steps:\n"
+        "      - id: upload_candidate\n"
+        "        uses: actions/upload-artifact@v4\n",
         "utf-8",
     )
     assert find_unknown_step_outputs(workflow) == []

--- a/tests/unit/scripts/publication/test_journal.py
+++ b/tests/unit/scripts/publication/test_journal.py
@@ -410,3 +410,85 @@ def test_historical_durable_transaction_reads_without_stale_receipt_error(
     )
     loaded = journal_mod.read_transaction(git_repo, state.durable_transaction_id, ref="publication")
     assert loaded.transaction_id == genesis_tx.transaction_id
+
+
+def test_unfinalized_verified_transaction_with_stale_receipt_fails_read(
+    git_repo: Path, genesis_tx: tx_mod.Transaction, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Unfinalized transactions in externally-verified state must NOT be exempt from receipt freshness."""
+    from scripts.publication.reconciliation import validate_live_receipt_contract as real_validate
+
+    monkeypatch.setattr(tx_mod, "validate_live_receipt_contract", real_validate)
+    monkeypatch.setattr("scripts.publication.reconciliation.verify_live_receipt_signature", lambda r: (True, None))
+
+    base_oid = subprocess.run(
+        ["git", "rev-parse", "refs/heads/publication"],
+        cwd=git_repo,
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.strip()
+
+    target = {"repository": "BenchBox-dev/BenchBox", "environment": "github-pages", "url": "https://benchbox.dev"}
+    genesis_tx.attestation.update(
+        {
+            "schema_version": 2,
+            "receipt_id": "live-genesis-stale-test",
+            "timestamp": "2025-01-01T00:00:00Z",
+            "develop_sha": "0" * 40,
+            "published_results_sha": "0" * 40,
+            "artifact": {"archive_sha256": genesis_tx.artifact["archive_sha256"]},
+            "artifacts": {"pages_assembly": {"digest": genesis_tx.artifact["archive_sha256"]}},
+            "observation_origin": "github-actions:publication-verify",
+            "nonce": "test-nonce",
+            "freshness_window": "24h",
+            "attestor": "github-actions:publication-deploy",
+            "signature": "mock-sig",
+            "status": "BUILT",
+            "target": "benchbox.dev",
+            "routes": [
+                {"path": "/", "status_code": 200, "ok": True, "sha256": "abc"},
+                {"path": "/docs/", "status_code": 200, "ok": True, "sha256": "abc"},
+                {"path": "/results/", "status_code": 200, "ok": True, "sha256": "abc"},
+                {"path": "/results/data/results.duckdb", "status_code": 200, "ok": True, "sha256": "abc"},
+            ],
+        }
+    )
+
+    state, commit_oid = journal_mod.init_genesis_journal(
+        repo_path=git_repo,
+        target=target,
+        genesis_transaction=genesis_tx,
+        base_commit_oid=base_oid,
+        ref="publication",
+    )
+
+    # Transition an active transaction to externally-verified with the stale receipt
+    from dataclasses import replace
+
+    active_tx = replace(
+        genesis_tx,
+        transaction_id="tx-stale-unfinalized",
+        generation=2,
+        state=tx_mod.STATE_EXTERNALLY_VERIFIED,
+    )
+    new_state = journal_mod.JournalState(
+        target=target,
+        next_generation=3,
+        active_transaction_id="tx-stale-unfinalized",
+        durable_transaction_id=state.durable_transaction_id,
+        write_block=None,
+        policy_digest="p-active",
+        tip_commit_oid=commit_oid,
+    )
+    journal_mod.write_journal_update(
+        repo_path=git_repo,
+        expected_parent_oid=commit_oid,
+        new_state=new_state,
+        transaction=active_tx,
+        ref="publication",
+    )
+
+    # Reading the unfinalized transaction with an expired receipt must raise JournalError
+    with pytest.raises(journal_mod.JournalError, match="stale"):
+        journal_mod.read_transaction(git_repo, "tx-stale-unfinalized", ref="publication")

--- a/tests/unit/scripts/publication/test_reconciliation.py
+++ b/tests/unit/scripts/publication/test_reconciliation.py
@@ -765,3 +765,36 @@ def test_operational_cli(tmp_path: Path) -> None:
 
     (d / receipts_mod.TAKEDOWN_DRILL_FILE).write_text("{bad", encoding="utf-8")
     assert receipts_mod.main(["--receipts-dir", str(d), "--json"]) == 2
+
+
+def test_validate_live_receipt_contract_with_none_max_age_preserves_syntax_and_skew(
+    attestor_keypair: Path,
+) -> None:
+    """Disabling receipt expiry via max_age_hours=None still rejects invalid timestamps and future skew."""
+    from datetime import datetime, timezone
+
+    now = datetime(2026, 9, 10, 12, 0, 0, tzinfo=timezone.utc)
+    _, _, _, valid_receipt = _distinct_states()
+    _sign_receipt(valid_receipt, attestor_keypair)
+
+    # 1. Very old receipt passes when max_age_hours=None
+    old_receipt = dict(valid_receipt)
+    old_receipt["timestamp"] = "2025-01-01T00:00:00Z"
+    findings = recon_mod.validate_live_receipt_contract(old_receipt, now=now, max_age_hours=None)
+    assert not any(f.drift_type == "STALE_RECEIPT" for f in findings)
+
+    # 2. Unparseable timestamp fails even when max_age_hours=None
+    bad_ts_receipt = dict(valid_receipt)
+    bad_ts_receipt["timestamp"] = "not-a-date"
+    findings = recon_mod.validate_live_receipt_contract(bad_ts_receipt, now=now, max_age_hours=None)
+    stale_findings = [f for f in findings if f.drift_type == "STALE_RECEIPT"]
+    assert len(stale_findings) == 1
+    assert "unparseable" in stale_findings[0].description
+
+    # 3. Future-skew timestamp fails even when max_age_hours=None
+    future_receipt = dict(valid_receipt)
+    future_receipt["timestamp"] = "2026-09-11T12:00:00Z"
+    findings = recon_mod.validate_live_receipt_contract(future_receipt, now=now, max_age_hours=None)
+    stale_findings = [f for f in findings if f.drift_type == "STALE_RECEIPT"]
+    assert len(stale_findings) == 1
+    assert "in the future" in stale_findings[0].description

--- a/tests/unit/scripts/publication/test_transaction.py
+++ b/tests/unit/scripts/publication/test_transaction.py
@@ -393,3 +393,28 @@ def test_invalid_state_transition_raises_error(base_context: dict[str, dict[str,
 
     with pytest.raises(tx_mod.TransactionError, match="Invalid transition"):
         tx_mod.transition(tx, tx_mod.EVENT_COMMIT_DURABLE)
+
+
+def test_transition_start_write_with_explicit_pages_build_version(base_context: dict[str, dict[str, str]]) -> None:
+    tx, _ = tx_mod.prepare_promotion(
+        target=base_context["target"],
+        generation=2,
+        parent_transaction_id="parent-uuid-001",
+        approval=base_context["approval"],
+        controller=base_context["controller"],
+        owner=base_context["owner"],
+        content=base_context["content"],
+        artifact=base_context["artifact"],
+    )
+    intent_oid = "1" * 40
+    wire_sha = "2" * 40
+    tx, effect = tx_mod.transition(
+        tx,
+        tx_mod.EVENT_START_WRITE,
+        {"intent_commit_oid": intent_oid, "pages_build_version": wire_sha},
+    )
+    assert tx.state == tx_mod.STATE_WRITE_STARTED
+    assert effect.action == "create_deployment"
+    assert effect.data["pages_build_version"] == wire_sha
+    assert tx.write["intent_commit_oid"] == intent_oid
+    assert tx.write["pages_build_version"] == wire_sha

--- a/tests/unit/scripts/publication/test_transaction_executor.py
+++ b/tests/unit/scripts/publication/test_transaction_executor.py
@@ -781,3 +781,97 @@ def _execute_simple_promotion(test_repo: Path, tmp_path: Path, tx_id: str, gen: 
             output_tx=str(tx_path),
         )
     )
+
+
+def test_cmd_start_write_with_explicit_pages_build_version(
+    test_repo: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """start-write CLI command records explicit pages_build_version and preserves intent OID."""
+    tx_id = "tx-explicit-version"
+    permit_path = tmp_path / f"p_{tx_id}.json"
+    tx_path = tmp_path / f"t_{tx_id}.json"
+    approval_path = tmp_path / f"a_{tx_id}.json"
+    github_output = tmp_path / "github_output.txt"
+    monkeypatch.setenv("GITHUB_OUTPUT", str(github_output))
+
+    candidate_digest = "c" * 64
+    cmd_prepare(
+        argparse.Namespace(
+            kind=KIND_PROMOTION,
+            target_repo="BenchBox-dev/BenchBox",
+            target_env="github-pages",
+            target_url="https://benchbox.dev",
+            develop_sha="c" * 40,
+            published_results_sha="c" * 40,
+            candidate_manifest_digest=candidate_digest,
+            candidate_artifact_id="111",
+            candidate_archive_sha256=candidate_digest,
+            restore_transaction_id=None,
+            failed_transaction_id=None,
+            barrier_evidence=None,
+            transaction_id=tx_id,
+            workflow_path=".github/workflows/publication-transaction.yml",
+            workflow_sha="c" * 40,
+            writer_run_id=f"run-{tx_id}",
+            ref="publication",
+            repo_path=str(test_repo),
+            output_permit=str(permit_path),
+            output_tx=str(tx_path),
+        )
+    )
+    permit = json.loads(permit_path.read_text(encoding="utf-8"))
+    permit_digest = hashlib.sha256(canonical_json(permit).encode("utf-8")).hexdigest()
+
+    cmd_authenticate_approval(
+        argparse.Namespace(
+            permit=str(permit_path),
+            run_id=f"run-{tx_id}",
+            run_attempt=1,
+            repo="BenchBox-dev/BenchBox",
+            github_token=None,
+            simulated_approval=str(
+                _write_temp_json(
+                    tmp_path / f"sim_{tx_id}.json",
+                    {
+                        "state": "approved",
+                        "environment": {"name": "github-pages"},
+                        "comment": f"publication-approval:{permit_digest}",
+                        "user": {"id": 1, "login": "joe"},
+                    },
+                )
+            ),
+            output_approval=str(approval_path),
+        )
+    )
+    cmd_record_prepared(
+        argparse.Namespace(
+            permit=str(permit_path),
+            approval=str(approval_path),
+            tx=str(tx_path),
+            ref="publication",
+            repo_path=str(test_repo),
+            output_tx=str(tx_path),
+        )
+    )
+
+    wire_sha = "w" * 40
+    cmd_start_write(
+        argparse.Namespace(
+            transaction_id=tx_id,
+            ref="publication",
+            repo_path=str(test_repo),
+            pages_build_version=wire_sha,
+            output_tx=str(tx_path),
+        )
+    )
+
+    tx = journal.read_transaction(test_repo, tx_id, ref="publication")
+    assert tx.state == STATE_WRITE_STARTED
+    assert tx.write["pages_build_version"] == wire_sha
+    assert tx.write["intent_commit_oid"] != wire_sha
+    assert len(tx.write["intent_commit_oid"]) == 40
+
+    # Verify GITHUB_OUTPUT contents
+    output_text = github_output.read_text(encoding="utf-8")
+    assert f"pages_build_version={wire_sha}" in output_text
+    assert f"intent_commit_oid={tx.write['intent_commit_oid']}" in output_text

--- a/tests/unit/workflows/test_publication_transaction.py
+++ b/tests/unit/workflows/test_publication_transaction.py
@@ -429,3 +429,17 @@ def test_isolated_job_rollback_contract(tmp_path: Path, monkeypatch: pytest.Monk
     assert report_success.ok is True
     assert report_success.matched_checksums["/"] == restored_root_sha
     assert report_success.matched_checksums["/results/data/results.duckdb"] == restored_db_sha
+
+
+def test_publication_deploy_validates_generation_against_journal_next_generation() -> None:
+    """publication-deploy.yml must reject requested generations beyond journal next_generation."""
+    deploy_wf = _load_yaml(DEPLOY_PATH)
+    inputs_step = next(s for s in deploy_wf["jobs"]["build"]["steps"] if s.get("id") == "inputs")
+    run_inputs = inputs_step.get("run", "")
+    assert "generation $GENERATION exceeds journal next_generation $JOURNAL_NEXT_GEN" in run_inputs
+    assert '[ "$GENERATION" -le "$JOURNAL_NEXT_GEN" ]' in run_inputs
+
+    lineage_step = next(s for s in deploy_wf["jobs"]["build"]["steps"] if s.get("id") == "lineage")
+    run_lineage = lineage_step.get("run", "")
+    assert "generation $GENERATION exceeds journal next_generation $JOURNAL_NEXT_GEN" in run_lineage
+    assert '[ "$GENERATION" -le "$JOURNAL_NEXT_GEN" ]' in run_lineage

--- a/tests/unit/workflows/test_validate_submission_changed_bundles.py
+++ b/tests/unit/workflows/test_validate_submission_changed_bundles.py
@@ -436,6 +436,47 @@ def test_deleted_primary_requires_deleting_every_same_stem_companion(tmp_path: P
     assert "also requires deleting its same-stem companion" in result.stdout
 
 
+def test_deleted_primary_with_many_surviving_files_does_not_sigpipe(tmp_path: Path) -> None:
+    """Consuming the full stream prevents git ls-tree SIGPIPE (exit 141) under pipefail."""
+    _git(tmp_path, "init", "--quiet")
+    _git(tmp_path, "config", "user.name", "Test")
+    _git(tmp_path, "config", "user.email", "test@example.invalid")
+
+    bundle_dir = tmp_path / "results-data" / "bundles"
+    bundle_dir.mkdir(parents=True)
+    primary = bundle_dir / "000_gone.json"
+    companion = bundle_dir / "000_gone.manifest.json"
+    primary.write_text('{"gone": 1}\n', encoding="utf-8")
+    companion.write_text("{}\n", encoding="utf-8")
+    # Add enough files so git ls-tree output exceeds pipe buffer
+    for i in range(1500):
+        (bundle_dir / f"zzz_{i:04d}.json").write_text("{}\n", encoding="utf-8")
+
+    _git(tmp_path, "add", str(bundle_dir.relative_to(tmp_path)))
+    _git(tmp_path, "commit", "--quiet", "-m", "base")
+    base_sha = _git(tmp_path, "rev-parse", "HEAD")
+
+    primary.unlink()
+    _git(tmp_path, "add", "-u", str(primary.relative_to(tmp_path)))
+    _git(tmp_path, "commit", "--quiet", "-m", "delete primary only")
+
+    skip_without_posix_shell()
+    result = run_posix_shell(
+        _changed_bundle_discovery_script(),
+        cwd=tmp_path,
+        check=False,
+        capture_output=True,
+        text=True,
+        env={**os.environ, "BASE_SHA": base_sha},
+    )
+
+    # Must emit the actionable annotation, not exit 141 (SIGPIPE)
+    assert result.returncode != 0
+    assert result.returncode != 141
+    assert "file=results-data/bundles/000_gone.manifest.json" in result.stdout
+    assert "also requires deleting its same-stem companion" in result.stdout
+
+
 def test_deleted_primary_does_not_match_differently_cased_stem(tmp_path: Path) -> None:
     """Companion suffixes are case-insensitive, but bundle stems are not."""
     _git(tmp_path, "init", "--quiet")
@@ -534,3 +575,109 @@ def test_deleted_backslash_primary_requires_deleting_companion(tmp_path: Path) -
 
     assert result.returncode != 0
     assert "foo\\bar.manifest.json" in result.stdout
+
+
+def test_deleted_bundle_requires_deleting_referencing_legacy_manifest(tmp_path: Path) -> None:
+    """Deleting a primary bundle must not leave a surviving legacy manifest referencing it."""
+    _git(tmp_path, "init", "--quiet")
+    _git(tmp_path, "config", "user.name", "Test")
+    _git(tmp_path, "config", "user.email", "test@example.invalid")
+
+    bundle_dir = tmp_path / "results-data" / "bundles" / "duckdb"
+    bundle_dir.mkdir(parents=True)
+    primary = bundle_dir / "gone.json"
+    legacy_manifest = bundle_dir / "submission-manifest.json"
+    primary.write_text('{"gone": 1}\n', encoding="utf-8")
+    legacy_manifest.write_text('{"bundle_file": "gone.json"}\n', encoding="utf-8")
+    _git(tmp_path, "add", str(bundle_dir.relative_to(tmp_path)))
+    _git(tmp_path, "commit", "--quiet", "-m", "base")
+    base_sha = _git(tmp_path, "rev-parse", "HEAD")
+
+    primary.unlink()
+    _git(tmp_path, "add", "-u", str(bundle_dir.relative_to(tmp_path)))
+    _git(tmp_path, "commit", "--quiet", "-m", "delete primary only")
+
+    skip_without_posix_shell()
+    result = run_posix_shell(
+        _changed_bundle_discovery_script(),
+        cwd=tmp_path,
+        check=False,
+        capture_output=True,
+        text=True,
+        env={**os.environ, "BASE_SHA": base_sha},
+    )
+
+    assert result.returncode != 0
+    assert "file=results-data/bundles/duckdb/submission-manifest.json" in result.stdout
+    assert "also requires deleting its referencing legacy manifest" in result.stdout
+
+
+def test_deleted_bundle_and_referencing_legacy_manifest_together_is_allowed(tmp_path: Path) -> None:
+    """Deleting both the primary bundle and its referencing legacy manifest passes."""
+    _git(tmp_path, "init", "--quiet")
+    _git(tmp_path, "config", "user.name", "Test")
+    _git(tmp_path, "config", "user.email", "test@example.invalid")
+
+    bundle_dir = tmp_path / "results-data" / "bundles" / "duckdb"
+    bundle_dir.mkdir(parents=True)
+    primary = bundle_dir / "gone.json"
+    legacy_manifest = bundle_dir / "submission-manifest.json"
+    primary.write_text('{"gone": 1}\n', encoding="utf-8")
+    legacy_manifest.write_text('{"bundle_file": "gone.json"}\n', encoding="utf-8")
+    _git(tmp_path, "add", str(bundle_dir.relative_to(tmp_path)))
+    _git(tmp_path, "commit", "--quiet", "-m", "base")
+    base_sha = _git(tmp_path, "rev-parse", "HEAD")
+
+    primary.unlink()
+    legacy_manifest.unlink()
+    _git(tmp_path, "add", "-u", str(bundle_dir.relative_to(tmp_path)))
+    _git(tmp_path, "commit", "--quiet", "-m", "delete primary and legacy manifest")
+
+    skip_without_posix_shell()
+    result = run_posix_shell(
+        _changed_bundle_discovery_script(),
+        cwd=tmp_path,
+        check=False,
+        capture_output=True,
+        text=True,
+        env={**os.environ, "BASE_SHA": base_sha},
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.strip() == ""
+
+
+def test_deleted_bundle_with_surviving_legacy_manifest_for_other_bundle_is_allowed(tmp_path: Path) -> None:
+    """Deleting an unrelated bundle when legacy manifest references another live bundle is allowed."""
+    _git(tmp_path, "init", "--quiet")
+    _git(tmp_path, "config", "user.name", "Test")
+    _git(tmp_path, "config", "user.email", "test@example.invalid")
+
+    bundle_dir = tmp_path / "results-data" / "bundles" / "duckdb"
+    bundle_dir.mkdir(parents=True)
+    surviving = bundle_dir / "keep.json"
+    primary = bundle_dir / "gone.json"
+    legacy_manifest = bundle_dir / "submission-manifest.json"
+    surviving.write_text('{"keep": 1}\n', encoding="utf-8")
+    primary.write_text('{"gone": 1}\n', encoding="utf-8")
+    legacy_manifest.write_text('{"bundle_file": "keep.json"}\n', encoding="utf-8")
+    _git(tmp_path, "add", str(bundle_dir.relative_to(tmp_path)))
+    _git(tmp_path, "commit", "--quiet", "-m", "base")
+    base_sha = _git(tmp_path, "rev-parse", "HEAD")
+
+    primary.unlink()
+    _git(tmp_path, "add", "-u", str(bundle_dir.relative_to(tmp_path)))
+    _git(tmp_path, "commit", "--quiet", "-m", "delete gone only")
+
+    skip_without_posix_shell()
+    result = run_posix_shell(
+        _changed_bundle_discovery_script(),
+        cwd=tmp_path,
+        check=False,
+        capture_output=True,
+        text=True,
+        env={**os.environ, "BASE_SHA": base_sha},
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.strip() == ""


### PR DESCRIPTION
## Summary
Hardens publication and submission CI pipelines across verification, validation, deployment, and transaction lifecycle scripts:

- **`.github/workflows/validate-submission.yml`**: Prevent SIGPIPE (exit 141) under `set -euo pipefail` by consuming the full stream in `awk` when inspecting companions, and verify that bundle deletion also removes any surviving legacy `submission-manifest.json` referencing the deleted bundle.
- **`scripts/publication/journal.py`**: Restrict live-receipt freshness exemptions during transaction reads to durable states (`STATE_DURABLE`, `STATE_ROLLBACK_DURABLE`), ensuring active unfinalized transactions retain freshness validation.
- **`scripts/publication/reconciliation.py`**: Preserve ISO timestamp parsing and future-skew rejection when `max_age_hours=None`, skipping only the upper age expiry threshold.
- **`tests/unit/scripts/publication/test_check_pages_artifact_wiring.py`**: Walk job-level `outputs` expressions to ensure declared output names in action invocations match their references.
- **`.github/workflows/publication-deploy.yml`**: Validate requested dispatch generations against `state.json.next_generation` to prevent deployments from skipping unreserved generations.
- **`scripts/publication/transaction_executor.py`, `scripts/publication/transaction.py`, `.github/workflows/publication-transaction.yml`**: Record the actual wire build version passed to GitHub Pages as `pages_build_version` while keeping the intent commit OID distinct.
