### PR TITLE
Filter benchmark list view by phase and retry leaderboard metadata

### DIFF
--- a/results-explorer/src/pages/BenchmarkIndex.tsx
+++ b/results-explorer/src/pages/BenchmarkIndex.tsx
@@ -1041,7 +1041,13 @@ export function BenchmarkIndex({ benchmark = "" }: BenchmarkIndexProps) {
         <h2 id="benchmark-heading-list" class="mb-3 text-lg font-semibold text-[var(--bb-data-fg-primary)]">
           List
         </h2>
-        <ListTable benchmark={benchmark} results={results} scaleFactor={effectiveSf} facets={facets} />
+        <ListTable
+          benchmark={benchmark}
+          results={results}
+          scaleFactor={effectiveSf}
+          phase={effectivePhase}
+          facets={facets}
+        />
       </section>
 
       <ExcludedRunsDisclosure rows={excludedRows} />
@@ -1172,11 +1178,13 @@ function ListTable({
   benchmark,
   results,
   scaleFactor,
+  phase,
   facets,
 }: {
   benchmark: string;
   results: ResultRow[];
   scaleFactor: string;
+  phase?: string;
   facets: FacetState;
 }) {
   const [sort, setSort] = useState<SortState<BenchmarkListSortKey>>({
@@ -1186,9 +1194,13 @@ function ListTable({
   const [visibleLimit, setVisibleLimit] = useState(TABLE_RENDER_LIMIT);
   const benchmarkResults = results.filter((r) => canonicalBenchmarkSlug(r.benchmark) === canonicalBenchmarkSlug(benchmark));
 
-  const byScale = benchmarkResults.filter((r) => String(r.scale_factor) === scaleFactor);
+  const byCohort = benchmarkResults.filter((r) => {
+    if (String(r.scale_factor) !== scaleFactor) return false;
+    if (phase && canonicalPhase(r.test_type) !== phase) return false;
+    return true;
+  });
 
-  const filtered = byScale
+  const filtered = byCohort
     .filter((row) => matchesFacetRow(row, facets, { keys: BENCHMARK_ROW_FACET_KEYS }))
     .sort((a, b) => compareListRows(a, b, sort));
   const [groupBy, setGroupBy] = useState<CohortGroupBy>("none");
@@ -1219,6 +1231,7 @@ function ListTable({
   }, [
     benchmark,
     scaleFactor,
+    phase,
     facets.platform,
     facets.execution_mode,
     facets.tuning_mode,

--- a/results-explorer/src/pages/Leaderboard.tsx
+++ b/results-explorer/src/pages/Leaderboard.tsx
@@ -168,6 +168,7 @@ export function Leaderboard({ notice = null }: LeaderboardProps) {
 
   useEffect(() => {
     let cancelled = false;
+    setMetaLeaderboardLoaded(false);
     markExplorerPerformance(EXPLORER_PERFORMANCE_MARKS.HOME_LEADERBOARD_DATA_START, { once: true });
     getMetaLeaderboardData()
       .then((data) => {
@@ -192,7 +193,7 @@ export function Leaderboard({ notice = null }: LeaderboardProps) {
     return () => {
       cancelled = true;
     };
-  }, []);
+  }, [resultsRetryToken]);
 
   // Cold-load mitigation (N5 in pass-2 review): unfiltered listResults() can briefly
   // resolve to [] on a cold DuckDB-WASM attach while the meta-leaderboard

--- a/results-explorer/src/pages/__tests__/BenchmarkIndex.test.tsx
+++ b/results-explorer/src/pages/__tests__/BenchmarkIndex.test.tsx
@@ -1199,4 +1199,26 @@ describe("BenchmarkIndex", () => {
     );
     expect(rankingCalls[rankingCalls.length - 1]?.[1]).toEqual(["tpch", 0.1, "power"]);
   });
+
+  it("filters list view rows by the selected phase when multiple phases exist at the same scale", async () => {
+    const mixedRows = [
+      ...RESULT_ROWS,
+      {
+        ...RESULT_ROWS[0],
+        result_id: "standard-r1",
+        test_type: "standard",
+        platform: "ClickHouse",
+        platform_id: "clickhouse",
+      },
+    ];
+    vi.mocked(queryRows).mockImplementation(defaultImpl(mixedRows, RANKING_ROWS, CELL_ROWS));
+
+    const { container } = render(<BenchmarkIndex benchmark="tpch" />);
+    await waitFor(() => screen.getAllByText("DuckDB"));
+
+    const listSection = container.querySelector("#benchmark-section-list");
+    expect(listSection).toBeTruthy();
+    expect(within(listSection as HTMLElement).getByText("Showing 2 of 2 results for SF 0.1")).toBeTruthy();
+    expect(within(listSection as HTMLElement).queryByText("ClickHouse")).toBeNull();
+  });
 });

--- a/results-explorer/src/pages/__tests__/Leaderboard.test.tsx
+++ b/results-explorer/src/pages/__tests__/Leaderboard.test.tsx
@@ -3,6 +3,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("@/db", () => ({
   queryRows: vi.fn(),
+  resetDuckDbInitializationFailures: vi.fn(),
 }));
 
 import { queryRows } from "@/db";
@@ -151,6 +152,43 @@ describe("Leaderboard", () => {
     expect(screen.getByText(/The rankings loaded, but the run list did not/)).toBeTruthy();
     expect(screen.queryByText("Initializing static DuckDB snapshot...")).toBeNull();
     expect(screen.queryByText("Recent results")).toBeNull();
+  });
+
+  it("retries both results and meta-leaderboard data when onRetry is clicked", async () => {
+    let resultCalls = 0;
+    let metaCalls = 0;
+    let shouldFail = true;
+
+    vi.mocked(queryRows).mockImplementation(async (sql: string) => {
+      const s = String(sql).replace(/\s+/g, " ").trim();
+      if (s.includes("FROM bench.results")) {
+        resultCalls += 1;
+        if (shouldFail) throw new Error("Network error loading results");
+        return RESULT_ROWS;
+      }
+      if (s.startsWith("SELECT platform_id, platform, avg_rank, n_cohorts FROM bench.meta_leaderboard")) {
+        metaCalls += 1;
+        if (shouldFail) throw new Error("Network error loading metadata");
+        return META_LEADERBOARD_ROWS;
+      }
+      if (s.includes("FROM bench.cohort_metadata")) {
+        return COHORT_ROWS;
+      }
+      return [];
+    });
+
+    render(<Leaderboard />);
+
+    await waitFor(() => expect(screen.getByText("Could not load results")).toBeTruthy());
+    expect(resultCalls).toBe(1);
+    expect(metaCalls).toBe(1);
+
+    shouldFail = false;
+    fireEvent.click(screen.getByRole("button", { name: "Retry" }));
+
+    await waitFor(() => expect(screen.getByText("Cross-benchmark rankings")).toBeTruthy());
+    expect(resultCalls).toBe(2);
+    expect(metaCalls).toBe(2);
   });
 
   it("renders the leaderboard-first product identity and dense cohort controls", async () => {


### PR DESCRIPTION
- Pass effectivePhase to ListTable in BenchmarkIndex to filter list view
  rows by the selected phase when multiple phases exist at the same scale.
- Include resultsRetryToken in the Leaderboard metadata loading effect to
  retry meta-leaderboard queries alongside run lists on failure recovery.
