### PR TITLE
Read every case variant when checking a deleted bundle's legacy manifest

### DIFF
--- a/.github/workflows/validate-submission.yml
+++ b/.github/workflows/validate-submission.yml
@@ -270,16 +270,25 @@ jobs:
 
               deleted_dir="${deleted_bundle%/*}"
               deleted_name="${deleted_bundle##*/}"
-              legacy_manifest=$(git ls-tree -rz --name-only "$EFFECTIVE_MERGE" -- "$deleted_dir" \
-                | awk -v RS='\0' -v dir="$deleted_dir" \
-                  'tolower($0) == tolower(dir "/submission-manifest.json") { if (!found) { print; found=1 } }')
-              if [ -n "$legacy_manifest" ]; then
+              # Check every case variant, not just the first. Git orders an uppercase
+              # variant ahead of the authoritative lowercase file, so stopping at the
+              # first match lets an unrelated uppercase manifest hide the dangling
+              # lowercase reference. The grep prefilter keeps the shell comparison
+              # cheap in directories with many entries, and comparing paths in the
+              # shell rather than awk avoids depending on how each awk handles a NUL
+              # record separator.
+              expected_manifest_lower=$(printf '%s' "$deleted_dir/submission-manifest.json" | tr 'A-Z' 'a-z')
+              while IFS= read -r -d '' legacy_manifest; do
+                if [ "$(printf '%s' "$legacy_manifest" | tr 'A-Z' 'a-z')" != "$expected_manifest_lower" ]; then
+                  continue
+                fi
                 referenced_bundle=$(git cat-file -p "$EFFECTIVE_MERGE:${legacy_manifest}" | python3 -c "import json, sys; data = json.load(sys.stdin); print(data.get('bundle_file', '') if isinstance(data, dict) else '')" 2>/dev/null || true)
                 if [ "$referenced_bundle" = "$deleted_name" ]; then
                   echo "::error file=${legacy_manifest}::Deleting ${deleted_bundle} also requires deleting its referencing legacy manifest"
                   exit 1
                 fi
-              fi
+              done < <(git ls-tree -rz --name-only "$EFFECTIVE_MERGE" -- "$deleted_dir" \
+                | grep -zi 'submission-manifest\.json$' || true)
           done < <(git diff --no-renames --name-only -z --diff-filter=D \
             "$BASE_SHA...$EFFECTIVE_MERGE" -- \
             ':(icase,glob)results-data/bundles/*.json' ':(icase,glob)results-data/bundles/**/*.json' \

--- a/tests/unit/workflows/test_validate_submission_changed_bundles.py
+++ b/tests/unit/workflows/test_validate_submission_changed_bundles.py
@@ -44,6 +44,24 @@ def _git(repo: Path, *args: str) -> str:
     return result.stdout.strip()
 
 
+def _hash_object(repo: Path, content: str) -> str:
+    """Store ``content`` as a blob and return its SHA.
+
+    Used to build trees through the index so a test can stage two path entries that
+    differ only in case, which a case-insensitive working tree cannot hold at once.
+    """
+    result = subprocess.run(
+        ["git", "hash-object", "-w", "--stdin"],
+        cwd=repo,
+        check=True,
+        capture_output=True,
+        text=True,
+        input=content,
+        encoding="utf-8",
+    )
+    return result.stdout.strip()
+
+
 def test_applied_only_change_discovers_paired_primary_bundle(tmp_path: Path) -> None:
     """An applied-ledger-only edit must still invoke primary-bundle validation."""
     _git(tmp_path, "init", "--quiet")
@@ -681,3 +699,63 @@ def test_deleted_bundle_with_surviving_legacy_manifest_for_other_bundle_is_allow
 
     assert result.returncode == 0, result.stderr
     assert result.stdout.strip() == ""
+
+
+def test_deleted_bundle_with_case_variant_decoy_legacy_manifest_is_rejected(tmp_path: Path) -> None:
+    """An uppercase manifest variant must not hide a dangling lowercase reference.
+
+    Git orders `Submission-Manifest.json` ahead of `submission-manifest.json`, so a
+    guard that stops at the first case-insensitive match reads the decoy and lets a
+    legacy manifest keep pointing at a deleted bundle. The variant tree is built
+    through the index so this reproduces on case-insensitive filesystems too.
+    """
+    _git(tmp_path, "init", "--quiet")
+    _git(tmp_path, "config", "user.name", "Test")
+    _git(tmp_path, "config", "user.email", "test@example.invalid")
+
+    bundle_dir = "results-data/bundles/duckdb"
+    (tmp_path / bundle_dir).mkdir(parents=True)
+    primary = tmp_path / bundle_dir / "gone.json"
+    primary.write_text('{"gone": 1}\n', encoding="utf-8")
+    _git(tmp_path, "add", str(bundle_dir))
+    _git(tmp_path, "commit", "--quiet", "-m", "base with primary")
+    base_sha = _git(tmp_path, "rev-parse", "HEAD")
+
+    # Build a head tree carrying both case variants, with the authoritative
+    # lowercase manifest still referencing the deleted bundle. The primary is
+    # removed from the index directly: a case-insensitive checkout cannot stage
+    # two paths that differ only in case from the working tree.
+    _git(tmp_path, "update-index", "--force-remove", f"{bundle_dir}/gone.json")
+    decoy_blob = _hash_object(tmp_path, '{"bundle_file": "unrelated.json"}\n')
+    authoritative_blob = _hash_object(tmp_path, '{"bundle_file": "gone.json"}\n')
+    _git(tmp_path, "update-index", "--add", "--cacheinfo", f"100644,{decoy_blob},{bundle_dir}/Submission-Manifest.json")
+    _git(
+        tmp_path,
+        "update-index",
+        "--add",
+        "--cacheinfo",
+        f"100644,{authoritative_blob},{bundle_dir}/submission-manifest.json",
+    )
+    tree = _git(tmp_path, "write-tree")
+    head = subprocess.run(
+        ["git", "commit-tree", tree, "-p", base_sha, "-m", "delete primary, keep dangling manifest"],
+        cwd=tmp_path,
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.strip()
+    _git(tmp_path, "update-ref", "HEAD", head)
+
+    skip_without_posix_shell()
+    result = run_posix_shell(
+        _changed_bundle_discovery_script(),
+        cwd=tmp_path,
+        check=False,
+        capture_output=True,
+        text=True,
+        env={**os.environ, "BASE_SHA": base_sha, "MERGE_SHA": head},
+    )
+
+    assert result.returncode != 0, result.stdout
+    assert "file=results-data/bundles/duckdb/submission-manifest.json" in result.stdout
+    assert "also requires deleting its referencing legacy manifest" in result.stdout


### PR DESCRIPTION
## What changed

The submission validator's dangling-manifest guard checked only the first
case-insensitive tree match for `submission-manifest.json`. Git orders
`Submission-Manifest.json` ahead of the lowercase file, so a bundle could carry
an uppercase variant referencing some other bundle, delete its primary bundle,
and leave the authoritative lowercase manifest pointing at a file that no longer
exists. The guard read the decoy, found no dangling reference, and passed.

The guard now walks every matching path and compares each one's `bundle_file`
against the deleted bundle name. Candidates are prefetched with `grep -z`,
matching how this step already filters NUL-separated paths, so the shell
comparison stays cheap in directories holding many entries. Path comparison
moved out of `awk` because handling a NUL record separator is not portable
across `awk` implementations.

## Why a separate change

This follows up review feedback on the submission-validation work in #2095,
which merged before the fix could land on that branch. `develop` still carried
the first-match guard, so the change is applied here against current `develop`.

## Testing

`tests/unit/workflows/test_validate_submission_changed_bundles.py` adds
`test_deleted_bundle_with_case_variant_decoy_legacy_manifest_is_rejected`, which
stages both case variants through the index and deletes the primary bundle. The
tree is built with `update-index`/`commit-tree` rather than files on disk so the
test reproduces on case-insensitive filesystems too.

The test fails against the previous guard (the script exits 0 and emits no
finding) and passes with this change. All 25 tests in that module pass, and
`make pr-preflight` is green.
