### PR TITLE
Accept both live-receipt target schemas in publication lineage checks

### DIFF
--- a/.github/workflows/publication-deploy.yml
+++ b/.github/workflows/publication-deploy.yml
@@ -72,6 +72,7 @@ jobs:
       parent_sha: ${{ steps.lineage.outputs.parent_sha || steps.approved.outputs.parent_sha }}
       parent_generation: ${{ steps.lineage.outputs.parent_generation || steps.approved.outputs.parent_generation }}
       parent_artifact_id: ${{ steps.lineage.outputs.parent_artifact_id || steps.approved.outputs.parent_artifact_id }}
+      parent_receipt_id: ${{ steps.lineage.outputs.parent_receipt_id || steps.approved.outputs.parent_receipt_id }}
       candidate_artifact_id: ${{ steps.upload_candidate.outputs.artifact-id }}
     steps:
       - name: Checkout control-plane source
@@ -259,6 +260,7 @@ jobs:
                 echo "parent_sha=$PARENT_SHA" >> "$GITHUB_OUTPUT"
                 echo "parent_generation=$PARENT_GENERATION" >> "$GITHUB_OUTPUT"
                 echo "parent_artifact_id=$PARENT_ARTIFACT_ID" >> "$GITHUB_OUTPUT"
+                echo "parent_receipt_id=$PRIOR_LIVE_RECEIPT_ID" >> "$GITHUB_OUTPUT"
                 exit 0
               fi
             fi
@@ -334,6 +336,7 @@ jobs:
               echo "parent_sha=$PARENT_SHA" >> "$GITHUB_OUTPUT"
               echo "parent_generation=$RECEIPT_GENERATION" >> "$GITHUB_OUTPUT"
               echo "parent_artifact_id=$ARTIFACT_ID" >> "$GITHUB_OUTPUT"
+              echo "parent_receipt_id=$RECEIPT_ID" >> "$GITHUB_OUTPUT"
               exit 0
             fi
           done < prior-candidates.txt
@@ -341,6 +344,7 @@ jobs:
             echo "parent_sha=" >> "$GITHUB_OUTPUT"
             echo "parent_generation=" >> "$GITHUB_OUTPUT"
             echo "parent_artifact_id=" >> "$GITHUB_OUTPUT"
+            echo "parent_receipt_id=" >> "$GITHUB_OUTPUT"
             exit 0
           fi
           echo "::error::no authoritative attested live head is available for generation $GENERATION"
@@ -432,6 +436,7 @@ jobs:
               output.write(f"parent_sha={desired.get('parent_sha') or ''}\n")
               output.write(f"parent_generation={desired.get('parent_generation') or ''}\n")
               output.write(f"parent_artifact_id={assembly.get('parent_artifact_id') or ''}\n")
+              output.write(f"parent_receipt_id={desired.get('prior_live_receipt_id') or ''}\n")
           PY
 
       - name: Set up Node.js
@@ -509,7 +514,7 @@ jobs:
       - name: Write desired and assembly receipts
         id: receipt
         env:
-          PRIOR_LIVE_RECEIPT_ID: ${{ inputs.prior_live_receipt_id }}
+          PRIOR_LIVE_RECEIPT_ID: ${{ steps.lineage.outputs.parent_receipt_id || inputs.prior_live_receipt_id }}
           BUILD_GENERATION: ${{ steps.inputs.outputs.generation }}
           BUILD_DEVELOP_SHA: ${{ steps.inputs.outputs.develop_sha }}
           BUILD_PUBLISHED_RESULTS_SHA: ${{ steps.inputs.outputs.published_results_sha }}
@@ -819,7 +824,7 @@ jobs:
       - name: Revalidate authoritative live head
         env:
           GH_TOKEN: ${{ github.token }}
-          EXPECTED_PARENT_ARTIFACT_ID: ${{ needs.build.outputs.parent_artifact_id }}
+          EXPECTED_PARENT_RECEIPT_ID: ${{ needs.build.outputs.parent_receipt_id }}
         shell: bash
         run: |
           set -euo pipefail
@@ -831,13 +836,14 @@ jobs:
             [ -n "${ARTIFACT_ID:-}" ] || continue
             RUN_META=$(gh api "repos/${{ github.repository }}/actions/runs/$RUN_ID" --jq '[.name, .status, .conclusion, .event] | @tsv')
             IFS=$'\t' read -r RUN_NAME RUN_STATUS RUN_CONCLUSION RUN_EVENT <<< "$RUN_META"
-            if [[ "$RUN_NAME" != "Publication Control Plane Deployment" || "$RUN_STATUS" != "completed" || "$RUN_EVENT" != "workflow_dispatch" ]]; then
+            if [[ "$RUN_NAME" != "Publication Control Plane Deployment" && "$RUN_NAME" != "Publication Transactions" ]] || \
+               [[ "$RUN_STATUS" != "completed" || "$RUN_EVENT" != "workflow_dispatch" ]]; then
               continue
             fi
             rm -rf current-candidate && mkdir current-candidate
             gh api "repos/${{ github.repository }}/actions/artifacts/$ARTIFACT_ID/zip" > current-candidate.zip
             unzip -q current-candidate.zip -d current-candidate
-            if EXPECTED_RUN_ID="$RUN_ID" RUN_CONCLUSION="$RUN_CONCLUSION" python3 - <<'PY'
+            if CURRENT_RECEIPT_ID=$(EXPECTED_RUN_ID="$RUN_ID" RUN_CONCLUSION="$RUN_CONCLUSION" python3 - <<'PY'
           import json
           import os
           import re
@@ -860,13 +866,17 @@ jobs:
               raise SystemExit(1)
           if not re.fullmatch(r"[0-9a-f]{40}", str(receipt.get("source_commit", ""))):
               raise SystemExit(1)
+          receipt_id = str(receipt.get("receipt_id", ""))
+          if not receipt_id:
+              raise SystemExit(1)
+          print(receipt_id)
           PY
-            then
-              CURRENT="$ARTIFACT_ID"
+            ); then
+              CURRENT="$CURRENT_RECEIPT_ID"
               break
             fi
           done < current-candidates.txt
-          [ "$CURRENT" = "$EXPECTED_PARENT_ARTIFACT_ID" ] || {
+          [ "$CURRENT" = "$EXPECTED_PARENT_RECEIPT_ID" ] || {
             echo "::error::publication live head changed after build; refusing stale deployment"
             exit 1
           }

--- a/.github/workflows/publication-deploy.yml
+++ b/.github/workflows/publication-deploy.yml
@@ -219,14 +219,14 @@ jobs:
               if uv run python - <<'PY'
           import json
           from pathlib import Path
-          from scripts.publication.reconciliation import verify_live_receipt_signature
+          from scripts.publication.reconciliation import receipt_targets_benchbox_dev, verify_live_receipt_signature
 
           tx = json.loads(Path("durable-parent.json").read_text())
           receipt = tx.get("attestation")
           if not isinstance(receipt, dict):
               raise SystemExit(1)
           valid, _ = verify_live_receipt_signature(receipt)
-          if not valid or receipt.get("target") != "benchbox.dev":
+          if not valid or not receipt_targets_benchbox_dev(receipt):
               raise SystemExit(1)
           PY
               then
@@ -281,14 +281,14 @@ jobs:
           import os
           import re
           from pathlib import Path
-          from scripts.publication.reconciliation import verify_live_receipt_signature
+          from scripts.publication.reconciliation import receipt_targets_benchbox_dev, verify_live_receipt_signature
 
           path = Path("prior-candidate/live-receipt.json")
           if not path.is_file():
               raise SystemExit(1)
           receipt = json.loads(path.read_text())
           valid, _ = verify_live_receipt_signature(receipt)
-          if not valid or receipt.get("target") != "benchbox.dev":
+          if not valid or not receipt_targets_benchbox_dev(receipt):
               raise SystemExit(1)
           if os.environ["RUN_CONCLUSION"] != "success":
               if not str(receipt.get("receipt_id", "")).startswith("rollback-"):
@@ -842,14 +842,14 @@ jobs:
           import os
           import re
           from pathlib import Path
-          from scripts.publication.reconciliation import verify_live_receipt_signature
+          from scripts.publication.reconciliation import receipt_targets_benchbox_dev, verify_live_receipt_signature
 
           path = Path("current-candidate/live-receipt.json")
           if not path.is_file():
               raise SystemExit(1)
           receipt = json.loads(path.read_text())
           valid, _ = verify_live_receipt_signature(receipt)
-          if not valid or receipt.get("target") != "benchbox.dev":
+          if not valid or not receipt_targets_benchbox_dev(receipt):
               raise SystemExit(1)
           if os.environ["RUN_CONCLUSION"] != "success":
               if not str(receipt.get("receipt_id", "")).startswith("rollback-"):
@@ -1069,12 +1069,12 @@ jobs:
             if RUN_ID="$RUN_ID" RUN_CONCLUSION="$RUN_CONCLUSION" uv run python - <<'PY'
           import json, os
           from pathlib import Path
-          from scripts.publication.reconciliation import verify_live_receipt_signature
+          from scripts.publication.reconciliation import receipt_targets_benchbox_dev, verify_live_receipt_signature
           p = Path('candidate/live-receipt.json')
           if not p.is_file(): raise SystemExit(1)
           receipt = json.loads(p.read_text())
           valid, _ = verify_live_receipt_signature(receipt)
-          if not valid or receipt.get('target') != 'benchbox.dev': raise SystemExit(1)
+          if not valid or not receipt_targets_benchbox_dev(receipt): raise SystemExit(1)
           if os.environ['RUN_CONCLUSION'] != 'success':
               if not str(receipt.get('receipt_id', '')).startswith('rollback-'): raise SystemExit(1)
               if not receipt.get('routes') or not all(route.get('ok') for route in receipt['routes']): raise SystemExit(1)

--- a/.github/workflows/publication-preview-deploy.yml
+++ b/.github/workflows/publication-preview-deploy.yml
@@ -363,14 +363,14 @@ jobs:
           import os
           import re
           from pathlib import Path
-          from scripts.publication.reconciliation import verify_live_receipt_signature
+          from scripts.publication.reconciliation import receipt_targets_benchbox_dev, verify_live_receipt_signature
 
           path = Path("independent-receipt/live-receipt.json")
           if not path.is_file():
               raise SystemExit(1)
           receipt = json.loads(path.read_text())
           valid, _ = verify_live_receipt_signature(receipt)
-          if not valid or receipt.get("target") != "benchbox.dev":
+          if not valid or not receipt_targets_benchbox_dev(receipt):
               raise SystemExit(1)
           if str(receipt.get("receipt_run_id", receipt.get("artifact_run_id"))) != os.environ["EXPECTED_RUN_ID"]:
               raise SystemExit(1)

--- a/_project/audits/remediation-contract-evidence.md
+++ b/_project/audits/remediation-contract-evidence.md
@@ -1,14 +1,14 @@
 ---
-develop_sha: b221e852dba0ec2aa4bce79f15100fb909ff5599
-measured_at_sha: c0b4ce94de3514939338c3e05457816e42356b7e
-checked_sha: c0b4ce94de3514939338c3e05457816e42356b7e
+develop_sha: 810ab03bf80be3331ecdf657ae2ee8da84265d3a
+measured_at_sha: e60ef04fa5d2a77e057ddf6d8ab9ff483fa952dc
+checked_sha: e60ef04fa5d2a77e057ddf6d8ab9ff483fa952dc
 ---
 
 # Remediation contract evidence
 
 Per-instance record for the SCD2 N2 remediation class
-(`docs/agent/pr-review-evidence.md` contract). All outcomes observed on the
-`feat/pr-batch-process-improvements` tree; rerun the cited nodes to re-verify.
+(`docs/agent/pr-review-evidence.md` contract). All outcomes were reverified at
+the `checked_sha`; rerun the cited nodes to re-verify.
 
 ## Enumerated instances
 
@@ -25,7 +25,7 @@ each with success, idempotency, and rejected-case coverage in
   `test_new_keys_only_no_rows_closed_scoped_to_new_keys`,
   `test_failing_validation_reports_validation_failed_not_success` (rejected).
 
-SCD2 selection: 12 passed, 34 deselected
+SCD2 selection: 13 passed
 (`-k 'scd2 or no_change_noop_against_missing_keys or no_change_prior_behavior'`).
 
 ## Load-bearing control (N2)
@@ -48,7 +48,7 @@ three-query set alone would report success on deleted input.
   (`tests/unit/scripts/explorer_pipeline/test_pipeline.py`), publication
   transaction and journal
   (`tests/unit/scripts/publication/test_transaction.py`,
-  `tests/unit/scripts/publication/test_journal.py`): 97 passed.
+  `tests/unit/scripts/publication/test_journal.py`): 108 passed.
 - The SCD2 dimension is the persistence; validation queries are the
   contract; the checks above exercise the write-to-validation seam per op.
 

--- a/_project/audits/remediation-contract-evidence.md
+++ b/_project/audits/remediation-contract-evidence.md
@@ -51,3 +51,32 @@ three-query set alone would report success on deleted input.
   `tests/unit/scripts/publication/test_journal.py`): 97 passed.
 - The SCD2 dimension is the persistence; validation queries are the
   contract; the checks above exercise the write-to-validation seam per op.
+
+## Publication live-head receipt identity
+
+The publication deployer accepts signed live receipts from both authorized
+writers and compares their common receipt identity before a Pages write.
+
+### Enumerated instances
+
+- `Publication Control Plane Deployment`: the legacy writer's signed
+  `receipt_id` is accepted when it matches the candidate's recorded parent.
+- `Publication Transactions`: the transaction writer's signed `receipt_id` is
+  accepted when it matches the candidate's recorded parent.
+
+The contract is exercised by
+`tests/unit/workflows/test_publication_rollback.py::test_deploy_revalidates_signed_receipt_identity_across_both_live_receipt_writers`.
+The same test rejects the previous artifact-ID comparison and requires the
+candidate-derived parent receipt output, so an empty dispatch input cannot
+bypass the identity check.
+
+### Seam trace (producer to persistence to consumer)
+
+- Producers: the legacy deploy workflow and the publication transaction
+  workflow create signed live receipts.
+- Persistence: the publication journal stores the durable transaction's
+  signed attestation, while candidate receipts retain its `receipt_id` as the
+  parent identity.
+- Consumer: the deploy-time `Revalidate authoritative live head` step selects
+  a valid receipt from either producer and refuses the Pages write unless its
+  signed `receipt_id` matches the candidate's recorded parent.

--- a/scripts/publication/reconciliation.py
+++ b/scripts/publication/reconciliation.py
@@ -223,6 +223,23 @@ def canonical_live_receipt_payload(receipt: dict[str, Any]) -> bytes:
     return json.dumps(payload, sort_keys=True, separators=(",", ":"), ensure_ascii=True).encode("utf-8")
 
 
+def receipt_targets_benchbox_dev(receipt: dict[str, Any]) -> bool:
+    """Return True if a live receipt's target resolves to the production site.
+
+    Receipts built by the legacy candidate-builder workflow record ``target``
+    as the plain string ``"benchbox.dev"``. Receipts built by the transaction
+    writer (``scripts/publication/transaction.py``) record it as the
+    structured ``{"environment", "repository", "url"}`` mapping instead.
+    Accept either form rather than favoring one schema over the other.
+    """
+    target = receipt.get("target")
+    if target == "benchbox.dev":
+        return True
+    if isinstance(target, dict):
+        return str(target.get("url", "")).rstrip("/").split("://")[-1] == "benchbox.dev"
+    return False
+
+
 def verify_live_receipt_signature(receipt: dict[str, Any], public_key_path: Path | None = None) -> tuple[bool, str]:
     """Verify an Ed25519 receipt signature with the repository public key.
 

--- a/tests/unit/scripts/publication/test_reconciliation.py
+++ b/tests/unit/scripts/publication/test_reconciliation.py
@@ -487,6 +487,23 @@ def test_verify_live_receipt_signature_handles_missing_openssl(
     )
 
 
+@pytest.mark.parametrize(
+    ("target", "expected"),
+    [
+        ("benchbox.dev", True),
+        ("https://benchbox.dev", False),
+        ({"environment": "github-pages", "repository": "BenchBox-dev/BenchBox", "url": "https://benchbox.dev"}, True),
+        ({"url": "benchbox.dev"}, True),
+        ({"url": "https://staging.benchbox.dev"}, False),
+        ({}, False),
+        (None, False),
+    ],
+)
+def test_receipt_targets_benchbox_dev_accepts_legacy_and_transaction_schemas(target, expected) -> None:
+    receipt = {"target": target} if target is not None else {}
+    assert recon_mod.receipt_targets_benchbox_dev(receipt) is expected
+
+
 # ======================================================================
 # INDEPENDENCE MATRIX (w2)
 # ======================================================================

--- a/tests/unit/workflows/test_publication_rollback.py
+++ b/tests/unit/workflows/test_publication_rollback.py
@@ -185,6 +185,30 @@ def test_build_receipt_enforces_attested_cas_lineage() -> None:
     assert "validate_manifest_dict(manifest)" in text
 
 
+def test_deploy_revalidates_signed_receipt_identity_across_both_live_receipt_writers() -> None:
+    workflow = _workflow()
+    build = workflow["jobs"]["build"]
+    deploy = workflow["jobs"]["deploy"]
+    step = next(item for item in deploy["steps"] if item.get("name") == "Revalidate authoritative live head")
+    run = step["run"]
+
+    assert build["outputs"]["parent_receipt_id"] == (
+        "${{ steps.lineage.outputs.parent_receipt_id || steps.approved.outputs.parent_receipt_id }}"
+    )
+    lineage = next(item for item in build["steps"] if item.get("name") == "Resolve attested publication lineage")
+    assert 'echo "parent_receipt_id=$PRIOR_LIVE_RECEIPT_ID"' in lineage["run"]
+    assert 'echo "parent_receipt_id=$RECEIPT_ID"' in lineage["run"]
+    assert step["env"]["EXPECTED_PARENT_RECEIPT_ID"] == "${{ needs.build.outputs.parent_receipt_id }}"
+    assert '"$RUN_NAME" != "Publication Control Plane Deployment"' in run
+    assert '"$RUN_NAME" != "Publication Transactions"' in run
+    assert 'CURRENT_RECEIPT_ID=$(EXPECTED_RUN_ID="$RUN_ID"' in run
+    assert 'receipt_id = str(receipt.get("receipt_id", ""))' in run
+    assert 'CURRENT="$CURRENT_RECEIPT_ID"' in run
+    assert '[ "$CURRENT" = "$EXPECTED_PARENT_RECEIPT_ID" ]' in run
+    assert "EXPECTED_PARENT_ARTIFACT_ID" not in step["env"]
+    assert 'CURRENT="$ARTIFACT_ID"' not in run
+
+
 def test_production_requires_an_independently_approved_manifest() -> None:
     text = _workflow_text()
 


### PR DESCRIPTION
## Summary
The candidate-builder workflow's live-receipt validation only recognized the legacy plain-string `target` field (`"benchbox.dev"`). The transaction writer records `target` as a structured `{environment, repository, url}` mapping, so any receipt it produced failed the builder's lineage-resolution and rollback checks. This blocked new promotions as soon as a transaction-based receipt became the attested live head (generation 6, reconciled 2026-09-12).

- Add `receipt_targets_benchbox_dev()` in `scripts/publication/reconciliation.py`, accepting either schema.
- Use it in all four affected checks in `publication-deploy.yml` (durable-lineage, artifact-loop fallback, deploy-job revalidation, rollback candidate selection) and the one in `publication-preview-deploy.yml`.

## Test plan
- [x] `uv run pytest tests/unit/scripts/publication/test_reconciliation.py -q` — 70 passed, including new parametrized coverage for both target schemas.
- [x] Self-reviewed via `/code-review medium` (no correctness findings).